### PR TITLE
refactor: remove --confirm option from project creation commands and adjust related logic

### DIFF
--- a/packages/e2e/scripts/global-setup.ts
+++ b/packages/e2e/scripts/global-setup.ts
@@ -18,7 +18,7 @@ async function globalSetup() {
     const template = process.env.TEST_TEMPLATE || 'nodejs'
 
     console.log(`📦 Creating test project with Motia CLI ${motiaVersion} and template ${template}...`)
-    const createCommand = `npx motia@${motiaVersion} create  ${TEST_PROJECT_NAME} -t ${template} --confirm`
+    const createCommand = `npx motia@${motiaVersion} create  ${TEST_PROJECT_NAME} -t ${template}`
 
     execSync(createCommand, {
       stdio: 'pipe',

--- a/packages/e2e/scripts/pr-global-setup.ts
+++ b/packages/e2e/scripts/pr-global-setup.ts
@@ -24,7 +24,7 @@ async function globalSetup() {
 
     console.log(`📦 Creating test project with built CLI and template ${template}...`)
 
-    const createCommand = `node ${cliPath} create  ${TEST_PROJECT_NAME} -t ${template} --confirm`
+    const createCommand = `node ${cliPath} create  ${TEST_PROJECT_NAME} -t ${template}`
 
     execSync(createCommand, {
       stdio: 'pipe',

--- a/packages/snap/src/cli.ts
+++ b/packages/snap/src/cli.ts
@@ -29,7 +29,6 @@ program
   .option('-t, --template <template>', 'The template to use for your project')
   .option('-p, --plugin', 'Create a plugin project')
   .option('-i, --interactive', 'Use interactive prompts to create project') // it's default
-  .option('-c, --confirm', 'Confirm the project creation', false)
   .action((projectName, options) => {
     const mergedArgs = { ...options, name: projectName }
     return handler(async (arg, context) => {
@@ -39,7 +38,6 @@ program
           name: arg.name,
           template: arg.template,
           plugin: !!arg.plugin,
-          confirm: !!arg.confirm,
         },
         context,
       )

--- a/packages/snap/src/create/interactive.ts
+++ b/packages/snap/src/create/interactive.ts
@@ -6,7 +6,6 @@ import { create } from './index'
 interface InteractiveAnswers {
   template: string
   projectName: string
-  proceed: boolean
 }
 
 const choices: Record<string, string> = {
@@ -21,7 +20,6 @@ interface CreateInteractiveArgs {
   name?: string
   template?: string
   plugin?: boolean
-  confirm?: boolean
 }
 
 export const createInteractive = async (args: CreateInteractiveArgs, context: CliContext): Promise<void> => {
@@ -81,23 +79,8 @@ export const createInteractive = async (args: CreateInteractiveArgs, context: Cl
     })
   }
 
-  if (!args.confirm) {
-    questions.push({
-      type: 'confirm',
-      name: 'proceed',
-      message: 'Proceed? [Y/n]:',
-      default: true,
-    })
-  }
-
   if (questions.length > 0) {
     const answers: InteractiveAnswers = await inquirer.prompt(questions)
-
-    if (!args.confirm && !answers.proceed) {
-      context.log('cancelled', (message) => message.tag('info').append('\n❌ Project creation cancelled.'))
-      return
-    }
-
     name = args.name || answers.projectName
     template = args.template || answers.template
   }

--- a/plugins/plugin-endpoint/src/play/side-panel.tsx
+++ b/plugins/plugin-endpoint/src/play/side-panel.tsx
@@ -63,7 +63,7 @@ export const SidePanel: FC<EndpointSidePanelProps> = memo(({ endpoint, onClose }
           <X />
         </Button>
       </div>
-      <div className={cn('grid grid-cols-[minmax(350px,1fr)_minmax(auto,1fr)]', !hasResponse && 'grid-cols-1')}>
+      <div className={cn('grid grid-cols-[minmax(380px,1fr)_minmax(auto,1fr)]', !hasResponse && 'grid-cols-1')}>
         <Tabs value={activeTab} onValueChange={(value: string) => setActiveTab(value as ActiveTab)}>
           <div className="grid grid-cols-[1fr_auto] items-center h-10 border-b px-5 bg-card">
             <TabsList>

--- a/plugins/plugin-endpoint/src/play/trigger-button.tsx
+++ b/plugins/plugin-endpoint/src/play/trigger-button.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@motiadev/ui'
 import Loader2 from 'lucide-react/icons/loader-2'
-import Play from 'lucide-react/icons/play'
 import { memo, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { getBodySelector, getHeadersSelector, useEndpointConfiguration } from '../hooks/use-endpoint-configuration'
@@ -49,8 +48,8 @@ export const TriggerButton = memo(({ method, path }: TriggerButtonProps) => {
   }
 
   return (
-    <Button variant="ghost" size="icon" onClick={onClick} disabled={isLoading} data-testid="endpoint-play-button">
-      {isLoading ? <Loader2 className="animate-spin" /> : <Play className="h-4 w-4" />}
+    <Button variant="accent" size="sm" onClick={onClick} disabled={isLoading} data-testid="endpoint-play-button">
+      {isLoading ? <Loader2 className="animate-spin" /> : 'Send'}
     </Button>
   )
 })


### PR DESCRIPTION
## Summary

This PR removes the `--confirm` option from the project creation commands in the Motia CLI, streamlining the project creation workflow. The confirmation prompt has been eliminated to provide a more direct user experience when creating new projects.

Additionally, includes minor UI improvements to the endpoint plugin's side panel and trigger button.

## Related Issues
<!-- List any related issues if applicable -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (please describe):

## Changes Made

### CLI Refactor
- **Removed `--confirm` CLI option** from the `create` command in `packages/snap/src/cli.ts`
- **Removed confirmation prompt logic** from `packages/snap/src/create/interactive.ts`
  - Eliminated the `proceed` field from `InteractiveAnswers` interface
  - Removed the `confirm` parameter from `CreateInteractiveArgs` interface
  - Removed the prompt asking "Proceed? [Y/n]:"
  - Removed the cancellation logic when user opts not to proceed

### Test Updates
- Updated E2E test setup scripts to remove `--confirm` flag:
  - `packages/e2e/scripts/global-setup.ts`
  - `packages/e2e/scripts/pr-global-setup.ts`

### UI Improvements (Endpoint Plugin)
- **Side Panel**: Adjusted grid column sizing from `350px` to `380px` minimum width for better layout
- **Trigger Button**: 
  - Changed from icon-only button to text button with "Send" label
  - Updated variant from `ghost` to `accent` for better visibility
  - Maintained loading state with spinner icon

## Impact

**Net Change**: -20 lines of code (5 insertions, 25 deletions)

**Files Modified**: 6 files
- 2 CLI core files
- 2 E2E test scripts
- 2 plugin UI files

## Breaking Changes

⚠️ **Potentially Breaking**: The `--confirm` flag is no longer recognized. Users or scripts relying on this flag will not receive an error, but the flag will be ignored. This should not cause issues as the flag only controlled whether a confirmation prompt was shown.

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots
<img width="2161" height="728" alt="Screenshot 2025-11-14 at 11 57 31" src="https://github.com/user-attachments/assets/ece7121e-e396-44f9-8af4-ffc0755d0454" />

### Before
The CLI would prompt: "Proceed? [Y/n]:" before creating a project

### After
Projects are created immediately after template selection without an additional confirmation step

## Additional Context

This refactoring simplifies the project creation flow by removing an unnecessary confirmation step. The interactive prompts already allow users to provide the necessary information (project name, template), and an additional confirmation adds friction without significant value.

The UI changes to the endpoint plugin improve usability by making the "Send" action more discoverable with a labeled button instead of an icon-only button.

