### PR TITLE
fix: motia create with next tag

### DIFF
--- a/packages/snap/src/cli.ts
+++ b/packages/snap/src/cli.ts
@@ -4,6 +4,7 @@ import { program } from 'commander'
 import path from 'path'
 import fs from 'fs'
 import './cloud'
+import { version } from './version'
 
 const defaultPort = 3000
 
@@ -12,10 +13,6 @@ require('ts-node').register({
   transpileOnly: true,
   compilerOptions: { module: 'commonjs' },
 })
-
-const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json')
-const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
-const version = `${packageJson.version}`
 
 program
   .command('version')

--- a/packages/snap/src/create/index.ts
+++ b/packages/snap/src/create/index.ts
@@ -4,6 +4,7 @@ import { templates } from './templates'
 import { executeCommand } from '../utils/execute-command'
 import { pythonInstall } from '../install'
 import { generateTypes } from '../generate-types'
+import { version } from '../version'
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 require('ts-node').register({
@@ -44,7 +45,7 @@ const installRequiredDependencies = async (packageManager: string, rootDir: stri
     pnpm: 'pnpm add',
   }[packageManager]
 
-  const dependencies = ['motia', 'zod@^3.24.4'].join(' ')
+  const dependencies = [`motia@^${version}`, 'zod@^3.24.4'].join(' ')
   const devDependencies = ['ts-node@^10.9.2', 'typescript@^5.7.3', '@types/react@^18.3.18'].join(' ')
 
   try {

--- a/packages/snap/src/version.ts
+++ b/packages/snap/src/version.ts
@@ -1,0 +1,7 @@
+import path from 'path'
+import fs from 'fs'
+
+const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json')
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+
+export const version = `${packageJson.version}`


### PR DESCRIPTION
When creating a new project with `npx motia@next create`, the motia dependency in the project is the `@latest`

![image](https://github.com/user-attachments/assets/6fb8dcfb-628b-450f-8e77-47f12b1bbd70)
![image](https://github.com/user-attachments/assets/2fdbc0fc-dab9-4f92-a944-3f23f2e2521b)
