### PR TITLE
Fix: Tutorial Grammar and Primitives

### DIFF
--- a/playground/steps/basic-tutorial/api.step.ts-features.json
+++ b/playground/steps/basic-tutorial/api.step.ts-features.json
@@ -2,7 +2,7 @@
   {
     "id": "step-configuration",
     "title": "Step Configuration",
-    "description": "All steps should have a defined configuration, this is how you define the step's behavior and how it will be triggered.",
+    "description": "All steps should have a defined configuration. This is how you define the step's behavior and how it will be triggered.",
     "lines": [
       "6-30"
     ]
@@ -26,7 +26,7 @@
   {
     "id": "response-payload",
     "title": "Response Payload",
-    "description": "Definition of the expected response payload, Motia will generate the types automatically based on this schema. This is also important to create the Open API spec later.",
+    "description": "Definition of the expected response payload. Motia will generate the types automatically based on this schema. This is also important to create the Open API spec later.",
     "lines": [
       "26-28"
     ]
@@ -34,7 +34,7 @@
   {
     "id": "event-driven-architecture",
     "title": "Emits",
-    "description": "We can define the events that this step will emit, this is how we can trigger other Motia Steps.",
+    "description": "We can define the events that this step will emit. This is how we can trigger other Motia steps.",
     "lines": [
       "29",
       "39-46"
@@ -59,7 +59,7 @@
   {
     "id": "http-response",
     "title": "HTTP Response",
-    "description": "The handler can return a response to the client. This is how we can return a response to the client. It must comply with the responseSchema defined in the step configuration.",
+    "description": "The handler can return a response to the client. It must comply with the responseSchema defined in the step configuration.",
     "lines": [
       "49"
     ]

--- a/playground/steps/basic-tutorial/process-food-order.step.ts-features.json
+++ b/playground/steps/basic-tutorial/process-food-order.step.ts-features.json
@@ -2,7 +2,7 @@
   {
     "id": "step-configuration",
     "title": "Step Configuration",
-    "description": "All steps should have a defined configuration, this is how you define the step's behavior and how it will be triggered.",
+    "description": "All steps should have a defined configuration. This is how you define the step's behavior and how it will be triggered.",
     "lines": [
       "5-17"
     ]
@@ -27,7 +27,7 @@
   {
     "id": "event-emits",
     "title": "Emits",
-    "description": "We can define the events that this step will emit, triggering other Motia Steps.",
+    "description": "We can define the events that this step will emit, triggering other Motia steps.",
     "lines": [
       "11"
     ]

--- a/playground/steps/basic-tutorial/state-audit-cron.step.ts-features.json
+++ b/playground/steps/basic-tutorial/state-audit-cron.step.ts-features.json
@@ -2,7 +2,7 @@
   {
     "id": "step-configuration",
     "title": "Step Configuration",
-    "description": "All steps should have a defined configuration, this is how you define the step's behavior and how it will be triggered.",
+    "description": "All steps should have a defined configuration. This is how you define the step's behavior and how it will be triggered.",
     "lines": [
       "3-10"
     ]

--- a/playground/tutorial.tsx
+++ b/playground/tutorial.tsx
@@ -63,12 +63,12 @@ export const steps: TutorialStep[] = [
           <br />
           <br />
           Let's start with the configuration, the common config attributes are
-          <i>type, name, description, and flows</i>.<br />
+          <i> type, name, description, and flows</i>.<br />
           <br />
         </p>
         <ul>
           <li>
-            The <b>type</b> attribute is important since it declares the type of Step primitive
+            The <b>type</b> attribute is important since it declares the type of step
           </li>
           <li>
             The <b>flows</b> attribute will associate your Step with a given flow or set of flows.
@@ -202,8 +202,8 @@ export const steps: TutorialStep[] = [
       <p>
         Now that we have an entry point in our flow, let's focus on subscribing to a <b>topic</b> and performing a
         specific task.
-        <br /> For this we will look at the <b>Event</b> Step.
-        <b>Event</b> Steps are an essential primitive for Motia's event driven architecture. Let's dive deeper into the
+        <br /> For this we will look at the <b>Event</b> Step. 
+        <b> Event</b> Steps are an essential step type for Motia's event driven architecture. Let's dive deeper into the
         anatomy of an Event Step by taking a look at the code visualization tool.
         <br />
         💡 <b>Event</b> Steps can only be triggered internally, through topic subscriptions.
@@ -222,7 +222,7 @@ export const steps: TutorialStep[] = [
         <br /> <br />
         For this we will look at the <b>Event</b> Step.
         <br /> <br />
-        <b>Event</b> Steps are an essential primitive for Motia's event driven architecture. Let's dive deeper into the
+        <b>Event</b> Steps are an essential step type for Motia's event driven architecture. Let's dive deeper into the
         anatomy of an Event Step by taking a look at the code visualization tool.
         <br /> <br />
         💡 <b>Event</b> Steps can only be triggered internally, through topic subscriptions.
@@ -238,7 +238,7 @@ export const steps: TutorialStep[] = [
     title: 'Event Step Input',
     description: () => (
       <p>
-        <b>Event</b> Steps like other primitives are composed by a configuration and a handler.
+        <b>Event</b> Steps like other step types are composed by a configuration and a handler.
         <br />
         <br />
         <b>Event</b> Steps have a specific attribute from their config, the <b>input</b> attribute, which declares the
@@ -261,7 +261,7 @@ export const steps: TutorialStep[] = [
         Let's take a look at the <b>Event</b> Step Handler.
         <br />
         <br />
-        The handler will seem familiar other primitive Step Handlers, but notice that the first argument holds the data
+        The handler will seem familiar to other step type handlers, but notice that the first argument holds the data
         provided for the topic or topics your Step subscribes to.
         <br />
         <br />
@@ -294,12 +294,12 @@ export const steps: TutorialStep[] = [
     link: 'https://www.motia.dev/docs/concepts/steps/cron',
     description: () => (
       <p>
-        Let's do a recap of what you've learned, thus far you've become familiar with three Motia primitives <b>API</b>{' '}
+        Let's do a recap of what you've learned, thus far you've become familiar with two step types: <b>API</b>{' '}
         and <b>Event</b> Steps.
         <br />
         <br />
-        You've also started to learn how to navigate around Workbench. Let's wrap up Motia's primitives with the last
-        one the <b>CRON</b> Step. Let's take a deeper look at its definition.
+        You've also started to learn how to navigate around Workbench. Let's wrap up the step types with the last
+        one: the <b>CRON</b> Step. Let's take a deeper look at its definition.
       </p>
     ),
     before: [{ type: 'click', selector: workbenchXPath.closePanelButton }],
@@ -310,7 +310,7 @@ export const steps: TutorialStep[] = [
     link: 'https://www.motia.dev/docs/concepts/steps/cron',
     description: () => (
       <p>
-        <b>CRON</b> Steps are similar to the other primitives, they are composed by a configuration and a handler.
+        <b>CRON</b> Steps are similar to the other step types, they are composed by a configuration and a handler.
         <br />
         <br />
         The <b>CRON</b> Step config has a distinct attribute, the <b>cron</b> attribute, through this attribute you will
@@ -350,7 +350,7 @@ export const steps: TutorialStep[] = [
     title: 'Endpoints',
     description: () => (
       <p>
-        Now that we've looked at Motia primitives, let's trigger the API Step from the <b>endpoints</b> section in
+        Now that we've looked at Motia step types, let's trigger the API Step from the <b>endpoints</b> section in
         Workbench.
         <br />
         <br />
@@ -606,7 +606,7 @@ export const steps: TutorialStep[] = [
         You've completed our Motia basics tutorial!
         <br />
         <br />
-        You've learned about Motia's primitives, how to navigate around Workbench, and how to use core features from the
+        You've learned about Motia's step types, how to navigate around Workbench, and how to use core features from the
         Motia Framework (State Management, Logging, and Tracing).
         <br />
         <br />


### PR DESCRIPTION
This pull request focuses on improving the clarity and consistency of terminology in the Motia tutorial and related configuration files. The main changes involve rewording descriptions and updating references to "primitives" to "step types" for better accuracy and readability.

### Terminology and Clarity Improvements

* Updated various tutorial descriptions in `playground/tutorial.tsx` to use "step type" instead of "primitive" and made related phrasing more consistent and clear. This includes sections describing API, Event, and CRON steps, as well as general references to Motia's architecture. [[1]](diffhunk://#diff-6c8d1837f7a9a93277ea155bda59e9bd45b7946b8d8f5a257cb07f7ece1e1c50L71-R71) [[2]](diffhunk://#diff-6c8d1837f7a9a93277ea155bda59e9bd45b7946b8d8f5a257cb07f7ece1e1c50L206-R206) [[3]](diffhunk://#diff-6c8d1837f7a9a93277ea155bda59e9bd45b7946b8d8f5a257cb07f7ece1e1c50L225-R225) [[4]](diffhunk://#diff-6c8d1837f7a9a93277ea155bda59e9bd45b7946b8d8f5a257cb07f7ece1e1c50L241-R241) [[5]](diffhunk://#diff-6c8d1837f7a9a93277ea155bda59e9bd45b7946b8d8f5a257cb07f7ece1e1c50L264-R264) [[6]](diffhunk://#diff-6c8d1837f7a9a93277ea155bda59e9bd45b7946b8d8f5a257cb07f7ece1e1c50L297-R302) [[7]](diffhunk://#diff-6c8d1837f7a9a93277ea155bda59e9bd45b7946b8d8f5a257cb07f7ece1e1c50L313-R313) [[8]](diffhunk://#diff-6c8d1837f7a9a93277ea155bda59e9bd45b7946b8d8f5a257cb07f7ece1e1c50L353-R353) [[9]](diffhunk://#diff-6c8d1837f7a9a93277ea155bda59e9bd45b7946b8d8f5a257cb07f7ece1e1c50L609-R609)

### Documentation and Description Refinements

* Improved the grammar and clarity of step descriptions in the JSON feature files for API, process-food-order, and state-audit-cron steps. This includes splitting run-on sentences and standardizing capitalization and terminology. [[1]](diffhunk://#diff-7d3e21378b41fa1c70a6104b9292ddedcded0e92ab4cdb9b78436e6cbb6eb45eL5-R5) [[2]](diffhunk://#diff-7d3e21378b41fa1c70a6104b9292ddedcded0e92ab4cdb9b78436e6cbb6eb45eL29-R37) [[3]](diffhunk://#diff-7d3e21378b41fa1c70a6104b9292ddedcded0e92ab4cdb9b78436e6cbb6eb45eL62-R62) [[4]](diffhunk://#diff-5eaacf105eabed3cbe3a951ae03d578809eb4702f43c355cb3c205c5b967d98cL5-R5) [[5]](diffhunk://#diff-5eaacf105eabed3cbe3a951ae03d578809eb4702f43c355cb3c205c5b967d98cL30-R30) [[6]](diffhunk://#diff-312704eda05de0ddce5e1828b683dfa833c2120e45899636cedead72c4df0b7dL5-R5)