### PR TITLE
fix: simplify tutorial by consolidating feature card steps

### DIFF
--- a/packages/snap/src/create/templates/nodejs/tutorial/tutorial.tsx.txt
+++ b/packages/snap/src/create/templates/nodejs/tutorial/tutorial.tsx.txt
@@ -69,7 +69,7 @@ export const steps: TutorialStep[] = [
         </p>
         <br />
         <p>
-          <b>Click on the feature cards</b> to learn about:
+          The feature cards explain:
         </p>
         <ul className="square-decoration">
           <li>
@@ -95,7 +95,6 @@ export const steps: TutorialStep[] = [
           </li>
         </ul>
         <br />
-        <p>Take your time exploring these features. Click <b>Continue</b> when you're ready to move on.</p>
       </div>
     ),
     before: [{ type: 'click', selector: workbenchXPath.flows.previewButton('apitrigger') }],
@@ -137,7 +136,7 @@ export const steps: TutorialStep[] = [
         </p>
         <br />
         <p>
-          <b>Click on the feature cards</b> to learn about:
+          The feature cards explain:
         </p>
         <ul className="square-decoration">
           <li>
@@ -156,7 +155,6 @@ export const steps: TutorialStep[] = [
         <br />
         <p>💡 <b>Event</b> Steps can only be triggered internally, through topic subscriptions.</p>
         <br />
-        <p>Click <b>Continue</b> when you're ready to move on.</p>
       </div>
     ),
     before: [{ type: 'click', selector: workbenchXPath.flows.previewButton('processfoodorder') }],
@@ -192,7 +190,7 @@ export const steps: TutorialStep[] = [
         </p>
         <br />
         <p>
-          <b>Click on the feature cards</b> to learn about:
+          The feature cards explain:
         </p>
         <ul className="square-decoration">
           <li>
@@ -206,7 +204,6 @@ export const steps: TutorialStep[] = [
         <br />
         <p>In this example, the CRON Step evaluates orders in state and emits warnings for unprocessed orders.</p>
         <br />
-        <p>Click <b>Continue</b> when you're ready to move on.</p>
       </div>
     ),
     before: [{ type: 'click', selector: workbenchXPath.flows.previewButton('stateauditjob') }],

--- a/packages/snap/src/create/templates/python/tutorial/tutorial.tsx.txt
+++ b/packages/snap/src/create/templates/python/tutorial/tutorial.tsx.txt
@@ -69,7 +69,7 @@ export const steps: TutorialStep[] = [
         </p>
         <br />
         <p>
-          <b>Click on the feature cards</b> to learn about:
+          The feature cards explain:
         </p>
         <ul className="square-decoration">
           <li>
@@ -95,7 +95,6 @@ export const steps: TutorialStep[] = [
           </li>
         </ul>
         <br />
-        <p>Take your time exploring these features. Click <b>Continue</b> when you're ready to move on.</p>
       </div>
     ),
     before: [{ type: 'click', selector: workbenchXPath.flows.previewButton('apitrigger') }],
@@ -137,7 +136,7 @@ export const steps: TutorialStep[] = [
         </p>
         <br />
         <p>
-          <b>Click on the feature cards</b> to learn about:
+          The feature cards explain:
         </p>
         <ul className="square-decoration">
           <li>
@@ -156,7 +155,6 @@ export const steps: TutorialStep[] = [
         <br />
         <p>💡 <b>Event</b> Steps can only be triggered internally, through topic subscriptions.</p>
         <br />
-        <p>Click <b>Continue</b> when you're ready to move on.</p>
       </div>
     ),
     before: [{ type: 'click', selector: workbenchXPath.flows.previewButton('processfoodorder') }],
@@ -192,7 +190,7 @@ export const steps: TutorialStep[] = [
         </p>
         <br />
         <p>
-          <b>Click on the feature cards</b> to learn about:
+          The feature cards explain:
         </p>
         <ul className="square-decoration">
           <li>
@@ -206,7 +204,6 @@ export const steps: TutorialStep[] = [
         <br />
         <p>In this example, the CRON Step evaluates orders in state and emits warnings for unprocessed orders.</p>
         <br />
-        <p>Click <b>Continue</b> when you're ready to move on.</p>
       </div>
     ),
     before: [{ type: 'click', selector: workbenchXPath.flows.previewButton('stateauditjob') }],

--- a/playground/tutorial/tutorial.tsx
+++ b/playground/tutorial/tutorial.tsx
@@ -67,9 +67,7 @@ export const steps: TutorialStep[] = [
           explain different parts of the code.
         </p>
         <br />
-        <p>
-          <b>Click on the feature cards</b> to learn about:
-        </p>
+        <p>The feature cards explain:</p>
         <ul className="square-decoration">
           <li>
             <b>Step Configuration</b> - Common attributes like type, name, description, and flows
@@ -93,10 +91,6 @@ export const steps: TutorialStep[] = [
             <b>HTTP Response</b> - Returning responses that match your responseSchema
           </li>
         </ul>
-        <br />
-        <p>
-          Take your time exploring these features. Click <b>Continue</b> when you're ready to move on.
-        </p>
       </div>
     ),
     before: [{ type: 'click', selector: workbenchXPath.flows.previewButton('apitrigger') }],
@@ -136,9 +130,7 @@ export const steps: TutorialStep[] = [
           specific tasks.
         </p>
         <br />
-        <p>
-          <b>Click on the feature cards</b> to learn about:
-        </p>
+        <p>The feature cards explain:</p>
         <ul className="square-decoration">
           <li>
             <b>Step Configuration</b> - Common attributes for Event Steps
@@ -156,10 +148,6 @@ export const steps: TutorialStep[] = [
         <br />
         <p>
           💡 <b>Event</b> Steps can only be triggered internally, through topic subscriptions.
-        </p>
-        <br />
-        <p>
-          Click <b>Continue</b> when you're ready to move on.
         </p>
       </div>
     ),
@@ -195,9 +183,7 @@ export const steps: TutorialStep[] = [
           difference is the <b>cron</b> attribute that defines the schedule.
         </p>
         <br />
-        <p>
-          <b>Click on the feature cards</b> to learn about:
-        </p>
+        <p>The feature cards explain:</p>
         <ul className="square-decoration">
           <li>
             <b>Cron Configuration</b> - How to define the cron schedule (e.g., every 5 minutes)
@@ -209,10 +195,6 @@ export const steps: TutorialStep[] = [
         </ul>
         <br />
         <p>In this example, the CRON Step evaluates orders in state and emits warnings for unprocessed orders.</p>
-        <br />
-        <p>
-          Click <b>Continue</b> when you're ready to move on.
-        </p>
       </div>
     ),
     before: [{ type: 'click', selector: workbenchXPath.flows.previewButton('stateauditjob') }],


### PR DESCRIPTION
## Summary
Consolidates multiple individual feature card tutorial steps into single "Explore the Code" steps for each step type. Instead of auto-clicking through each feature card, the tutorial now opens the code viewer and lets users explore feature cards at their own pace. Reduces step count and eliminates duplicate explanations.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (please describe): Improvement

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)


## Additional Context
<!-- Add any other context or information about the PR here --> 