### PR TITLE
refactor: simplify panel ID generation and update XPath selectors in workbench components

### DIFF
--- a/packages/workbench/src/components/bottom-panel.tsx
+++ b/packages/workbench/src/components/bottom-panel.tsx
@@ -1,17 +1,16 @@
 import { CollapsiblePanel, TabsContent, TabsList, TabsTrigger } from '@motiadev/ui'
-import { memo, useId } from 'react'
+import { memo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { type AppTabsState, TabLocation, useAppTabsStore } from '../stores/use-app-tabs-store'
 import { useTabsStore } from '../stores/use-tabs-store'
 
 const bottomTabsSelector = (state: AppTabsState) => state.tabs[TabLocation.BOTTOM]
+const bottomPanelId = 'bottom-panel'
 
 export const BottomPanel = memo(() => {
   const defaultTab = useTabsStore((state) => state.tab.bottom)
   const setBottomTab = useTabsStore((state) => state.setBottomTab)
   const tabs = useAppTabsStore(useShallow(bottomTabsSelector))
-
-  const bottomPanelId = useId()
 
   return (
     <CollapsiblePanel

--- a/packages/workbench/src/components/top-panel.tsx
+++ b/packages/workbench/src/components/top-panel.tsx
@@ -1,17 +1,16 @@
 import { CollapsiblePanel, TabsContent, TabsList, TabsTrigger } from '@motiadev/ui'
-import { memo, useId } from 'react'
+import { memo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { type AppTabsState, TabLocation, useAppTabsStore } from '../stores/use-app-tabs-store'
 import { useTabsStore } from '../stores/use-tabs-store'
 
 const topTabsSelector = (state: AppTabsState) => state.tabs[TabLocation.TOP]
+const topPanelId = 'top-panel'
 
 export const TopPanel = memo(() => {
   const defaultTab = useTabsStore((state) => state.tab.top)
   const setTopTab = useTabsStore((state) => state.setTopTab)
   const tabs = useAppTabsStore(useShallow(topTabsSelector))
-
-  const topPanelId = useId()
 
   return (
     <CollapsiblePanel

--- a/packages/workbench/src/components/tutorial/engine/workbench-xpath.ts
+++ b/packages/workbench/src/components/tutorial/engine/workbench-xpath.ts
@@ -26,7 +26,7 @@ export const workbenchXPath = {
   },
 
   tracing: {
-    trace: (index: number) => `(//div[contains(@class, 'motia-trace-group')])[${index}]`,
+    trace: (index: number) => `(//button[contains(@class, 'motia-trace-group')])[${index}]`,
     details: '//div[@data-testid="trace-details"]',
     timeline: (index: number) => `(//div[@data-testid="trace-timeline-item"])[${index}]`,
   },
@@ -46,7 +46,7 @@ export const workbenchXPath = {
   links: {
     flows: '//div[@data-testid="flows-dropdown-trigger"]',
     endpoints: '//button[@data-testid="endpoints-link"]',
-    tracing: '//button[@data-testid="traces-link"]',
+    tracing: '//button[@data-testid="tracing-link"]',
     logs: '//button[@data-testid="logs-link"]',
     states: '//button[@data-testid="states-link"]',
   },

--- a/plugins/plugin-observability/src/components/observability-tab-label.tsx
+++ b/plugins/plugin-observability/src/components/observability-tab-label.tsx
@@ -2,9 +2,9 @@ import GanttChart from 'lucide-react/icons/gantt-chart'
 import { memo } from 'react'
 
 export const ObservabilityTabLabel = memo(() => (
-  <>
+  <div data-testid="observability-link">
     <GanttChart aria-hidden="true" />
     <span>Tracing</span>
-  </>
+  </div>
 ))
 ObservabilityTabLabel.displayName = 'ObservabilityTabLabel'


### PR DESCRIPTION
## Summary

This PR fixes tutorial-related warnings by refactoring panel ID generation and updating XPath selectors to match the actual DOM structure in the workbench.

### Changes Made:
- **Simplified panel ID generation**: Replaced dynamic `useId()` hooks with static IDs (`top-panel` and `bottom-panel`) for more predictable and testable component behavior
- **Fixed XPath selectors**: Updated selectors in the tutorial engine to accurately target DOM elements:
  - Changed trace group selector from `div` to `button` element
  - Updated tracing link selector from `traces-link` to `tracing-link` to match actual `data-testid`
- **Improved testability**: Added `data-testid="observability-link"` to the observability tab label wrapper for better test targeting

These changes ensure that the tutorial system can correctly identify and interact with workbench elements, eliminating selector-related warnings.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Files Changed
- `packages/workbench/src/components/bottom-panel.tsx` - Replaced dynamic ID generation with static ID
- `packages/workbench/src/components/top-panel.tsx` - Replaced dynamic ID generation with static ID
- `packages/workbench/src/components/tutorial/engine/workbench-xpath.ts` - Updated XPath selectors to match actual DOM
- `plugins/plugin-observability/src/components/observability-tab-label.tsx` - Added test ID wrapper

## Impact
- **Tutorial System**: Tutorial interactions will now work reliably without selector warnings
- **Testing**: More predictable IDs make automated testing easier
- **No Breaking Changes**: The changes are internal refactors that don't affect the public API

## Additional Context

The changes were identified by analyzing tutorial warnings where XPath selectors were failing to locate elements. The root causes were:
1. Dynamic IDs generated by `useId()` made it difficult to target panels consistently
2. XPath selectors referencing incorrect element types or test IDs
3. Missing test IDs on interactive elements

By using static IDs and correcting the selectors, the tutorial engine can now reliably interact with all workbench components.

