### PR TITLE
feat: rRefactor Endpoint Components and Add Sidebar Tabs

### DIFF
--- a/packages/e2e/tests/page-objects/EnpointPage.ts
+++ b/packages/e2e/tests/page-objects/EnpointPage.ts
@@ -3,12 +3,16 @@ import { MotiaApplicationPage } from './MotiaApplicationPage'
 
 export class EndpointPage extends MotiaApplicationPage {
   readonly firstEndpointItem: Locator
+  readonly callTab: Locator
+  readonly detailsTab: Locator
   readonly editor: Locator
   readonly playButton: Locator
   readonly responseContainer: Locator
 
   constructor(page: Page) {
     super(page)
+    this.callTab = page.getByTestId('endpoint-call-tab')
+    this.detailsTab = page.getByTestId('endpoint-details-tab')
     this.firstEndpointItem = page.getByTestId('endpoint-POST-/default')
     this.editor = page.locator('.monaco-editor')
     this.playButton = page.getByTestId('endpoint-play-button')

--- a/packages/e2e/tests/workbench/endpoint-call.spec.ts
+++ b/packages/e2e/tests/workbench/endpoint-call.spec.ts
@@ -11,6 +11,7 @@ test.describe('Workbench - Endpoint Call JSON Validation', () => {
     await workbench.open()
     await workbench.navigateToEndpoints()
     await endpoint.firstEndpointItem.click()
+    await endpoint.callTab.click()
   })
 
   test('should validate JSON body input', async () => {

--- a/packages/ui/src/components/ui/panel.stories.tsx
+++ b/packages/ui/src/components/ui/panel.stories.tsx
@@ -159,8 +159,7 @@ export const WithTabs: Story = {
     title: 'Dashboard Overview',
     subtitle: 'Comprehensive system monitoring',
     variant: 'default',
-    tabs: {
-      tabs: [
+    tabs: [
         {
           label: 'Overview',
           content: (
@@ -293,7 +292,6 @@ export const WithTabs: Story = {
           ),
         },
       ],
-    },
     actions: [
       {
         icon: <Copy />,
@@ -315,8 +313,7 @@ export const SimpleTabs: Story = {
     title: 'Product Details',
     variant: 'outlined',
     size: 'sm',
-    tabs: {
-      tabs: [
+    tabs: [
         {
           label: 'Description',
           content: (
@@ -388,7 +385,6 @@ export const SimpleTabs: Story = {
           ),
         },
       ],
-    },
   },
 }
 

--- a/packages/ui/src/components/ui/panel.tsx
+++ b/packages/ui/src/components/ui/panel.tsx
@@ -17,6 +17,7 @@ export interface PanelAction {
 }
 
 export interface PanelProps {
+  'data-testid'?: string
   title: ReactNode
   subtitle?: ReactNode
   details?: PanelDetailItem[]
@@ -28,6 +29,7 @@ export interface PanelProps {
   tabs?: {
     label: string
     content: ReactNode
+    'data-testid'?: string
   }[]
   contentClassName?: string
 }
@@ -40,6 +42,7 @@ const panelVariants = {
 }
 
 export const Panel: FC<PanelProps> = ({
+  'data-testid': dataTestId,
   title,
   subtitle,
   details,
@@ -63,7 +66,7 @@ export const Panel: FC<PanelProps> = ({
             })}
           >
             {tabs?.map((tab) => (
-              <TabsTrigger key={tab.label} value={tab.label}>
+              <TabsTrigger key={tab.label} value={tab.label} data-testid={tab['data-testid']}>
                 {tab.label}
               </TabsTrigger>
             ))}
@@ -119,6 +122,7 @@ export const Panel: FC<PanelProps> = ({
         panelVariants[variant],
         className,
       )}
+      data-testid={dataTestId}
     >
       <div className="flex flex-col size-full">
         <div

--- a/packages/ui/src/components/ui/panel.tsx
+++ b/packages/ui/src/components/ui/panel.tsx
@@ -26,11 +26,9 @@ export interface PanelProps {
   size?: 'sm' | 'md'
   variant?: 'default' | 'outlined' | 'filled' | 'ghost'
   tabs?: {
-    tabs: {
-      label: string
-      content: ReactNode
-    }[]
-  }
+    label: string
+    content: ReactNode
+  }[]
   contentClassName?: string
 }
 
@@ -53,7 +51,7 @@ export const Panel: FC<PanelProps> = ({
   contentClassName,
   tabs,
 }) => {
-  const hasTabs = tabs && tabs.tabs.length > 0
+  const hasTabs = tabs && tabs.length > 0
 
   const content = useMemo(() => {
     const _view = (
@@ -64,7 +62,7 @@ export const Panel: FC<PanelProps> = ({
               'bg-transparent': variant === 'ghost',
             })}
           >
-            {tabs?.tabs.map((tab) => (
+            {tabs?.map((tab) => (
               <TabsTrigger key={tab.label} value={tab.label}>
                 {tab.label}
               </TabsTrigger>
@@ -94,7 +92,7 @@ export const Panel: FC<PanelProps> = ({
           ))}
 
           {hasTabs &&
-            tabs.tabs.map((tab) => (
+            tabs.map((tab) => (
               <TabsContent key={tab.label} value={tab.label}>
                 {tab.content}
               </TabsContent>
@@ -106,7 +104,7 @@ export const Panel: FC<PanelProps> = ({
     )
 
     if (hasTabs) {
-      return <Tabs defaultValue={tabs?.tabs[0]?.label}>{_view}</Tabs>
+      return <Tabs defaultValue={tabs?.[0]?.label}>{_view}</Tabs>
     }
 
     return _view

--- a/packages/workbench/src/components/endpoints/endpoint-body-panel.tsx
+++ b/packages/workbench/src/components/endpoints/endpoint-body-panel.tsx
@@ -1,0 +1,35 @@
+import { useJsonSchemaToJson } from './hooks/use-json-schema-to-json'
+import { ApiEndpoint } from '@/types/endpoint'
+import { Panel } from '@motiadev/ui'
+import { FC } from 'react'
+import { JsonEditor } from './json-editor'
+import ReactJson from 'react18-json-view'
+import 'react18-json-view/src/dark.css'
+import 'react18-json-view/src/style.css'
+import { convertJsonSchemaToJson } from './hooks/utils'
+type Props = { endpoint: ApiEndpoint; onChange?: (body: string) => void; onValidate?: (isValid: boolean) => void }
+
+export const EndpointBodyPanel: FC<Props> = ({ endpoint, onChange, onValidate }) => {
+  const shouldHaveBody = ['post', 'put', 'patch'].includes(endpoint.method.toLowerCase())
+  const { body, setBody } = useJsonSchemaToJson(endpoint.bodySchema)
+
+  const handleBodyChange = (body: string) => {
+    setBody(body)
+    onChange?.(body)
+  }
+
+  if (!shouldHaveBody) {
+    return null
+  }
+  console.log(endpoint.bodySchema)
+
+  return (
+    <Panel title="Body" size="sm" contentClassName="p-0" data-testid="endpoint-body-panel">
+      {onChange ? (
+        <JsonEditor value={body} schema={endpoint.bodySchema} onChange={handleBodyChange} onValidate={onValidate} />
+      ) : (
+        <ReactJson src={convertJsonSchemaToJson(endpoint.bodySchema ?? {})} theme="default" enableClipboard={false} />
+      )}
+    </Panel>
+  )
+}

--- a/packages/workbench/src/components/endpoints/endpoint-body-panel.tsx
+++ b/packages/workbench/src/components/endpoints/endpoint-body-panel.tsx
@@ -21,7 +21,6 @@ export const EndpointBodyPanel: FC<Props> = ({ endpoint, onChange, onValidate })
   if (!shouldHaveBody) {
     return null
   }
-  console.log(endpoint.bodySchema)
 
   return (
     <Panel title="Body" size="sm" contentClassName="p-0" data-testid="endpoint-body-panel">

--- a/packages/workbench/src/components/endpoints/endpoint-call.tsx
+++ b/packages/workbench/src/components/endpoints/endpoint-call.tsx
@@ -1,18 +1,15 @@
-import { Sidebar } from '@/components/sidebar/sidebar'
 import { ApiEndpoint } from '@/types/endpoint'
 import { Button, Input, Panel } from '@motiadev/ui'
-import { Loader2, Play, X } from 'lucide-react'
+import { Loader2, Play } from 'lucide-react'
 import { FC, useEffect, useMemo, useState } from 'react'
-import { EndpointBadge } from './endpoint-badge'
 import { EndpointResponse } from './endpoint-response'
-import { EndpointResponseSchema } from './endpoint-response-schema'
 import { useJsonSchemaToJson } from './hooks/use-json-schema-to-json'
 import { usePathParams } from './hooks/use-path-params'
 import { JsonEditor } from './json-editor'
 
-type Props = { endpoint: ApiEndpoint; onClose: () => void }
+type Props = { endpoint: ApiEndpoint }
 
-export const EndpointCall: FC<Props> = ({ endpoint, onClose }) => {
+export const EndpointCall: FC<Props> = ({ endpoint }) => {
   const shouldHaveBody = ['post', 'put', 'patch'].includes(endpoint.method.toLowerCase())
   const [isRequestLoading, setIsRequestLoading] = useState(false)
   const [responseCode, setResponseCode] = useState<number | undefined>(undefined)
@@ -82,25 +79,7 @@ export const EndpointCall: FC<Props> = ({ endpoint, onClose }) => {
   }
 
   return (
-    <Sidebar
-      initialWidth={600}
-      title={
-        <div className="flex flex-row gap-2 items-center">
-          <EndpointBadge variant={endpoint.method as never}>{endpoint.method.toUpperCase()}</EndpointBadge>
-          <span className="text-md font-bold">{endpoint.path}</span>
-        </div>
-      }
-      onClose={onClose}
-      actions={[
-        {
-          icon: <X className="cursor-pointer w-4 h-4" onClick={onClose} />,
-          onClick: onClose,
-        },
-      ]}
-    >
-      {endpoint.description && (
-        <div className="rounded-lg border p-4 font-medium text-muted-foreground">{endpoint.description}</div>
-      )}
+    <div className="space-y-3">
       {!!pathParams.length && (
         <Panel title="Path params" size="sm">
           <table>
@@ -156,13 +135,6 @@ export const EndpointCall: FC<Props> = ({ endpoint, onClose }) => {
       </Button>
 
       <EndpointResponse responseCode={responseCode} responseBody={responseBody} executionTime={executionTime} />
-
-      <EndpointResponseSchema
-        items={Object.entries(endpoint?.responseSchema ?? {}).map(([status, schema]) => ({
-          responseCode: status,
-          bodySchema: schema,
-        }))}
-      />
-    </Sidebar>
+    </div>
   )
 }

--- a/packages/workbench/src/components/endpoints/endpoint-description.tsx
+++ b/packages/workbench/src/components/endpoints/endpoint-description.tsx
@@ -1,0 +1,21 @@
+import { FC } from 'react'
+import { EndpointResponseSchema } from './endpoint-response-schema'
+import { ApiEndpoint } from '@/types/endpoint'
+
+type Props = { endpoint: ApiEndpoint }
+
+export const EndpointDescription: FC<Props> = ({ endpoint }) => {
+  return (
+    <div className="space-y-3">
+      {endpoint.description && (
+        <div className="rounded-lg border p-4 font-medium text-muted-foreground">{endpoint.description}</div>
+      )}
+      <EndpointResponseSchema
+        items={Object.entries(endpoint?.responseSchema ?? {}).map(([status, schema]) => ({
+          responseCode: status,
+          bodySchema: schema,
+        }))}
+      />
+    </div>
+  )
+}

--- a/packages/workbench/src/components/endpoints/endpoint-description.tsx
+++ b/packages/workbench/src/components/endpoints/endpoint-description.tsx
@@ -1,15 +1,18 @@
 import { FC } from 'react'
 import { EndpointResponseSchema } from './endpoint-response-schema'
 import { ApiEndpoint } from '@/types/endpoint'
+import { EndpointPathParamsPanel } from './endpoint-path-params-panel'
+import { EndpointQueryParamsPanel } from './endpoint-query-params-panel'
+import { EndpointBodyPanel } from './endpoint-body-panel'
 
 type Props = { endpoint: ApiEndpoint }
 
 export const EndpointDescription: FC<Props> = ({ endpoint }) => {
   return (
     <div className="space-y-3">
-      {endpoint.description && (
-        <div className="rounded-lg border p-4 font-medium text-muted-foreground">{endpoint.description}</div>
-      )}
+      <EndpointPathParamsPanel endpoint={endpoint} />
+      <EndpointQueryParamsPanel endpoint={endpoint} />
+      <EndpointBodyPanel endpoint={endpoint} />
       <EndpointResponseSchema
         items={Object.entries(endpoint?.responseSchema ?? {}).map(([status, schema]) => ({
           responseCode: status,

--- a/packages/workbench/src/components/endpoints/endpoint-path-params-panel.tsx
+++ b/packages/workbench/src/components/endpoints/endpoint-path-params-panel.tsx
@@ -1,0 +1,59 @@
+import { Input, Panel } from '@motiadev/ui'
+import { FC, Fragment, useMemo, useState } from 'react'
+import { usePathParams } from './hooks/use-path-params'
+import { ApiEndpoint } from '@/types/endpoint'
+
+type Props = { endpoint: ApiEndpoint; onChange?: (pathParamsValues: Record<string, string>) => void }
+
+export const EndpointPathParamsPanel: FC<Props> = ({ endpoint, onChange }) => {
+  const pathParams = usePathParams(endpoint.path)
+  const [pathParamsValues, setPathParamsValues] = useState<Record<string, string>>(
+    pathParams?.reduce((acc, param) => ({ ...acc, [param]: '' }), {} as Record<string, string>),
+  )
+
+  const onPathParamChange = (param: string, value: string) => {
+    const newPathParamsValues = { ...pathParamsValues, [param]: value }
+    setPathParamsValues(newPathParamsValues)
+    onChange?.(newPathParamsValues)
+  }
+
+  const subtitle = useMemo(() => {
+    if (onChange) {
+      return Object.entries(pathParamsValues).reduce((acc, [param, value]) => {
+        if (!value) {
+          return acc
+        }
+        return acc.replace(`:${param}`, value)
+      }, endpoint.path)
+    }
+    return endpoint.path
+  }, [pathParamsValues, endpoint.path, onChange])
+
+  if (!pathParams.length) {
+    return null
+  }
+
+  return (
+    <Panel title="Path params" subtitle={subtitle} size="sm" variant="outlined">
+      <div className="grid gap-3" style={{ gridTemplateColumns: '1fr 2fr' }}>
+        {pathParams.map((param) => (
+          <Fragment key={param}>
+            <div className="font-bold leading-[36px] flex text-xs">{param}</div>
+            <div className="flex items-center text-xs">
+              {onChange ? (
+                <Input
+                  className="w-full text-xs"
+                  placeholder={`:${param}`}
+                  value={pathParamsValues[param]}
+                  onChange={(e) => onPathParamChange(param, e.target.value)}
+                />
+              ) : (
+                <span className="text-xs">{`:${param}`}</span>
+              )}
+            </div>
+          </Fragment>
+        ))}
+      </div>
+    </Panel>
+  )
+}

--- a/packages/workbench/src/components/endpoints/endpoint-query-params-panel.tsx
+++ b/packages/workbench/src/components/endpoints/endpoint-query-params-panel.tsx
@@ -1,0 +1,46 @@
+import { ApiEndpoint } from '@/types/endpoint'
+import { Input } from '@motiadev/ui'
+import { Panel } from '@motiadev/ui'
+import { FC, Fragment, useState } from 'react'
+
+type Props = { endpoint: ApiEndpoint; onChange?: (queryParamsValues: Record<string, string>) => void }
+
+export const EndpointQueryParamsPanel: FC<Props> = ({ endpoint, onChange }) => {
+  const [queryParamsValues, setQueryParamsValues] = useState<Record<string, string>>(
+    endpoint.queryParams?.reduce((acc, param) => ({ ...acc, [param.name]: '' }), {} as Record<string, string>) ?? {},
+  )
+
+  const onQueryParamChange = (param: string, value: string) => {
+    const newQueryParamsValues = { ...queryParamsValues, [param]: value }
+    setQueryParamsValues(newQueryParamsValues)
+    onChange?.(newQueryParamsValues)
+  }
+
+  if (!endpoint.queryParams?.length) {
+    return null
+  }
+
+  return (
+    <Panel title="Query params" size="sm" variant="outlined">
+      <div className="grid gap-3" style={{ gridTemplateColumns: '1fr 2fr', gridTemplateRows: '1fr 1fr' }}>
+        {endpoint.queryParams.map((param) => (
+          <Fragment key={param.name}>
+            <div className="font-bold leading-[36px] flex text-xs">{param.name}</div>
+            <div className="flex items-center text-xs ">
+              {onChange ? (
+                <Input
+                  className="text-xs"
+                  placeholder={param.description}
+                  value={queryParamsValues[param.name]}
+                  onChange={(e) => onQueryParamChange(param.name, e.target.value)}
+                />
+              ) : (
+                <span>{param.description}</span>
+              )}
+            </div>
+          </Fragment>
+        ))}
+      </div>
+    </Panel>
+  )
+}

--- a/packages/workbench/src/components/endpoints/endpoint-response-schema.tsx
+++ b/packages/workbench/src/components/endpoints/endpoint-response-schema.tsx
@@ -39,7 +39,7 @@ export const EndpointResponseSchema: FC<EndpointResponseProps> = ({ items }) => 
   }
 
   return (
-    <div className="flex flex-col rounded-lg border" data-testid="endpoint-response-container">
+    <div className="flex flex-col rounded-lg border">
       <Tabs defaultValue={items[0].responseCode}>
         <div className="flex items-center justify-between bg-card">
           <TabsList className="bg-transparent p-0">

--- a/packages/workbench/src/components/endpoints/endpoint-response.tsx
+++ b/packages/workbench/src/components/endpoints/endpoint-response.tsx
@@ -50,30 +50,24 @@ export const EndpointResponse: FC<EndpointResponseProps> = ({ responseCode, exec
     <Panel
       tabs={
         isStreamed
-          ? {
-              tabs: [
-                {
-                  label: 'Streamed Response',
-                  content: (
-                    <ReactJson
-                      src={data as object}
-                      dark={theme === 'dark'}
-                      style={{ backgroundColor: 'transparent' }}
-                    />
-                  ),
-                },
-                {
-                  label: 'Original',
-                  content: (
-                    <ReactJson
-                      src={originalData as object}
-                      dark={theme === 'dark'}
-                      style={{ backgroundColor: 'transparent' }}
-                    />
-                  ),
-                },
-              ],
-            }
+          ? [
+              {
+                label: 'Streamed Response',
+                content: (
+                  <ReactJson src={data as object} dark={theme === 'dark'} style={{ backgroundColor: 'transparent' }} />
+                ),
+              },
+              {
+                label: 'Original',
+                content: (
+                  <ReactJson
+                    src={originalData as object}
+                    dark={theme === 'dark'}
+                    style={{ backgroundColor: 'transparent' }}
+                  />
+                ),
+              },
+            ]
           : undefined
       }
       title={

--- a/packages/workbench/src/components/endpoints/endpoint-response.tsx
+++ b/packages/workbench/src/components/endpoints/endpoint-response.tsx
@@ -48,6 +48,7 @@ export const EndpointResponse: FC<EndpointResponseProps> = ({ responseCode, exec
 
   return (
     <Panel
+      data-testid={'endpoint-response-container'}
       tabs={
         isStreamed
           ? [

--- a/packages/workbench/src/components/endpoints/endpoint-side-panel.tsx
+++ b/packages/workbench/src/components/endpoints/endpoint-side-panel.tsx
@@ -21,12 +21,14 @@ export const EndpointSidePanel: FC<Props> = ({ endpoint, onClose }) => {
       onClose={onClose}
       tabs={[
         {
-          label: 'Description',
+          label: 'Details',
           content: <EndpointDescription endpoint={endpoint} />,
+          'data-testid': 'endpoint-details-tab',
         },
         {
           label: 'Call',
           content: <EndpointCall endpoint={endpoint} />,
+          'data-testid': 'endpoint-call-tab',
         },
       ]}
       actions={[

--- a/packages/workbench/src/components/endpoints/endpoint-side-panel.tsx
+++ b/packages/workbench/src/components/endpoints/endpoint-side-panel.tsx
@@ -12,6 +12,7 @@ export const EndpointSidePanel: FC<Props> = ({ endpoint, onClose }) => {
   return (
     <Sidebar
       initialWidth={600}
+      subtitle={endpoint.description}
       title={
         <div className="flex flex-row gap-2 items-center">
           <EndpointBadge variant={endpoint.method as never}>{endpoint.method.toUpperCase()}</EndpointBadge>

--- a/packages/workbench/src/components/endpoints/endpoint-side-panel.tsx
+++ b/packages/workbench/src/components/endpoints/endpoint-side-panel.tsx
@@ -1,0 +1,40 @@
+import { Sidebar } from '@/components/sidebar/sidebar'
+import { ApiEndpoint } from '@/types/endpoint'
+import { X } from 'lucide-react'
+import { FC } from 'react'
+import { EndpointBadge } from './endpoint-badge'
+import { EndpointCall } from './endpoint-call'
+import { EndpointDescription } from './endpoint-description'
+
+type Props = { endpoint: ApiEndpoint; onClose: () => void }
+
+export const EndpointSidePanel: FC<Props> = ({ endpoint, onClose }) => {
+  return (
+    <Sidebar
+      initialWidth={600}
+      title={
+        <div className="flex flex-row gap-2 items-center">
+          <EndpointBadge variant={endpoint.method as never}>{endpoint.method.toUpperCase()}</EndpointBadge>
+          <span className="text-md font-bold">{endpoint.path}</span>
+        </div>
+      }
+      onClose={onClose}
+      tabs={[
+        {
+          label: 'Description',
+          content: <EndpointDescription endpoint={endpoint} />,
+        },
+        {
+          label: 'Call',
+          content: <EndpointCall endpoint={endpoint} />,
+        },
+      ]}
+      actions={[
+        {
+          icon: <X className="cursor-pointer w-4 h-4" onClick={onClose} />,
+          onClick: onClose,
+        },
+      ]}
+    />
+  )
+}

--- a/packages/workbench/src/components/endpoints/endpoints-page.tsx
+++ b/packages/workbench/src/components/endpoints/endpoints-page.tsx
@@ -2,7 +2,7 @@ import { cn } from '@/lib/utils'
 import { useGlobalStore } from '@/stores/use-global-store'
 import { useMemo } from 'react'
 import { EndpointBadge } from './endpoint-badge'
-import { EndpointCall } from './endpoint-call'
+import { EndpointSidePanel } from './endpoint-side-panel'
 import { useGetEndpoints } from './hooks/use-get-endpoints'
 
 export const EndpointsPage = () => {
@@ -32,7 +32,10 @@ export const EndpointsPage = () => {
           </div>
         ))}
       </div>
-      {selectedEndpoint && <EndpointCall endpoint={selectedEndpoint} onClose={() => selectEndpointId(undefined)} />}
+
+      {selectedEndpoint && (
+        <EndpointSidePanel endpoint={selectedEndpoint} onClose={() => selectEndpointId(undefined)} />
+      )}
     </div>
   )
 }

--- a/packages/workbench/src/components/endpoints/hooks/utils.ts
+++ b/packages/workbench/src/components/endpoints/hooks/utils.ts
@@ -17,7 +17,7 @@ export const convertJsonSchemaToJson = (schema: Record<string, any>): any => {
     case 'array':
       return [convertJsonSchemaToJson(schema.items)]
     case 'string':
-      return schema.description ?? 'string'
+      return schema.enum?.[0] ?? schema.description ?? 'string'
     case 'number':
       return schema.description ?? 0
     case 'integer':

--- a/packages/workbench/src/components/endpoints/json-editor.tsx
+++ b/packages/workbench/src/components/endpoints/json-editor.tsx
@@ -6,7 +6,7 @@ type JsonEditorProps = {
   value: string
   schema: Record<string, unknown> | undefined
   onChange: (value: string) => void
-  onValidate: (isValid: boolean) => void
+  onValidate?: (isValid: boolean) => void
 }
 
 export const JsonEditor: FC<JsonEditorProps> = ({ value, schema, onChange, onValidate }) => {
@@ -38,11 +38,11 @@ export const JsonEditor: FC<JsonEditorProps> = ({ value, schema, onChange, onVal
       theme={editorTheme}
       onChange={(value) => {
         if (!value) {
-          onValidate(false)
+          onValidate?.(false)
         }
         onChange(value ?? '')
       }}
-      onValidate={(markers) => onValidate(markers.length === 0)}
+      onValidate={(markers) => onValidate?.(markers.length === 0)}
       options={{ lineNumbers: 'off', minimap: { enabled: false } }}
     />
   )

--- a/packages/workbench/src/components/logs/logs-page.tsx
+++ b/packages/workbench/src/components/logs/logs-page.tsx
@@ -5,7 +5,7 @@ import { useLogsStore } from '@/stores/use-logs-store'
 import { useMemo, useState } from 'react'
 import { LogDetail } from './log-detail'
 import { LogLevelDot } from './log-level-dot'
-import { Button, Input } from '@motiadev/ui'
+import { Button, cn, Input } from '@motiadev/ui'
 import { CircleX, Trash } from 'lucide-react'
 
 export const LogsPage = () => {
@@ -52,7 +52,14 @@ export const LogsPage = () => {
         <Table>
           <TableBody className="font-mono font-medium">
             {filteredLogs.map((log, index) => (
-              <TableRow key={index} className="cursor-pointer border-0" onClick={() => selectLogId(log.id)}>
+              <TableRow
+                className={cn('font-mono font-semibold cursor-pointer border-0', {
+                  'bg-muted-foreground/10 hover:bg-muted-foreground/20': selectedLogId === log.id,
+                  'hover:bg-muted-foreground/10': selectedLogId !== log.id,
+                })}
+                key={index}
+                onClick={() => selectLogId(log.id)}
+              >
                 <TableCell
                   data-testid={`time-${index}`}
                   className="whitespace-nowrap flex items-center gap-2 text-muted-foreground"

--- a/packages/workbench/src/components/states/states-page.tsx
+++ b/packages/workbench/src/components/states/states-page.tsx
@@ -36,7 +36,7 @@ export const StatesPage = () => {
               key={`${item.groupId}:${item.key}`}
               onClick={() => handleRowClick(item)}
               className={cn(
-                'font-mono font-semibold',
+                'font-mono font-semibold cursor-pointer border-0',
                 selectedItem === item
                   ? 'bg-muted-foreground/10 hover:bg-muted-foreground/20'
                   : 'hover:bg-muted-foreground/10',

--- a/playground/types.d.ts
+++ b/playground/types.d.ts
@@ -8,7 +8,6 @@ import { EventHandler, ApiRouteHandler, ApiResponse, MotiaStream } from 'motia'
 
 declare module 'motia' {
   interface FlowContextStateStreams {
-    'message_python': MotiaStream<{ message: string }>
     'message': MotiaStream<{ message: string; from: 'user' | 'assistant'; status: 'created' | 'pending' | 'completed' }>
   }
 
@@ -25,8 +24,6 @@ declare module 'motia' {
     'Parallel Merge': ApiRouteHandler<Record<string, unknown>, unknown, { topic: 'pms.start'; data: {} }>
     'join-step': EventHandler<{ msg: string; timestamp: number }, { topic: 'pms.join.complete'; data: { stepA: { msg: string; timestamp: number }; stepB: unknown; stepC: unknown; mergedAt: string } }>
     'JoinComplete': EventHandler<{ stepA: { msg: string; timestamp: number }; stepB: unknown; stepC: unknown; mergedAt: string }, never>
-    'CallOpenAiPython': EventHandler<{ message: string; assistantMessageId: string; threadId: string }, never>
-    'OpenAiApiPython': ApiRouteHandler<{ message: string; threadId?: string }, ApiResponse<200, { threadId: string }>, { topic: 'openai-prompt-python'; data: { message: string; assistantMessageId: string; threadId: string } }>
     'CallOpenAi': EventHandler<{ message: string; assistantMessageId: string; threadId: string }, never>
     'OpenAiApi': ApiRouteHandler<{ message: string }, ApiResponse<200, { message: string; from: 'user' | 'assistant'; status: 'created' | 'pending' | 'completed' }>, { topic: 'openai-prompt'; data: { message: string; assistantMessageId: string; threadId: string } }>
     'CheckStateChange': EventHandler<{ key: string; expected: string }, never>


### PR DESCRIPTION
## 📋 Summary

This PR refactors the endpoint components in the Workbench to improve code organization and user experience by introducing a tabbed interface in the endpoint sidebar panel.

## 🎯 What Changed

### ✨ New Features
- **Tabbed Endpoint Sidebar**: Added tabs to organize endpoint information into "Description" and "Call" sections
- **Improved Navigation**: Enhanced visual feedback for selected items in logs and states pages

https://github.com/user-attachments/assets/7a76150c-9b08-4881-8192-88d4848be293


### 🔧 Refactoring
- **Component Split**: Broke down the monolithic `EndpointCall` component into focused, reusable pieces:
  - `EndpointCall` - Focused on API call functionality only
  - `EndpointDescription` - Dedicated component for endpoint documentation
  - `EndpointSidePanel` - Orchestrates the sidebar with tabs
- **Panel Component Simplification**: Streamlined the tabs API by removing unnecessary nested object structure