### PR TITLE
base ruby step for extensions and to get out of global namespace

### DIFF
--- a/packages/core/src/ruby/base_step.rb
+++ b/packages/core/src/ruby/base_step.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+# require_relative './base_validator' # Not currently used
+# require_relative './step_decorators' # Not currently used
+
+class BaseStep
+  attr_reader :args, :ctx, :trace_id, :flows
+
+  def self.step_config(config = {})
+    all_emit = ['global.step_success', 'global.step_failure', 'global.error']
+    config[:emits] = (config[:emits] || []) + all_emit
+    config
+  end
+
+  def initialize(args = nil, ctx = nil)
+    @args = args
+    @ctx = ctx
+    @trace_id = ctx&.trace_id
+    @flows = ctx&.flows
+  end
+
+  def valid_input?
+    # Placeholder for being overridden by subclasses
+    true
+  end
+
+  def handle
+    unless valid_input?
+      # If API step, return a problem response immediately
+      return { status: 421, body: { success: false, message: 'Input validation failed', errors: errors } } if api?
+
+      raise 'Input validation failed'
+
+    end
+
+    log("Processing step #{step_name} for trace #{trace_id}", level: :info)
+
+    success = process
+
+    if api?
+      if success
+        return { status: 200,
+                 body: { success: true, message: @_step_success_message || 'Step completed successfully.' } }
+      end
+
+      { status: 421,
+        body: { success: false, message: @_step_failure_message || 'Step failed.', errors: @_step_errors } }
+    else
+      success
+    end
+  rescue StandardError => e
+    log("Error in step #{step_name} for trace #{trace_id}: #{e.message}", level: :error,
+                                                                          data: { error: e, backtrace: e.backtrace })
+    handle_error(e)
+  end
+
+  def process
+    # Placeholder for being overridden by subclasses
+    # Should return true on success, false on failure.
+    # Can set @_step_success_message, @_step_failure_message, @_step_errors for API responses.
+    true
+  end
+
+  def emit_success
+    log("Step #{step_name} completed successfully", level: :debug)
+    emit(topic: 'step_success')
+  end
+
+  def emit_failure
+    log("Step #{step_name} failed", level: :error)
+    emit(topic: 'step_failure')
+  end
+
+  def emit(topic: nil, data: {})
+    effective_topic = topic || self.class.step_config[:emits]&.first
+    raise 'No topic specified and no default emit topic found in step config' unless effective_topic
+
+    log("Emitting event: #{effective_topic}", data: data, level: :debug)
+    ctx.emit({ topic: effective_topic, data: data })
+  end
+
+  def log(message, level: :info, data: nil)
+    ctx&.logger&.send(level, message, data)
+  end
+
+  def step_name
+    self.class.step_config[:name] || self.class.name
+  end
+
+  def step_type
+    self.class.step_config[:type]&.to_sym
+  end
+
+  def api?
+    step_type == :api
+  end
+
+  def event?
+    step_type == :event
+  end
+
+  def noop?
+    step_type == :noop
+  end
+
+  def cron?
+    step_type == :cron
+  end
+
+  def api_response(status: 200, body: {})
+    { status: status, body: body }
+  end
+
+  def error_response(status: 500, message: 'Internal Server Error')
+    api_response(status: status, body: { success: false, message: message })
+  end
+
+  def problem_response(status: 400, message: 'Bad Request', errors: nil)
+    body = { success: false, message: message }
+    body[:errors] = errors if errors # Include errors if provided
+    api_response(status: status, body: body)
+  end
+
+  # --- State Management Helpers ---
+  def get_state(key)
+    ctx&.state&.get(trace_id, key)
+  end
+
+  def set_state(key, value)
+    ctx&.state&.set(trace_id, key, value)
+  end
+
+  def delete_state(key)
+    ctx&.state&.delete(trace_id, key)
+  end
+
+  # --- Error Handling ---
+  def handle_error(error)
+    detailed_message = error.message
+    detailed_message += "\n#{error.backtrace.first(5).join("\n")}" if error.respond_to?(:backtrace)
+
+    log("Error handled in step #{step_name}: #{detailed_message}", level: :error)
+    emit(topic: 'error', data: { error: error.message, details: detailed_message })
+
+    # Return an API error response structure if it's an API step
+    if api?
+      error_response(message: "An internal error occurred: #{error.message}")
+    else
+      false # Indicate failure for non-API steps
+    end
+  end
+
+  # Placeholder for potential errors access in handle
+  def errors
+    @_step_errors || []
+  end
+end

--- a/packages/core/src/ruby/get-config.rb
+++ b/packages/core/src/ruby/get-config.rb
@@ -1,61 +1,89 @@
+# frozen_string_literal: true
+
 require 'json'
+require_relative 'base_step' # Load BaseStep from the current directory
 
 # Get the FD from ENV with a default fallback for testing
 NODEIPCFD = (ENV['NODE_CHANNEL_FD'] || 1).to_i
 
 def send_message(message)
+  # Ensure the IO object is correctly created and used
+  io = IO.new(NODEIPCFD, 'w')
+  json_message = "#{message.to_json}\n"
+  io.write(json_message)
+  io.flush
+rescue Errno::EBADF => e
+  # Provide a more informative error message
+  raise "Error writing config to IPC channel FD #{NODEIPCFD}: #{e.message}"
+ensure
+  # Safely close the IO object
+  io.close if io && !io.closed?
+end
+
+# Helper to find the first class inheriting from BaseStep in a file
+def find_step_class(file_path)
+  # Keep track of defined classes before requiring the target file
+  existing_classes = ObjectSpace.each_object(Class).to_a
+
+  # Require the file relative to the current script's directory
   begin
-    io = IO.new(NODEIPCFD, 'w')
-    json_message = message.to_json + "\n"
-    io.write(json_message)
-    io.flush
-  rescue Errno::EBADF => e
-    raise "Error writing to IPC channel: #{e.message}"
-  ensure
-    io.close if io && !io.closed?
+    require File.expand_path(file_path)
+  rescue LoadError => e
+    raise "Failed to require step file '#{file_path}': #{e.message}"
   end
+
+  # Find newly defined classes that are descendants of BaseStep
+  new_classes = ObjectSpace.each_object(Class).to_a - existing_classes
+  step_classes = new_classes.select { |cls| cls < BaseStep && cls != BaseStep }
+
+  if step_classes.empty?
+    raise NameError, "No class inheriting from BaseStep found in #{file_path}"
+  elsif step_classes.length > 1
+    warn "Warning: Multiple BaseStep subclasses found in #{file_path}. Using the first one: #{step_classes.first.name}"
+  end
+
+  step_classes.first
 end
 
 def extract_config(file_path)
-  begin
-    unless File.exist?(file_path)
-      raise LoadError, "Could not load module from #{file_path}"
-    end
+  step_class = find_step_class(file_path)
 
-    # Load the file in a clean context
-    load file_path
-
-    unless defined?(config)
-      raise NameError, "Function 'config' not found in module #{file_path}"
-    end
-
-    config()
-  rescue NameError => e
-    raise "Error accessing config: #{e.message}"
-  rescue => e
-    raise "Error processing config file: #{e.message}"
+  unless step_class.respond_to?(:step_config)
+    raise NoMethodError, "Class #{step_class.name} does not have a step_config class method."
   end
+
+  # Use the step_config method from BaseStep which merges defaults
+  step_class.step_config(step_class.config)
+rescue NameError, NoMethodError => e
+  raise "Error accessing config for step in #{file_path}: #{e.message}"
+rescue StandardError => e
+  raise "Error processing config for step file #{file_path}: #{e.message}\n#{e.backtrace.join("\n")}"
 end
 
 # Main execution block
 begin
-  if ARGV.empty?
-    raise 'Error: No file path provided'
-  end
+  raise 'Error: No file path provided.' if ARGV.empty?
 
   file_path = ARGV[0]
-  
-  unless File.exist?(file_path)
-    raise "Error: File not found: #{file_path}"
-  end
-  
-  unless File.readable?(file_path)
-    raise "Error: File is not readable: #{file_path}"
-  end
+
+  raise "Error: File not found: #{file_path}" unless File.exist?(file_path)
+
+  raise "Error: File is not readable: #{file_path}" unless File.readable?(file_path)
 
   # Extract and send config
   config = extract_config(file_path)
   send_message(config)
-  
+
   exit(0)
+rescue StandardError => e
+  # Send error back over IPC for the host to potentially catch
+  error_message = { error: e.message, backtrace: e.backtrace }
+  # Use a different mechanism or FD for errors if available, otherwise stderr
+  begin
+    send_message(error_message)
+  rescue StandardError => send_err
+    warn "Failed to send error over IPC: #{send_err.message}"
+    warn "Original Error: #{e.message}\n#{e.backtrace.join("\n")}"
+  end
+  exit(1) # Exit with error status
 end

--- a/packages/core/src/ruby/ruby-runner.rb
+++ b/packages/core/src/ruby/ruby-runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'io/console'
 require 'ostruct'
@@ -5,90 +7,118 @@ require 'pathname'
 require_relative 'logger'
 require_relative 'rpc'
 require_relative 'rpc_state_manager'
+require_relative 'base_step'
 
 def parse_args(arg)
-  begin
-    JSON.parse(arg, object_class: OpenStruct)
-  rescue JSON::ParserError
-    puts "Error parsing args: #{arg}"
-    arg
-  end
+  JSON.parse(arg, object_class: OpenStruct)
+rescue JSON::ParserError
+  # Log the error and return the original arg for potential debugging
+  warn "Error parsing args JSON: #{arg}"
+  arg
 end
 
 class Context
-  attr_reader :trace_id, :traceId, :flows, :file_name, :state, :logger
+  attr_reader :trace_id, :traceId, :flows, :file_name, :state, :logger, :rpc # Expose rpc for state manager etc.
 
   def emit(event)
-    # Add type field if not present to match Node.js/Python behavior
-    event = { topic: event[:topic] || event['topic'], data: event[:data] || event['data'] } unless event.is_a?(String)
-    promise = @rpc.send('emit', event)
-    promise  # Return promise to maintain async pattern
+    # Ensure event is a hash with :topic and :data
+    unless event.is_a?(Hash) && event.key?(:topic)
+      raise ArgumentError, "Event must be a Hash with at least a :topic key. Got: #{event.inspect}"
+    end
+
+    # Default data if missing
+    event_data = { topic: event[:topic], data: event[:data] || {} }
+
+    # Use send_no_wait for emits as they usually don't require a response
+    @rpc.send_no_wait('emit', event_data)
+    # No promise needed for send_no_wait
   end
 
   def initialize(rpc, args)
     @rpc = rpc
-    @trace_id = args.traceId
-    @traceId = args.traceId
-    @flows = args.flows
+    # Ensure traceId exists, providing a default if necessary
+    @trace_id = args&.traceId || SecureRandom.uuid
+    @traceId = @trace_id # Maintain alias for compatibility
+    @flows = args&.flows || []
     @state = RpcStateManager.new(rpc)
     @logger = CustomLogger.new(@trace_id, @flows, @rpc)
   end
 end
 
+# Helper to find the first class inheriting from BaseStep in a file
+# Still a bit of magic but nothing terrible
+def find_step_class(file_path)
+  existing_classes = ObjectSpace.each_object(Class).to_a
+  begin
+    require File.expand_path(file_path)
+  rescue LoadError => e
+    raise "Failed to require step file '#{file_path}': #{e.message}"
+  end
+  new_classes = ObjectSpace.each_object(Class).to_a - existing_classes
+  step_classes = new_classes.select { |cls| cls < BaseStep && cls != BaseStep }
+
+  if step_classes.empty?
+    raise NameError, "No class inheriting from BaseStep found in #{file_path}"
+  elsif step_classes.length > 1
+    warn "Warning: Multiple BaseStep subclasses found in #{file_path}. Using the first one: #{step_classes.first.name}"
+  end
+
+  step_classes.first
+end
+
 def run_ruby_module(file_path, args)
   rpc = nil
   begin
-    unless File.exist?(file_path)
-      raise LoadError, "Could not load module from #{file_path}"
-    end
+    raise LoadError, "Could not load module file: #{file_path}" unless File.exist?(file_path)
 
-    # Load the file in a clean context
-    load file_path
-
-    unless defined?(handler)
-      raise NameError, "Function 'handler' not found in module #{file_path}"
-    end
+    # Find the step class within the file
+    step_class = find_step_class(file_path)
 
     rpc = RpcSender.new
     context = Context.new(rpc, args)
     rpc.init
 
-    # Call handler and wait for any promises
-    if args.contextInFirstArg
-      result = handler(context)
-    else
-      result = handler(args.data, context)
-    end
+    # Instantiate the step class
+    # Note: Passes the full parsed args object (which includes data, traceId, etc.) and the context
+    step_instance = step_class.new(args, context)
 
-    if result
-      rpc.send('result', result)
-    end
+    # Call the handle method of the step instance itself yay!
+    result = step_instance.handle
 
-  rescue => e
-    $stderr.puts "Error running Ruby module: #{e.message}"
-    $stderr.puts e.backtrace
-    raise
+    # Send the result back if it's not nil
+    # BaseStep handle method returns API responses or nil/false for non-API steps
+    rpc.send('result', result) if result
+  rescue StandardError => e
+    error_message = "Error running Ruby step #{file_path}: #{e.message}\nBacktrace:\n#{e.backtrace.join("\n")}"
+    warn error_message
+    # Attempt to send error via RPC if possible
+    if rpc && !rpc.instance_variable_get(:@closed)
+      rpc&.send_no_wait('error',
+                        { message: e.message, backtrace: e.backtrace })
+    end
+    raise # Re-raise the error to ensure the script exits with an error code
   ensure
-    rpc&.close if rpc
+    # Ensure RPC connection is closed cleanly
+    rpc&.close
   end
 end
 
 if __FILE__ == $PROGRAM_NAME
-  if ARGV.length < 1
-    $stderr.puts 'Usage: ruby ruby-runner.rb <file-path> <arg>'
+  if ARGV.empty?
+    warn 'Usage: ruby ruby-runner.rb <file-path> [json-args]'
     exit 1
   end
 
   file_path = ARGV[0]
-  arg = ARGV[1] || nil
+  # Handle case where args might not be provided
+  arg_string = ARGV[1] || '{}' # Default to empty JSON object if no args string
 
   begin
-    parsed_args = parse_args(arg)
+    parsed_args = parse_args(arg_string)
     run_ruby_module(file_path, parsed_args)
-    exit 0
-  rescue => e
-    $stderr.puts "Error: #{e.message}"
-    $stderr.puts e.backtrace
+    exit 0 # Exit cleanly on success
+  rescue StandardError
+    # Error already logged in run_ruby_module, just exit with error status
     exit 1
   end
 end

--- a/playground/steps/rubyTest/global_handlers/error_step.rb
+++ b/playground/steps/rubyTest/global_handlers/error_step.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../../packages/core/src/ruby/base_step'
+
+class ErrorStep < BaseStep
+  def self.config
+    {
+      type: 'event',
+      name: 'Global Error Handler',
+      subscribes: ['global.error'],
+      flows: ['reporting']
+    }
+  end
+
+  def process
+    error_data = args.data
+
+    log("Global Error Handler triggered for trace #{trace_id}", level: :error, data: error_data)
+
+    true
+  end
+end

--- a/playground/steps/rubyTest/global_handlers/step_failure_step.rb
+++ b/playground/steps/rubyTest/global_handlers/step_failure_step.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../../packages/core/src/ruby/base_step'
+
+class StepFailureStep < BaseStep
+  def self.config
+    {
+      type: 'event',
+      name: 'Global Step Failure Handler',
+      subscribes: ['global.step_failure'],
+      flows: ['reporting']
+    }
+  end
+
+  def process
+    failure_data = args.data
+
+    log("Global Step Failure Handler triggered for trace #{trace_id}", level: :warn, data: failure_data)
+
+    true
+  end
+end

--- a/playground/steps/rubyTest/global_handlers/step_success_step.rb
+++ b/playground/steps/rubyTest/global_handlers/step_success_step.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../../packages/core/src/ruby/base_step'
+
+class StepSuccessStep < BaseStep
+  def self.config
+    {
+      type: 'event',
+      name: 'Global Step Success Handler',
+      subscribes: ['global.step_success'],
+      flows: ['reporting']
+    }
+  end
+
+  def process
+    success_data = args.data
+
+    log("Global Step Success Handler triggered for trace #{trace_id}", level: :info, data: success_data)
+
+    true
+  end
+end

--- a/playground/steps/rubyTest/user_flow/user_validation_step.rb
+++ b/playground/steps/rubyTest/user_flow/user_validation_step.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require_relative '../../packages/core/src/ruby/base_step'
+require 'json-schema'
+
+class UserDataSchema
+  def self.definition
+    {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        email: { type: 'string' }
+      },
+      required: %w[name email]
+    }
+  end
+end
+
+class UserValidationStep < BaseStep
+  def self.config
+    {
+      type: 'api',
+      name: 'User Data Validator API',
+      path: '/user_verify',
+      method: 'POST',
+      emits: ['user.validated', 'user.invalid'],
+      flows: %w[user-processing reporting]
+    }
+  end
+
+  private
+
+  def validate_user_data
+    return @validate_user_data if defined?(@validate_user_data)
+
+    user_data = args&.body&.dig('user')
+    unless user_data
+      return @validate_user_data = { valid: false, data: nil,
+                                     errors: ['User data missing in request body. Expected in body.user'] }
+    end
+
+    is_valid = JSON::Schema.validate(UserDataSchema.definition, user_data)
+
+    if is_valid[:valid]
+      @validate_user_data = { valid: true, data: user_data, errors: [] }
+    else
+      errors = JSON::Schema.fully_validate(UserDataSchema.definition, user_data)
+      @validate_user_data = { valid: false, data: nil, errors: errors }
+    end
+
+    @validate_user_data
+  end
+
+  # Override BaseStep's valid_input? to use our specific validation
+  def valid_input?
+    validate_user_data[:valid]
+  end
+
+  # Override BaseStep's process method with the core step logic
+  def process
+    # Get the memoized validation result
+    validation_result = validate_user_data
+
+    if validation_result[:valid]
+      log("User data is valid for trace #{trace_id}", level: :info)
+      emit(topic: 'user.validated', data: { user: validation_result[:data] })
+      @_step_success_message = 'User data validated successfully'
+      true # Indicate success
+    else
+      log("User data validation failed for trace #{trace_id}", level: :warn,
+                                                               data: { errors: validation_result[:errors] })
+      emit(topic: 'user.invalid', data: { errors: validation_result[:errors] })
+      # Store errors for potential use in the API response
+      @_step_errors = validation_result[:errors]
+      @_step_failure_message = 'User data validation failed'
+      false # Indicate failure
+    end
+  end
+end


### PR DESCRIPTION
Hey all - I only kicked the tires on this a bit so I wouldn't just merge it right in (and was having trouble figuring out where to write the tests for it)

But I think it would be of Great Use to get step files out of the global namespace, and also provide a nice base class that can be extended or monkeypatched to add hooks, decorators, format responses, etc (input validation of data, output validation, clusters of shared functionality, etc) so just wanted to throw up a proof of concept that it's pretty straightforward

Also I think by doing load_file we are reloading every request basically, so if any constants get defined there etc ruby is not gonna like it too much

feel free to grab something out of this if you want it, otherwise let me know what you think or just close it out if busy with other stuff! I can get it cleaned up a bit more if desired but node is not my daily or even yearly driver so someone needs to just clue me in on where tests go and how they run!