### PR TITLE
fix(core): memory leak in QueueManager + integrate Printer in plugins

### DIFF
--- a/packages/core/src/motia.ts
+++ b/packages/core/src/motia.ts
@@ -28,6 +28,7 @@ export type PluginApiConfig = {
 export type UnregisterMotiaPluginApi = () => void
 
 export type MotiaPluginContext = {
+  printer: Printer
   state: StateAdapter
   lockedData: LockedData
   tracerFactory: TracerFactory

--- a/packages/core/src/observability/tracer.ts
+++ b/packages/core/src/observability/tracer.ts
@@ -10,7 +10,7 @@ import { TraceStreamAdapter } from './trace-stream-adapter'
 import type { Trace, TraceGroup } from './types'
 
 const MAX_TRACE_GROUPS = process.env.MOTIA_MAX_TRACE_GROUPS //
-  ? parseInt(process.env.MOTIA_MAX_TRACE_GROUPS)
+  ? Number.parseInt(process.env.MOTIA_MAX_TRACE_GROUPS, 10)
   : 50
 
 export class BaseTracerFactory implements TracerFactory {

--- a/packages/core/src/printer.ts
+++ b/packages/core/src/printer.ts
@@ -16,6 +16,9 @@ const removed = colors.red('➜ [REMOVED]')
 const invalidEmit = colors.red('➜ [INVALID EMIT]')
 const error = colors.red('[ERROR]')
 const warning = colors.yellow('[WARNING]')
+const warnIcon = colors.yellow('⚠')
+const infoIcon = colors.blue('ℹ')
+const errorIcon = colors.red('✖')
 
 export class Printer {
   constructor(private readonly baseDir: string) {}
@@ -32,7 +35,6 @@ export class Printer {
     emit: { topic: string },
     details: { missingFields?: string[]; extraFields?: string[]; typeMismatches?: string[] },
   ) {
-    const warnIcon = colors.yellow('⚠')
     const emitPath = colors.bold(colors.cyan(`Emit ${emit.topic}`))
 
     console.log(`${warnIcon} ${warning} ${emitPath} validation issues:`)
@@ -104,7 +106,7 @@ export class Printer {
 
   printInvalidEmitConfiguration(step: Step, emit: string) {
     console.log(
-      `${warning} ${stepTag} ${this.getStepType(step)} ${this.getStepPath(step)} emits to ${colors.yellow(emit)}, but there is no subscriber defined`,
+      `${warnIcon} ${warning} ${stepTag} ${this.getStepType(step)} ${this.getStepPath(step)} emits to ${colors.yellow(emit)}, but there is no subscriber defined`,
     )
   }
 
@@ -154,20 +156,17 @@ export class Printer {
 
   printPluginLog(message: string) {
     const pluginTag = colors.bold(colors.cyan('[motia-plugins]'))
-    const levelTag = colors.blue('ℹ')
-    console.log(`${levelTag} ${pluginTag} ${message}`)
+    console.log(`${infoIcon} ${pluginTag} ${message}`)
   }
 
   printPluginWarn(message: string) {
     const pluginTag = colors.bold(colors.cyan('[motia-plugins]'))
-    const levelTag = colors.yellow('⚠')
-    console.warn(`${levelTag} ${pluginTag} ${colors.yellow(message)}`)
+    console.warn(`${warnIcon} ${pluginTag} ${colors.yellow(message)}`)
   }
 
-  printPluginError(message: string) {
+  printPluginError(message: string, ...args: unknown[]) {
     const pluginTag = colors.bold(colors.cyan('[motia-plugins]'))
-    const levelTag = colors.red('✖')
-    console.error(`${levelTag} ${pluginTag} ${colors.red(message)}`)
+    console.error(`${errorIcon} ${pluginTag} ${colors.red(message)}`, ...args)
   }
 }
 


### PR DESCRIPTION
## Summary

This PR improves memory management and logging consistency in the Motia plugin system. The main focus is on eliminating memory leaks caused by uncleaned event listeners in the `QueueManager` and improving plugin logging by integrating the `Printer` class into the plugin context.

### Key Changes:

- **Memory Leak Fix**: Removed per-topic event listeners in `QueueManager` that were causing memory leaks when subscriptions were added/removed dynamically
- **Enhanced Plugin Logging**: Integrated `Printer` into `MotiaPluginContext` for consistent, formatted logging across all plugin operations
- **Code Quality Improvements**: Refactored code to use proper parsing methods and removed unused variables

## Related Issues

- Memory leak issue in queue management system
- Inconsistent logging in plugin processing

## Type of Change

- [x] Bug fix (memory leak in QueueManager)
- [ ] New feature
- [ ] Breaking change
- [x] Refactor (logging improvements)
- [ ] Other (please describe):

## Detailed Changes

### Core Package (`packages/core/`)

#### 1. `motia.ts`

- Added `printer: Printer` to `MotiaPluginContext` type to enable consistent logging in plugins

#### 2. `queue-manager.ts` (Memory Leak Fix) ⭐

- **Removed**: `topicListeners` Map that was storing individual event listeners per topic
- **Changed**: Event listener registration to use a single shared listener in constructor
- **Benefit**: Prevents memory leaks from accumulated event listeners when subscriptions are dynamically added/removed
- **Before**: Each topic created its own event listener that wasn't properly cleaned up
- **After**: Single event listener in constructor handles all topics, comparing topic names directly

#### 3. `printer.ts`

- Moved icon constants (`warnIcon`, `infoIcon`, `errorIcon`) to class-level scope for reusability
- Updated `printPluginError()` to accept additional arguments (`...args`) for better error logging
- Cleaned up duplicate icon definitions in methods

#### 4. `server.ts`

- Added `printer` to the `MotiaServer` type and return value
- Fixed tracer initialization for API steps - only create tracer when calling step files (not for internal handlers)
- Improved performance by avoiding unnecessary tracer creation for simple emit-only API handlers

#### 5. `observability/tracer.ts`

- Changed `parseInt()` to `Number.parseInt()` with explicit radix (10) for better code quality

### Snap Package (`packages/snap/`)

#### 6. `generate-plugins.ts`

- Integrated `Printer` throughout plugin loading and processing pipeline
- Replaced all `console.log()`, `console.warn()`, and `console.error()` calls with proper `Printer` methods
- Updated function signatures to accept and pass `printer` instance:
  - `collectPluginSteps()`
  - `loadConfig()`
  - `processSteps()`
- Improved error messages and logging consistency across plugin operations

## Testing

- [x] Tested locally with dynamic queue subscriptions to verify no memory leaks
- [x] Verified plugin logging displays correctly with new Printer integration
- [x] Confirmed existing functionality remains intact

## Performance Impact

✅ **Positive**: Reduced memory footprint by eliminating listener accumulation in long-running processes
✅ **Positive**: Slight performance improvement by avoiding unnecessary tracer creation for simple API handlers

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable) - N/A, no UI changes

## Additional Context

### Why This Matters

**Memory Leak Impact**: In production systems with dynamic queue subscriptions (topics being subscribed/unsubscribed frequently), the old implementation would accumulate event listeners indefinitely. Each subscription would add a new listener that was never properly removed, leading to:

- Increased memory usage over time
- Potential performance degradation
- Risk of crashes in long-running processes

**Logging Consistency**: By integrating `Printer` into the plugin context, all plugin-related messages now follow Motia's established formatting patterns with proper colors, icons, and prefixes, making it easier to:

- Debug plugin-related issues
- Maintain consistent user experience
- Distinguish between different types of messages

### Migration Notes

⚠️ **Breaking Change for Plugin Developers**: If any custom plugins were accessing internal queue manager structures or relying on per-topic listeners, they will need to be updated. However, this is unlikely as these were internal implementation details.

No API changes for end users - all public interfaces remain the same.
