### PR TITLE
fix(tutorial): use filter button for trace ID filtering step

### DIFF
--- a/packages/workbench/src/components/tutorial/engine/workbench-xpath.ts
+++ b/packages/workbench/src/components/tutorial/engine/workbench-xpath.ts
@@ -34,7 +34,7 @@ export const workbenchXPath = {
   logs: {
     container: '//div[@data-testid="logs-container"]',
     searchContainer: '//div[@data-testid="logs-search-container"]',
-    traceColumn: (index: number) => `(//td[starts-with(@data-testid, 'trace')])[${index}]`,
+    traceColumn: (index: number) => `(//button[starts-with(@data-testid, 'trace-filter')])[${index}]`,
     row: '//div[@data-testid="log-row"]',
   },
 


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->
Updated the XPath selector in workbench-xpath.ts to target the filter button (data-testid starting with trace-filter) instead of the trace ID text. The tutorial now clicks the filter icon, which correctly filters logs by trace ID.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->
<img width="300" alt="image" src="https://github.com/user-attachments/assets/2d3d2920-7129-49ee-b79e-0da72ecea44d" />
<img width="500" alt="image" src="https://github.com/user-attachments/assets/656ed301-d7c1-4ff0-9dc1-02db4b4af409" />


## Additional Context
<!-- Add any other context or information about the PR here --> 