### PR TITLE
fix: add @motiadev/workbench to project template dependencies

### DIFF
--- a/packages/snap/src/create/index.ts
+++ b/packages/snap/src/create/index.ts
@@ -32,7 +32,12 @@ const installRequiredDependencies = async (packageManager: string, rootDir: stri
     ...pluginDependencies.map((dep: string) => `${dep}@${version}`),
   ].join(' ')
 
-  const devDependencies = ['ts-node@10.9.2', 'typescript@5.7.3', '@types/react@19.1.1'].join(' ')
+  const devDependencies = [
+    'ts-node@10.9.2',
+    'typescript@5.7.3',
+    '@types/react@19.1.1',
+    `@motiadev/workbench@${version}`,
+  ].join(' ')
 
   try {
     await executeCommand(`${installCommand} ${dependencies}`, rootDir)


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->
Added @motiadev/workbench@${version} to the devDependencies list in the project creation flow. This ensures the package is installed when creating new projects, so the tutorial import resolves.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 