### PR TITLE
fix: support log listeners for logger used in each runner

### DIFF
--- a/packages/core/src/node/logger.ts
+++ b/packages/core/src/node/logger.ts
@@ -1,6 +1,10 @@
 import type { RpcSender } from './rpc'
 
+export type LogListener = (level: string, message: string, args?: unknown) => void
+
 export class Logger {
+  private readonly listeners: LogListener[] = []
+
   constructor(
     private readonly traceId: string,
     private readonly flows: string[],
@@ -29,6 +33,8 @@ export class Logger {
     }
 
     this.sender.sendNoWait('log', logEntry)
+
+    this.listeners.forEach((listener) => listener(level, message, args))
   }
 
   info(message: string, args?: Record<string, unknown>): void {
@@ -45,5 +51,9 @@ export class Logger {
 
   warn(message: string, args?: Record<string, unknown>): void {
     this._log('warn', message, args)
+  }
+
+  addListener(listener: LogListener) {
+    this.listeners.push(listener)
   }
 }


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->
The logger used for the step runners is different from the motia core logger, based on the FlowContext type definition the logger passed in context should have support for adding listeners. Looking at the runner implementation, there are different logger implementations that don't match the logger type def in FlowContext.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->
https://github.com/MotiaDev/motia/issues/869

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)