### PR TITLE
fix(iii-worker): route 127.0.0.1 to host and fix ERROR-level VM console logs

### DIFF
--- a/crates/iii-init/src/network.rs
+++ b/crates/iii-init/src/network.rs
@@ -80,7 +80,9 @@ pub fn configure_network() -> Result<(), InitError> {
     // Write /etc/hosts mapping localhost to the gateway IP so DNS resolution
     // of "localhost" returns the gateway (reachable via the virtual network)
     // instead of 127.0.0.1 (unreachable guest loopback).
-    let _ = std::fs::write("/etc/hosts", format!("{gw}\tlocalhost\n"));
+    if let Err(e) = std::fs::write("/etc/hosts", format!("{gw}\tlocalhost\n")) {
+        eprintln!("iii-init: warning: failed to write /etc/hosts: {e}");
+    }
 
     result
 }

--- a/crates/iii-init/src/network.rs
+++ b/crates/iii-init/src/network.rs
@@ -314,5 +314,4 @@ mod tests {
         assert_eq!(iface_name(b"eth0\0"), "eth0");
         assert_eq!(iface_name(b"lo\0"), "lo");
     }
-
 }

--- a/crates/iii-init/src/network.rs
+++ b/crates/iii-init/src/network.rs
@@ -30,10 +30,14 @@ pub fn write_resolv_conf() -> Result<(), InitError> {
 /// If `III_INIT_IP` is not set, network configuration is skipped (backward compat).
 ///
 /// Sequence:
-/// 1. Bring up loopback (lo)
-/// 2. Assign IP and netmask to eth0
-/// 3. Bring up eth0
-/// 4. Add default route via gateway
+/// 1. Assign IP and netmask to eth0
+/// 2. Bring up eth0
+/// 3. Add default route via gateway
+/// 4. Write /etc/hosts mapping localhost to the gateway IP
+///
+/// The loopback interface is intentionally left down so that traffic to
+/// `127.0.0.1` falls through to the default route, reaching the host via
+/// the smoltcp TCP proxy.
 pub fn configure_network() -> Result<(), InitError> {
     let ip_str = match std::env::var("III_INIT_IP") {
         Ok(v) => v,
@@ -62,7 +66,8 @@ pub fn configure_network() -> Result<(), InitError> {
     }
 
     let result = (|| {
-        set_interface_up(sock, b"lo\0")?;
+        // Skip bringing up lo so that 127.0.0.1 traffic goes through eth0
+        // via the default route, reaching the host through the smoltcp proxy.
         set_ip_address(sock, b"eth0\0", ip)?;
         set_netmask(sock, b"eth0\0", mask)?;
         set_interface_up(sock, b"eth0\0")?;
@@ -71,6 +76,12 @@ pub fn configure_network() -> Result<(), InitError> {
     })();
 
     unsafe { libc::close(sock) };
+
+    // Write /etc/hosts mapping localhost to the gateway IP so DNS resolution
+    // of "localhost" returns the gateway (reachable via the virtual network)
+    // instead of 127.0.0.1 (unreachable guest loopback).
+    let _ = std::fs::write("/etc/hosts", format!("{gw}\tlocalhost\n"));
+
     result
 }
 
@@ -301,4 +312,5 @@ mod tests {
         assert_eq!(iface_name(b"eth0\0"), "eth0");
         assert_eq!(iface_name(b"lo\0"), "lo");
     }
+
 }

--- a/crates/iii-init/tests/init_integration.rs
+++ b/crates/iii-init/tests/init_integration.rs
@@ -16,9 +16,7 @@ fn configure_network_source_omits_loopback_setup() {
         .expect("configure_network function exists");
     let block = &source[fn_start..];
     let closure_start = block.find("let result = (||").expect("closure exists");
-    let closure_end = block[closure_start..]
-        .find("})();")
-        .expect("closure end");
+    let closure_end = block[closure_start..].find("})();").expect("closure end");
     let closure_body = &block[closure_start..closure_start + closure_end];
 
     // The closure must NOT bring up lo -- that's the whole point of the change.

--- a/crates/iii-init/tests/init_integration.rs
+++ b/crates/iii-init/tests/init_integration.rs
@@ -4,6 +4,53 @@
 //! reimplementing logic from scratch. All iii-init functionality is Linux-only,
 //! so every test is gated with `#[cfg(target_os = "linux")]`.
 
+// These tests inspect source code and formatting conventions, no Linux APIs needed.
+
+/// Verify that configure_network does NOT bring up the loopback interface.
+/// Without lo, 127.0.0.1 traffic routes through eth0 to the host via smoltcp.
+#[test]
+fn configure_network_source_omits_loopback_setup() {
+    let source = include_str!("../src/network.rs");
+    let fn_start = source
+        .find("fn configure_network")
+        .expect("configure_network function exists");
+    let block = &source[fn_start..];
+    let closure_start = block.find("let result = (||").expect("closure exists");
+    let closure_end = block[closure_start..]
+        .find("})();")
+        .expect("closure end");
+    let closure_body = &block[closure_start..closure_start + closure_end];
+
+    // The closure must NOT bring up lo -- that's the whole point of the change.
+    assert!(
+        !closure_body.contains(r#"set_interface_up(sock, b"lo\0")"#),
+        "configure_network must NOT bring up the loopback interface; \
+         127.0.0.1 traffic should route through eth0 to reach the host"
+    );
+
+    // It MUST still configure eth0.
+    assert!(
+        closure_body.contains("eth0"),
+        "configure_network must still configure eth0"
+    );
+}
+
+/// Verify the /etc/hosts content format maps localhost to a gateway IP,
+/// not to 127.0.0.1 (which would be the unreachable guest loopback).
+#[test]
+fn etc_hosts_format_maps_localhost_to_gateway() {
+    let source = include_str!("../src/network.rs");
+    // The write call should produce "<gateway>\tlocalhost\n", not "127.0.0.1\tlocalhost"
+    assert!(
+        source.contains(r#"format!("{gw}\tlocalhost\n")"#),
+        "should write /etc/hosts mapping localhost to the gateway IP"
+    );
+    assert!(
+        !source.contains(r#""127.0.0.1\tlocalhost"#),
+        "should NOT write 127.0.0.1 as localhost in /etc/hosts"
+    );
+}
+
 #[cfg(target_os = "linux")]
 mod linux {
     use iii_init::error::InitError;

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -530,8 +530,8 @@ pub async fn start_local_worker(worker_name: &str, worker_path: &str, port: u16)
     // 7. Build script
     let script = build_libkrun_local_script(&project, is_prepared);
 
-    let script_path = managed_dir.join("tmp").join("iii-dev-run.sh");
-    std::fs::create_dir_all(managed_dir.join("tmp")).ok();
+    let script_path = managed_dir.join("opt").join("iii").join("dev-run.sh");
+    std::fs::create_dir_all(managed_dir.join("opt").join("iii")).ok();
     if let Err(e) = std::fs::write(&script_path, &script) {
         eprintln!("{} Failed to write run script: {}", "error:".red(), e);
         return 1;
@@ -575,7 +575,7 @@ pub async fn start_local_worker(worker_name: &str, worker_path: &str, port: u16)
     let exec_path = "/bin/sh";
     let args = vec![
         "-c".to_string(),
-        "cd /workspace && exec bash /tmp/iii-dev-run.sh".to_string(),
+        "cd /workspace && exec bash /opt/iii/dev-run.sh".to_string(),
     ];
 
     super::worker_manager::libkrun::run_dev(

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -167,6 +167,7 @@ pub fn build_libkrun_local_script(project: &ProjectInfo, prepared: bool) -> Stri
     let env_exports = build_env_exports(&project.env);
     let mut parts: Vec<String> = Vec::new();
 
+    parts.push("export HOME=${HOME:-/root}".to_string());
     parts.push("export PATH=/usr/local/bin:/usr/bin:/bin:$PATH".to_string());
     parts.push("export LANG=${LANG:-C.UTF-8}".to_string());
     parts.push("echo $$ > /sys/fs/cgroup/worker/cgroup.procs 2>/dev/null || true".to_string());

--- a/crates/iii-worker/src/cli/project.rs
+++ b/crates/iii-worker/src/cli/project.rs
@@ -42,8 +42,8 @@ pub fn infer_scripts(
         ),
         ("rust", _) => (
             "command -v cargo >/dev/null || (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y)".to_string(),
-            ". $HOME/.cargo/env && cargo build".to_string(),
-            ". $HOME/.cargo/env && cargo run".to_string(),
+            "[ -f \"$HOME/.cargo/env\" ] && . \"$HOME/.cargo/env\"; cargo build".to_string(),
+            "[ -f \"$HOME/.cargo/env\" ] && . \"$HOME/.cargo/env\"; cargo run".to_string(),
         ),
         _ => (String::new(), String::new(), entry.to_string()),
     }
@@ -148,9 +148,9 @@ pub fn auto_detect_project(path: &std::path::Path) -> Option<ProjectInfo> {
         ProjectInfo {
             name: "rust".into(),
             language: Some("rust".into()),
-            setup_cmd: "command -v cargo >/dev/null || (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && . $HOME/.cargo/env)".into(),
-            install_cmd: ". $HOME/.cargo/env && cargo build --release".into(),
-            run_cmd: ". $HOME/.cargo/env && cargo run --release".into(),
+            setup_cmd: "command -v cargo >/dev/null || (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y)".into(),
+            install_cmd: "[ -f \"$HOME/.cargo/env\" ] && . \"$HOME/.cargo/env\"; cargo build --release".into(),
+            run_cmd: "[ -f \"$HOME/.cargo/env\" ] && . \"$HOME/.cargo/env\"; cargo run --release".into(),
             env: HashMap::new(),
         }
     } else if path.join("pyproject.toml").exists() || path.join("requirements.txt").exists() {

--- a/crates/iii-worker/src/cli/worker_manager/libkrun.rs
+++ b/crates/iii-worker/src/cli/worker_manager/libkrun.rs
@@ -117,6 +117,8 @@ pub async fn run_dev(
                 return 1;
             }
         };
+        cmd.arg("--console-output")
+            .arg(logs_dir.join("stdout.log"));
         cmd.stdout(stdout_file).stderr(stderr_file);
     }
 

--- a/crates/iii-worker/src/cli/worker_manager/libkrun.rs
+++ b/crates/iii-worker/src/cli/worker_manager/libkrun.rs
@@ -117,8 +117,7 @@ pub async fn run_dev(
                 return 1;
             }
         };
-        cmd.arg("--console-output")
-            .arg(logs_dir.join("stdout.log"));
+        cmd.arg("--console-output").arg(logs_dir.join("stdout.log"));
         cmd.stdout(stdout_file).stderr(stderr_file);
     }
 

--- a/crates/iii-worker/tests/vm_args_integration.rs
+++ b/crates/iii-worker/tests/vm_args_integration.rs
@@ -644,3 +644,70 @@ fn resolve_krunfw_file_path_returns_option() {
         assert!(path.exists(), "returned firmware path should exist");
     }
 }
+
+// ===========================================================================
+// Group 13: run_dev console-output convention (ensures VM console output
+// goes to stdout.log instead of through PortOutputLog at ERROR level)
+// ===========================================================================
+
+/// Verify that the dev-worker logs dir + stdout.log path convention matches
+/// the managed-worker console_output convention. Both paths must end with
+/// stdout.log so VM console output is written to a file rather than going
+/// through PortOutputLog (which hardcodes ERROR level for all lines).
+#[test]
+fn run_dev_console_output_path_convention() {
+    let worker_name = "image-resize";
+    // Dev worker path: ~/.iii/logs/<name>/stdout.log
+    let dev_logs_dir = dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+        .join(".iii/logs")
+        .join(worker_name);
+    let dev_console_output = dev_logs_dir.join("stdout.log");
+
+    let dev_str = dev_console_output.to_string_lossy();
+    assert!(
+        dev_str.ends_with("stdout.log"),
+        "dev console output should end with stdout.log, got: {}",
+        dev_str
+    );
+    assert!(
+        dev_str.contains(".iii/logs/image-resize"),
+        "dev console output should be under .iii/logs/<worker>, got: {}",
+        dev_str
+    );
+
+    // Managed worker path: ~/.iii/managed/<name>/logs/stdout.log
+    let managed_console_output = LibkrunAdapter::logs_dir(worker_name).join("stdout.log");
+    let managed_str = managed_console_output.to_string_lossy();
+    assert!(
+        managed_str.ends_with("stdout.log"),
+        "managed console output should also end with stdout.log, got: {}",
+        managed_str
+    );
+}
+
+/// Verify that --console-output can be parsed as a valid VmBootArgs field
+/// when set to the dev-worker logs path, proving the __vm-boot subprocess
+/// will accept it.
+#[test]
+fn run_dev_console_output_parses_as_vm_boot_arg() {
+    let dev_console_path = dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+        .join(".iii/logs/test-worker/stdout.log");
+    let path_str = dev_console_path.to_string_lossy().to_string();
+
+    let cli = TestCli::parse_from([
+        "test",
+        "--rootfs",
+        "/tmp/rootfs",
+        "--exec",
+        "/bin/sh",
+        "--console-output",
+        &path_str,
+    ]);
+    assert_eq!(
+        cli.args.console_output.as_deref(),
+        Some(path_str.as_str()),
+        "dev console output path should parse into VmBootArgs.console_output"
+    );
+}


### PR DESCRIPTION
## Summary

- **VM console output logged at ERROR**: `run_dev` (local-path workers) did not pass `--console-output` to `__vm-boot`, so all guest output (cargo downloads, compiles, app logs) went through `msb_krun`'s `PortOutputLog` which hardcodes `log::Level::Error` for every line. Now passes `--console-output` pointing to `stdout.log`, matching the managed worker path.
- **127.0.0.1 unreachable from guest VM**: The loopback interface inside the VM captured traffic to `127.0.0.1`, preventing it from reaching the host via the smoltcp proxy. Now skips bringing up `lo` so `127.0.0.1` falls through to the default route via `eth0`. Also writes `/etc/hosts` mapping `localhost` to the gateway IP.
- **Cargo env sourcing**: Guards `.cargo/env` sourcing with existence check and ensures `HOME` is set in the dev run script.

## Test plan

- [x] 423 tests pass (`cargo test -p iii-init -p iii-worker`)
- [x] 4 new tests cover both fixes:
  - `configure_network_source_omits_loopback_setup` — verifies lo is not brought up
  - `etc_hosts_format_maps_localhost_to_gateway` — verifies /etc/hosts format
  - `run_dev_console_output_path_convention` — verifies stdout.log path convention
  - `run_dev_console_output_parses_as_vm_boot_arg` — verifies --console-output parsing
- [ ] Manual: `iii worker logs <name> -f` should show clean output without ERROR prefix
- [ ] Manual: Worker connecting to `ws://127.0.0.1:49134` inside VM should reach engine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dev VM background mode reports console output to a persistent stdout.log path.
  * Init now attempts to write a /etc/hosts entry mapping localhost to the configured gateway (failure now emits a warning rather than failing).

* **Improvements**
  * Generated run script is placed under /opt/iii/ and executed from there; HOME is ensured (defaults to /root).
  * Cargo environment is sourced only when its env file exists.

* **Tests**
  * Added tests for network hosts behavior, absence of loopback setup, console-output path handling, and conditional Cargo sourcing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->