### PR TITLE
fix(python-sdk): sync handlers fail after main thread exits

### DIFF
--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -895,7 +895,19 @@ class III:
             else:
 
                 async def wrapped(input_data: Any) -> Any:
-                    return await self._loop.run_in_executor(None, handler, input_data)
+                    loop = asyncio.get_running_loop()
+                    future: asyncio.Future[Any] = loop.create_future()
+
+                    def _run() -> None:
+                        try:
+                            result = handler(input_data)
+                            loop.call_soon_threadsafe(future.set_result, result)
+                        except BaseException as exc:
+                            loop.call_soon_threadsafe(future.set_exception, exc)
+
+                    t = threading.Thread(target=_run, daemon=True)
+                    t.start()
+                    return await future
 
             self._functions[func.id] = RemoteFunctionData(message=msg, handler=wrapped)
 


### PR DESCRIPTION
## Summary

- Fixes `RuntimeError: cannot schedule new futures after shutdown` when triggering sync Python handlers after the main thread finishes execution

## Problem

When a Python worker script finishes its module-level code (e.g. `register_worker` + `register_function` with no blocking call), the main thread completes. Python's `atexit` handlers then call `concurrent.futures.thread._python_exit()`, which sets a **module-level** `_shutdown` flag that prevents **all** `ThreadPoolExecutor` instances from accepting new work.

The SDK's background event loop thread (non-daemon) keeps the process alive and continues receiving WebSocket invocations, but `loop.run_in_executor(None, handler, data)` fails because the global shutdown flag rejects the submission — even with a custom executor.

**Reproducer:**
```python
from iii import register_worker, InitOptions

iii = register_worker("ws://localhost:49134", InitOptions(worker_name="math-worker"))

def add_handler(payload):
    return {"c": payload["a"] + payload["b"]}

iii.register_function("math::add", add_handler)
# main thread exits here, atexit shuts down all executors
```

```bash
iii trigger --function-id='math::add' --payload='{"a": 2, "b": 3}'
# => RuntimeError: cannot schedule new futures after shutdown
```

## Fix

Replace `loop.run_in_executor` with a manual `threading.Thread` per sync handler invocation. This bypasses `concurrent.futures.ThreadPoolExecutor` entirely, avoiding the interpreter-shutdown guard. The thread resolves an `asyncio.Future` via `call_soon_threadsafe`.

## Test plan

- [ ] Run `uv run test.py` in the example project, trigger `math::add` → returns `{"c": 5}` successfully
- [ ] Existing Python SDK unit tests pass (`test_invocation_exception.py`, `test_register_function_args.py`, etc.)
- [ ] Async handlers still work (not affected — they don't use the executor path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handler execution mechanism for enhanced performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->