### PR TITLE
feat: add deprecation warning for .step.py Python files

### DIFF
--- a/packages/snap/src/cloud/build/build-validation.ts
+++ b/packages/snap/src/cloud/build/build-validation.ts
@@ -29,7 +29,7 @@ export const validateStepsConfig = (builder: Builder) => {
   // Check for deprecated .step.py pattern
   const deprecatedPythonSteps = globSync('**/*.step.py', {
     absolute: true,
-    cwd: path.join(builder.projectDir, 'steps')
+    cwd: path.join(builder.projectDir, 'steps'),
   })
 
   if (deprecatedPythonSteps.length > 0) {
@@ -40,11 +40,11 @@ export const validateStepsConfig = (builder: Builder) => {
         `Please rename them to ${colors.green('_step.py')} format.`,
         '',
         'Deprecated files:',
-        ...deprecatedPythonSteps.map(stepPath => {
+        ...deprecatedPythonSteps.map((stepPath) => {
           const relative = path.relative(builder.projectDir, stepPath)
           const newName = relative.replace('.step.py', '_step.py')
           return `  ${colors.yellow('➜')} ${colors.cyan(relative)} → ${colors.green(newName)}`
-        })
+        }),
       ].join('\n'),
       step: Object.values(builder.stepsConfig)[0], // Use first step as reference
     })


### PR DESCRIPTION
## Summary

Adds deprecation warnings for Python step files using the `.step.py` extension, guiding users to migrate to the new `_step.py` naming convention.

## Changes

- Detects deprecated `.step.py` files in the steps directory
- Shows clear migration path with before/after file names
- Non-blocking warnings that don't prevent builds

## Example Output
```
Python steps with .step.py extension are deprecated.
Please rename them to _step.py format.

Deprecated files:
  ➜ auth/login.step.py → auth/login_step.py
```

<img width="762" height="76" alt="image" src="https://github.com/user-attachments/assets/973d9420-8848-43b8-afbf-93f43d75bd23" />
