### PR TITLE
fix: replace dynamic require with static import for node sdk SDK_VERSION

### DIFF
--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -1,5 +1,4 @@
 import { context, trace } from '@opentelemetry/api'
-import { createRequire } from 'node:module'
 import * as os from 'node:os'
 import { type Data, WebSocket } from 'ws'
 import { ChannelReader, ChannelWriter } from './channels'
@@ -59,9 +58,7 @@ import type {
   FunctionRef,
 } from './types'
 import { isChannelRef } from './utils'
-
-const require = createRequire(import.meta.url)
-const { version: SDK_VERSION } = require('../package.json')
+import { version as SDK_VERSION } from '../package.json'
 
 function getOsInfo(): string {
   return `${os.platform()} ${os.release()} (${os.arch()})`


### PR DESCRIPTION
`iii.ts` was loading the package version at runtime via `createRequire`, which is unnecessary given `resolveJsonModule: true` is already set in `tsconfig.json`.

## Changes

- **`src/iii.ts`**: Swap dynamic `createRequire`-based version load for a static ES import:

```typescript
// Before
import { createRequire } from 'node:module'
const require = createRequire(import.meta.url)
const { version: SDK_VERSION } = require('../package.json')

// After
import { version as SDK_VERSION } from '../package.json'
```

Fix: https://github.com/iii-hq/iii/issues/1261


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated SDK module initialization approach for improved code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->