### PR TITLE
feat: remove express dependency to consolidated APIs

### DIFF
--- a/packages/snap/src/cloud/build/builders/node/index.ts
+++ b/packages/snap/src/cloud/build/builders/node/index.ts
@@ -42,7 +42,12 @@ export class NodeBuilder implements StepBuilder {
       )
       .replace(
         '// {{router paths}}',
-        steps.map((step, index) => `'${step.config.method} ${step.config.path}': { stepName: '${step.config.name}', handler: route${index}.handler, config: route${index}.config }`).join(',\n'),
+        steps
+          .map(
+            (step, index) =>
+              `'${step.config.method} ${step.config.path}': { stepName: '${step.config.name}', handler: route${index}.handler, config: route${index}.config }`,
+          )
+          .join(',\n'),
       )
 
     const tsRouter = path.join(this.builder.distDir, 'router.ts')

--- a/packages/snap/src/cloud/build/builders/node/router-template.ts
+++ b/packages/snap/src/cloud/build/builders/node/router-template.ts
@@ -11,4 +11,3 @@ type RouterPath = {
 export const routerPaths: Record<string, RouterPath> = {
   // {{router paths}}
 }
-


### PR DESCRIPTION
```
var routerPaths = {
  "Parallel Merge": { path: "/api/parallel-merge", method: "POST", handler, config },
  "Get Content": { path: "/content/:contentId", method: "GET", handler: handler2, config: config2 },
  "Content": { path: "/generate-content", method: "POST", handler: handler3, config: config3 }
};
```