### PR TITLE
refactor(hmr): streamline hot module replacement logic and improve plugin tab refresh handling

### DIFF
--- a/packages/workbench/motia-plugin/index.ts
+++ b/packages/workbench/motia-plugin/index.ts
@@ -170,8 +170,9 @@ export default function motiaPluginsPlugin(plugins: WorkbenchPlugin[]): Plugin {
       const modulesToUpdate = handlePluginHotUpdate(ctx, plugins, printer)
 
       if (modulesToUpdate && modulesToUpdate.length > 0) {
-        printer.printPluginLog(`HMR: Successfully updated ${modulesToUpdate.length} module(s)`)
-        return modulesToUpdate
+        const merged = Array.from(new Set([...(ctx.modules || []), ...modulesToUpdate]))
+        printer.printPluginLog(`HMR: Successfully updated ${merged.length} module(s)`)
+        return merged
       }
     },
 

--- a/packages/workbench/src/lib/plugins.tsx
+++ b/packages/workbench/src/lib/plugins.tsx
@@ -1,7 +1,7 @@
 import { plugins } from 'virtual:motia-plugins'
 import { DynamicIcon, dynamicIconImports, type IconName } from 'lucide-react/dynamic'
 import { memo } from 'react'
-import { type AppTab, TabLocation } from '@/stores/use-app-tabs-store'
+import { type AppTab, TabLocation, useAppTabsStore } from '@/stores/use-app-tabs-store'
 import { isValidTabLocation } from './utils'
 
 export const registerPluginTabs = (addTab: (position: TabLocation, tab: AppTab) => void): void => {
@@ -68,5 +68,65 @@ export const registerPluginTabs = (addTab: (position: TabLocation, tab: AppTab) 
     } catch (error) {
       console.error(`[Motia] Error registering plugin "${plugin.label}":`, error)
     }
+  })
+}
+
+const refreshPluginTabs = (nextPlugins: typeof plugins): void => {
+  try {
+    const state = useAppTabsStore.getState()
+    const { removeTab, addTab } = state
+
+    const idsToRefresh = new Set(nextPlugins.map((p) => (p.label || '').toLowerCase()))
+
+    idsToRefresh.forEach((id) => {
+      removeTab(TabLocation.TOP, id)
+      removeTab(TabLocation.BOTTOM, id)
+    })
+
+    nextPlugins.forEach((plugin, index) => {
+      try {
+        if (!plugin.label || !plugin.component) return
+
+        const position = plugin.position || 'top'
+        const tabLocation = isValidTabLocation(position) ? position : TabLocation.TOP
+
+        const PluginTabLabel = memo(() => {
+          const hasIcon = Object.keys(dynamicIconImports).includes(plugin.labelIcon as IconName)
+          const iconName: IconName = hasIcon ? (plugin.labelIcon as IconName) : 'toy-brick'
+          return (
+            <>
+              <DynamicIcon name={iconName} />
+              <span>{plugin.label}</span>
+            </>
+          )
+        })
+        PluginTabLabel.displayName = `${plugin.label}TabLabel_HMR_${index}`
+
+        const PluginContent = memo(() => {
+          const Component = plugin.component as React.ElementType
+          const props = plugin.props || {}
+          if (!Component) return <div>Error: Plugin component not found</div>
+          return <Component {...props} />
+        })
+        PluginContent.displayName = `${plugin.label}Content_HMR_${index}`
+
+        addTab(tabLocation, {
+          id: plugin.label.toLowerCase(),
+          tabLabel: PluginTabLabel,
+          content: PluginContent,
+        })
+      } catch (error) {
+        console.error(`[Motia] Error refreshing plugin "${plugin.label}":`, error)
+      }
+    })
+  } catch (err) {
+    console.error('[Motia] Failed to refresh plugin tabs via HMR:', err)
+  }
+}
+
+if (import.meta.hot) {
+  import.meta.hot.accept('virtual:motia-plugins', (mod) => {
+    const next = (mod as unknown as { plugins?: typeof plugins })?.plugins || []
+    refreshPluginTabs(next)
   })
 }

--- a/plugins/plugin-endpoint/vite.config.ts
+++ b/plugins/plugin-endpoint/vite.config.ts
@@ -7,6 +7,7 @@ import dts from 'vite-plugin-dts'
 export default defineConfig({
   plugins: [react(), tailwindcss(), dts({ insertTypesEntry: true })],
   build: {
+    emptyOutDir: false,
     lib: {
       entry: {
         index: resolve(__dirname, 'src/index.ts'),

--- a/plugins/plugin-example/vite.config.ts
+++ b/plugins/plugin-example/vite.config.ts
@@ -7,6 +7,7 @@ import dts from 'vite-plugin-dts'
 export default defineConfig({
   plugins: [react(), tailwindcss(), dts({ insertTypesEntry: true })],
   build: {
+    emptyOutDir: false,
     lib: {
       entry: {
         index: resolve(__dirname, 'src/index.ts'),

--- a/plugins/plugin-logs/vite.config.ts
+++ b/plugins/plugin-logs/vite.config.ts
@@ -7,6 +7,7 @@ import dts from 'vite-plugin-dts'
 export default defineConfig({
   plugins: [react(), tailwindcss(), dts({ insertTypesEntry: true })],
   build: {
+    emptyOutDir: false,
     lib: {
       entry: {
         index: resolve(__dirname, 'src/index.ts'),

--- a/plugins/plugin-observability/vite.config.ts
+++ b/plugins/plugin-observability/vite.config.ts
@@ -7,6 +7,7 @@ import dts from 'vite-plugin-dts'
 export default defineConfig({
   plugins: [react(), tailwindcss(), dts({ insertTypesEntry: true })],
   build: {
+    emptyOutDir: false,
     lib: {
       entry: {
         index: resolve(__dirname, 'src/index.ts'),

--- a/plugins/plugin-states/vite.config.ts
+++ b/plugins/plugin-states/vite.config.ts
@@ -7,6 +7,7 @@ import dts from 'vite-plugin-dts'
 export default defineConfig({
   plugins: [react(), tailwindcss(), dts({ insertTypesEntry: true })],
   build: {
+    emptyOutDir: false,
     lib: {
       entry: {
         index: resolve(__dirname, 'src/index.ts'),


### PR DESCRIPTION
## Summary

This PR refactors and improves the Hot Module Replacement (HMR) system for plugins in the Motia workbench. The changes streamline the HMR logic, making it more efficient and reliable, while also implementing proper plugin tab refresh handling to ensure a smooth development experience.

### Key Improvements:

- **Streamlined HMR Logic**: Simplified the hot update flow by reorganizing the module invalidation checks and reducing recursive complexity
- **Enhanced Plugin Tab Refresh**: Added automatic plugin tab refresh mechanism that properly handles HMR updates without requiring full page reloads
- **Better Module Update Handling**: Improved the way modules are tracked and updated, using Sets to prevent duplicates and ensuring proper module invalidation
- **Build Configuration Fix**: Added `emptyOutDir: false` to all plugin vite configs to prevent accidental deletion of build artifacts

## Related Issues

<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (please describe):

## Changes in Detail

### 1. HMR Logic Refactor (`packages/workbench/motia-plugin/hmr.ts`)

- **Reorganized validation flow**: Moved config file check before plugin scope validation for better performance
- **Simplified module invalidation**: Removed recursive `addImporters` function in favor of a direct iteration approach
- **Improved module tracking**: Changed from array-based to Set-based module collection to prevent duplicates
- **Better logging**: Enhanced log messages for clearer debugging (e.g., "delegating to Vite default handling", "triggering full reload as fallback")
- **Removed redundant WS send**: Simplified the update mechanism by letting the caller handle the actual module updates

### 2. Plugin HMR Handler (`packages/workbench/motia-plugin/index.ts`)

- **Module merging**: Added proper merging of context modules with hot-updated modules to ensure all affected modules are included
- **Duplicate prevention**: Used Set to merge modules and prevent duplicate updates

### 3. Plugin Tab Refresh System (`packages/workbench/src/lib/plugins.tsx`)

- **New `refreshPluginTabs` function**: Implements intelligent plugin tab refresh that:
  - Removes existing plugin tabs before re-registering them
  - Properly recreates React components with unique display names for HMR
  - Handles errors gracefully per plugin to prevent cascade failures
- **HMR acceptance**: Added `import.meta.hot.accept` handler for the virtual plugins module
- **Component memoization**: Plugin tab labels and content are properly memoized with unique display names to support HMR

### 4. Vite Configuration Updates (all plugins)

- Added `emptyOutDir: false` to prevent Vite from deleting the entire output directory on rebuild
- Affects: `plugin-endpoint`, `plugin-example`, `plugin-logs`, `plugin-observability`, `plugin-states`

## Technical Details

### HMR Flow Before:

1. File change detected
2. Check if should invalidate plugins (early exit if no)
3. Check if config file (full reload if yes)
4. Invalidate virtual module + all importers recursively
5. Send WS update manually

### HMR Flow After:

1. File change detected
2. Check if config file (full reload if yes - early exit)
3. Check if should invalidate plugins (delegate to Vite if no)
4. Invalidate virtual module + direct importers only
5. Return modules to update (Vite handles WS)

This new flow is more efficient and reduces unnecessary invalidations.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Testing

The changes were tested locally by:

1. Starting the workbench in development mode
2. Making changes to plugin files and verifying hot reload works correctly
3. Modifying plugin configurations and ensuring tabs refresh properly
4. Checking that non-plugin file changes still trigger normal Vite HMR

## Screenshots (if applicable)

<!-- Add before/after screenshots or GIFs here -->

## Additional Context

This refactor addresses issues with plugin hot reloading that could cause:

- Unnecessary full page reloads
- Stale plugin tabs after updates
- Build output directory being emptied on rebuilds
- Duplicate module updates

The new implementation is more robust, efficient, and provides a better developer experience when working with plugins.
