### PR TITLE
fix: isolate e2e test project in temp directory to avoid pnpm workspace conflicts

### DIFF
--- a/packages/e2e/scripts/global-teardown.ts
+++ b/packages/e2e/scripts/global-teardown.ts
@@ -31,14 +31,14 @@ async function globalTeardown() {
 
     await new Promise((resolve) => setTimeout(resolve, 3000))
 
-    const testProjectPath = process.env.TEST_PROJECT_PATH
-    if (testProjectPath && existsSync(testProjectPath)) {
+    const testProjectRoot = process.env.TEST_PROJECT_ROOT || process.env.TEST_PROJECT_PATH
+    if (testProjectRoot && existsSync(testProjectRoot)) {
       console.log('🗑️  Removing test project directory...')
 
       if (isWindows) {
-        await removeDirectoryWithRetry(testProjectPath, 3)
+        await removeDirectoryWithRetry(testProjectRoot, 3)
       } else {
-        rmSync(testProjectPath, { recursive: true, force: true })
+        rmSync(testProjectRoot, { recursive: true, force: true })
       }
     }
 


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->
Fix e2e test setup by creating test project in temp directory instead of monorepo to avoid pnpm workspace conflicts with npm install.


## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 