### PR TITLE
fix: install scripts asset selection for multi-binary releases

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -478,14 +478,14 @@ if [[ -z "$binary_path" ]]; then
   # Extract asset URL for the target (exclude .sha256 checksum files)
   if command -v jq >/dev/null 2>&1; then
     asset_url=$(printf '%s' "$json" \
-      | jq -r --arg target "$target" \
-        '.assets[] | select((.name | contains($target)) and (.name | test("\\.(tar\\.gz|tgz|zip)$"))) | .browser_download_url' \
+      | jq -r --arg bn "$BIN_NAME" --arg target "$target" \
+        '.assets[] | select((.name | startswith($bn + "-")) and (.name | contains($target)) and (.name | test("\\.(tar\\.gz|tgz|zip)$"))) | .browser_download_url' \
       | head -n 1)
   else
     asset_url=$(printf '%s' "$json" \
       | grep -oE '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]+"' \
       | sed -E 's/.*"([^"]+)".*/\1/' \
-      | grep -F "$target" \
+      | grep -F "$BIN_NAME-$target" \
       | grep -E '\.(tar\.gz|tgz|zip)$' \
       | head -n 1)
   fi

--- a/console/install.sh
+++ b/console/install.sh
@@ -425,14 +425,14 @@ if [[ -z "$binary_path" ]]; then
   # Extract asset URL for the target (exclude .sha256 checksum files)
   if command -v jq >/dev/null 2>&1; then
     asset_url=$(printf '%s' "$json" \
-      | jq -r --arg target "$target" \
-        '.assets[] | select((.name | contains($target)) and (.name | test("\\.(tar\\.gz|tgz|zip)$"))) | .browser_download_url' \
+      | jq -r --arg bn "$BIN_NAME" --arg target "$target" \
+        '.assets[] | select((.name | startswith($bn + "-")) and (.name | contains($target)) and (.name | test("\\.(tar\\.gz|tgz|zip)$"))) | .browser_download_url' \
       | head -n 1)
   else
     asset_url=$(printf '%s' "$json" \
       | grep -oE '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]+"' \
       | sed -E 's/.*"([^"]+)".*/\1/' \
-      | grep -F "$target" \
+      | grep -F "$BIN_NAME-$target" \
       | grep -E '\.(tar\.gz|tgz|zip)$' \
       | head -n 1)
   fi

--- a/engine/install.sh
+++ b/engine/install.sh
@@ -207,13 +207,15 @@ fi
 
 if command -v jq >/dev/null 2>&1; then
   asset_url=$(printf '%s' "$json" \
-    | jq -r --arg target "$target" '.assets[] | select(.name | test($target)) | .browser_download_url' \
+    | jq -r --arg bn "$BIN_NAME" --arg target "$target" \
+      '.assets[] | select((.name | startswith($bn + "-")) and (.name | contains($target)) and (.name | test("\\.(tar\\.gz|tgz|zip)$"))) | .browser_download_url' \
     | head -n 1)
 else
   asset_url=$(printf '%s' "$json" \
     | grep -oE '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]+"' \
     | sed -E 's/.*"([^"]+)".*/\1/' \
-    | grep "$target" \
+    | grep -F "$BIN_NAME-$target" \
+    | grep -E '\.(tar\.gz|tgz|zip)$' \
     | head -n 1)
 fi
 


### PR DESCRIPTION
## Summary

PR #1252 fixed the tag prefix (`iii/v` → `v`), but all three install scripts still failed because the asset selection logic was wrong:

- **engine**: Picked `iii-aarch64-apple-darwin.sha256` (checksum file) instead of `.tar.gz` — no extension filter
- **cli/console**: Picked `iii-aarch64-apple-darwin.tar.gz` (engine binary) instead of their own — no BIN_NAME filter

## Changes

- **engine/install.sh**: Add `startswith($BIN_NAME + "-")` and extension filter `\.(tar\.gz|tgz|zip)$` to jq; add `grep -F "$BIN_NAME-$target"` and extension filter to fallback
- **cli/install.sh**: Add `startswith($BIN_NAME + "-")` to jq; add `grep -F "$BIN_NAME-$target"` to fallback
- **console/install.sh**: Same as cli

## Test plan

- `curl -fsSL https://install.iii.dev/iii/main/install.sh | sh -- --no-cli` installs engine v0.8.0
- `curl -fsSL https://install.iii.dev/iii-cli/main/install.sh | sh -- --no-modify-path --force` installs iii-cli v0.8.0
- `curl -fsSL https://install.iii.dev/console/main/install.sh | sh -- --no-modify-path` installs iii-console v0.8.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced installation process with stricter asset validation when fetching from release sources. The installer now requires downloaded assets to match the binary name prefix, target platform, and supported archive formats, ensuring correct packages are selected. This significantly reduces the likelihood of installation failures due to mismatched or incompatible assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->