### PR TITLE
ci: skip CI pipelines on docs and skills-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,20 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'skills/**'
+      - '**/*.md'
+      - '**/*.mdx'
+      - '.cursor/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'skills/**'
+      - '**/*.md'
+      - '**/*.mdx'
+      - '.cursor/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -3,8 +3,20 @@ name: License Header Check
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'skills/**'
+      - '**/*.md'
+      - '**/*.mdx'
+      - '.cursor/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'skills/**'
+      - '**/*.md'
+      - '**/*.mdx'
+      - '.cursor/**'
 
 jobs:
   check-license-headers:


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to `ci.yml` and `license-check.yml` so that pushes/PRs touching only `docs/`, `skills/`, `.cursor/`, or markdown files (`*.md`, `*.mdx`) skip the full CI pipeline
- `workflow_dispatch` remains unaffected — manual runs still work regardless of paths
- Other workflows (`generate-api-docs`, `docker-engine`, releases) already have proper path/tag filtering and are unaffected

## Test plan
- [ ] Push a docs-only change to a PR branch and verify CI does not trigger
- [ ] Push a code change alongside docs and verify CI still triggers
- [ ] Verify `workflow_dispatch` still works manually

Resolves MOT-3023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI and license-check workflows to skip running when changes are limited to documentation, certain directories, or configuration files, improving pipeline efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->