### PR TITLE
feat: add clickable Trace ID navigation from Logs to Tracing tab

### DIFF
--- a/packages/workbench/src/components/bottom-panel.tsx
+++ b/packages/workbench/src/components/bottom-panel.tsx
@@ -1,5 +1,5 @@
 import { CollapsiblePanel, TabsContent, TabsList, TabsTrigger } from '@motiadev/ui'
-import { memo } from 'react'
+import { memo, useEffect } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { type AppTabsState, TabLocation, useAppTabsStore } from '../stores/use-app-tabs-store'
 import { useTabsStore } from '../stores/use-tabs-store'
@@ -12,6 +12,19 @@ export const BottomPanel = memo(() => {
   const defaultTab = useTabsStore((state) => state.tab.bottom)
   const setBottomTab = useTabsStore((state) => state.setBottomTab)
   const tabs = useAppTabsStore(useShallow(bottomTabsSelector))
+
+  useEffect(() => {
+    const handleNavigateToTrace = () => {
+      // Switch to tracing tab when trace navigation is requested
+      setBottomTab('tracing')
+    }
+
+    window.addEventListener('motia:navigate-to-trace', handleNavigateToTrace)
+
+    return () => {
+      window.removeEventListener('motia:navigate-to-trace', handleNavigateToTrace)
+    }
+  }, [setBottomTab])
 
   return (
     <CollapsiblePanel

--- a/plugins/plugin-logs/src/components/log-detail.tsx
+++ b/plugins/plugin-logs/src/components/log-detail.tsx
@@ -1,7 +1,7 @@
 import { LevelDot, Sidebar } from '@motiadev/ui'
 import { X } from 'lucide-react'
 import type React from 'react'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import ReactJson from 'react18-json-view'
 import 'react18-json-view/src/dark.css'
 import 'react18-json-view/src/style.css'
@@ -35,6 +35,17 @@ export const LogDetail: React.FC<Props> = ({ log, onClose }) => {
     )
   }, [log])
 
+  const handleTraceIdClick = useCallback(() => {
+    if (!log?.traceId) return
+
+    // Use window event to communicate with other plugins
+    window.dispatchEvent(
+      new CustomEvent('motia:navigate-to-trace', {
+        detail: { traceId: log.traceId },
+      }),
+    )
+  }, [log])
+
   if (!log) {
     return null
   }
@@ -58,7 +69,19 @@ export const LogDetail: React.FC<Props> = ({ log, onClose }) => {
         { label: 'Time', value: formatTimestamp(log.time) },
         { label: 'Step', value: log.step },
         { label: 'Flows', value: log.flows.join(', ') },
-        { label: 'Trace ID', value: log.traceId },
+        {
+          label: 'Trace ID',
+          value: (
+            <button
+              type="button"
+              onClick={handleTraceIdClick}
+              className="font-mono text-sm text-primary hover:underline cursor-pointer bg-transparent border-none p-0 text-left"
+              title="Click to view trace in Tracing tab"
+            >
+              {log.traceId}
+            </button>
+          ),
+        },
       ]}
     >
       {hasOtherProps && <ReactJson src={otherPropsObject} theme="default" enableClipboard />}

--- a/plugins/plugin-observability/src/components/observability-page.tsx
+++ b/plugins/plugin-observability/src/components/observability-page.tsx
@@ -1,10 +1,32 @@
-import { memo } from 'react'
+import { memo, useEffect } from 'react'
+import { useObservabilityStore } from '../stores/use-observability-store'
 import { SearchBar } from './search-bar'
 import { TraceEmptyState } from './trace-empty-state'
 import { TraceTimeline } from './trace-timeline'
 import { TracesGroups } from './traces-groups'
 
 export const ObservabilityPage = memo(() => {
+  const setSearch = useObservabilityStore((state) => state.setSearch)
+  const selectTraceGroupId = useObservabilityStore((state) => state.selectTraceGroupId)
+
+  useEffect(() => {
+    const handleNavigateToTrace = (event: CustomEvent<{ traceId: string }>) => {
+      const { traceId } = event.detail
+      if (traceId) {
+        // Set search to the trace ID
+        setSearch(traceId)
+        // Select the trace group
+        selectTraceGroupId(traceId)
+      }
+    }
+
+    window.addEventListener('motia:navigate-to-trace', handleNavigateToTrace as EventListener)
+
+    return () => {
+      window.removeEventListener('motia:navigate-to-trace', handleNavigateToTrace as EventListener)
+    }
+  }, [setSearch, selectTraceGroupId])
+
   return (
     <div className="grid grid-rows-[auto_1fr] h-full">
       <SearchBar />


### PR DESCRIPTION
## Description

This PR implements an interactive Trace ID feature in the Log Details sidebar that enables seamless navigation to the Tracing tab with automatic search filtering, significantly improving the debugging workflow.

Fixes #1095

## Problem Statement

When debugging issues in the Logs view, developers often need to investigate the full trace associated with a problematic log entry. Previously, this required a manual three-step process:

1. Manually select and copy the Trace ID from the Log Details sidebar
2. Navigate to the Tracing tab
3. Paste the ID into the search bar

This manual context switching created friction in the debugging workflow and slowed down issue investigation.

## Solution

This PR transforms the Trace ID in the Log Details sidebar into an interactive element that automates the entire navigation process.

### Implementation Details

**1. Interactive Trace ID Component** (`plugin-logs`)
- Converted the static Trace ID text into a clickable button
- Added visual affordances: primary color styling, underline on hover, pointer cursor
- Added descriptive title attribute: "Click to view trace in Tracing tab"
- Dispatches a custom `motia:navigate-to-trace` event with the Trace ID

**2. Event-Based Cross-Plugin Communication**
- Uses `CustomEvent` API for decoupled plugin communication
- Event payload includes `{ traceId: string }`
- Allows future extensibility for other plugins to respond to trace navigation

**3. Observability Plugin Integration** (`plugin-observability`)
- Added event listener for `motia:navigate-to-trace` events
- Automatically updates search filter with the clicked Trace ID
- Selects the corresponding trace group when available

**4. Tab Navigation** (`workbench`)
- Integrated tab switching logic in BottomPanel component
- Automatically switches to "tracing" tab when event is received
- Ensures user lands on the correct view immediately

### User Experience Flow

**Before:**
1. User sees Trace ID in Log Details: `abc-123-xyz`
2. User selects and copies the ID
3. User clicks Tracing tab
4. User clicks search bar
5. User pastes ID and presses enter

**After:**
1. User clicks Trace ID in Log Details
2. ✅ **Donepush -u origin feat/clickable-trace-id-navigation* Automatically switched to Tracing tab with search filter applied

## Technical Approach

### Why Custom Events?

- **Plugin Independence**: Avoids tight coupling between plugins
- **Maintainability**: Each plugin remains independently testable
- **Extensibility**: Other plugins can easily subscribe to navigation events
- **Clean Architecture**: Follows observer pattern for loosely coupled components

### Code Changes

- **Modified Files**: 3
- **Lines Added**: 62
- **Lines Removed**: 4

## Testing

- ✅ Built all affected packages successfully
- ✅ No TypeScript compilation errors
- ✅ Event dispatch and handling logic verified
- ✅ Visual styling tested for interactive button

### Manual Testing Steps

1. Start Motia workbench: `npm run dev`
2. Navigate to Logs tab
3. Click on any log entry to open Log Details
4. Click the Trace ID (should show hover effects)
5. Verify:
   - Automatically switches to Tracing tab
   - Search filter is populated with the Trace ID
   - Trace group is selected if available

## Impact

### User Benefits
- **Faster Debugging**: Eliminates 4 manual steps from the workflow
- **Reduced Context Switching**: Single-click navigation
- **Better Developer Experience**: Intuitive, discoverable interaction
- **Reduced Errors**: No need to manually copy/paste IDs

### Performance
- Minimal overhead: Event dispatching is lightweight
- No additional network requests
- Event listeners cleaned up on component unmount

## Screenshots

### Before
Trace ID displayed as plain text with no interaction

### After
Trace ID is clickable with visual affordances:
- Primary blue color indicating clickability
- Underline on hover
- Pointer cursor
- Tooltip explaining the action

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have built all affected packages successfully
- [x] I have tested the feature in the workbench UI
- [x] The implementation is extensible for future enhancements

## Future Enhancements

Potential follow-up improvements (not included in this PR):
- Add keyboard shortcut (e.g., Ctrl+Click) for opening in new tab
- Show loading indicator while navigating
- Highlight the selected trace in the timeline
- Add analytics tracking for feature usage