### PR TITLE
update expired Discord links as reported by our community member

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <a href="https://twitter.com/motiadev" target="_blank">
     <img src="https://img.shields.io/badge/Follow-@motiadev-1DA1F2?style=flat&logo=twitter&logoColor=white&labelColor=000000" alt="Twitter Follow">
   </a>
-  <a href="https://discord.gg/7rXsekMK" target="_blank">
+  <a href="https://discord.gg/EnfDRFYW" target="_blank">
     <img src="https://img.shields.io/discord/1322278831184281721?style=flat&logo=discord&logoColor=white&color=5865F2&label=Discord&labelColor=000000" alt="Discord">
   </a>
 </p>

--- a/packages/docs/content/docs/contribution/how-to-contribute.mdx
+++ b/packages/docs/content/docs/contribution/how-to-contribute.mdx
@@ -34,6 +34,6 @@ If you have built something interesting with Motia or have a real-world use case
 
 ## Spreading the Word
 
-Help spread the word about Motia by sharing it with your friends, colleagues, and the developer community. You can also star our [GitHub repository](https://github.com/MotiaDev/motia), follow us on [Twitter](https://twitter.com/motiadev), and join our [Discord community](https://discord.gg/nJFfsH5d6v) to stay updated with the latest news and engage with other Motia developers.
+Help spread the word about Motia by sharing it with your friends, colleagues, and the developer community. You can also star our [GitHub repository](https://github.com/MotiaDev/motia), follow us on [Twitter](https://twitter.com/motiadev), and join our [Discord community](https://discord.gg/EnfDRFYW) to stay updated with the latest news and engage with other Motia developers.
 
 We appreciate all forms of contributions and look forward to collaborating with you to make Motia even better! 

--- a/packages/snap/README.md
+++ b/packages/snap/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.npmjs.com/package/motia"><img src="https://img.shields.io/npm/v/motia.svg" alt="npm version"></a>
   <a href="https://github.com/MotiaDev/motia/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="license"></a>
   <a href="https://twitter.com/motiadev" target="_blank"><img src="https://img.shields.io/twitter/follow/motiadev.svg?style=social&label=Follow"></a>
-  <a href="https://discord.gg/7rXsekMK" target="_blank"><img src="https://img.shields.io/discord/1322278831184281721"></a>
+  <a href="https://discord.gg/EnfDRFYW" target="_blank"><img src="https://img.shields.io/discord/1322278831184281721"></a>
 </p>
 
 **Unify APIs and agents with built-in observability and one-click deployment**


### PR DESCRIPTION
One of our community members flagged that the Discord invite link in the Github repo and in the docs has expired. This PR fixes those links.