### PR TITLE
fix: truncate long step names in the tracing tab

### DIFF
--- a/plugins/plugin-observability/src/components/trace-group-item.tsx
+++ b/plugins/plugin-observability/src/components/trace-group-item.tsx
@@ -43,7 +43,7 @@ export const TraceGroupItem: React.FC<TraceGroupItemProps> = memo(
       >
         <div className="p-3 flex flex-col gap-1">
           <div className="flex flex-row justify-between items-center gap-2">
-            <span className="font-semibold text-lg">{groupName}</span>
+            <span className="font-semibold text-lg truncate flex-1 min-w-0">{groupName}</span>
             <TraceStatusBadge status={groupStatus} duration={duration} />
           </div>
 


### PR DESCRIPTION
## Summary
Truncate long step names in the tracing tab.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->
<img width="265" height="92" alt="image" src="https://github.com/user-attachments/assets/324712ba-923a-4805-87b5-64b557dfade7" />


## Additional Context
<!-- Add any other context or information about the PR here --> 