### PR TITLE
fix: moving http trigger props from the step config to trigger config

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1126,16 +1126,18 @@ If your project has both Node and Python steps, you now configure **separate Exe
 modules:
   - class: modules::shell::ExecModule
     config:
-      watch:
+      watch:                          # Glob patterns to watch for hot-reload
         - steps/**/*.ts
-      exec:
+        - motia.config.ts
+      exec:                           # Commands to run as the SDK process (in order)
         - npx motia dev
+        - bun run --enable-source-maps dist/index-dev.js
 
   - class: modules::shell::ExecModule
     config:
-      watch:
+      watch:                          # Glob patterns to watch for hot-reload
         - steps/**/*.py
-      exec:
+      exec:                           # Commands to run as the SDK process (in order)
         - uv run motia dev --dir steps
 ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated migration guide to show middleware now configured inside HTTP trigger definitions and refreshed examples.
  * Added configuration checklist to help users update their setups and verify migrated configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->