### PR TITLE
fix: search icon overlap in workbench search bars

### DIFF
--- a/plugins/plugin-endpoint/src/components/endpoints-search.tsx
+++ b/plugins/plugin-endpoint/src/components/endpoints-search.tsx
@@ -17,7 +17,7 @@ export const EndpointsSearch = ({ value, onChange, onClear }: EndpointsSearchPro
           variant="shade"
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          className="px-9 font-medium"
+          className="px-9! font-medium"
           placeholder="Search by Method or Path"
         />
         <X

--- a/plugins/plugin-logs/src/components/logs-page.tsx
+++ b/plugins/plugin-logs/src/components/logs-page.tsx
@@ -37,7 +37,7 @@ export const LogsPage = () => {
               variant="shade"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="px-9 font-medium"
+              className="px-9! font-medium"
               placeholder="Search by Trace ID or Message"
             />
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground/50" />

--- a/plugins/plugin-states/src/components/states-page.tsx
+++ b/plugins/plugin-states/src/components/states-page.tsx
@@ -83,7 +83,7 @@ export const StatesPage = () => {
               variant="shade"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="px-9 font-medium"
+              className="px-9! font-medium"
               placeholder="Search by Group ID or Key"
             />
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground/50" />


### PR DESCRIPTION
## Summary
- Add !important modifier to px-9 padding in search inputs.
- Fixes overlap issue in endpoints, logs, and states search components.
- Applies same fix pattern from observability search-bar component.


## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<img width="344" height="86" alt="image" src="https://github.com/user-attachments/assets/5030f190-1160-49a4-b7c8-825b42789ceb" />
<img width="344" height="86" alt="image" src="https://github.com/user-attachments/assets/5b6ec5c9-4d2c-4b7f-bb04-3dcefb781d78" />
<img width="344" height="86" alt="image" src="https://github.com/user-attachments/assets/ebe7aa20-1a4e-477e-9368-a962625e9959" />


## Additional Context
<!-- Add any other context or information about the PR here --> 