### PR TITLE
feat: add `--host` option to `dev` command

### DIFF
--- a/packages/docs/content/docs/concepts/cli.mdx
+++ b/packages/docs/content/docs/concepts/cli.mdx
@@ -83,6 +83,7 @@ npx motia dev [options]
 
 Options:
 - `-p, --port <port>`: The port to run the server on (default: 3000).
+- `-H, --host [host]`: The host address for the server (default: localhost).
 - `-v, --verbose`: Enable verbose logging.
 - `-d, --debug`: Enable debug logging.
 

--- a/packages/snap/README.md
+++ b/packages/snap/README.md
@@ -182,6 +182,7 @@ bun run dev  [options]
 
 # options:
   # -p, --port <port>     The port to run the server on (default: 3000)
+  # -H, --host [host]     The host address for the server (default: localhost)
   # -v, --verbose         Enable verbose logging
   # -d, --debug          Enable debug logging
   # -m, --mermaid        Enable mermaid diagram generation

--- a/packages/snap/src/cli.ts
+++ b/packages/snap/src/cli.ts
@@ -2,11 +2,11 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 import { program } from 'commander'
 import path from 'path'
-import fs from 'fs'
 import './cloud'
 import { version } from './version'
 
 const defaultPort = 3000
+const defaultHost = 'localhost'
 
 require('dotenv/config')
 require('ts-node').register({
@@ -80,6 +80,7 @@ program
   .command('dev')
   .description('Start the development server')
   .option('-p, --port <port>', 'The port to run the server on', `${defaultPort}`)
+  .option('-H, --host [host]', 'The host address for the server', `${defaultHost}`)
   .option('-v, --disable-verbose', 'Disable verbose logging')
   .option('-d, --debug', 'Enable debug logging')
   .option('-m, --mermaid', 'Enable mermaid diagram generation')
@@ -90,8 +91,9 @@ program
     }
 
     const port = arg.port ? parseInt(arg.port) : defaultPort
+    const host = arg.host ? arg.host : defaultHost
     const { dev } = require('./dev')
-    await dev(port, arg.disableVerbose, arg.mermaid)
+    await dev(port, host, arg.disableVerbose, arg.mermaid)
   })
 
 program

--- a/packages/snap/src/dev.ts
+++ b/packages/snap/src/dev.ts
@@ -22,7 +22,7 @@ require('ts-node').register({
   compilerOptions: { module: 'commonjs' },
 })
 
-export const dev = async (port: number, disableVerbose: boolean, enableMermaid: boolean): Promise<void> => {
+export const dev = async (port: number, hostname: string, disableVerbose: boolean, enableMermaid: boolean): Promise<void> => {
   const baseDir = process.cwd()
   const isVerbose = !disableVerbose
 
@@ -69,9 +69,9 @@ export const dev = async (port: number, disableVerbose: boolean, enableMermaid: 
 
   stateEndpoints(motiaServer, state)
 
-  motiaServer.server.listen(port)
+  motiaServer.server.listen(port, hostname)
   console.log('🚀 Server ready and listening on port', port)
-  console.log(`🔗 Open http://localhost:${port}/ to open workbench 🛠️`)
+  console.log(`🔗 Open http://${hostname}:${port}/ to open workbench 🛠️`)
 
   trackEvent('dev_server_ready', {
     port,


### PR DESCRIPTION
### Feature: Add `--host` option to `dev` command

#### Summary

This PR adds a new `--host` (`-H`) option to the `dev` command, allowing users to specify the hostname or network interface that the development server should bind to.

#### :sparkles: Changes

* Added `-H, --host [host]` option to the `dev` command.
* Default host is set to `localhost`.

#### :package: Example usage

```bash
motia dev --host 0.0.0.0
# or
motia dev -H 0.0.0.0
```

This will start the dev server on `http://0.0.0.0:3000`, making it accessible over the network.

#### :pencil: Notes

* `-h` was **not** used as the short flag to avoid conflict with the built-in `--help` option.
* Uses `'localhost'` as the default host to preserve existing behavior.
