### PR TITLE
fix: make stream item id conditionall to allow for id's that can have a dynamic value

### DIFF
--- a/packages/stream-client-react/src/use-stream-item.ts
+++ b/packages/stream-client-react/src/use-stream-item.ts
@@ -5,7 +5,7 @@ import { useMotiaStream } from './use-motia-stream'
 export type StreamItemArgs = {
   streamName: string
   groupId: string
-  id: string
+  id?: string
 }
 
 /**


### PR DESCRIPTION
## Why?

The current implementation allows for an id to not be present, and skip setting up the stream until it is defined, but the type definion only makes the args optional, causing dynamic id values to force unnecessary patterns in react apps.

i.e.: a record id is used as the `id` for the stream, that record id might be `null` depending on what the user has selected, instead of having to mount/unmount a component with the hook just to get the stream, we can just make the id optinal and the logic inside the useEffect should already handle conditionally setting up the stream (this is similar to how a useQuery from the graphql client sdk would behave to only execute when the enabled flag is turned on).