### PR TITLE
feat: add start command to docs and templates

### DIFF
--- a/packages/docs/content/docs/api-reference.mdx
+++ b/packages/docs/content/docs/api-reference.mdx
@@ -1391,7 +1391,7 @@ motia dev --port 4000 --host 0.0.0.0
 
 ### `motia start`
 
-Start production server (no Workbench, no hot reload).
+Start production server without hot reload. Workbench is included by default (can be disabled via `MOTIA_DOCKER_DISABLE_WORKBENCH` environment variable).
 
 ```bash
 motia start

--- a/packages/docs/content/docs/development-guide/cli.mdx
+++ b/packages/docs/content/docs/development-guide/cli.mdx
@@ -110,7 +110,7 @@ The deployment process:
 
 ### `dev`
 
-Start the development server.
+Start the development server with hot reload and Workbench.
 
 ```bash
 npx motia dev [options]
@@ -121,6 +121,36 @@ Options:
 - `-p, --port <port>`: The port to run the server on (default: 3000).
 - `-H, --host [host]`: The host address for the server (default: localhost).
 - `-d, --debug`: Enable debug logging.
+- `-m, --mermaid`: Enable Mermaid diagram generation.
+- `--motia-dir <path>`: Custom path for `.motia` folder.
+
+### `start`
+
+Start the production server without hot reload. Workbench is included by default (can be disabled via `MOTIA_DOCKER_DISABLE_WORKBENCH` environment variable).
+
+```bash
+npx motia start [options]
+```
+
+Options:
+
+- `-p, --port <port>`: The port to run the server on (default: 3000).
+- `-H, --host [host]`: The host address for the server (default: localhost).
+- `-d, --debug`: Enable debug logging.
+- `--motia-dir <path>`: Custom path for `.motia` folder.
+
+Example:
+
+```bash
+# Start production server on port 8080
+npx motia start --port 8080
+
+# Start on a specific host
+npx motia start --host 0.0.0.0 --port 3000
+
+# Start without Workbench
+MOTIA_DOCKER_DISABLE_WORKBENCH=true npx motia start
+```
 
 ### `get-config`
 

--- a/packages/docs/public/llm-docs/concepts/cli.mdx.md
+++ b/packages/docs/public/llm-docs/concepts/cli.mdx.md
@@ -73,7 +73,7 @@ The deployment process:
 
 ### `dev`
 
-Start the development server.
+Start the development server with hot reload and Workbench.
 
 ```bash
 npx motia dev [options]
@@ -84,6 +84,23 @@ Options:
 - `-p, --port <port>`: The port to run the server on (default: 3000).
 - `-H, --host [host]`: The host address for the server (default: localhost).
 - `-d, --debug`: Enable debug logging.
+- `-m, --mermaid`: Enable Mermaid diagram generation.
+- `--motia-dir <path>`: Custom path for `.motia` folder.
+
+### `start`
+
+Start the production server without hot reload. Workbench is included by default (can be disabled via `MOTIA_DOCKER_DISABLE_WORKBENCH` environment variable).
+
+```bash
+npx motia start [options]
+```
+
+Options:
+
+- `-p, --port <port>`: The port to run the server on (default: 3000).
+- `-H, --host [host]`: The host address for the server (default: localhost).
+- `-d, --debug`: Enable debug logging.
+- `--motia-dir <path>`: Custom path for `.motia` folder.
 
 ### `get-config`
 

--- a/packages/snap/src/create/index.ts
+++ b/packages/snap/src/create/index.ts
@@ -122,6 +122,7 @@ export const create = async ({ projectName, template, cursorEnabled, context }: 
       scripts: {
         postinstall: 'motia install',
         dev: 'motia dev',
+        start: 'motia start',
         'generate-types': 'motia generate-types',
         build: 'motia build',
         clean: 'rm -rf dist node_modules python_modules .motia .mermaid',

--- a/packages/snap/src/create/templates/hello/README.md.txt
+++ b/packages/snap/src/create/templates/hello/README.md.txt
@@ -44,6 +44,13 @@ yarn dev
 # or
 pnpm dev
 
+# Start production server (without hot reload)
+npm run start
+# or
+yarn start
+# or
+pnpm start
+
 # Generate TypeScript types from Step configs
 npm run generate-types
 # or

--- a/packages/snap/src/create/templates/hello_js/README.md.txt
+++ b/packages/snap/src/create/templates/hello_js/README.md.txt
@@ -44,6 +44,13 @@ yarn dev
 # or
 pnpm dev
 
+# Start production server (without hot reload)
+npm run start
+# or
+yarn start
+# or
+pnpm start
+
 # Generate TypeScript types from Step configs
 npm run generate-types
 # or

--- a/packages/snap/src/create/templates/hello_python/README.md.txt
+++ b/packages/snap/src/create/templates/hello_python/README.md.txt
@@ -44,6 +44,13 @@ yarn dev
 # or
 pnpm dev
 
+# Start production server (without hot reload)
+npm run start
+# or
+yarn start
+# or
+pnpm start
+
 # Generate TypeScript types from Step configs
 npm run generate-types
 # or

--- a/packages/snap/src/create/templates/nodejs/README.md.txt
+++ b/packages/snap/src/create/templates/nodejs/README.md.txt
@@ -43,6 +43,13 @@ yarn dev
 # or
 pnpm dev
 
+# Start production server (without hot reload)
+npm run start
+# or
+yarn start
+# or
+pnpm start
+
 # Generate TypeScript types from Step configs
 npm run generate-types
 # or

--- a/packages/snap/src/create/templates/python/README.md.txt
+++ b/packages/snap/src/create/templates/python/README.md.txt
@@ -43,6 +43,13 @@ yarn dev
 # or
 pnpm dev
 
+# Start production server (without hot reload)
+npm run start
+# or
+yarn start
+# or
+pnpm start
+
 # Generate TypeScript types from Step configs
 npm run generate-types
 # or

--- a/packages/snap/src/cursor-rules/dot-files/AGENTS.md
+++ b/packages/snap/src/cursor-rules/dot-files/AGENTS.md
@@ -20,8 +20,11 @@ This is a **Motia** application - a framework for building event-driven, type-sa
 # Install dependencies
 npm install
 
-# Start development server
+# Start development server (with hot reload)
 npm run dev
+
+# Start production server (without hot reload)
+npm run start
 
 # Generate TypeScript types from steps
 npx motia generate-types

--- a/packages/snap/src/cursor-rules/dot-files/CLAUDE.md
+++ b/packages/snap/src/cursor-rules/dot-files/CLAUDE.md
@@ -48,9 +48,9 @@ See `AGENTS.md` in this directory for a quick overview and links to specific gui
 ## Key Commands
 
 ```bash
-npm run dev              # Start development server
+npm run dev              # Start development server (with hot reload)
+npm run start            # Start production server (without hot reload)
 npx motia generate-types # Regenerate TypeScript types
-npx motia workbench      # Open visual workflow designer
 ```
 
 ---


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->
Added documentation for the motia start command across all relevant documentation files and project templates.


## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (please describe): Improvement

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

### Additional Context

**What was changed:**

| File | Change |
|------|--------|
| `packages/docs/content/docs/development-guide/cli.mdx` | Added `start` command docs, added missing `--mermaid` and `--motia-dir` options to `dev` |
| `packages/docs/content/docs/api-reference.mdx` | Fixed `start` command description |
| `packages/snap/src/create/index.ts` | Added `start: 'motia start'` to generated `package.json` |
| `packages/snap/src/create/templates/*/README.md.txt` | Added `npm run start` to all 5 templates |
| `packages/snap/src/cursor-rules/dot-files/AGENTS.md` | Added `npm run start` to Quick Start Commands |
| `packages/snap/src/cursor-rules/dot-files/CLAUDE.md` | Added `npm run start` to Key Commands |

**Important finding:**
- The `start` command **includes Workbench by default** (can be disabled via `MOTIA_DOCKER_DISABLE_WORKBENCH` env var)
- The only difference from `dev` is that `start` doesn't have hot reload