### PR TITLE
feat: add projectRoot parameter to communication and step config func…

### DIFF
--- a/packages/core/src/call-step-file.ts
+++ b/packages/core/src/call-step-file.ts
@@ -74,6 +74,7 @@ export const callStepFile = <TData>(options: CallStepFileOptions, motia: Motia):
       args: [...args, runner, step.filePath, jsonData],
       logger,
       context: 'StepExecution',
+      projectRoot: motia.lockedData.baseDir,
     })
 
     trackEvent('step_execution_started', {

--- a/packages/core/src/get-step-config.ts
+++ b/packages/core/src/get-step-config.ts
@@ -34,7 +34,7 @@ const getLanguageBasedRunner = (
   throw Error(`Unsupported file extension ${stepFilePath}`)
 }
 
-const getConfig = <T>(file: string): Promise<T | null> => {
+const getConfig = <T>(file: string, projectRoot?: string): Promise<T | null> => {
   const { runner, command, args } = getLanguageBasedRunner(file)
 
   return new Promise((resolve, reject) => {
@@ -45,6 +45,7 @@ const getConfig = <T>(file: string): Promise<T | null> => {
       args: [...args, runner, file],
       logger: globalLogger,
       context: 'Config',
+      projectRoot,
     })
 
     processManager
@@ -86,10 +87,10 @@ const getConfig = <T>(file: string): Promise<T | null> => {
   })
 }
 
-export const getStepConfig = (file: string): Promise<StepConfig | null> => {
-  return getConfig<StepConfig>(file)
+export const getStepConfig = (file: string, projectRoot?: string): Promise<StepConfig | null> => {
+  return getConfig<StepConfig>(file, projectRoot)
 }
 
-export const getStreamConfig = (file: string): Promise<StreamConfig | null> => {
-  return getConfig<StreamConfig>(file)
+export const getStreamConfig = (file: string, projectRoot?: string): Promise<StreamConfig | null> => {
+  return getConfig<StreamConfig>(file, projectRoot)
 }

--- a/packages/core/src/process-communication/communication-config.ts
+++ b/packages/core/src/process-communication/communication-config.ts
@@ -7,7 +7,7 @@ export interface CommunicationConfig {
   spawnOptions: SpawnOptions
 }
 
-export function createCommunicationConfig(command: string): CommunicationConfig {
+export function createCommunicationConfig(command: string, projectRoot?: string): CommunicationConfig {
   const type = command === 'python' && process.platform === 'win32' ? 'rpc' : 'ipc'
 
   const spawnOptions: SpawnOptions = {
@@ -20,7 +20,7 @@ export function createCommunicationConfig(command: string): CommunicationConfig 
   if (command === 'python') {
     spawnOptions.env = {
       ...process.env,
-      PYTHONPATH: process.cwd(),
+      PYTHONPATH: projectRoot || process.cwd(),
     }
   }
 

--- a/packages/core/src/process-communication/process-manager.ts
+++ b/packages/core/src/process-communication/process-manager.ts
@@ -10,6 +10,7 @@ export interface ProcessManagerOptions {
   args: string[]
   logger: Logger
   context?: string
+  projectRoot?: string
 }
 
 export class ProcessManager {
@@ -20,10 +21,10 @@ export class ProcessManager {
   constructor(private options: ProcessManagerOptions) {}
 
   async spawn(): Promise<ChildProcess> {
-    const { command, args, logger, context = 'Process' } = this.options
+    const { command, args, logger, context = 'Process', projectRoot } = this.options
 
     // Get communication configuration
-    const commConfig = createCommunicationConfig(command)
+    const commConfig = createCommunicationConfig(command, projectRoot)
     this.communicationType = commConfig.type
 
     logger.debug(`[${context}] Spawning process`, {

--- a/packages/snap/src/generate-locked-data.ts
+++ b/packages/snap/src/generate-locked-data.ts
@@ -33,7 +33,7 @@ export const collectFlows = async (projectDir: string, lockedData: LockedData): 
 
   for (const filePath of stepFiles) {
     try {
-      const config = await getStepConfig(filePath)
+      const config = await getStepConfig(filePath, projectDir)
 
       if (!config) {
         console.warn(`No config found in step ${filePath}, step skipped`)

--- a/packages/snap/src/generate-types.ts
+++ b/packages/snap/src/generate-types.ts
@@ -10,7 +10,7 @@ export const generateTypes = async (projectDir: string) => {
   const lockedData = new LockedData(projectDir, 'memory', new Printer(projectDir))
 
   for (const filePath of files) {
-    const config = await getStepConfig(filePath)
+    const config = await getStepConfig(filePath, projectDir)
 
     if (config) {
       lockedData.createStep({ filePath, version, config }, { disableTypeCreation: true })
@@ -18,7 +18,7 @@ export const generateTypes = async (projectDir: string) => {
   }
 
   for (const filePath of streamsFiles) {
-    const config = await getStreamConfig(filePath)
+    const config = await getStreamConfig(filePath, projectDir)
 
     if (config) {
       lockedData.createStream({ filePath, config }, { disableTypeCreation: true })

--- a/packages/snap/src/watcher.ts
+++ b/packages/snap/src/watcher.ts
@@ -62,7 +62,7 @@ export class Watcher {
       return
     }
 
-    const config = await getStepConfig(path).catch((err) => console.error(err))
+    const config = await getStepConfig(path, this.dir).catch((err) => console.error(err))
 
     if (!config) {
       return
@@ -75,7 +75,7 @@ export class Watcher {
   }
 
   private async onStepFileChange(path: string): Promise<void> {
-    const config = await getStepConfig(path).catch((err) => {
+    const config = await getStepConfig(path, this.dir).catch((err) => {
       console.error(err)
     })
 


### PR DESCRIPTION
…tions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Passes projectRoot into ProcessManager and config readers, using it to set PYTHONPATH for Python runners and updating callers to provide projectDir.
> 
> - **Core**:
>   - **Process management**: `ProcessManager` accepts `projectRoot` and forwards it to `createCommunicationConfig`, which sets `PYTHONPATH` to `projectRoot` for Python; updated `call-step-file` to pass `motia.lockedData.baseDir`.
>   - **Config loading**: `getConfig`, `getStepConfig`, and `getStreamConfig` accept optional `projectRoot` and pass it to `ProcessManager`.
> - **Snap**:
>   - **Call sites updated**: `generate-locked-data`, `generate-types`, and `watcher` now pass `projectDir`/`this.dir` to `getStepConfig`/`getStreamConfig`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13a1f87ebb04b68488c3a1f235550b968c033e62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->