### PR TITLE
Bug/1112 missing leading slash in api path

### DIFF
--- a/plugins/plugin-endpoint/src/components/endpoint-path-preview.tsx
+++ b/plugins/plugin-endpoint/src/components/endpoint-path-preview.tsx
@@ -12,6 +12,7 @@ export const EndpointPathPreview: FC<EndpointPathPreviewProps> = ({ path, baseUr
   const pathUrl = usePathUrl(path)
   const fullUrl = `${baseUrl}${pathUrl.startsWith('/') ? pathUrl : '/' + pathUrl}`
   const [copied, setCopied] = useState(false)
+
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(fullUrl)


### PR DESCRIPTION
## Summary
Missing leading slash in API path causes malformed URLs on workbench.

const fullUrl = `${baseUrl}${pathUrl.startsWith('/') ? pathUrl : '/' + pathUrl}`

I have changed the code such that if it has "/" it will do nothing and if it doesn't have "/" it will add there


## Related Issues
#1112 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)


## Additional Context
<!-- Add any other context or information about the PR here --> 