### PR TITLE
docs(readme): add Node.js >=20.11.1 requirement in prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,9 @@ We welcome contributions! Check our **[Contributing Guide](https://github.com/Mo
 <sub>⭐ **Star us if you find Motia useful!**</sub>
 
 </div>
+### ⚡ Prerequisites
+
+- Node.js **>=20.11.1**  
+  (Motia specifies this in `package.json` via Volta. We recommend using [Volta](https://volta.sh) or [nvm](https://github.com/nvm-sh/nvm) to manage Node versions.)
+- [pnpm](https://pnpm.io) (Motia uses pnpm for package management)
+


### PR DESCRIPTION
### Summary
This PR updates the README prerequisites to clarify that Motia requires Node.js >=20.11.1.  
The version requirement is defined in `package.json` via Volta, but it wasn’t documented in the README.

### Motivation
While setting up Motia locally, I encountered issues running it with Node.js v18.  
Explicitly mentioning the Node.js >=20.11.1 requirement will help contributors avoid setup errors.

### Changes
- Updated `README.md` prerequisites section to include Node.js >=20.11.1  
- Added recommendation to use Volta or nvm for managing Node versions

---
