### PR TITLE
Fix: typo on docs code link for python

### DIFF
--- a/packages/docs/content/docs/real-world-use-cases/rag-docling-weaviate-agent.mdx
+++ b/packages/docs/content/docs/real-world-use-cases/rag-docling-weaviate-agent.mdx
@@ -28,7 +28,7 @@ import { CodeFetcher } from '../../../components/CodeFetcher'
   <CodeFetcher path="examples/rag-docling-weaviate-agent/steps/api-steps" tab="api-query-rag" value="api-query-rag" />
   <CodeFetcher path="examples/rag-docling-weaviate-agent/steps/event-steps" tab="init-weaviate" value="init-weaviate" />
   <CodeFetcher path="examples/rag-docling-weaviate-agent/steps/event-steps" tab="load-weaviate" value="load-weaviate" />
-  <CodeFetcher path="examples/rag-docling-weaviate-agent/steps/event-steps" tab="process-pdfs" value="process-pdfs" />
+  <CodeFetcher path="examples/rag-docling-weaviate-agent/steps/event-steps" tab="process-pdfs" value="process-pdfs" fileExtension="py" />
 </Tabs>
 
 ## 🚀 Features


### PR DESCRIPTION
- fixes a code linking issue in the example docs