### PR TITLE
feat: add status filter for traces

### DIFF
--- a/plugins/plugin-observability/src/components/search-bar.tsx
+++ b/plugins/plugin-observability/src/components/search-bar.tsx
@@ -1,12 +1,19 @@
-import { Button, cn, Input } from '@motiadev/ui'
-import { Search, Trash, X } from 'lucide-react'
+import { Button, cn, Input, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@motiadev/ui'
+import { ListFilter, Search, Trash, X } from 'lucide-react'
 import { memo } from 'react'
 import { useObservabilityStore } from '../stores/use-observability-store'
+import type { TraceStatus } from '../types/observability'
 
 export const SearchBar = memo(() => {
   const search = useObservabilityStore((state) => state.search)
   const setSearch = useObservabilityStore((state) => state.setSearch)
+  const statusFilter = useObservabilityStore((state) => state.statusFilter)
+  const setStatusFilter = useObservabilityStore((state) => state.setStatusFilter)
   const clearTraces = useObservabilityStore((state) => state.clearTraces)
+
+  const handleStatusChange = (value: string) => {
+    setStatusFilter(value as TraceStatus | 'all')
+  }
 
   return (
     <div className="flex p-2 border-b gap-2" data-testid="logs-search-container">
@@ -30,6 +37,18 @@ export const SearchBar = memo(() => {
           onClick={() => setSearch('')}
         />
       </div>
+      <Select value={statusFilter} onValueChange={handleStatusChange}>
+        <SelectTrigger className="w-auto h-8.5 gap-2 px-3">
+          <ListFilter className="w-3.5 h-3.5 text-muted-foreground" />
+          {statusFilter === 'all' ? <span>Status</span> : <SelectValue />}
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All</SelectItem>
+          <SelectItem value="running">Running</SelectItem>
+          <SelectItem value="completed">Completed</SelectItem>
+          <SelectItem value="failed">Failed</SelectItem>
+        </SelectContent>
+      </Select>
       <Button variant="default" onClick={clearTraces} className="h-[34px]">
         <Trash /> Clear
       </Button>

--- a/plugins/plugin-observability/src/hooks/use-filtered-trace-groups.ts
+++ b/plugins/plugin-observability/src/hooks/use-filtered-trace-groups.ts
@@ -5,6 +5,7 @@ import { deriveTraceGroup } from './use-derive-trace-group'
 export const useFilteredTraceGroups = () => {
   const traceGroupMetas = useObservabilityStore((state) => state.traceGroupMetas)
   const tracesByGroupId = useObservabilityStore((state) => state.tracesByGroupId)
+  const statusFilter = useObservabilityStore((state) => state.statusFilter)
   const search = useObservabilityStore((state) => state.search)
 
   return useMemo(() => {
@@ -25,10 +26,11 @@ export const useFilteredTraceGroups = () => {
       return deriveTraceGroup(meta, traces)
     })
 
-    return traceGroups.filter(
-      (group) =>
-        group.name.toLowerCase().includes(search.toLowerCase()) ||
-        group.id.toLowerCase().includes(search.toLowerCase()),
-    )
-  }, [traceGroupMetas, tracesByGroupId, search])
+    return traceGroups.filter((group) => {
+      const matchesSearch =
+        group.name.toLowerCase().includes(search.toLowerCase()) || group.id.toLowerCase().includes(search.toLowerCase())
+      const matchesStatus = statusFilter === 'all' || group.status === statusFilter
+      return matchesSearch && matchesStatus
+    })
+  }, [traceGroupMetas, tracesByGroupId, search, statusFilter])
 }

--- a/plugins/plugin-observability/src/stores/use-observability-store.ts
+++ b/plugins/plugin-observability/src/stores/use-observability-store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { deriveTraceGroup } from '../hooks/use-derive-trace-group'
-import type { Trace, TraceGroup, TraceGroupMeta } from '../types/observability'
+import type { Trace, TraceGroup, TraceGroupMeta, TraceStatus } from '../types/observability'
 
 export type ObservabilityState = {
   traceGroupMetas: TraceGroupMeta[]
@@ -9,12 +9,14 @@ export type ObservabilityState = {
   selectedTraceGroupId: string
   selectedTraceId?: string
   search: string
+  statusFilter: TraceStatus | 'all'
   setTraceGroupMetas: (metas: TraceGroupMeta[]) => void
   setTraces: (traces: Trace[]) => void
   setTracesForGroup: (groupId: string, traces: Trace[]) => void
   selectTraceGroupId: (groupId?: string) => void
   selectTraceId: (traceId?: string) => void
   setSearch: (search: string) => void
+  setStatusFilter: (status: TraceStatus | 'all') => void
   clearTraces: () => void
   getTraceGroups: () => TraceGroup[]
 }
@@ -26,6 +28,7 @@ export const useObservabilityStore = create<ObservabilityState>()((set, get) => 
   selectedTraceGroupId: '',
   selectedTraceId: undefined,
   search: '',
+  statusFilter: 'all',
   setTraceGroupMetas: (metas: TraceGroupMeta[]) => {
     const safeMetas = Array.isArray(metas) ? metas : []
     set({ traceGroupMetas: safeMetas })
@@ -51,8 +54,10 @@ export const useObservabilityStore = create<ObservabilityState>()((set, get) => 
   },
   selectTraceId: (traceId) => set({ selectedTraceId: traceId }),
   setSearch: (search) => set({ search }),
+  setStatusFilter: (statusFilter) => set({ statusFilter }),
   clearTraces: () => {
     fetch('/__motia/trace/clear', { method: 'POST' })
+    set({ statusFilter: 'all', search: '' })
   },
   getTraceGroups: () => {
     const state = get()

--- a/plugins/plugin-observability/src/types/observability.ts
+++ b/plugins/plugin-observability/src/types/observability.ts
@@ -4,8 +4,10 @@ export interface TraceGroupMeta {
   startTime: number
 }
 
+export type TraceStatus = 'running' | 'completed' | 'failed'
+
 export interface TraceGroup extends TraceGroupMeta {
-  status: 'running' | 'completed' | 'failed'
+  status: TraceStatus
   endTime?: number
   lastActivity: number
   metadata: {
@@ -20,7 +22,7 @@ export interface Trace {
   name: string
   correlationId?: string
   parentTraceId?: string
-  status: 'running' | 'completed' | 'failed'
+  status: TraceStatus
   startTime: number
   endTime?: number
   entryPoint: { type: 'api' | 'event' | 'cron'; stepName: string }


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->
Adds a trace status filter to the workbench, allowing users to filter trace groups by execution status (Running, Completed, Failed). This improves trace discovery and debugging as the number of traces grows.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->
- Closes #1067

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->
[Screencast from 2025-12-17 22-28-12.webm](https://github.com/user-attachments/assets/d52d56e1-226e-4732-9f4a-998bdeb8b6e4)


## Additional Context
<!-- Add any other context or information about the PR here --> 
**Implementation details:**
- Added statusFilter state to useObservabilityStore
- Introduced reusable TraceStatus type
- Updated useFilteredTraceGroups hook to apply status-based filtering
- Reset search and status filter when clearing traces

This change is backward-compatible and defaults to All to preserve existing behavior.