### PR TITLE
fix: move plugins from devDependencies to dependencies

### DIFF
--- a/packages/snap/src/create/index.ts
+++ b/packages/snap/src/create/index.ts
@@ -25,16 +25,18 @@ const installRequiredDependencies = async (packageManager: string, rootDir: stri
     pnpm: 'pnpm add',
   }[packageManager]
 
-  const dependencies = [`motia@${version}`, 'zod@3.24.4'].join(' ')
+  const dependencies = [`motia@${version}`, 'zod@3.24.4', ...pluginDependencies.map((dep) => `${dep}@${version}`)].join(
+    ' ',
+  )
+
   const devDependencies = [
     'ts-node@10.9.2',
     'typescript@5.7.3',
-    '@types/react@18.3.18',
+    '@types/react@19.1.1',
     '@jest/globals@^29.7.0',
     '@types/jest@^29.5.14',
     'jest@^29.7.0',
     'ts-jest@^29.2.5',
-    ...pluginDependencies.map((dep) => `${dep}@${version}`),
   ].join(' ')
 
   try {


### PR DESCRIPTION
## Summary
This PR refactors how plugin dependencies are managed in Motia projects. Previously, plugin dependencies (like `@motia/plugin-observability`, `@motia/plugin-states`, etc.) were installed as dev dependencies. This change moves them to regular production dependencies, which is more appropriate since plugins are required at runtime, not just during development.

**Key Changes:**
- Plugin dependencies are now installed as regular dependencies instead of dev dependencies
- During project creation, plugin dependencies are added alongside core dependencies
- The plugin installation process now migrates existing plugin deps from devDependencies to dependencies
- Updated `@types/react` from 18.3.18 to 19.1.1

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Technical Details

### Changes in `packages/snap/src/create/index.ts`
- Modified `installRequiredDependencies` function to add plugin dependencies during initial setup
- Plugin dependencies now install with the core `motia` package and `zod` as regular dependencies
- Dev dependencies no longer include plugin packages

### Changes in `packages/snap/src/plugins/install-plugin-dependencies.ts`
- Added logic to migrate plugin dependencies from `devDependencies` to `dependencies`
- Automatically removes plugin packages from `devDependencies` if they exist there
- Adds missing plugin dependencies to `dependencies` section
- Ensures `package.json` is properly updated with the correct dependency placement

## Impact
This change ensures that:
1. Plugin dependencies are correctly categorized as runtime dependencies
2. Production builds will include necessary plugin packages
3. Existing projects with plugins in devDependencies will be automatically migrated
4. New projects created with `snap create` will have the correct dependency structure from the start

## Additional Context
This fix addresses the architectural concern where runtime-required plugins were being classified as development dependencies. The change is backward compatible as it includes migration logic for existing projects.

