### PR TITLE
fix: clean up RPC connection resources and improve state operations

### DIFF
--- a/packages/core/src/process-communication/process-manager.ts
+++ b/packages/core/src/process-communication/process-manager.ts
@@ -94,6 +94,7 @@ export class ProcessManager {
     if (this.child) {
       this.child.kill('SIGKILL')
     }
+    this.child = undefined
   }
 
   close(): void {
@@ -101,7 +102,6 @@ export class ProcessManager {
       this.processor.close()
     }
     this.processor = undefined
-    this.child = undefined
   }
 
   get process(): ChildProcess | undefined {

--- a/packages/core/src/step-handler-rpc-stdin-processor.ts
+++ b/packages/core/src/step-handler-rpc-stdin-processor.ts
@@ -96,6 +96,7 @@ export class RpcStdinProcessor implements RpcProcessorInterface {
     this.isClosed = true
     this.messageCallback = undefined
     if (this.rl) {
+      this.rl.removeAllListeners()
       this.rl.close()
     }
   }


### PR DESCRIPTION
## Summary
This PR addresses resource cleanup in RPC connections by properly handling resources in `RpcStdinProcessor` and `ProcessManager`. It also includes performance improvements to state operations by using `Promise.all` for parallel state retrieval and updates the linting configuration for better diagnostics.

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Changes Made

### Core Changes
- **RPC Resource Cleanup**: Implemented proper cleanup of resources in `RpcStdinProcessor` and `ProcessManager` to prevent resource leaks and ensure clean shutdown of RPC connections

### Performance Improvements
- **Optimized State Operations**: Updated `joinStep.step.ts` to use `Promise.all` for concurrent state retrieval of `stepA`, `stepB`, and `stepC`, improving performance in parallel merge operations

### Development Experience
- **Linting Configuration**: Added `--diagnostic-level=error` to `lint:fix` script in `package.json` for more precise error reporting

### Workbench Updates
- Updated `motia-workbench.json` with new flow configurations for improved development workflow

## Additional Context
This fix ensures that RPC connections are properly terminated and resources are cleaned up, which is crucial for long-running processes and preventing resource exhaustion.