### PR TITLE
fix: response schema with multiple response codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,22 +146,22 @@ npx motia emit --topic test-state --message '{}'
 ```TypeScript
 import { OpenAI } from 'openai';
 import { z } from 'zod';
-import type { EventConfig, StepHandler } from 'motia';
+import type { EventConfig, Handlers } from 'motia';
 
 const openai = new OpenAI({
-    apiKey: process.env.OPENAI_API_KEY,
+  apiKey: process.env.OPENAI_API_KEY,
 });
 
 export const config: EventConfig = {
   type: 'event',
-  name: 'Auto-Reply to Support Emails',
+  name: 'Auto-Reply',
   subscribes: ['email.received'],
   emits: ['email.send'],
   flows: ['email-support'],
   input: z.object({ subject: z.string(), body: z.string(), from: z.string() }),
 };
 
-export const handler: StepHandler<typeof config> = async (inputData, context) => {
+export const handler: Handlers['Auto-Reply'] = async (inputData, context) => {
   const { subject, body, from } = inputData;
   const { emit, logger } = context;
 

--- a/packages/core/src/__tests__/steps/api-step.ts
+++ b/packages/core/src/__tests__/steps/api-step.ts
@@ -1,4 +1,4 @@
-import { ApiRouteConfig, ApiRouteHandler, FlowContext } from '../../types'
+import { ApiResponse, ApiRouteConfig, ApiRouteHandler, FlowContext } from '../../types'
 
 export const config: ApiRouteConfig = {
   type: 'api',
@@ -10,7 +10,10 @@ export const config: ApiRouteConfig = {
 
 type EmitData = { topic: 'TEST_EVENT'; data: { test: string } }
 
-export const handler: ApiRouteHandler<unknown, unknown, EmitData> = async (_, ctx: FlowContext<EmitData>) => {
+export const handler: ApiRouteHandler<unknown, ApiResponse<200, { traceId: string }>, EmitData> = async (
+  _,
+  ctx: FlowContext<EmitData>,
+) => {
   await ctx.emit({ data: { test: 'data' }, topic: 'TEST_EVENT' })
 
   return { status: 200, body: { traceId: ctx.traceId } }

--- a/packages/core/src/api-endpoints.ts
+++ b/packages/core/src/api-endpoints.ts
@@ -1,10 +1,8 @@
 import { Express, Response } from 'express'
-import zodToJsonSchema from 'zod-to-json-schema'
+import { Server as SocketIOServer } from 'socket.io'
+import { isApiStep } from './guards'
 import { LockedData } from './locked-data'
 import { ApiRouteMethod, Step } from './types'
-import { ZodObject } from 'zod'
-import { isApiStep } from './guards'
-import { Server as SocketIOServer } from 'socket.io'
 import { JsonSchema } from './types/schema.types'
 
 type QueryParam = {

--- a/packages/core/src/api-endpoints.ts
+++ b/packages/core/src/api-endpoints.ts
@@ -5,6 +5,7 @@ import { ApiRouteMethod, Step } from './types'
 import { ZodObject } from 'zod'
 import { isApiStep } from './guards'
 import { Server as SocketIOServer } from 'socket.io'
+import { JsonSchema } from './types/schema.types'
 
 type QueryParam = {
   name: string
@@ -16,8 +17,8 @@ type ApiEndpoint = {
   path: string
   description?: string
   queryParams?: QueryParam[]
-  responseBody?: Record<string, unknown>
-  bodySchema?: Record<string, unknown>
+  responseSchema?: JsonSchema
+  bodySchema?: JsonSchema
 }
 
 export const apiEndpoints = (lockedData: LockedData, app: Express, io: SocketIOServer) => {
@@ -35,14 +36,8 @@ export const apiEndpoints = (lockedData: LockedData, app: Express, io: SocketIOS
       path: step.config.path,
       description: step.config.description,
       queryParams: step.config.queryParams,
-      responseBody:
-        step.config.responseBody instanceof ZodObject
-          ? zodToJsonSchema(step.config.responseBody)
-          : step.config.responseBody,
-      bodySchema:
-        step.config.bodySchema instanceof ZodObject //
-          ? zodToJsonSchema(step.config.bodySchema)
-          : step.config.bodySchema,
+      responseSchema: step.config.responseSchema as never as JsonSchema,
+      bodySchema: step.config.bodySchema as never as JsonSchema,
     }))
 
     res.status(200).send(endpoints)

--- a/packages/core/src/node/get-config.ts
+++ b/packages/core/src/node/get-config.ts
@@ -25,8 +25,12 @@ async function getConfig(filePath: string) {
       module.config.bodySchema = zodToJsonSchema(module.config.bodySchema)
     }
 
-    if (module.config.responseBody instanceof ZodObject) {
-      module.config.responseBody = zodToJsonSchema(module.config.responseBody)
+    if (module.config.responseSchema) {
+      for (const [status, schema] of Object.entries(module.config.responseSchema)) {
+        if (schema instanceof ZodObject) {
+          module.config.responseSchema[status] = zodToJsonSchema(schema)
+        }
+      }
     }
 
     process.send?.(module.config)

--- a/packages/core/src/step-validator.ts
+++ b/packages/core/src/step-validator.ts
@@ -88,7 +88,7 @@ const apiSchema = z
     middleware: z.array(z.any()).optional(),
     queryParams: z.array(z.object({ name: z.string(), description: z.string().optional() })).optional(),
     bodySchema: z.union([jsonSchema, z.object({}), z.null()]).optional(),
-    responseSchema: z.union([z.map(z.number(), jsonSchema), z.null()]).optional(),
+    responseSchema: z.record(z.string(), jsonSchema).optional(),
   })
   .strict()
 

--- a/packages/core/src/step-validator.ts
+++ b/packages/core/src/step-validator.ts
@@ -88,7 +88,7 @@ const apiSchema = z
     middleware: z.array(z.any()).optional(),
     queryParams: z.array(z.object({ name: z.string(), description: z.string().optional() })).optional(),
     bodySchema: z.union([jsonSchema, z.object({}), z.null()]).optional(),
-    responseBody: z.union([jsonSchema, z.object({}), z.null()]).optional(),
+    responseSchema: z.union([z.map(z.number(), jsonSchema), z.null()]).optional(),
   })
   .strict()
 

--- a/packages/core/src/steps/emit.step.ts
+++ b/packages/core/src/steps/emit.step.ts
@@ -1,4 +1,4 @@
-import { ApiRouteConfig, ApiRouteHandler } from '../types'
+import { ApiResponse, ApiRouteConfig, ApiRouteHandler } from '../types'
 import { z } from 'zod'
 
 export const config: ApiRouteConfig = {
@@ -17,7 +17,11 @@ export const config: ApiRouteConfig = {
 
 type EmitData = { topic: string; data: Record<string, unknown> }
 
-export const handler: ApiRouteHandler<EmitData, unknown, EmitData> = async (req, { emit, logger }) => {
+export const handler: ApiRouteHandler<
+  EmitData,
+  ApiResponse<200, { success: true; emitted: EmitData }>,
+  EmitData
+> = async (req, { emit, logger }) => {
   const { topic, data } = req.body
 
   logger.info('[Event Emitter] Emitting event', { topic, data })

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -53,8 +53,8 @@ export type ApiRouteMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'OPTI
 export type ApiMiddleware<TBody = unknown, TEmitData = never, TResult = unknown> = (
   req: ApiRequest<TBody>,
   ctx: FlowContext<TEmitData>,
-  next: () => Promise<ApiResponse<TResult>>,
-) => Promise<ApiResponse<TResult>>
+  next: () => Promise<ApiResponse<number, TResult>>,
+) => Promise<ApiResponse<number, TResult>>
 
 type QueryParam = {
   name: string
@@ -73,7 +73,7 @@ export type ApiRouteConfig = {
   flows?: string[]
   middleware?: ApiMiddleware<any, any, any>[] // eslint-disable-line @typescript-eslint/no-explicit-any
   bodySchema?: ZodObject<any> // eslint-disable-line @typescript-eslint/no-explicit-any
-  responseBody?: ZodObject<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+  responseSchema?: Record<number, ZodObject<any>> // eslint-disable-line @typescript-eslint/no-explicit-any
   queryParams?: QueryParam[]
   /**
    * Files to include in the step bundle.
@@ -94,16 +94,17 @@ export type ApiRequest<TBody = unknown> = {
       }
 }
 
-export type ApiResponse<TBody = string | Buffer | Record<string, unknown>> = {
-  status: number
+export type ApiResponse<TStatus extends number = number, TBody = string | Buffer | Record<string, unknown>> = {
+  status: TStatus
   headers?: Record<string, string>
   body: TBody
 }
 
-export type ApiRouteHandler<TRequestBody = unknown, TResponseBody = unknown, TEmitData = never> = (
-  req: ApiRequest<TRequestBody>,
-  ctx: FlowContext<TEmitData>,
-) => Promise<ApiResponse<TResponseBody>>
+export type ApiRouteHandler<
+  TRequestBody = unknown,
+  TResponseBody extends ApiResponse<number, unknown> = ApiResponse<number, unknown>,
+  TEmitData = never,
+> = (req: ApiRequest<TRequestBody>, ctx: FlowContext<TEmitData>) => Promise<TResponseBody>
 
 export type CronConfig = {
   type: 'cron'
@@ -122,6 +123,9 @@ export type CronConfig = {
 
 export type CronHandler<TEmitData = never> = (ctx: FlowContext<TEmitData>) => Promise<void>
 
+/**
+ * @deprecated Use `Handlers` instead.
+ */
 export type StepHandler<T> = T extends EventConfig
   ? EventHandler<z.infer<T['input']>, { topic: string; data: any }> // eslint-disable-line @typescript-eslint/no-explicit-any
   : T extends ApiRouteConfig

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -129,7 +129,7 @@ export type CronHandler<TEmitData = never> = (ctx: FlowContext<TEmitData>) => Pr
 export type StepHandler<T> = T extends EventConfig
   ? EventHandler<z.infer<T['input']>, { topic: string; data: any }> // eslint-disable-line @typescript-eslint/no-explicit-any
   : T extends ApiRouteConfig
-    ? ApiRouteHandler<any, any, { topic: string; data: any }> // eslint-disable-line @typescript-eslint/no-explicit-any
+    ? ApiRouteHandler<any, ApiResponse<number, any>, { topic: string; data: any }> // eslint-disable-line @typescript-eslint/no-explicit-any
     : T extends CronConfig
       ? CronHandler<{ topic: string; data: any }> // eslint-disable-line @typescript-eslint/no-explicit-any
       : never

--- a/packages/core/src/types/generate-types-from-response.ts
+++ b/packages/core/src/types/generate-types-from-response.ts
@@ -1,0 +1,11 @@
+import { generateTypeFromSchema } from './generate-type-from-schema'
+import { JsonSchema } from './schema.types'
+
+export const generateTypesFromResponse = (record: Record<number, JsonSchema>): string => {
+  return Object.entries(record)
+    .map(([status, schema]) => {
+      const schemaType = generateTypeFromSchema(schema as JsonSchema)
+      return `ApiResponse<${status}, ${schemaType}>`
+    })
+    .join(' | ')
+}

--- a/packages/core/src/types/generate-types.ts
+++ b/packages/core/src/types/generate-types.ts
@@ -2,6 +2,7 @@ import { isApiStep, isCronStep, isEventStep } from '../guards'
 import { Printer } from '../printer'
 import { Emit, Step } from '../types'
 import { generateTypeFromSchema } from './generate-type-from-schema'
+import { generateTypesFromResponse } from './generate-types-from-response'
 import { mergeSchemas } from './merge-schemas'
 import { JsonSchema, JsonSchemaError } from './schema.types'
 
@@ -85,8 +86,8 @@ export const generateTypesFromSteps = (steps: Step[], printer: Printer): Handler
       const input = step.config.bodySchema
         ? generateTypeFromSchema(step.config.bodySchema as never as JsonSchema)
         : 'Record<string, unknown>'
-      const result = step.config.responseBody
-        ? generateTypeFromSchema(step.config.responseBody as never as JsonSchema)
+      const result = step.config.responseSchema
+        ? generateTypesFromResponse(step.config.responseSchema as never as Record<number, JsonSchema>)
         : 'unknown'
       handlers[step.config.name] = { type: 'ApiRouteHandler', generics: [input, result, emits] }
     } else if (isCronStep(step)) {

--- a/packages/core/src/types/generate-types.ts
+++ b/packages/core/src/types/generate-types.ts
@@ -15,7 +15,7 @@ export const generateTypesString = (handlers: HandlersMap): string => {
  * 
  * Consider adding this file to .prettierignore and eslint ignore.
  */
-import { EventHandler, ApiRouteHandler } from 'motia'
+import { EventHandler, ApiRouteHandler, ApiResponse } from 'motia'
 
 declare module 'motia' {
   type Handlers = {

--- a/packages/docs/app/(home)/components/codeExamples.ts
+++ b/packages/docs/app/(home)/components/codeExamples.ts
@@ -2,7 +2,7 @@
 export const codeExamples = {
   typescript: `import { OpenAI } from 'openai';
 import { z } from 'zod';
-import type { EventConfig, StepHandler } from 'motia';
+import type { EventConfig, Handlers } from 'motia';
 
 const openai = new OpenAI({
     apiKey: process.env.OPENAI_API_KEY,
@@ -17,7 +17,7 @@ export const config: EventConfig = {
   input: z.object({ subject: z.string(), body: z.string(), from: z.string() }),
 };
 
-export const handler: StepHandler<typeof config> = async (inputData, context) => {
+export const handler: Handlers['Auto-Reply to Support Emails'] = async (inputData, context) => {
     const { subject, body, from } = inputData;
     const { emit, logger } = context;
 

--- a/packages/docs/app/(home)/components/codeExamples.ts
+++ b/packages/docs/app/(home)/components/codeExamples.ts
@@ -2,7 +2,7 @@
 export const codeExamples = {
   typescript: `import { OpenAI } from 'openai';
 import { z } from 'zod';
-import type { EventConfig, Handlers } from 'motia';
+import type { EventConfig, StepHandler } from 'motia';
 
 const openai = new OpenAI({
     apiKey: process.env.OPENAI_API_KEY,
@@ -17,7 +17,7 @@ export const config: EventConfig = {
   input: z.object({ subject: z.string(), body: z.string(), from: z.string() }),
 };
 
-export const handler: Handlers['Auto-Reply to Support Emails'] = async (inputData, context) => {
+export const handler: StepHandler<typeof config> = async (inputData, context) => {
     const { subject, body, from } = inputData;
     const { emit, logger } = context;
 

--- a/packages/docs/content/docs/concepts/logging-and-debugging.mdx
+++ b/packages/docs/content/docs/concepts/logging-and-debugging.mdx
@@ -27,7 +27,7 @@ Motia supports four standard log levels:
 <Tabs items={['TS', 'JS', 'Python']}>
   <Tab value='TS'>
     ```typescript
-    export const handler: StepHandler<typeof config> = async (input, { logger }) => {
+    export const handler: Handlers['StepName'] = async (input, { logger }) => {
       // Basic logging
       logger.info('Starting process')
 
@@ -220,7 +220,7 @@ logger.info(`Payment ${paymentId} processed: amount=${amount}`)
 ### Performance Monitoring
 
 ```typescript
-export const handler: StepHandler<typeof config> = async (input, { logger }) => {
+export const handler: Handlers['StepName'] = async (input, { logger }) => {
   const startTime = performance.now()
 
   // Process operation

--- a/packages/docs/content/docs/concepts/state-management.mdx
+++ b/packages/docs/content/docs/concepts/state-management.mdx
@@ -64,14 +64,14 @@ State data is stored as key-value pairs, namespaced under a scope string. When u
 <Tabs items={['TypeScript', 'JavaScript', 'Python']}>
   <Tab label="TypeScript">
     ```typescript
-    import { StepHandler } from 'motia'
+    import { Handlers } from 'motia'
 
     interface BookingData {
       customer: { name: string; email: string };
       venue: { id: string; name: string };
     }
 
-    export const handler: StepHandler<typeof config> = async (input, { state, traceId }) => { // Get traceId from context
+    export const handler: Handlers['StepName'] = async (input, { state, traceId }) => { // Get traceId from context
       // Store state (using traceId as scope)
       await state.set<BookingData>(traceId, 'booking', {
         customer: input.customer,
@@ -93,9 +93,9 @@ State data is stored as key-value pairs, namespaced under a scope string. When u
 
   <Tab label="JavaScript">
     ```javascript
-    import { StepHandler } from 'motia'
+    import { Handlers } from 'motia'
 
-    export const handler = async (input, { state, traceId }) => { // Get traceId from context
+    export const handler: Handlers['StepName'] = async (input, { state, traceId }) => { // Get traceId from context
       // Store state (using traceId as scope)
       await state.set(traceId, 'booking', {
         customer: input.customer,
@@ -293,7 +293,7 @@ Always clean up state when you're done with it:
 <Tabs items={['TypeScript', 'JavaScript', 'Python']}>
     <Tab label="TypeScript">
       ```typescript
-      export const handler: StepHandler<typeof config> = async (input, { state, traceId }) => {
+      export const handler: Handlers['StepName'] = async (input, { state, traceId }) => {
         try {
           await processBooking(input)
           // Clean up specific keys

--- a/packages/docs/content/docs/concepts/steps/api.mdx
+++ b/packages/docs/content/docs/concepts/steps/api.mdx
@@ -23,9 +23,9 @@ The following properties are specific to the API Step, in addition to the [commo
         'Schema for validating the request body. For TypeScript/JavaScript steps, it uses zod schemas. For Python steps, it uses Pydantic models.',
       type: 'object',
     },
-    responseBody: {
+    responseSchema: {
       description:
-        'Mostly used for documentation, the expected output of an API endpoint. For TypeScript/JavaScript steps, it uses zod schemas. For Python steps, it uses Pydantic models.',
+        'Mostly used for documentation, the expected output of an API endpoint. For TypeScript/JavaScript steps, it uses zod schemas. For Python steps, it uses Pydantic models or Dict Json Schema.',
       type: 'object',
     },
     queryParams: {
@@ -44,20 +44,23 @@ The following properties are specific to the API Step, in addition to the [commo
 <Tabs items={['TypeScript', 'JavaScript', 'Python']}>
   <Tab value="TypeScript">
     ```typescript
-    import { ApiRouteConfig, StepHandler } from '@motiadev/core'
+    import { ApiRouteConfig, Handlers } from '@motiadev/core'
     import { z } from 'zod'
-
-    const responseSchema = z.object({ message: z.string({ description: 'The message from OpenAI' }) })
 
     export const config: ApiRouteConfig = {
       type: 'api',
-      name: 'Get Message by Trace ID',
+      name: 'GetMessage',
       description: 'Retrieves a generated message from OpenAI based on the Trace ID returned by the POST /openai endpoint',
       path: '/openai/:traceId',
       method: 'GET',
       emits: ['call-openai'],
       flows: ['openai'],
-      responseBody: responseSchema,
+      responseSchema: {
+        // When response code is 200
+        200: z.object({ message: z.string({ description: 'The message from OpenAI' }) }),
+        // When response code is 400
+        400: z.object({ message: z.string({ description: 'The error message' }) })
+      },
       queryParams: [
         {
           name: 'includeProps',
@@ -66,7 +69,7 @@ The following properties are specific to the API Step, in addition to the [commo
       ],
     }
 
-    export const handler: StepHandler<typeof config> = async (req, { logger }) => {
+    export const handler: Handlers['GetMessage'] = async (req, { logger }) => {
       logger.info('[Call OpenAI] Received callOpenAi event', req)
 
       return {
@@ -81,8 +84,6 @@ The following properties are specific to the API Step, in addition to the [commo
     ```typescript
     const { z } = require('zod')
 
-    const responseSchema = z.object({ message: z.string({ description: 'The message from OpenAI' }) })
-
     export const config = {
       type: 'api',
       name: 'Get Message by Trace ID',
@@ -91,7 +92,12 @@ The following properties are specific to the API Step, in addition to the [commo
       method: 'GET',
       emits: ['call-openai'],
       flows: ['openai'],
-      responseBody: responseSchema,
+      responseSchema: {
+        // When response code is 200
+        200: z.object({ message: z.string({ description: 'The message from OpenAI' }) }),
+        // When response code is 400
+        400: z.object({ message: z.string({ description: 'The error message' }) })
+      },
       queryParams: [
         {
           name: 'includeProps',
@@ -127,7 +133,9 @@ The following properties are specific to the API Step, in addition to the [commo
       "method": "GET",
       "emits": ["call-openai"],
       "flows": ["openai"],
-      "responseBody": RequestBody.model_json_schema(),
+      "responseSchema": {
+        "200": RequestBody.model_json_schema()
+      },
       "queryParams": [
         {
           "name": "includeProps",

--- a/packages/docs/content/docs/concepts/steps/api.mdx
+++ b/packages/docs/content/docs/concepts/steps/api.mdx
@@ -44,7 +44,7 @@ The following properties are specific to the API Step, in addition to the [commo
 <Tabs items={['TypeScript', 'JavaScript', 'Python']}>
   <Tab value="TypeScript">
     ```typescript
-    import { ApiRouteConfig, Handlers } from '@motiadev/core'
+    import { ApiRouteConfig, Handlers } from 'motia'
     import { z } from 'zod'
 
     export const config: ApiRouteConfig = {
@@ -323,12 +323,12 @@ const rateLimiterMiddleware: ApiMiddleware = (() => {
 <Tabs items={['TypeScript', 'JavaScript', 'Python']}>
   <Tab value="TypeScript">
     ```typescript
-      import { ApiRouteConfig, StepHandler } from 'motia'
+      import { ApiRouteConfig, Handlers } from 'motia'
       import { z } from 'zod'
 
       export const config: ApiRouteConfig = {
         type: 'api',
-        name: 'Test state api trigger',
+        name: 'TestStateApiTrigger',
         description: 'test state',
         path: '/test-state',
         method: 'POST',
@@ -337,7 +337,7 @@ const rateLimiterMiddleware: ApiMiddleware = (() => {
         flows: ['test-state'],
       }
 
-      export const handler: StepHandler<typeof config> = async (req, { logger, emit }) => {
+      export const handler: Handlers['TestStateApiTrigger'] = async (req, { logger, emit }) => {
         logger.info('[Test State] Received request', req)
 
         await emit({

--- a/packages/docs/content/docs/concepts/steps/cron.mdx
+++ b/packages/docs/content/docs/concepts/steps/cron.mdx
@@ -22,7 +22,7 @@ The following examples showcase how to configure an **CRON Step**
 <Tabs  items={['TS', 'JS', 'Python']}>
   <Tab value="TS">
     ```typescript
-    import { CronConfig } from 'motia'
+    import { CronConfig, Handlers } from 'motia'
 
     export const config: CronConfig = {
       type: 'cron' as const,
@@ -33,7 +33,7 @@ The following examples showcase how to configure an **CRON Step**
       flows: ['cron-example'],
     }
 
-    export const handler: StepHandler<typeof config> = async ({ emit }) => {
+    export const handler: Handlers['PeriodicJob'] = async ({ emit }) => {
       await emit({
         topic: 'cron-ticked',
         data: { message: 'Cron job executed' },

--- a/packages/docs/content/docs/concepts/steps/defining-steps.mdx
+++ b/packages/docs/content/docs/concepts/steps/defining-steps.mdx
@@ -84,16 +84,16 @@ Here're examples of how to define a handler in the Motia supported languages:
 <Tabs items={['TS', 'JS', 'Python']}>
   <Tab value="TS">
     ```typescript
-    import { EventConfig, StepHandler } from 'motia'
+    import { EventConfig, Handlers } from 'motia'
 
     export const config: EventConfig = {
       type: 'event',
-      name: 'Minimal Step',
+      name: 'MinimalStep',
       subscribes: ['start'],
       emits: ['done'],
     }
 
-    export const handler: StepHandler<typeof config> = async (input, { emit, traceId, state, logger }) => {
+    export const handler: Handlers['MinimalStep'] = async (input, { emit, traceId, state, logger }) => {
       await emit({ topic: 'done', data: {} })
     }
     ```

--- a/packages/docs/content/docs/concepts/steps/event.mdx
+++ b/packages/docs/content/docs/concepts/steps/event.mdx
@@ -23,7 +23,7 @@ The following examples showcase how to configure an **Event Step**
 <Tabs  items={['TS', 'JS', 'Python']}>
   <Tab value="TS">
     ```typescript
-    import { EventConfig, StepHandler } from 'motia'
+    import { EventConfig, Handlers } from 'motia'
     import { z } from 'zod'
 
     export const config: EventConfig = {
@@ -36,7 +36,7 @@ The following examples showcase how to configure an **Event Step**
       flows: ['parallel-merge'],
     }
 
-    export const handler: StepHandler<typeof config> = async (input, { emit, logger }) => {
+    export const handler: Handlers['stepA'] = async (input, { emit, logger }) => {
       logger.info('Processing message:', input.message)
 
       await emit({

--- a/packages/dot-files/.cursor/rules/api-steps.mdc
+++ b/packages/dot-files/.cursor/rules/api-steps.mdc
@@ -9,7 +9,7 @@ API Steps expose HTTP endpoints for external interaction with workflows.
 
 ## Basic Configuration
 ```typescript
-import { ApiMiddleware, ApiRouteConfig, ApiRequest, FlowContext } from 'motia'
+import { ApiMiddleware, ApiRouteConfig, ApiRequest, FlowContext, Handlers } from 'motia'
  
 // Logging middleware
 const loggingMiddleware: ApiMiddleware = async (req, ctx, next) => {
@@ -53,7 +53,7 @@ export const config = {
   ]
 }
  
-export const handler: StepHandler<typeof config> = async (req: ApiRouteConfig, ctx: FlowContext) => {
+export const handler: Handlers['protected-endpoint'] = async (req: ApiRouteConfig, ctx: FlowContext) => {
   // This handler will only be called if all middleware pass
   return {
     status: 200,

--- a/packages/dot-files/.cursor/rules/architecture.mdc
+++ b/packages/dot-files/.cursor/rules/architecture.mdc
@@ -48,7 +48,7 @@ export const config = {
   flows: ['flow-name']
 }
 
-export const handler: StepHandler<typeof config> = async (input, context: FlowContext) => {
+export const handler: Handlers['unique-step-name'] = async (input, context: FlowContext) => {
   // Business logic here
 }
 ```

--- a/packages/dot-files/.cursor/rules/cron-steps.mdc
+++ b/packages/dot-files/.cursor/rules/cron-steps.mdc
@@ -9,7 +9,7 @@ Cron Steps enable scheduled task execution using cron expressions.
 
 ## Configuration
 ```typescript
-import { CronConfig } from 'motia'
+import { CronConfig, Handlers } from 'motia'
  
 export const config: CronConfig = {
   type: 'cron' as const,
@@ -20,7 +20,7 @@ export const config: CronConfig = {
   flows: ['cron-example'],
 }
  
-export const handler: StepHandler<typeof config> = async ({ emit }) => {
+export const handler: Handlers['PeriodicJob'] = async ({ emit }) => {
   await emit({
     topic: 'cron-ticked',
     data: { message: 'Cron job executed' },
@@ -73,6 +73,7 @@ end
 // Every 5 minutes
 export const config: CronConfig = {
   type: 'cron',
+  name: 'CronJob',
   schedule: '*/5 * * * *',
   // ...
 };
@@ -80,6 +81,7 @@ export const config: CronConfig = {
 // Daily at midnight
 export const config: CronConfig = {
   type: 'cron',
+  name: 'CronJob',
   schedule: '0 0 * * *',
   timezone: 'UTC',
   // ...
@@ -88,7 +90,7 @@ export const config: CronConfig = {
 
 ### State Management
 ```typescript
-export const handler: StepHandler<typeof config> = async (_, { state }: FlowContext) => {
+export const handler: Handler['CronJob'] = async (_, { state }: FlowContext) => {
   // Get last run timestamp
   const lastRun = await state.get('lastRunTime');
   

--- a/packages/dot-files/.cursor/rules/event-steps.mdc
+++ b/packages/dot-files/.cursor/rules/event-steps.mdc
@@ -11,26 +11,20 @@ Calling generative LLMs, accessing files, python or ruby logic.
 
 ## Examples
 ```typescript
-import { EventConfig, StepHandler } from 'motia'
+import { EventConfig, Handlers } from 'motia'
 import { z } from 'zod'
  
-const inputSchema = z.object({
-  message: z.string()
-})
- 
-type Input = typeof inputSchema
- 
-export const config: EventConfig<Input> = {
+export const config: EventConfig = {
   type: 'event',
   name: 'stepA',
   description: 'Hello from Step A',
   subscribes: ['pms.start'],
   emits: ['pms.stepA.done'],
-  input: inputSchema,
+  input: z.object({ message: z.string() }),
   flows: ['parallel-merge'],
 }
  
-export const handler: StepHandler<typeof config> = async (input, { emit, logger }) => {
+export const handler: Handlers['stepA'] = async (input, { emit, logger }) => {
   logger.info('Processing message:', input.message)
  
   await emit({
@@ -96,7 +90,7 @@ end
 
 ### Sequential Processing
 ```typescript
-export const handler: StepHandler<typeof config> = async (input, { emit }: FlowContext) => {
+export const handler: Handlers['{{StepName}}'] = async (input, { emit }: FlowContext) => {
   // Process input
   const result = await processData(input);
   
@@ -110,7 +104,7 @@ export const handler: StepHandler<typeof config> = async (input, { emit }: FlowC
 
 ### Parallel Processing
 ```typescript
-export const handler: StepHandler<typeof config> = async (input, { emit }) => {
+export const handler: Handlers['{{StepName}}'] = async (input, { emit }) => {
   // Emit multiple events
   await Promise.all([
     emit({ topic: 'branch1', data: input }),

--- a/packages/dot-files/.cursor/rules/steps.mdc
+++ b/packages/dot-files/.cursor/rules/steps.mdc
@@ -22,20 +22,16 @@ Steps are self-contained units of business logic that process events and emit re
 // Input validation
 import { z } from 'zod';
 
-const inputSchema = z.object({
-  message: z.string()
-});
-
-export const config: EventConfig<typeof inputSchema> = {
+export const config: EventConfig = {
   type: 'event',
   name: 'Minimal Step',
-  input: inputSchema,
+  input: z.object({ message: z.string() }),
   subscribes: ['start'],
   emits: ['done'],
 };
 
 // State management
-export const handler: StepHandler<typeof config> = async (input, { state }: FlowContext) => {
+export const handler: Handlers['Minimal Step'] = async (input, { state }: FlowContext) => {
   const currentCount = await state.get('counter') || 0;
   await state.set('counter', currentCount + 1);
 };

--- a/packages/snap/src/create-step/templates/api/template.typescript.txt
+++ b/packages/snap/src/create-step/templates/api/template.typescript.txt
@@ -1,4 +1,4 @@
-import { ApiRouteConfig, StepHandler } from '@motiadev/core'
+import { ApiRouteConfig, Handlers } from 'motia'
 import { z } from 'zod'
 
 export const config: ApiRouteConfig = {
@@ -11,10 +11,15 @@ export const config: ApiRouteConfig = {
   flows: {{FLOWS}},
   bodySchema: z.object({
     // Add your schema here
-  })
+  }),
+  responseSchema: {
+    200: z.object({ 
+      // add your response schema here
+    }),
+  },
 }
 
-export const handler: StepHandler<typeof config> = async (req, { logger, emit }) => {
+export const handler: Handlers['{{STEP_NAME}}'] = async (req, { logger, emit }) => {
   logger.info('Processing {{STEP_NAME}}', req)
 
   // Add your handler logic here

--- a/packages/snap/src/create-step/templates/cron/template.type.txt
+++ b/packages/snap/src/create-step/templates/cron/template.type.txt
@@ -1,4 +1,4 @@
-import { CronConfig, StepHandler } from '@motiadev/core'
+import { CronConfig, Handlers } from 'motia'
 
 export const config: CronConfig = {
   type: 'cron',
@@ -9,7 +9,7 @@ export const config: CronConfig = {
   flows: {{FLOWS}}
 }
 
-export const handler: StepHandler<typeof config> = async ({ logger, emit }) => {
+export const handler: Handlers['{{STEP_NAME}}'] = async ({ logger, emit }) => {
   logger.info('Running {{STEP_NAME}} cron job')
 
   // Add your cron logic here

--- a/packages/snap/src/create-step/templates/cron/template.typescript.txt
+++ b/packages/snap/src/create-step/templates/cron/template.typescript.txt
@@ -1,4 +1,4 @@
-import { CronConfig, FlowContext } from '@motiadev/core'
+import { CronConfig, FlowContext } from 'motia'
 
 export const config = {
   type: 'cron',

--- a/packages/snap/src/create-step/templates/event/template.typescript.txt
+++ b/packages/snap/src/create-step/templates/event/template.typescript.txt
@@ -1,11 +1,5 @@
-import { EventConfig, StepHandler } from '@motiadev/core'
+import { EventConfig, Handlers } from 'motia'
 import { z } from 'zod'
-
-type Input = typeof inputSchema
-
-const inputSchema = z.object({
-  // Add your schema here
-})
 
 export const config: EventConfig = {
   type: 'event',
@@ -13,11 +7,13 @@ export const config: EventConfig = {
   description: '{{DESCRIPTION}}',
   subscribes: {{SUBSCRIPTIONS}},
   emits: {{EMITS}},
-  input: inputSchema,
+  input: inputSchema = z.object({
+    // Add your schema here
+  }),
   flows: {{FLOWS}}
 }
 
-export const handler: StepHandler<typeof config> = async (input, { logger, emit }) => {
+export const handler: Handlers['{{STEP_NAME}}'] = async (input, { logger, emit }) => {
   logger.info('Processing {{STEP_NAME}}', input)
 
   // Add your handler logic here

--- a/packages/snap/src/create-step/templates/noop/template.typescript.txt
+++ b/packages/snap/src/create-step/templates/noop/template.typescript.txt
@@ -1,4 +1,4 @@
-import { NoopConfig } from '@motiadev/core'
+import { NoopConfig } from 'motia'
 
 export const config: NoopConfig = {
   type: 'noop',

--- a/packages/snap/src/create/templates/default/steps/01-api.step.ts.txt
+++ b/packages/snap/src/create/templates/default/steps/01-api.step.ts.txt
@@ -22,7 +22,9 @@ export const config: ApiRouteConfig = {
   /** 
    * Expected response body for type checking and documentation
    */
-  responseBody: z.object({ message: z.string() }),
+  responseSchema: {
+    200: z.object({ message: z.string() })
+  },
 
   /** 
    * We're using virtual subscribes to virtually connect noop step

--- a/packages/snap/src/create/templates/python/steps/01-api.step.py.txt
+++ b/packages/snap/src/create/templates/python/steps/01-api.step.py.txt
@@ -16,9 +16,11 @@ config = {
   },
 
   # Expected response body for type checking and documentation
-  "responseBody": {
-    "type": "object",
-    "properties": { "message": { "type": "string" } }
+  "responseSchema": {
+    "200": {
+      "type": "object",
+      "properties": { "message": { "type": "string" } }
+    }
   },
 
   # The virtual subscribes this step has, will be available in Workbench

--- a/packages/workbench/src/components/endpoints/hooks/use-get-endpoints.ts
+++ b/packages/workbench/src/components/endpoints/hooks/use-get-endpoints.ts
@@ -9,8 +9,8 @@ export type ApiEndpoint = {
   path: string
   description?: string
   queryParams?: QueryParam[]
-  responseBody?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
-  bodySchema?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+  responseSchema?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+  bodySchema?: Record<string, Record<string, any>> // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 export const useGetEndpoints = () => {

--- a/packages/workbench/src/components/endpoints/response-body.tsx
+++ b/packages/workbench/src/components/endpoints/response-body.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { useJsonSchemaToJson } from './hooks/use-json-schema-to-json'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Props = { status: string; body: Record<string, any> }
+
+export const ResponseBody: React.FC<Props> = ({ status, body }) => {
+  const { body: responseBody } = useJsonSchemaToJson(body)
+
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-xs font-bold">{status}</span>
+      <span className="text-xs font-mono bg-black/50 p-2 rounded-lg whitespace-pre-wrap">{responseBody}</span>
+    </div>
+  )
+}

--- a/packages/workbench/src/components/endpoints/selected-endpoint.tsx
+++ b/packages/workbench/src/components/endpoints/selected-endpoint.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { ApiEndpoint } from './hooks/use-get-endpoints'
 import { useJsonSchemaToJson } from './hooks/use-json-schema-to-json'
+import { ResponseBody } from './response-body'
 
 type Props = { endpoint: ApiEndpoint }
 
 export const SelectedEndpoint: React.FC<Props> = ({ endpoint }) => {
-  const { body: responseBody } = useJsonSchemaToJson(endpoint.responseBody)
   const { body: requestBody } = useJsonSchemaToJson(endpoint.bodySchema)
 
   return (
@@ -30,10 +30,12 @@ export const SelectedEndpoint: React.FC<Props> = ({ endpoint }) => {
           <span className="text-xs font-mono bg-black/50 p-2 rounded-lg whitespace-pre-wrap">{requestBody}</span>
         </div>
       )}
-      {responseBody && (
+      {endpoint.responseSchema && (
         <div className="flex flex-col gap-2">
           <span className="text-xs font-bold">Response</span>
-          <span className="text-xs font-mono bg-black/50 p-2 rounded-lg whitespace-pre-wrap">{responseBody}</span>
+          {Object.entries(endpoint.responseSchema).map(([status, schema]) => (
+            <ResponseBody key={status} status={status} body={schema} />
+          ))}
         </div>
       )}
     </>

--- a/playground/steps/cronExample/handlePeriodicJob.step.ts
+++ b/playground/steps/cronExample/handlePeriodicJob.step.ts
@@ -1,4 +1,4 @@
-import { CronHandler } from '@motiadev/core'
+import { CronHandler } from 'motia'
 
 export const config = {
   type: 'event',

--- a/playground/steps/parallelMergeState/joinComplete.step.ts
+++ b/playground/steps/parallelMergeState/joinComplete.step.ts
@@ -1,11 +1,11 @@
-import { EventConfig, StepHandler } from '@motiadev/core'
+import { EventConfig, Handlers } from 'motia'
 import { z } from 'zod'
 
 const stepSchema = z.object({ msg: z.string(), timestamp: z.number() })
 
 export const config: EventConfig = {
   type: 'event',
-  name: 'Join Complete',
+  name: 'JoinComplete',
   description: 'Logs the merge',
   subscribes: ['pms.join.complete'],
   emits: [],
@@ -13,6 +13,6 @@ export const config: EventConfig = {
   flows: ['parallel-merge'],
 }
 
-export const handler: StepHandler<typeof config> = async (input, { logger }) => {
+export const handler: Handlers['JoinComplete'] = async (input, { logger }) => {
   logger.info('[Join Complete] Handling Join Complete', { input })
 }

--- a/playground/steps/parallelMergeState/joinStep.step.ts
+++ b/playground/steps/parallelMergeState/joinStep.step.ts
@@ -1,7 +1,6 @@
+import { EventConfig, Handlers } from 'motia'
 import { z } from 'zod'
-import { EventConfig } from '@motiadev/core'
 import { ParallelMergeStep } from './parallelMerge.types'
-import { Handlers } from 'motia'
 
 export const config: EventConfig = {
   type: 'event',

--- a/playground/steps/parallelMergeState/noopStartButton.step.ts
+++ b/playground/steps/parallelMergeState/noopStartButton.step.ts
@@ -1,4 +1,4 @@
-import { NoopConfig } from '@motiadev/core'
+import { NoopConfig } from 'motia'
 
 export const config: NoopConfig = {
   type: 'noop',

--- a/playground/steps/parallelMergeState/startParallelMerge.step.ts
+++ b/playground/steps/parallelMergeState/startParallelMerge.step.ts
@@ -1,4 +1,4 @@
-import { ApiRouteConfig, StepHandler, ApiMiddleware } from '@motiadev/core'
+import { ApiRouteConfig, Handlers, ApiMiddleware } from 'motia'
 
 const timingMiddleware: ApiMiddleware = async (_, ctx, next) => {
   const start = Date.now()
@@ -23,7 +23,7 @@ export const config: ApiRouteConfig = {
   middleware: [timingMiddleware],
 }
 
-export const handler: StepHandler<typeof config> = async (req, { emit, logger }) => {
+export const handler: Handlers['Parallel Merge'] = async (_, { emit, logger }) => {
   logger.info('Starting parallel merge')
 
   await emit({ topic: 'pms.start', data: {} })

--- a/playground/steps/parallelMergeState/stepA.step.ts
+++ b/playground/steps/parallelMergeState/stepA.step.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { EventConfig, StepHandler } from '@motiadev/core'
+import { EventConfig, Handlers } from 'motia'
 import { ParallelMergeStep } from './parallelMerge.types'
 
 export const config: EventConfig = {
@@ -12,7 +12,7 @@ export const config: EventConfig = {
   flows: ['parallel-merge'],
 }
 
-export const handler: StepHandler<typeof config> = async (_, { emit, traceId, state, logger }) => {
+export const handler: Handlers['stepA'] = async (_, { emit, traceId, state, logger }) => {
   logger.info('[stepA] received pms.start')
 
   await new Promise((resolve) => setTimeout(resolve, 300))

--- a/playground/steps/testState/checkStateChange.step.ts
+++ b/playground/steps/testState/checkStateChange.step.ts
@@ -1,10 +1,10 @@
-import { EventConfig, StepHandler } from '@motiadev/core'
+import { EventConfig, Handlers } from 'motia'
 import { z } from 'zod'
 import equal from 'deep-equal'
 
 export const config: EventConfig = {
   type: 'event',
-  name: 'Check state change',
+  name: 'CheckStateChange',
   description: 'check state change',
   subscribes: ['check-state-change'],
   emits: [],
@@ -15,7 +15,7 @@ export const config: EventConfig = {
   flows: ['test-state'],
 }
 
-export const handler: StepHandler<typeof config> = async (input, { traceId, logger, state }) => {
+export const handler: Handlers['CheckStateChange'] = async (input, { traceId, logger, state }) => {
   logger.info('[Test motia state with TS] received check-state-change event', input)
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/playground/steps/testState/testState.api.step.ts
+++ b/playground/steps/testState/testState.api.step.ts
@@ -1,9 +1,9 @@
-import { ApiRouteConfig, StepHandler } from '@motiadev/core'
+import { ApiRouteConfig, Handlers } from 'motia'
 import { z } from 'zod'
 
 export const config: ApiRouteConfig = {
   type: 'api',
-  name: 'Test state api trigger',
+  name: 'TestStateApiTrigger',
   description: 'test state',
   path: '/test-state',
   method: 'POST',
@@ -12,7 +12,7 @@ export const config: ApiRouteConfig = {
   flows: ['test-state'],
 }
 
-export const handler: StepHandler<typeof config> = async (req, { logger, emit }) => {
+export const handler: Handlers['TestStateApiTrigger'] = async (req, { logger, emit }) => {
   logger.info('[Test motia state] triggering api step', req)
 
   await emit({

--- a/playground/steps/testState/test_state.step.py
+++ b/playground/steps/testState/test_state.step.py
@@ -3,7 +3,10 @@ config = {
     "name": "Test State With Python",
     "subscribes": ["test-state"], 
     "emits": ["check-state-change"],
-    "input": None,  # No schema validation in Python version
+    "input": {
+        "key": { "type": "string" },
+        "expected": { "type": "string" },
+    },
     "flows": ["test-state"]
 }
 

--- a/playground/types.d.ts
+++ b/playground/types.d.ts
@@ -21,6 +21,6 @@ declare module 'motia' {
     'Parallel Merge': ApiRouteHandler<never, never, { topic: 'pms.start'; data: {} }>
     'join-step': EventHandler<{ msg: string; timestamp: number }, { topic: 'pms.join.complete'; data: { stepA: { msg: string; timestamp: number }; stepB: unknown; stepC: unknown; mergedAt: string } }>
     'Join Complete': EventHandler<{ stepA: { msg: string; timestamp: number }; stepB: unknown; stepC: unknown; mergedAt: string }, never>
-    'HandlePeriodicJob': EventHandler<never, never>
+   'HandlePeriodicJob': EventHandler<never, never>
   }
 }

--- a/playground/types.d.ts
+++ b/playground/types.d.ts
@@ -8,19 +8,19 @@ import { EventHandler, ApiRouteHandler } from 'motia'
 
 declare module 'motia' {
   type Handlers = {
-    'Test State With Python': EventHandler<never, { topic: 'check-state-change'; data: { key: string; expected?: unknown } }>
-    'Test state api trigger': ApiRouteHandler<{}, never, never>
+    'Test State With Python': EventHandler<unknown, { topic: 'check-state-change'; data: { key: string; expected?: unknown } }>
+    'TestStateApiTrigger': ApiRouteHandler<{}, unknown, { topic: 'test-state'; data: unknown }>
     'Test State With Ruby': EventHandler<never, never>
-    'Check state change': EventHandler<{ key: string; expected?: unknown }, never>
+    'CheckStateChange': EventHandler<{ key: string; expected?: unknown }, never>
     'Tested Event': EventHandler<never, never>
     'Test Event': EventHandler<never, never>
-    'Test API Endpoint': ApiRouteHandler<never, never, never>
+    'Test API Endpoint': ApiRouteHandler<Record<string, unknown>, unknown, never>
     'stepC': EventHandler<never, { topic: 'pms.stepC.done'; data: { msg: string; timestamp: number } }>
     'stepB': EventHandler<never, { topic: 'pms.stepB.done'; data: { msg: string; timestamp: number } }>
     'stepA': EventHandler<{}, { topic: 'pms.stepA.done'; data: { msg: string; timestamp: number } }>
-    'Parallel Merge': ApiRouteHandler<never, never, { topic: 'pms.start'; data: {} }>
+    'Parallel Merge': ApiRouteHandler<Record<string, unknown>, unknown, { topic: 'pms.start'; data: {} }>
     'join-step': EventHandler<{ msg: string; timestamp: number }, { topic: 'pms.join.complete'; data: { stepA: { msg: string; timestamp: number }; stepB: unknown; stepC: unknown; mergedAt: string } }>
-    'Join Complete': EventHandler<{ stepA: { msg: string; timestamp: number }; stepB: unknown; stepC: unknown; mergedAt: string }, never>
-   'HandlePeriodicJob': EventHandler<never, never>
+    'JoinComplete': EventHandler<{ stepA: { msg: string; timestamp: number }; stepB: unknown; stepC: unknown; mergedAt: string }, never>
+    'HandlePeriodicJob': EventHandler<never, never>
   }
 }


### PR DESCRIPTION
We were not supporting different response body schemas depending on the response code.

Example: 404 should return a different body, 200 would be the main body.

This PR also updates tons of usage on the previous way of implementing Step handlers