### PR TITLE
fix(motia-js): add missing state/stream guard helpers (#1183)

### DIFF
--- a/frameworks/motia/motia-js/packages/motia/__tests__/guards.test.ts
+++ b/frameworks/motia/motia-js/packages/motia/__tests__/guards.test.ts
@@ -2,6 +2,8 @@ import {
   getApiTriggers,
   getCronTriggers,
   getQueueTriggers,
+  getStateTriggers,
+  getStreamTriggers,
   isApiTrigger,
   isCronTrigger,
   isQueueTrigger,
@@ -114,6 +116,34 @@ describe('guards', () => {
       expect(result).toHaveLength(2)
       expect(result[0].expression).toBe('0 * * * *')
       expect(result[1].expression).toBe('0 0 * * *')
+    })
+
+    it('getStateTriggers filters state triggers from mixed array', () => {
+      const step = {
+        filePath: 'test.step.ts',
+        config: {
+          name: 'test',
+          triggers: [state(), queue('q'), state({ keys: ['a'] }), http('GET', '/x')],
+        },
+      }
+      const result = getStateTriggers(step)
+      expect(result).toHaveLength(2)
+      expect(result[0].type).toBe('state')
+      expect(result[1].type).toBe('state')
+    })
+
+    it('getStreamTriggers filters stream triggers from mixed array', () => {
+      const step = {
+        filePath: 'test.step.ts',
+        config: {
+          name: 'test',
+          triggers: [stream('a'), cron('0 0 * * *'), stream('b'), state()],
+        },
+      }
+      const result = getStreamTriggers(step)
+      expect(result).toHaveLength(2)
+      expect(result[0].streamName).toBe('a')
+      expect(result[1].streamName).toBe('b')
     })
   })
 })

--- a/frameworks/motia/motia-js/packages/motia/src/guards.ts
+++ b/frameworks/motia/motia-js/packages/motia/src/guards.ts
@@ -22,3 +22,7 @@ export const getApiTriggers = (step: Step): ApiTriggerType[] => step.config.trig
 export const getQueueTriggers = (step: Step): QueueTriggerType[] => step.config.triggers.filter(isQueueTrigger)
 
 export const getCronTriggers = (step: Step): CronTriggerType[] => step.config.triggers.filter(isCronTrigger)
+
+export const getStateTriggers = (step: Step): StateTriggerType[] => step.config.triggers.filter(isStateTrigger)
+
+export const getStreamTriggers = (step: Step): StreamTriggerType[] => step.config.triggers.filter(isStreamTrigger)


### PR DESCRIPTION
## Summary
- add missing guard helpers `getStateTriggers` and `getStreamTriggers` in `motia-js`
- add focused unit tests for both helpers in mixed trigger arrays

## Why
Issue #1183 reports missing state/stream trigger guard helpers while API/queue/cron equivalents already exist.

## Changes
- `frameworks/motia/motia-js/packages/motia/src/guards.ts`
  - add `getStateTriggers(step)`
  - add `getStreamTriggers(step)`
- `frameworks/motia/motia-js/packages/motia/__tests__/guards.test.ts`
  - add test: `getStateTriggers filters state triggers from mixed array`
  - add test: `getStreamTriggers filters stream triggers from mixed array`

## Validation
- `pnpm exec jest __tests__/guards.test.ts --selectProjects unit`

Closes #1183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `getStateTriggers` and `getStreamTriggers` functions to the guards module, enabling filtering of state and stream triggers from step configurations. These functions complement existing trigger filtering capabilities.

* **Tests**
  * Added tests verifying correct filtering behavior for state and stream triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->