### PR TITLE
fix: support non-JSON response types in API routes

### DIFF
--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -192,9 +192,7 @@ export const createServer = (
         res.status(result.status)
 
         // Handle different body types
-        if (Buffer.isBuffer(result.body)) {
-          res.send(result.body)
-        } else if (typeof result.body === 'string') {
+        if (Buffer.isBuffer(result.body) || typeof result.body === 'string') {
           res.send(result.body)
         } else {
           res.json(result.body)

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -190,7 +190,15 @@ export const createServer = (
         }
 
         res.status(result.status)
-        res.json(result.body)
+
+        // Handle different body types
+        if (Buffer.isBuffer(result.body)) {
+          res.send(result.body)
+        } else if (typeof result.body === 'string') {
+          res.send(result.body)
+        } else {
+          res.json(result.body)
+        }
       } catch (error) {
         trackEvent('api_call_error', {
           stepName,


### PR DESCRIPTION
Currently the API step only supports JSON ouput, if you give it a string or Buffer, it will still return a JSON object.

I guess it also somehow related to:
https://github.com/MotiaDev/motia/issues/670 