### PR TITLE
feat(rabbitmq): add dead letter queue support to RabbitMQEventAdapter

### DIFF
--- a/packages/adapter-rabbitmq-events/src/types.ts
+++ b/packages/adapter-rabbitmq-events/src/types.ts
@@ -1,12 +1,14 @@
 export interface RabbitMQEventAdapterConfig {
   url: string
-  exchangeName: string
   exchangeType: 'direct' | 'topic' | 'fanout' | 'headers'
+  exchangeName: string
   durable?: boolean
   autoDelete?: boolean
   connectionTimeout?: number
   reconnectDelay?: number
   prefetch?: number
+  deadLetterExchange?: string
+  deadLetterRoutingKey?: string
 }
 
 export interface RabbitMQSubscribeOptions {


### PR DESCRIPTION
## Summary
This PR adds dead letter queue (DLQ) support to the RabbitMQEventAdapter, allowing failed messages to be automatically routed to a dead letter queue for further inspection and handling. This improves error handling and observability for RabbitMQ event processing.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
This change enhances the RabbitMQEventAdapter with DLQ configuration support:
- Enhanced RabbitMQEventAdapter with DLQ configuration support
- Updated types to include DLQ-related options
- Improved error handling and message routing for failed events