### PR TITLE
Fix mobile broken vercel link

### DIFF
--- a/packages/docs/components/ui/Navbar.tsx
+++ b/packages/docs/components/ui/Navbar.tsx
@@ -253,14 +253,14 @@ export default function Navbar() {
           <Link
             href="https://vercel.com/blog/summer-2025-oss-program#motia"
             target="_blank"
-            className="vercel-oss-button gap-2 max-md:hidden"
+            className="vercel-oss-button inline-flex items-center gap-2 max-md:hidden mr-3 leading-none"
           >
             <svg
               aria-label="Vercel logomark"
-              height="15"
+              height="12"
               role="img"
               viewBox="0 0 74 64"
-              className="fill-current"
+              className="fill-current block m-0 p-0"
             >
               <path
                 d="M37.5896 0.25L74.5396 64.25H0.639648L37.5896 0.25Z"


### PR DESCRIPTION
This pull request makes a small UI update to the `Navbar` component. The Vercel OSS link is now only visible on desktop devices and hidden on mobile, improving the navigation experience for mobile users.

* The Vercel OSS link in the `Navbar` is now wrapped in a `div` with the `hidden md:block` classes, making it visible only on medium and larger screens (desktop) and hidden on mobile devices. (`packages/docs/components/ui/Navbar.tsx`) [[1]](diffhunk://#diff-7f51faf9c46aaa6dc33d5511aced48a668ce348110d56fa0bc2f27e622708ba5L251-R257) [[2]](diffhunk://#diff-7f51faf9c46aaa6dc33d5511aced48a668ce348110d56fa0bc2f27e622708ba5R273)