### PR TITLE
fix: removing verbose command from template

### DIFF
--- a/packages/docs/content/docs/concepts/cli.mdx
+++ b/packages/docs/content/docs/concepts/cli.mdx
@@ -92,7 +92,6 @@ Options:
 
 - `-p, --port <port>`: The port to run the server on (default: 3000).
 - `-H, --host [host]`: The host address for the server (default: localhost).
-- `-v, --verbose`: Enable verbose logging.
 - `-d, --debug`: Enable debug logging.
 
 ### `get-config`

--- a/packages/docs/public/llm-docs/concepts/cli.mdx.md
+++ b/packages/docs/public/llm-docs/concepts/cli.mdx.md
@@ -92,7 +92,6 @@ Options:
 
 - `-p, --port <port>`: The port to run the server on (default: 3000).
 - `-H, --host [host]`: The host address for the server (default: localhost).
-- `-v, --verbose`: Enable verbose logging.
 - `-d, --debug`: Enable debug logging.
 
 ### `get-config`

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -369,7 +369,6 @@ Options:
 
 - `-p, --port <port>`: The port to run the server on (default: 3000).
 - `-H, --host [host]`: The host address for the server (default: localhost).
-- `-v, --verbose`: Enable verbose logging.
 - `-d, --debug`: Enable debug logging.
 
 ### `get-config`

--- a/packages/snap/README.md
+++ b/packages/snap/README.md
@@ -98,24 +98,24 @@ Backend teams juggle **fragmented runtimes** across APIs, background queues, and
 
 Motia unifies your entire backend into a **unified state**. APIs, background jobs, and AI agents become interconnected Steps with shared state and integrated observability.
 
-| **Before** | **After (Motia)** |
-|---|---|
-| Multiple deployment targets | **Single unified deployment** |
-| Fragmented observability | **End-to-end tracing** |
-| Language dependent | **JavaScript, TypeScript, Python, etc** |
-| Context-switching overhead | **Single intuitive model** |
-| Complex error handling | **Automatic retries & fault tolerance** |
+| **Before**                  | **After (Motia)**                       |
+| --------------------------- | --------------------------------------- |
+| Multiple deployment targets | **Single unified deployment**           |
+| Fragmented observability    | **End-to-end tracing**                  |
+| Language dependent          | **JavaScript, TypeScript, Python, etc** |
+| Context-switching overhead  | **Single intuitive model**              |
+| Complex error handling      | **Automatic retries & fault tolerance** |
 
 ---
 
 ## 🔧 Supported Step Types
 
-| Type | Trigger | Use Case |
-|---|---|---|
-| **`api`** | HTTP Request | Expose REST endpoints |
-| **`event`** | Emitted Topics | React to internal or external events  |
-| **`cron`** | Scheduled Time (cron) | Automate recurring jobs |
-| **`noop`** | None | Placeholder for manual/external tasks |
+| Type        | Trigger               | Use Case                              |
+| ----------- | --------------------- | ------------------------------------- |
+| **`api`**   | HTTP Request          | Expose REST endpoints                 |
+| **`event`** | Emitted Topics        | React to internal or external events  |
+| **`cron`**  | Scheduled Time (cron) | Automate recurring jobs               |
+| **`noop`**  | None                  | Placeholder for manual/external tasks |
 
 ---
 
@@ -123,9 +123,9 @@ Motia unifies your entire backend into a **unified state**. APIs, background job
 
 Motia's architecture is built around a single, powerful primitive: the **Step**. A Step is not just a trigger; it's a powerful container for your business logic. You can write anything from a simple database query to a complex AI agent interaction inside a single step. Instead of managing separate services for APIs, background workers, and scheduled tasks, you simply define how your steps are triggered.
 
--   **Need a public API?** Create an `api` step. This defines a route and handler for HTTP requests. You can build a complete REST or GraphQL API just with these steps.
--   **Need a background job or queue?** Have your `api` step `emit` an event. An `event` step subscribed to that event's topic will pick up the job and process it asynchronously. This is how you handle anything that shouldn't block the main request thread, from sending emails to complex data processing.
--   **Need to run a task on a schedule?** Use a `cron` step. It will trigger automatically based on the schedule you define.
+- **Need a public API?** Create an `api` step. This defines a route and handler for HTTP requests. You can build a complete REST or GraphQL API just with these steps.
+- **Need a background job or queue?** Have your `api` step `emit` an event. An `event` step subscribed to that event's topic will pick up the job and process it asynchronously. This is how you handle anything that shouldn't block the main request thread, from sending emails to complex data processing.
+- **Need to run a task on a schedule?** Use a `cron` step. It will trigger automatically based on the schedule you define.
 
 This model means you no longer need to glue together separate frameworks and tools. A single Motia application can replace a stack that might otherwise include **Nest.js** (for APIs), **Temporal** (for workflows), and **Celery/BullMQ** (for background jobs). It's all just steps and events.
 
@@ -173,9 +173,9 @@ Motia unifies your entire backend into a **unified state**. APIs, background job
 
 Motia's architecture is built around a single, powerful primitive: the **Step**. A Step is not just a trigger; it's a powerful container for your business logic. You can write anything from a simple database query to a complex AI agent interaction inside a single step. Instead of managing separate services for APIs, background workers, and scheduled tasks, you simply define how your steps are triggered.
 
--   **Need a public API?** Create an `api` step. This defines a route and handler for HTTP requests. You can build a complete REST or GraphQL API just with these steps.
--   **Need a background job or queue?** Have your `api` step `emit` an event. An `event` step subscribed to that event's topic will pick up the job and process it asynchronously. This is how you handle anything that shouldn't block the main request thread, from sending emails to complex data processing.
--   **Need to run a task on a schedule?** Use a `cron` step. It will trigger automatically based on the schedule you define.
+- **Need a public API?** Create an `api` step. This defines a route and handler for HTTP requests. You can build a complete REST or GraphQL API just with these steps.
+- **Need a background job or queue?** Have your `api` step `emit` an event. An `event` step subscribed to that event's topic will pick up the job and process it asynchronously. This is how you handle anything that shouldn't block the main request thread, from sending emails to complex data processing.
+- **Need to run a task on a schedule?** Use a `cron` step. It will trigger automatically based on the schedule you define.
 
 This model means you no longer need to glue together separate frameworks and tools. A single Motia application can replace a stack that might otherwise include **Nest.js** (for APIs), **Temporal** (for workflows), and **Celery/BullMQ** (for background jobs). It's all just steps and events.
 
@@ -184,24 +184,31 @@ This model means you no longer need to glue together separate frameworks and too
 The **Step** is Motia's core primitive. The following concepts are deeply integrated with Steps to help you build powerful, complex, and scalable backends:
 
 ### 🔑 Steps & Step Types
+
 Understand the three ways Steps are triggered:
+
 - **HTTP (`api`)** – Build REST/GraphQL endpoints with zero boilerplate.
 - **Events (`event`)** – React to internal or external events emitted by other steps.
 - **Cron (`cron`)** – Schedule recurring jobs with a familiar cron syntax.
 
 ### 📣 Emit & Subscribe (Event-Driven Workflows)
+
 Steps talk to each other by **emitting** and **subscribing** to topics. This decouples producers from consumers and lets you compose complex workflows with simple, declarative code.
 
 ### 🏪 State Management
+
 All steps share a unified key-value state store. Every `get`, `set`, and `delete` is automatically traced so you always know when and where your data changed.
 
 ### 📊 Structured Logging
+
 Motia provides structured, JSON logs correlated with trace IDs and step names. Search and filter your logs without regex gymnastics.
 
 ### 📡 Streams: Real-time Messaging
+
 Push live updates from long-running or asynchronous workflows to clients without polling. Perfect for dashboards, progress indicators, and interactive AI agents.
 
 ### 👁️ End-to-End Observability with Traces
+
 Every execution generates a full trace, capturing step timelines, state operations, emits, stream calls, and logs. Visualise everything in the Workbench's Traces UI and debug faster.
 
 ---
@@ -211,7 +218,9 @@ Every execution generates a full trace, capturing step timelines, state operatio
 Motia comes with a range of [powerful CLI commands](https://www.motia.dev/docs/concepts/cli) to help you manage your projects:
 
 ### `npx motia create [options]`
+
 Create a new Motia project in a fresh directory or the current one.
+
 ```sh
 npx motia create [options]
 
@@ -238,12 +247,12 @@ bun run dev  [options]
 # options:
   # -p, --port <port>     The port to run the server on (default: 3000)
   # -H, --host [host]     The host address for the server (default: localhost)
-  # -v, --verbose         Enable verbose logging
   # -d, --debug          Enable debug logging
   # -m, --mermaid        Enable mermaid diagram generation
 ```
 
 ### `npx motia build`
+
 Compiles all your steps (Node.js, Python and more) and builds a lock file based on your current project setup, which is then used by the Motia ecosystem.
 
 ```bash
@@ -256,12 +265,12 @@ motia build
 
 Write steps in your preferred language:
 
-| Language       | Status        | Example           |
-| -------------- | ------------- | ----------------- |
+| Language       | Status         | Example           |
+| -------------- | -------------- | ----------------- |
 | **JavaScript** | ✅ Stable      | `handler.step.js` |
 | **TypeScript** | ✅ Stable      | `handler.step.ts` |
 | **Python**     | ✅ Stable      | `handler.step.py` |
-| **Ruby**       | 🚧 Beta | `handler.step.rb` |
+| **Ruby**       | 🚧 Beta        | `handler.step.rb` |
 | **Go**         | 🔄 Coming Soon | `handler.step.go` |
 | **Rust**       | 🔄 Coming Soon | `handler.step.rs` |
 
@@ -276,6 +285,7 @@ motia <command> --help
 ```
 
 ### 💬 **Get Help**
+
 - **📋 Questions**: Use our [Discord community](https://discord.gg/motia)
 - **🐛 Bug Reports**: [GitHub Issues](https://github.com/MotiaDev/motia/issues)
 - **📖 Documentation**: [Official Docs](https://motia.dev/docs)
@@ -284,6 +294,7 @@ motia <command> --help
 ### 🤝 **Contributing**
 
 We welcome contributions! Whether it's:
+
 - 🐛 Bug fixes and improvements
 - ✨ New features and step types
 - 📚 Documentation and examples

--- a/packages/snap/src/create/index.ts
+++ b/packages/snap/src/create/index.ts
@@ -130,7 +130,6 @@ export const create = async ({ projectName, template, cursorEnabled, context }: 
       scripts: {
         postinstall: 'motia install',
         dev: 'motia dev',
-        'dev:debug': 'motia dev --verbose',
         'generate-types': 'motia generate-types',
         build: 'motia build',
         clean: 'rm -rf dist node_modules python_modules .motia .mermaid',

--- a/playground/package.json
+++ b/playground/package.json
@@ -5,7 +5,6 @@
     "python-setup": "python3 -m venv python_modules && python_modules/bin/pip install -r requirements.txt && python_modules/bin/pip install -r ../packages/core/requirements.txt",
     "dev": "motia dev",
     "dev:workbench": "__MOTIA_DEV_MODE__=1 motia dev",
-    "dev:debug": "motia dev --debug",
     "clean": "rm -rf .mermaid node_modules python_modules",
     "get-config": "motia get-config --output ./",
     "test:tsc-check": "tsc -p ./tests/tsconfig.test.json --noEmit",


### PR DESCRIPTION
--verbose flag was removed a while ago but still exist in package.json generated by the template