### PR TITLE
fix: types generation with interface

### DIFF
--- a/packages/core/src/printer.ts
+++ b/packages/core/src/printer.ts
@@ -15,6 +15,7 @@ const updated = colors.yellow('➜ [UPDATED]')
 const removed = colors.red('➜ [REMOVED]')
 const invalidEmit = colors.red('➜ [INVALID EMIT]')
 const error = colors.red('[ERROR]')
+const warning = colors.yellow('[WARNING]')
 
 export class Printer {
   constructor(private readonly baseDir: string) {}
@@ -67,6 +68,12 @@ export class Printer {
 
   printStreamRemoved(stream: Stream) {
     console.log(`${removed} ${streamTag} ${this.getStreamPath(stream)} removed`)
+  }
+
+  printInvalidEmitConfiguration(step: Step, emit: string) {
+    console.log(
+      `${warning} ${stepTag} ${this.getStepType(step)} ${this.getStepPath(step)} emits to ${colors.yellow(emit)}, but there is no subscriber defined`,
+    )
   }
 
   printInvalidSchema(topic: string, step: Step[]) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -173,4 +173,5 @@ export type Flow = {
   steps: Step[]
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface Handlers {}

--- a/packages/core/src/types/generate-types.ts
+++ b/packages/core/src/types/generate-types.ts
@@ -43,7 +43,16 @@ export const generateTypesFromSteps = (steps: Step[], printer: Printer): Handler
   const topicsSteps: Record<string, Step[]> = {}
 
   for (const step of steps) {
-    if (isEventStep(step) && step.config.input) {
+    if (isEventStep(step)) {
+      if (!step.config.input) {
+        for (const topic of step.config.subscribes) {
+          if (!topics[topic]) {
+            topics[topic] = 'never'
+          }
+        }
+        continue
+      }
+
       for (const topic of step.config.subscribes) {
         const existingSchema = topicsSchemas[topic]
 
@@ -64,7 +73,7 @@ export const generateTypesFromSteps = (steps: Step[], printer: Printer): Handler
     }
   }
 
-  const generateEmitData = (emit: Emit[]): string => {
+  const generateEmitData = (emit: Emit[], step: Step): string => {
     const emits = emit
       .reduce((acc, emit) => {
         const topic = typeof emit === 'string' ? emit : emit.topic
@@ -72,6 +81,8 @@ export const generateTypesFromSteps = (steps: Step[], printer: Printer): Handler
 
         if (topicType) {
           acc.push(`{ topic: '${topic.replace(/'/g, "\\'")}'; data: ${topicType} }`)
+        } else {
+          printer.printInvalidEmitConfiguration(step, topic)
         }
 
         return acc
@@ -82,7 +93,7 @@ export const generateTypesFromSteps = (steps: Step[], printer: Printer): Handler
   }
 
   for (const step of steps) {
-    const emits = 'emits' in step.config ? generateEmitData(step.config.emits) : 'never'
+    const emits = 'emits' in step.config ? generateEmitData(step.config.emits, step) : 'never'
 
     if (isEventStep(step)) {
       const input = step.config.input ? generateTypeFromSchema(step.config.input as never as JsonSchema) : 'never'

--- a/playground/steps/cronExample/handlePeriodicJob.step.ts
+++ b/playground/steps/cronExample/handlePeriodicJob.step.ts
@@ -1,14 +1,19 @@
-import { CronHandler } from 'motia'
+import { CronConfig, Handlers } from 'motia'
 
-export const config = {
-  type: 'event',
+export const config: CronConfig = {
+  type: 'cron',
   name: 'HandlePeriodicJob',
   description: 'Handles the periodic job event',
-  subscribes: ['cron-ticked'],
-  emits: [],
+  cron: '0 */1 * * *',
+  emits: ['periodic-job-handled'],
   flows: ['cron-example'],
 }
 
-export const handler: CronHandler = async ({ logger }) => {
+export const handler: Handlers['HandlePeriodicJob'] = async ({ logger, emit }) => {
   logger.info('Periodic job executed')
+
+  await emit({
+    topic: 'periodic-job-handled',
+    data: { message: 'Periodic job executed' },
+  })
 }

--- a/playground/steps/cronExample/periodicJobHandled.step.ts
+++ b/playground/steps/cronExample/periodicJobHandled.step.ts
@@ -1,0 +1,18 @@
+import { EventConfig, Handlers } from 'motia'
+import { z } from 'zod'
+
+export const config: EventConfig = {
+  type: 'event',
+  name: 'PeriodicJobHandled',
+  description: 'Handles the periodic job event',
+  subscribes: ['periodic-job-handled'],
+  input: z.object({
+    message: z.string(),
+  }),
+  emits: ['tested'],
+  flows: ['cron-example'],
+}
+
+export const handler: Handlers['PeriodicJobHandled'] = async (input, { logger }) => {
+  logger.info('Periodic job executed', { input })
+}

--- a/playground/types.d.ts
+++ b/playground/types.d.ts
@@ -4,7 +4,7 @@
  * 
  * Consider adding this file to .prettierignore and eslint ignore.
  */
-import { EventHandler, ApiRouteHandler, ApiResponse, MotiaStream } from 'motia'
+import { EventHandler, ApiRouteHandler, ApiResponse, CronHandler, MotiaStream } from 'motia'
 
 declare module 'motia' {
   interface FlowContextStateStreams {
@@ -12,7 +12,7 @@ declare module 'motia' {
     'message_python': MotiaStream<{ message: string }>
   }
 
-  type Handlers = {
+  interface Handlers {
     'Test State With Python': EventHandler<unknown, { topic: 'test-state-check'; data: { key: string; expected?: unknown } }>
     'TestStateCheck': EventHandler<{ key: string; expected?: unknown }, never>
     'TestStateApiTrigger': ApiRouteHandler<{}, unknown, { topic: 'test-state-python'; data: unknown }>
@@ -27,10 +27,11 @@ declare module 'motia' {
     'CheckStateChange': EventHandler<{ key: string; expected: string }, never>
     'SetStateChange': EventHandler<{ message: string }, { topic: 'check-state-change'; data: { key: string; expected: string } }>
     'ApiTrigger': ApiRouteHandler<{ message: string }, ApiResponse<200, { message: string; traceId: string }>, { topic: 'test-state'; data: { message: string } }>
-    'HandlePeriodicJob': EventHandler<never, never>
+    'PeriodicJobHandled': EventHandler<{ message: string }, { topic: 'tested'; data: never }>
+    'HandlePeriodicJob': CronHandler<{ topic: 'periodic-job-handled'; data: { message: string } }>
     'Tested Event': EventHandler<never, never>
-    'Test Event': EventHandler<never, never>
-    'Test API Endpoint': ApiRouteHandler<Record<string, unknown>, unknown, never>
+    'Test Event': EventHandler<never, { topic: 'tested'; data: never }>
+    'Test API Endpoint': ApiRouteHandler<Record<string, unknown>, unknown, { topic: 'test'; data: never }>
     'CallOpenAiPython': EventHandler<{ message: string; assistantMessageId: string; threadId: string }, never>
     'OpenAiApiPython': ApiRouteHandler<{ message: string; threadId?: string }, ApiResponse<200, { threadId: string }>, { topic: 'openai-prompt-python'; data: { message: string; assistantMessageId: string; threadId: string } }>
   }


### PR DESCRIPTION
* Making ApiRequest an interface to allow customization in projects
* Making `Handlers` interface to work on other tsconfig
* Adding CronHandler to generated types
* Adding warning to emits without subscribers

<img width="1395" height="75" alt="image" src="https://github.com/user-attachments/assets/8be789d2-cfcf-4a12-923f-bbfd135ab1d1" />
