### PR TITLE
feat: enhance Panel component with custom tab labels and additional props

### DIFF
--- a/packages/ui/src/components/ui/panel.stories.tsx
+++ b/packages/ui/src/components/ui/panel.stories.tsx
@@ -54,7 +54,16 @@ const meta: Meta<typeof Panel> = {
     },
     tabs: {
       control: 'object',
-      description: 'Tabs configuration with array of tab objects containing label and content',
+      description:
+        'Tabs configuration with array of tab objects { label, content, labelComponent?, data-testid? }',
+    },
+    contentClassName: {
+      control: 'text',
+      description: 'Additional CSS classes to apply to the panel content area',
+    },
+    'data-testid': {
+      control: 'text',
+      description: 'Optional test id for the root panel element',
     },
   },
 }
@@ -297,6 +306,7 @@ export const WithTabs: Story = {
         icon: <Copy />,
         onClick: () => console.log('Copy clicked'),
         label: 'Copy data',
+        active: true,
       },
       {
         icon: <X />,
@@ -580,5 +590,67 @@ export const WithChildren: Story = {
         </div>
       </div>
     ),
+  },
+}
+
+// Tabs with custom label components (icons + text)
+export const TabsWithCustomLabels: Story = {
+  args: {
+    title: 'Analytics',
+    variant: 'default',
+    tabs: [
+      {
+        label: 'Overview',
+        labelComponent: (
+          <div className="flex items-center gap-2">
+            <Activity className="w-4 h-4" />
+            <span>Overview</span>
+          </div>
+        ),
+        content: <div className="text-sm text-muted-foreground">Overview content</div>,
+      },
+      {
+        label: 'Users',
+        labelComponent: (
+          <div className="flex items-center gap-2">
+            <Users className="w-4 h-4" />
+            <span>Users</span>
+          </div>
+        ),
+        content: <div className="text-sm text-muted-foreground">Users content</div>,
+      },
+      {
+        label: 'Settings',
+        labelComponent: (
+          <div className="flex items-center gap-2">
+            <Settings className="w-4 h-4" />
+            <span>Settings</span>
+          </div>
+        ),
+        content: <div className="text-sm text-muted-foreground">Settings content</div>,
+      },
+    ],
+    actions: [
+      {
+        icon: <Copy />,
+        onClick: () => console.log('Copy clicked'),
+        label: 'Copy',
+      },
+    ],
+  },
+}
+
+// Demonstrates custom styling for the content area
+export const WithCustomContentClassName: Story = {
+  args: {
+    title: 'Custom Content Area',
+    subtitle: 'Using contentClassName to style the inner area',
+    variant: 'outlined',
+    contentClassName: 'bg-secondary/30 rounded-md',
+    details: [
+      { label: 'A', value: 'Alpha' },
+      { label: 'B', value: 'Beta', highlighted: true },
+      { label: 'C', value: 'Charlie' },
+    ],
   },
 }

--- a/packages/ui/src/components/ui/panel.tsx
+++ b/packages/ui/src/components/ui/panel.tsx
@@ -18,7 +18,7 @@ export interface PanelAction {
 
 export interface PanelProps {
   'data-testid'?: string
-  title: ReactNode
+  title?: ReactNode
   subtitle?: ReactNode
   details?: PanelDetailItemProps[]
   actions?: PanelAction[]
@@ -28,6 +28,7 @@ export interface PanelProps {
   variant?: 'default' | 'outlined' | 'filled' | 'ghost'
   tabs?: {
     label: string
+    labelComponent?: ReactNode
     content: ReactNode
     'data-testid'?: string
   }[]
@@ -85,8 +86,13 @@ export const Panel: FC<PanelProps> = ({
             })}
           >
             {tabs?.map((tab) => (
-              <TabsTrigger key={tab.label} value={tab.label} data-testid={tab['data-testid']}>
-                {tab.label}
+              <TabsTrigger
+                key={tab.label}
+                value={tab.label}
+                data-testid={tab['data-testid']}
+                className="cursor-pointer"
+              >
+                {tab.labelComponent || tab.label}
               </TabsTrigger>
             ))}
           </TabsList>
@@ -131,44 +137,46 @@ export const Panel: FC<PanelProps> = ({
             'border-b-0': hasTabs,
           })}
         >
-          <div
-            className={cn('flex flex-col gap-1 px-5 py-4', {
-              'px-4 py-3': size === 'sm',
-              'px-5 py-4': size === 'md',
-              'pb-0': hasTabs,
-            })}
-          >
-            <div className="flex items-center w-full">
-              <div
-                className={cn(
-                  'font-semibold text-foreground tracking-[-0.25px] leading-tight flex-1',
-                  size === 'sm' ? 'text-xs' : 'text-base',
-                )}
-              >
-                {title}
-              </div>
-              {actions && actions.length > 0 && (
-                <div className="flex items-center gap-1">
-                  {actions.map((action, index) => (
-                    <Button
-                      key={index}
-                      onClick={action.onClick}
-                      variant="ghost"
-                      className={cn(action.active && 'bg-muted-foreground/20 hover:bg-muted-foreground/30')}
-                      size="icon"
-                      aria-label={action.label}
-                      data-testid="close-panel"
-                    >
-                      {action.icon}
-                    </Button>
-                  ))}
+          {title && (
+            <div
+              className={cn('flex flex-col gap-1 px-5 py-4', {
+                'px-4 py-3': size === 'sm',
+                'px-5 py-4': size === 'md',
+                'pb-0': hasTabs,
+              })}
+            >
+              <div className="flex items-center w-full">
+                <div
+                  className={cn(
+                    'font-semibold text-foreground tracking-[-0.25px] leading-tight flex-1',
+                    size === 'sm' ? 'text-xs' : 'text-base',
+                  )}
+                >
+                  {title}
                 </div>
+                {actions && actions.length > 0 && (
+                  <div className="flex items-center gap-1">
+                    {actions.map((action, index) => (
+                      <Button
+                        key={index}
+                        onClick={action.onClick}
+                        variant="ghost"
+                        className={cn(action.active && 'bg-muted-foreground/20 hover:bg-muted-foreground/30')}
+                        size="icon"
+                        aria-label={action.label}
+                        data-testid="close-panel"
+                      >
+                        {action.icon}
+                      </Button>
+                    ))}
+                  </div>
+                )}
+              </div>
+              {subtitle && (
+                <p className="text-sm font-medium text-muted-foreground tracking-[-0.25px] leading-tight">{subtitle}</p>
               )}
             </div>
-            {subtitle && (
-              <p className="text-sm font-medium text-muted-foreground tracking-[-0.25px] leading-tight">{subtitle}</p>
-            )}
-          </div>
+          )}
         </div>
 
         <div className="flex-1 overflow-auto">{content}</div>

--- a/packages/workbench/src/App.tsx
+++ b/packages/workbench/src/App.tsx
@@ -1,8 +1,8 @@
-import { CollapsiblePanel, CollapsiblePanelGroup, TabsContent, TabsList, TabsTrigger } from '@motiadev/ui'
+import { CollapsiblePanel, CollapsiblePanelGroup, Panel, TabsContent, TabsList, TabsTrigger } from '@motiadev/ui'
 import { ReactFlowProvider } from '@xyflow/react'
 import { analytics } from '@/lib/analytics'
 import { File, GanttChart, Link2, LogsIcon } from 'lucide-react'
-import { FC, useCallback, useMemo } from 'react'
+import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { EndpointsPage } from './components/endpoints/endpoints-page'
 import { FlowPage } from './components/flow/flow-page'
 import { FlowTabMenuItem } from './components/flow/flow-tab-menu-item'
@@ -22,6 +22,7 @@ export const App: FC = () => {
   const tab = useTabsStore((state) => state.tab)
   const setTopTab = useTabsStore((state) => state.setTopTab)
   const setBottomTab = useTabsStore((state) => state.setBottomTab)
+  const [viewMode, setViewMode] = useState<'project' | 'system'>('system')
 
   const tabChangeCallbacks = useMemo<Record<TabLocation, (tab: string) => void>>(
     () => ({
@@ -38,6 +39,49 @@ export const App: FC = () => {
     },
     [tabChangeCallbacks, tab],
   )
+  useEffect(() => {
+    const url = new URL(window.location.href)
+    const viewMode = url.searchParams.get('view-mode') as 'project' | 'system'
+    if (viewMode) {
+      setViewMode(viewMode)
+    }
+  }, [setViewMode])
+
+  if (viewMode === 'project') {
+    return (
+      <div className="grid grid-rows-[auto_1fr] grid-cols-[1fr_auto] bg-background text-foreground h-screen ">
+        <main className="m-2 overflow-hidden" role="main">
+          <Panel
+            className={'py-2'}
+            tabs={[
+              {
+                label: 'Flow',
+                labelComponent: <FlowTabMenuItem />,
+                content: (
+                  <ReactFlowProvider>
+                    <div className="h-[calc(100vh-100px)] w-full">
+                      <FlowPage />
+                    </div>
+                  </ReactFlowProvider>
+                ),
+              },
+              {
+                label: 'Endpoint',
+                labelComponent: (
+                  <>
+                    <Link2 />
+                    Endpoint
+                  </>
+                ),
+                content: <EndpointsPage />,
+              },
+            ]}
+          />
+        </main>
+        <div id={APP_SIDEBAR_CONTAINER_ID} />
+      </div>
+    )
+  }
 
   return (
     <div className="grid grid-rows-[auto_1fr] grid-cols-[1fr_auto] bg-background text-foreground h-screen">

--- a/packages/workbench/src/App.tsx
+++ b/packages/workbench/src/App.tsx
@@ -52,7 +52,6 @@ export const App: FC = () => {
       <div className="grid grid-rows-[auto_1fr] grid-cols-[1fr_auto] bg-background text-foreground h-screen ">
         <main className="m-2 overflow-hidden" role="main">
           <Panel
-            className={'py-2'}
             tabs={[
               {
                 label: 'Flow',

--- a/packages/workbench/src/components/ui/theme-toggle.tsx
+++ b/packages/workbench/src/components/ui/theme-toggle.tsx
@@ -1,7 +1,7 @@
 import { Moon, Sun } from 'lucide-react'
-import { useThemeStore } from '@/stores/use-theme-store'
+import { Theme, useThemeStore } from '@/stores/use-theme-store'
 import { cn } from '@/lib/utils'
-import React from 'react'
+import React, { useEffect } from 'react'
 
 export const ThemeToggle: React.FC = () => {
   const theme = useThemeStore((state) => state.theme)
@@ -10,6 +10,14 @@ export const ThemeToggle: React.FC = () => {
   const toggleTheme = () => {
     setTheme(theme === 'light' ? 'dark' : 'light')
   }
+
+  useEffect(() => {
+    const url = new URL(window.location.href)
+    const colorScheme = url.searchParams.get('color-scheme') as Theme
+    if (colorScheme) {
+      setTheme(colorScheme)
+    }
+  }, [setTheme])
 
   return (
     <button

--- a/packages/workbench/src/stores/use-theme-store.tsx
+++ b/packages/workbench/src/stores/use-theme-store.tsx
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
 
-type Theme = 'dark' | 'light' | 'system'
+export type Theme = 'dark' | 'light' | 'system'
 
 const updateTheme = (theme: Theme) => {
   const root = window.document.body


### PR DESCRIPTION
- Updated PanelProps to include optional title and labelComponent for tabs.
- Added new stories to demonstrate custom tab labels and content styling.
- Improved documentation for tab configuration in stories.
- Added query param to workbench to allow changing the color-scheme  and the view-mode 'project' | 'system'

<img width="1654" height="1390" alt="Screenshot 2025-08-20 at 19 53 45" src="https://github.com/user-attachments/assets/bfbaa7f2-713f-48a9-bcc8-2349abb16ee0" />

