### PR TITLE
add reo beacon

### DIFF
--- a/packages/docs/app/layout.tsx
+++ b/packages/docs/app/layout.tsx
@@ -161,6 +161,16 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <head>
         <GoogleTagManager gtmId={GTM_ID} />
+        {/* Start of Reo Javascript */}
+        <script
+          type="text/javascript"
+          dangerouslySetInnerHTML={{
+            __html: `
+              !function(){var e,t,n;e="d8f0ce9cae8ae64",t=function(){Reo.init({clientID:"d8f0ce9cae8ae64"})},(n=document.createElement("script")).src="https://static.reo.dev/"+e+"/reo.js",n.defer=!0,n.onload=t,document.head.appendChild(n)}();
+            `,
+          }}
+        />
+        {/* End of Reo Javascript */}
         {/* Additional iOS/Safari compatibility */}
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
         <meta name="mobile-web-app-capable" content="yes" />

--- a/packages/workbench/index.html
+++ b/packages/workbench/index.html
@@ -23,6 +23,12 @@
       })
     </script>
 
+    <!-- Start of Reo Javascript -->
+    <script type="text/javascript">
+      !function(){var e,t,n;e="d8f0ce9cae8ae64",t=function(){Reo.init({clientID:"d8f0ce9cae8ae64"})},(n=document.createElement("script")).src="https://static.reo.dev/"+e+"/reo.js",n.defer=!0,n.onload=t,document.head.appendChild(n)}();
+    </script>
+    <!-- End of Reo Javascript -->
+
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Motia Workbench</title>
   </head>


### PR DESCRIPTION
This pull request introduces the Reo JavaScript integration to both the documentation site and the workbench application. The main change is the addition of a script that loads and initializes the Reo client, which may be used for analytics, user engagement, or other third-party functionality.

Integration of Reo JavaScript:

* Added a script in `packages/docs/app/layout.tsx` to load and initialize the Reo client using the provided `clientID` during page rendering.
* Inserted an equivalent script in `packages/workbench/index.html` to ensure Reo is loaded and initialized in the workbench application as well.