### PR TITLE
Update links in deployment guide for clarity

### DIFF
--- a/packages/docs/content/docs/deployment-guide/getting-started.mdx
+++ b/packages/docs/content/docs/deployment-guide/getting-started.mdx
@@ -7,10 +7,10 @@ full: true
 When you're ready to deploy your Motia project to production, there are the two paths you can take:
 
 <Cards>
-  <Card href="/docs/concepts/deployment/motia-cloud/features" title="Deploy with Motia">
+  <Card href="/docs/deployment-guide/motia-cloud/features" title="Deploy with Motia">
     Deploy your Motia project to production using Motia.
   </Card>
-  <Card href="/docs/concepts/deployment/self-hosted" title="Self-Hosted">
+  <Card href="/docs/deployment-guide/self-hosted " title="Self-Hosted">
     Deploy your Motia project to production using motia-docker.
   </Card>
 </Cards>


### PR DESCRIPTION
This pull request updates the deployment guide to use the correct documentation paths for Motia Cloud and self-hosted deployment options. This ensures that users are directed to the most current and relevant documentation when choosing a deployment method.

Documentation path updates:

* Updated the Motia Cloud deployment card link to `/docs/deployment-guide/motia-cloud/features` for accuracy and consistency.
* Updated the Self-Hosted deployment card link to `/docs/deployment-guide/self-hosted` to match the new documentation structure.