### PR TITLE
docs: fixes for railway, self-hosted, fly deployment guide

### DIFF
--- a/packages/docs/content/docs/deployment-guide/fly.mdx
+++ b/packages/docs/content/docs/deployment-guide/fly.mdx
@@ -11,6 +11,10 @@ This guide walks you through deploying a Motia app to Fly.io with production Red
 **What you'll get:** A containerized Motia app running on Fly.io with Upstash Redis for state, events, streams, and cron locking.
 </Callout>
 
+<Callout type="info">
+**Example Project:** Follow along with the [Todo App example](https://github.com/MotiaDev/motia-examples/tree/main/examples/foundational/api-patterns/todo-app) - a complete deployment-ready Motia app with Redis configuration.
+</Callout>
+
 ---
 
 ## Prerequisites
@@ -155,9 +159,75 @@ Fly injects the port via environment variables. Update your `package.json`:
 
 The `--host 0.0.0.0` is important - Fly needs your app to listen on all interfaces.
 
-### Configure Redis Adapters
+### Configure Redis
 
-Install the adapter packages:
+Motia supports two approaches for production Redis configuration:
+
+#### Option 1: Simple Redis Config (Recommended)
+
+Use Motia's built-in `redis` configuration option:
+
+```typescript title="motia.config.ts"
+import { config } from 'motia'
+import statesPlugin from '@motiadev/plugin-states/plugin'
+import endpointPlugin from '@motiadev/plugin-endpoint/plugin'
+import logsPlugin from '@motiadev/plugin-logs/plugin'
+import observabilityPlugin from '@motiadev/plugin-observability/plugin'
+import bullmqPlugin from '@motiadev/plugin-bullmq/plugin'
+
+// Determine Redis configuration based on environment
+const getRedisConfig = () => {
+  const useExternalRedis = process.env.USE_REDIS === 'true' || 
+    (process.env.USE_REDIS !== 'false' && process.env.NODE_ENV === 'production')
+
+  if (!useExternalRedis) {
+    return { useMemoryServer: true as const }
+  }
+
+  const redisUrl = process.env.REDIS_URL
+  if (redisUrl) {
+    try {
+      const url = new URL(redisUrl)
+      return {
+        useMemoryServer: false as const,
+        host: url.hostname,
+        port: parseInt(url.port || '6379', 10),
+        password: url.password || undefined,
+        username: url.username || undefined,
+      }
+    } catch (e) {
+      console.error('[motia] Failed to parse REDIS_URL:', e)
+    }
+  }
+
+  return {
+    useMemoryServer: false as const,
+    host: process.env.REDIS_HOST || 'localhost',
+    port: parseInt(process.env.REDIS_PORT || '6379', 10),
+    password: process.env.REDIS_PASSWORD,
+    username: process.env.REDIS_USERNAME,
+  }
+}
+
+export default config({
+  plugins: [
+    observabilityPlugin,
+    statesPlugin,
+    endpointPlugin,
+    logsPlugin,
+    bullmqPlugin,
+  ],
+  redis: getRedisConfig(),
+})
+```
+
+<Callout type="info">
+**That's it!** The config parses `REDIS_URL` automatically. Fly sets this when you run `flyctl redis create`.
+</Callout>
+
+#### Option 2: Custom Adapters (Advanced)
+
+For more control over individual adapters:
 
 ```bash
 npm install @motiadev/adapter-redis-state \
@@ -166,14 +236,16 @@ npm install @motiadev/adapter-redis-state \
             @motiadev/adapter-bullmq-events
 ```
 
-Update your `motia.config.ts`:
-
 ```typescript title="motia.config.ts"
-import { defineConfig } from '@motiadev/core'
+import { config } from 'motia'
 import { RedisStateAdapter } from '@motiadev/adapter-redis-state'
 import { RedisStreamAdapterManager } from '@motiadev/adapter-redis-streams'
 import { RedisCronAdapter } from '@motiadev/adapter-redis-cron'
 import { BullMQEventAdapter } from '@motiadev/adapter-bullmq-events'
+import statesPlugin from '@motiadev/plugin-states/plugin'
+import endpointPlugin from '@motiadev/plugin-endpoint/plugin'
+import logsPlugin from '@motiadev/plugin-logs/plugin'
+import observabilityPlugin from '@motiadev/plugin-observability/plugin'
 
 // Parse REDIS_URL (set automatically by Fly when you attach Upstash Redis)
 // Format: rediss://default:password@host:port
@@ -187,8 +259,16 @@ const redisConfig = {
   tls: url.protocol === 'rediss:',  // Upstash requires TLS
 }
 
-export default defineConfig({
-  adapters: {
+const useRedis = process.env.USE_REDIS === 'true' || process.env.NODE_ENV === 'production'
+
+export default config({
+  plugins: [
+    observabilityPlugin,
+    statesPlugin,
+    endpointPlugin,
+    logsPlugin,
+  ],
+  adapters: useRedis ? {
     state: new RedisStateAdapter({
       socket: { host: redisConfig.host, port: redisConfig.port, tls: redisConfig.tls },
       username: redisConfig.username,
@@ -214,13 +294,9 @@ export default defineConfig({
       username: redisConfig.username,
       password: redisConfig.password,
     }),
-  },
+  } : undefined,
 })
 ```
-
-<Callout type="info">
-**That's it!** The config parses `REDIS_URL` automatically. Fly sets this when you run `flyctl redis create`.
-</Callout>
 
 ---
 
@@ -244,7 +320,7 @@ Choose Fly.io if you need low-latency responses globally. Choose Railway for sim
 # Check app status
 flyctl status
 
-# View logs
+# View logs (streams in real-time)
 flyctl logs
 
 # SSH into your app
@@ -297,6 +373,18 @@ flyctl apps destroy my-motia-app
 const useTls = url.protocol === 'rediss:'
 ```
 
+### Plugin Not Loading
+
+**Cause:** Plugin imports might not be resolving correctly.
+
+**Fix:** Use ESM imports (recommended for `"type": "module"` projects):
+
+```typescript
+// ✅ Correct - ESM imports
+import statesPlugin from '@motiadev/plugin-states/plugin'
+import endpointPlugin from '@motiadev/plugin-endpoint/plugin'
+```
+
 ### Machine Keeps Restarting
 
 **Symptom:** App restarts repeatedly in logs
@@ -314,45 +402,6 @@ flyctl logs
 
 ---
 
-## Local Testing with Docker
-
-Test your production setup locally before deploying:
-
-```yaml title="docker-compose.yml"
-services:
-  redis:
-    image: redis:7-alpine
-    ports:
-      - "6379:6379"
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-
-  motia:
-    build: .
-    ports:
-      - "3000:3000"
-    environment:
-      - NODE_ENV=production
-      - USE_REDIS=true
-      - REDIS_URL=redis://redis:6379
-    depends_on:
-      redis:
-        condition: service_healthy
-```
-
-Run:
-
-```bash
-docker-compose up --build
-```
-
-If it works locally, it'll work on Fly.
-
----
-
 ## Scaling Globally
 
 Fly makes global deployment easy. Add machines in different regions:
@@ -365,7 +414,7 @@ flyctl machine clone --region ams
 flyctl machine clone --region syd
 ```
 
-With Redis adapters configured, all machines share state automatically. Users connect to the nearest machine for lowest latency.
+With Redis configured, all machines share state automatically. Users connect to the nearest machine for lowest latency.
 
 ---
 

--- a/packages/docs/content/docs/deployment-guide/railway.mdx
+++ b/packages/docs/content/docs/deployment-guide/railway.mdx
@@ -11,13 +11,17 @@ This guide walks you through deploying a production-ready Motia app with real Re
 **What you'll get:** A fully containerized Motia app running on Railway with external Redis for state, events, streams, and cron locking.
 </Callout>
 
+<Callout type="info">
+**Example Project:** Follow along with the [Todo App example](https://github.com/MotiaDev/motia-examples/tree/main/examples/foundational/api-patterns/todo-app) - a complete deployment-ready Motia app with Redis configuration.
+</Callout>
+
 ---
 
 ## Prerequisites
 
 Before you start:
 
-- A [Railway account](https://railway.app) (free tier works)
+- A [Railway account](https://railway.com) (free tier works)
 - [Railway CLI](https://docs.railway.com/guides/cli) installed
 - Docker running locally (for testing)
 - A Motia project ready to deploy
@@ -49,20 +53,45 @@ This opens your browser for authentication.
 From your Motia project root:
 
 ```bash
-railway init
+railway init -n my-motia-app
 ```
 
-Give your project a name when prompted.
+This creates a new Railway project with the specified name.
 
 </Step>
 <Step>
 #### Add Redis
 
 ```bash
-railway add --plugin redis
+railway add -d redis
 ```
 
 Railway provisions a managed Redis instance automatically.
+
+</Step>
+<Step>
+#### Create an app service
+
+```bash
+railway add -s my-app
+```
+
+This creates an empty service for your Motia app.
+
+</Step>
+<Step>
+#### Link and configure
+
+```bash
+# Link to your app service
+railway service my-app
+
+# Set environment variables
+railway variables --set "NODE_ENV=production"
+railway variables --set "USE_REDIS=true"
+railway variables --set 'REDIS_URL=${{Redis.REDIS_URL}}'
+railway variables --set 'REDIS_PRIVATE_URL=${{Redis.REDIS_PRIVATE_URL}}'
+```
 
 </Step>
 <Step>
@@ -136,16 +165,84 @@ Create a `railway.json` in your project root:
 ```
 
 <Callout type="warn">
-**Healthchecks:** Railway's default healthcheck expects a `200` response on `/`. If your app doesn't serve the root path, either add a health endpoint or remove healthcheck settings from `railway.json`.
+**Healthchecks:** Railway's default healthcheck expects a `200` response on `/`. Motia's Workbench serves the root path, so this should work out of the box.
 </Callout>
 
 ---
 
-## Configure Redis Adapters
+## Configure Redis
 
-For production, you want Motia to use Railway's Redis instead of the built-in memory server.
+Motia supports two approaches for production Redis configuration:
 
-### Install Adapter Packages
+### Option 1: Simple Redis Config (Recommended)
+
+The simplest approach uses Motia's built-in `redis` configuration option:
+
+```typescript title="motia.config.ts"
+import { config } from 'motia'
+import statesPlugin from '@motiadev/plugin-states/plugin'
+import endpointPlugin from '@motiadev/plugin-endpoint/plugin'
+import logsPlugin from '@motiadev/plugin-logs/plugin'
+import observabilityPlugin from '@motiadev/plugin-observability/plugin'
+import bullmqPlugin from '@motiadev/plugin-bullmq/plugin'
+
+// Determine Redis configuration based on environment
+const getRedisConfig = () => {
+  const useExternalRedis = process.env.USE_REDIS === 'true' || 
+    (process.env.USE_REDIS !== 'false' && process.env.NODE_ENV === 'production')
+
+  if (!useExternalRedis) {
+    // Use Motia's built-in in-memory Redis for development
+    return { useMemoryServer: true as const }
+  }
+
+  // Parse Redis URL for production
+  const redisUrl = process.env.REDIS_PRIVATE_URL || process.env.REDIS_URL
+  
+  if (redisUrl) {
+    try {
+      const url = new URL(redisUrl)
+      return {
+        useMemoryServer: false as const,
+        host: url.hostname,
+        port: parseInt(url.port || '6379', 10),
+        password: url.password || undefined,
+        username: url.username || undefined,
+      }
+    } catch (e) {
+      console.error('[motia] Failed to parse REDIS_URL:', e)
+    }
+  }
+
+  // Fallback to individual env vars
+  return {
+    useMemoryServer: false as const,
+    host: process.env.REDIS_HOST || 'localhost',
+    port: parseInt(process.env.REDIS_PORT || '6379', 10),
+    password: process.env.REDIS_PASSWORD,
+    username: process.env.REDIS_USERNAME,
+  }
+}
+
+export default config({
+  plugins: [
+    observabilityPlugin,
+    statesPlugin,
+    endpointPlugin,
+    logsPlugin,
+    bullmqPlugin,
+  ],
+  redis: getRedisConfig(),
+})
+```
+
+<Callout type="info">
+**That's it!** Motia handles the Redis adapters automatically when you use the `redis` config option. Railway auto-injects `REDIS_URL` when you link the Redis service to your app.
+</Callout>
+
+### Option 2: Custom Adapters (Advanced)
+
+For more control over individual adapters, you can configure them manually:
 
 ```bash
 npm install @motiadev/adapter-redis-state \
@@ -154,14 +251,16 @@ npm install @motiadev/adapter-redis-state \
             @motiadev/adapter-bullmq-events
 ```
 
-### Update motia.config.ts
-
 ```typescript title="motia.config.ts"
-import { defineConfig } from '@motiadev/core'
+import { config } from 'motia'
 import { RedisStateAdapter } from '@motiadev/adapter-redis-state'
 import { RedisStreamAdapterManager } from '@motiadev/adapter-redis-streams'
 import { RedisCronAdapter } from '@motiadev/adapter-redis-cron'
 import { BullMQEventAdapter } from '@motiadev/adapter-bullmq-events'
+import statesPlugin from '@motiadev/plugin-states/plugin'
+import endpointPlugin from '@motiadev/plugin-endpoint/plugin'
+import logsPlugin from '@motiadev/plugin-logs/plugin'
+import observabilityPlugin from '@motiadev/plugin-observability/plugin'
 
 // Parse REDIS_URL (Railway sets this automatically when you add Redis)
 // Format: redis://default:password@host:port
@@ -175,8 +274,17 @@ const redisConfig = {
   tls: url.protocol === 'rediss:',
 }
 
-export default defineConfig({
-  adapters: {
+// Only use custom adapters in production
+const useRedis = process.env.USE_REDIS === 'true' || process.env.NODE_ENV === 'production'
+
+export default config({
+  plugins: [
+    observabilityPlugin,
+    statesPlugin,
+    endpointPlugin,
+    logsPlugin,
+  ],
+  adapters: useRedis ? {
     state: new RedisStateAdapter({
       socket: { host: redisConfig.host, port: redisConfig.port, tls: redisConfig.tls },
       username: redisConfig.username,
@@ -202,26 +310,22 @@ export default defineConfig({
       username: redisConfig.username,
       password: redisConfig.password,
     }),
-  },
+  } : undefined,
 })
 ```
-
-<Callout type="info">
-**That's it!** Railway auto-injects `REDIS_URL` when you link the Redis plugin to your service.
-</Callout>
 
 ---
 
 ## Set Environment Variables
 
-Railway auto-provisions Redis variables when you add the Redis plugin. Link them to your app:
+Railway auto-provisions Redis variables when you add the Redis database. Link them to your app:
 
 <Steps>
 <Step>
 #### Link to your app service
 
 ```bash
-railway service
+railway service my-app
 ```
 
 Select your app service (not Redis).
@@ -233,7 +337,8 @@ Select your app service (not Redis).
 ```bash
 railway variables --set "NODE_ENV=production"
 railway variables --set "USE_REDIS=true"
-railway variables --set "REDIS_URL=\${{Redis.REDIS_URL}}"
+railway variables --set 'REDIS_URL=${{Redis.REDIS_URL}}'
+railway variables --set 'REDIS_PRIVATE_URL=${{Redis.REDIS_PRIVATE_URL}}'
 ```
 
 The `${{Redis.REDIS_URL}}` syntax tells Railway to inject the actual Redis URL at runtime.
@@ -252,7 +357,7 @@ You should see your variables listed.
 </Steps>
 
 <Callout type="warn">
-**Internal vs Public URL:** Railway provides both internal (`redis.railway.internal`) and public proxy URLs for Redis. The internal URL only works within Railway's network. If you have connection issues, try the public URL from your Redis service's settings.
+**Internal vs Public URL:** Railway provides both internal (`redis.railway.internal`) and public proxy URLs for Redis. Use `REDIS_PRIVATE_URL` for faster internal connections. If you have connection issues, try the public URL from your Redis service's settings.
 </Callout>
 
 ---
@@ -302,10 +407,10 @@ Check what's happening in your deployed app:
 railway logs
 ```
 
-Add `--follow` to stream logs in real-time:
+Add `--tail` to stream logs in real-time:
 
 ```bash
-railway logs --follow
+railway logs --tail
 ```
 
 ---
@@ -331,13 +436,25 @@ railway logs --follow
 2. Is `REDIS_URL` set correctly? Run `railway variables` to verify.
 3. Try the public Redis URL if internal isn't working.
 
+### Plugin Not Loading
+
+**Cause:** Plugin imports might not be resolving correctly.
+
+**Fix:** Use ESM imports (recommended for `"type": "module"` projects):
+
+```typescript
+// ✅ Correct - ESM imports
+import statesPlugin from '@motiadev/plugin-states/plugin'
+import endpointPlugin from '@motiadev/plugin-endpoint/plugin'
+```
+
 ### Healthcheck Failed
 
 **Cause:** Railway expects a 200 response on your healthcheck path.
 
 **Options:**
 1. Remove healthcheck settings from `railway.json`
-2. Add a health endpoint that returns 200
+2. Motia Workbench serves `/` by default which returns 200
 3. Increase the healthcheck timeout
 
 ### Still Seeing "Redis Memory Server Started"
@@ -345,47 +462,9 @@ railway logs --follow
 **Cause:** The app is falling back to in-memory Redis.
 
 **Check:**
-1. Is `NODE_ENV=production` set?
+1. Is `NODE_ENV=production` or `USE_REDIS=true` set?
 2. Is `REDIS_URL` resolving correctly?
 3. Check logs for Redis connection errors.
-
----
-
-## Local Testing with Docker
-
-Before deploying, test your production setup locally:
-
-```yaml title="docker-compose.yml"
-services:
-  redis:
-    image: redis:7-alpine
-    ports:
-      - "6379:6379"
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-
-  motia:
-    build: .
-    ports:
-      - "3000:3000"
-    environment:
-      - NODE_ENV=production
-      - REDIS_URL=redis://redis:6379
-    depends_on:
-      redis:
-        condition: service_healthy
-```
-
-Run it:
-
-```bash
-docker-compose up --build
-```
-
-Test at `http://localhost:3000`. If it works here, it'll work on Railway.
 
 ---
 
@@ -401,7 +480,7 @@ Need more instances? Update your `railway.json`:
 }
 ```
 
-With Redis adapters configured, all instances share state, events, and streams. Requests get load-balanced automatically.
+With Redis configured, all instances share state, events, and streams. Requests get load-balanced automatically.
 
 ---
 

--- a/packages/docs/content/docs/deployment-guide/self-hosted.mdx
+++ b/packages/docs/content/docs/deployment-guide/self-hosted.mdx
@@ -11,6 +11,10 @@ Run your Motia app in Docker containers. Same environment everywhere - dev, stag
 
 <Callout type="warn">You need motia package **0.5.2-beta.101 or higher**</Callout>
 
+<Callout type="info">
+**Example Project:** Follow along with the [Todo App example](https://github.com/MotiaDev/motia-examples/tree/main/examples/foundational/api-patterns/todo-app) - a complete deployment-ready Motia app with Redis configuration.
+</Callout>
+
 ## Quick Start
 
 <Callout type="info">
@@ -237,25 +241,25 @@ Create a Web Service, point to your repo. Render builds automatically. Add a Red
 
 ---
 
-## Configuring Adapters for Production
+## Configuring Redis for Production
 
-When deploying multiple Motia instances, you need distributed adapters to share state, events, and streams across instances. Without them, each instance operates in isolation.
+When deploying to production or running multiple Motia instances, you need to configure Redis for shared state, events, and streams.
 
-### When to Use Distributed Adapters
+### When to Use External Redis
 
-**Use default adapters when:**
+**Use in-memory Redis (default) when:**
 - Running a single Motia instance
 - Development and testing
 - Simple deployments
 
-**Use distributed adapters when:**
+**Use external Redis when:**
 - Running multiple Motia instances (horizontal scaling)
 - Production deployments requiring high availability
 - Need shared state/events/streams across instances
 
 ### Docker Compose with Redis
 
-For production deployments, use Docker Compose to run Motia with Redis. This setup uses Redis for everything: state, streams, events (via BullMQ), and cron locking.
+For production deployments, use Docker Compose to run Motia with Redis:
 
 ```yaml title="docker-compose.yml"
 services:
@@ -295,19 +299,93 @@ services:
 - No RabbitMQ needed - BullMQ handles events using Redis
 </Callout>
 
-### Configure Adapters in motia.config.ts
+### Configure Redis in motia.config.ts
 
-Update your configuration to use distributed adapters. This config works locally with Docker and on cloud platforms:
+#### Option 1: Simple Redis Config (Recommended)
+
+Use Motia's built-in `redis` configuration option:
 
 ```typescript title="motia.config.ts"
-import { defineConfig } from '@motiadev/core'
+import { config } from 'motia'
+import statesPlugin from '@motiadev/plugin-states/plugin'
+import endpointPlugin from '@motiadev/plugin-endpoint/plugin'
+import logsPlugin from '@motiadev/plugin-logs/plugin'
+import observabilityPlugin from '@motiadev/plugin-observability/plugin'
+import bullmqPlugin from '@motiadev/plugin-bullmq/plugin'
+
+// Determine Redis configuration based on environment
+const getRedisConfig = () => {
+  const useExternalRedis = process.env.USE_REDIS === 'true' || 
+    (process.env.USE_REDIS !== 'false' && process.env.NODE_ENV === 'production')
+
+  if (!useExternalRedis) {
+    return { useMemoryServer: true as const }
+  }
+
+  const redisUrl = process.env.REDIS_URL
+  if (redisUrl) {
+    try {
+      const url = new URL(redisUrl)
+      return {
+        useMemoryServer: false as const,
+        host: url.hostname,
+        port: parseInt(url.port || '6379', 10),
+        password: url.password || undefined,
+        username: url.username || undefined,
+      }
+    } catch (e) {
+      console.error('[motia] Failed to parse REDIS_URL:', e)
+    }
+  }
+
+  return {
+    useMemoryServer: false as const,
+    host: process.env.REDIS_HOST || 'localhost',
+    port: parseInt(process.env.REDIS_PORT || '6379', 10),
+    password: process.env.REDIS_PASSWORD,
+    username: process.env.REDIS_USERNAME,
+  }
+}
+
+export default config({
+  plugins: [
+    observabilityPlugin,
+    statesPlugin,
+    endpointPlugin,
+    logsPlugin,
+    bullmqPlugin,
+  ],
+  redis: getRedisConfig(),
+})
+```
+
+<Callout type="info">
+**Local vs Production:** Set `USE_REDIS=true` in your docker-compose.yml for production. Without it, Motia uses the built-in in-memory Redis (great for local development).
+</Callout>
+
+#### Option 2: Custom Adapters (Advanced)
+
+For more control, configure adapters manually:
+
+```bash
+npm install @motiadev/adapter-redis-state \
+            @motiadev/adapter-redis-streams \
+            @motiadev/adapter-redis-cron \
+            @motiadev/adapter-bullmq-events
+```
+
+```typescript title="motia.config.ts"
+import { config } from 'motia'
 import { RedisStateAdapter } from '@motiadev/adapter-redis-state'
 import { RedisStreamAdapterManager } from '@motiadev/adapter-redis-streams'
 import { RedisCronAdapter } from '@motiadev/adapter-redis-cron'
 import { BullMQEventAdapter } from '@motiadev/adapter-bullmq-events'
+import statesPlugin from '@motiadev/plugin-states/plugin'
+import endpointPlugin from '@motiadev/plugin-endpoint/plugin'
+import logsPlugin from '@motiadev/plugin-logs/plugin'
+import observabilityPlugin from '@motiadev/plugin-observability/plugin'
 
 // Parse REDIS_URL from environment
-// Format: redis://username:password@host:port or rediss://... for TLS
 const url = new URL(process.env.REDIS_URL || 'redis://localhost:6379')
 
 const redisConfig = {
@@ -318,10 +396,15 @@ const redisConfig = {
   tls: url.protocol === 'rediss:',
 }
 
-// Set USE_REDIS=true in production, omit for local development
 const useRedis = process.env.USE_REDIS === 'true'
 
-export default defineConfig({
+export default config({
+  plugins: [
+    observabilityPlugin,
+    statesPlugin,
+    endpointPlugin,
+    logsPlugin,
+  ],
   adapters: useRedis ? {
     state: new RedisStateAdapter({
       socket: { host: redisConfig.host, port: redisConfig.port, tls: redisConfig.tls },
@@ -348,23 +431,8 @@ export default defineConfig({
       username: redisConfig.username,
       password: redisConfig.password,
     }),
-  } : undefined, // Falls back to in-memory adapters for local development
+  } : undefined,
 })
-```
-
-<Callout type="info">
-**Local vs Production:** Set `USE_REDIS=true` in your docker-compose.yml for production. Without it, Motia uses in-memory adapters (great for local development).
-</Callout>
-
-### Install Adapter Packages
-
-Add the adapter packages to your project:
-
-```bash
-npm install @motiadev/adapter-redis-state \
-            @motiadev/adapter-redis-streams \
-            @motiadev/adapter-redis-cron \
-            @motiadev/adapter-bullmq-events
 ```
 
 ### Test Your Setup
@@ -393,7 +461,7 @@ This same Docker Compose setup works as a foundation for deploying to any platfo
 
 ### Scaling Multiple Instances
 
-With distributed adapters configured, you can scale to multiple instances:
+With Redis configured, you can scale to multiple instances:
 
 ```yaml title="docker-compose.yml"
 services:
@@ -445,7 +513,7 @@ services:
 All instances share the same state, events, and streams through Redis. Put a load balancer in front and requests get distributed across all instances.
 
 <Callout type="warn">
-Without distributed adapters, each Motia instance has isolated state and events. Use Redis adapters (with BullMQ for events) for multi-instance deployments.
+Without Redis configuration, each Motia instance has isolated state and events. Configure Redis for multi-instance deployments.
 </Callout>
 
 [Learn more about adapters →](/docs/development-guide/adapters/usage)

--- a/packages/snap/src/cursor-rules/dot-files/.cursor/rules/motia/motia-config.mdc
+++ b/packages/snap/src/cursor-rules/dot-files/.cursor/rules/motia/motia-config.mdc
@@ -181,11 +181,10 @@ export type MotiaPluginBuilder = (motia: MotiaPluginContext) => MotiaPlugin
 
 ```typescript
 import { config } from 'motia'
-
-const statesPlugin = require('@motiadev/plugin-states/plugin')
-const endpointPlugin = require('@motiadev/plugin-endpoint/plugin')
-const logsPlugin = require('@motiadev/plugin-logs/plugin')
-const observabilityPlugin = require('@motiadev/plugin-observability/plugin')
+import statesPlugin from '@motiadev/plugin-states/plugin'
+import endpointPlugin from '@motiadev/plugin-endpoint/plugin'
+import logsPlugin from '@motiadev/plugin-logs/plugin'
+import observabilityPlugin from '@motiadev/plugin-observability/plugin'
 
 export default config({
   plugins: [observabilityPlugin, statesPlugin, endpointPlugin, logsPlugin],


### PR DESCRIPTION
This pull request updates the Motia deployment documentation for Fly.io, Railway, and self-hosted environments, focusing on simplifying and clarifying Redis configuration, improving onboarding, and aligning with modern Motia best practices. The guides now recommend a simpler, built-in Redis config for most users, provide clearer step-by-step instructions, and include troubleshooting tips for common deployment issues.

**Key improvements and changes:**

### Redis Configuration Simplification and Best Practices

- Rewrote the Redis configuration sections in both the Fly.io and Railway guides to recommend Motia's built-in `redis` config option as the default, with clear code examples and environment variable handling. Advanced manual adapter setup is now an explicit secondary option. [[1]](diffhunk://#diff-449c16f4af78a1b95896ac7f8d51af8259277ec5c923e5adcf9a7672566c825dL158-R230) [[2]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aL139-R245)
- Updated all relevant code samples to use the new `config` API from `motia` instead of the old `defineConfig`, and modernized plugin imports to ESM style. [[1]](diffhunk://#diff-449c16f4af78a1b95896ac7f8d51af8259277ec5c923e5adcf9a7672566c825dL169-R248) [[2]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aL157-R263)

### Improved Onboarding and Example Usage

- Added prominent "Example Project" callouts at the top of each deployment guide, linking to a complete, deployment-ready Motia Todo App with Redis configuration. [[1]](diffhunk://#diff-449c16f4af78a1b95896ac7f8d51af8259277ec5c923e5adcf9a7672566c825dR14-R17) [[2]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aR14-R24) [[3]](diffhunk://#diff-f957914060fb03ee03ce7aa77660d9d4da0e698273010f56fad59245cedfaad5R14-R17)
- Expanded and clarified step-by-step instructions for setting up Railway projects, services, and environment variables, including use of `REDIS_PRIVATE_URL` for optimal internal connectivity. [[1]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aL52-R95) [[2]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aL236-R341) [[3]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aL255-R360)

### Troubleshooting and Developer Experience

- Added new troubleshooting sections for plugin import issues, recommending ESM imports for `"type": "module"` projects, and clarified solutions for common Redis connection and healthcheck problems. [[1]](diffhunk://#diff-449c16f4af78a1b95896ac7f8d51af8259277ec5c923e5adcf9a7672566c825dR376-R387) [[2]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aR439-L391)
- Updated log streaming instructions for both Fly.io and Railway to use the latest CLI flags (`flyctl logs`, `railway logs --tail`). [[1]](diffhunk://#diff-449c16f4af78a1b95896ac7f8d51af8259277ec5c923e5adcf9a7672566c825dL247-R323) [[2]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aL305-R413)

### Documentation Cleanup and Consistency

- Removed outdated or redundant Docker Compose/local testing sections from the guides to reduce confusion and focus on production deployment. [[1]](diffhunk://#diff-449c16f4af78a1b95896ac7f8d51af8259277ec5c923e5adcf9a7672566c825dL317-L355) [[2]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aR439-L391)
- Improved language and terminology throughout for clarity, such as distinguishing between internal and public Redis URLs and updating provider links. [[1]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aR14-R24) [[2]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aL255-R360)

### Minor Fixes and Updates

- Fixed small typos, updated provider URLs (e.g., Railway), and clarified healthcheck behavior for Motia Workbench. [[1]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aR14-R24) [[2]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aL139-R245) [[3]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aR439-L391)

These changes make it much easier for users to deploy Motia apps with production Redis, reduce onboarding friction, and provide a more robust and modern deployment experience.

- [[1]](diffhunk://#diff-449c16f4af78a1b95896ac7f8d51af8259277ec5c923e5adcf9a7672566c825dR14-R17) [[2]](diffhunk://#diff-449c16f4af78a1b95896ac7f8d51af8259277ec5c923e5adcf9a7672566c825dL158-R230) [[3]](diffhunk://#diff-449c16f4af78a1b95896ac7f8d51af8259277ec5c923e5adcf9a7672566c825dL169-R248) [[4]](diffhunk://#diff-449c16f4af78a1b95896ac7f8d51af8259277ec5c923e5adcf9a7672566c825dL190-R271) [[5]](diffhunk://#diff-449c16f4af78a1b95896ac7f8d51af8259277ec5c923e5adcf9a7672566c825dL217-L224) [[6]](diffhunk://#diff-449c16f4af78a1b95896ac7f8d51af8259277ec5c923e5adcf9a7672566c825dL247-R323) [[7]](diffhunk://#diff-449c16f4af78a1b95896ac7f8d51af8259277ec5c923e5adcf9a7672566c825dR376-R387) [[8]](diffhunk://#diff-449c16f4af78a1b95896ac7f8d51af8259277ec5c923e5adcf9a7672566c825dL317-L355) [[9]](diffhunk://#diff-449c16f4af78a1b95896ac7f8d51af8259277ec5c923e5adcf9a7672566c825dL368-R417)
- [[1]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aR14-R24) [[2]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aL52-R95) [[3]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aL139-R245) [[4]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aL157-R263) [[5]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aL178-R287) [[6]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aL205-R328) [[7]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aL236-R341) [[8]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aL255-R360) [[9]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aL305-R413) [[10]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aR439-L391) [[11]](diffhunk://#diff-ea14493269dbe326a6f71ef8828d6f2d28b3168771b5f9075a84a1a1d01e542aL404-R483)
- [packages/docs/content/docs/deployment-guide/self-hosted.mdxR14-R17](diffhunk://#diff-f957914060fb03ee03ce7aa77660d9d4da0e698273010f56fad59245cedfaad5R14-R17)