### PR TITLE
update command to use latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ Backend teams juggle **fragmented runtimes** across APIs, background queues, and
 
 Motia unifies your entire backend into a **unified state**. APIs, background jobs, and AI agents become interconnected Steps with shared state and integrated observability.
 
-| **Before**                  | **After (Motia)**                        |
-| --------------------------- | ---------------------------------------- |
-| Multiple deployment targets | **Single unified deployment**            |
-| Fragmented observability    | **End-to-end tracing**                   |
+| **Before**                  | **After (Motia)**                       |
+| --------------------------- | --------------------------------------- |
+| Multiple deployment targets | **Single unified deployment**           |
+| Fragmented observability    | **End-to-end tracing**                  |
 | Language dependent          | **JavaScript, TypeScript, Python, etc** |
-| Context-switching overhead  | **Single intuitive model**               |
-| Complex error handling      | **Automatic retries & fault tolerance**  |
+| Context-switching overhead  | **Single intuitive model**              |
+| Complex error handling      | **Automatic retries & fault tolerance** |
 
 ---
 
@@ -96,7 +96,7 @@ Get up and running in **under 60 seconds**:
 ### 1. Create Your Project
 
 ```bash
-npx motia create -i
+npx motia@latest create -i
 ```
 - Enter project details like template, project name, etc
 

--- a/packages/snap/README.md
+++ b/packages/snap/README.md
@@ -73,7 +73,7 @@ Motia unifies your entire backend into a unified state. APIs, background jobs, a
 1. **Create a project**, and `cd` into its directory:
 
 ```bash
-npx motia create -i
+npx motia@latest create -i
 ```
 - Enter project details like the template you wanna use, project name, etc.
 


### PR DESCRIPTION
Update the commands in readme (github and npm) to use `motia@latest` instead of the current `motia`.

I've already pushed the update for this command in docs in my last [commit](https://github.com/MotiaDev/motia/pull/267/commits/aac3c6c374cff13c3212a75a08197d6c77de8069)