### PR TITLE
fix: exclude compiled files from step and stream discovery

### DIFF
--- a/packages/snap/src/generate-locked-data.ts
+++ b/packages/snap/src/generate-locked-data.ts
@@ -26,8 +26,8 @@ const getStepFilesFromDir = (dir: string): string[] => {
     return []
   }
   return [
-    ...globSync('**/*.step.{ts,js,rb}', { absolute: true, cwd: dir }),
-    ...globSync('**/*_step.{ts,js,py,rb}', { absolute: true, cwd: dir }),
+    ...globSync('**/*.step.{ts,js,rb}', { absolute: true, cwd: dir, ignore: ['**/.motia/compiled/**'] }),
+    ...globSync('**/*_step.{ts,js,py,rb}', { absolute: true, cwd: dir, ignore: ['**/.motia/compiled/**'] }),
   ]
 }
 
@@ -42,8 +42,8 @@ const getStreamFilesFromDir = (dir: string): string[] => {
     return []
   }
   return [
-    ...globSync('**/*.stream.{ts,js,rb}', { absolute: true, cwd: dir }),
-    ...globSync('**/*_stream.{ts,js,py,rb}', { absolute: true, cwd: dir }),
+    ...globSync('**/*.stream.{ts,js,rb}', { absolute: true, cwd: dir, ignore: ['**/.motia/compiled/**'] }),
+    ...globSync('**/*_stream.{ts,js,py,rb}', { absolute: true, cwd: dir, ignore: ['**/.motia/compiled/**'] }),
   ]
 }
 


### PR DESCRIPTION
Prevent .motia/compiled/** directory from being included in step and stream discovery glob patterns. This fixes the issue where compiled JavaScript files appear as duplicate steps in the Workbench during development with hot-reload.

Fixes #1064



## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)



## Additional Context
<!-- Add any other context or information about the PR here --> 