### PR TITLE
updated indexes

### DIFF
--- a/packages/docs/content/docs/concepts/meta.json
+++ b/packages/docs/content/docs/concepts/meta.json
@@ -2,7 +2,6 @@
   "title": "Core Concepts",
   "defaultOpen": true,
   "pages": [
-    "index",
     "steps",
     "flows-and-visualization",
     "state-management", 

--- a/packages/docs/content/docs/getting-started/build-your-first-app/meta.json
+++ b/packages/docs/content/docs/getting-started/build-your-first-app/meta.json
@@ -2,7 +2,6 @@
   "title": "Build Your First Motia App",
   "defaultOpen": true,
   "pages": [
-    "index",
     "creating-your-first-rest-api",
     "build-your-first-background-jobs"
   ]


### PR DESCRIPTION
This pull request makes a minor update to the documentation navigation structure by removing the `index` page from the `pages` array in two `meta.json` files. This change likely affects how the documentation sidebar displays sections.

* Removed the `index` page from the `pages` array in `packages/docs/content/docs/concepts/meta.json`, which may streamline the "Core Concepts" section navigation.
* Removed the `index` page from the `pages` array in `packages/docs/content/docs/getting-started/build-your-first-app/meta.json`, affecting the "Build Your First Motia App" section navigation.