### PR TITLE
feat: create start command for docker

### DIFF
--- a/packages/snap/src/cli.ts
+++ b/packages/snap/src/cli.ts
@@ -179,6 +179,23 @@ state
     }
   })
 
+program
+  .command('start')
+  .description('Start a server to run your Motia project')
+  .option('-p, --port <port>', 'The port to run the server on', `${defaultPort}`)
+  .option('-v, --disable-verbose', 'Disable verbose logging')
+  .option('-d, --debug', 'Enable debug logging')
+  .action(async (arg) => {
+    if (arg.debug) {
+      console.log('🔍 Debug logging enabled')
+      process.env.LOG_LEVEL = 'debug'
+    }
+
+    const port = arg.port ? parseInt(arg.port) : defaultPort
+    const { start } = require('./start')
+    await start(port, arg.disableVerbose)
+  })
+
 program.version(version, '-V, --version', 'Output the current version')
 
 program.parse(process.argv)

--- a/packages/snap/src/start.ts
+++ b/packages/snap/src/start.ts
@@ -1,0 +1,96 @@
+// packages/snap/src/dev.ts
+import {
+  createEventManager,
+  createMermaidGenerator,
+  createServer,
+  createStateAdapter,
+  getProjectIdentifier,
+  trackEvent,
+} from '@motiadev/core'
+import path from 'path'
+import { flush } from '@amplitude/analytics-node'
+import { generateLockedData, getStepFiles } from './generate-locked-data'
+import { createDevWatchers } from './dev-watchers'
+import { stateEndpoints } from './dev/state-endpoints'
+import { activatePythonVenv } from './utils/activate-python-env'
+import { identifyUser } from './utils/analytics'
+import { version } from './version'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+require('ts-node').register({
+  transpileOnly: true,
+  compilerOptions: { module: 'commonjs' },
+})
+
+export const start = async (port: number, disableVerbose: boolean): Promise<void> => {
+  const baseDir = process.cwd()
+  const isVerbose = !disableVerbose
+
+  identifyUser()
+
+  const stepFiles = getStepFiles(baseDir)
+  const hasPythonFiles = stepFiles.some((file) => file.endsWith('.py'))
+
+  trackEvent('server_started', {
+    port,
+    verbose_mode: isVerbose,
+    has_python_files: hasPythonFiles,
+    total_step_files: stepFiles.length,
+    project_name: getProjectIdentifier(baseDir),
+  })
+
+  if (hasPythonFiles) {
+    console.log('⚙️ Activating Python environment...')
+    activatePythonVenv({ baseDir, isVerbose })
+    trackEvent('python_environment_activated')
+  }
+
+  const lockedData = await generateLockedData(baseDir)
+
+  const eventManager = createEventManager()
+  const state = createStateAdapter({
+    adapter: 'default',
+    filePath: path.join(baseDir, '.motia'),
+  })
+
+  const config = { isVerbose }
+  const motiaServer = createServer(lockedData, eventManager, state, config)
+  // const watcher = createDevWatchers(lockedData, motiaServer, motiaServer.motiaEventManager, motiaServer.cronManager)
+
+  stateEndpoints(motiaServer, state)
+
+  motiaServer.server.listen(port)
+  console.log('🚀 Server ready and listening on port', port)
+  console.log(`🔗 Open http://localhost:${port}/ to open workbench 🛠️`)
+
+  trackEvent('server_ready', {
+    port,
+    flows_count: lockedData.flows?.length || 0,
+    steps_count: lockedData.activeSteps?.length || 0,
+    flows: Object.keys(lockedData.flows || {}),
+    steps: lockedData.activeSteps.map((step) => step.config.name),
+    streams: Object.keys(lockedData.getStreams() || {}),
+    runtime_version: version,
+    environment: process.env.NODE_ENV || 'development',
+  })
+
+  if (!process.env.MOTIA_DOCKER_DISABLE_WORKBENCH) {
+    const { applyMiddleware } = require('@motiadev/workbench/dist/middleware')
+    await applyMiddleware(motiaServer.app)
+  }
+
+  // 6) Gracefully shut down on SIGTERM
+  process.on('SIGTERM', async () => {
+    trackEvent('server_shutdown', { reason: 'SIGTERM' })
+    motiaServer.server.close()
+    await flush().promise
+    process.exit(0)
+  })
+
+  process.on('SIGINT', async () => {
+    trackEvent('server_shutdown', { reason: 'SIGINT' })
+    motiaServer.server.close()
+    await flush().promise
+    process.exit(0)
+  })
+}

--- a/packages/snap/src/utils/analytics.ts
+++ b/packages/snap/src/utils/analytics.ts
@@ -31,6 +31,9 @@ export const identifyUser = () => {
     identifyObj.postInsert('project_id', getProjectName(process.cwd()))
     identifyObj.postInsert('motia_version', version || 'unknown')
     identifyObj.postInsert('project_version', process.env.npm_package_version || 'unknown')
+    if (process.env.MOTIA_DOCKER) {
+      identifyObj.postInsert('docker', true)
+    }
     identify(identifyObj, {
       user_id: getUserIdentifier(),
     })


### PR DESCRIPTION
## Why?

We need to provide a cli command to spin up the dev server boilerplate, but without some features such as the dev watcher, mermaid, and the dev middleware for workbench. In addition we want to be able to conditionally run workbench.

## What?

Create a start command that will spin up a similar boilerplate to the `dev` command but without any file listeners or extra features that are specific to local development.