### PR TITLE
docs: clarify visual vs logical connection requirements in flows

### DIFF
--- a/packages/docs/content/docs/development-guide/flows.mdx
+++ b/packages/docs/content/docs/development-guide/flows.mdx
@@ -51,6 +51,14 @@ const config = {
 </Tab>
 </Tabs>
 
+<Callout type="info">
+**Visual vs. Logical Connections**
+
+Logical execution (`emits`/`subscribes`) is separate from **visualization**.
+
+Steps must share a common name in their `flows` array to appear connected in the Workbench diagram.
+</Callout>
+
 ---
 
 ## Example


### PR DESCRIPTION
## Summary
Added a "Key Concept" callout to the **Flows** documentation to clarify the distinction between logical execution and visual diagrams.

## Related Issues
Fixes #1084 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (please describe): Documentation Improvement

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
**Preview of the new Callout in Docs:** ![view](https://github.com/user-attachments/assets/d2eb02f9-2149-4307-8ee6-89c2a5e412cc)

## Additional Context
Currently, it is not immediately obvious to new users that emits and subscribes (logical connection) do not automatically generate a connection line in the Workbench. Users often expect steps to be visually connected based on their event subscriptions, but they appear as disconnected nodes unless the flows array is explicitly configured. This update clarifies that requirement upfront.