### PR TITLE
fix: types generation graceful error

### DIFF
--- a/packages/core/src/types/generate-types.ts
+++ b/packages/core/src/types/generate-types.ts
@@ -5,7 +5,7 @@ import { Stream } from '../types-stream'
 import { generateTypeFromSchema } from './generate-type-from-schema'
 import { generateTypesFromResponse } from './generate-types-from-response'
 import { mergeSchemas } from './merge-schemas'
-import { JsonSchema, JsonSchemaError } from './schema.types'
+import { JsonSchema } from './schema.types'
 
 type HandlersMap = Record<string, { type: string; generics: string[] }>
 type StreamsMap = Record<string, string>


### PR DESCRIPTION
We have an user whos struggling to find out the error in types generation

<img width="1181" height="987" alt="image" src="https://github.com/user-attachments/assets/eb57c4b8-e5a1-437e-9e70-59097fa44a2f" />

it's an issue in the schema configuration, but they can't find out which step is failing