### PR TITLE
feat: enhance logging functionality in printer and HMR modules

### DIFF
--- a/packages/core/src/printer.ts
+++ b/packages/core/src/printer.ts
@@ -2,7 +2,7 @@ import colors from 'colors'
 import path from 'path'
 import { isApiStep, isCronStep, isEventStep, isNoopStep } from './guards'
 import type { ValidationError } from './step-validator'
-import type { Event, Step } from './types'
+import type { Step } from './types'
 import type { Stream } from './types-stream'
 
 const stepTag = colors.bold(colors.magenta('Step'))
@@ -151,6 +151,24 @@ export class Printer {
     const streamPath = this.getRelativePath(stream.filePath)
     return colors.bold(colors.magenta(streamPath))
   }
+
+  printPluginLog(message: string) {
+    const pluginTag = colors.bold(colors.cyan('[motia-plugins]'))
+    const levelTag = colors.blue('ℹ')
+    console.log(`${levelTag} ${pluginTag} ${message}`)
+  }
+
+  printPluginWarn(message: string) {
+    const pluginTag = colors.bold(colors.cyan('[motia-plugins]'))
+    const levelTag = colors.yellow('⚠')
+    console.warn(`${levelTag} ${pluginTag} ${colors.yellow(message)}`)
+  }
+
+  printPluginError(message: string) {
+    const pluginTag = colors.bold(colors.cyan('[motia-plugins]'))
+    const levelTag = colors.red('✖')
+    console.error(`${levelTag} ${pluginTag} ${colors.red(message)}`)
+  }
 }
 
 export class NoPrinter extends Printer {
@@ -173,4 +191,8 @@ export class NoPrinter extends Printer {
   printStreamCreated() {}
   printStreamUpdated() {}
   printStreamRemoved() {}
+
+  printPluginLog() {}
+  printPluginWarn() {}
+  printPluginError() {}
 }

--- a/packages/workbench/motia-plugin/hmr.ts
+++ b/packages/workbench/motia-plugin/hmr.ts
@@ -1,7 +1,17 @@
+import type { Printer } from '@motiadev/core'
+import path from 'path'
 import type { HmrContext, ModuleNode } from 'vite'
+import { resolvePluginPackage } from './resolver'
 import type { WorkbenchPlugin } from './types'
 import { CONSTANTS } from './types'
-import { normalizePath } from './utils'
+import { isLocalPlugin, normalizePath } from './utils'
+
+const WATCHED_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.css', '.scss', '.less']
+
+export function isConfigFile(file: string): boolean {
+  const normalizedFile = normalizePath(file)
+  return normalizedFile.endsWith('motia.config.ts') || normalizedFile.endsWith('motia.config.js')
+}
 
 /**
  * Checks if a file change should trigger HMR for plugins.
@@ -12,20 +22,32 @@ import { normalizePath } from './utils'
  */
 export function shouldInvalidatePlugins(file: string, plugins: WorkbenchPlugin[]): boolean {
   const normalizedFile = normalizePath(file)
+  const absoluteFile = path.isAbsolute(normalizedFile) ? normalizedFile : path.resolve(process.cwd(), normalizedFile)
 
-  // Check if the changed file is a local plugin
+  if (isConfigFile(file)) {
+    return true
+  }
+
+  const hasWatchedExtension = WATCHED_EXTENSIONS.some((ext) => absoluteFile.endsWith(ext))
+  if (!hasWatchedExtension) {
+    return false
+  }
+
   for (const plugin of plugins) {
-    if (plugin.packageName.startsWith('~/')) {
-      const pluginPath = plugin.packageName.replace('~/', '')
-      if (normalizedFile.includes(pluginPath)) {
+    if (isLocalPlugin(plugin.packageName)) {
+      const resolved = resolvePluginPackage(plugin)
+      const pluginAbsolutePath = path.isAbsolute(resolved.resolvedPath)
+        ? resolved.resolvedPath
+        : path.resolve(process.cwd(), resolved.resolvedPath)
+
+      const normalizedPluginPath = pluginAbsolutePath.endsWith(path.sep)
+        ? pluginAbsolutePath
+        : `${pluginAbsolutePath}${path.sep}`
+
+      if (absoluteFile.startsWith(normalizedPluginPath) || absoluteFile === pluginAbsolutePath) {
         return true
       }
     }
-  }
-
-  // Check if it's a plugin configuration file
-  if (normalizedFile.endsWith('motia.config.ts') || normalizedFile.endsWith('motia.config.js')) {
-    return true
   }
 
   return false
@@ -37,42 +59,82 @@ export function shouldInvalidatePlugins(file: string, plugins: WorkbenchPlugin[]
  *
  * @param ctx - Vite's HMR context
  * @param plugins - Current plugin configurations
+ * @param printer - Printer instance for logging
  * @returns Array of modules to update, or undefined to continue with default behavior
  */
-export function handlePluginHotUpdate(ctx: HmrContext, plugins: WorkbenchPlugin[]): ModuleNode[] | void {
-  const { file, server } = ctx
+export function handlePluginHotUpdate(
+  ctx: HmrContext,
+  plugins: WorkbenchPlugin[],
+  printer: Printer,
+): ModuleNode[] | undefined {
+  const { file, server, timestamp } = ctx
 
-  console.log('[motia-plugins] HMR: File changed:', file)
+  printer.printPluginLog(`HMR: File changed: ${normalizePath(file)}`)
 
   // Check if this change affects plugins
   if (!shouldInvalidatePlugins(file, plugins)) {
     return // Let Vite handle it normally
   }
 
-  console.log('[motia-plugins] HMR: Plugin configuration or local plugin changed, invalidating virtual module')
+  if (isConfigFile(file)) {
+    printer.printPluginLog('HMR: Config file changed, triggering full page reload')
+    printer.printPluginWarn(
+      'Configuration changes require a server restart for full effect. Please restart the dev server to apply all changes.',
+    )
+    server.ws.send({
+      type: 'full-reload',
+      path: '*',
+    })
+    return
+  }
+
+  printer.printPluginLog('HMR: Plugin change detected, invalidating virtual module')
 
   // Find the virtual module
   const virtualModule = server.moduleGraph.getModuleById(CONSTANTS.RESOLVED_VIRTUAL_MODULE_ID)
 
-  if (virtualModule) {
-    // Invalidate the virtual module to force regeneration
-    server.moduleGraph.invalidateModule(virtualModule)
-    console.log('[motia-plugins] HMR: Virtual module invalidated')
+  if (!virtualModule) {
+    printer.printPluginWarn('HMR: Virtual module not found, triggering full reload')
+    server.ws.send({
+      type: 'full-reload',
+      path: '*',
+    })
+    return
   }
 
-  // Return modules to update (includes the virtual module and any dependent modules)
-  const modulesToUpdate: ModuleNode[] = []
+  server.moduleGraph.invalidateModule(virtualModule, new Set(), timestamp)
+  printer.printPluginLog('HMR: Virtual module invalidated')
 
-  if (virtualModule) {
-    modulesToUpdate.push(virtualModule)
+  const modulesToUpdate: ModuleNode[] = [virtualModule]
+  const processedModules = new Set<ModuleNode>([virtualModule])
+
+  // Recursively add all importers
+  const addImporters = (module: ModuleNode) => {
+    for (const importer of module.importers) {
+      if (!processedModules.has(importer)) {
+        processedModules.add(importer)
+        modulesToUpdate.push(importer)
+        server.moduleGraph.invalidateModule(importer, new Set(), timestamp)
+        addImporters(importer)
+      }
+    }
   }
 
-  // Add any modules that import the virtual module
-  const importers = virtualModule?.importers || new Set()
-  for (const importer of importers) {
-    modulesToUpdate.push(importer)
-    console.log('[motia-plugins] HMR: Invalidating importer:', importer.id)
-  }
+  addImporters(virtualModule)
+
+  server.ws.send({
+    type: 'update',
+    updates: modulesToUpdate
+      .filter((m) => m.url)
+      .map((m) => ({
+        type: m.type === 'css' ? ('css-update' as const) : ('js-update' as const),
+        path: m.url,
+        acceptedPath: m.url,
+        timestamp,
+      })),
+  })
+
+  printer.printPluginLog(`HMR: Updated ${modulesToUpdate.length} module(s)`)
 
   return modulesToUpdate
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,33 +290,6 @@ importers:
         specifier: ^7.0.3
         version: 7.0.3
 
-  packages/motia-e2e-test-project:
-    dependencies:
-      '@motiadev/core':
-        specifier: workspace:*
-        version: link:../core
-      '@motiadev/plugin-endpoint':
-        specifier: workspace:*
-        version: link:../../plugins/plugin-endpoint
-      '@motiadev/plugin-logs':
-        specifier: workspace:*
-        version: link:../../plugins/plugin-logs
-      '@motiadev/plugin-observability':
-        specifier: workspace:*
-        version: link:../../plugins/plugin-observability
-      '@motiadev/plugin-states':
-        specifier: workspace:*
-        version: link:../../plugins/plugin-states
-      '@motiadev/workbench':
-        specifier: workspace:*
-        version: link:../workbench
-      motia:
-        specifier: workspace:*
-        version: link:../snap
-      zod:
-        specifier: ^3.24.4
-        version: 3.24.4
-
   packages/snap:
     dependencies:
       '@amplitude/analytics-node':


### PR DESCRIPTION
## Summary

This PR enhances the Hot Module Replacement (HMR) functionality for the Motia Workbench plugin system and adds comprehensive logging capabilities for better visibility during development.

### Key Changes:

- **Enhanced Logging**: Added plugin-specific logging methods (`printPluginLog`, `printPluginWarn`, `printPluginError`) to the `Printer` class for better categorization and visibility of plugin-related messages
- **Improved HMR Handling**: Refactored HMR logic to properly handle configuration file changes and local plugin updates
- **Better File Watching**: Implemented extension-based filtering (`.ts`, `.tsx`, `.js`, `.jsx`, `.css`, `.scss`, `.less`) and improved path resolution for local plugins
- **Config File Detection**: Added dedicated handling for `motia.config.ts/js` changes with appropriate warnings about server restarts
- **Recursive Importer Invalidation**: Fixed module invalidation to recursively invalidate all dependent modules

### Technical Details:

- Modified `packages/core/src/printer.ts` to add colored, tagged logging methods for plugins
- Enhanced `packages/workbench/motia-plugin/hmr.ts` with:
  - Better file path resolution using absolute paths
  - Extension-based file filtering to reduce unnecessary HMR triggers
  - Recursive module invalidation for proper dependency updates
  - Full page reload for configuration changes
- Updated `packages/workbench/motia-plugin/index.ts` to utilize new logging methods

## Related Issues

<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (please describe):

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)

### Before

- Plugin logs were mixed with other system logs
- HMR triggers were not properly handling local plugin changes
- No clear indication when configuration files changed

### After

- Plugin-specific logs are now clearly tagged with `[motia-plugins]` prefix
- Color-coded log levels (ℹ Info, ⚠ Warning, ✖ Error)
- Proper warnings when config files change requiring server restart
- HMR correctly invalidates plugin modules and their dependencies

## Additional Context

### Files Changed:

```
 packages/core/src/printer.ts             |  24 additions
 packages/workbench/motia-plugin/hmr.ts   | 118 additions, 76 deletions
 packages/workbench/motia-plugin/index.ts |  79 additions, 76 deletions
 pnpm-lock.yaml                           |  27 deletions
```

### Motivation:

During development, it was difficult to track plugin-related events and HMR behavior. This PR improves the developer experience by:

1. Providing clear, categorized logging for plugin operations
2. Making HMR more reliable for local plugin development
3. Ensuring proper module invalidation cascades through dependencies
4. Warning developers when changes require a full server restart

### Testing:

- Tested local plugin file modifications
- Tested configuration file changes
- Verified recursive module invalidation
- Confirmed proper color-coded logging output
