### PR TITLE
feat: add copy button to trace items

### DIFF
--- a/plugins/plugin-observability/src/components/trace-group-item.tsx
+++ b/plugins/plugin-observability/src/components/trace-group-item.tsx
@@ -5,6 +5,7 @@ import { memo, useCallback, useMemo } from 'react'
 import { formatDuration } from '../lib/utils'
 import { useObservabilityStore } from '../stores/use-observability-store'
 import { TraceStatusBadge } from './trace-status'
+import { CopyButton } from './ui/copy-button'
 
 interface TraceGroupItemProps {
   groupId: string
@@ -32,8 +33,7 @@ export const TraceGroupItem: React.FC<TraceGroupItemProps> = memo(
     }, [groupId, selectTraceGroupId])
 
     return (
-      <button
-        type="button"
+      <div
         data-testid={`trace-${groupId}`}
         key={groupId}
         className={cn(
@@ -50,9 +50,17 @@ export const TraceGroupItem: React.FC<TraceGroupItemProps> = memo(
           </div>
 
           <div className="text-xs text-muted-foreground space-y-1">
-            <div className="flex justify-between">
-              <div data-testid="trace-id" className="text-xs text-muted-foreground font-mono tracking-[1px]">
+            <div className="flex justify-between items-center">
+              <div
+                data-testid="trace-id"
+                className="text-xs text-muted-foreground font-mono tracking-[1px] flex items-center gap-1.5 group"
+              >
                 {groupId}
+                <CopyButton
+                  textToCopy={groupId}
+                  className="w-4 h-4 p-0 opacity-0 group-hover:opacity-100 transition-opacity focus:opacity-100"
+                  title="Copy Trace ID"
+                />
               </div>
               <span>{totalSteps} steps</span>
             </div>
@@ -60,7 +68,7 @@ export const TraceGroupItem: React.FC<TraceGroupItemProps> = memo(
             {activeSteps > 0 && <div className="text-blue-600">{activeSteps} active</div>}
           </div>
         </div>
-      </button>
+      </div>
     )
   },
 )

--- a/plugins/plugin-observability/src/components/ui/copy-button.tsx
+++ b/plugins/plugin-observability/src/components/ui/copy-button.tsx
@@ -11,15 +11,19 @@ type CopyButtonProps = {
 export const CopyButton: React.FC<CopyButtonProps> = ({ textToCopy, className, title }) => {
   const [copied, setCopied] = useState(false)
 
-  const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(textToCopy)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch (error) {
-      console.error('Failed to copy:', error)
-    }
-  }, [textToCopy])
+  const handleCopy = useCallback(
+    async (e: React.MouseEvent) => {
+      e.stopPropagation()
+      try {
+        await navigator.clipboard.writeText(textToCopy)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      } catch (error) {
+        console.error('Failed to copy:', error)
+      }
+    },
+    [textToCopy],
+  )
 
   return (
     <Button


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->
Added a "Copy to Clipboard" button next to the Trace ID in the observability trace list. This allows users to quickly grab the trace ID for filtering logs or other debugging tasks without needing to manually select and copy the text.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->
- Fixes #1015 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

https://github.com/user-attachments/assets/e8962f21-0738-498f-8db3-0e5e6c6cd025

## Additional Context
<!-- Add any other context or information about the PR here --> 

- **Trace Group Item**: Refactored from a `<button>` to a `<div>` to support nested interactive elements (the copy button) and added the CopyButton.
- **Copy Button**: Updated to `stopPropagation` so clicking "Copy" doesn't inadvertently select the trace row.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Adds trace ID copy action to trace list and updates container**
> 
> - Inserts `CopyButton` next to `trace-id` in `TraceGroupItem`, revealed on hover/focus; clicking copies `groupId`.
> - Refactors the trace row root from a `button` to a `div` to allow nested interactive elements while preserving row click selection.
> - Updates `CopyButton` to `stopPropagation` on click, show a temporary "Copied!" state, and tweaks styles/titles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1c7486c739b14032bb7f431305ef14db52216cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->