### PR TITLE
fix: broken links in the tutorial

### DIFF
--- a/packages/snap/src/create/templates/nodejs/tutorial/tutorial.tsx.txt
+++ b/packages/snap/src/create/templates/nodejs/tutorial/tutorial.tsx.txt
@@ -202,7 +202,7 @@ export const steps: TutorialStep[] = [
   {
     elementXpath: workbenchXPath.flows.node('processfoodorder'),
     title: 'Event Step',
-    link: 'https://www.motia.dev/docs/concepts/steps#event-trigger:~:text=API-,Event,-Cron',
+    link: 'https://www.motia.dev/docs/concepts/steps#event-trigger',
     description: () => (
       <p>
         Now that we have an entry point in our flow, let's focus on subscribing to a <b>topic</b> and performing a
@@ -224,7 +224,7 @@ export const steps: TutorialStep[] = [
   {
     elementXpath: workbenchXPath.sidebarContainer,
     title: 'Event Step',
-    link: 'https://www.motia.dev/docs/concepts/steps#event-trigger:~:text=API-,Event,-Cron',
+    link: 'https://www.motia.dev/docs/concepts/steps#event-trigger',
     description: () => (
       <p>
         Now that we have an entry point in our flow, let's focus on subscribing to a <b>topic</b> and performing a

--- a/packages/snap/src/create/templates/python/tutorial/tutorial.tsx.txt
+++ b/packages/snap/src/create/templates/python/tutorial/tutorial.tsx.txt
@@ -202,7 +202,7 @@ export const steps: TutorialStep[] = [
   {
     elementXpath: workbenchXPath.flows.node('processfoodorder'),
     title: 'Event Step',
-    link: 'https://www.motia.dev/docs/concepts/steps#event-trigger:~:text=API-,Event,-Cron',
+    link: 'https://www.motia.dev/docs/concepts/steps#event-trigger',
     description: () => (
       <p>
         Now that we have an entry point in our flow, let's focus on subscribing to a <b>topic</b> and performing a
@@ -224,7 +224,7 @@ export const steps: TutorialStep[] = [
   {
     elementXpath: workbenchXPath.sidebarContainer,
     title: 'Event Step',
-    link: 'https://www.motia.dev/docs/concepts/steps#event-trigger:~:text=API-,Event,-Cron',
+    link: 'https://www.motia.dev/docs/concepts/steps#event-trigger',
     description: () => (
       <p>
         Now that we have an entry point in our flow, let's focus on subscribing to a <b>topic</b> and performing a

--- a/playground/tutorial/tutorial.tsx
+++ b/playground/tutorial/tutorial.tsx
@@ -200,7 +200,7 @@ export const steps: TutorialStep[] = [
   {
     elementXpath: workbenchXPath.flows.node('processfoodorder'),
     title: 'Event Step',
-    link: 'https://www.motia.dev/docs/concepts/steps#event-trigger:~:text=API-,Event,-Cron',
+    link: 'https://www.motia.dev/docs/concepts/steps#event-trigger',
     description: () => (
       <p>
         Now that we have an entry point in our flow, let's focus on subscribing to a <b>topic</b> and performing a
@@ -221,7 +221,7 @@ export const steps: TutorialStep[] = [
   {
     elementXpath: workbenchXPath.sidebarContainer,
     title: 'Event Step',
-    link: 'https://www.motia.dev/docs/concepts/steps#event-trigger:~:text=API-,Event,-Cron',
+    link: 'https://www.motia.dev/docs/concepts/steps#event-trigger',
     description: () => (
       <p>
         Now that we have an entry point in our flow, let's focus on subscribing to a <b>topic</b> and performing a


### PR DESCRIPTION
## Summary
Fix broken links in the tutorial:
- https://www.motia.dev/docs/concepts/steps/api -> https://www.motia.dev/docs/concepts/steps#api-trigger
- https://zod.dev/ -> https://zod.dev/api
- https://www.motia.dev/docs/concepts/steps/event -> https://www.motia.dev/docs/concepts/steps#event-trigger:~:text=API-,Event,-Cron
- https://www.motia.dev/docs/concepts/state-management -> https://www.motia.dev/docs/development-guide/state-management
- https://www.motia.dev/docs/concepts/steps/cron -> https://www.motia.dev/docs/concepts/steps#cron-trigger

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 