### PR TITLE
fix: broken links in workbench and docs

### DIFF
--- a/packages/docs/content/docs/deployment-guide/motia-cloud/features.mdx
+++ b/packages/docs/content/docs/deployment-guide/motia-cloud/features.mdx
@@ -77,4 +77,4 @@ Motia Cloud supports creating multiple environments for your projects.
 
 ## Learn how to deploy
 
-Learn how to deploy your project to Motia Cloud in the [Deployment](/docs/concepts/deployment/motia-cloud/deployment) page.
+Learn how to deploy your project to Motia Cloud in the [Deployment](/docs/deployment-guide/motia-cloud/deployment) page.

--- a/packages/workbench/src/components/header/deploy-button.tsx
+++ b/packages/workbench/src/components/header/deploy-button.tsx
@@ -56,7 +56,7 @@ export const DeployButton = () => {
             </div>
 
             <a
-              href="https://www.motia.dev/docs/concepts/deployment/motia-cloud/features"
+              href="https://www.motia.dev/docs/deployment-guide/motia-cloud/features"
               target="_blank"
               className="text-foreground text-xs font-semibold px-4 hover:underline"
               rel="noopener"


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->
- Fix the learn more link in the Deploy to Motia Cloud modal.
- Fix the broken link in this section: https://www.motia.dev/docs/deployment-guide/motia-cloud/features#learn-how-to-deploy.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 