### PR TITLE
Fix: Add data prop to BaseNode

### DIFF
--- a/packages/workbench/src/publicComponents/base-node.tsx
+++ b/packages/workbench/src/publicComponents/base-node.tsx
@@ -5,6 +5,7 @@ import React, { PropsWithChildren } from 'react'
 import { BaseHandle } from './base-handle'
 import { LanguageIndicator } from '../views/flow/nodes/language-indicator'
 import { colorMap } from './colorMap'
+import { BaseNodeProps } from './node-props'
 
 const baseDot = cva('w-[6px] h-[6px] rounded-full', {
   variants: {
@@ -21,6 +22,7 @@ type Props = PropsWithChildren<{
   title: string
   variant: VariantProps<typeof baseDot>['variant']
   language?: string
+  data?: BaseNodeProps
   headerChildren?: React.ReactNode
   className?: string
   disableSourceHandle?: boolean


### PR DESCRIPTION
Double check my work here, but I get an error in the `noop.step.tsx` that the data prop is missing from BaseNode. I think this is the correct type for it.