### PR TITLE
docs: update README to use motia-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
 </p>
 
 <p align="center">
-  <strong>🔥 The Unified Backend Framework That Eliminates Runtime Fragmentation 🔥</strong>
+  <strong>Build production-grade backends with a single primitive</strong>
 </p>
 <p align="center">
-  <em>APIs, background jobs, queueing, streaming, states, workflows, AI agents, observability, scaling, and deployment all in one system. JavaScript, TypeScript, Python, and more in a single core primitive</em>
+  <em>APIs, background jobs, workflows, AI agents, streaming, state management, and observability — unified in one framework. TypeScript, JavaScript, and Python.</em>
 </p>
 
 <p align="center">
@@ -187,6 +187,51 @@ const handler = async (input, { logger }) => {
 };
 
 module.exports = { config, handler };
+```
+
+</details>
+
+<details>
+<summary><b>Python</b></summary>
+
+```python
+# steps/send_message_step.py
+config = {
+    "name": "SendMessage",
+    "triggers": [
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/messages",
+        }
+    ],
+    "enqueues": ["message.sent"],
+}
+
+
+async def handler(req, ctx):
+    await ctx.enqueue({
+        "topic": "message.sent",
+        "data": {"text": req.body.get("text")},
+    })
+    return {"status": 200, "body": {"ok": True}}
+```
+
+```python
+# steps/process_message_step.py
+config = {
+    "name": "ProcessMessage",
+    "triggers": [
+        {
+            "type": "queue",
+            "topic": "message.sent",
+        }
+    ],
+}
+
+
+async def handler(input, ctx):
+    ctx.logger.info("Processing message", input)
 ```
 
 </details>


### PR DESCRIPTION
## Summary

- Replace `npx motia@latest create` with `motia-cli` install instructions (Homebrew + curl)
- Remove manual iii engine install from prerequisites — `motia-cli create` now auto-detects and installs iii
- Renumber quickstart steps (0. Prerequisites → 1. Install CLI → 2. Create project → 3. Start iii)

## Changes

**"Create your first Motia App" section:**
- Before: `npx motia@latest create`
- After: `brew tap MotiaDev/tap && brew install motia-cli` or `curl` install, then `motia-cli create my-app`

**Quickstart section:**
- Removed iii engine from prerequisites (CLI handles it)
- Added step 1 for CLI installation
- Updated bootstrap command to `motia-cli create my-app`
- Added note: "The CLI auto-detects and installs the iii engine if it's not already on your system"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Overhauled getting started guide with a clarified 3-step quickstart (Install CLI, Bootstrap project, Start engine), new prerequisites, and richer feature summaries.
  * Added Brew and shell-script installation options, explicit project creation flow, Python examples, and expanded "What is" and core primitive explanations.
  * Removed the Remix in Replit subsection and updated callouts and visuals to match the new quickstart.

* **New Features**
  * Revised hero messaging and subheading to highlight APIs, workflows, streaming, state, and observability across TypeScript, JavaScript, and Python.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->