### PR TITLE
Simple docs improvements- fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ npx motia emit --topic test-state --message '{}'
 
 ## Start building your APIs, agents and automations with simple steps
 
-- Configure a simple to emit/subscribe, assign to a flow and inculde runtime validation
+- Configure a simple step to emit/subscribe, assign to a flow and include runtime validation
 - Define a function to handle when the step is triggered
 - Import any package
 

--- a/packages/docs/content/docs/concepts/cli.mdx
+++ b/packages/docs/content/docs/concepts/cli.mdx
@@ -148,6 +148,6 @@ This will set the `LOG_LEVEL` environment variable to `'debug'`, providing more 
 
 ## Next Steps
 
-- Explore the [Core Concepts](/docs/core) to learn more about Steps, Flows, Events, and Topics.
+- Explore the [Core Concepts](/docs/getting-started/core-concepts) to learn more about Steps, Flows, Events, and Topics.
 - Check out the [Examples](/docs/examples) for common patterns and use cases.
 - Join our [Community](/community) for help and discussions. 

--- a/packages/docs/content/docs/concepts/flows-and-visualization.mdx
+++ b/packages/docs/content/docs/concepts/flows-and-visualization.mdx
@@ -2,15 +2,15 @@
 title: Flows
 ---
 
-A **Flow** allows you to group [**steps**](/docs/core/steps/defining-steps), making it seamless to visually map out how events move through a sequence of [steps](/docs/core/steps/defining-steps). While flows are technically optional, they're invaluable for:
+A **Flow** allows you to group [**steps**](/docs/concepts/steps/defining-steps), making it seamless to visually map out how events move through a sequence of [steps](/docs/concepts/steps/defining-steps). While flows are technically optional, they're invaluable for:
 
-- **Clarity**: Understand how [**steps**](/docs/core/steps/defining-steps) interact with each other at a glance
-- **Visualization**: Get a visual representation of event flow across your [**steps**](/docs/core/steps/defining-steps)
+- **Clarity**: Understand how [**steps**](/docs/concepts/steps/defining-steps) interact with each other at a glance
+- **Visualization**: Get a visual representation of event flow across your [**steps**](/docs/concepts/steps/defining-steps)
 - **Observability**: Group logs and events by flow name for easier debugging
 
 ### Creating and Tagging Steps with a Flow
 
-Flows are defined by tagging your [steps](/docs/core/steps/defining-steps) with a flow name. Here's how to associate [steps](/docs/core/steps/defining-steps) with a flow:
+Flows are defined by tagging your [steps](/docs/concepts/steps/defining-steps) with a flow name. Here's how to associate [steps](/docs/concepts/steps/defining-steps) with a flow:
 
 ```js
 // addNumbers.step.js
@@ -25,7 +25,7 @@ exports.config = {
 // ... handler definition
 ```
 
-You can create complex workflows by connecting multiple [steps](/docs/core/steps/defining-steps) within the same flow:
+You can create complex workflows by connecting multiple [steps](/docs/concepts/steps/defining-steps) within the same flow:
 
 ```js
 // validateNumbers.step.js
@@ -43,7 +43,7 @@ exports.config = {
 <Callout type="info">
   💡 Best Practices:
   - Use descriptive flow names that reflect their purpose (e.g., 'user-registration-flow', 'payment-processing-flow')
-  - A [step](/docs/core/steps/defining-steps) can belong to multiple flows: `flows: ['billing-flow', 'analytics-flow']`
+  - A [step](/docs/concepts/steps/defining-steps) can belong to multiple flows: `flows: ['billing-flow', 'analytics-flow']`
   - Keep flows focused on specific business processes for better organization
 </Callout>
 
@@ -83,15 +83,15 @@ After you've defined your flows, you can visualize them in [Motia Workbench](/do
     ![Flow Visualization in Workbench](./../img/demo-workbench.png)
   </Step>
   <Step>
-    **Navigate** to your flow name on the left sidebar and click it. You'll see a visual graph where each [**step**](/docs/core/steps/defining-steps) is represented as a node, with connecting lines showing event flow patterns.
+    **Navigate** to your flow name on the left sidebar and click it. You'll see a visual graph where each [**step**](/docs/concepts/steps/defining-steps) is represented as a node, with connecting lines showing event flow patterns.
   </Step>
   <Step>
-    **Click** on any [**step**](/docs/core/steps/defining-steps) node to inspect its configuration details, including name, emits, subscribes, and other properties.
+    **Click** on any [**step**](/docs/concepts/steps/defining-steps) node to inspect its configuration details, including name, emits, subscribes, and other properties.
   </Step>
 </Steps>
 
 Checkout the [Motia Workbench](/docs/workbench/overview) docs for more information.
 
 <Callout>
-New to Motia? Follow the **[quick start](/docs/quick-start)** guide to get set up.
+New to Motia? Follow the **[quick start](/docs/getting-started/quick-start)** guide to get set up.
 </Callout>

--- a/packages/docs/content/docs/concepts/logging-and-debugging.mdx
+++ b/packages/docs/content/docs/concepts/logging-and-debugging.mdx
@@ -215,7 +215,7 @@ Motia supports four standard log levels:
   <Step>
   ### Trigger and Monitor Flows
 
-    You can trigger flows using either the CLI or an [API step](/docs/core/steps/api):
+    You can trigger flows using either the CLI or an [API step](/docs/concepts/steps/api):
 
     <Tabs items={['cli', 'api']}>
       <Tab value='cli'>

--- a/packages/docs/content/docs/concepts/state-management.mdx
+++ b/packages/docs/content/docs/concepts/state-management.mdx
@@ -57,7 +57,7 @@ State data is stored as key-value pairs, namespaced under a scope string. When u
 }
 ```
 
-> **Info:** You can access the `state` manager within any step through the `ctx` (context) argument, which is automatically injected into your [step handler](/docs/core/steps/defining-steps#handler). While **`traceId` from `ctx.traceId` is the recommended scope for flow isolation**, remember that **you can use any string as the scope** parameter in `state` methods for more advanced state management scenarios.
+> **Info:** You can access the `state` manager within any step through the `ctx` (context) argument, which is automatically injected into your [step handler](/docs/concepts/steps/defining-steps#handler). While **`traceId` from `ctx.traceId` is the recommended scope for flow isolation**, remember that **you can use any string as the scope** parameter in `state` methods for more advanced state management scenarios.
 
 ## Using State in Steps
 

--- a/packages/docs/content/docs/concepts/steps/api.mdx
+++ b/packages/docs/content/docs/concepts/steps/api.mdx
@@ -6,7 +6,7 @@ An **API step** is exposed as an HTTP endpoint that acts as an entry point into 
 
 ## Config
 
-The following properties are specific to the API Step, in addition to the [common step config](/docs/core/steps/defining-steps#config).
+The following properties are specific to the API Step, in addition to the [common step config](/docs/concepts/steps/defining-steps#config).
 
 <DescriptionTable
   type={{

--- a/packages/docs/content/docs/concepts/steps/cron.mdx
+++ b/packages/docs/content/docs/concepts/steps/cron.mdx
@@ -6,7 +6,7 @@ The **Cron Step** allows you to schedule your steps to run at specified interval
 
 ## Config
 
-The following properties are specific to the Cron Step, in addition to the [common step config](/docs/core/steps/defining-steps#config).
+The following properties are specific to the Cron Step, in addition to the [common step config](/docs/concepts/steps/defining-steps#config).
 
 <DescriptionTable
   type={{

--- a/packages/docs/content/docs/concepts/steps/defining-steps.mdx
+++ b/packages/docs/content/docs/concepts/steps/defining-steps.mdx
@@ -19,7 +19,7 @@ This modular approach allows you to:
 - Maintain clear separation of concerns
 - Scale and modify parts of your system independently
 
-Steps can be defined in any language that Motia supports, such as TypeScript, JavaScript, Python, and Ruby. Steps can be of type [`event`](/docs/core/steps/event), [`api`](/docs/core/steps/api), or [`cron`](/docs/core/steps/cron). Steps are composed of a `config` object and a `handler` function.
+Steps can be defined in any language that Motia supports, such as TypeScript, JavaScript, Python, and Ruby. Steps can be of type [`event`](/docs/concepts/steps/event), [`api`](/docs/concepts/steps/api), or [`cron`](/docs/concepts/steps/cron). Steps are composed of a `config` object and a `handler` function.
 
 ## Config
 
@@ -144,5 +144,5 @@ Here're examples of how to define a handler in the Motia supported languages:
 </Tabs>
 
 <Callout>
-Follow the **[quick start](/docs/quick-start)** guide if you haven't set up Motia yet.
+Follow the **[quick start](/docs/getting-started/quick-start)** guide if you haven't set up Motia yet.
 </Callout>

--- a/packages/docs/content/docs/concepts/steps/event.mdx
+++ b/packages/docs/content/docs/concepts/steps/event.mdx
@@ -6,7 +6,7 @@ The **Event Step** lets you define custom logic in response to subscribed events
 
 ## Config
 
-The following properties are specific to the Event Step, in addition to the [common step config](/docs/core/steps/defining-steps#config).
+The following properties are specific to the Event Step, in addition to the [common step config](/docs/concepts/steps/defining-steps#config).
 
 <DescriptionTable
   type={{

--- a/packages/docs/content/docs/welcome.mdx
+++ b/packages/docs/content/docs/welcome.mdx
@@ -76,7 +76,7 @@ Motia is versatile and can be applied across various industries and use cases, s
 
 Embark on your Motia journey and start building powerful workflows today:
 
-1.  **Quick Start Guide:** Follow our [Quick Start](/docs/quick-start) to set up your first Motia project and create a minimal workflow.
+1.  **Quick Start Guide:** Follow our [Quick Start](/docs/getting-started/quick-start) to set up your first Motia project and create a minimal workflow.
 2.  **Explore Examples:** Dive into practical [Examples](/docs/examples) to understand common patterns and real-world use cases.
 3.  **Dive into Concepts:**  Delve deeper into Motia's [Core Concepts](/docs/concepts) to gain a solid understanding of the framework's architecture and principles.
 

--- a/packages/docs/content/docs/workbench/overview.mdx
+++ b/packages/docs/content/docs/workbench/overview.mdx
@@ -114,6 +114,6 @@ UI steps allow you to customize how your steps appear in the Workbench visualiza
 }]} />
 
 <Callout>
-New to Motia? Follow the **[quick start](/docs/quick-start)** guide to get set up.
+New to Motia? Follow the **[quick start](/docs/getting-started/quick-start)** guide to get set up.
 </Callout>
 

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -224,7 +224,7 @@ This will set the `LOG_LEVEL` environment variable to `'debug'`, providing more 
 
 ## Next Steps
 
-- Explore the [Core Concepts](/docs/core) to learn more about Steps, Flows, Events, and Topics.
+- Explore the [Core Concepts](/docs/getting-started/core-concepts) to learn more about Steps, Flows, Events, and Topics.
 - Check out the [Examples](/docs/examples) for common patterns and use cases.
 - Join our [Community](/community) for help and discussions. 
 
@@ -345,15 +345,15 @@ If you encounter issues during deployment, try these steps:
 title: Flows
 ---
 
-A **Flow** allows you to group [**steps**](/docs/core/steps/defining-steps), making it seamless to visually map out how events move through a sequence of [steps](/docs/core/steps/defining-steps). While flows are technically optional, they're invaluable for:
+A **Flow** allows you to group [**steps**](/docs/concepts/steps/defining-steps), making it seamless to visually map out how events move through a sequence of [steps](/docs/concepts/steps/defining-steps). While flows are technically optional, they're invaluable for:
 
-- **Clarity**: Understand how [**steps**](/docs/core/steps/defining-steps) interact with each other at a glance
-- **Visualization**: Get a visual representation of event flow across your [**steps**](/docs/core/steps/defining-steps)
+- **Clarity**: Understand how [**steps**](/docs/concepts/steps/defining-steps) interact with each other at a glance
+- **Visualization**: Get a visual representation of event flow across your [**steps**](/docs/concepts/steps/defining-steps)
 - **Observability**: Group logs and events by flow name for easier debugging
 
 ### Creating and Tagging Steps with a Flow
 
-Flows are defined by tagging your [steps](/docs/core/steps/defining-steps) with a flow name. Here's how to associate [steps](/docs/core/steps/defining-steps) with a flow:
+Flows are defined by tagging your [steps](/docs/concepts/steps/defining-steps) with a flow name. Here's how to associate [steps](/docs/concepts/steps/defining-steps) with a flow:
 
 ```js
 // addNumbers.step.js
@@ -368,7 +368,7 @@ exports.config = {
 // ... handler definition
 ```
 
-You can create complex workflows by connecting multiple [steps](/docs/core/steps/defining-steps) within the same flow:
+You can create complex workflows by connecting multiple [steps](/docs/concepts/steps/defining-steps) within the same flow:
 
 ```js
 // validateNumbers.step.js
@@ -386,7 +386,7 @@ exports.config = {
 <Callout type="info">
   💡 Best Practices:
   - Use descriptive flow names that reflect their purpose (e.g., 'user-registration-flow', 'payment-processing-flow')
-  - A [step](/docs/core/steps/defining-steps) can belong to multiple flows: `flows: ['billing-flow', 'analytics-flow']`
+  - A [step](/docs/concepts/steps/defining-steps) can belong to multiple flows: `flows: ['billing-flow', 'analytics-flow']`
   - Keep flows focused on specific business processes for better organization
 </Callout>
 
@@ -426,17 +426,17 @@ After you've defined your flows, you can visualize them in [Motia Workbench](/do
     ![Flow Visualization in Workbench](./../img/demo-workbench.png)
   </Step>
   <Step>
-    **Navigate** to your flow name on the left sidebar and click it. You'll see a visual graph where each [**step**](/docs/core/steps/defining-steps) is represented as a node, with connecting lines showing event flow patterns.
+    **Navigate** to your flow name on the left sidebar and click it. You'll see a visual graph where each [**step**](/docs/concepts/steps/defining-steps) is represented as a node, with connecting lines showing event flow patterns.
   </Step>
   <Step>
-    **Click** on any [**step**](/docs/core/steps/defining-steps) node to inspect its configuration details, including name, emits, subscribes, and other properties.
+    **Click** on any [**step**](/docs/concepts/steps/defining-steps) node to inspect its configuration details, including name, emits, subscribes, and other properties.
   </Step>
 </Steps>
 
 Checkout the [Motia Workbench](/docs/workbench/overview) docs for more information.
 
 <Callout>
-New to Motia? Follow the **[quick start](/docs/quick-start)** guide to get set up.
+New to Motia? Follow the **[quick start](/docs/getting-started/quick-start)** guide to get set up.
 </Callout>
 
 -   [Logging & Debugging](/docs/concepts/logging-and-debugging.md): Documentation for Logging & Debugging.
@@ -657,7 +657,7 @@ Motia supports four standard log levels:
   <Step>
   ### Trigger and Monitor Flows
 
-    You can trigger flows using either the CLI or an [API step](/docs/core/steps/api):
+    You can trigger flows using either the CLI or an [API step](/docs/concepts/steps/api):
 
     <Tabs items={['cli', 'api']}>
       <Tab value='cli'>
@@ -817,7 +817,7 @@ State data is stored as key-value pairs, namespaced under a scope string.  When 
 }
 ```
 
-> **Info:** You can access the `state` manager within any step through the `ctx` (context) argument, which is automatically injected into your [step handler](/docs/core/steps/defining-steps#handler). While **`traceId` from `ctx.traceId` is the recommended scope for flow isolation**, remember that **you can use any string as the scope** parameter in `state` methods for more advanced state management scenarios.
+> **Info:** You can access the `state` manager within any step through the `ctx` (context) argument, which is automatically injected into your [step handler](/docs/concepts/steps/defining-steps#handler). While **`traceId` from `ctx.traceId` is the recommended scope for flow isolation**, remember that **you can use any string as the scope** parameter in `state` methods for more advanced state management scenarios.
 
 ## Using State in Steps
 
@@ -1271,7 +1271,7 @@ An **API step** is exposed as an HTTP endpoint that acts as an entry point into 
 
 ## Config
 
-The following properties are specific to the API Step, in addition to the [common step config](/docs/core/steps/defining-steps#config).
+The following properties are specific to the API Step, in addition to the [common step config](/docs/concepts/steps/defining-steps#config).
 
 <DescriptionTable
   type={{
@@ -1676,7 +1676,7 @@ The **Cron Step** allows you to schedule your steps to run at specified interval
 
 ## Config
 
-The following properties are specific to the Cron Step, in addition to the [common step config](/docs/core/steps/defining-steps#config).
+The following properties are specific to the Cron Step, in addition to the [common step config](/docs/concepts/steps/defining-steps#config).
 
 <DescriptionTable
   type={{
@@ -1800,7 +1800,7 @@ This modular approach allows you to:
 - Maintain clear separation of concerns
 - Scale and modify parts of your system independently
 
-Steps can be defined in any language that Motia supports, such as TypeScript, JavaScript, Python, and Ruby. Steps can be of type [`event`](/docs/core/steps/event), [`api`](/docs/core/steps/api), or [`cron`](/docs/core/steps/cron). Steps are composed of a `config` object and a `handler` function.
+Steps can be defined in any language that Motia supports, such as TypeScript, JavaScript, Python, and Ruby. Steps can be of type [`event`](/docs/concepts/steps/event), [`api`](/docs/concepts/steps/api), or [`cron`](/docs/concepts/steps/cron). Steps are composed of a `config` object and a `handler` function.
 
 ## Config
 
@@ -1925,7 +1925,7 @@ Here're examples of how to define a handler in the Motia supported languages:
 </Tabs>
 
 <Callout>
-Follow the **[quick start](/docs/quick-start)** guide if you haven't set up Motia yet.
+Follow the **[quick start](/docs/getting-started/quick-start)** guide if you haven't set up Motia yet.
 </Callout>
 
 
@@ -1938,7 +1938,7 @@ The **Event Step** lets you define custom logic in response to subscribed events
 
 ## Config
 
-The following properties are specific to the Event Step, in addition to the [common step config](/docs/core/steps/defining-steps#config).
+The following properties are specific to the Event Step, in addition to the [common step config](/docs/concepts/steps/defining-steps#config).
 
 <DescriptionTable
   type={{
@@ -5829,7 +5829,7 @@ Motia is versatile and can be applied across various industries and use cases, s
 
 Embark on your Motia journey and start building powerful workflows today:
 
-1.  **Quick Start Guide:** Follow our [Quick Start](/docs/quick-start) to set up your first Motia project and create a minimal workflow.
+1.  **Quick Start Guide:** Follow our [Quick Start](/docs/getting-started/quick-start) to set up your first Motia project and create a minimal workflow.
 2.  **Explore Examples:** Dive into practical [Examples](/docs/examples) to understand common patterns and real-world use cases.
 3.  **Dive into Concepts:**  Delve deeper into Motia's [Core Concepts](/docs/concepts) to gain a solid understanding of the framework's architecture and principles.
 
@@ -6375,7 +6375,7 @@ UI steps allow you to customize how your steps appear in the Workbench visualiza
 }]} />
 
 <Callout>
-New to Motia? Follow the **[quick start](/docs/quick-start)** guide to get set up.
+New to Motia? Follow the **[quick start](/docs/getting-started/quick-start)** guide to get set up.
 </Callout>
 
 


### PR DESCRIPTION
- Fix 404s from structural change without redirects
- Fix typo in README.md

Found an issue with the links while looking around the docs that was created by moving Quick Start & Core Concepts into a Getting Started folder. I was unsure of how to stage the site locally from [Contribute](https://github.com/MotiaDev/motia/blob/main/packages/docs/content/docs/contribution/how-to-contribute.mdx) so this should definitely be tested, would suggest including that info on Contribute if possible. 