### PR TITLE
refactor: rename analytics with motiaAnalytics across components

### DIFF
--- a/packages/workbench/src/components/flow/flow-tab-menu-item.tsx
+++ b/packages/workbench/src/components/flow/flow-tab-menu-item.tsx
@@ -2,7 +2,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { ChevronsUpDown, Workflow } from 'lucide-react'
 import { useShallow } from 'zustand/react/shallow'
 import { useFetchFlows } from '@/hooks/use-fetch-flows'
-import { analytics } from '@/lib/analytics'
+import { motiaAnalytics } from '@/lib/motia-analytics'
 import { useFlowStore } from '@/stores/use-flow-store'
 
 export const FlowTabMenuItem = () => {
@@ -18,7 +18,7 @@ export const FlowTabMenuItem = () => {
 
   const handleFlowSelect = (flowId: string) => {
     selectFlowId(flowId)
-    analytics.track('flow_selected', { flow: flowId })
+    motiaAnalytics.track('flow_selected', { flow: flowId })
   }
 
   return (

--- a/packages/workbench/src/components/header/deploy-button.tsx
+++ b/packages/workbench/src/components/header/deploy-button.tsx
@@ -1,32 +1,32 @@
 import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@motiadev/ui'
 import { Rocket } from 'lucide-react'
 import { useState } from 'react'
-import { analytics } from '@/lib/analytics'
+import { motiaAnalytics } from '@/lib/motia-analytics'
 
 export const DeployButton = () => {
   const [isOpen, setIsOpen] = useState(false)
 
   const onDeployButtonClick = () => {
-    analytics.track('deploy_button_clicked')
+    motiaAnalytics.track('deploy_button_clicked')
   }
 
   const onDeployClick = () => {
     setIsOpen(false)
-    analytics.track('deploy_button_deploy_clicked')
+    motiaAnalytics.track('deploy_button_deploy_clicked')
   }
 
   const onClose = () => {
     setIsOpen(false)
-    analytics.track('deploy_button_closed')
+    motiaAnalytics.track('deploy_button_closed')
   }
 
   const onMotiaCloudClick = () => {
     setIsOpen(true)
-    analytics.track('deploy_button_motia_cloud_clicked')
+    motiaAnalytics.track('deploy_button_motia_cloud_clicked')
   }
 
   const onSelfHostedClick = () => {
-    analytics.track('deploy_button_self_hosted_clicked')
+    motiaAnalytics.track('deploy_button_self_hosted_clicked')
     window.open('https://www.motia.dev/docs/deployment-guide/self-hosted', '_blank')
   }
 

--- a/packages/workbench/src/components/root-motia.tsx
+++ b/packages/workbench/src/components/root-motia.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 import type { PropsWithChildren } from 'react'
-import { useAnalytics } from '@/lib/analytics'
+import { useAnalytics } from '@/lib/motia-analytics'
 
 export const RootMotia: React.FC<PropsWithChildren> = ({ children }) => {
   useAnalytics()

--- a/packages/workbench/src/components/tutorial/tutorial-button.tsx
+++ b/packages/workbench/src/components/tutorial/tutorial-button.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@motiadev/ui'
 import { Book } from 'lucide-react'
 import type { FC } from 'react'
-import { analytics } from '@/lib/analytics'
+import { motiaAnalytics } from '@/lib/motia-analytics'
 import { Tooltip } from '../ui/tooltip'
 import { useTutorial } from './hooks/use-tutorial'
 
@@ -14,7 +14,7 @@ export const TutorialButton: FC = () => {
       open()
     }
 
-    analytics.track('tutorial_button_clicked', { isTutorialFlowMissing })
+    motiaAnalytics.track('tutorial_button_clicked', { isTutorialFlowMissing })
   }
 
   const trigger = (

--- a/packages/workbench/src/components/tutorial/tutorial.tsx
+++ b/packages/workbench/src/components/tutorial/tutorial.tsx
@@ -1,4 +1,4 @@
-import { analytics } from '@/lib/analytics'
+import { motiaAnalytics } from '@/lib/motia-analytics'
 import { useTutorialEngine } from './hooks/use-tutorial-engine'
 import { TutorialStep } from './tutorial-step'
 import './tutorial.css'
@@ -13,11 +13,11 @@ export const Tutorial = () => {
     engine.moveStep(nextStep)
 
     if (engine.currentStep === engine.totalSteps) {
-      analytics.track('tutorial_completed', {
+      motiaAnalytics.track('tutorial_completed', {
         manualOpen: engine.manualOpenRef.current,
       })
     } else {
-      analytics.track('tutorial_next_step', {
+      motiaAnalytics.track('tutorial_next_step', {
         step: nextStep,
         manualOpen: engine.manualOpenRef.current,
       })
@@ -25,7 +25,7 @@ export const Tutorial = () => {
   }
 
   const onClose = () => {
-    analytics.track('tutorial_closed', {
+    motiaAnalytics.track('tutorial_closed', {
       step: engine.currentStepRef.current,
       manualOpen: engine.manualOpenRef.current,
     })

--- a/packages/workbench/src/lib/motia-analytics.ts
+++ b/packages/workbench/src/lib/motia-analytics.ts
@@ -122,15 +122,15 @@ class WorkbenchAnalytics {
   }
 }
 
-export const analytics = new WorkbenchAnalytics()
+export const motiaAnalytics = new WorkbenchAnalytics()
 
 export const useAnalytics = () => {
   const track = useCallback((eventName: string, properties?: Record<string, any>) => {
-    analytics.track(eventName, properties)
+    motiaAnalytics.track(eventName, properties)
   }, [])
 
   const getAnalyticsIds = useCallback(() => {
-    return analytics.getAnalyticsIds()
+    return motiaAnalytics.getAnalyticsIds()
   }, [])
 
   return {

--- a/packages/workbench/src/system-view-mode.tsx
+++ b/packages/workbench/src/system-view-mode.tsx
@@ -9,7 +9,7 @@ import {
 import { useCallback, useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { Header } from './components/header/header'
-import { analytics } from './lib/analytics'
+import { motiaAnalytics } from './lib/motia-analytics'
 import { type AppTabsState, TabLocation, useAppTabsStore } from './stores/use-app-tabs-store'
 import { useTabsStore } from './stores/use-tabs-store'
 
@@ -32,7 +32,7 @@ export const SystemViewMode = () => {
 
   const onTabChange = useCallback(
     (location: TabLocation) => (newTab: string) => {
-      analytics.track(`${location} tab changed`, { [`new.${location}`]: newTab, tab })
+      motiaAnalytics.track(`${location} tab changed`, { [`new.${location}`]: newTab, tab })
       tabChangeCallbacks[location](newTab)
     },
     [tabChangeCallbacks, tab],


### PR DESCRIPTION
## Summary
This PR renames the analytics module from `analytics` to `motia-analytics` to prevent ad-blocking browser extensions from blocking our internal analytics functionality. Ad-blockers commonly target files and variables containing the word "analytics" in isolation, which was causing our workbench analytics to be blocked for users with such extensions enabled.

### Changes Made
- Renamed file: `packages/workbench/src/lib/analytics.ts` → `packages/workbench/src/lib/motia-analytics.ts`
- Updated the exported instance from `analytics` to `motiaAnalytics`
- Updated all imports across the codebase from `@/lib/analytics` to `@/lib/motia-analytics`
- Updated all references from `analytics.track()` to `motiaAnalytics.track()` in 6 component files

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Additional Context
### Why This Change Is Important
Modern ad-blocking extensions (such as uBlock Origin, AdBlock Plus, etc.) use aggressive pattern matching to block analytics scripts. Files named `analytics.ts` or variables named `analytics` are commonly flagged and blocked, even when they're used for legitimate internal application telemetry rather than third-party tracking.

By renaming to `motia-analytics`, we:
1. ✅ Avoid false-positive blocking by ad-blockers
2. ✅ Maintain our internal analytics functionality for all users
3. ✅ Keep the same API and functionality (100% backward compatible in behavior)
4. ✅ Follow a more specific naming convention that aligns with our brand

### Testing
- Verified that all analytics events still fire correctly in the workbench
- Tested with ad-blocking extensions enabled (uBlock Origin)
- Confirmed no console errors or broken imports
- All existing analytics functionality works as expected

### Migration Notes
This is a pure refactor with no API changes. No migration is needed for downstream consumers as this is an internal workbench module.

