### PR TITLE
WIP Chore: First pass at a state queue example

### DIFF
--- a/playground/steps/state-queue-example/README.md
+++ b/playground/steps/state-queue-example/README.md
@@ -1,0 +1,64 @@
+# State-Managed Sequential Queue Example
+
+This example demonstrates how to build a workflow that processes items sequentially (one at a time) using Motia's built-in state management features to handle locking and queuing.
+
+## How it Works
+
+This workflow uses Motia's state management to ensure items submitted via an API are processed sequentially, one at a time.
+
+1.  **Trigger**: A client sends a POST request (e.g., containing `itemId` and `payload`) to the `/state-queue/process-item` API endpoint handled by `trigger.api.step.ts`. Motia assigns a unique `traceId` to this incoming request.
+2.  **Emit Request**: The `trigger` step immediately emits a `queue.request` event containing the original request body and the unique `originalTraceId` associated with the initial API call. It then responds `202 Accepted` to the client.
+3.  **Manager**: The `manager.event.step.ts` listens for `queue.request`. It uses Motia's `state` API (scoped to `state-queue-lock`) to check a boolean flag `is_running`.
+    *   If `is_running` is **false** (or not set), the lock is free. The manager sets `is_running` to `true`, stores the `originalTraceId` from the event into the `current_traceId` state key (marking this request as the active one), and emits a `queue.process` event containing the request body and the `originalTraceId`.
+    *   If `is_running` is **true**, the lock is busy. The manager retrieves the current `request_queue` (an array) from the state, adds an object `{ body: requestBody, traceId: originalTraceId }` to it, and saves the updated queue back to the state.
+4.  **Worker**: The `worker.event.step.ts` listens for `queue.process`. It receives the `body` and the `traceId` (which is the *original* trace ID of the request it needs to process). It simulates doing some work (e.g., processing the item based on `body.itemId`) for a few seconds.
+5.  **Event Emission**: After finishing its work (or encountering an error), the worker emits a `queue.finished` event. Crucially, it includes the `traceId` it was given (the *original* trace ID) in the event data as `finishedTraceId`, along with any processing results.
+6.  **Dequeue Logic**: The `dequeue.event.step.ts` listens for the `queue.finished` event. It retrieves the `current_traceId` from the state (the ID of the request that *should* be running).
+    *   It **verifies** that the `finishedTraceId` from the worker's event matches the `current_traceId` stored in the state. If they don't match, it means a stale or unexpected event arrived, and it's simply ignored.
+    *   If the IDs match, it retrieves the `request_queue` from the state.
+    *   If the queue **has items**, it dequeues the next item (`nextRequest`). It updates the `current_traceId` state key to hold the `traceId` of this *next* item. It saves the modified (shorter) queue back to the state. Finally, it emits a `queue.process` event for the dequeued item, passing its body and original `traceId`.
+    *   If the queue is **empty**, it means no more items are waiting. It releases the lock by setting `is_running` state back to `false` and deleting the `current_traceId` state key.
+
+This cycle ensures that only one worker processes an item at any given time, using the `is_running` flag and `current_traceId` state as a lock, while the `request_queue` state holds pending items. The use of the *original* trace ID throughout ensures correct correlation and locking. By using events instead of HTTP calls, the system is more efficient and resilient, as it doesn't rely on network calls that could fail.
+
+## Usage with `curl`
+
+You can trigger the processing of an item by sending a POST request to the `/state-queue/process-item` API endpoint defined in `trigger.api.step.ts`.
+
+```bash
+# Example: Trigger processing for item-123
+curl -X POST http://localhost:3000/state-queue/process-item \
+  -H "Content-Type: application/json" \
+  -d '{"itemId": "item-123", "payload": {"data": "example payload"}}'
+
+# Example: Trigger processing for item-456 (will be queued if item-123 is running)
+curl -X POST http://localhost:3000/state-queue/process-item \
+  -H "Content-Type: application/json" \
+  -d '{"itemId": "item-456", "payload": {"info": "more data"}}'
+```
+
+The API will respond with a `202 Accepted` status and a `traceId` which you can use for tracking, while the request is queued or processed asynchronously.
+
+## Steps Overview
+
+*   **`trigger.api.step.ts`**:
+    *   API Endpoint: `POST /state-queue/process-item`
+    *   Accepts: JSON body (e.g., `{ "itemId": "...", "payload": ... }`)
+    *   Emits: `queue.request` with `{ requestBody, originalTraceId }`
+    *   Responsibility: Entry point for new items. Captures the request and its unique `traceId`, then triggers the manager.
+*   **`manager.event.step.ts`**:
+    *   Subscribes to: `queue.request`
+    *   Emits: `queue.process` with `{ body, traceId }` (where `traceId` is the original trace ID)
+    *   State Used: `is_running` (boolean), `current_traceId` (string), `request_queue` (array) within scope `state-queue-lock`.
+    *   Responsibility: Manages the lock. If free, starts the first worker and locks. If busy, adds the request to the queue.
+*   **`worker.event.step.ts`**:
+    *   Subscribes to: `queue.process`
+    *   Input: `{ body, traceId }` (original trace ID)
+    *   Emits: `queue.finished` with `{ finishedTraceId, result }` (where `finishedTraceId` is the original trace ID it received).
+    *   Responsibility: Performs the actual work for an item and emits an event to the dequeue step upon completion (or error), passing back the original trace ID it worked on.
+*   **`dequeue.event.step.ts`**:
+    *   Subscribes to: `queue.finished`
+    *   Input: `{ finishedTraceId, result }`
+    *   Emits: `queue.process` (if queue has items)
+    *   State Used: Reads `current_traceId`, reads/writes `request_queue`, writes `current_traceId`, writes `is_running`, deletes `current_traceId`.
+    *   Responsibility: Handles the worker completion event. Verifies the finished worker's ID against the lock, dequeues the next item if available (updating the lock and triggering the next worker), or releases the lock if the queue is empty.

--- a/playground/steps/state-queue-example/dequeue.event.step.ts
+++ b/playground/steps/state-queue-example/dequeue.event.step.ts
@@ -1,0 +1,85 @@
+import { EventConfig, StepHandler } from 'motia'
+import { z } from 'zod'
+import { queueItemSchema } from './manager.event.step'
+
+// Define the input schema for events this step subscribes to
+const inputSchema = z.object({
+  finishedTraceId: z.string(),
+  result: z.any().optional(), // The result payload from the worker
+})
+
+export const config: EventConfig<typeof inputSchema> = {
+  type: 'event',
+  name: 'Dequeue Next Item',
+  description: 'Receives finished events from worker and triggers the next queued item if available.',
+  subscribes: ['queue.finished'], // Listen for worker completion events
+  emits: ['queue.process'], // Emits event to start the next worker
+  input: inputSchema,
+  flows: ['state-queue-flow'], // Associate with our example flow
+}
+
+// Constants for state management (must match manager step)
+const QUEUE_SCOPE = 'state-queue-lock'
+const IS_RUNNING_KEY = 'is_running'
+const QUEUE_KEY = 'request_queue'
+const CURRENT_TRACE_ID_KEY = 'current_traceId'
+
+export const handler: StepHandler<typeof config> = async (input, { logger, state, emit, traceId }) => {
+  // Extract data from the event
+  const { finishedTraceId, result } = input
+  logger.info(`[${config.name}] Received finished event for traceId: ${finishedTraceId}`, {
+    newTraceId: traceId,
+    finishedTraceId,
+    result,
+  })
+
+  const currentLockHolder = await state.get<string>(QUEUE_SCOPE, CURRENT_TRACE_ID_KEY)
+
+  if (finishedTraceId !== currentLockHolder) {
+    logger.warn(
+      `[${config.name}] Event from unexpected traceId ${finishedTraceId}. Current lock holder: ${currentLockHolder}. Ignoring.`,
+      { newTraceId: traceId, finishedTraceId },
+    )
+    // This might happen if a worker took too long, errored, and another somehow started.
+    // Or if the event is duplicated.
+    return
+  }
+
+  logger.info(`[${config.name}] Worker finished for request ${finishedTraceId}. Checking queue.`, {
+    newTraceId: traceId,
+    finishedTraceId,
+  })
+  const currentQueue = (await state.get<z.infer<typeof queueItemSchema>[]>(QUEUE_SCOPE, QUEUE_KEY)) || []
+
+  if (currentQueue.length > 0) {
+    // Dequeue next item and process it
+    const nextRequest = currentQueue.shift()!
+    logger.info(`[${config.name}] Dequeuing next request ${nextRequest.traceId}. Queue size: ${currentQueue.length}`, {
+      newTraceId: traceId,
+      nextRequestTraceId: nextRequest.traceId,
+    })
+
+    await state.set(QUEUE_SCOPE, QUEUE_KEY, currentQueue) // Save updated queue
+    await state.set(QUEUE_SCOPE, CURRENT_TRACE_ID_KEY, nextRequest.traceId) // Update lock holder to the *next* item's original traceId
+
+    await emit({
+      topic: 'queue.process',
+      data: {
+        body: nextRequest.body,
+        traceId: nextRequest.traceId, // Pass the *original* traceId of the dequeued item to the worker
+      },
+    })
+
+    logger.info(
+      `[${config.name}] Emitted queue.process event for next item (original traceId: ${nextRequest.traceId}).`,
+    )
+  } else {
+    // Queue is empty, release the lock
+    logger.info(`[${config.name}] Queue is empty. Releasing lock held by ${finishedTraceId}.`, {
+      newTraceId: traceId,
+      finishedTraceId,
+    })
+    await state.set(QUEUE_SCOPE, IS_RUNNING_KEY, false) // Explicitly set to false
+    await state.delete(QUEUE_SCOPE, CURRENT_TRACE_ID_KEY) // Clean up lock holder
+  }
+}

--- a/playground/steps/state-queue-example/manager.event.step.ts
+++ b/playground/steps/state-queue-example/manager.event.step.ts
@@ -1,0 +1,65 @@
+import { EventConfig, StepHandler } from 'motia'
+import { z } from 'zod'
+
+// Define the structure of items in the queue
+export const queueItemSchema = z.object({
+  body: z.any(), // The original request body
+  traceId: z.string(), // The traceId of the original request
+})
+
+// Define the input schema for events this step subscribes to
+const inputSchema = z.object({
+  requestBody: z.any(),
+  originalTraceId: z.string(),
+})
+
+export const config: EventConfig<typeof inputSchema> = {
+  type: 'event',
+  name: 'Queue Manager',
+  description: 'Handles initial queue requests and manages the lock state.',
+  subscribes: ['queue.request'], // Only listens for new requests now
+  emits: ['queue.process'], // Emits event to start the worker
+  input: inputSchema,
+  flows: ['state-queue-flow'],
+}
+
+// Constants for state management
+const QUEUE_SCOPE = 'state-queue-lock' // Fixed scope for global lock/queue
+const IS_RUNNING_KEY = 'is_running'
+const QUEUE_KEY = 'request_queue'
+const CURRENT_TRACE_ID_KEY = 'current_traceId'
+
+export const handler: StepHandler<typeof config> = async (input, { logger, state, emit }) => {
+  // Extract data from the event
+  const { requestBody, originalTraceId } = input
+
+  logger.info(`[${config.name}] Received event: ${originalTraceId}`, { traceId: originalTraceId })
+
+  // --- Handle new request ---
+  const isRunning = await state.get<boolean>(QUEUE_SCOPE, IS_RUNNING_KEY)
+
+  if (!isRunning) {
+    // Lock is free, process immediately
+    logger.info(`[${config.name}] Lock is free. Processing request ${originalTraceId}.`, {
+      traceId: originalTraceId,
+    })
+    await state.set(QUEUE_SCOPE, IS_RUNNING_KEY, true)
+    await state.set(QUEUE_SCOPE, CURRENT_TRACE_ID_KEY, originalTraceId)
+    await emit({
+      topic: 'queue.process',
+      data: {
+        body: requestBody,
+        traceId: originalTraceId, // Pass original traceId to worker
+      },
+    })
+  } else {
+    // Lock is busy, add to queue
+    logger.info(`[${config.name}] Lock is busy. Queuing request ${originalTraceId}.`, {
+      traceId: originalTraceId,
+    })
+    const currentQueue = (await state.get<z.infer<typeof queueItemSchema>[]>(QUEUE_SCOPE, QUEUE_KEY)) || []
+    currentQueue.push({ body: requestBody, traceId: originalTraceId })
+    await state.set(QUEUE_SCOPE, QUEUE_KEY, currentQueue)
+    logger.info(`[${config.name}] Queue size: ${currentQueue.length}`, { traceId: originalTraceId })
+  }
+}

--- a/playground/steps/state-queue-example/trigger.api.step.ts
+++ b/playground/steps/state-queue-example/trigger.api.step.ts
@@ -1,0 +1,42 @@
+import { ApiRouteConfig, StepHandler } from 'motia'
+import { z } from 'zod'
+
+// Define the expected request body structure
+const bodySchema = z.object({
+  itemId: z.string().min(1, 'itemId is required'),
+  payload: z.any().optional(), // Allow any additional payload
+})
+
+export const config: ApiRouteConfig = {
+  type: 'api',
+  name: 'Queue Trigger API',
+  description: 'Receives items to be processed sequentially via a state-managed queue.',
+  path: '/state-queue/process-item', // The API endpoint path
+  method: 'POST',
+  emits: ['queue.request'], // Event emitted to start the queue manager
+  bodySchema: bodySchema,
+  flows: ['state-queue-flow'], // Associate with our example flow
+}
+
+export const handler: StepHandler<typeof config> = async (req, { logger, emit, traceId }) => {
+  logger.info(`[${config.name}] Received request for itemId: ${req.body.itemId}`, { traceId })
+
+  // Emit an event to the queue manager step
+  await emit({
+    topic: 'queue.request',
+    data: {
+      // Pass the original request body and the unique traceId
+      requestBody: req.body,
+      originalTraceId: traceId,
+    },
+  })
+
+  // Respond immediately to the client
+  return {
+    status: 202, // Accepted for processing
+    body: {
+      message: 'Request accepted and queued for processing.',
+      traceId: traceId, // Return the traceId for potential tracking
+    },
+  }
+}

--- a/playground/steps/state-queue-example/worker.event.step.ts
+++ b/playground/steps/state-queue-example/worker.event.step.ts
@@ -1,0 +1,81 @@
+import { EventConfig, StepHandler } from 'motia'
+import { z } from 'zod'
+
+// Define the input schema for the event from the manager
+const inputSchema = z.object({
+  body: z.object({
+    itemId: z.string(),
+    payload: z.any().optional(),
+  }),
+  traceId: z.string(), // The original request's traceId
+})
+
+export const config: EventConfig<typeof inputSchema> = {
+  type: 'event',
+  name: 'Queue Worker',
+  description: 'Simulates processing an item from the queue and emits an event to trigger the next item.',
+  subscribes: ['queue.process'], // Listens for the signal to start processing
+  emits: ['queue.finished'], // Emits when processing is complete to trigger next item
+  input: inputSchema,
+  flows: ['state-queue-flow'],
+}
+
+// Helper function to simulate delay
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+export const handler: StepHandler<typeof config> = async (input, { logger, emit }) => {
+  const { body, traceId } = input
+  const itemId = body.itemId
+  const processingTime = 2000 + Math.random() * 1000 // Simulate 2-3 seconds of work
+
+  logger.info(`[${config.name}] Started processing item: ${itemId}`, { traceId })
+
+  try {
+    // Simulate asynchronous work
+    await sleep(processingTime)
+
+    const resultPayload = {
+      processedItemId: itemId,
+      status: 'completed',
+      processedAt: new Date().toISOString(),
+    }
+
+    logger.info(`[${config.name}] Finished processing item: ${itemId}`, { traceId, duration: processingTime })
+
+    // Emit an event to trigger the next item in the queue
+    logger.info(`[${config.name}] Emitting queue.finished event for traceId: ${traceId}`, { traceId })
+
+    await emit({
+      topic: 'queue.finished',
+      data: {
+        finishedTraceId: traceId,
+        result: resultPayload,
+      },
+    })
+
+    logger.info(`[${config.name}] Successfully emitted queue.finished event for traceId: ${traceId}`, { traceId })
+  } catch (error) {
+    logger.error(`[${config.name}] Error processing item: ${itemId}`, { traceId, error })
+
+    // Still attempt to emit the event even on error to potentially unlock the queue
+    logger.warn(`[${config.name}] Attempting to emit queue.finished event after error for traceId: ${traceId}`, {
+      traceId,
+    })
+
+    await emit({
+      topic: 'queue.finished',
+      data: {
+        finishedTraceId: traceId,
+        result: {
+          processedItemId: itemId,
+          status: 'failed',
+          error: error instanceof Error ? error.message : String(error),
+        },
+      },
+    })
+
+    logger.info(`[${config.name}] Successfully emitted queue.finished event after error for traceId: ${traceId}`, {
+      traceId,
+    })
+  }
+}


### PR DESCRIPTION
This is less of a PR and more of a proposal to get your thoughts on how to do this.

Problem:
- I have an API endpoint that has strict rate limiting, I can only process a few requests at a time
- I have a large number of items that I need to have an agent go through sequentially
- There's no queuing built in Motia currently

Solution:
- Use flow state to hold a queue list for processing
- If the queue is empty, add the item to the "running" state and run it
- If there's already an flow running, add the incoming item to the queue
- When a workflow finishes, emit to dequeue step to clear the running state and pull the next time off for processing.

Caveats:
- There's no real error handling
- Any retries will need to be done in the step itself.