### PR TITLE
docs: Remove bun run dev command from workbench docs

### DIFF
--- a/packages/docs/content/docs/concepts/workbench.mdx
+++ b/packages/docs/content/docs/concepts/workbench.mdx
@@ -33,11 +33,6 @@ Fire up the Workbench:
   npm run dev
   ```
   </Tab>
-  <Tab value="bun">
-  ```bash
-  bun run dev
-  ```
-  </Tab>
 </Tabs>
 
 This starts two things:


### PR DESCRIPTION
Removed bun command from the workbench documentation.

## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 