### PR TITLE
fix: include stream files in python installation detection

### DIFF
--- a/packages/snap/src/cloud/new-deployment/build.ts
+++ b/packages/snap/src/cloud/new-deployment/build.ts
@@ -1,7 +1,7 @@
 import { isApiStep, LockedData, MemoryStreamAdapterManager } from '@motiadev/core'
 import { NoPrinter } from '@motiadev/core/dist/src/printer'
 import fs from 'fs'
-import { collectFlows, getStepFiles } from '../../generate-locked-data'
+import { collectFlows, getStepFiles, getStreamFiles } from '../../generate-locked-data'
 import { instanceRedisMemoryServer } from '../../redis-memory-manager'
 import { BuildError, BuildErrorType } from '../../utils/errors/build.error'
 import { Builder, type StepsConfigFile } from '../build/builder'
@@ -17,6 +17,7 @@ const hasPythonSteps = (stepFiles: string[]) => {
 export const build = async (listener: BuildListener): Promise<Builder> => {
   const builder = new Builder(projectDir, listener)
   const stepFiles = getStepFiles(projectDir)
+  const streamFiles = getStreamFiles(projectDir)
 
   if (stepFiles.length === 0) {
     throw new Error('Project contains no steps, please add some steps before building')
@@ -31,7 +32,7 @@ export const build = async (listener: BuildListener): Promise<Builder> => {
   const redisClient = await instanceRedisMemoryServer(projectDir, false)
   const lockedData = new LockedData(projectDir, new MemoryStreamAdapterManager(), new NoPrinter(), redisClient)
 
-  if (hasPythonSteps(stepFiles)) {
+  if (hasPythonSteps([...stepFiles, ...streamFiles])) {
     builder.registerBuilder('python', new PythonBuilder(builder, listener))
   }
 

--- a/packages/snap/src/generate-locked-data.ts
+++ b/packages/snap/src/generate-locked-data.ts
@@ -64,7 +64,8 @@ export const collectFlows = async (projectDir: string, lockedData: LockedData): 
     ...(existsSync(srcDir) ? globSync('**/*.step.py', { absolute: true, cwd: srcDir }) : []),
   ]
 
-  const hasPythonFiles = stepFiles.some((file) => file.endsWith('.py'))
+  const hasPythonFiles =
+    stepFiles.some((file) => file.endsWith('.py')) || streamFiles.some((file) => file.endsWith('.py'))
 
   if (hasPythonFiles) {
     activatePythonVenv({ baseDir: projectDir })

--- a/packages/snap/src/install.ts
+++ b/packages/snap/src/install.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { getStepFiles } from './generate-locked-data'
+import { getStepFiles, getStreamFiles } from './generate-locked-data'
 import { activatePythonVenv } from './utils/activate-python-env'
 import { ensureUvInstalled } from './utils/ensure-uv'
 import { executeCommand } from './utils/execute-command'
@@ -74,7 +74,8 @@ export const install = async ({ isVerbose = false, pythonVersion = '3.13' }: Ins
   const baseDir = process.cwd()
 
   const steps = getStepFiles(baseDir)
-  if (steps.some((file) => file.endsWith('.py'))) {
+  const streams = getStreamFiles(baseDir)
+  if (steps.some((file) => file.endsWith('.py')) || streams.some((file) => file.endsWith('.py'))) {
     await pythonInstall({ baseDir, isVerbose, pythonVersion })
   }
 


### PR DESCRIPTION
## Summary

Fixed Python module installation detection to include `_stream.py` files in addition to `_step.py` files. Previously, projects with only `_stream.py` files would not trigger Python dependency installation, requiring users to add at least one `_step.py` file to make installation work.

## Related Issues

<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Additional Context

This fix ensures that Python virtual environment activation and dependency installation work correctly for projects that only use stream files (e.g., `*_stream.py`). The changes maintain backward compatibility - projects with only `_step.py` files continue to work as before, and projects with both file types are also handled correctly.

Note: `start.ts` and `dev.ts` already correctly combined both file types, so no changes were needed there.
