### PR TITLE
fix: update install.sh scripts to use v-prefixed release tags

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -433,7 +433,7 @@ if [[ -z "$binary_path" ]]; then
     _bare="${_bare#v}"
     check_version "$_bare"
     printf "${MUTED}Installing ${NC}%s ${MUTED}version: ${NC}%s\n" "$BIN_NAME" "$requested_version"
-    _tag="iii/v${_bare}"
+    _tag="v${_bare}"
     api_url="https://api.github.com/repos/$REPO/releases/tags/$_tag"
     json=$(github_api "$api_url") || err "release tag not found: $requested_version (tried tag: $_tag)"
   else
@@ -442,13 +442,13 @@ if [[ -z "$binary_path" ]]; then
     json_list=$(github_api "$api_url") || err "failed to fetch releases from $REPO"
     if command -v jq >/dev/null 2>&1; then
       json=$(printf '%s' "$json_list" \
-        | jq -c 'first(.[] | select(.prerelease == false and (.tag_name | startswith("iii/v"))))')
+        | jq -c 'first(.[] | select(.prerelease == false and (.tag_name | startswith("v"))))')
       [[ "$json" == "null" || -z "$json" ]] && err "no stable iii release found"
     else
       _tag=$(printf '%s' "$json_list" \
-        | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"iii/v[^"]+"' \
+        | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"v[^"]+"' \
         | head -n 1 \
-        | sed -E 's/.*"(iii\/v[^"]+)".*/\1/')
+        | sed -E 's/.*"(v[^"]+)".*/\1/')
       [[ -z "$_tag" ]] && err "could not determine latest release"
       api_url="https://api.github.com/repos/$REPO/releases/tags/$_tag"
       json=$(github_api "$api_url") || err "failed to fetch release $_tag"

--- a/console/install.sh
+++ b/console/install.sh
@@ -380,7 +380,7 @@ if [[ -z "$binary_path" ]]; then
     _bare="${_bare#v}"
     check_version "$_bare"
     printf "${MUTED}Installing ${NC}%s ${MUTED}version: ${NC}%s\n" "$BIN_NAME" "$requested_version"
-    _tag="iii/v${_bare}"
+    _tag="v${_bare}"
     api_url="https://api.github.com/repos/$REPO/releases/tags/$_tag"
     json=$(github_api "$api_url") || err "release tag not found: $requested_version (tried tag: $_tag)"
   else
@@ -389,13 +389,13 @@ if [[ -z "$binary_path" ]]; then
     json_list=$(github_api "$api_url") || err "failed to fetch releases from $REPO"
     if command -v jq >/dev/null 2>&1; then
       json=$(printf '%s' "$json_list" \
-        | jq -c 'first(.[] | select(.prerelease == false and (.tag_name | startswith("iii/v"))))')
+        | jq -c 'first(.[] | select(.prerelease == false and (.tag_name | startswith("v"))))')
       [[ "$json" == "null" || -z "$json" ]] && err "no stable iii release found"
     else
       _tag=$(printf '%s' "$json_list" \
-        | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"iii/v[^"]+"' \
+        | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"v[^"]+"' \
         | head -n 1 \
-        | sed -E 's/.*"(iii\/v[^"]+)".*/\1/')
+        | sed -E 's/.*"(v[^"]+)".*/\1/')
       [[ -z "$_tag" ]] && err "could not determine latest release"
       api_url="https://api.github.com/repos/$REPO/releases/tags/$_tag"
       json=$(github_api "$api_url") || err "failed to fetch release $_tag"

--- a/engine/install.sh
+++ b/engine/install.sh
@@ -173,7 +173,7 @@ github_api() {
   curl -fsSL $api_headers "$1"
 }
 
-TAG_PREFIX="iii/v"
+TAG_PREFIX="v"
 
 if [ -n "$VERSION" ]; then
   echo "installing version: $VERSION"
@@ -188,15 +188,15 @@ else
   json_list=$(github_api "$api_url")
   if command -v jq >/dev/null 2>&1; then
     json=$(printf '%s' "$json_list" \
-      | jq -c 'first(.[] | select(.prerelease == false and (.tag_name | startswith("iii/v"))))')
+      | jq -c 'first(.[] | select(.prerelease == false and (.tag_name | startswith("v"))))')
     if [ "$json" = "null" ] || [ -z "$json" ]; then
       err "no stable iii release found"
     fi
   else
     _tag=$(printf '%s' "$json_list" \
-      | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"iii/v[^"]+"' \
+      | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"v[^"]+"' \
       | head -n 1 \
-      | sed -E 's/.*"(iii\/v[^"]+)".*/\1/')
+      | sed -E 's/.*"(v[^"]+)".*/\1/')
     if [ -z "$_tag" ]; then
       err "could not determine latest release"
     fi


### PR DESCRIPTION
## Summary

- `taiki-e/upload-rust-binary-action` strips the `iii/` namespace prefix from tags when uploading assets, so GitHub releases are tagged `v0.8.0` rather than `iii/v0.8.0`
- All three `install.sh` scripts (`engine/`, `cli/`, `console/`) were querying the GitHub API using the `iii/v` prefix, making every version lookup and latest-release discovery fail
- Updated `TAG_PREFIX`, tag construction, `startswith` filters, and grep patterns to use `v` instead of `iii/v`

## Test plan

- [ ] Verify `engine/install.sh` resolves latest release correctly (no `iii/v` lookups)
- [ ] Verify `cli/install.sh` resolves latest release correctly
- [ ] Verify `console/install.sh` resolves latest release correctly
- [ ] Verify a specific version install (e.g. `VERSION=0.8.0`) works for each script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Installation scripts for CLI, console, and engine components have been updated to use a simplified release tag naming format. All release discovery, version resolution, and asset selection mechanisms continue to function reliably with this change. Error handling and control flow remain unchanged, ensuring a consistent and stable installation experience across all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->