### PR TITLE
chore: updates the link to correct documentation in tutorials.tsx

### DIFF
--- a/packages/snap/src/create/templates/nodejs/tutorial.tsx.txt
+++ b/packages/snap/src/create/templates/nodejs/tutorial.tsx.txt
@@ -653,7 +653,7 @@ export const steps: TutorialStep[] = [
         <br />
         <br />
         We recommend you give our{' '}
-        <a href="https://www.motia.dev/docs/concepts" target="_blank">
+        <a href="https://www.motia.dev/docs/concepts/overview" target="_blank">
           core concepts
         </a>{' '}
         a read if you wish to learn further about Motia's fundamentals.

--- a/packages/snap/src/create/templates/python/tutorial.tsx.txt
+++ b/packages/snap/src/create/templates/python/tutorial.tsx.txt
@@ -653,7 +653,7 @@ export const steps: TutorialStep[] = [
         <br />
         <br />
         We recommend you give our{' '}
-        <a href="https://www.motia.dev/docs/concepts" target="_blank">
+        <a href="https://www.motia.dev/docs/concepts/overview" target="_blank">
           core concepts
         </a>{' '}
         a read if you wish to learn further about Motia's fundamentals.

--- a/playground/tutorial.tsx
+++ b/playground/tutorial.tsx
@@ -645,7 +645,7 @@ export const steps: TutorialStep[] = [
         <br />
         <br />
         We recommend you give our{' '}
-        <a href="https://www.motia.dev/docs/concepts" target="_blank" rel="noopener">
+        <a href="https://www.motia.dev/docs/concepts/overview" target="_blank" rel="noopener">
           core concepts
         </a>{' '}
         a read if you wish to learn further about Motia's fundamentals.


### PR DESCRIPTION
## Summary
Fixes incorrect core concepts page link in tutorials.tsx. The links were redirecting to the wrong pages, so I updated them to point to the correct URLs.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->
Fixes #874 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
Correct URL: https://www.motia.dev/docs/concepts/overview
<img width="1691" height="934" alt="image" src="https://github.com/user-attachments/assets/05b7cff4-a810-4528-b13c-1624875c2485" />


## Additional Context
NO