### PR TITLE
Add OpenAPI generation command and Ruby API step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ agents/**/components/
 .mermaid/
 
 playground/motia-workbench.json
+playground/openapi.json

--- a/packages/docs/content/docs/concepts/cli.mdx
+++ b/packages/docs/content/docs/concepts/cli.mdx
@@ -127,6 +127,13 @@ Options:
 
 - `-d, --dir <step file path>`: The path relative to the steps directory to create the step file.
 
+#### `generate openapi`
+
+Generate OpenAPI spec for your project.
+
+```bash
+npx motia generate openapi
+```
 ### `state`
 
 Manage application state.

--- a/packages/e2e/tests/release/cli/cli-validation.spec.ts
+++ b/packages/e2e/tests/release/cli/cli-validation.spec.ts
@@ -60,6 +60,32 @@ test.describe('CLI Validation', () => {
     }
   })
 
+
+  test('should generate openapi.json with correct content', async () => {
+    const openapiPath = path.join(testProjectPath, 'openapi.json')
+
+    try {
+      console.log(`Running 'npx motia generate openapi' in ${testProjectPath}`);
+      execSync('npx motia generate openapi', {
+        cwd: testProjectPath,
+        stdio: 'inherit',
+      })
+    } catch (error) {
+      console.error('Error generating openapi.json:', error)
+      expect(error).toBeNull()
+    }
+
+    expect(existsSync(openapiPath)).toBeTruthy()
+
+    const openapiJson = JSON.parse(readFileSync(openapiPath, 'utf8'))
+
+    expect(openapiJson.openapi).toBe('3.0.0')
+    expect(openapiJson.info.title).toBe('Motia Project API')
+    expect(openapiJson.paths).toBeDefined()
+
+    expect(JSON.stringify(openapiJson, null, 2)).toMatchSnapshot('openapi.json')
+  })
+
   test('should build project successfully', async () => {
     try {
       execSync('npm run build', {

--- a/packages/e2e/tests/release/cli/cli-validation.spec.ts
+++ b/packages/e2e/tests/release/cli/cli-validation.spec.ts
@@ -80,7 +80,7 @@ test.describe('CLI Validation', () => {
     const openapiJson = JSON.parse(readFileSync(openapiPath, 'utf8'))
 
     expect(openapiJson.openapi).toBe('3.0.0')
-    expect(openapiJson.info.title).toBe('Motia Project API')
+    expect(openapiJson.info.title).toBe('motia-e2e-test-project')
     expect(openapiJson.paths).toBeDefined()
 
     expect(JSON.stringify(openapiJson, null, 2)).toMatchSnapshot('openapi.json')

--- a/packages/e2e/tests/release/cli/cli-validation.spec.ts
+++ b/packages/e2e/tests/release/cli/cli-validation.spec.ts
@@ -77,13 +77,7 @@ test.describe('CLI Validation', () => {
 
     expect(existsSync(openapiPath)).toBeTruthy()
 
-    const openapiJson = JSON.parse(readFileSync(openapiPath, 'utf8'))
-
-    expect(openapiJson.openapi).toBe('3.0.0')
-    expect(openapiJson.info.title).toBe('motia-e2e-test-project')
-    expect(openapiJson.paths).toBeDefined()
-
-    expect(JSON.stringify(openapiJson, null, 2)).toMatchSnapshot('openapi.json')
+    expect(readFileSync(openapiPath, 'utf8')).toMatchSnapshot('openapi.json')
   })
 
   test('should build project successfully', async () => {

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -68,6 +68,7 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "typescript": "^5.7.2",
-    "typescript-transform-paths": "^3.5.3"
+    "typescript-transform-paths": "^3.5.3",
+    "openapi-types": "^12.1.3"
   }
 }

--- a/packages/snap/src/cli.ts
+++ b/packages/snap/src/cli.ts
@@ -2,8 +2,8 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 import { program } from 'commander'
 import './cloud'
-import { version } from './version'
 import { handler } from './cloud/config-utils'
+import { version } from './version'
 
 const defaultPort = 3000
 const defaultHost = '0.0.0.0'
@@ -159,6 +159,17 @@ generate
     await createStep({
       stepFilePath: arg.dir,
     })
+  })
+
+generate
+  .command('openapi')
+  .description('Generate OpenAPI spec for your project')
+  .option('-t, --title <title>', 'Title for the OpenAPI document')
+  .option('-v, --version <version>', 'Version for the OpenAPI document', '1.0.0')
+  .action(async (options) => {
+    const { generateOpenApi } = require('./generate-openapi')
+    await generateOpenApi(process.cwd(), options.title, options.version)
+    process.exit(0)
   })
 
 const docker = program.command('docker').description('Motia docker commands')

--- a/packages/snap/src/generate-locked-data.ts
+++ b/packages/snap/src/generate-locked-data.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto'
 import { globSync } from 'glob'
 import path from 'path'
 import { CompilationError } from './utils/errors/compilation.error'
+import { activatePythonVenv } from './utils/activate-python-env'
 
 const version = `${randomUUID()}:${Math.floor(Date.now() / 1000)}`
 
@@ -30,6 +31,12 @@ export const collectFlows = async (projectDir: string, lockedData: LockedData): 
   const stepFiles = getStepFiles(projectDir)
   const streamFiles = getStreamFiles(projectDir)
   const deprecatedSteps = globSync('**/*.step.py', { absolute: true, cwd: path.join(projectDir, 'steps') })
+
+  const hasPythonFiles = stepFiles.some((file) => file.endsWith('.py'));
+
+  if (hasPythonFiles) {
+    activatePythonVenv({ baseDir: projectDir });
+  }
 
   for (const filePath of stepFiles) {
     try {

--- a/packages/snap/src/generate-openapi.ts
+++ b/packages/snap/src/generate-openapi.ts
@@ -1,0 +1,175 @@
+
+import { LockedData } from '@motiadev/core';
+import * as fs from 'fs';
+import { OpenAPIV3 } from 'openapi-types';
+import * as path from 'path';
+import { generateLockedData } from './generate-locked-data';
+
+export async function generateOpenApi(projectDir: string, title?: string, version?: string) {
+  const lockedData: LockedData = await generateLockedData(projectDir);
+  const apiSteps = lockedData.apiSteps();
+
+  // read package.json to get project name for default title & version
+  if (!title || !version) {
+    try {
+      const packageJsonPath = path.join(projectDir, 'package.json');
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+      title = packageJson.name;
+      version = packageJson.version;
+    } catch (error) {
+      console.warn(`Could not read package.json in ${projectDir} to determine project name. Using default.`);
+    }
+  }
+
+  const openApi: OpenAPIV3.Document = {
+    openapi: '3.0.0',
+    info: {
+      title: title ?? 'Motia Project API',
+      version: version ?? '1.0.0',
+    },
+    paths: {},
+    components: {
+      schemas: {},
+    },
+  };
+
+  for (const step of apiSteps) {
+    const pathItem = openApi.paths[step.config.path] || {};
+    const method = step.config.method.toLowerCase();
+
+    const operation: OpenAPIV3.OperationObject = {
+      summary: step.config.name,
+      description: step.config.description,
+      requestBody: undefined,
+      responses: {},
+    };
+
+    if (step.config.queryParams) {
+      operation.parameters = operation.parameters || [];
+
+      for (const param of step.config.queryParams) {
+        operation.parameters.push({
+          in: 'query',
+          name: param.name,
+          description: param.description,
+          required: false,
+          schema: {
+            type: 'string',
+          },
+        });
+      }
+    }
+
+    if (step.config.bodySchema) {
+      const bodySchema = { ...step.config.bodySchema } as any;
+
+      delete bodySchema.$schema;
+
+      processSchema(bodySchema, openApi);
+
+      operation.requestBody = {
+        content: {
+          'application/json': {
+            schema: bodySchema,
+          },
+        },
+      };
+    }
+
+    if (step.config.responseSchema) {
+      for (const [statusCode, responseSchema] of Object.entries(step.config.responseSchema)) {
+        const resSchema = { ...responseSchema } as any;
+
+        delete resSchema.$schema;
+
+        processSchema(resSchema, openApi);
+
+        operation.responses[statusCode] = {
+          description: `Response for status code ${statusCode}`,
+          content: {
+            'application/json': {
+              schema: resSchema,
+            },
+          },
+        };
+      }
+    }
+
+    if (isHttpMethod(method)) {
+      pathItem[method] = operation;
+    }
+
+    openApi.paths[step.config.path] = pathItem;
+  }
+
+  const openApiJson = JSON.stringify(openApi, null, 2);
+  fs.writeFileSync(path.join(projectDir, 'openapi.json'), openApiJson);
+
+  console.log('✅ OpenAPI specification generated successfully at openapi.json');
+}
+
+
+function isHttpMethod(method: string): method is OpenAPIV3.HttpMethods {
+  return Object.values(OpenAPIV3.HttpMethods).includes(method as OpenAPIV3.HttpMethods);
+}
+
+function processSchema(schema: any, openApi: OpenAPIV3.Document) {
+  if (!schema || typeof schema !== 'object') {
+    return;
+  }
+
+  if (schema.$defs) {
+    if (!openApi.components) {
+      openApi.components = {};
+    }
+
+    if (!openApi.components.schemas) {
+      openApi.components.schemas = {};
+    }
+
+    // copy all definitions to components/schemas for compatibility
+    for (const defName in schema.$defs) {
+      if (schema.$defs.hasOwnProperty(defName)) {
+        (openApi.components.schemas as any)[defName] = schema.$defs[defName];
+      }
+    }
+
+    delete schema.$defs;
+  }
+
+  if (Array.isArray(schema.anyOf)) {
+    const nullIndex = schema.anyOf.findIndex((item: any) => item && item.type === 'null');
+
+    if (nullIndex !== -1) {
+      schema.anyOf.splice(nullIndex, 1);
+
+      schema.nullable = true;
+
+      if (schema.anyOf.length === 1) {
+        // if only one schema remains, lift it up
+        const remainingSchema = schema.anyOf[0];
+
+        for (const key in remainingSchema) {
+          if (remainingSchema.hasOwnProperty(key)) {
+            schema[key] = remainingSchema[key];
+          }
+        }
+
+        delete schema.anyOf;
+      }
+    }
+  }
+
+  for (const key in schema) {
+    if (schema.hasOwnProperty(key)) {
+      if (key === '$ref' && typeof schema[key] === 'string' && schema[key].startsWith('#/$defs/')) {
+        // convert $ref to OpenAPI components/schemas format
+        schema[key] = schema[key].replace('#/$defs/', '#/components/schemas/');
+
+      } else if (typeof schema[key] === 'object') {
+        processSchema(schema[key], openApi);
+      }
+    }
+  }
+}

--- a/playground/steps/rb_api_step.rb
+++ b/playground/steps/rb_api_step.rb
@@ -1,0 +1,30 @@
+def config
+  {
+    "type" => "api",
+    "name" => "RubyApiStep",
+    "description" => "A sample Ruby API step",
+    "path" => "/rb-api",
+    "method" => "GET",
+    "emits" => ["ruby-api-event"],
+    "bodySchema" => {
+      "type" => "object",
+      "properties" => {
+        "rbMessage" => { "type" => "string", "description" => "A message from Ruby" }
+      },
+      "required" => ["rbMessage"]
+    },
+    "responseSchema" => {
+      "200" => {
+        "type" => "object",
+        "properties" => {
+          "rbResponse" => { "type" => "string", "description" => "A response from Ruby" }
+        },
+        "required" => ["rbResponse"]
+      }
+    }
+  }
+end
+
+def handler(req, context)
+  { "status" => 200, "body" => { "rbResponse" => "Hello from Ruby!" } }
+end

--- a/playground/types.d.ts
+++ b/playground/types.d.ts
@@ -28,6 +28,7 @@ declare module 'motia' {
     'Notification': EventHandler<{ templateId: string; email: string; templateData: Record<string, unknown> }, never>
     'ApiTrigger': ApiRouteHandler<{ pet: { name: string; photoUrl: string }; foodOrder?: { id: string; quantity: number } }, ApiResponse<200, { id: number; name: string; photoUrl: string }>, { topic: 'process-food-order'; data: { email: string; quantity: number; petId: number } }>
     'ArrayStep': ApiRouteHandler<{ pet: { name: string; photoUrl: string }; foodOrder?: { id: string; quantity: number } }[], ApiResponse<200, { id: number; name: string; photoUrl: string }[]>, { topic: 'process-food-order'; data: { email: string; quantity: number; petId: number } }>
+    'RubyApiStep': ApiRouteHandler<{ rbMessage: string }, ApiResponse<200, { rbResponse: string }>, never>
     'Test State With Python': EventHandler<unknown, { topic: 'test-state-check'; data: { key: string; expected?: unknown } }>
     'Tested Event': EventHandler<never, never>
     'Test Event': EventHandler<never, { topic: 'tested'; data: never }>


### PR DESCRIPTION
Introduce a command to generate OpenAPI specifications for the project and integrate Python virtual environment activation. Add a Ruby API step with its configuration and handler, along with tests to ensure the correct generation of the OpenAPI JSON file. Update the .gitignore to exclude generated files and fix minor issues in the OpenAPI title and validation.