### PR TITLE
feat: add wsPlugin, streamsPlugin, cronPlugin to all config templates

### DIFF
--- a/packages/docs/content/docs/development-guide/plugins.mdx
+++ b/packages/docs/content/docs/development-guide/plugins.mdx
@@ -24,7 +24,7 @@ Plugins in Motia allow you to:
   <Card title="Reusable Modules">Share reusable functionality across projects</Card>
 </Cards>
 
-Motia comes with several official plugins like `plugin-logs`, `plugin-endpoint`, `plugin-observability`, `plugin-states`, `ws-plugin`, and `cron-plugin` that demonstrate the power and flexibility of the plugin system.
+Motia comes with several official plugins like `plugin-logs`, `plugin-endpoint`, `plugin-observability`, `plugin-states`, `plugin-streams`, `plugin-ws`, and `plugin-cron` that demonstrate the power and flexibility of the plugin system.
 
 ## Plugin Architecture
 

--- a/packages/snap/src/create/templates/hello/motia.config.ts.txt
+++ b/packages/snap/src/create/templates/hello/motia.config.ts.txt
@@ -4,7 +4,10 @@ import logsPlugin from '@motiadev/plugin-logs/plugin'
 import observabilityPlugin from '@motiadev/plugin-observability/plugin'
 import statesPlugin from '@motiadev/plugin-states/plugin'
 import bullmqPlugin from '@motiadev/plugin-bullmq/plugin'
+import wsPlugin from '@motiadev/plugin-ws/plugin'
+import streamsPlugin from '@motiadev/plugin-streams/plugin'
+import cronPlugin from '@motiadev/plugin-cron/plugin'
 
 export default defineConfig({
-  plugins: [observabilityPlugin, statesPlugin, endpointPlugin, logsPlugin, bullmqPlugin],
+  plugins: [observabilityPlugin, statesPlugin, endpointPlugin, logsPlugin, bullmqPlugin, wsPlugin, streamsPlugin, cronPlugin],
 })

--- a/packages/snap/src/create/templates/hello_js/motia.config.ts.txt
+++ b/packages/snap/src/create/templates/hello_js/motia.config.ts.txt
@@ -4,7 +4,10 @@ import logsPlugin from '@motiadev/plugin-logs/plugin'
 import observabilityPlugin from '@motiadev/plugin-observability/plugin'
 import statesPlugin from '@motiadev/plugin-states/plugin'
 import bullmqPlugin from '@motiadev/plugin-bullmq/plugin'
+import wsPlugin from '@motiadev/plugin-ws/plugin'
+import streamsPlugin from '@motiadev/plugin-streams/plugin'
+import cronPlugin from '@motiadev/plugin-cron/plugin'
 
 export default defineConfig({
-  plugins: [observabilityPlugin, statesPlugin, endpointPlugin, logsPlugin, bullmqPlugin],
+  plugins: [observabilityPlugin, statesPlugin, endpointPlugin, logsPlugin, bullmqPlugin, wsPlugin, streamsPlugin, cronPlugin],
 })

--- a/packages/snap/src/create/templates/hello_multilang/motia.config.ts.txt
+++ b/packages/snap/src/create/templates/hello_multilang/motia.config.ts.txt
@@ -4,7 +4,10 @@ import logsPlugin from '@motiadev/plugin-logs/plugin'
 import observabilityPlugin from '@motiadev/plugin-observability/plugin'
 import statesPlugin from '@motiadev/plugin-states/plugin'
 import bullmqPlugin from '@motiadev/plugin-bullmq/plugin'
+import wsPlugin from '@motiadev/plugin-ws/plugin'
+import streamsPlugin from '@motiadev/plugin-streams/plugin'
+import cronPlugin from '@motiadev/plugin-cron/plugin'
 
 export default defineConfig({
-  plugins: [observabilityPlugin, statesPlugin, endpointPlugin, logsPlugin, bullmqPlugin],
+  plugins: [observabilityPlugin, statesPlugin, endpointPlugin, logsPlugin, bullmqPlugin, wsPlugin, streamsPlugin, cronPlugin],
 })

--- a/packages/snap/src/create/templates/hello_python/motia.config.ts.txt
+++ b/packages/snap/src/create/templates/hello_python/motia.config.ts.txt
@@ -4,7 +4,10 @@ import logsPlugin from '@motiadev/plugin-logs/plugin'
 import observabilityPlugin from '@motiadev/plugin-observability/plugin'
 import statesPlugin from '@motiadev/plugin-states/plugin'
 import bullmqPlugin from '@motiadev/plugin-bullmq/plugin'
+import wsPlugin from '@motiadev/plugin-ws/plugin'
+import streamsPlugin from '@motiadev/plugin-streams/plugin'
+import cronPlugin from '@motiadev/plugin-cron/plugin'
 
 export default defineConfig({
-  plugins: [observabilityPlugin, statesPlugin, endpointPlugin, logsPlugin, bullmqPlugin],
+  plugins: [observabilityPlugin, statesPlugin, endpointPlugin, logsPlugin, bullmqPlugin, wsPlugin, streamsPlugin, cronPlugin],
 })

--- a/packages/snap/src/create/templates/motia.config.external-redis.ts.txt
+++ b/packages/snap/src/create/templates/motia.config.external-redis.ts.txt
@@ -4,6 +4,9 @@ import logsPlugin from '@motiadev/plugin-logs/plugin'
 import observabilityPlugin from '@motiadev/plugin-observability/plugin'
 import statesPlugin from '@motiadev/plugin-states/plugin'
 import bullmqPlugin from '@motiadev/plugin-bullmq/plugin'
+import wsPlugin from '@motiadev/plugin-ws/plugin'
+import streamsPlugin from '@motiadev/plugin-streams/plugin'
+import cronPlugin from '@motiadev/plugin-cron/plugin'
 
 export default config({
   redis: {
@@ -11,6 +14,6 @@ export default config({
     host: '127.0.0.1',
     port: 6379,
   },
-  plugins: [observabilityPlugin, statesPlugin, endpointPlugin, logsPlugin, bullmqPlugin],
+  plugins: [observabilityPlugin, statesPlugin, endpointPlugin, logsPlugin, bullmqPlugin, wsPlugin, streamsPlugin, cronPlugin],
 })
 

--- a/packages/snap/src/create/templates/nodejs/motia.config.ts.txt
+++ b/packages/snap/src/create/templates/nodejs/motia.config.ts.txt
@@ -4,7 +4,10 @@ import logsPlugin from '@motiadev/plugin-logs/plugin'
 import observabilityPlugin from '@motiadev/plugin-observability/plugin'
 import statesPlugin from '@motiadev/plugin-states/plugin'
 import bullmqPlugin from '@motiadev/plugin-bullmq/plugin'
+import wsPlugin from '@motiadev/plugin-ws/plugin'
+import streamsPlugin from '@motiadev/plugin-streams/plugin'
+import cronPlugin from '@motiadev/plugin-cron/plugin'
 
 export default defineConfig({
-  plugins: [observabilityPlugin, statesPlugin, endpointPlugin, logsPlugin, bullmqPlugin],
+  plugins: [observabilityPlugin, statesPlugin, endpointPlugin, logsPlugin, bullmqPlugin, wsPlugin, streamsPlugin, cronPlugin],
 })

--- a/packages/snap/src/create/templates/python/motia.config.ts.txt
+++ b/packages/snap/src/create/templates/python/motia.config.ts.txt
@@ -4,7 +4,10 @@ import logsPlugin from '@motiadev/plugin-logs/plugin'
 import observabilityPlugin from '@motiadev/plugin-observability/plugin'
 import statesPlugin from '@motiadev/plugin-states/plugin'
 import bullmqPlugin from '@motiadev/plugin-bullmq/plugin'
+import wsPlugin from '@motiadev/plugin-ws/plugin'
+import streamsPlugin from '@motiadev/plugin-streams/plugin'
+import cronPlugin from '@motiadev/plugin-cron/plugin'
 
 export default defineConfig({
-  plugins: [observabilityPlugin, statesPlugin, endpointPlugin, logsPlugin, bullmqPlugin],
+  plugins: [observabilityPlugin, statesPlugin, endpointPlugin, logsPlugin, bullmqPlugin, wsPlugin, streamsPlugin, cronPlugin],
 })

--- a/playground/motia.config.ts
+++ b/playground/motia.config.ts
@@ -7,6 +7,7 @@ import examplePlugin from '@motiadev/plugin-example/plugin'
 import logsPlugin from '@motiadev/plugin-logs/plugin'
 import observabilityPlugin from '@motiadev/plugin-observability/plugin'
 import statesPlugin from '@motiadev/plugin-states/plugin'
+import streamsPlugin from '@motiadev/plugin-streams/plugin'
 import wsPlugin from '@motiadev/plugin-ws/plugin'
 import { z } from 'zod'
 
@@ -97,6 +98,7 @@ export default defineConfig({
     examplePlugin,
     bullmqPlugin,
     wsPlugin,
+    streamsPlugin,
     cronPlugin,
     localPluginExample,
   ],

--- a/plugins/plugin-cron/README.md
+++ b/plugins/plugin-cron/README.md
@@ -23,20 +23,6 @@ npm install @motiadev/plugin-cron
 pnpm add @motiadev/plugin-cron
 ```
 
-## Usage
-
-Add the plugin to your `motia.config.ts`:
-
-```typescript
-import cronPlugin from '@motiadev/plugin-cron/plugin'
-
-export default {
-  plugins: [cronPlugin],
-}
-```
-
-The plugin will automatically appear as a "Cron Jobs" tab in the bottom panel of your Motia workbench.
-
 ## Features
 
 ### Job Monitoring

--- a/plugins/plugin-streams/README.md
+++ b/plugins/plugin-streams/README.md
@@ -16,21 +16,9 @@ A Motia Workbench plugin for visualizing and managing streams in your applicatio
 npm install @motiadev/plugin-streams
 ```
 
-## Configuration
-
-Add the plugin to your `motia.config.ts`:
-
-```typescript
-import { defineConfig } from 'motia'
-
-export default defineConfig({
-  plugins: ['@motiadev/plugin-streams/plugin'],
-})
-```
-
 ## Usage
 
-Once installed, the Streams tab will appear in the Motia Workbench. Click on any stream to view its groups and items.
+The Streams tab will appear in the Motia Workbench. Click on any stream to view its groups and items.
 
 ### Stream Panel
 

--- a/plugins/plugin-ws/README.md
+++ b/plugins/plugin-ws/README.md
@@ -25,20 +25,6 @@ npm install @motiadev/plugin-ws
 pnpm add @motiadev/plugin-ws
 ```
 
-## Usage
-
-Add the plugin to your `motia.config.ts`:
-
-```typescript
-import wsPlugin from '@motiadev/plugin-ws/plugin'
-
-export default {
-  plugins: [wsPlugin],
-}
-```
-
-The plugin will automatically appear as a "WebSockets" tab in the bottom panel of your Motia workbench.
-
 ## Features
 
 ### Stream Subscriptions


### PR DESCRIPTION
- Added wsPlugin, streamsPlugin, and cronPlugin to all motia.config.ts templates
- Updated playground/motia.config.ts with missing streamsPlugin
- Fixed plugins.mdx documentation to use consistent plugin names
- Cleaned up plugin READMEs (removed Usage sections, updated licenses)
