### PR TITLE
feat(iii-worker): add --force, reinstall, and clear commands

### DIFF
--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -4,10 +4,22 @@
 // This software is patent protected. We welcome discussions - reach out at support@motia.dev
 // See LICENSE and PATENTS files for details.
 
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 
 /// Default engine WebSocket port (must match engine's DEFAULT_PORT).
 pub const DEFAULT_PORT: u16 = 49134;
+
+/// Shared arguments for `add` and `reinstall` commands.
+#[derive(Args, Debug)]
+pub struct AddArgs {
+    /// Worker names or OCI image references (e.g., "pdfkit", "pdfkit@1.0.0", "ghcr.io/org/worker:tag")
+    #[arg(value_name = "WORKER[@VERSION]", required = true, num_args = 1..)]
+    pub worker_names: Vec<String>,
+
+    /// Reset config: also remove config.yaml entry before re-adding (requires --force on add)
+    #[arg(long)]
+    pub reset_config: bool,
+}
 
 #[derive(Parser, Debug)]
 #[command(name = "iii-worker", version, about = "iii managed worker runtime")]
@@ -20,9 +32,12 @@ pub struct Cli {
 pub enum Commands {
     /// Add one or more workers from the registry or by OCI image reference
     Add {
-        /// Worker names or OCI image references (e.g., "pdfkit", "pdfkit@1.0.0", "ghcr.io/org/worker:tag")
-        #[arg(value_name = "WORKER[@VERSION]", required = true, num_args = 1..)]
-        worker_names: Vec<String>,
+        #[command(flatten)]
+        args: AddArgs,
+
+        /// Force re-download: delete existing artifacts before adding
+        #[arg(long, short = 'f')]
+        force: bool,
     },
 
     /// Remove one or more workers (stops and removes containers)
@@ -30,6 +45,23 @@ pub enum Commands {
         /// Worker names to remove (e.g., "pdfkit")
         #[arg(value_name = "WORKER", required = true, num_args = 1..)]
         worker_names: Vec<String>,
+    },
+
+    /// Re-download a worker (equivalent to `add --force`; pass `--reset-config` to also clear config.yaml)
+    Reinstall {
+        #[command(flatten)]
+        args: AddArgs,
+    },
+
+    /// Clear downloaded worker artifacts from ~/.iii/ (local-only, no engine connection needed)
+    Clear {
+        /// Worker name to clear (omit to clear all)
+        #[arg(value_name = "WORKER")]
+        worker_name: Option<String>,
+
+        /// Skip confirmation prompt
+        #[arg(long, short = 'y')]
+        yes: bool,
     },
 
     /// Start a previously stopped managed worker container

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -1523,4 +1523,81 @@ mod tests {
         let input = "Y\n";
         assert!(input.trim().eq_ignore_ascii_case("y"));
     }
+
+    #[test]
+    fn delete_worker_artifacts_removes_binary_file() {
+        // Test the legacy single-file binary path
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("test-worker");
+        std::fs::write(&binary, "fake binary content 1234567890").unwrap(); // 30 bytes
+
+        // delete_worker_artifacts operates on ~/.iii/workers/{name}
+        // We can't easily redirect it, but we can test dir_size + remove_dir_all directly
+        let size_before = dir_size(dir.path());
+        assert!(size_before >= 30);
+
+        // Verify the file exists, then remove and check
+        assert!(binary.exists());
+        std::fs::remove_file(&binary).unwrap();
+        assert!(!binary.exists());
+        assert_eq!(dir_size(dir.path()), 0);
+    }
+
+    #[test]
+    fn delete_worker_artifacts_removes_nested_binary_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let worker_dir = dir.path().join("my-worker");
+        std::fs::create_dir_all(&worker_dir).unwrap();
+        std::fs::write(worker_dir.join("binary"), "executable bytes").unwrap();
+        std::fs::write(worker_dir.join("worker.pid"), "12345").unwrap();
+
+        let size = dir_size(&worker_dir);
+        assert!(size > 0);
+
+        // Simulate what delete_worker_artifacts does for binary dirs
+        std::fs::remove_dir_all(&worker_dir).unwrap();
+        assert!(!worker_dir.exists());
+    }
+
+    #[test]
+    fn is_worker_running_invalid_pid_content() {
+        // PID file with non-numeric content should return false
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("worker.pid");
+        std::fs::write(&pid_file, "not-a-number").unwrap();
+
+        // parse::<u32>() will fail, so the loop continues and returns false
+        let content = std::fs::read_to_string(&pid_file).unwrap();
+        assert!(content.trim().parse::<u32>().is_err());
+    }
+
+    #[test]
+    fn is_worker_running_empty_pid_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("worker.pid");
+        std::fs::write(&pid_file, "").unwrap();
+
+        let content = std::fs::read_to_string(&pid_file).unwrap();
+        assert!(content.trim().parse::<u32>().is_err());
+    }
+
+    #[test]
+    fn image_cache_dir_deterministic_hash() {
+        // Same ref always produces same path
+        let a = image_cache_dir("ghcr.io/org/worker:1.0");
+        let b = image_cache_dir("ghcr.io/org/worker:1.0");
+        assert_eq!(a, b);
+
+        // Path ends with a hex string (16 chars for 8 bytes)
+        let hash_component = a.file_name().unwrap().to_str().unwrap();
+        assert_eq!(hash_component.len(), 16);
+        assert!(hash_component.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn image_cache_dir_under_iii_images() {
+        let dir = image_cache_dir("test:latest");
+        let path_str = dir.to_string_lossy();
+        assert!(path_str.contains(".iii/images/") || path_str.contains(".iii\\images\\"));
+    }
 }

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -161,7 +161,7 @@ pub async fn handle_managed_add_many(worker_names: &[String]) -> i32 {
         if brief {
             eprintln!("  [{}/{}] Adding {}...", i + 1, total, name.bold());
         }
-        let result = handle_managed_add(name, brief, registry.as_ref()).await;
+        let result = handle_managed_add(name, brief, registry.as_ref(), false, false).await;
         if result != 0 {
             fail_count += 1;
         }
@@ -186,7 +186,74 @@ pub async fn handle_managed_add(
     image_or_name: &str,
     brief: bool,
     cached_registry: Option<&RegistryV2>,
+    force: bool,
+    reset_config: bool,
 ) -> i32 {
+    // --force: delete existing artifacts before re-downloading
+    if force {
+        // Extract plain name (strip @version if present)
+        let (plain_name, _) = super::registry::parse_worker_input(image_or_name);
+
+        // Validate name only for non-OCI references (OCI refs contain '/' or ':')
+        let is_oci_ref = plain_name.contains('/') || plain_name.contains(':');
+        if !is_oci_ref {
+            if let Err(e) = super::registry::validate_worker_name(&plain_name) {
+                eprintln!("{} {}", "error:".red(), e);
+                return 1;
+            }
+        }
+
+        if is_worker_running(&plain_name) {
+            eprintln!(
+                "{} Worker '{}' is currently running. Stop it first with `iii worker stop {}`",
+                "error:".red(),
+                plain_name,
+                plain_name,
+            );
+            return 1;
+        }
+
+        // Check for engine-builtin workers — no artifacts to delete
+        if super::builtin_defaults::get_builtin_default(&plain_name).is_some() {
+            eprintln!(
+                "  {} '{}' is a builtin worker, no artifacts to re-download.",
+                "info:".cyan(),
+                plain_name,
+            );
+            // Still proceed — force on builtins just re-applies config
+        } else {
+            let freed = delete_worker_artifacts(&plain_name);
+            if freed > 0 {
+                eprintln!(
+                    "  {} Cleared {:.1} MB of artifacts for {}",
+                    "✓".green(),
+                    freed as f64 / 1_048_576.0,
+                    plain_name.bold(),
+                );
+            }
+        }
+
+        if reset_config {
+            match super::config_file::remove_worker(&plain_name) {
+                Ok(()) => {
+                    eprintln!(
+                        "  {} Config for {} reset",
+                        "✓".green(),
+                        plain_name.bold(),
+                    );
+                }
+                Err(e) => {
+                    eprintln!(
+                        "  {} Could not reset config for {}: {}",
+                        "warning:".yellow(),
+                        plain_name.bold(),
+                        e,
+                    );
+                }
+            }
+        }
+    }
+
     // Check for engine-builtin workers first (no network needed).
     if let Some(default_yaml) = get_builtin_default(image_or_name) {
         let already_exists = super::config_file::worker_exists(image_or_name);
@@ -312,17 +379,7 @@ async fn handle_oci_pull_and_add(name: &str, image_ref: &str, brief: bool) -> i3
     }
 
     // Extract OCI env vars from the pulled image rootfs and write as config:
-    let rootfs_dir = {
-        use sha2::Digest;
-        let mut hasher = sha2::Sha256::new();
-        hasher.update(image_ref.as_bytes());
-        let hash = hex::encode(&hasher.finalize()[..8]);
-        dirs::home_dir()
-            .unwrap_or_default()
-            .join(".iii")
-            .join("images")
-            .join(hash)
-    };
+    let rootfs_dir = image_cache_dir(image_ref);
     let oci_env = super::worker_manager::oci::read_oci_env(&rootfs_dir);
     let config_yaml = if oci_env.is_empty() {
         None
@@ -424,6 +481,262 @@ pub async fn handle_managed_remove(worker_name: &str, brief: bool) -> i32 {
         );
     }
     0
+}
+
+pub fn handle_managed_clear(worker_name: Option<&str>, skip_confirm: bool) -> i32 {
+    match worker_name {
+        Some(name) => clear_single_worker(name),
+        None => clear_all_workers(skip_confirm),
+    }
+}
+
+fn clear_single_worker(worker_name: &str) -> i32 {
+    if let Err(e) = super::registry::validate_worker_name(worker_name) {
+        eprintln!("{} {}", "error:".red(), e);
+        return 1;
+    }
+
+    if is_worker_running(worker_name) {
+        eprintln!(
+            "{} Worker '{}' is currently running. Stop it first with `iii worker stop {}`",
+            "error:".red(),
+            worker_name,
+            worker_name,
+        );
+        return 1;
+    }
+
+    let freed = delete_worker_artifacts(worker_name);
+    if freed == 0 {
+        eprintln!("  Nothing to clear for '{}'.", worker_name);
+    } else {
+        eprintln!(
+            "  {} Cleared {:.1} MB of artifacts for {}",
+            "✓".green(),
+            freed as f64 / 1_048_576.0,
+            worker_name.bold(),
+        );
+    }
+    0
+}
+
+/// Prompts the user for confirmation before clearing all artifacts.
+/// Returns `true` if the user confirms with "y".
+fn confirm_clear() -> bool {
+    eprint!("  This will remove all downloaded workers and images. Continue? [y/N] ");
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input).is_ok() && input.trim().eq_ignore_ascii_case("y")
+}
+
+fn clear_all_workers(skip_confirm: bool) -> i32 {
+    let home = dirs::home_dir().unwrap_or_default();
+    let workers_dir = home.join(".iii/workers");
+    let images_dir = home.join(".iii/images");
+
+    if !workers_dir.exists() && !images_dir.exists() {
+        eprintln!("  Nothing to clear.");
+        return 0;
+    }
+
+    if !skip_confirm && !confirm_clear() {
+        eprintln!("  Aborted.");
+        return 0;
+    }
+
+    let mut skipped: Vec<String> = Vec::new();
+    let mut total_freed: u64 = 0;
+    let mut worker_count: u32 = 0;
+    let mut image_count: u32 = 0;
+
+    // Clear binary workers
+    if workers_dir.exists() {
+        if let Ok(entries) = std::fs::read_dir(&workers_dir) {
+            for entry in entries.flatten() {
+                let name = entry.file_name().to_string_lossy().to_string();
+                // Skip entries with invalid names (e.g. symlinks with path traversal)
+                if super::registry::validate_worker_name(&name).is_err() {
+                    continue;
+                }
+                // Verify resolved path stays under workers_dir
+                if let Ok(resolved) = entry.path().canonicalize() {
+                    if let Ok(base) = workers_dir.canonicalize() {
+                        if !resolved.starts_with(&base) {
+                            continue;
+                        }
+                    }
+                }
+                if is_worker_running(&name) {
+                    skipped.push(name);
+                    continue;
+                }
+                total_freed += dir_size(&entry.path());
+                let _ = std::fs::remove_dir_all(entry.path());
+                worker_count += 1;
+            }
+        }
+    }
+
+    // Clear OCI images — protect running OCI workers
+    if images_dir.exists() {
+        // Build set of image hashes belonging to running OCI workers
+        let mut protected_hashes = std::collections::HashSet::new();
+        for name in super::config_file::list_worker_names() {
+            if is_worker_running(&name) {
+                if let Some((image_ref, _)) = super::config_file::get_worker_start_info(&name) {
+                    let dir = image_cache_dir(&image_ref);
+                    if let Some(hash) = dir.file_name().and_then(|f| f.to_str()) {
+                        protected_hashes.insert(hash.to_string());
+                    }
+                }
+            }
+        }
+
+        if let Ok(entries) = std::fs::read_dir(&images_dir) {
+            for entry in entries.flatten() {
+                let dir_name = entry.file_name().to_string_lossy().to_string();
+                if protected_hashes.contains(&dir_name) {
+                    skipped.push(format!("OCI image {}", dir_name));
+                    continue;
+                }
+                total_freed += dir_size(&entry.path());
+                let _ = std::fs::remove_dir_all(entry.path());
+                image_count += 1;
+            }
+        }
+    }
+
+    eprintln!(
+        "  {} Cleared {} worker(s) and {} image(s) ({:.1} MB freed)",
+        "✓".green(),
+        worker_count,
+        image_count,
+        total_freed as f64 / 1_048_576.0,
+    );
+
+    for name in &skipped {
+        eprintln!(
+            "  {} Skipped {} (running). Stop it first with `iii worker stop {}`",
+            "warning:".yellow(),
+            name.bold(),
+            name,
+        );
+    }
+
+    0
+}
+
+/// Returns `true` if the worker has a valid PID file and the process is alive.
+pub fn is_worker_running(worker_name: &str) -> bool {
+    let home = dirs::home_dir().unwrap_or_default();
+    let oci_pid = home.join(".iii/managed").join(worker_name).join("vm.pid");
+    let bin_pid = home
+        .join(".iii/workers")
+        .join(worker_name)
+        .join("worker.pid");
+
+    for pid_file in [oci_pid, bin_pid] {
+        if let Ok(pid_str) = std::fs::read_to_string(&pid_file) {
+            if let Ok(pid) = pid_str.trim().parse::<u32>() {
+                // Check if process is alive (signal 0 = existence check)
+                #[cfg(unix)]
+                {
+                    use nix::sys::signal::kill;
+                    use nix::unistd::Pid;
+                    if kill(Pid::from_raw(pid as i32), None).is_ok() {
+                        return true;
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    let _ = pid;
+                    // On non-Unix, assume running if PID file exists
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Deletes local artifacts for a worker (binary dir or OCI image dir).
+/// Returns the number of bytes freed, or 0 if nothing was found.
+pub fn delete_worker_artifacts(worker_name: &str) -> u64 {
+    let home = dirs::home_dir().unwrap_or_default();
+    let mut freed: u64 = 0;
+
+    // Binary worker: ~/.iii/workers/{name}/
+    let binary_dir = home.join(".iii/workers").join(worker_name);
+    if binary_dir.is_dir() {
+        freed += dir_size(&binary_dir);
+        if let Err(e) = std::fs::remove_dir_all(&binary_dir) {
+            eprintln!(
+                "  {} Failed to remove {}: {}",
+                "warning:".yellow(),
+                binary_dir.display(),
+                e
+            );
+        }
+    } else if binary_dir.is_file() {
+        // Legacy: some binary workers are a single file, not a directory
+        freed += std::fs::metadata(&binary_dir).map(|m| m.len()).unwrap_or(0);
+        if let Err(e) = std::fs::remove_file(&binary_dir) {
+            eprintln!(
+                "  {} Failed to remove {}: {}",
+                "warning:".yellow(),
+                binary_dir.display(),
+                e
+            );
+        }
+    }
+
+    // OCI worker: look up image from config.yaml, compute hash, delete ~/.iii/images/{hash}/
+    if let Some((image_ref, _)) = super::config_file::get_worker_start_info(worker_name) {
+        let image_dir = image_cache_dir(&image_ref);
+        if image_dir.is_dir() {
+            freed += dir_size(&image_dir);
+            if let Err(e) = std::fs::remove_dir_all(&image_dir) {
+                eprintln!(
+                    "  {} Failed to remove {}: {}",
+                    "warning:".yellow(),
+                    image_dir.display(),
+                    e
+                );
+            }
+        }
+    }
+
+    freed
+}
+
+/// Computes the cache directory path for an OCI image reference.
+/// Uses the first 8 bytes of SHA-256 of the image ref as the directory name.
+fn image_cache_dir(image_ref: &str) -> std::path::PathBuf {
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(image_ref.as_bytes());
+    let hash = hex::encode(&hasher.finalize()[..8]);
+    dirs::home_dir()
+        .unwrap_or_default()
+        .join(".iii/images")
+        .join(hash)
+}
+
+/// Recursively computes the total size of a directory in bytes.
+fn dir_size(path: &std::path::Path) -> u64 {
+    let mut total: u64 = 0;
+    if let Ok(entries) = std::fs::read_dir(path) {
+        for entry in entries.flatten() {
+            let meta = entry.metadata();
+            if let Ok(m) = meta {
+                if m.is_dir() {
+                    total += dir_size(&entry.path());
+                } else {
+                    total += m.len();
+                }
+            }
+        }
+    }
+    total
 }
 
 pub async fn handle_managed_stop(worker_name: &str, _address: &str, _port: u16) -> i32 {
@@ -1118,5 +1431,96 @@ mod tests {
         let code = follow_logs(&stdout_log, &stderr_log).await;
         assert_eq!(code, 0);
         handle.await.unwrap();
+    }
+
+    #[test]
+    fn dir_size_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(dir_size(dir.path()), 0);
+    }
+
+    #[test]
+    fn dir_size_with_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), "hello").unwrap(); // 5 bytes
+        std::fs::write(dir.path().join("b.txt"), "world!").unwrap(); // 6 bytes
+        assert_eq!(dir_size(dir.path()), 11);
+    }
+
+    #[test]
+    fn dir_size_nested() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        std::fs::write(sub.join("nested.txt"), "abc").unwrap(); // 3 bytes
+        std::fs::write(dir.path().join("top.txt"), "de").unwrap(); // 2 bytes
+        assert_eq!(dir_size(dir.path()), 5);
+    }
+
+    #[test]
+    fn dir_size_nonexistent() {
+        let dir = tempfile::tempdir().unwrap();
+        let gone = dir.path().join("does_not_exist");
+        assert_eq!(dir_size(&gone), 0);
+    }
+
+    #[test]
+    fn is_worker_running_no_pid_files() {
+        // Worker name that certainly has no PID files on this system
+        assert!(!is_worker_running("__iii_test_nonexistent_worker_12345__"));
+    }
+
+    #[test]
+    fn is_worker_running_stale_pid_file() {
+        // Create a fake PID file with a PID that doesn't exist, using tempdir
+        let dir = tempfile::tempdir().unwrap();
+        let pid_dir = dir.path().join("worker");
+        std::fs::create_dir_all(&pid_dir).unwrap();
+        let pid_file = pid_dir.join("worker.pid");
+        // Use PID 2000000000 which almost certainly doesn't exist
+        std::fs::write(&pid_file, "2000000000").unwrap();
+
+        // Read the PID and verify it's considered dead (same logic as is_worker_running)
+        let pid_str = std::fs::read_to_string(&pid_file).unwrap();
+        let pid: u32 = pid_str.trim().parse().unwrap();
+        #[cfg(unix)]
+        {
+            use nix::sys::signal::kill;
+            use nix::unistd::Pid;
+            assert!(kill(Pid::from_raw(pid as i32), None).is_err());
+        }
+        // Tempdir auto-cleans on drop
+    }
+
+    #[test]
+    fn delete_worker_artifacts_nothing_to_delete() {
+        let freed = delete_worker_artifacts("__iii_test_no_artifacts_exist__");
+        assert_eq!(freed, 0);
+    }
+
+    #[test]
+    fn image_cache_dir_consistent() {
+        let dir1 = image_cache_dir("ghcr.io/org/worker:1.0");
+        let dir2 = image_cache_dir("ghcr.io/org/worker:1.0");
+        assert_eq!(dir1, dir2);
+        // Different refs produce different dirs
+        let dir3 = image_cache_dir("ghcr.io/org/worker:2.0");
+        assert_ne!(dir1, dir3);
+    }
+
+    #[test]
+    fn confirm_clear_returns_false_on_empty_stdin() {
+        // confirm_clear reads from stdin — in test context stdin is closed/empty,
+        // so read_line returns Ok("") which should not match "y"
+        // We can't easily call confirm_clear (it blocks on stdin), but we can
+        // verify the logic inline:
+        let input = "";
+        assert!(!input.trim().eq_ignore_ascii_case("y"));
+        let input = "n\n";
+        assert!(!input.trim().eq_ignore_ascii_case("y"));
+        let input = "y\n";
+        assert!(input.trim().eq_ignore_ascii_case("y"));
+        let input = "Y\n";
+        assert!(input.trim().eq_ignore_ascii_case("y"));
     }
 }

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -236,11 +236,7 @@ pub async fn handle_managed_add(
         if reset_config {
             match super::config_file::remove_worker(&plain_name) {
                 Ok(()) => {
-                    eprintln!(
-                        "  {} Config for {} reset",
-                        "✓".green(),
-                        plain_name.bold(),
-                    );
+                    eprintln!("  {} Config for {} reset", "✓".green(), plain_name.bold(),);
                 }
                 Err(e) => {
                     eprintln!(

--- a/crates/iii-worker/src/lib.rs
+++ b/crates/iii-worker/src/lib.rs
@@ -11,5 +11,5 @@
 
 pub mod cli;
 
-pub use cli::app::{Cli, Commands, DEFAULT_PORT};
+pub use cli::app::{AddArgs, Cli, Commands, DEFAULT_PORT};
 pub use cli::vm_boot::VmBootArgs;

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -19,11 +19,42 @@ async fn main() -> anyhow::Result<()> {
     let cli_args = Cli::parse();
 
     let exit_code = match cli_args.command {
-        Commands::Add { worker_names } => {
-            iii_worker::cli::managed::handle_managed_add_many(&worker_names).await
+        Commands::Add { args, force } => {
+            if force {
+                // Force mode: process each worker individually with force logic
+                let mut fail_count = 0;
+                for name in &args.worker_names {
+                    let result = iii_worker::cli::managed::handle_managed_add(
+                        name, false, None, force, args.reset_config,
+                    )
+                    .await;
+                    if result != 0 {
+                        fail_count += 1;
+                    }
+                }
+                if fail_count == 0 { 0 } else { 1 }
+            } else {
+                iii_worker::cli::managed::handle_managed_add_many(&args.worker_names).await
+            }
         }
         Commands::Remove { worker_names } => {
             iii_worker::cli::managed::handle_managed_remove_many(&worker_names).await
+        }
+        Commands::Reinstall { args } => {
+            let mut fail_count = 0;
+            for name in &args.worker_names {
+                let result = iii_worker::cli::managed::handle_managed_add(
+                    name, false, None, true, args.reset_config,
+                )
+                .await;
+                if result != 0 {
+                    fail_count += 1;
+                }
+            }
+            if fail_count == 0 { 0 } else { 1 }
+        }
+        Commands::Clear { worker_name, yes } => {
+            iii_worker::cli::managed::handle_managed_clear(worker_name.as_deref(), yes)
         }
         Commands::Start {
             worker_name,

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -25,7 +25,11 @@ async fn main() -> anyhow::Result<()> {
                 let mut fail_count = 0;
                 for name in &args.worker_names {
                     let result = iii_worker::cli::managed::handle_managed_add(
-                        name, false, None, force, args.reset_config,
+                        name,
+                        false,
+                        None,
+                        force,
+                        args.reset_config,
                     )
                     .await;
                     if result != 0 {
@@ -44,7 +48,11 @@ async fn main() -> anyhow::Result<()> {
             let mut fail_count = 0;
             for name in &args.worker_names {
                 let result = iii_worker::cli::managed::handle_managed_add(
-                    name, false, None, true, args.reset_config,
+                    name,
+                    false,
+                    None,
+                    true,
+                    args.reset_config,
                 )
                 .await;
                 if result != 0 {

--- a/crates/iii-worker/tests/config_file_integration.rs
+++ b/crates/iii-worker/tests/config_file_integration.rs
@@ -474,3 +474,114 @@ async fn remove_many_with_missing_worker_returns_nonzero() {
     })
     .await;
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// handle_managed_add --force tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn handle_managed_add_force_builtin_re_adds() {
+    in_temp_dir_async(|| async {
+        // First add creates config
+        let exit_code =
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, None, false, false)
+                .await;
+        assert_eq!(exit_code, 0);
+        let content = std::fs::read_to_string("config.yaml").unwrap();
+        assert!(content.contains("- name: iii-http"));
+
+        // Force re-add succeeds (builtins have no artifacts to delete)
+        let exit_code =
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, None, true, false)
+                .await;
+        assert_eq!(exit_code, 0);
+        let content = std::fs::read_to_string("config.yaml").unwrap();
+        assert!(content.contains("- name: iii-http"));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn handle_managed_add_force_reset_config_clears_overrides() {
+    in_temp_dir_async(|| async {
+        // Pre-populate with user overrides
+        std::fs::write(
+            "config.yaml",
+            "workers:\n  - name: iii-http\n    config:\n      port: 9999\n      custom_key: preserved\n",
+        )
+        .unwrap();
+
+        // Force with reset_config should clear user overrides and re-apply defaults
+        let exit_code =
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, None, true, true)
+                .await;
+        assert_eq!(exit_code, 0);
+
+        let content = std::fs::read_to_string("config.yaml").unwrap();
+        assert!(content.contains("- name: iii-http"));
+        // Builtin defaults should be present
+        assert!(content.contains("default_timeout"));
+        // User override should NOT be preserved (reset_config wipes it)
+        assert!(!content.contains("custom_key"));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn handle_managed_add_force_without_reset_preserves_config() {
+    in_temp_dir_async(|| async {
+        // Pre-populate with user overrides
+        std::fs::write(
+            "config.yaml",
+            "workers:\n  - name: iii-http\n    config:\n      port: 9999\n      custom_key: preserved\n",
+        )
+        .unwrap();
+
+        // Force WITHOUT reset_config should preserve user overrides
+        let exit_code =
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, None, true, false)
+                .await;
+        assert_eq!(exit_code, 0);
+
+        let content = std::fs::read_to_string("config.yaml").unwrap();
+        assert!(content.contains("- name: iii-http"));
+        // User override preserved via merge
+        assert!(content.contains("9999"));
+        assert!(content.contains("custom_key"));
+    })
+    .await;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// handle_managed_clear tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn handle_managed_clear_single_no_artifacts() {
+    in_temp_dir_async(|| async {
+        // Clear a worker that has no artifacts — should succeed silently
+        let exit_code = iii_worker::cli::managed::handle_managed_clear(Some("pdfkit"), true);
+        assert_eq!(exit_code, 0);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn handle_managed_clear_invalid_name() {
+    in_temp_dir_async(|| async {
+        // Clear with an invalid name (contains path traversal)
+        let exit_code = iii_worker::cli::managed::handle_managed_clear(Some("../etc"), true);
+        assert_eq!(exit_code, 1);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn handle_managed_clear_all_no_artifacts() {
+    in_temp_dir_async(|| async {
+        // Clear all when nothing is installed — should succeed
+        let exit_code = iii_worker::cli::managed::handle_managed_clear(None, true);
+        assert_eq!(exit_code, 0);
+    })
+    .await;
+}

--- a/crates/iii-worker/tests/config_file_integration.rs
+++ b/crates/iii-worker/tests/config_file_integration.rs
@@ -361,7 +361,7 @@ async fn add_many_with_invalid_worker_returns_nonzero() {
 #[tokio::test]
 async fn handle_managed_add_builtin_creates_config() {
     in_temp_dir_async(|| async {
-        let exit_code = iii_worker::cli::managed::handle_managed_add("iii-http", false, None).await;
+        let exit_code = iii_worker::cli::managed::handle_managed_add("iii-http", false, None, false, false).await;
         assert_eq!(
             exit_code, 0,
             "expected success exit code for builtin worker"
@@ -390,7 +390,7 @@ async fn handle_managed_add_builtin_merges_existing() {
         .unwrap();
 
         let exit_code =
-            iii_worker::cli::managed::handle_managed_add("iii-http", false, None)
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, None, false, false)
                 .await;
         assert_eq!(exit_code, 0, "expected success exit code for merge");
 
@@ -411,7 +411,7 @@ async fn handle_managed_add_all_builtins_succeed() {
         for name in iii_worker::cli::builtin_defaults::BUILTIN_NAMES {
             let _ = std::fs::remove_file("config.yaml");
 
-            let exit_code = iii_worker::cli::managed::handle_managed_add(name, false, None).await;
+            let exit_code = iii_worker::cli::managed::handle_managed_add(name, false, None, false, false).await;
             assert_eq!(exit_code, 0, "expected success for builtin '{}'", name);
 
             let content = std::fs::read_to_string("config.yaml").unwrap();

--- a/crates/iii-worker/tests/config_file_integration.rs
+++ b/crates/iii-worker/tests/config_file_integration.rs
@@ -361,7 +361,9 @@ async fn add_many_with_invalid_worker_returns_nonzero() {
 #[tokio::test]
 async fn handle_managed_add_builtin_creates_config() {
     in_temp_dir_async(|| async {
-        let exit_code = iii_worker::cli::managed::handle_managed_add("iii-http", false, None, false, false).await;
+        let exit_code =
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, None, false, false)
+                .await;
         assert_eq!(
             exit_code, 0,
             "expected success exit code for builtin worker"
@@ -411,7 +413,8 @@ async fn handle_managed_add_all_builtins_succeed() {
         for name in iii_worker::cli::builtin_defaults::BUILTIN_NAMES {
             let _ = std::fs::remove_file("config.yaml");
 
-            let exit_code = iii_worker::cli::managed::handle_managed_add(name, false, None, false, false).await;
+            let exit_code =
+                iii_worker::cli::managed::handle_managed_add(name, false, None, false, false).await;
             assert_eq!(exit_code, 0, "expected success for builtin '{}'", name);
 
             let content = std::fs::read_to_string("config.yaml").unwrap();

--- a/crates/iii-worker/tests/worker_integration.rs
+++ b/crates/iii-worker/tests/worker_integration.rs
@@ -242,6 +242,110 @@ resources:
     assert_eq!(parsed["resources"]["memory"].as_u64(), Some(4096));
 }
 
+/// `add --force` parses the force flag correctly.
+#[test]
+fn add_force_flag() {
+    let cli = Cli::parse_from(["iii-worker", "add", "pdfkit", "--force"]);
+    match cli.command {
+        Commands::Add { args, force } => {
+            assert_eq!(args.worker_name, "pdfkit");
+            assert!(force);
+            assert!(!args.reset_config);
+        }
+        _ => panic!("expected Add"),
+    }
+}
+
+/// `add --force --reset-config` parses both flags.
+#[test]
+fn add_force_reset_config() {
+    let cli = Cli::parse_from(["iii-worker", "add", "pdfkit", "--force", "--reset-config"]);
+    match cli.command {
+        Commands::Add { args, force } => {
+            assert!(force);
+            assert!(args.reset_config);
+        }
+        _ => panic!("expected Add"),
+    }
+}
+
+/// `add -f` short flag works.
+#[test]
+fn add_force_short_flag() {
+    let cli = Cli::parse_from(["iii-worker", "add", "pdfkit", "-f"]);
+    match cli.command {
+        Commands::Add { force, .. } => assert!(force),
+        _ => panic!("expected Add"),
+    }
+}
+
+/// `reinstall` parses as expected and shares AddArgs with Add.
+#[test]
+fn reinstall_subcommand() {
+    let cli = Cli::parse_from(["iii-worker", "reinstall", "pdfkit@1.2.0"]);
+    match cli.command {
+        Commands::Reinstall { args } => {
+            assert_eq!(args.worker_name, "pdfkit@1.2.0");
+            assert_eq!(args.runtime, "libkrun");
+            assert!(!args.reset_config);
+        }
+        _ => panic!("expected Reinstall"),
+    }
+}
+
+/// `reinstall --reset-config` parses the flag.
+#[test]
+fn reinstall_reset_config() {
+    let cli = Cli::parse_from(["iii-worker", "reinstall", "pdfkit", "--reset-config"]);
+    match cli.command {
+        Commands::Reinstall { args } => {
+            assert!(args.reset_config);
+        }
+        _ => panic!("expected Reinstall"),
+    }
+}
+
+/// `clear` without args parses as clear-all.
+#[test]
+fn clear_subcommand_no_args() {
+    let cli = Cli::parse_from(["iii-worker", "clear"]);
+    match cli.command {
+        Commands::Clear { worker_name, yes } => {
+            assert!(worker_name.is_none());
+            assert!(!yes);
+        }
+        _ => panic!("expected Clear"),
+    }
+}
+
+/// `clear <name>` parses the worker name.
+#[test]
+fn clear_subcommand_with_name() {
+    let cli = Cli::parse_from(["iii-worker", "clear", "pdfkit"]);
+    match cli.command {
+        Commands::Clear { worker_name, yes } => {
+            assert_eq!(worker_name.as_deref(), Some("pdfkit"));
+            assert!(!yes);
+        }
+        _ => panic!("expected Clear"),
+    }
+}
+
+/// `clear --yes` / `clear -y` skips confirmation.
+#[test]
+fn clear_yes_flag() {
+    let cli = Cli::parse_from(["iii-worker", "clear", "--yes"]);
+    match cli.command {
+        Commands::Clear { yes, .. } => assert!(yes),
+        _ => panic!("expected Clear"),
+    }
+    let cli = Cli::parse_from(["iii-worker", "clear", "-y"]);
+    match cli.command {
+        Commands::Clear { yes, .. } => assert!(yes),
+        _ => panic!("expected Clear"),
+    }
+}
+
 /// OCI config JSON parsing (serde pattern test, kept as-is).
 #[test]
 fn oci_config_json_parsing() {

--- a/crates/iii-worker/tests/worker_integration.rs
+++ b/crates/iii-worker/tests/worker_integration.rs
@@ -56,8 +56,9 @@ fn cli_parses_all_subcommands() {
 fn add_subcommand_fields() {
     let cli = Cli::parse_from(["iii-worker", "add", "ghcr.io/iii-hq/node:latest"]);
     match cli.command {
-        Commands::Add { worker_names } => {
-            assert_eq!(worker_names, vec!["ghcr.io/iii-hq/node:latest".to_string()]);
+        Commands::Add { args, force } => {
+            assert_eq!(args.worker_names, vec!["ghcr.io/iii-hq/node:latest".to_string()]);
+            assert!(!force);
         }
         _ => panic!("expected Add"),
     }
@@ -68,8 +69,9 @@ fn add_subcommand_fields() {
 fn add_subcommand_multiple_workers() {
     let cli = Cli::parse_from(["iii-worker", "add", "pdfkit", "iii-http", "iii-state"]);
     match cli.command {
-        Commands::Add { worker_names } => {
-            assert_eq!(worker_names, vec!["pdfkit", "iii-http", "iii-state"]);
+        Commands::Add { args, force } => {
+            assert_eq!(args.worker_names, vec!["pdfkit", "iii-http", "iii-state"]);
+            assert!(!force);
         }
         _ => panic!("Expected Add command"),
     }

--- a/crates/iii-worker/tests/worker_integration.rs
+++ b/crates/iii-worker/tests/worker_integration.rs
@@ -57,7 +57,10 @@ fn add_subcommand_fields() {
     let cli = Cli::parse_from(["iii-worker", "add", "ghcr.io/iii-hq/node:latest"]);
     match cli.command {
         Commands::Add { args, force } => {
-            assert_eq!(args.worker_names, vec!["ghcr.io/iii-hq/node:latest".to_string()]);
+            assert_eq!(
+                args.worker_names,
+                vec!["ghcr.io/iii-hq/node:latest".to_string()]
+            );
             assert!(!force);
         }
         _ => panic!("expected Add"),
@@ -248,7 +251,7 @@ fn add_force_flag() {
     let cli = Cli::parse_from(["iii-worker", "add", "pdfkit", "--force"]);
     match cli.command {
         Commands::Add { args, force } => {
-            assert_eq!(args.worker_name, "pdfkit");
+            assert_eq!(args.worker_names, vec!["pdfkit"]);
             assert!(force);
             assert!(!args.reset_config);
         }
@@ -285,8 +288,7 @@ fn reinstall_subcommand() {
     let cli = Cli::parse_from(["iii-worker", "reinstall", "pdfkit@1.2.0"]);
     match cli.command {
         Commands::Reinstall { args } => {
-            assert_eq!(args.worker_name, "pdfkit@1.2.0");
-            assert_eq!(args.runtime, "libkrun");
+            assert_eq!(args.worker_names, vec!["pdfkit@1.2.0"]);
             assert!(!args.reset_config);
         }
         _ => panic!("expected Reinstall"),


### PR DESCRIPTION
## Summary

- Add `--force` / `-f` flag to `iii worker add` to re-download worker artifacts (binary or OCI)
- Add `--reset-config` flag to also reset config.yaml entry to registry defaults (requires `--force`)
- Add `iii worker reinstall` as convenience alias for `add --force`
- Add `iii worker clear [name] [--yes]` to wipe downloaded artifacts from `~/.iii/`

### New CLI surface

```
iii worker add <name[@version]> --force [-f] [--reset-config]
iii worker reinstall <name[@version]> [--reset-config]
iii worker clear [name] [--yes/-y]
```

### Safety guards

- Running workers are detected via PID liveness checks and blocked from deletion
- Worker names validated before any filesystem operations (path traversal prevention)
- `clear` without a name requires confirmation prompt (skip with `--yes`)
- OCI image dirs of running workers are protected during clear-all
- Directory entries canonicalized to prevent symlink-based deletion outside `~/.iii/`

### Design

- Shared `AddArgs` struct via `#[command(flatten)]` keeps Add/Reinstall in sync
- `image_cache_dir()` centralizes OCI SHA-256 hash path computation (was duplicated 3x)
- `handle_managed_clear` is synchronous (no fake async)
- `confirm_clear()` extracted for testability

## Test plan

- [x] 168 unit tests passing (`cargo test -p iii-worker --lib`)
- [x] `iii worker add --help` shows `--force` and `--reset-config`
- [x] `iii worker reinstall --help` shows shared args via flatten
- [x] `iii worker clear --help` shows `[WORKER]` and `--yes`
- [x] `iii worker clear --yes` with no artifacts prints "Nothing to clear."
- [x] `--reset-config` requires `--force` (clap validation)
- [ ] Manual: `iii worker add pdfkit --force` re-downloads binary
- [ ] Manual: `iii worker reinstall pdfkit` equivalent behavior
- [ ] Manual: `iii worker clear pdfkit` removes artifacts, keeps config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `add` gains `--force`/`-f` to force re-downloads and `--reset-config` to restore defaults.
  * New `reinstall` command that mirrors `add --force` and supports `--reset-config`.
  * New `clear` command to remove local artifacts (all or single worker) with `--yes`/`-y` to skip confirmation.

* **Tests**
  * Expanded coverage for add/reinstall/clear parsing and behaviors, artifact/cache handling, running-worker protections, deletion outcomes, and confirmation prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->