### PR TITLE
fix: handle optional deployment URL in progress message and ensure correct response data retrieval

### DIFF
--- a/packages/snap/src/cloud/new-deployment/cloud-api/start-deployment.ts
+++ b/packages/snap/src/cloud/new-deployment/cloud-api/start-deployment.ts
@@ -15,5 +15,6 @@ type StartDeploymentResult = {
 }
 
 export const startDeployment = async (request: StartDeploymentRequest): Promise<StartDeploymentResult> => {
-  return axios.post<StartDeploymentRequest, StartDeploymentResult>(cloudEndpoints.startDeployment, request)
+  const response = await axios.post<StartDeploymentResult>(cloudEndpoints.startDeployment, request)
+  return response.data
 }

--- a/packages/snap/src/cloud/new-deployment/deploy.ts
+++ b/packages/snap/src/cloud/new-deployment/deploy.ts
@@ -60,7 +60,7 @@ export const deploy = async (input: DeployInput): Promise<void> => {
     context.log('deploy-progress', (message) =>
       message
         .tag('progress')
-        .append(`Deployment in progress... You can view the deployment at ${response.deploymentUrl}`),
+        .append(`Deployment in progress... You can view the deployment at ${response?.deploymentUrl}`),
     )
     client.close()
   }


### PR DESCRIPTION
Fixes deployment URL handling to prevent undefined references and ensure proper response data retrieval.

## Changes

- Handle optional deployment URL in CI deployment progress messages using optional chaining
- Ensure correct response data retrieval in `startDeployment` function

## Files Modified

- `packages/snap/src/cloud/new-deployment/cloud-api/start-deployment.ts`
- `packages/snap/src/cloud/new-deployment/deploy.ts`

This prevents potential runtime errors when deployment URL is not available in the response.