### PR TITLE
fix: invoke CLI installer with bash instead of sh

### DIFF
--- a/engine/install.sh
+++ b/engine/install.sh
@@ -32,10 +32,10 @@ install_cli() {
 
   if [ -n "$cli_dir" ]; then
     # shellcheck disable=SC2086
-    INSTALL_DIR="$cli_dir" sh "$cli_script" $cli_sh_args
+    INSTALL_DIR="$cli_dir" bash "$cli_script" $cli_sh_args
   else
     # shellcheck disable=SC2086
-    sh "$cli_script" $cli_sh_args
+    bash "$cli_script" $cli_sh_args
   fi
 
   cli_exit=$?


### PR DESCRIPTION
## Summary

- The engine install script invokes the CLI install script via `sh`, but the CLI script uses `set -o pipefail` (a bash feature)
- On Ubuntu/Debian where `sh` is `dash`, this fails with: `Illegal option -o pipefail`
- Fix: use `bash` instead of `sh` to invoke the CLI installer

This was the second fix from #1259 that was lost during squash merge.

## Test plan

- [ ] Run `curl -fsSL https://install.iii.dev/iii/main/install.sh | sh` on Ubuntu and verify CLI installs without "Illegal option" error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified the CLI installer script to use bash instead of sh for script execution in both installation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->