### PR TITLE
fix: disable the domain check in the vite config used for workbench

### DIFF
--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -18,15 +18,12 @@ export default defineConfig({
       writeBundle() {
         try {
           mkdirSync(resolve(__dirname, 'dist/styles'), { recursive: true })
-          copyFileSync(
-            resolve(__dirname, 'src/styles/globals.css'),
-            resolve(__dirname, 'dist/globals.css')
-          )
+          copyFileSync(resolve(__dirname, 'src/styles/globals.css'), resolve(__dirname, 'dist/globals.css'))
         } catch (err) {
           console.warn('Failed to copy globals.css:', err)
         }
-      }
-    }
+      },
+    },
   ],
   build: {
     lib: {
@@ -50,5 +47,8 @@ export default defineConfig({
     alias: {
       '@': resolve(__dirname, 'src'),
     },
+  },
+  server: {
+    allowedHosts: true, // This will disable the host check
   },
 })


### PR DESCRIPTION
## Why?

Testing the motia-docker implementation and deploying to a cloud provider, the workbench deployment succeeded but it is failing due to the server.allowedHosts config blocking the cloud provider assigned domain.

## What?

- Disable `server.allowedHosts` check for workbench for now in order to unblock progress with motia-docker, we will probably need to make sure this is not causing any vulnerability.

<img width="983" height="206" alt="image" src="https://github.com/user-attachments/assets/b158346f-d047-425d-911e-94b3aaa2e5be" />
