### PR TITLE
Chore/add issue templates sidd

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: "Bug Report"
+description: "Report a bug to help us improve Motia."
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Thanks for reporting a bug!
+        Please fill out the following details so we can help you as quickly as possible.
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: "OS, Node version, Docker version, browser, etc."
+      placeholder: "e.g. Windows 10, Node 18.16, Docker 24.0, Chrome 123"
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: "How can we reproduce the bug? Please provide a step-by-step guide."
+      placeholder: "1. Go to ...\n2. Click ...\n3. See error ..."
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: "What did you expect to happen?"
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: "What actually happened?"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs/Console Output
+      description: "Paste any error messages or logs here."
+      render: shell
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: "If applicable, add screenshots to help explain your problem."
+  - type: input
+    id: version
+    attributes:
+      label: Motia Version
+      description: "What version/commit are you running? (if known)"
+      placeholder: "e.g. v2.1.0, commit abc1234"
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: "Add any other context about the problem here." 

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,47 @@
+name: "Documentation Issue"
+description: "Report an issue or suggest an improvement for the documentation."
+labels: [documentation]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Documentation Issue
+        Please provide details about the documentation problem or improvement.
+  - type: textarea
+    id: section
+    attributes:
+      label: Section / Page
+      description: "Which page or section of the documentation does this relate to?"
+      placeholder: "e.g. Getting Started / Installation / API Reference"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Issue
+      description: "Describe the documentation issue or what is unclear."
+      placeholder: "Explain what is missing, incorrect, or confusing."
+    validations:
+      required: true
+  - type: textarea
+    id: suggested_fix
+    attributes:
+      label: Suggested Fix / Improvement
+      description: "Provide a suggested fix, clarification, or improvement for the documentation."
+      placeholder: "Describe how the documentation could be improved."
+  - type: textarea
+    id: examples
+    attributes:
+      label: Examples / References
+      description: "Provide examples, links, or references if applicable."
+  - type: input
+    id: version
+    attributes:
+      label: Version / Branch
+      description: "Specify the version or branch of the project the docs relate to."
+      placeholder: "e.g. v2.1.0, main branch"
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: "Any other context or comments regarding this documentation issue."

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: "Feature Request"
+description: "Suggest an idea or enhancement for Motia."
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Thanks for suggesting a feature!
+        Please help us understand your use case and how this feature would help.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: "What problem are you trying to solve?"
+      placeholder: "Describe the problem or need."
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: "Describe the solution you'd like."
+      placeholder: "How would you like this to work?"
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: "Have you considered any alternative solutions or workarounds?"
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: "Add any other context, screenshots, or references here."
+  - type: checkboxes
+    id: willing_to_help
+    attributes:
+      label: Willing to Help Implement?
+      description: "Would you like to work on or help with this feature?"
+      options:
+        - label: I would like to work/help with this 


### PR DESCRIPTION
# PR: Add GitHub Issue Templates for OSS Project

## Description

This PR adds GitHub issue templates to standardize issue reporting in the repository. It includes templates for:

* **Bug Report**
* **Feature Request**
* **Documentation Issue**

These templates will help contributors provide consistent, complete, and useful information when creating issues.

## Changes

* Added `.github/ISSUE_TEMPLATE/bug_report.yml`
* Added `.github/ISSUE_TEMPLATE/feature_request.yml`
* Added `.github/ISSUE_TEMPLATE/documentation.yml`

## Benefits

* Ensures consistency in issue reporting.
* Helps maintainers quickly understand, reproduce, and prioritize issues.
* Improves collaboration and onboarding experience for contributors.
* Reduces back-and-forth for missing details in issues.

## How to Test

1. Navigate to the repository on GitHub.
2. Click on "New Issue".
3. Verify that the new templates appear and guide contributors correctly:

   * Bug Report
   * Feature Request
   * Documentation Issue
4. Optionally, submit a test issue using each template to confirm the guidance works.

## Fixes: #789 

## Notes

* These templates are fully compatible with GitHub's standard issue template system.
* No changes to code functionality; purely a contribution to repository workflow and contributor experience.
