### PR TITLE
fix: update install.sh scripts to use v-prefixed release tags

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -433,7 +433,7 @@ if [[ -z "$binary_path" ]]; then
     _bare="${_bare#v}"
     check_version "$_bare"
     printf "${MUTED}Installing ${NC}%s ${MUTED}version: ${NC}%s\n" "$BIN_NAME" "$requested_version"
-    _tag="iii/v${_bare}"
+    _tag="v${_bare}"
     api_url="https://api.github.com/repos/$REPO/releases/tags/$_tag"
     json=$(github_api "$api_url") || err "release tag not found: $requested_version (tried tag: $_tag)"
   else
@@ -442,13 +442,13 @@ if [[ -z "$binary_path" ]]; then
     json_list=$(github_api "$api_url") || err "failed to fetch releases from $REPO"
     if command -v jq >/dev/null 2>&1; then
       json=$(printf '%s' "$json_list" \
-        | jq -c 'first(.[] | select(.prerelease == false and (.tag_name | startswith("iii/v"))))')
+        | jq -c 'first(.[] | select(.prerelease == false and (.tag_name | startswith("v"))))')
       [[ "$json" == "null" || -z "$json" ]] && err "no stable iii release found"
     else
       _tag=$(printf '%s' "$json_list" \
-        | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"iii/v[^"]+"' \
+        | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"v[^"]+"' \
         | head -n 1 \
-        | sed -E 's/.*"(iii\/v[^"]+)".*/\1/')
+        | sed -E 's/.*"(v[^"]+)".*/\1/')
       [[ -z "$_tag" ]] && err "could not determine latest release"
       api_url="https://api.github.com/repos/$REPO/releases/tags/$_tag"
       json=$(github_api "$api_url") || err "failed to fetch release $_tag"

--- a/console/install.sh
+++ b/console/install.sh
@@ -380,7 +380,7 @@ if [[ -z "$binary_path" ]]; then
     _bare="${_bare#v}"
     check_version "$_bare"
     printf "${MUTED}Installing ${NC}%s ${MUTED}version: ${NC}%s\n" "$BIN_NAME" "$requested_version"
-    _tag="iii/v${_bare}"
+    _tag="v${_bare}"
     api_url="https://api.github.com/repos/$REPO/releases/tags/$_tag"
     json=$(github_api "$api_url") || err "release tag not found: $requested_version (tried tag: $_tag)"
   else
@@ -389,13 +389,13 @@ if [[ -z "$binary_path" ]]; then
     json_list=$(github_api "$api_url") || err "failed to fetch releases from $REPO"
     if command -v jq >/dev/null 2>&1; then
       json=$(printf '%s' "$json_list" \
-        | jq -c 'first(.[] | select(.prerelease == false and (.tag_name | startswith("iii/v"))))')
+        | jq -c 'first(.[] | select(.prerelease == false and (.tag_name | startswith("v"))))')
       [[ "$json" == "null" || -z "$json" ]] && err "no stable iii release found"
     else
       _tag=$(printf '%s' "$json_list" \
-        | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"iii/v[^"]+"' \
+        | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"v[^"]+"' \
         | head -n 1 \
-        | sed -E 's/.*"(iii\/v[^"]+)".*/\1/')
+        | sed -E 's/.*"(v[^"]+)".*/\1/')
       [[ -z "$_tag" ]] && err "could not determine latest release"
       api_url="https://api.github.com/repos/$REPO/releases/tags/$_tag"
       json=$(github_api "$api_url") || err "failed to fetch release $_tag"

--- a/engine/install.sh
+++ b/engine/install.sh
@@ -173,7 +173,7 @@ github_api() {
   curl -fsSL $api_headers "$1"
 }
 
-TAG_PREFIX="iii/v"
+TAG_PREFIX="v"
 
 if [ -n "$VERSION" ]; then
   echo "installing version: $VERSION"
@@ -188,15 +188,15 @@ else
   json_list=$(github_api "$api_url")
   if command -v jq >/dev/null 2>&1; then
     json=$(printf '%s' "$json_list" \
-      | jq -c 'first(.[] | select(.prerelease == false and (.tag_name | startswith("iii/v"))))')
+      | jq -c 'first(.[] | select(.prerelease == false and (.tag_name | startswith("v"))))')
     if [ "$json" = "null" ] || [ -z "$json" ]; then
       err "no stable iii release found"
     fi
   else
     _tag=$(printf '%s' "$json_list" \
-      | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"iii/v[^"]+"' \
+      | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"v[^"]+"' \
       | head -n 1 \
-      | sed -E 's/.*"(iii\/v[^"]+)".*/\1/')
+      | sed -E 's/.*"(v[^"]+)".*/\1/')
     if [ -z "$_tag" ]; then
       err "could not determine latest release"
     fi


### PR DESCRIPTION
## Summary

- `taiki-e/upload-rust-binary-action` strips the `iii/` namespace prefix when uploading release assets, so GitHub releases end up tagged `v0.8.0` rather than `iii/v0.8.0`
- All three install scripts (`engine`, `cli`, `console`) were filtering the releases API with `startswith("iii/v")` and `TAG_PREFIX="iii/v"`, which caused them to skip the latest release and fall back to `iii/v0.7.0` — which has no `iii-cli` or `iii-console` assets
- Fixes `curl https://install.iii.dev/console/main/install.sh | sh` failing with _"binary 'iii-console' not found in downloaded asset"_

## Changes

- `engine/install.sh`: `TAG_PREFIX="iii/v"` → `TAG_PREFIX="v"`, `startswith("iii/v")` → `startswith("v")`
- `cli/install.sh`: same
- `console/install.sh`: same

## Test plan

- [ ] `curl -fsSL https://install.iii.dev/iii/main/install.sh | sh` installs latest engine (v0.8.0)
- [ ] `curl -fsSL https://install.iii.dev/iii-cli/main/install.sh | sh` installs latest CLI (v0.8.0)
- [ ] `curl -fsSL https://install.iii.dev/console/main/install.sh | sh` installs latest console (v0.8.0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated installation scripts across all components to use a simplified release tag naming convention. This modernizes the version reference system while maintaining full compatibility with existing installation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->