### PR TITLE
Refactor TailwindCSS postcss config to standalone file

### DIFF
--- a/packages/workbench/middleware.ts
+++ b/packages/workbench/middleware.ts
@@ -3,7 +3,6 @@ import fs from 'fs'
 import path from 'path'
 import { createServer as createViteServer } from 'vite'
 import react from '@vitejs/plugin-react'
-import tailwindcssPostcss from '@tailwindcss/postcss'
 
 export const applyMiddleware = async (app: Express) => {
   const vite = await createViteServer({
@@ -21,11 +20,6 @@ export const applyMiddleware = async (app: Express) => {
       alias: { '@': path.resolve(__dirname, './src') },
     },
     plugins: [react()],
-    css: {
-      postcss: {
-        plugins: [tailwindcssPostcss({ base: path.join(__dirname, './src') })],
-      },
-    },
   })
 
   app.use(vite.middlewares)

--- a/packages/workbench/postcss.config.mjs
+++ b/packages/workbench/postcss.config.mjs
@@ -1,0 +1,9 @@
+import path from 'path'
+
+export default {
+  plugins: {
+    "@tailwindcss/postcss": {
+      base: path.join(import.meta.dirname, './src'),
+    },
+  }
+}


### PR DESCRIPTION
Moved TailwindCSS PostCSS configuration from Vite middleware to a standalone `postcss.config.mjs` file. This improves separation of concerns and simplifies the middleware setup.