### PR TITLE
proper logic for the finalProject name for when used blank

### DIFF
--- a/packages/snap/src/create/index.ts
+++ b/packages/snap/src/create/index.ts
@@ -125,7 +125,10 @@ export const create = async ({ projectName, template, cursorEnabled, context }: 
   }
 
   if (!checkIfFileExists(rootDir, 'package.json')) {
-    const finalProjectName = isCurrentDir ? path.basename(rootDir) : projectName
+    const finalProjectName =
+      !projectName || projectName === '.' || projectName === './' || projectName === '.\\'
+        ? path.basename(process.cwd())
+        : projectName.trim()
     const packageJsonContent = {
       name: finalProjectName,
       description: '',


### PR DESCRIPTION
## Summary
- changes in the final name is no name is given it takes name from cwd
- and if name is given then it uses that only
- now follows the ideal flow (just like next js)

## Related Issues
- Fixes: #805 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<img width="1308" height="736" alt="image" src="https://github.com/user-attachments/assets/a63ae566-b3c0-481d-870b-b306cb06f2da" />