### PR TITLE
docs: document Zod default values bug in bodySchema

### DIFF
--- a/playground/steps/bugfix-examples/README.md
+++ b/playground/steps/bugfix-examples/README.md
@@ -1,0 +1,84 @@
+# Bug: Zod Default Values Not Applied to req.body
+
+## Issue Description
+
+When using Zod schemas with `.default()` values in `bodySchema`, those defaults are **not applied** to `req.body` when fields are omitted from the request.
+
+### Expected Behavior
+
+```typescript
+bodySchema: z.object({
+  message: z.string(),
+  priority: z.string().default('normal'),
+  retryCount: z.number().default(3),
+})
+```
+
+When a request is sent with only `{ "message": "test" }`, we expect:
+- `req.body.priority` → `"normal"` 
+- `req.body.retryCount` → `3`
+
+### Actual Behavior
+
+Instead, we receive:
+- `req.body.priority` → `undefined`
+- `req.body.retryCount` → `undefined`
+
+## Root Cause
+
+The Zod schema validation in Motia's bodySchema doesn't parse/transform the request body with defaults. It only validates the structure.
+
+## Workaround
+
+Use explicit JavaScript default parameters in destructuring:
+
+```typescript
+export const handler: Handlers['MyStep'] = async (req, { logger }) => {
+  // WORKAROUND: Apply defaults in JavaScript
+  const { 
+    message, 
+    priority = 'normal',    // JS default
+    retryCount = 3,         // JS default
+    enabled = true          // JS default
+  } = req.body
+
+  // Now priority, retryCount, and enabled will have values even when omitted
+}
+```
+
+## Test Steps
+
+1. **Bug Demonstration**: `POST /api/zod-defaults-bug`
+   ```bash
+   curl -X POST http://localhost:3000/api/zod-defaults-bug \
+     -H "Content-Type: application/json" \
+     -d '{"message":"test"}'
+   ```
+   Response shows `bugPresent: true` and undefined values
+
+2. **Fixed Version**: `POST /api/zod-defaults-fixed`
+   ```bash
+   curl -X POST http://localhost:3000/api/zod-defaults-fixed \
+     -H "Content-Type: application/json" \
+     -d '{"message":"test"}'
+   ```
+   Response shows `defaultsApplied: true` with correct default values
+
+## Affected Areas
+
+This bug affects any API step that:
+- Uses `bodySchema` with `.default()` values
+- Expects those defaults to be available in `req.body`
+- Doesn't manually apply defaults in the handler
+
+## Recommendation
+
+Until this bug is fixed in the framework:
+1. Always use JavaScript default parameters in destructuring
+2. Document this pattern in handler code
+3. Consider framework-level fix to apply Zod defaults during parsing
+
+## Example Files
+
+- `zod-defaults-bug.step.ts` - Demonstrates the bug
+- `zod-defaults-fixed.step.ts` - Shows the workaround

--- a/playground/steps/bugfix-examples/zod-defaults-bug.step.ts
+++ b/playground/steps/bugfix-examples/zod-defaults-bug.step.ts
@@ -1,0 +1,87 @@
+import { ApiRouteConfig, Handlers } from 'motia'
+import { z } from 'zod'
+
+/**
+ * This step demonstrates a bug where Zod schema defaults
+ * defined in bodySchema are not applied to req.body.
+ * 
+ * BUG: When fields with .default() are omitted from the request,
+ * they arrive as undefined in req.body instead of the default value.
+ * 
+ * WORKAROUND: Use explicit JavaScript default parameters in destructuring.
+ */
+
+export const config: ApiRouteConfig = {
+  type: 'api',
+  name: 'ZodDefaultsBug',
+  description: 'Demonstrates Zod default values not being applied to req.body',
+  flows: ['bugfix-examples'],
+  method: 'POST',
+  path: '/api/zod-defaults-bug',
+  bodySchema: z.object({
+    message: z.string(),
+    // These defaults are NOT applied to req.body
+    priority: z.string().default('normal'),
+    retryCount: z.number().default(3),
+    enabled: z.boolean().default(true),
+  }),
+  responseSchema: {
+    200: z.object({
+      received: z.object({
+        message: z.string(),
+        priority: z.string().optional(),
+        retryCount: z.number().optional(),
+        enabled: z.boolean().optional(),
+      }),
+      expectedDefaults: z.object({
+        priority: z.string(),
+        retryCount: z.number(),
+        enabled: z.boolean(),
+      }),
+      bugPresent: z.boolean(),
+    }),
+  },
+  emits: [],
+}
+
+export const handler: Handlers['ZodDefaultsBug'] = async (req, { logger }) => {
+  // BUG: Zod defaults are NOT applied here
+  // If fields are omitted, they will be undefined instead of default values
+  const { message, priority, retryCount, enabled } = req.body
+
+  logger.info('Received values (bug demonstration)', {
+    message,
+    priority,
+    retryCount,
+    enabled,
+    priorityIsUndefined: priority === undefined,
+    retryCountIsUndefined: retryCount === undefined,
+    enabledIsUndefined: enabled === undefined,
+  })
+
+  // WORKAROUND: Apply defaults manually in destructuring
+  // const { 
+  //   message, 
+  //   priority = 'normal', 
+  //   retryCount = 3, 
+  //   enabled = true 
+  // } = req.body
+
+  return {
+    status: 200,
+    body: {
+      received: {
+        message,
+        priority,
+        retryCount,
+        enabled,
+      },
+      expectedDefaults: {
+        priority: 'normal',
+        retryCount: 3,
+        enabled: true,
+      },
+      bugPresent: priority === undefined || retryCount === undefined || enabled === undefined,
+    },
+  }
+}

--- a/playground/steps/bugfix-examples/zod-defaults-fixed.step.ts
+++ b/playground/steps/bugfix-examples/zod-defaults-fixed.step.ts
@@ -1,0 +1,68 @@
+import { ApiRouteConfig, Handlers } from 'motia'
+import { z } from 'zod'
+
+/**
+ * This step shows the WORKAROUND for Zod default values not being applied.
+ * 
+ * SOLUTION: Use explicit JavaScript default parameters in destructuring.
+ * This ensures default values are applied even when Zod doesn't pass them through.
+ */
+
+export const config: ApiRouteConfig = {
+  type: 'api',
+  name: 'ZodDefaultsFixed',
+  description: 'Demonstrates workaround for Zod default values bug',
+  flows: ['bugfix-examples'],
+  method: 'POST',
+  path: '/api/zod-defaults-fixed',
+  bodySchema: z.object({
+    message: z.string(),
+    priority: z.string().default('normal'),
+    retryCount: z.number().default(3),
+    enabled: z.boolean().default(true),
+  }),
+  responseSchema: {
+    200: z.object({
+      received: z.object({
+        message: z.string(),
+        priority: z.string(),
+        retryCount: z.number(),
+        enabled: z.boolean(),
+      }),
+      defaultsApplied: z.boolean(),
+    }),
+  },
+  emits: [],
+}
+
+export const handler: Handlers['ZodDefaultsFixed'] = async (req, { logger }) => {
+  // WORKAROUND: Apply defaults manually in JavaScript destructuring
+  // This works around the bug where Zod bodySchema defaults aren't applied
+  const { 
+    message, 
+    priority = 'normal',      // JS default parameter
+    retryCount = 3,            // JS default parameter  
+    enabled = true             // JS default parameter
+  } = req.body
+
+  logger.info('Received values (with workaround)', {
+    message,
+    priority,
+    retryCount,
+    enabled,
+    allDefaultsApplied: priority !== undefined && retryCount !== undefined && enabled !== undefined,
+  })
+
+  return {
+    status: 200,
+    body: {
+      received: {
+        message,
+        priority,
+        retryCount,
+        enabled,
+      },
+      defaultsApplied: true,
+    },
+  }
+}


### PR DESCRIPTION
Document bug where Zod schema defaults defined in bodySchema are not applied to req.body when fields are omitted.

Adds:
- Bug demonstration step showing undefined values
- Fixed step showing JavaScript default parameter workaround
- Comprehensive documentation with test cases

Issue: When using .default() in Zod bodySchema, those defaults don't get applied to req.body. Fields arrive as undefined instead.

Workaround: Use explicit JavaScript default parameters in
destructuring: const { field = 'default' } = req.body

This affects any API step expecting Zod defaults to work.