### PR TITLE
chore(docs): update documentation to reflect flexible step discovery

### DIFF
--- a/packages/docs/content/docs/concepts/steps.mdx
+++ b/packages/docs/content/docs/concepts/steps.mdx
@@ -12,8 +12,12 @@ Every Step file contains two parts:
 - **Config** → defines when and how the Step runs, and gives it a unique `name`  
 - **Handler** → the function that executes your business logic  
 
-Motia automatically discovers any file ending in `.step.ts`, `.step.js`, or `_step.py`.  
-The filename tells Motia to load it, and the `name` in the `config` uniquely identifies the Step inside your system.
+Motia automatically discovers any file ending in `.step.ts`, `.step.js`, or `_step.py` from your `steps/` or `src/` directories.  
+The filename pattern tells Motia to load it, and the `name` in the `config` uniquely identifies the Step inside your system.
+
+<Callout type="info">
+**Flexible Organization** - Steps can be placed in either `steps/` or `src/` directories (or both). Motia discovers them automatically regardless of which directory you choose or how deeply nested they are.
+</Callout>
 
 ---
 

--- a/packages/docs/content/docs/development-guide/plugins.mdx
+++ b/packages/docs/content/docs/development-guide/plugins.mdx
@@ -492,6 +492,8 @@ return {
 ```
 
 This loads API routes, event handlers, and other step types directly from the plugin directory.
+
+**Note:** Plugin steps follow the same discovery rules as regular steps - they can be organized in subdirectories and will be discovered recursively. The `dirname` specifies the root directory to scan, and steps can be nested at any depth within it.
 </Callout>
 
 ### Best Practices for Local Plugins

--- a/packages/docs/content/docs/development-guide/project-structure.mdx
+++ b/packages/docs/content/docs/development-guide/project-structure.mdx
@@ -18,6 +18,10 @@ Here's what a typical Motia project looks like:
     <File name="send-notification.step.js" />
     <File name="send-notification.tsx" />
   </Folder>
+  <Folder name="src" defaultOpen>
+    <File name="user-handler.step.ts" />
+    <File name="email-service_step.py" />
+  </Folder>
   <File name="package.json" />
   <File name="requirements.txt" />
   <File name="tsconfig.json" />
@@ -42,16 +46,21 @@ Here's what a typical Motia project looks like:
 | `config.yml` | Optional Motia configuration | Config | - |
 
 <Callout type="info">
-The `steps/` and `src/` directories are the heart of your Motia application - this is where all your workflow logic lives. Motia automatically discovers and registers any file following the naming pattern from both directories.
+**Flexible Step Discovery**
+
+Motia automatically discovers and registers steps from **both** `steps/` and `src/` directories. You're **not required** to use a specific directory structure - organize your code however makes sense for your project!
 </Callout>
 
-<Callout>
-<strong>Location and nesting rules</strong>
+<Callout type="success">
+<strong>Directory flexibility and organization</strong>
 
-- Both the `steps/` and `src/` directories are supported at the <em>project root</em> (e.g., `my-motia-project/steps` or `my-motia-project/src`).
-- You can freely nest steps in subfolders under either directory (e.g., `steps/aaa/a1.step.ts`, `src/bbb/ccc/c1_step.py`).
-- Discovery is recursive inside both directories, so deeper folder structures for large apps are supported.
-- You can use either `steps/`, `src/`, or both directories in your project.
+- **Both `steps/` and `src/` directories are supported** - use whichever fits your team's conventions
+- **Use one or both directories** - mix and match based on your preferences
+- **Recursive discovery** - nest steps in subfolders as deeply as you need (e.g., `steps/api/v1/users.step.ts`, `src/services/email/send_step.py`)
+- **No hierarchy or priority** - both directories are treated equally
+- **Organize freely** - structure by feature, language, team, or any pattern that works for you
+
+This means existing projects using `steps/` continue to work, while new projects can use `src/` or both directories together.
 </Callout>
 
 ## Automatic Step Discovery
@@ -59,12 +68,12 @@ The `steps/` and `src/` directories are the heart of your Motia application - th
 <Callout type="default">
 **Key Concept: Automatic Discovery** 
 
-Motia will automatically discover and register **any file** that follows the `.step.` naming pattern as a workflow step. You don't need to manually register steps - just create a file with the right naming pattern and Motia will find it.
+Motia automatically discovers and registers **any file** that follows the `.step.` naming pattern as a workflow step, **regardless of where it's located** in your `steps/` or `src/` directories. No manual registration required - just create a file with the right naming pattern and Motia will find it.
 </Callout>
 
 ### Discovery Rules
 
-Motia scans your `steps/` and `src/` directories and automatically registers files as steps based on these rules:
+Motia scans your project and automatically registers files as steps based on these simple rules:
 
 1. **File must contain `.step.` or `_step.` in the filename** (e.g., `my-task.step.ts`, `my_task_step.py`)
 2. **File must export a `config` object** defining the step configuration
@@ -72,11 +81,15 @@ Motia scans your `steps/` and `src/` directories and automatically registers fil
 4. **File extension determines the runtime** (`.ts` = TypeScript, `.py` = Python, `.js` = JavaScript)
 
 When you run `motia dev`, Motia will:
-- Scan both the `steps/` and `src/` directories recursively
-- Find all files matching `*.step.*` in both directories
+- **Recursively scan** both `steps/` and `src/` directories (if they exist)
+- **Find all files** matching `*.step.*` or `*_step.*` patterns in either directory
 - Parse their `config` exports to understand step types and connections
 - Register them in the workflow engine
 - Make them available in the Workbench
+
+<Callout type="success">
+**No directory requirement** - Steps are discoverable from anywhere within `steps/` or `src/`, regardless of folder depth or organization pattern. Both directories are treated equally with no preference or priority.
+</Callout>
 
 ## File Naming Convention
 
@@ -109,13 +122,17 @@ The `.step.` part in the filename is **required** - this is how Motia identifies
 
 ## Step Organization Patterns
 
-<Tabs items={["Sequential", "Feature-Based", "Language-Specific"]}>
+<Callout type="info">
+All examples below can use either `steps/` or `src/` as the root directory - choose what works best for your team!
+</Callout>
+
+<Tabs items={["Sequential", "Feature-Based", "Language-Specific", "Mixed Directories"]}>
 <Tab value="Sequential">
 
 ### Sequential Flow Organization
 Perfect for linear workflows where order matters:
 
-<Folder name="steps" defaultOpen>
+<Folder name="src" defaultOpen>
   <File name="01-api-start.step.ts" />
   <File name="02-validate-data_step.py" />
   <File name="03-process-payment.step.js" />
@@ -137,7 +154,7 @@ Perfect for linear workflows where order matters:
 ### Feature-Based Organization
 Organize by business domains for complex applications:
 
-<Folder name="steps" defaultOpen>
+<Folder name="src" defaultOpen>
   <Folder name="authentication" defaultOpen>
     <File name="login.step.ts" />
     <File name="verify-token_step.py" />
@@ -190,6 +207,37 @@ Group by programming language for team specialization:
 - Consistent tooling and patterns
 - Easy onboarding for language experts
 - Shared libraries and utilities
+
+</Tab>
+<Tab value="Mixed Directories">
+
+### Mixed Directory Organization
+Use both `steps/` and `src/` for maximum flexibility:
+
+<Folder name="project-root" defaultOpen>
+  <Folder name="src" defaultOpen>
+    <Folder name="api" defaultOpen>
+      <File name="users.step.ts" />
+      <File name="products.step.ts" />
+    </Folder>
+    <Folder name="services" defaultOpen>
+      <File name="email-service_step.py" />
+      <File name="payment-service.step.js" />
+    </Folder>
+  </Folder>
+  <Folder name="steps" defaultOpen>
+    <Folder name="workflows" defaultOpen>
+      <File name="onboarding.step.ts" />
+      <File name="analytics_step.py" />
+    </Folder>
+  </Folder>
+</Folder>
+
+**Benefits:**
+- Combine organizational patterns
+- Migrate gradually from one structure to another
+- Separate concerns (e.g., APIs in `src/`, workflows in `steps/`)
+- Team autonomy in different parts of the codebase
 
 </Tab>
 </Tabs>
@@ -436,9 +484,10 @@ export const handler = async (input, ctx) => {
   <Folder name="lib">
     <File name="user-handler.step.ts" />
   </Folder>
-  <Folder name="components">
+  <Folder name="utils">
     <File name="processor_step.py" />
   </Folder>
+  <File name="helper.step.js" />
 </Folder>
 </div>
 <div>
@@ -448,13 +497,15 @@ export const handler = async (input, ctx) => {
     <File name="user-handler.step.ts" />
   </Folder>
   <Folder name="src" defaultOpen>
-    <File name="processor_step.py" />
+    <Folder name="services">
+      <File name="processor_step.py" />
+    </Folder>
   </Folder>
 </Folder>
 </div>
 </div>
 
-Note: Both `steps/` and `src/` directories are supported. Files must be in one of these directories to be discovered.
+**Note:** Steps must be located within `steps/` or `src/` directories to be discovered. Both directories are treated equally - use whichever fits your project structure. Files can be nested at any depth within these directories.
 
 </Tab>
 </Tabs>

--- a/packages/docs/content/docs/examples/ai-deep-research-agent.mdx
+++ b/packages/docs/content/docs/examples/ai-deep-research-agent.mdx
@@ -40,6 +40,10 @@ import { CodeFetcher } from '../../../components/CodeFetcher'
   <File name="status-api.step.ts" />
 </Folder>
 
+<Callout type="info">
+This example uses the `steps/` directory, but you can also use `src/` or both. Motia discovers step files from either location automatically.
+</Callout>
+
 <Tabs items={['analyze-content', 'compile-report', 'extract-content', 'follow-up-research', 'generate-queries', 'report-api', 'research-api', 'search-web', 'status-api']}>
   <CodeFetcher path="examples/ai-deep-research-agent/steps" tab="analyze-content" value="analyze-content" />
   <CodeFetcher path="examples/ai-deep-research-agent/steps" tab="compile-report" value="compile-report" />

--- a/packages/docs/content/docs/examples/finance-agent.mdx
+++ b/packages/docs/content/docs/examples/finance-agent.mdx
@@ -36,6 +36,10 @@ import { CodeFetcher } from '../../../components/CodeFetcher'
   <File name="web-search.step.ts" />
 </Folder>
 
+<Callout type="info">
+This example uses the `steps/` directory, but you can also use `src/` or both. Motia discovers step files from either location automatically.
+</Callout>
+
 <Tabs items={['finance-data', 'openai-analysis', 'query-api', 'response-coordinator', 'result-api', 'save-result', 'web-search']}>
   <CodeFetcher path="examples/finance-agent/steps" tab="finance-data" value="finance-data" />
   <CodeFetcher path="examples/finance-agent/steps" tab="openai-analysis" value="openai-analysis" />

--- a/packages/docs/content/docs/examples/github-integration-workflow.mdx
+++ b/packages/docs/content/docs/examples/github-integration-workflow.mdx
@@ -51,6 +51,10 @@ The GitHub integration workflow is organized into two main components:
   </Folder>
 </Folder>
 
+<Callout type="info">
+This example uses the `steps/` directory, but you can also use `src/` or both. Motia discovers step files from either location automatically.
+</Callout>
+
 <Tabs items={['issue-webhook', 'issue-classifier', 'label-assigner', 'assignee-selector']}>
   <GitHubWorkflowTab tab="issue-webhook" value="github-webhook" folder="issue-triage" />
   <GitHubWorkflowTab tab="issue-classifier" value="issue-classifier" folder="issue-triage" />

--- a/packages/docs/content/docs/examples/gmail-automation.mdx
+++ b/packages/docs/content/docs/examples/gmail-automation.mdx
@@ -38,6 +38,10 @@ import { GmailTab } from '../../../components/GmailCodeFetcher'
   <File name="organize-email.step.ts" />
 </Folder>
 
+<Callout type="info">
+This example uses the `steps/` directory, but you can also use `src/` or both. Motia discovers step files from either location automatically.
+</Callout>
+
 <Tabs items={['webhook', 'analyze-email', 'auto-responder', 'daily-summary', 'fetch-email', 'organize-email']}>
   <GmailTab tab="webhook" value="gmail-webhook" />
   <GmailTab tab="analyze-email" value="analyze-email" fileExtension="py" />

--- a/packages/docs/content/docs/examples/trello-automation.mdx
+++ b/packages/docs/content/docs/examples/trello-automation.mdx
@@ -47,6 +47,10 @@ The Trello board is organized into four main lists:
   <File name="slack-notifier.step.ts" />
 </Folder>
 
+<Callout type="info">
+This example uses the `steps/` directory, but you can also use `src/` or both. Motia discovers step files from either location automatically.
+</Callout>
+
 <Tabs items={['webhook', 'validation', 'requirements', 'assigned', 'review', 'completion', 'overdue', 'slack']}>
   <TrelloTab tab="webhook" value="trello-webhook" />
   <TrelloTab tab="validation" value="trello-webhook-validation" />

--- a/packages/docs/content/docs/getting-started/build-your-first-motia-app/ai-agents.mdx
+++ b/packages/docs/content/docs/getting-started/build-your-first-motia-app/ai-agents.mdx
@@ -92,6 +92,8 @@ Your Workbench will be available at `http://localhost:3000`.
 </Folder>
 
 <Callout type="info">
+**Project organization** - This example uses the `steps/` directory, but you can also use `src/` or both directories in your project. Motia discovers step files from either location automatically.
+
 Files like `features.json` and `tutorial/tutorial.tsx` are only for the interactive tutorial and are not part of Motia's project structure.
 </Callout>
 

--- a/packages/docs/content/docs/getting-started/build-your-first-motia-app/api-endpoints.mdx
+++ b/packages/docs/content/docs/getting-started/build-your-first-motia-app/api-endpoints.mdx
@@ -80,6 +80,8 @@ Your Workbench will be available at `http://localhost:3000`.
 </Folder>
 
 <Callout type="info">
+**Project organization** - This example uses the `steps/` directory, but you can also use `src/` or both directories in your project. Motia discovers step files from either location automatically. 
+
 Files like `features.json` and `tutorial/tutorial.tsx` are only for the interactive tutorial and are not part of Motia's project structure.
 </Callout>
 

--- a/packages/docs/content/docs/getting-started/build-your-first-motia-app/background-jobs.mdx
+++ b/packages/docs/content/docs/getting-started/build-your-first-motia-app/background-jobs.mdx
@@ -71,6 +71,8 @@ Your Workbench will be available at `http://localhost:3000`.
 </Folder>
 
 <Callout type="info">
+**Project organization** - This example uses the `steps/` directory, but you can also use `src/` or both directories in your project. Motia discovers step files from either location automatically.
+
 Files like `features.json` and `tutorial/tutorial.tsx` are only for the interactive tutorial and are not part of Motia's project structure.
 </Callout>
 

--- a/packages/docs/content/docs/getting-started/build-your-first-motia-app/streaming-agents.mdx
+++ b/packages/docs/content/docs/getting-started/build-your-first-motia-app/streaming-agents.mdx
@@ -90,6 +90,8 @@ Your Workbench will be available at `http://localhost:3000`.
 </Folder>
 
 <Callout type="info">
+**Project organization** - This example uses the `steps/` directory, but you can also use `src/` or both directories in your project. Motia discovers step files from either location automatically.
+
 Files like `features.json` and `tutorial/tutorial.tsx` are only for the interactive tutorial and are not part of Motia's project structure.
 </Callout>
 

--- a/packages/docs/content/docs/getting-started/build-your-first-motia-app/workflows.mdx
+++ b/packages/docs/content/docs/getting-started/build-your-first-motia-app/workflows.mdx
@@ -73,6 +73,8 @@ Your Workbench will be available at `http://localhost:3000`.
 </Folder>
 
 <Callout type="info">
+**Project organization** - This example uses the `steps/` directory, but you can also use `src/` or both directories in your project. Motia discovers step files from either location automatically.
+
 Files like `features.json` and `tutorial/tutorial.tsx` are only for the interactive tutorial and are not part of Motia's project structure.
 </Callout>
 

--- a/packages/docs/content/docs/index.mdx
+++ b/packages/docs/content/docs/index.mdx
@@ -30,7 +30,7 @@ To read more about this, check out our [manifesto](/manifesto).
 
 At the heart of Motia is a single primitive: the **Step**.  
 
-A Step is just a file with a `config` and a `handler`. Motia auto-discovers these files from `/steps` directory and connects them automatically.
+A Step is just a file with a `config` and a `handler`. Motia auto-discovers these files from your project (either `steps/` or `src/` directories) and connects them automatically - no manual registration required.
 
 Here’s a simple example of two Steps working together: an API Step that emits an event, and an Event Step that processes it.
 


### PR DESCRIPTION

- Update project structure docs to emphasize both steps/ and src/ directories are supported
- Add callouts to all tutorials explaining directory flexibility
- Update all example documentation with directory choice clarification
- Clarify that step discovery is automatic from either directory
- Emphasize no directory requirement - developers can organize freely

Related to PR https://github.com/MotiaDev/motia/pull/886 which added src/ directory support for step discovery


## Related PRs
https://github.com/MotiaDev/motia/pull/886