### PR TITLE
fix: restore iii-cloud binary registry entry

### DIFF
--- a/engine/src/cli/registry.rs
+++ b/engine/src/cli/registry.rs
@@ -119,6 +119,25 @@ pub static REGISTRY: &[BinarySpec] = &[
         tag_prefix: None,
     },
     BinarySpec {
+        name: "iii-cloud",
+        repo: "iii-hq/iii-cloud-cli",
+        has_checksum: true,
+        supported_targets: &[
+            "aarch64-apple-darwin",
+            "x86_64-apple-darwin",
+            "x86_64-pc-windows-msvc",
+            "aarch64-pc-windows-msvc",
+            "x86_64-unknown-linux-gnu",
+            "x86_64-unknown-linux-musl",
+            "aarch64-unknown-linux-gnu",
+        ],
+        commands: &[CommandMapping {
+            cli_command: "cloud",
+            binary_subcommand: None,
+        }],
+        tag_prefix: None,
+    },
+    BinarySpec {
         name: "iii-worker",
         repo: "iii-hq/iii",
         has_checksum: true,
@@ -205,6 +224,14 @@ mod tests {
         let (spec, sub) = resolve_command("motia").unwrap();
         assert_eq!(spec.name, "motia-cli");
         assert_eq!(spec.repo, "MotiaDev/motia-cli");
+        assert!(sub.is_none());
+    }
+
+    #[test]
+    fn test_resolve_cloud() {
+        let (spec, sub) = resolve_command("cloud").unwrap();
+        assert_eq!(spec.name, "iii-cloud");
+        assert_eq!(spec.repo, "iii-hq/iii-cloud-cli");
         assert!(sub.is_none());
     }
 


### PR DESCRIPTION
## Summary

- The `iii-cloud` `BinarySpec` was accidentally replaced by `iii-worker` in #1402 (`cb54ced3`) instead of being added alongside it
- This broke `iii cloud` with `Unknown command: 'cloud'` since `resolve_command("cloud")` could no longer find a registry entry
- Restores the original `iii-cloud` entry (repo: `iii-hq/iii-cloud-cli`, all 7 targets, `tag_prefix: None`) and its test

## Test plan

- [x] `cargo test -p iii --lib -- registry` — all 45 tests pass (including restored `test_resolve_cloud`)
- [ ] `iii cloud --help` works after installing the new binary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `cloud` command to the CLI for accessing cloud service operations.
* **Tests**
  * Updated test coverage to verify the new `cloud` command resolves correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->