### PR TITLE
chore: Added a config file to allow custom configuration for the core module (#516)

### DIFF
--- a/packages/core/core.config.js
+++ b/packages/core/core.config.js
@@ -1,0 +1,10 @@
+const bodyParserOptions = {
+  json: { limit: '100kb'},
+  urlencoded: { limit: '100kb', extended: true },
+}
+
+module.exports = {
+  server: {
+    bodyParser: bodyParserOptions,
+  }
+}

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -6,6 +6,7 @@ import { Server as WsServer } from 'ws'
 import { analyticsEndpoint } from './analytics-endpoint'
 import { trackEvent } from './analytics/utils'
 import { callStepFile } from './call-step-file'
+import coreConfig from '../core.config'
 import { CronManager, setupCronHandlers } from './cron-handler'
 import { flowsConfigEndpoint } from './flows-config-endpoint'
 import { flowsEndpoint } from './flows-endpoint'
@@ -210,8 +211,9 @@ export const createServer = (
     }
   }
 
-  app.use(bodyParser.json())
-  app.use(bodyParser.urlencoded({ extended: true }))
+  const bodyParserOptions = coreConfig.server.bodyParser;
+  app.use(bodyParser.json(bodyParserOptions.json))
+  app.use(bodyParser.urlencoded(bodyParserOptions.urlencoded))
 
   const router = express.Router()
 


### PR DESCRIPTION
This PR addresses #516 by adding a config file to allow configurable options for the core module. Currently it includes the size limit configuration for the bodyparser middleware set to its default 100kb to prevent conflicts with existing functionality. More options can be configured in the file as per user requirements.