### PR TITLE
chore: remove bun package manager references

### DIFF
--- a/packages/docs/content/docs/concepts/workbench.mdx
+++ b/packages/docs/content/docs/concepts/workbench.mdx
@@ -17,7 +17,7 @@ Workbench is where you'll spend most of your time building with Motia. Think of 
 
 Fire up the Workbench:
 
-<Tabs items={['npm', 'yarn', 'pnpm', 'bun']}>
+<Tabs items={['npm', 'yarn', 'pnpm']}>
   <Tab value="pnpm">
   ```bash
   pnpm run dev

--- a/packages/docs/content/docs/getting-started/quick-start.mdx
+++ b/packages/docs/content/docs/getting-started/quick-start.mdx
@@ -35,7 +35,7 @@ npx motia dev
 ![run dev command](/docs-images/motia-terminal.gif)
 
 <Callout>
-The `create` command uses `npm` by default. If you chose a different package manager during setup, use `pnpm dev`, `yarn dev`, or `bun dev`.
+The `create` command uses `npm` by default. If you chose a different package manager during setup, use `pnpm dev` or `yarn dev`.
 </Callout>
 
 This command starts the Motia runtime and the Workbench, a powerful UI for developing and debugging your workflows. By default, it's available at [`http://localhost:3000`](http://localhost:3000).

--- a/packages/docs/public/llm-docs/getting-started/quick-start.mdx.md
+++ b/packages/docs/public/llm-docs/getting-started/quick-start.mdx.md
@@ -31,7 +31,7 @@ npx motia dev
 ![run dev command](/docs-images/motia-terminal.gif)
 
 <Callout>
-The `create` command uses `npm` by default. If you chose a different package manager during setup, use `pnpm dev`, `yarn dev`, or `bun dev`.
+The `create` command uses `npm` by default. If you chose a different package manager during setup, use `pnpm dev`, `yarn dev`.
 </Callout>
 
 This command starts the Motia runtime and the Workbench, a powerful UI for developing and debugging your workflows. By default, it's available at [`http://localhost:3000`](http://localhost:3000).

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -16148,7 +16148,7 @@ npx motia dev
 ![run dev command](/docs-images/motia-terminal.gif)
 
 <Callout>
-The `create` command uses `npm` by default. If you chose a different package manager during setup, use `pnpm dev`, `yarn dev`, or `bun dev`.
+The `create` command uses `npm` by default. If you chose a different package manager during setup, use `pnpm dev`, `yarn dev`.
 </Callout>
 
 This command starts the Motia runtime and the Workbench, a powerful UI for developing and debugging your workflows. By default, it's available at [`http://localhost:3000`](http://localhost:3000).

--- a/packages/snap/src/plugins/install-plugin-dependencies.ts
+++ b/packages/snap/src/plugins/install-plugin-dependencies.ts
@@ -54,7 +54,6 @@ export const installPluginDependencies = async (baseDir: string, printer: Printe
     npm: 'npm install',
     yarn: 'yarn install',
     pnpm: 'pnpm install',
-    bun: 'bun install',
   }
 
   const installCommand = installCommands[packageManager] || 'npm install'

--- a/packages/snap/src/utils/validate-python-environment.ts
+++ b/packages/snap/src/utils/validate-python-environment.ts
@@ -22,8 +22,6 @@ function getInstallCommand(baseDir: string): string {
       return 'yarn install'
     case 'pnpm':
       return 'pnpm install'
-    case 'bun':
-      return 'bun install'
     case 'npm':
     default:
       return 'npm install'


### PR DESCRIPTION
## Summary
- Remove bun from supported package managers in documentation
- Remove bun install commands from CLI utilities
- Standardize on npm, yarn, and pnpm as the officially supported package managers

## Changes Made
- **Documentation**: Removed bun from package manager tabs in Workbench and Quick Start guides
- **CLI Utilities**: Removed bun install commands from:
  - `packages/snap/src/plugins/install-plugin-dependencies.ts`
  - `packages/snap/src/utils/validate-python-environment.ts`
- **Generated Docs**: Updated LLM documentation files to reflect changes

## Test Plan
- [x] Verify documentation renders correctly without bun references
- [x] Ensure CLI install commands work for npm, yarn, and pnpm
- [ ] Review all changes for completeness
- [ ] Test that no bun references remain in user-facing documentation