### PR TITLE
feat: update tutorial navigation text

### DIFF
--- a/packages/workbench/src/components/tutorial/tutorial.css
+++ b/packages/workbench/src/components/tutorial/tutorial.css
@@ -1,6 +1,6 @@
-@import "@motiadev/ui/styles.css";
-@import "@motiadev/ui/globals.css";
-@import "tw-animate-css";
+@import '@motiadev/ui/styles.css';
+@import '@motiadev/ui/globals.css';
+@import 'tw-animate-css';
 
 :root {
   --tutorial-text-color: var(--dark-800);
@@ -121,7 +121,7 @@
 }
 
 .driver-popover-navigation-btns-hint:hover:before {
-  content: "Use arrow keys to navigate";
+  content: 'Use the right arrow key to navigate';
   position: absolute;
   color: white;
   top: -20px;


### PR DESCRIPTION
## Summary
Since the tutorial only works with the right arrow key, update the navigation text.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
Before:
<img height="103" alt="image" src="https://github.com/user-attachments/assets/8bd1e49e-3787-4b18-a241-d70ec5057300" />

After:
<img width="239" height="103" alt="image" src="https://github.com/user-attachments/assets/47330676-1e0d-44cc-be4f-0b7685715031" />


## Additional Context
<!-- Add any other context or information about the PR here --> 