### PR TITLE
fix: install script jq path selects wrong asset on x86_64

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -479,7 +479,7 @@ if [[ -z "$binary_path" ]]; then
   if command -v jq >/dev/null 2>&1; then
     asset_url=$(printf '%s' "$json" \
       | jq -r --arg bn "$BIN_NAME" --arg target "$target" \
-        '.assets[] | select((.name | startswith($bn + "-")) and (.name | contains($target)) and (.name | test("\\.(tar\\.gz|tgz|zip)$"))) | .browser_download_url' \
+        '.assets[] | select((.name | startswith($bn + "-" + $target)) and (.name | test("\\.(tar\\.gz|tgz|zip)$"))) | .browser_download_url' \
       | head -n 1)
   else
     asset_url=$(printf '%s' "$json" \

--- a/console/install.sh
+++ b/console/install.sh
@@ -426,7 +426,7 @@ if [[ -z "$binary_path" ]]; then
   if command -v jq >/dev/null 2>&1; then
     asset_url=$(printf '%s' "$json" \
       | jq -r --arg bn "$BIN_NAME" --arg target "$target" \
-        '.assets[] | select((.name | startswith($bn + "-")) and (.name | contains($target)) and (.name | test("\\.(tar\\.gz|tgz|zip)$"))) | .browser_download_url' \
+        '.assets[] | select((.name | startswith($bn + "-" + $target)) and (.name | test("\\.(tar\\.gz|tgz|zip)$"))) | .browser_download_url' \
       | head -n 1)
   else
     asset_url=$(printf '%s' "$json" \

--- a/engine/install.sh
+++ b/engine/install.sh
@@ -208,7 +208,7 @@ fi
 if command -v jq >/dev/null 2>&1; then
   asset_url=$(printf '%s' "$json" \
     | jq -r --arg bn "$BIN_NAME" --arg target "$target" \
-      '.assets[] | select((.name | startswith($bn + "-")) and (.name | contains($target)) and (.name | test("\\.(tar\\.gz|tgz|zip)$"))) | .browser_download_url' \
+      '.assets[] | select((.name | startswith($bn + "-" + $target)) and (.name | test("\\.(tar\\.gz|tgz|zip)$"))) | .browser_download_url' \
     | head -n 1)
 else
   asset_url=$(printf '%s' "$json" \


### PR DESCRIPTION
## Summary

- **jq asset selection bug**: The jq filter used `startswith("iii-")` which also matched `iii-cli-*` and `iii-console-*` assets. On x86_64/i686 targets, `iii-cli-x86_64-*` sorts alphabetically before `iii-x86_64-*`, so `head -n 1` picked the CLI archive instead of the engine → "binary not found in downloaded asset". Fixed by using `startswith($bn + "-" + $target)` to exactly match.
- **CLI invocation bug**: The engine installer invoked the CLI install script via `sh`, but the CLI script uses `set -o pipefail` (a bash feature). On Ubuntu where `sh` is dash, this fails with "Illegal option -o pipefail". Fixed by using `bash` instead of `sh`.

## Test plan

- [x] Verified the fixed jq filter returns only the correct asset for all targets (aarch64-apple-darwin, x86_64-apple-darwin, x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, x86_64-pc-windows-msvc, i686-pc-windows-msvc)
- [ ] Test install on Linux x86_64 with jq installed: `curl -fsSL https://install.iii.dev/iii/main/install.sh | sh`
- [ ] Verify CLI sub-install completes without "Illegal option" error