### PR TITLE
Docs: rewrite quickstart as a step-by-step tutorial

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "iii"
-version = "0.11.0-next.6"
+version = "0.11.0-next.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "iii-console"
-version = "0.11.0-next.6"
+version = "0.11.0-next.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -2536,7 +2536,7 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.11.0-next.6"
+version = "0.11.0-next.7"
 dependencies = [
  "async-trait",
  "ctor",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -12,6 +12,19 @@
     "dark": "/images/icons/iii-white.svg"
   },
   "favicon": "/images/favicon/favicon.svg",
+  "navbar": {
+    "links": [
+      {
+        "type": "github",
+        "href": "https://github.com/iii-hq/iii"
+      }
+    ],
+    "primary": {
+      "type": "button",
+      "label": "Install",
+      "href": "/install"
+    }
+  },
   "navigation": {
     "versions": [
       {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4,8 +4,8 @@
   "theme": "mint",
   "colors": {
     "primary": "#8a8c00",
-    "light": "#f3f724",
-    "dark": "#fcff5d"
+    "light": "#c8ca00",
+    "dark": "#6b6d00"
   },
   "logo": {
     "light": "/images/icons/iii-black.svg",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -134,7 +134,7 @@
             "groups": [
               {
                 "group": "Getting Started",
-                "pages": ["index", "quickstart"]
+                "pages": ["index", "install", "quickstart"]
               },
               {
                 "group": "Primitives & Concepts",

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -56,33 +56,7 @@ This results in the ability to:
 
 ## Getting Started
 
-The best way to understand iii is to try it:
-
-### 1. Install iii
-
-Install the iii engine:
-
-```bash
-curl -fsSL https://install.iii.dev/iii/main/install.sh | sh
-```
-
-### 2. Verify installation
-
-Check that iii has installed correctly with the following command. It should return a version number.
-
-```bash
-iii --version
-```
-
-### 3. Add Agent Skills
-
-Give your AI coding agent full context on iii:
-
-```bash
-npx skills add iii-hq/iii
-```
-
-Skills covering every iii primitive — works with Claude Code, Cursor, Gemini CLI, Codex, and [30+ other agents](https://agentskills.io).
+The best way to understand iii is to try it. [Install iii](/install) and then follow the [Quickstart](/quickstart) to create your first iii powered project.
 
 ## Next Steps
 

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -1,0 +1,39 @@
+---
+title: 'Install'
+description: 'Install the iii engine and set up your development environment.'
+---
+
+## 1. Install iii
+
+Install the iii engine:
+
+```bash
+curl -fsSL https://install.iii.dev/iii/main/install.sh | sh
+```
+
+## 2. Verify installation
+
+Check that iii has installed correctly with the following command. It should return a version number.
+
+```bash
+iii --version
+```
+
+## 3. Add Agent Skills
+
+Give your AI coding agent full context on iii:
+
+```bash
+npx skillkit add iii-hq/iii
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" href="/quickstart" icon="terminal">
+    Follow the Quickstart and explore a live iii application.
+  </Card>
+  <Card title="Concepts" href="/primitives-and-concepts" icon="table-layout">
+    Understand Functions and Triggers from a conceptual point of view.
+  </Card>
+</CardGroup>

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -19,12 +19,12 @@ Check that iii has installed correctly with the following command. It should ret
 iii --version
 ```
 
-## 3. Add Agent Skills
+## 3. Add Agent Skills (Optional)
 
-Give your AI coding agent full context on iii:
+Give your IDEs and AI coding agents full context on iii:
 
 ```bash
-npx skillkit add iii-hq/iii
+npx skillkit add iii-hq/iii/skills
 ```
 
 ## Next Steps

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -64,6 +64,10 @@ iii trigger --function-id='math::add' --payload='{"a": 2, "b": 3}'
 However this is not much different than running an equivalent script on its own. The utility of iii comes from being able to place
 any functionality into a worker and then seamlessly compose that worker with other workers.
 
+<Tip>
+  Workers need a moment to install their runtime dependencies after being added. If you see `"message": "Function math::add not found"`, wait a few seconds and try again.
+</Tip>
+
 ## 4. Start the TypeScript worker
 
 ```bash
@@ -81,10 +85,6 @@ Path  /Users/tony/iii/projects/testing/quickstart/workers/caller-worker
 ```
 
 This worker registered the function `math::add_two_numbers` with the engine.
-
-<Tip>
-  Workers need a moment to install their runtime dependencies after being added. If you see `"message": "Function math::add not found"`, wait a few seconds and try again.
-</Tip>
 
 ## 5. Call across languages
 
@@ -112,7 +112,6 @@ Now open `workers/math-worker/math_worker.py` and uncomment the state block so t
 
 ```python
 def add_handler(payload: dict) -> dict:
-    payload = payload.get("body", payload) # Handle http messages
     a = payload.get("a", 0)
     b = payload.get("b", 0)
     logger.info(f"math::add called in Python with a={a}, b={b}")
@@ -171,12 +170,23 @@ From the folder containing iii's `config.yaml` run:
 iii worker add iii-http
 ```
 
-Open `workers/caller-worker/src/worker.ts` and uncomment the trigger registration at the bottom of the file:
+Open `workers/caller-worker/src/worker.ts` and uncomment the HTTP block at the bottom of the file:
 
 ```typescript
+iii.registerFunction(
+  'http::add_two_numbers',
+  async (payload: { body: { a: number; b: number } }) => {
+    const result = await iii.trigger({
+      function_id: 'math::add_two_numbers',
+      payload: payload.body,
+    });
+    return { status_code: 200, body: result, headers: { 'Content-Type': 'application/json' } };
+  },
+);
+
 iii.registerTrigger({
   type: 'http',
-  function_id: 'math::add_two_numbers',
+  function_id: 'http::add_two_numbers',
   config: { api_path: '/math/add-two-numbers', http_method: 'POST' },
 });
 ```
@@ -218,7 +228,6 @@ logger = Logger()
 
 
 def add_handler(payload: dict) -> dict:
-    payload = payload.get("body", payload)  # Handle http messages
     a = payload.get("a", 0)
     b = payload.get("b", 0)
     logger.info(f"math::add called in Python with a={a}, b={b}")

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,9 +1,9 @@
 ---
 title: 'Quickstart'
-description: 'Scaffold a cross-language project and call functions across Python and TypeScript through the iii engine.'
+description: 'Scaffold a cross-language project and compose Python and TypeScript workers with the iii engine.'
 ---
 
-In this tutorial you will setup a simple iii project that demonstrates cross-language function calls between Python and TypeScript workers.
+In this tutorial you will setup a simple iii project and run two services (which we call workers) that are inherently composable.
 
 <Info title="Install iii before proceeding">
   Make sure you have installed iii before proceeding. If you haven't then visit the [Install](/install) guide first.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -82,6 +82,10 @@ Path  /Users/tony/iii/projects/testing/quickstart/workers/caller-worker
 
 This worker registered the function `math::add_two_numbers` with the engine.
 
+<Tip>
+  Workers need a moment to install their runtime dependencies after being added. If you see `"message": "Function math::add not found"`, wait a few seconds and try again.
+</Tip>
+
 ## 5. Call across languages
 
 Call the TypeScript worker. It will call the Python worker through the engine and return the result:

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -297,15 +297,14 @@ scripts:
 ```mermaid
 graph TD
   CLI["iii trigger (CLI)"] <-->|WS| Engine["iii engine :49134"]
-  HTTP["curl / HTTP"] <-->|WS :3111| Engine
+  HTTP["curl / HTTP"] <-->|HTTP :3111| Engine
 
-  Engine --> Math["math-worker\n(Python)\nmath::add"]
-  Engine --> Caller["caller-worker\n(TypeScript)\nmath::add_two_numbers"]
+  Engine --> Math["math-worker (Python) math::add"]
+  Engine --> Caller["caller-worker (TypeScript) math::add_two_numbers"]
 
-  Caller --> State["iii-state\n(KV store)"]
-  Caller --> HttpWorker["iii-http\n(:3111)"]
+  Math --> State["iii-state (KV store)"]
+  Caller --> HttpWorker["iii-http (:3111)"]
 ```
-
 
 ## 9. Explore with the iii Console (Optional)
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -40,7 +40,7 @@ The engine is now listening on `ws://localhost:49134`. Keep this terminal open.
 
 ## 3. Start the Python worker
 
-Open a second terminal in the `quickstart` directory and run the following command:
+Open a second terminal in the `quickstart` directory and start the first worker:
 
 ```bash
 iii worker dev ./workers/math-worker
@@ -63,7 +63,7 @@ any functionality into a worker and then seamlessly compose that worker with oth
 
 ## 4. Start the TypeScript worker
 
-Open a third terminal in the `quickstart` directory:
+Open a third terminal in the `quickstart` directory and start the second worker:
 
 ```bash
 iii worker dev ./workers/caller-worker
@@ -77,24 +77,7 @@ Caller worker started - listening for calls
 
 This worker registered the function `math::add_two_numbers` with the engine.
 
-## 5. Call the Python function
-
-Open a fourth terminal in the `quickstart` directory and call the Python worker directly:
-
-```bash
-iii trigger --function-id='math::add' --payload='{"a": 2, "b": 3}'
-```
-
-```json
-{ 
-  "c": 5,
-  // ...
-}
-```
-
-The CLI sent a trigger to the engine, the engine routed it to the Python worker, and the result came back.
-
-## 6. Call across languages
+## 5. Call across languages
 
 Now open a fourth terminal in the `quickstart` directory and call the TypeScript worker.
 The TypeScript worker will then call the Python worker and return the result:
@@ -107,7 +90,7 @@ iii trigger --function-id='math::add_two_numbers' --payload='{"a": 10, "b": 20}'
 { "c": 30 }
 ```
 
-## 7. How it works
+## 6. How it works
 
 ### Python worker
 
@@ -204,7 +187,7 @@ scripts:
 ```
 
 
-## 8. Explore with the iii Console
+## 7. Explore with the iii Console
 
 Start the console in a new terminal:
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -112,6 +112,7 @@ Now open `workers/math-worker/math_worker.py` and uncomment the state block so t
 
 ```python
 def add_handler(payload: dict) -> dict:
+    payload = payload.get("body", payload)
     a = payload.get("a", 0)
     b = payload.get("b", 0)
     logger.info(f"math::add called in Python with a={a}, b={b}")

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -112,21 +112,25 @@ Now open `workers/math-worker/math_worker.py` and uncomment the state block so t
 
 ```python
 def add_handler(payload: dict) -> dict:
-    payload = payload.get("body", payload)
+    payload = payload.get("body", payload) # Handle http messages
     a = payload.get("a", 0)
     b = payload.get("b", 0)
     logger.info(f"math::add called in Python with a={a}, b={b}")
     result = {"c": a + b}
 
-    running_total = iii.trigger({
-        "function_id": "state::get",
-        "payload": {"scope": "math", "key": "running_total"},
-    })
+    running_total = iii.trigger(
+        {
+            "function_id": "state::get",
+            "payload": {"scope": "math", "key": "running_total"},
+        }
+    )
     new_total = (running_total or 0) + result["c"]
-    iii.trigger({
-        "function_id": "state::set",
-        "payload": {"scope": "math", "key": "running_total", "value": new_total},
-    })
+    iii.trigger(
+        {
+            "function_id": "state::set",
+            "payload": {"scope": "math", "key": "running_total", "value": new_total},
+        }
+    )
     result["running_total"] = new_total
 
     return result
@@ -167,14 +171,9 @@ From the folder containing iii's `config.yaml` run:
 iii worker add iii-http
 ```
 
-Open `workers/caller-worker/src/worker.ts` and uncomment the trigger registrations at the bottom of the file:
+Open `workers/caller-worker/src/worker.ts` and uncomment the trigger registration at the bottom of the file:
 
 ```typescript
-iii.registerTrigger({
-  type: 'http',
-  function_id: 'math::add',
-  config: { api_path: '/math/add', http_method: 'POST' },
-});
 iii.registerTrigger({
   type: 'http',
   function_id: 'math::add_two_numbers',
@@ -182,21 +181,11 @@ iii.registerTrigger({
 });
 ```
 
-Restart the TypeScript worker, then call both endpoints with curl:
+Restart the TypeScript worker, then call the new endpoint with curl:
 
 ```bash
 iii worker stop caller-worker
 iii worker start caller-worker
-```
-
-```bash
-curl -X POST http://localhost:3111/math/add \
-  -H 'Content-Type: application/json' \
-  -d '{"a": 4, "b": 6}'
-```
-
-```json
-{ "c": 10, "running_total": 45 }
 ```
 
 ```bash
@@ -206,7 +195,7 @@ curl -X POST http://localhost:3111/math/add-two-numbers \
 ```
 
 ```json
-{ "c": 300, "running_total": 345 }
+{ "c": 300, "running_total": 335 }
 ```
 
 The same functions that respond to `iii trigger` now also respond to HTTP requests with no code changes to the handlers themselves.
@@ -229,6 +218,7 @@ logger = Logger()
 
 
 def add_handler(payload: dict) -> dict:
+    payload = payload.get("body", payload)  # Handle http messages
     a = payload.get("a", 0)
     b = payload.get("b", 0)
     logger.info(f"math::add called in Python with a={a}, b={b}")

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -290,28 +290,16 @@ scripts:
 
 ### Architecture
 
-```
-┌──────────────┐          ┌──────────────────┐
-│  iii trigger  │◀────────▶│    iii engine     │
-│  (CLI)        │   WS     │   :49134          │
-└──────────────┘          └──┬────┬────┬────┬─┘
-                             │    │    │    │
-┌──────────────┐     WS     │    │    │    │
-│  curl / HTTP  │◀──:3111──▶│    │    │    │
-└──────────────┘            │    │    │    │
-                            ▼    ▼    │    │
-               ┌────────────┐ ┌──────────────┐
-               │math-worker │ │caller-worker │
-               │(Python)    │ │(TypeScript)  │
-               │math::add   │ │math::add_two │
-               │            │ │  _numbers    │
-               └────────────┘ └──────────────┘
-                            ┌────┘    └────┐
-                            ▼              ▼
-                     ┌──────────┐   ┌──────────┐
-                     │iii-state │   │iii-http  │
-                     │(KV store)│   │(:3111)   │
-                     └──────────┘   └──────────┘
+```mermaid
+graph TD
+  CLI["iii trigger (CLI)"] <-->|WS| Engine["iii engine :49134"]
+  HTTP["curl / HTTP"] <-->|WS :3111| Engine
+
+  Engine --> Math["math-worker\n(Python)\nmath::add"]
+  Engine --> Caller["caller-worker\n(TypeScript)\nmath::add_two_numbers"]
+
+  Caller --> State["iii-state\n(KV store)"]
+  Caller --> HttpWorker["iii-http\n(:3111)"]
 ```
 
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Quickstart'
-description: 'Scaffold a cross-language project, start two workers, and call functions across Python and TypeScript through the iii engine.'
+description: 'Scaffold a cross-language project and call functions across Python and TypeScript through the iii engine.'
 ---
 
 In this tutorial you will scaffold a cross-language project with the iii, start a Python worker and a TypeScript worker, and call functions across languages through the iii engine.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -3,7 +3,7 @@ title: 'Quickstart'
 description: 'Scaffold a cross-language project and call functions across Python and TypeScript through the iii engine.'
 ---
 
-In this tutorial you will setup a simple iii project that ...
+In this tutorial you will setup a simple iii project that demonstrates cross-language function calls between Python and TypeScript workers.
 
 <Info title="Install iii before proceeding">
   Make sure you have installed iii before proceeding. If you haven't then visit the [Install](/install) guide first.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -20,14 +20,11 @@ This creates the two workers that you'll run: a Python worker that adds two numb
 
 ```
 quickstart/
-├── workers/
-│   ├── math-worker/          # Python
-│   │   ├── iii.worker.yaml
-│   │   ├── math_worker.py
-│   └── caller-worker/        # TypeScript
-│       ├── iii.worker.yaml
-│       └── src/
-│           └── worker.ts
+  workers/
+    math-worker/          # Python
+      math_worker.py
+    caller-worker/        # TypeScript
+      src/worker.ts
 ```
 
 ## 2. Start the engine
@@ -53,7 +50,11 @@ iii worker add ./workers/math-worker
 You should see:
 
 ```
-math-worker started — registered math::add
+✓ Worker math-worker added to config.yaml
+Path  /Users/tony/iii/projects/testing/quickstart/workers/math-worker
+✓ Using cached deps (use --force to reinstall)
+✓ math-worker started (pid: 12345)
+✓ Worker auto-started
 ```
 
 This worker registered the function `math::add` with the engine. You could call this function right now using the command below.
@@ -76,7 +77,11 @@ iii worker add ./workers/caller-worker
 You should see:
 
 ```
-caller-worker started — registered math::add_two_numbers
+✓ Worker caller-worker added to config.yaml
+Path  /Users/tony/iii/projects/testing/quickstart/workers/caller-worker
+✓ Using cached deps (use --force to reinstall)
+✓ caller-worker started (pid: 23456)
+✓ Worker auto-started
 ```
 
 This worker registered the function `math::add_two_numbers` with the engine.
@@ -127,7 +132,12 @@ def add_handler(payload: dict) -> dict:
     return result
 ```
 
-Restart the Python worker (stop it with `Ctrl+C` and re-run `iii worker add ./workers/math-worker`), then call it a few times:
+Restart the Python worker and call it a few times:
+
+```bash
+iii worker stop math-worker
+iii worker add ./workers/math-worker
+```
 
 ```bash
 iii trigger --function-id='math::add' --payload='{"a": 2, "b": 3}'
@@ -172,7 +182,12 @@ iii.registerTrigger({
 });
 ```
 
-Restart the TypeScript worker (stop it with `Ctrl+C` and re-run `iii worker add ./workers/caller-worker`), then call both endpoints with curl:
+Restart the TypeScript worker, then call both endpoints with curl:
+
+```bash
+iii worker stop caller-worker
+iii worker add ./workers/caller-worker
+```
 
 ```bash
 curl -X POST http://localhost:3111/math/add \
@@ -251,7 +266,7 @@ iii.registerFunction(
 ```
 
 `registerWorker` connects to the engine the same way the Python worker does. The `iii.trigger()` call inside the handler invokes
-`math::add` on the Python worker through the engine the TypeScript worker doesn't need to know where the `math::add` function
+`math::add` on the Python worker through the engine. The TypeScript worker doesn't need to know where the `math::add` function
 is running, its language, or anything else.
 
 ### Worker manifest

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -136,7 +136,7 @@ Restart the Python worker and call it a few times:
 
 ```bash
 iii worker stop math-worker
-iii worker add ./workers/math-worker
+iii worker start math-worker
 ```
 
 ```bash
@@ -186,7 +186,7 @@ Restart the TypeScript worker, then call both endpoints with curl:
 
 ```bash
 iii worker stop caller-worker
-iii worker add ./workers/caller-worker
+iii worker start caller-worker
 ```
 
 ```bash

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,138 +1,224 @@
 ---
 title: 'Quickstart'
-description: 'Learn everything you need to start building with iii and the iii SDK'
+description: 'Scaffold a cross-language project, start two workers, and call functions across Python and TypeScript through the iii engine.'
 ---
 
-This Quickstart will show how any project can leverage iii and the iii SDK to unify their backend stack.
+In this tutorial you will scaffold a cross-language project with the iii, start a Python worker and a TypeScript worker, and call functions across languages through the iii engine.
 
-### 1. Create a new quickstart project
+<Info title="Install iii before proceeding">
+  Make sure you have installed iii before proceeding. If you haven't then visit the [Getting Started](/index#getting-started) guide first.
+</Info>
 
-<Warning title="install iii">
-  Make sure to install iii before proceeding:
-```bash
-curl -fsSL https://install.iii.dev/iii/main/install.sh | sh
-```
-</Warning>
-
-The project setup will indicate that this project includes TypeScript, Python, and Rust languages. The README contains instructions for using Docker Compose in case not all of these runtimes are available on the system.
+## 1. Scaffold the project
 
 ```bash
 iii create --template quickstart --directory quickstart
 cd quickstart
 ```
 
-### 2. Run the Engine
+This creates the two workers that you'll run: a Python worker that adds two numbers, and a TypeScript worker that calls the Python worker through the iii engine.
 
-```bash
-iii --config iii-config.yaml
+```
+quickstart/
+├── workers/
+│   ├── math-worker/          # Python
+│   │   ├── iii.worker.yaml
+│   │   ├── math_worker.py
+│   └── caller-worker/        # TypeScript
+│       ├── iii.worker.yaml
+│       └── src/
+│           └── worker.ts
 ```
 
-### 3. Open the project
-
-Open the project and README in your IDE. You can use this shorthand from a second terminal window in the project directory:
-
-<Tabs>
-  <Tab title="VS Code">
+## 2. Start the engine
 
 ```bash
-code . README.md
+iii --config config.yaml
 ```
 
-  </Tab>
-  <Tab title="Cursor">
+The engine is now listening on `ws://localhost:49134`. Keep this terminal open.
+
+## 3. Start the Python worker
+
+Open a second terminal in the `quickstart` directory and run the following command:
 
 ```bash
-cursor . README.md
+iii worker dev ./workers/math-worker
 ```
 
-  </Tab>
-  <Tab title="JetBrains">
+You should see:
+
+```
+Math worker started - listening for calls
+```
+
+This worker registered the function `math::add` with the engine. You could call this function right now using the command below.
 
 ```bash
-idea . README.md
+iii trigger --function-id='math::add' --payload='{"a": 2, "b": 3}'
 ```
 
-  </Tab>
-  <Tab title="Sublime">
+However this is not much different than running an equivalent script on its own. The utility of iii comes from being able to place
+any functionality into a worker and then seamlessly compose that worker with other workers.
+
+## 4. Start the TypeScript worker
+
+Open a third terminal in the `quickstart` directory:
 
 ```bash
-subl . README.md
+iii worker dev ./workers/caller-worker
 ```
 
-  </Tab>
-  <Tab title="Neovim">
+You should see:
+
+```
+Caller worker started - listening for calls
+```
+
+This worker registered the function `math::add_two_numbers` with the engine.
+
+## 5. Call the Python function
+
+Open a fourth terminal in the `quickstart` directory and call the Python worker directly:
 
 ```bash
-nvim README.md
+iii trigger --function-id='math::add' --payload='{"a": 2, "b": 3}'
 ```
 
-  </Tab>
-</Tabs>
+```json
+{ 
+  "c": 5,
+  // ...
+}
+```
 
-### 4. Continue with the README
+The CLI sent a trigger to the engine, the engine routed it to the Python worker, and the result came back.
 
-The README will explain what the project is doing and how to start
-the services that will connect to the iii engine and use it for their communication.
+## 6. Call across languages
 
-After completing the project, explore the `worker.ts` file from the project
-directory and then navigate back here to learn more about how iii works and can be
-used to streamline backend orchestration.
+Now open a fourth terminal in the `quickstart` directory and call the TypeScript worker.
+The TypeScript worker will then call the Python worker and return the result:
 
-### 5. Try the iii Console
+```bash
+iii trigger --function-id='math::add_two_numbers' --payload='{"a": 10, "b": 20}'
+```
 
-iii also comes with a web console that shows logs, traces, and runtime state for the iii-powered application.
-Start it in a new terminal window with:
+```json
+{ "c": 30 }
+```
+
+## 7. How it works
+
+### Python worker
+
+`workers/math-worker/math_worker.py`:
+
+```python
+import os
+from iii import register_worker, InitOptions, Logger
+
+iii = register_worker(
+    os.environ.get("III_URL", "ws://localhost:49134"),
+    InitOptions(worker_name="math-worker"),
+)
+logger = Logger()
+
+
+def add_handler(payload: dict) -> dict:
+    a = payload.get("a", 0)
+    b = payload.get("b", 0)
+    logger.info(f"math::add called in Python with a={a}, b={b}")
+    return {"c": a + b}
+
+
+iii.register_function("math::add", add_handler)
+```
+
+`register_worker` connects to the engine over WebSocket. `register_function` makes `math::add` available to the entire system.
+
+### TypeScript worker
+
+`workers/caller-worker/src/worker.ts`:
+
+```typescript
+import { registerWorker, Logger } from 'iii-sdk';
+
+const iii = registerWorker(process.env.III_URL ?? 'ws://localhost:49134');
+const logger = new Logger();
+
+iii.registerFunction(
+  'math::add_two_numbers',
+  async (payload: { a: number; b: number }) => {
+    logger.info('math::add_two_numbers called in TypeScript', payload);
+
+    const result = await iii.trigger({
+      function_id: 'math::add',
+      payload,
+    });
+
+    return result;
+  },
+);
+```
+
+`registerWorker` connects to the engine the same way the Python worker does. The `iii.trigger()` call inside the handler invokes
+`math::add` on the Python worker through the engine the TypeScript worker doesn't need to know where the `math::add` function
+is running, its language, or anything else.
+
+### Worker manifest
+
+Each worker has an `iii.worker.yaml` that describes how to run the worker. Here is the Python worker's manifest.
+While these workers are started with the `iii worker dev` command they do not need to be running alongside the iii
+instance. These workers can run anywhere and even be replicated. Every worker simply connects to iii over WebSocket.
+iii then handles all routing.
+
+```yaml
+name: math-worker
+runtime:
+  language: python
+  package_manager: pip
+  entry: math_worker.py
+scripts:
+  install: "pip install -r requirements.txt"
+  start: "python math_worker.py"
+```
+
+`name` identifies the worker. `runtime` tells the engine the language and entrypoint. `scripts` define how to install dependencies and start the worker.
+
+### Architecture
+
+```
+┌──────────────┐          ┌──────────────────┐
+│  iii trigger  │◀────────▶│    iii engine     │
+│  (CLI)        │   WS     │   :49134          │
+└──────────────┘          └──────┬───────┬────┘
+                                 │       │
+                          WS     │       │  WS
+                                 ▼       ▼
+                        ┌────────────┐  ┌──────────────┐
+                        │math-worker │  │caller-worker │
+                        │(Python)    │  │(TypeScript)  │
+                        │math::add   │  │math::add_two │
+                        │            │  │  _numbers    │
+                        └────────────┘  └──────────────┘
+```
+
+
+## 8. Explore with the iii Console
+
+Start the console in a new terminal:
 
 ```bash
 iii console
 ```
 
-Then open your web browser to: http://localhost:3113/
+Open your browser to [http://localhost:3113/](http://localhost:3113/) to see logs, traces, and runtime state for the running system.
 
 <img src="/images/console/dashboard.png" alt="iii Console dashboard" />
 
-### 6. Add Agent Skills
-
-Give your AI coding agent full context on every iii primitive:
-
-```bash
-npx skills add iii-hq/iii
-```
-
-This installs skills covering HTTP endpoints, cron scheduling, queues, state management, streams, custom triggers, and more. Works with Claude Code, Cursor, Gemini CLI, Codex, and [30+ other agents](https://agentskills.io).
-
-<Tabs>
-  <Tab title="Claude Code">
-
-```bash
-npx skills add iii-hq/iii
-```
-
-  </Tab>
-  <Tab title="Cursor">
-
-```bash
-npx skillkit install iii-hq/iii --agent cursor
-```
-
-  </Tab>
-  <Tab title="Gemini CLI">
-
-```bash
-npx skillkit install iii-hq/iii --agent gemini-cli
-```
-
-  </Tab>
-  <Tab title="Codex">
-
-```bash
-npx skillkit install iii-hq/iii --agent codex
-```
-
-  </Tab>
-</Tabs>
-
 ## Next Steps
+
+You scaffolded a project, started two workers in different languages, and called functions across them through the iii engine.
 
 <CardGroup cols={2}>
   <Card title="How to use Functions & Triggers" href="/how-to/use-functions-and-triggers" icon="book-open">

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,9 +1,9 @@
 ---
 title: 'Quickstart'
-description: 'Scaffold a cross-language project and compose Python and TypeScript workers with the iii engine.'
+description: 'Scaffold a cross-language project, compose Python and TypeScript workers, and incrementally add functionality to a live system with zero downtime.'
 ---
 
-In this tutorial you will setup a simple iii project and run two services (which we call workers) that are inherently composable.
+In this tutorial you will learn how iii makes it unreasonably simple to build and extend backend software.
 
 <Info title="Install iii before proceeding">
   Make sure you have installed iii before proceeding. If you haven't then visit the [Install](/install) guide first.
@@ -94,7 +94,109 @@ iii trigger --function-id='math::add_two_numbers' --payload='{"a": 10, "b": 20}'
 { "c": 30 }
 ```
 
-## 6. How it works
+## 6. Add state
+
+The `iii worker add` command incrementally adds built-in workers to your running system. Start by adding the state worker, which gives every function access to a persistent key-value store.
+
+From the folder containing iii's `config.yaml` run:
+
+```bash
+iii worker add iii-state
+```
+
+Now open `workers/math-worker/math_worker.py` and uncomment the state block so the handler looks like this:
+
+```python
+def add_handler(payload: dict) -> dict:
+    a = payload.get("a", 0)
+    b = payload.get("b", 0)
+    logger.info(f"math::add called in Python with a={a}, b={b}")
+    result = {"c": a + b}
+
+    running_total = iii.trigger({
+        "function_id": "state::get",
+        "payload": {"scope": "math", "key": "running_total"},
+    })
+    new_total = (running_total or 0) + result["c"]
+    iii.trigger({
+        "function_id": "state::set",
+        "payload": {"scope": "math", "key": "running_total", "value": new_total},
+    })
+    result["running_total"] = new_total
+
+    return result
+```
+
+Restart the Python worker (stop it with `Ctrl+C` and re-run `iii worker add ./workers/math-worker`), then call it a few times:
+
+```bash
+iii trigger --function-id='math::add' --payload='{"a": 2, "b": 3}'
+```
+
+```json
+{ "c": 5, "running_total": 5 }
+```
+
+```bash
+iii trigger --function-id='math::add' --payload='{"a": 10, "b": 20}'
+```
+
+```json
+{ "c": 30, "running_total": 35 }
+```
+
+The running total persists across every call — including calls that arrive through `math::add_two_numbers`.
+
+## 7. Add HTTP endpoints
+
+Now let's add an HTTP worker to expose your functions as REST endpoints.
+
+From the folder containing iii's `config.yaml` run:
+
+```bash
+iii worker add iii-http
+```
+
+Open `workers/caller-worker/src/worker.ts` and uncomment the trigger registrations at the bottom of the file:
+
+```typescript
+iii.registerTrigger({
+  type: 'http',
+  function_id: 'math::add',
+  config: { api_path: '/math/add', http_method: 'POST' },
+});
+iii.registerTrigger({
+  type: 'http',
+  function_id: 'math::add_two_numbers',
+  config: { api_path: '/math/add-two-numbers', http_method: 'POST' },
+});
+```
+
+Restart the TypeScript worker (stop it with `Ctrl+C` and re-run `iii worker add ./workers/caller-worker`), then call both endpoints with curl:
+
+```bash
+curl -X POST http://localhost:3111/math/add \
+  -H 'Content-Type: application/json' \
+  -d '{"a": 4, "b": 6}'
+```
+
+```json
+{ "c": 10, "running_total": 45 }
+```
+
+```bash
+curl -X POST http://localhost:3111/math/add-two-numbers \
+  -H 'Content-Type: application/json' \
+  -d '{"a": 100, "b": 200}'
+```
+
+```json
+{ "c": 300, "running_total": 345 }
+```
+
+The same functions that respond to `iii trigger` now also respond to HTTP requests with no code changes to the handlers themselves.
+
+## 8. How it works
 
 ### Python worker
 
@@ -178,20 +280,28 @@ scripts:
 ┌──────────────┐          ┌──────────────────┐
 │  iii trigger  │◀────────▶│    iii engine     │
 │  (CLI)        │   WS     │   :49134          │
-└──────────────┘          └──────┬───────┬────┘
-                                 │       │
-                          WS     │       │  WS
-                                 ▼       ▼
-                        ┌────────────┐  ┌──────────────┐
-                        │math-worker │  │caller-worker │
-                        │(Python)    │  │(TypeScript)  │
-                        │math::add   │  │math::add_two │
-                        │            │  │  _numbers    │
-                        └────────────┘  └──────────────┘
+└──────────────┘          └──┬────┬────┬────┬─┘
+                             │    │    │    │
+┌──────────────┐     WS     │    │    │    │
+│  curl / HTTP  │◀──:3111──▶│    │    │    │
+└──────────────┘            │    │    │    │
+                            ▼    ▼    │    │
+               ┌────────────┐ ┌──────────────┐
+               │math-worker │ │caller-worker │
+               │(Python)    │ │(TypeScript)  │
+               │math::add   │ │math::add_two │
+               │            │ │  _numbers    │
+               └────────────┘ └──────────────┘
+                            ┌────┘    └────┐
+                            ▼              ▼
+                     ┌──────────┐   ┌──────────┐
+                     │iii-state │   │iii-http  │
+                     │(KV store)│   │(:3111)   │
+                     └──────────┘   └──────────┘
 ```
 
 
-## 7. Explore with the iii Console
+## 9. Explore with the iii Console
 
 Start the console in a new terminal:
 
@@ -209,7 +319,7 @@ Open your browser to [http://localhost:3113/](http://localhost:3113/) to see log
 
 ## Next Steps
 
-You scaffolded a project, started two workers in different languages, and called functions across them through the iii engine.
+You scaffolded a project, started two workers in different languages, called functions across them, added persistent state, and exposed everything over HTTP — all by incrementally adding workers to a running system.
 
 <CardGroup cols={2}>
   <Card title="How to use Functions & Triggers" href="/how-to/use-functions-and-triggers" icon="book-open">

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -3,10 +3,10 @@ title: 'Quickstart'
 description: 'Scaffold a cross-language project and call functions across Python and TypeScript through the iii engine.'
 ---
 
-In this tutorial you will scaffold a cross-language project with the iii, start a Python worker and a TypeScript worker, and call functions across languages through the iii engine.
+In this tutorial you will setup a simple iii project that ...
 
 <Info title="Install iii before proceeding">
-  Make sure you have installed iii before proceeding. If you haven't then visit the [Getting Started](/index#getting-started) guide first.
+  Make sure you have installed iii before proceeding. If you haven't then visit the [Install](/install) guide first.
 </Info>
 
 ## 1. Scaffold the project
@@ -40,16 +40,20 @@ The engine is now listening on `ws://localhost:49134`. Keep this terminal open.
 
 ## 3. Start the Python worker
 
+<Info title="Workers can run anywhere">
+  Workers only need a WebSocket connection to the iii engine. They can run locally, in the cloud, replicated in kubernetes, or anywhere else.
+</Info>
+
 Open a second terminal in the `quickstart` directory and start the first worker:
 
 ```bash
-iii worker dev ./workers/math-worker
+iii worker add ./workers/math-worker
 ```
 
 You should see:
 
 ```
-Math worker started - listening for calls
+math-worker started — registered math::add
 ```
 
 This worker registered the function `math::add` with the engine. You could call this function right now using the command below.
@@ -66,13 +70,13 @@ any functionality into a worker and then seamlessly compose that worker with oth
 Open a third terminal in the `quickstart` directory and start the second worker:
 
 ```bash
-iii worker dev ./workers/caller-worker
+iii worker add ./workers/caller-worker
 ```
 
 You should see:
 
 ```
-Caller worker started - listening for calls
+caller-worker started — registered math::add_two_numbers
 ```
 
 This worker registered the function `math::add_two_numbers` with the engine.
@@ -151,7 +155,7 @@ is running, its language, or anything else.
 ### Worker manifest
 
 Each worker has an `iii.worker.yaml` that describes how to run the worker. Here is the Python worker's manifest.
-While these workers are started with the `iii worker dev` command they do not need to be running alongside the iii
+While these workers are started with the `iii worker add` command they do not need to be running alongside the iii
 instance. These workers can run anywhere and even be replicated. Every worker simply connects to iii over WebSocket.
 iii then handles all routing.
 
@@ -198,6 +202,10 @@ iii console
 Open your browser to [http://localhost:3113/](http://localhost:3113/) to see logs, traces, and runtime state for the running system.
 
 <img src="/images/console/dashboard.png" alt="iii Console dashboard" />
+
+<Tip>
+  See the full [Console documentation](/console) for details on invoking functions, inspecting traces, viewing state, and more.
+</Tip>
 
 ## Next Steps
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -33,15 +33,13 @@ quickstart/
 iii --config config.yaml
 ```
 
-The engine is now listening on `ws://localhost:49134`. Keep this terminal open.
+The engine is now listening on `ws://localhost:49134`. Keep this terminal open and open a second terminal in the `quickstart` directory for the remaining commands.
 
 ## 3. Start the Python worker
 
 <Info title="Workers can run anywhere">
   Workers only need a WebSocket connection to the iii engine. They can run locally, in the cloud, replicated in kubernetes, or anywhere else.
 </Info>
-
-Open a second terminal in the `quickstart` directory and start the first worker:
 
 ```bash
 iii worker add ./workers/math-worker
@@ -68,8 +66,6 @@ any functionality into a worker and then seamlessly compose that worker with oth
 
 ## 4. Start the TypeScript worker
 
-Open a third terminal in the `quickstart` directory and start the second worker:
-
 ```bash
 iii worker add ./workers/caller-worker
 ```
@@ -88,8 +84,7 @@ This worker registered the function `math::add_two_numbers` with the engine.
 
 ## 5. Call across languages
 
-Now open a fourth terminal in the `quickstart` directory and call the TypeScript worker.
-The TypeScript worker will then call the Python worker and return the result:
+Call the TypeScript worker. It will call the Python worker through the engine and return the result:
 
 ```bash
 iii trigger --function-id='math::add_two_numbers' --payload='{"a": 10, "b": 20}'

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -180,7 +180,11 @@ iii.registerFunction(
       function_id: 'math::add_two_numbers',
       payload: payload.body,
     });
-    return { status_code: 200, body: result, headers: { 'Content-Type': 'application/json' } };
+    return {
+      status_code: 200,
+      body: { c: result.c, running_total: result.running_total },
+      headers: { 'Content-Type': 'application/json' },
+    };
   },
 );
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -302,8 +302,8 @@ graph TD
   Engine --> Math["math-worker (Python) math::add"]
   Engine --> Caller["caller-worker (TypeScript) math::add_two_numbers"]
 
-  Math --> State["iii-state (KV store)"]
-  Caller --> HttpWorker["iii-http (:3111)"]
+  Math --> State["iii-state"]
+  Caller --> HttpWorker["iii-http"]
 ```
 
 ## 9. Explore with the iii Console (Optional)

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -316,9 +316,11 @@ scripts:
 ```
 
 
-## 9. Explore with the iii Console
+## 9. Explore with the iii Console (Optional)
 
-Start the console in a new terminal:
+iii contains an interactive web interface to help observe a iii system end to end. It's particularly useful for debugging.
+
+The console can be started in a new terminal:
 
 ```bash
 iii console
@@ -331,6 +333,14 @@ Open your browser to [http://localhost:3113/](http://localhost:3113/) to see log
 <Tip>
   See the full [Console documentation](/console) for details on invoking functions, inspecting traces, viewing state, and more.
 </Tip>
+
+## 10. Add Agent Skills (Optional)
+
+Give your IDEs and AI coding agents full context on iii:
+
+```bash
+npx skillkit add iii-hq/iii/skills
+```
 
 ## Next Steps
 


### PR DESCRIPTION
Replace the thin "scaffold and read the README" page with a self-contained tutorial that walks through scaffolding, starting workers, calling functions across languages, and understanding the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote Quickstart into a concrete cross-language end-to-end walkthrough
  * Added a new Install page and updated Getting Started navigation
  * Added scaffolded project steps, engine startup flow, and CLI worker commands
  * Included Python and TypeScript examples demonstrating cross-language calls and JSON payloads
  * Documented worker manifest fields and added a CLI→engine→workers architecture diagram
  * Reframed console exploration wording and expanded “Next Steps” guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->