### PR TITLE
feat(docs): Update SuperchargeAI, AIReady, CTASection, ChooseLanguage, Comparison component accessibility

### DIFF
--- a/packages/docs/components/AIReady.tsx
+++ b/packages/docs/components/AIReady.tsx
@@ -15,8 +15,8 @@ export default function AIReady() {
           </div>
         </div>
         <CardText
-          title="Make your own AI Agents"
-          subtitle="Leverage the existing PyPi and NPM ecosystem for AI Agents"
+          title="AI-Ready Workflows"
+          subtitle="Plug into 400k+ Python packages and 2M+ npm modules"
           textBoxWidth="w-[280px]"
         />
       </BentoCard>

--- a/packages/docs/components/CTASection.tsx
+++ b/packages/docs/components/CTASection.tsx
@@ -77,10 +77,10 @@ export default function CTASection() {
         <Ray delay={1} />
       </SectionAppearAnimation>
       <div className="flex w-full flex-col items-center px-[16px] text-center">
-        <Title className="max-w-[792px]">Automate everything with Motia&apos;s framework</Title>
+        <Title className="max-w-[792px]">Code-first AI automation framework</Title>
         <p className="w-full max-w-[440px] pt-[20px] text-[20px] text-white/60">
-          Code in any language. Automate everything. From AI agents to backend ops, Motia runs event-driven workflows
-          with zero overhead.
+          Write in Python, TypeScript, JavaScript, or Ruby. Deploy with confidence using industry standard test
+          suites, evals and monitoring.
         </p>
       </div>
       {/* CTAs */}

--- a/packages/docs/components/ChooseLanguage.tsx
+++ b/packages/docs/components/ChooseLanguage.tsx
@@ -17,7 +17,7 @@ export default function ChooseLanguage() {
           />
         </div>
         <CardText
-          title="Choose any language"
+          title="Multi-Language Workflows"
           subtitle="Write and connect steps in Python, TypeScript, JavaScript or Ruby"
         />
       </BentoCard>

--- a/packages/docs/components/Comparison.tsx
+++ b/packages/docs/components/Comparison.tsx
@@ -111,9 +111,9 @@ export default function Comparison() {
   return (
     <div className="relative w-full max-w-[1248px] pt-[180px] max-md:pt-[120px]">
       <div className="w-full px-[16px] pb-[80px] text-center">
-        <Title>Unmatched benchmarks.</Title>
+        <Title>Production-ready reliability.</Title>
         <SectionAppearAnimation delay={0.35}>
-          <Title className="opacity-40">Relentless performance.</Title>
+          <Title className="opacity-40"> Developer-first design.</Title>
         </SectionAppearAnimation>
       </div>
 

--- a/packages/docs/components/SuperchargeAI.tsx
+++ b/packages/docs/components/SuperchargeAI.tsx
@@ -24,12 +24,12 @@ export default function SuperchargeAI() {
 
       <div className="relative flex w-full flex-col items-center gap-[20px] px-[16px] pt-[180px] max-md:pt-0">
         <SectionAppearAnimation>
-          <Image src={superchargeAgentsIcon} alt="super charge your agents" className="w-[100px]" />
+          <Image src={superchargeAgentsIcon} alt="Build with the tools you know and love icon" className="w-[100px]" />
         </SectionAppearAnimation>
-        <Title className="text-center">Supercharge your agents</Title>
+        <Title className="text-center">Build with the tools you know and love</Title>
         <p className="w-[350px] max-w-full text-center text-[16px] font-light text-white opacity-60">
           <TextAppearBlur delay={0.25}>
-            Seamlessly integrate anything from the entire NPM and PyPi ecosystems
+            Integrate with the libraries you already use to build practical, scalable, and reliable solutions.
           </TextAppearBlur>
         </p>
         {superchargeAgentsHeaderGraphic}


### PR DESCRIPTION
This pull request updates the marketing copy across several components in the documentation site to better align with the product's messaging and emphasize its features. The changes primarily focus on rephrasing titles, subtitles, and descriptions to highlight the flexibility, reliability, and developer-friendly nature of the framework.

### Messaging Updates:

* **AIReady Component (`packages/docs/components/AIReady.tsx`)**:
  Updated the card text to emphasize "AI-Ready Workflows" and the ability to leverage extensive Python and npm ecosystems.

* **CTASection Component (`packages/docs/components/CTASection.tsx`)**:
  Revised the title to "Code-first AI automation framework" and the description to highlight supported languages and robust deployment features like test suites, evals, and monitoring.

* **ChooseLanguage Component (`packages/docs/components/ChooseLanguage.tsx`)**:
  Changed the card title to "Multi-Language Workflows" to emphasize the framework's support for multiple programming languages.

* **Comparison Component (`packages/docs/components/Comparison.tsx`)**:
  Updated titles to "Production-ready reliability" and "Developer-first design" to shift focus from performance benchmarks to reliability and developer-centric features.

* **SuperchargeAI Component (`packages/docs/components/SuperchargeAI.tsx`)**:
  Adjusted the title and description to emphasize building with familiar tools and integrating with existing libraries for scalable and practical solutions.