### PR TITLE
refactor(runtime): update trigger suffix format and add metadata to function registration

### DIFF
--- a/motia-py/packages/motia/src/motia/runtime.py
+++ b/motia-py/packages/motia/src/motia/runtime.py
@@ -261,7 +261,7 @@ class Motia:
         for index, trigger in enumerate(config.triggers):
             trigger_suffix = _get_trigger_suffix(trigger)
             if trigger_suffix in seen_suffixes:
-                trigger_suffix = f"{trigger_suffix}::{index}"
+                trigger_suffix = f"{trigger_suffix}-{index}"
             seen_suffixes.add(trigger_suffix)
             function_id = f"steps::{config.name}::trigger::{trigger_suffix}"
 
@@ -373,7 +373,7 @@ class Motia:
                     record_exception(span, exc)
                     raise
 
-        get_instance().register_function(function_id, api_handler)
+        get_instance().register_function(function_id, api_handler, metadata=metadata)
 
         api_path = trigger.path.lstrip("/")
         trigger_config: dict[str, Any] = {
@@ -413,7 +413,7 @@ class Motia:
                     record_exception(span, exc)
                     raise
 
-        get_instance().register_function(function_id, queue_handler)
+        get_instance().register_function(function_id, queue_handler, metadata=metadata)
 
         trigger_config: dict[str, Any] = {
             "topic": trigger.topic,
@@ -448,7 +448,7 @@ class Motia:
                     record_exception(span, exc)
                     raise
 
-        get_instance().register_function(function_id, cron_handler)
+        get_instance().register_function(function_id, cron_handler, metadata=metadata)
 
         trigger_config: dict[str, Any] = {
             "expression": trigger.expression,
@@ -483,7 +483,7 @@ class Motia:
                     record_exception(span, exc)
                     raise
 
-        get_instance().register_function(function_id, state_handler)
+        get_instance().register_function(function_id, state_handler, metadata=metadata)
 
         trigger_config: dict[str, Any] = {"metadata": metadata}
 
@@ -515,7 +515,7 @@ class Motia:
                     record_exception(span, exc)
                     raise
 
-        get_instance().register_function(function_id, stream_handler)
+        get_instance().register_function(function_id, stream_handler, metadata=metadata)
 
         trigger_config: dict[str, Any] = {
             "metadata": metadata,

--- a/motia-py/packages/motia/src/motia/types.py
+++ b/motia-py/packages/motia/src/motia/types.py
@@ -429,7 +429,6 @@ class StepConfig(BaseModel):
     description: str | None = None
     flows: list[str] | None = None
     include_files: list[str] | None = Field(default=None, serialization_alias="includeFiles")
-    infrastructure: InfrastructureConfig | None = None
 
 
 class Step(BaseModel):


### PR DESCRIPTION
## Summary
- **Trigger suffix format**: When multiple triggers share the same suffix, the disambiguator is now `{suffix}-{index}` instead of `{suffix}::{index}` (e.g. `api-0`, `api-1`).
- **Function registration metadata**: All trigger handlers (API, queue, cron, state, stream) now pass `metadata` into `register_function()`, so the engine receives consistent metadata for each registered function.
- **Types cleanup**: Removed unused `infrastructure` field from `StepConfig` in `motia-py` types.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/MotiaDev/motia/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
- Python SDK only; no JS/Rust SDK changes in this PR.
- Trigger suffix change avoids double colons in function IDs and aligns with a simpler disambiguation format.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate trigger naming now uses hyphens instead of double colons for clearer disambiguation.

* **Refactor**
  * Removed the infrastructure configuration option from step settings.

* **Chores**
  * Step metadata is now propagated when registering dynamic handlers, ensuring handler registrations carry step context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->