### PR TITLE
chore: block deploy when build fails

### DIFF
--- a/packages/snap/src/cloud/cli/build.ts
+++ b/packages/snap/src/cloud/cli/build.ts
@@ -1,14 +1,14 @@
 import colors from 'colors'
 import { program } from 'commander'
 import { build } from '../build'
-import { handler } from '../config-utils'
+import { CliContext, handler } from '../config-utils'
 
 program
   .command('build')
   .description('Build the project')
   .action(
-    handler(async () => {
-      await build()
+    handler(async (_: unknown, context: CliContext) => {
+      await build(context)
       console.log(colors.green('✓ [SUCCESS]'), 'Build completed')
     }),
   )

--- a/packages/snap/src/cloud/cli/deploy.ts
+++ b/packages/snap/src/cloud/cli/deploy.ts
@@ -17,7 +17,7 @@ cloudCli
   .action(
     handler(async (arg, context) => {
       const versionManager = new VersionManager()
-      const builder = await build()
+      const builder = await build(context)
       const { errors, warnings } = validateStepsConfig(builder)
 
       if (warnings.length > 0) {


### PR DESCRIPTION
We were not blocking deployment when build had steps with validation issues causing a deployment with only part of the steps

![image](https://github.com/user-attachments/assets/29db5e22-352d-4b91-8724-c3fac830440c)
