### PR TITLE
fix: use GitHub usernames instead of Git author names in release notes

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -138,6 +138,8 @@ jobs:
 
       - name: Generate enhanced changelog
         id: changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Get the previous tag
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 ${{ needs.prepare.outputs.tag_name }}^)
@@ -147,8 +149,22 @@ jobs:
           mkdir -p /tmp/changelog
           touch /tmp/changelog/{features,fixes,performance,docs,deps,refactor,tests,build,ci,chores,reverts,other}.md
 
+          # Function to get GitHub username from commit hash
+          get_github_username() {
+            local commit_hash=$1
+            local username=$(gh api repos/${{ github.repository }}/commits/${commit_hash} --jq '.author.login // .commit.author.name' 2>/dev/null)
+            if [ -z "$username" ] || [ "$username" = "null" ]; then
+              # Fallback to commit author name if GitHub username not available
+              username=$(git show -s --format='%an' ${commit_hash})
+            fi
+            echo "$username"
+          }
+
           # Process commits and categorize them
-          git log $PREVIOUS_TAG..${{ needs.prepare.outputs.tag_name }} --pretty=format:"%s|%h|%an" --no-merges | while IFS='|' read -r subject hash author; do
+          git log $PREVIOUS_TAG..${{ needs.prepare.outputs.tag_name }} --pretty=format:"%s|%h" --no-merges | while IFS='|' read -r subject hash; do
+            # Get GitHub username for this commit
+            author=$(get_github_username "$hash")
+            
             # Extract conventional commit type
             if [[ $subject =~ ^(feat|feature)(\(.+\))?!?:(.+) ]]; then
               echo "- ${BASH_REMATCH[3]} ([${hash}](https://github.com/${{ github.repository }}/commit/${hash})) by @${author}" >> /tmp/changelog/features.md


### PR DESCRIPTION
### Problem
Release notes were showing incorrect contributor attributions due to using Git author names instead of GitHub usernames. This resulted in broken mentions like `@Glauber`, `@Rohit`, `@abhinav` instead of proper GitHub handles.

**Example of the issue:**
- Showed: `@Glauber Castro` (displayed as `@Glauber`)
- Should show: `@sergiofilhowz` (actual GitHub username)

### Solution
Updated the `finalize-release.yml` workflow to:
1. **Query GitHub API** for each commit to fetch the actual GitHub username
2. **Use `gh api`** to look up commit authors via `repos/{repo}/commits/{hash}`
3. **Fallback gracefully** to Git author name if GitHub username is unavailable
4. **Proper attribution** with clickable, linkable GitHub handles

### Changes
- Modified the changelog generation step in `.github/workflows/finalize-release.yml`
- Added `get_github_username()` function to fetch real GitHub usernames
- Changed from `%an` (author name) to API-based username lookup
- Added `GH_TOKEN` environment variable to enable GitHub CLI API calls

### Benefits
- ✅ Contributors get proper credit with correct GitHub handles
- ✅ Usernames are clickable and link to actual profiles
- ✅ Improved release notes readability
- ✅ Better community engagement and attribution
- ✅ No additional secrets required (uses built-in `github.token`)