### PR TITLE
fix: update Docker workflow to use v-prefixed release tags in descrip…

### DIFF
--- a/.github/workflows/docker-engine.yml
+++ b/.github/workflows/docker-engine.yml
@@ -4,13 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release tag to build from (e.g., iii/v1.2.3)'
+        description: 'Release tag to build from (e.g., v1.2.3)'
         required: true
         type: string
   workflow_call:
     inputs:
       release_tag:
-        description: 'Release tag to build from (e.g., iii/v1.2.3)'
+        description: 'Release tag to build from (e.g., v1.2.3)'
         required: true
         type: string
 
@@ -35,7 +35,7 @@ jobs:
         env:
           TAG: ${{ inputs.release_tag }}
         run: |
-          VERSION="${TAG#iii/v}"
+          VERSION="${TAG#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "::notice::Docker build for iii v$VERSION (tag=$TAG)"
 


### PR DESCRIPTION
…tions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release tag format expectations from `iii/v1.2.3` to `v1.2.3` for consistency.
  * Improved version extraction process in release workflows to support the new tag format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->