### PR TITLE
docs: reduce callouts on quick-start, move relevant callout to build-your-first

### DIFF
--- a/packages/docs/content/docs/getting-started/build-your-first-motia-app/index.mdx
+++ b/packages/docs/content/docs/getting-started/build-your-first-motia-app/index.mdx
@@ -27,6 +27,18 @@ You'll need:
 
 That's it. No database setup, no complex config, no separate services to run.
 
+<Callout type="info">
+**Using Your Own Redis?**
+
+If you already have Redis running or prefer to use an external Redis instance, use the `--skip-redis` flag:
+
+```bash
+npx motia@latest create my-app --skip-redis
+```
+
+See [CLI documentation](/docs/development-guide/cli#create) for more details.
+</Callout>
+
 ---
 
 ## Your Journey

--- a/packages/docs/content/docs/getting-started/quick-start.mdx
+++ b/packages/docs/content/docs/getting-started/quick-start.mdx
@@ -15,38 +15,8 @@ npx motia@latest create
 
 The installer will guide you through a few questions to set up your project, including choosing a template. Once it's done, you will have a new project directory ready to go.
 
-<Callout type="info">
-**Quick Start with a Specific Template**
-
-If you already know which template you want, you can skip the interactive prompts:
-
-```bash
-# All languages (TypeScript/JavaScript + Python)
-npx motia@latest create my-app --template starter-multilang
-
-# TypeScript only
-npx motia@latest create my-app --template starter-typescript
-
-# JavaScript only
-npx motia@latest create my-app --template starter-javascript
-
-# Python only
-npx motia@latest create my-app --template starter-python
-```
-
-See the [CLI documentation](/docs/development-guide/cli#create) for all available templates.
-</Callout>
-
-<Callout type="info">
-**Using Your Own Redis?**
-
-If you already have Redis running or prefer to use an external Redis instance, use the `--skip-redis` flag:
-
-```bash
-npx motia@latest create my-app --skip-redis
-```
-
-See [CLI documentation](/docs/development-guide/cli#create) for more details.
+<Callout>
+Choose a **Tutorial** template for an interactive walkthrough, or a **Starter** template to skip the walkthrough.
 </Callout>
 
 </Step>
@@ -75,7 +45,7 @@ This command starts the Motia runtime and the Workbench, a powerful UI for devel
 <Step>
 ### 3. Run Your First Flow
 
-The starter project comes with a pre-built `basic-tutorial` flow. Let's run it.
+Tutorial projects come with a pre-built Tutorial flow. To step through the tutorial:
 
 1.  **Open the Workbench** in your browser at [`http://localhost:3000`](http://localhost:3000).
 2.  **Click the `Tutorial`** button on the top right of the workbench.


### PR DESCRIPTION


## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->
1. Remove the --template callout from the quickstart as it's a bit too much info to provide to brand new users
2. Move the redis callout to the build-your-first-app docs instead for similar reasons.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (please describe): Docs

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 