### PR TITLE
Fix Python asyncio event loop deprecation warning

### DIFF
--- a/packages/core/src/python/python-runner.py
+++ b/packages/core/src/python/python-runner.py
@@ -27,7 +27,11 @@ class Context:
         self.rpc = rpc
         self.state = RpcStateManager(rpc)
         self.logger = Logger(self.trace_id, self.flows, rpc)
-        self._loop = asyncio.get_event_loop()
+        try:
+            self._loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
         self.is_api_handler = is_api_handler
         self._pending_tasks = []
 
@@ -141,6 +145,10 @@ if __name__ == "__main__":
     arg = sys.argv[2] if len(sys.argv) > 2 else None
 
     rpc = RpcSender()
-    loop = asyncio.get_event_loop()
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     tasks = asyncio.gather(rpc.init(), run_python_module(file_path, rpc, parse_args(arg)))
     loop.run_until_complete(tasks)


### PR DESCRIPTION
## Summary 

Removed the `asyncio.get_event_loop()` deprecated call in favor of `get_running_loop` and `new_event_loop`

## Description

`get_running_loop()` will raise a `RuntimeError` when:
- There is no event loop running in the current thread
- The code is running outside of an async context

Common scenarios where this happens:
- When the Python script starts (like in our case) - there's no event loop yet
- When running in a synchronous context that needs to initiate async operations
- In background threads that need their own event loop

In our Motia context, when the Python runner starts up, there typically won't be a running event loop yet.
This is why we need the fallback to create a new one.
The pattern we're using is a common one for scripts that need to bootstrap their own async environment.