### PR TITLE
fix: change default host to 0.0.0.0 instead of localhost

### DIFF
--- a/packages/docs/content/docs/concepts/deployment/self-hosted.mdx
+++ b/packages/docs/content/docs/concepts/deployment/self-hosted.mdx
@@ -5,6 +5,8 @@ description: Learn how to deploy your Motia project to production using motia-do
 
 We provide a docker image that you can use to deploy your Motia project to production. You can use it as a base image and add your own customizations or use it as is.
 
+<Callout type="warn">You will need to use the latest version of the motia package **0.5.2-beta.101 or higher**</Callout>
+
 ## Using the docker image
 
 You will need to implement your own Dockerfile where you will use the motia-docker image as a base image. Use the following template as a starting point for your Dockerfile:

--- a/packages/snap/src/cli.ts
+++ b/packages/snap/src/cli.ts
@@ -5,7 +5,7 @@ import './cloud'
 import { version } from './version'
 
 const defaultPort = 3000
-const defaultHost = 'localhost'
+const defaultHost = '0.0.0.0'
 
 require('dotenv/config')
 require('ts-node').register({


### PR DESCRIPTION
## What?

- Change the default host to be `0.0.0.0` instead of `localhost`
- Add callout in the motia-docker example to make sure folks use the latest version of the motia package