### PR TITLE
feat: add dynamic schedule step control (pause/resume/list cron jobs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,7 +1719,7 @@ dependencies = [
 
 [[package]]
 name = "iii"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1739,7 +1739,7 @@ dependencies = [
  "hostname",
  "http-body-util",
  "iana-time-zone",
- "iii-sdk 0.4.1",
+ "iii-sdk 0.8.0",
  "indexmap",
  "inventory",
  "lapin",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "iii-console"
-version = "0.2.4"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1821,7 +1821,7 @@ dependencies = [
 name = "iii-example"
 version = "0.0.0"
 dependencies = [
- "iii-sdk 0.4.1",
+ "iii-sdk 0.8.0",
  "reqwest",
  "serde",
  "serde_json",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.4.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -78,10 +78,9 @@ impl AppState {
         std::fs::write(&temp_path, &content)?;
 
         // Atomic rename
-        std::fs::rename(&temp_path, path).map_err(|e| {
+        std::fs::rename(&temp_path, path).inspect_err(|_e| {
             // Clean up temp file on failure
             let _ = std::fs::remove_file(&temp_path);
-            e
         })?;
 
         Ok(())

--- a/cli/src/update.rs
+++ b/cli/src/update.rs
@@ -110,10 +110,7 @@ pub async fn run_background_check(
         (updates, true) // true = check completed, should update timestamp
     };
 
-    match tokio::time::timeout(Duration::from_millis(timeout_ms), check).await {
-        Ok(result) => Some(result),
-        Err(_) => None, // Timed out, will retry next run
-    }
+    tokio::time::timeout(Duration::from_millis(timeout_ms), check).await.ok()
 }
 
 /// Check if a managed binary is installed on disk.

--- a/console/packages/console-rust/build.rs
+++ b/console/packages/console-rust/build.rs
@@ -26,7 +26,7 @@ fn main() {
 
         // Run vite build via pnpm from workspace root
         let build_result = Command::new("pnpm")
-            .current_dir(&workspace_root)
+            .current_dir(workspace_root)
             .args(["run", "build:binary"])
             .status();
 

--- a/docs/content/how-to/schedule-cron-task.mdx
+++ b/docs/content/how-to/schedule-cron-task.mdx
@@ -151,6 +151,69 @@ This runs the Function every 6 hours. The `expression` field uses standard cron 
 
 The Function executes automatically on the defined schedule. The Engine handles scheduling, no external cron daemon needed.
 
+## Controlling Cron Jobs at Runtime
+
+You can dynamically **pause**, **resume**, and **list** cron jobs without redeploying or changing cron expressions.
+
+### Using Motia Framework (`ctx.cron`)
+
+Inside any step handler, use `ctx.cron` to control cron jobs:
+
+```typescript title="control-cron.step.ts"
+import { step, http } from 'motia'
+
+export default step(
+  {
+    name: 'control-cron',
+    triggers: [http('POST', '/cron/control')],
+    enqueues: [],
+  },
+  async ({ request }, ctx) => {
+    const { action, triggerId } = request.body
+
+    switch (action) {
+      case 'pause':
+        // Pause a cron job — it stays registered but skips executions
+        await ctx.cron.pause(triggerId)
+        return { status: 200, body: { message: `Paused ${triggerId}` } }
+
+      case 'resume':
+        // Resume a paused cron job
+        await ctx.cron.resume(triggerId)
+        return { status: 200, body: { message: `Resumed ${triggerId}` } }
+
+      case 'list':
+        // List all cron jobs and their paused status
+        const jobs = await ctx.cron.list()
+        return { status: 200, body: { jobs } }
+    }
+  },
+)
+```
+
+### Using the SDK directly
+
+```typescript title="cron-control-sdk.ts"
+import { init } from 'iii-sdk'
+
+const iii = init('ws://localhost:49134')
+
+// Pause a cron job by its trigger ID
+await iii.call('pause_cron', { id: 'my-trigger-id' })
+
+// Resume it later
+await iii.call('resume_cron', { id: 'my-trigger-id' })
+
+// List all cron jobs
+const jobs = await iii.call('list_cron_jobs', {})
+// => [{ id: '...', function_id: '...', paused: false }, ...]
+```
+
+<Callout title="Trigger IDs" type="info">
+The trigger ID is assigned when a cron trigger is registered. In Motia, it follows the pattern
+`steps::<step-name>::trigger::cron(<expression>)`. Use `ctx.cron.list()` to discover trigger IDs.
+</Callout>
+
 {/* TODO: Uncomment once the Cron module reference page exists */}
 {/* <Callout title="See also" type="info">
   For advanced scheduling options, see the [Cron module reference](/docs/modules/module-cron).

--- a/docs/content/how-to/use-queues.mdx
+++ b/docs/content/how-to/use-queues.mdx
@@ -417,6 +417,59 @@ iii.register_trigger("queue", "orders::high-value-alert", json!({
 
 The producer returns immediately after enqueueing. The queue adapter distributes the message to all subscribed functions, which process it independently on their own workers. If a consumer fails, it does not affect the producer or other consumers.
 
+## Delayed Enqueue
+
+You can delay message delivery by specifying a `delay_ms` (milliseconds) when enqueuing. The engine holds the message for the specified duration before publishing it to consumers. Maximum delay: **15 minutes** (900,000 ms).
+
+### Using Motia Framework (`ctx.delay`)
+
+```typescript title="delayed-step.step.ts"
+import { step, http, queue } from 'motia'
+
+export default step(
+  {
+    name: 'send-reminder',
+    triggers: [http('POST', '/reminders')],
+    enqueues: ['reminder.send'],
+  },
+  async ({ request }, ctx) => {
+    const { userId, message } = request.body
+
+    // Send a reminder after 5 minutes
+    await ctx.delay('reminder.send', { userId, message }, 5 * 60 * 1000)
+
+    return { status: 200, body: { scheduled: true } }
+  },
+)
+```
+
+### Using `enqueue` with `delayMs`
+
+You can also pass `delayMs` directly through `ctx.enqueue`:
+
+```typescript title="delayed-enqueue.step.ts"
+await ctx.enqueue({
+  topic: 'order.follow-up',
+  data: { orderId: '123' },
+  delayMs: 30_000, // 30 seconds
+})
+```
+
+### Using the SDK directly
+
+```typescript title="delayed-enqueue-sdk.ts"
+iii.triggerVoid('enqueue', {
+  topic: 'order.follow-up',
+  data: { orderId: '123' },
+  delay_ms: 30000, // 30 seconds
+})
+```
+
+<Callout title="Delay limits" type="warn">
+The maximum `delay_ms` value is **900,000** (15 minutes). For longer delays, consider using a cron trigger
+with a condition check, or enqueue a delayed message that re-enqueues itself with the remaining delay.
+</Callout>
+
 ## Queue vs triggerVoid
 
 | | `enqueue` | `triggerVoid()` |

--- a/engine/function-macros/src/lib.rs
+++ b/engine/function-macros/src/lib.rs
@@ -145,8 +145,7 @@ pub fn service(attr: TokenStream, item: TokenStream) -> TokenStream {
                         .sig
                         .inputs
                         .iter()
-                        .skip_while(|arg| matches!(arg, syn::FnArg::Receiver(_)))
-                        .next()
+                        .find(|arg| !matches!(arg, syn::FnArg::Receiver(_)))
                     {
                         Some(syn::FnArg::Typed(pat_type)) => {
                             let ty = &*pat_type.ty;

--- a/engine/src/modules/cron/cron.rs
+++ b/engine/src/modules/cron/cron.rs
@@ -12,8 +12,10 @@ use std::{
 
 use async_trait::async_trait;
 use colored::Colorize;
+use function_macros::{function, service};
 use futures::Future;
 use once_cell::sync::Lazy;
+use serde::Deserialize;
 use serde_json::Value;
 
 use super::{
@@ -21,8 +23,10 @@ use super::{
     structs::{CronAdapter, CronSchedulerAdapter},
 };
 use crate::{
-    engine::{Engine, EngineTrait},
+    engine::{Engine, EngineTrait, Handler, RegisterFunctionRequest},
+    function::FunctionResult,
     modules::module::{AdapterFactory, ConfigurableModule, Module},
+    protocol::ErrorBody,
     trigger::{Trigger, TriggerRegistrator},
 };
 
@@ -31,6 +35,69 @@ pub struct CronCoreModule {
     adapter: Arc<CronAdapter>,
     engine: Arc<Engine>,
     _config: CronModuleConfig,
+}
+
+#[derive(Deserialize)]
+pub struct CronJobIdInput {
+    /// The trigger ID of the cron job to target.
+    id: String,
+}
+
+#[service(name = "cron")]
+impl CronCoreModule {
+    #[function(id = "pause_cron", description = "Pause a cron job by trigger ID")]
+    pub async fn pause_cron(
+        &self,
+        input: CronJobIdInput,
+    ) -> FunctionResult<Option<Value>, ErrorBody> {
+        match self.adapter.pause(&input.id).await {
+            Ok(_) => FunctionResult::Success(Some(
+                serde_json::json!({ "status": "paused", "id": input.id }),
+            )),
+            Err(e) => FunctionResult::Failure(ErrorBody {
+                code: "cron_pause_failed".into(),
+                message: e.to_string(),
+            }),
+        }
+    }
+
+    #[function(
+        id = "resume_cron",
+        description = "Resume a paused cron job by trigger ID"
+    )]
+    pub async fn resume_cron(
+        &self,
+        input: CronJobIdInput,
+    ) -> FunctionResult<Option<Value>, ErrorBody> {
+        match self.adapter.resume(&input.id).await {
+            Ok(_) => FunctionResult::Success(Some(
+                serde_json::json!({ "status": "resumed", "id": input.id }),
+            )),
+            Err(e) => FunctionResult::Failure(ErrorBody {
+                code: "cron_resume_failed".into(),
+                message: e.to_string(),
+            }),
+        }
+    }
+
+    #[function(
+        id = "list_cron_jobs",
+        description = "List all cron jobs with their status"
+    )]
+    pub async fn list_cron_jobs(&self, _input: Value) -> FunctionResult<Option<Value>, ErrorBody> {
+        let jobs = self.adapter.list_jobs().await;
+        let result: Vec<Value> = jobs
+            .into_iter()
+            .map(|(id, function_id, paused)| {
+                serde_json::json!({
+                    "id": id,
+                    "function_id": function_id,
+                    "paused": paused,
+                })
+            })
+            .collect();
+        FunctionResult::Success(Some(serde_json::json!(result)))
+    }
 }
 
 #[async_trait]
@@ -43,7 +110,9 @@ impl Module for CronCoreModule {
         Self::create_with_adapters(engine, config).await
     }
 
-    fn register_functions(&self, _engine: Arc<Engine>) {}
+    fn register_functions(&self, engine: Arc<Engine>) {
+        self.register_functions(engine);
+    }
 
     async fn initialize(&self) -> anyhow::Result<()> {
         tracing::info!("Initializing CronModule");

--- a/engine/src/modules/cron/structs.rs
+++ b/engine/src/modules/cron/structs.rs
@@ -41,6 +41,8 @@ pub(crate) struct CronJobInfo {
     #[allow(dead_code)]
     pub condition_function_id: Option<String>,
     pub task_handle: JoinHandle<()>,
+    /// When true, the job loop skips execution until resumed.
+    pub paused: Arc<AtomicBool>,
 }
 
 pub struct CronAdapter {
@@ -79,6 +81,7 @@ impl CronAdapter {
         schedule: Schedule,
         function_id: String,
         condition_function_id: Option<String>,
+        paused: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
         let scheduler = Arc::clone(&self.adapter);
         let engine = Arc::clone(&self.engine);
@@ -125,6 +128,15 @@ impl CronAdapter {
                 if *shutdown_rx.borrow() {
                     tracing::info!(job_id = %job_id, "Cron job shutting down");
                     break;
+                }
+
+                // Check if the job is paused
+                if paused.load(Ordering::SeqCst) {
+                    tracing::debug!(
+                        job_id = %job_id,
+                        "Cron job is paused, skipping execution"
+                    );
+                    continue;
                 }
 
                 // Try to acquire the distributed lock
@@ -246,6 +258,8 @@ impl CronAdapter {
             function_id.cyan()
         );
 
+        let paused = Arc::new(AtomicBool::new(false));
+
         // Start the cron job
         let task_handle = self
             .start_cron_job(
@@ -253,6 +267,7 @@ impl CronAdapter {
                 schedule.clone(),
                 function_id.to_string(),
                 condition_function_id.clone(),
+                Arc::clone(&paused),
             )
             .await;
 
@@ -266,6 +281,7 @@ impl CronAdapter {
                 function_id: function_id.to_string(),
                 condition_function_id,
                 task_handle,
+                paused,
             },
         );
 
@@ -312,6 +328,65 @@ impl CronAdapter {
             }
             self.adapter.release_lock(&id).await;
         }
+    }
+
+    /// Pause a cron job by its trigger ID. The job loop continues but skips executions.
+    pub async fn pause(&self, id: &str) -> anyhow::Result<()> {
+        let jobs = self.jobs.read().await;
+        if let Some(job_info) = jobs.get(id) {
+            job_info.paused.store(true, Ordering::SeqCst);
+            tracing::info!(
+                "{} Cron job {} → {}",
+                "[PAUSED]".yellow(),
+                id.purple(),
+                job_info.function_id.cyan()
+            );
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("Cron job '{}' not found", id))
+        }
+    }
+
+    /// Resume a previously paused cron job.
+    pub async fn resume(&self, id: &str) -> anyhow::Result<()> {
+        let jobs = self.jobs.read().await;
+        if let Some(job_info) = jobs.get(id) {
+            job_info.paused.store(false, Ordering::SeqCst);
+            tracing::info!(
+                "{} Cron job {} → {}",
+                "[RESUMED]".green(),
+                id.purple(),
+                job_info.function_id.cyan()
+            );
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("Cron job '{}' not found", id))
+        }
+    }
+
+    /// Check if a cron job is currently paused.
+    #[allow(dead_code)]
+    pub async fn is_paused(&self, id: &str) -> anyhow::Result<bool> {
+        let jobs = self.jobs.read().await;
+        if let Some(job_info) = jobs.get(id) {
+            Ok(job_info.paused.load(Ordering::SeqCst))
+        } else {
+            Err(anyhow::anyhow!("Cron job '{}' not found", id))
+        }
+    }
+
+    /// List all cron jobs with their status (id, function_id, paused).
+    pub async fn list_jobs(&self) -> Vec<(String, String, bool)> {
+        let jobs = self.jobs.read().await;
+        jobs.values()
+            .map(|j| {
+                (
+                    j.id.clone(),
+                    j.function_id.clone(),
+                    j.paused.load(Ordering::SeqCst),
+                )
+            })
+            .collect()
     }
 }
 
@@ -411,5 +486,66 @@ mod tests {
         // Verify all tasks are finished and map is drained
         let jobs = adapter.jobs.read().await;
         assert!(jobs.is_empty(), "All jobs should be drained after shutdown");
+    }
+
+    #[tokio::test]
+    async fn pause_and_resume_cron_job() {
+        let engine = test_engine();
+        let adapter = CronAdapter::new(Arc::new(NoopSchedulerAdapter), engine);
+
+        adapter
+            .register("job-1", "0 0 * * * *", "fn-1", None)
+            .await
+            .unwrap();
+
+        // Initially not paused
+        assert!(!adapter.is_paused("job-1").await.unwrap());
+
+        // Pause
+        adapter.pause("job-1").await.unwrap();
+        assert!(adapter.is_paused("job-1").await.unwrap());
+
+        // Resume
+        adapter.resume("job-1").await.unwrap();
+        assert!(!adapter.is_paused("job-1").await.unwrap());
+
+        adapter.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn pause_nonexistent_job_returns_error() {
+        let engine = test_engine();
+        let adapter = CronAdapter::new(Arc::new(NoopSchedulerAdapter), engine);
+
+        assert!(adapter.pause("nonexistent").await.is_err());
+        assert!(adapter.resume("nonexistent").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn list_jobs_returns_correct_state() {
+        let engine = test_engine();
+        let adapter = CronAdapter::new(Arc::new(NoopSchedulerAdapter), engine);
+
+        adapter
+            .register("job-1", "0 0 * * * *", "fn-1", None)
+            .await
+            .unwrap();
+        adapter
+            .register("job-2", "0 30 * * * *", "fn-2", None)
+            .await
+            .unwrap();
+
+        adapter.pause("job-1").await.unwrap();
+
+        let jobs = adapter.list_jobs().await;
+        assert_eq!(jobs.len(), 2);
+
+        let job1 = jobs.iter().find(|(id, _, _)| id == "job-1").unwrap();
+        assert!(job1.2, "job-1 should be paused");
+
+        let job2 = jobs.iter().find(|(id, _, _)| id == "job-2").unwrap();
+        assert!(!job2.2, "job-2 should not be paused");
+
+        adapter.shutdown().await;
     }
 }

--- a/engine/src/modules/queue/queue.rs
+++ b/engine/src/modules/queue/queue.rs
@@ -41,7 +41,15 @@ pub struct QueueCoreModule {
 pub struct QueueInput {
     topic: String,
     data: Value,
+    /// Optional delay in milliseconds before the message is enqueued.
+    /// When set, the engine will wait `delay_ms` milliseconds before publishing.
+    /// Maximum allowed value: 900000 (15 minutes).
+    #[serde(default)]
+    delay_ms: Option<u64>,
 }
+
+/// Maximum allowed delay: 15 minutes (in milliseconds)
+const MAX_DELAY_MS: u64 = 900_000;
 
 #[service(name = "queue")]
 impl QueueCoreModule {
@@ -58,6 +66,18 @@ impl QueueCoreModule {
             });
         }
 
+        if let Some(delay) = input.delay_ms
+            && delay > MAX_DELAY_MS
+        {
+            return FunctionResult::Failure(ErrorBody {
+                code: "delay_too_large".into(),
+                message: format!(
+                    "delay_ms cannot exceed {} ms (15 minutes), got {}",
+                    MAX_DELAY_MS, delay
+                ),
+            });
+        }
+
         // Record the queue topic on the current span for trace visibility
         let current_span = tracing::Span::current();
         current_span.set_attribute("messaging.destination.name", topic.clone());
@@ -67,6 +87,27 @@ impl QueueCoreModule {
         let ctx = current_span.context();
         let traceparent = inject_traceparent_from_context(&ctx);
         let baggage = inject_baggage_from_context(&ctx);
+
+        if let Some(delay) = input.delay_ms
+            && delay > 0
+        {
+            tracing::debug!(
+                topic = %topic,
+                delay_ms = delay,
+                "Scheduling delayed enqueue"
+            );
+            current_span.set_attribute("messaging.delay_ms", delay as i64);
+
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                let _ = adapter
+                    .enqueue(&topic, event_data, traceparent, baggage)
+                    .await;
+                crate::modules::telemetry::collector::track_queue_emit();
+            });
+
+            return FunctionResult::Success(None);
+        }
 
         tracing::debug!(topic = %topic, traceparent = ?traceparent, baggage = ?baggage, "Enqueuing message with trace context");
         let _ = adapter

--- a/frameworks/motia/motia-js/packages/motia/src/new/build/utils.ts
+++ b/frameworks/motia/motia-js/packages/motia/src/new/build/utils.ts
@@ -78,8 +78,25 @@ const flowContext = <EnqueueData, TInput = unknown>(
 ): FlowContext<EnqueueData, TInput> => {
   const { logger, trace } = getContext()
   const traceId = trace?.spanContext().traceId ?? crypto.randomUUID()
-  const enqueue: Enqueuer<EnqueueData> = async (queue: EnqueueData): Promise<void> =>
-    getInstance().call('enqueue', queue)
+  const enqueue: Enqueuer<EnqueueData> = async (queue: EnqueueData): Promise<void> => {
+    // biome-ignore lint/suspicious/noExplicitAny: map delayMs to delay_ms for engine compatibility
+    const payload: any = { topic: (queue as any).topic, data: (queue as any).data }
+    if ((queue as any).messageGroupId) payload.messageGroupId = (queue as any).messageGroupId
+    if ((queue as any).delayMs) payload.delay_ms = (queue as any).delayMs
+    return getInstance().call('enqueue', payload)
+  }
+
+  const delay = async <TData = unknown>(topic: string, data: TData, delayMs: number): Promise<void> =>
+    getInstance().call('enqueue', { topic, data, delay_ms: delayMs })
+
+  const cronControl = {
+    pause: async (triggerId: string): Promise<{ status: string; id: string }> =>
+      getInstance().call('pause_cron', { id: triggerId }),
+    resume: async (triggerId: string): Promise<{ status: string; id: string }> =>
+      getInstance().call('resume_cron', { id: triggerId }),
+    list: async (): Promise<Array<{ id: string; function_id: string; paused: boolean }>> =>
+      getInstance().call('list_cron_jobs', {}),
+  }
 
   const context: FlowContext<EnqueueData, TInput> = {
     enqueue,
@@ -88,6 +105,8 @@ const flowContext = <EnqueueData, TInput = unknown>(
     logger,
     streams: streamManager.streams,
     trigger,
+    delay,
+    cron: cronControl,
 
     is: {
       queue: (inp: TInput): inp is ExtractQueueInput<TInput> => trigger.type === 'queue',

--- a/frameworks/motia/motia-js/packages/motia/src/types.ts
+++ b/frameworks/motia/motia-js/packages/motia/src/types.ts
@@ -25,7 +25,7 @@ export type InternalStateManager = {
   clear(groupId: string): Promise<void>
 }
 
-export type EnqueueData<T = unknown> = { topic: string; data: T; messageGroupId?: string }
+export type EnqueueData<T = unknown> = { topic: string; data: T; messageGroupId?: string; delayMs?: number }
 export type Enqueuer<TData> = (event: TData) => Promise<void>
 
 export type ExtractQueueInput<TInput> = Exclude<Exclude<Exclude<TInput, ApiRequest>, MotiaHttpArgs>, undefined>
@@ -62,6 +62,46 @@ export interface FlowContext<TEnqueueData = never, TInput = unknown> {
   logger: Logger
   streams: Streams
   trigger: TriggerInfo
+
+  /**
+   * Enqueue a message with a delay before it becomes visible to consumers.
+   * This is a convenience wrapper around `enqueue` with `delayMs`.
+   *
+   * @param topic - The queue topic to enqueue to
+   * @param data - The data payload
+   * @param delayMs - Delay in milliseconds before the message is enqueued (max 900000 = 15 minutes)
+   *
+   * @example
+   * ```ts
+   * // Delay processing by 30 seconds
+   * await ctx.delay('process-order', orderData, 30_000)
+   * ```
+   */
+  delay: <TData = unknown>(topic: string, data: TData, delayMs: number) => Promise<void>
+
+  /**
+   * Control cron/schedule triggers programmatically.
+   *
+   * @example
+   * ```ts
+   * // Pause a cron trigger
+   * await ctx.cron.pause('trigger-id')
+   *
+   * // Resume it later
+   * await ctx.cron.resume('trigger-id')
+   *
+   * // List all cron jobs
+   * const jobs = await ctx.cron.list()
+   * ```
+   */
+  cron: {
+    /** Pause a cron job by its trigger ID. The schedule continues but executions are skipped. */
+    pause: (triggerId: string) => Promise<{ status: string; id: string }>
+    /** Resume a previously paused cron job. */
+    resume: (triggerId: string) => Promise<{ status: string; id: string }>
+    /** List all registered cron jobs with their current status. */
+    list: () => Promise<Array<{ id: string; function_id: string; paused: boolean }>>
+  }
 
   is: {
     queue: (input: TInput) => input is ExtractQueueInput<TInput>


### PR DESCRIPTION
## Summary

Fixes #1219

Adds the ability to dynamically control cron/schedule trigger steps at runtime — pause, resume, and list cron jobs — instead of requiring hard-coded cron expressions with no way to stop or control them after deployment.

## Changes

### Engine - Cron Module
- **`pause_cron`** function: Pause a running cron job by trigger ID
- **`resume_cron`** function: Resume a paused cron job by trigger ID  
- **`list_cron_jobs`** function: List all cron jobs with their current status (active/paused)
- Added pause/resume state tracking in `CronAdapter` (`engine/src/modules/cron/structs.rs`)
- Exposed new functions via the cron module (`engine/src/modules/cron/cron.rs`)

### Engine - Queue Module
- Added delayed enqueue support with configurable `delay_ms` (`engine/src/modules/queue/queue.rs`)

### Framework (motia-js)
- Updated TypeScript types to support schedule control options
- Updated build utils for new step configurations

### Documentation
- Added how-to guide for scheduling cron tasks with dynamic control
- Added how-to guide for using queues with delay support

### Code Quality Fixes
- Fixed `skip_while_next` clippy lint in `function-macros`
- Fixed `needless_borrows_for_generic_args` in console build script
- Fixed `collapsible_if` warnings in queue module
- Fixed `manual_inspect` and `manual_ok_err` in CLI crate
- Applied `cargo fmt` formatting fixes

## Testing

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added delayed message enqueuing with configurable delays (maximum 15 minutes)
  * Added runtime cron job controls: pause, resume, and list active jobs

* **Documentation**
  * Added guide for controlling cron jobs at runtime with code examples
  * Added guide for delayed message enqueuing across framework implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->