### PR TITLE
fix: handle missing plugins in configuration

### DIFF
--- a/packages/snap/src/generate-plugins.ts
+++ b/packages/snap/src/generate-plugins.ts
@@ -152,6 +152,11 @@ export const processPlugins = async (motiaServer: MotiaServer): Promise<MotiaPlu
 
   const appConfig: Config = await loadConfig(baseDir)
 
+  if (!appConfig?.plugins) {
+    console.warn('No plugins found in motia.config.ts')
+    return []
+  }
+
   const plugins: MotiaPlugin[] = appConfig.plugins?.flatMap((item) => item(context)) || []
 
   await processSteps(motiaServer, plugins, baseDir)

--- a/packages/workbench/motia-plugin/index.ts
+++ b/packages/workbench/motia-plugin/index.ts
@@ -105,7 +105,7 @@ export default function motiaPluginsPlugin(plugins: WorkbenchPlugin[]): Plugin {
     async transform(code, id) {
       const normalizedId = normalizePath(id)
 
-      if (!normalizedId.endsWith('/workbench/src/index.css')) {
+      if (!normalizedId.endsWith('src/index.css')) {
         return null
       }
 


### PR DESCRIPTION
- Updated the plugin processing logic to return an empty array when no plugins are specified, preventing potential errors during execution.
