### PR TITLE
docs: update star history chart in README with dogfooding our own API

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,13 @@ We welcome contributions! Check our **[Contributing Guide](https://github.com/Mo
 
 **[🚀 Get Started](https://motia.dev)** • **[📖 Docs](https://motia.dev/docs)** • **[💬 Discord](https://discord.gg/motia)**
 
-[![Star History Chart](https://api.star-history.com/svg?repos=motiadev/motia&type=Date)](https://www.star-history.com/#motiadev/motia&Date)
+<a href="https://git-history.com">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://git-history.com/api/embed/stars?repos=MotiaDev/motia&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://git-history.com/api/embed/stars?repos=MotiaDev/motia&theme=light" />
+    <img alt="Star History Chart" src="https://git-history.com/api/embed/stars?repos=MotiaDev/motia&theme=dark" width="100%" />
+  </picture>
+</a>
 
 <sub>⭐ **Star us if you find Motia useful!**</sub>
 


### PR DESCRIPTION
This pull request updates the star history chart in the `README.md` to use a new embed from `git-history.com` that supports both dark and light themes. This improves the visual integration of the chart with different user color schemes.

- Documentation update:
  * Replaced the old star history chart image with a `<picture>` element that loads the appropriate chart from `git-history.com` based on the user's color scheme, offering better theme support and a more modern embed.