### PR TITLE
fix: add missing armv7 and i686 targets to CLI platform detection

### DIFF
--- a/cli/src/platform.rs
+++ b/cli/src/platform.rs
@@ -9,34 +9,40 @@ use crate::registry::BinarySpec;
 /// Linux aarch64 uses gnu (no musl builds available).
 pub fn current_target() -> &'static str {
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    {
-        "aarch64-apple-darwin"
-    }
+    return "aarch64-apple-darwin";
 
     #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
-    {
-        "x86_64-apple-darwin"
-    }
+    return "x86_64-apple-darwin";
 
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-    {
-        "x86_64-unknown-linux-musl"
-    }
+    return "x86_64-unknown-linux-musl";
 
     #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
-    {
-        "aarch64-unknown-linux-gnu"
-    }
+    return "aarch64-unknown-linux-gnu";
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    return "armv7-unknown-linux-gnueabihf";
 
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
-    {
-        "x86_64-pc-windows-msvc"
-    }
+    return "x86_64-pc-windows-msvc";
+
+    #[cfg(all(target_os = "windows", target_arch = "x86"))]
+    return "i686-pc-windows-msvc";
 
     #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
-    {
-        "aarch64-pc-windows-msvc"
-    }
+    return "aarch64-pc-windows-msvc";
+
+    #[cfg(not(any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "macos", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "arm"),
+        all(target_os = "windows", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "x86"),
+        all(target_os = "windows", target_arch = "aarch64"),
+    )))]
+    compile_error!("unsupported target platform for iii-cli")
 }
 
 /// Returns the archive extension for the current platform.
@@ -140,7 +146,9 @@ fn format_target_human(target: &str) -> String {
         "x86_64-unknown-linux-gnu" => "Linux x86_64 (glibc)".to_string(),
         "x86_64-unknown-linux-musl" => "Linux x86_64 (musl)".to_string(),
         "aarch64-unknown-linux-gnu" => "Linux ARM64".to_string(),
+        "armv7-unknown-linux-gnueabihf" => "Linux ARMv7".to_string(),
         "x86_64-pc-windows-msvc" => "Windows x86_64".to_string(),
+        "i686-pc-windows-msvc" => "Windows x86".to_string(),
         "aarch64-pc-windows-msvc" => "Windows ARM64".to_string(),
         other => other.to_string(),
     }


### PR DESCRIPTION
## Summary

- Adds `armv7-unknown-linux-gnueabihf` (`target_arch = "arm"`) case to `current_target()` in `cli/src/platform.rs`
- Adds `i686-pc-windows-msvc` (`target_arch = "x86"`) case to `current_target()`
- Adds a `compile_error!` fallback for any future unsupported targets
- Adds human-readable labels for both new targets in `format_target_human()`

## Root cause

The release pipeline builds CLI binaries for all targets in the matrix — including `armv7-unknown-linux-gnueabihf` and `i686-pc-windows-msvc`. These two targets had no matching `#[cfg]` branch in `current_target()`, so the function implicitly returned `()` and Rust failed with:

```
error[E0308]: mismatched types
  --> cli/src/platform.rs:10:28
   |
10 | pub fn current_target() -> &'static str {
   |        --------------      ^^^^^^^^^^^^ expected `&str`, found `()`
```

The same targets succeed for the engine binary because the engine does not have this function.

## Test plan

- [x] `cargo build --manifest-path cli/Cargo.toml` passes locally
- [ ] Verify `CLI Binary Release / Build armv7-unknown-linux-gnueabihf` passes in CI
- [ ] Verify `CLI Binary Release / Build i686-pc-windows-msvc` passes in CI

Fixes: https://github.com/iii-hq/iii/actions/runs/22780885652/job/66086129284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Linux ARMv7 processor architecture, expanding platform compatibility.
  * Enhanced platform identification with improved human-readable labels for all targets.

* **Improvements**
  * Strengthened error detection for unsupported platform combinations at compile time.
  * Refined platform naming and formatting for greater clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->