### PR TITLE
feat(errors): introduce LockedDataGenerationError and enhance error handling

### DIFF
--- a/packages/snap/src/generate-locked-data.ts
+++ b/packages/snap/src/generate-locked-data.ts
@@ -7,6 +7,7 @@ import { globSync } from 'glob'
 import path from 'path'
 import { activatePythonVenv } from './utils/activate-python-env'
 import { CompilationError } from './utils/errors/compilation.error'
+import { LockedDataGenerationError } from './utils/errors/locked-data-generation.error'
 
 const version = `${randomUUID()}:${Math.floor(Date.now() / 1000)}`
 
@@ -142,6 +143,10 @@ export const generateLockedData = async (config: {
     return lockedData
   } catch (error) {
     console.error(error)
-    throw Error('Failed to parse the project, generating locked data step failed')
+
+    throw new LockedDataGenerationError(
+      'Failed to parse the project, generating locked data step failed',
+      error as Error,
+    )
   }
 }

--- a/packages/snap/src/utils/analytics.ts
+++ b/packages/snap/src/utils/analytics.ts
@@ -3,6 +3,7 @@ import { getUserIdentifier, isAnalyticsEnabled, trackEvent } from '@motiadev/cor
 import { getProjectName } from '@motiadev/core/dist/src/analytics/utils'
 import { version } from '../version'
 import { MotiaEnrichmentPlugin } from './amplitude/enrichment-plugin'
+import { BuildError } from './errors/build.error'
 
 init('ab2408031a38aa5cb85587a27ecfc69c', {
   logLevel: Types.LogLevel.None,
@@ -39,12 +40,12 @@ export const identifyUser = () => {
   }
 }
 
-export const logCliError = (command: string, error: unknown) => {
+export const logCliError = (command: string, error: BuildError) => {
   try {
-    const errorMessage = error instanceof Error ? error.message : String(error)
-    const errorType = error instanceof Error ? error.constructor.name : 'Unknown'
-    const errorStack =
-      error instanceof Error && error.stack ? error.stack.split('\n').slice(0, 10).join('\n') : undefined
+    const cause = error.cause instanceof BuildError ? error.cause : (error as Error)
+    const errorMessage = cause?.message || 'Unknown error'
+    const errorType = cause?.constructor?.name || 'Unknown error type'
+    const errorStack = cause?.stack ? cause.stack.split('\n').slice(0, 10).join('\n') : undefined
 
     const truncatedMessage = errorMessage.length > 500 ? `${errorMessage.substring(0, 500)}...` : errorMessage
 

--- a/packages/snap/src/utils/errors/build.error.ts
+++ b/packages/snap/src/utils/errors/build.error.ts
@@ -1,5 +1,6 @@
 export enum BuildErrorType {
   COMPILATION = 'COMPILATION',
+  LOCKED_DATA_GENERATION = 'LOCKED_DATA_GENERATION',
 }
 
 export class BuildError extends Error {

--- a/packages/snap/src/utils/errors/locked-data-generation.error.ts
+++ b/packages/snap/src/utils/errors/locked-data-generation.error.ts
@@ -1,0 +1,8 @@
+import { BuildError, BuildErrorType } from './build.error'
+
+export class LockedDataGenerationError extends BuildError {
+  constructor(message: string, cause?: Error) {
+    super(BuildErrorType.LOCKED_DATA_GENERATION, undefined, message, cause)
+    this.name = 'LockedDataGenerationError'
+  }
+}


### PR DESCRIPTION
## Summary
This PR introduces a new `LockedDataGenerationError` class to replace generic `Error` instances in the locked data generation process. The new error properly encapsulates the root cause, making debugging easier and maintaining proper error chains.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Changes Made
- Added `LOCKED_DATA_GENERATION` error type to `BuildErrorType` enum
- Created new `LockedDataGenerationError` class extending `BuildError`
- Updated `generateLockedData` function to throw `LockedDataGenerationError` with root cause encapsulation
- Error now properly maintains error chain through `cause` property

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Additional Context
This change improves error handling by ensuring that when locked data generation fails, the original error is preserved in the `cause` property, allowing developers to trace the root cause of failures more effectively.