### PR TITLE
Changed theme to ocean

### DIFF
--- a/packages/docs/app/globals.css
+++ b/packages/docs/app/globals.css
@@ -1,5 +1,5 @@
 @import 'tailwindcss';
-@import 'fumadocs-ui/css/neutral.css';
+@import 'fumadocs-ui/css/ocean.css';
 @import 'fumadocs-ui/css/preset.css';
 
 :root {


### PR DESCRIPTION
This pull request updates the global styles for the documentation site by switching to a new theme.

* [`packages/docs/app/globals.css`](diffhunk://#diff-df369541c52fba6b79092536334335927fdc3c13b58062bfddd8092d9c20f303L2-R2): Replaced the `neutral.css` theme with the `ocean.css` theme to update the visual design of the site.