### PR TITLE
fix: broken links in home documentation page

### DIFF
--- a/packages/docs/content/docs/index.mdx
+++ b/packages/docs/content/docs/index.mdx
@@ -76,9 +76,9 @@ Motia is versatile and can be applied across various industries and use cases, s
 
 Embark on your Motia journey and start building powerful workflows today:
 
-1.  **Quick Start Guide:** Follow our [Quick Start](/docs/quick-start) to set up your first Motia project and create a minimal workflow.
+1.  **Quick Start Guide:** Follow our [Quick Start](/docs/getting-started/quick-start) to set up your first Motia project and create a minimal workflow.
 2.  **Explore Examples:** Dive into practical [Examples](/docs/examples) to understand common patterns and real-world use cases.
-3.  **Dive into Concepts:**  Delve deeper into Motia's [Core Concepts](/docs/concepts) to gain a solid understanding of the framework's architecture and principles.
+3.  **Dive into Concepts:**  Delve deeper into Motia's [Core Concepts](/docs/getting-started/core-concepts) to gain a solid understanding of the framework's architecture and principles.
 
 ## Join the Motia Community
 


### PR DESCRIPTION
Hey !
I was reading your docs and noticed two links were invalid in the home page. Here's a little fix :) 