### PR TITLE
chore: update the start command to support overriding the hostname

### DIFF
--- a/packages/snap/src/cli.ts
+++ b/packages/snap/src/cli.ts
@@ -99,6 +99,7 @@ program
   .command('start')
   .description('Start a server to run your Motia project')
   .option('-p, --port <port>', 'The port to run the server on', `${defaultPort}`)
+  .option('-H, --host [host]', 'The host address for the server', `${defaultHost}`)
   .option('-v, --disable-verbose', 'Disable verbose logging')
   .option('-d, --debug', 'Enable debug logging')
   .action(async (arg) => {
@@ -108,8 +109,9 @@ program
     }
 
     const port = arg.port ? parseInt(arg.port) : defaultPort
+    const host = arg.host ? arg.host : defaultHost
     const { start } = require('./start')
-    await start(port, arg.disableVerbose)
+    await start(port, host, arg.disableVerbose)
   })
 
 program

--- a/packages/snap/src/start.ts
+++ b/packages/snap/src/start.ts
@@ -10,7 +10,7 @@ require('ts-node').register({
   compilerOptions: { module: 'commonjs' },
 })
 
-export const start = async (port: number, disableVerbose: boolean): Promise<void> => {
+export const start = async (port: number, hostname: string, disableVerbose: boolean): Promise<void> => {
   const baseDir = process.cwd()
   const isVerbose = !disableVerbose
 
@@ -33,9 +33,9 @@ export const start = async (port: number, disableVerbose: boolean): Promise<void
   const config = { isVerbose }
   const motiaServer = createServer(lockedData, eventManager, state, config)
 
-  motiaServer.server.listen(port)
+  motiaServer.server.listen(port, hostname)
   console.log('🚀 Server ready and listening on port', port)
-  console.log(`🔗 Open http://localhost:${port}/ to open workbench 🛠️`)
+  console.log(`🔗 Open http://${hostname}:${port}/ to open workbench 🛠️`)
 
   if (!process.env.MOTIA_DOCKER_DISABLE_WORKBENCH) {
     stateEndpoints(motiaServer, state)


### PR DESCRIPTION
## What?

Add support to override the hostname for the start command (similar to what is performed in the `dev` command)
