### PR TITLE
fix: start III Engine in test-node deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,6 +111,9 @@ jobs:
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
 
+      - name: Start III Engine
+        uses: ./.github/actions/iii-engine
+
       - name: Run linter
         working-directory: motia-js
         run: pnpm lint:ci
@@ -118,6 +121,12 @@ jobs:
       - name: Run tests
         working-directory: motia-js
         run: pnpm test:ci
+        env:
+          III_URL: ws://localhost:49199
+
+      - name: Stop III Engine
+        if: always()
+        run: docker rm -f iii-engine || true
 
   test-python:
     name: Test Python


### PR DESCRIPTION
## Summary

- The `test-node` job in `deploy.yml` was missing the III Engine startup steps that exist in `ci-node.yml`
- Added `Start III Engine` step (using `./.github/actions/iii-engine`) before running tests
- Added `III_URL: ws://localhost:49199` env var to the test run step
- Added `Stop III Engine` cleanup step with `if: always()` guard

## Test plan
- [ ] Verify `test-node` job passes on the next tag-triggered deploy run
- [ ] Confirm III Engine container is cleaned up after the job completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to improve test infrastructure setup and cleanup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->