### PR TITLE
fix(logs): handle non-string values in search to prevent runtime crash

### DIFF
--- a/plugins/plugin-logs/src/components/logs-page.tsx
+++ b/plugins/plugin-logs/src/components/logs-page.tsx
@@ -21,9 +21,15 @@ export const LogsPage = () => {
   const filteredLogs = useMemo(() => {
     return logs.filter((log) => {
       return (
-        log.msg.toLowerCase().includes(search.toLowerCase()) ||
-        log.traceId.toLowerCase().includes(search.toLowerCase()) ||
-        log.step.toLowerCase().includes(search.toLowerCase())
+        String(log.msg || '')
+          .toLowerCase()
+          .includes(search.toLowerCase()) ||
+        String(log.traceId || '')
+          .toLowerCase()
+          .includes(search.toLowerCase()) ||
+        String(log.step || '')
+          .toLowerCase()
+          .includes(search.toLowerCase())
       )
     })
   }, [logs, search])


### PR DESCRIPTION


## Summary
The LogsPage component crashes at runtime when the backend sends a log
with `msg`, `traceId`, or `step` that is not a string. Since the UI
calls `.toLowerCase()` during filtering, any non-string value (null,
number, object, undefined) immediately triggers a TypeError.

This PR normalizes these fields to empty strings before applying
`.toLowerCase()`, ensuring the filtering logic never crashes even when
the backend sends unexpected data types.
## Related Issues
Fixes #992 
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 