### PR TITLE
fix(docs): prevent inconsistent agent button heights on tablets

### DIFF
--- a/packages/docs/components/TabSelector.tsx
+++ b/packages/docs/components/TabSelector.tsx
@@ -62,7 +62,7 @@ export const AgentTab: React.FC<AgentTab> = ({ variant = 'inactive', children, o
               'radial-gradient(136.33% 100% at 50% 0%, rgba(13, 20, 54,1) 0%, rgba(8, 24, 101, 1) 71.63%, rgba(5, 28, 138, 1) 100%)',
           },
         }}
-        className="font-tasa flex items-center justify-center gap-3 rounded-[inherit] bg-black p-[12px] text-[16px] font-medium tracking-[0.48px] text-white"
+        className="font-tasa flex items-center justify-center gap-3 rounded-[inherit] bg-black p-[12px] text-[16px] font-medium tracking-[0.48px] whitespace-nowrap text-white"
       >
         {children}
       </motion.div>
@@ -108,7 +108,7 @@ interface TabSelector {
 export const TabSelector: React.FC<TabSelector> = ({ agent, setAgent = () => {} }) => {
   return (
     <div className="scrollbar-hide mt-[80px] mb-[10px] w-full overflow-x-auto px-[16px]">
-      <div className="flex w-full gap-[16px] pb-[30px] max-md:w-[320%] max-md:max-w-[1000px]">
+      <div className="flex w-full gap-[16px] pb-[30px] max-md:w-[320%] max-md:max-w-[1000px] md:w-[130%] lg:w-full">
         {AGENT_TABS.map((tab, i) => {
           return (
             <AgentTab


### PR DESCRIPTION
## Summary

This PR fixes a visual bug on the homepage where the agent selector buttons would develop inconsistent heights on tablet-sized screens. It happened because longer button text would wrap onto a second line, making some buttons taller than others.

Implemented fix involves two parts:
1.  Making the button container horizontally scrollable on medium (`md`) viewports.
2.  Adding a `whitespace-nowrap` utility to the buttons to ensure the text always remains on a single line.

Above mentioned combination restores a clean, uniform layout on all screen sizes.

## Related Issues

Closes #878

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)

**Before:** On an iPad-sized screen, the text wraps, causing misaligned button heights.

<img width="657" height="636" alt="screenshot" src="https://github.com/user-attachments/assets/777f21f6-2cad-45ad-b82a-05c8f442870c" />

**After:** The container now scrolls, and the text stays on one line, ensuring all buttons have a uniform height.

<img width="657" height="637" alt="screenshot" src="https://github.com/user-attachments/assets/5a8c70b7-0d68-4c9f-a54d-751d4b2a5993" />

## Additional Context

Initially, just making the container scrollable wasn't enough. The flex items (the buttons) were still shrinking slightly, which caused the text to wrap. The key was to also add `whitespace-nowrap` to the button's inner div, which forces the text to stay on one line and allows the button to claim its natural width within the now-scrollable container.

This approach aligns the tablet behavior with the existing mobile behavior and has no impact on the desktop layout.