### PR TITLE
fix(iii-init): mount /tmp and /run as tmpfs in VM guest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "iii"
-version = "0.11.0-next.6"
+version = "0.11.0-next.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "iii-console"
-version = "0.11.0-next.6"
+version = "0.11.0-next.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -2536,7 +2536,7 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.11.0-next.6"
+version = "0.11.0-next.7"
 dependencies = [
  "async-trait",
  "ctor",

--- a/crates/iii-init/src/mount.rs
+++ b/crates/iii-init/src/mount.rs
@@ -44,6 +44,8 @@ fn mount_ignore_busy(
 /// 4. `/dev/pts` as devpts (MS_NOEXEC | MS_NOSUID | MS_RELATIME)
 /// 5. `/dev/shm` as tmpfs (MS_NOEXEC | MS_NOSUID | MS_RELATIME)
 /// 6. `/dev/fd` symlink to `/proc/self/fd` (if not already present)
+/// 7. `/tmp` as tmpfs (MS_NOSUID | MS_NODEV | MS_RELATIME, mode=1777)
+/// 8. `/run` as tmpfs (MS_NOSUID | MS_NODEV | MS_RELATIME, mode=755)
 pub fn mount_filesystems() -> Result<(), InitError> {
     let nodev_noexec_nosuid =
         MsFlags::MS_NODEV | MsFlags::MS_NOEXEC | MsFlags::MS_NOSUID | MsFlags::MS_RELATIME;
@@ -107,7 +109,28 @@ pub fn mount_filesystems() -> Result<(), InitError> {
         })?;
     }
 
-    // 7. /sys/fs/cgroup -- cgroup2 (best-effort, used for worker memory limits)
+    // 7. /tmp -- tmpfs (real kernel tmpfs so Unix domain sockets work;
+    //    the rootfs passthrough filesystem does not implement mknod)
+    mkdir_ignore_exists("/tmp")?;
+    mount_ignore_busy(
+        Some("tmpfs"),
+        "/tmp",
+        Some("tmpfs"),
+        MsFlags::MS_NOSUID | MsFlags::MS_NODEV | MsFlags::MS_RELATIME,
+        Some("mode=1777"),
+    )?;
+
+    // 8. /run -- tmpfs (runtime scratch space)
+    mkdir_ignore_exists("/run")?;
+    mount_ignore_busy(
+        Some("tmpfs"),
+        "/run",
+        Some("tmpfs"),
+        MsFlags::MS_NOSUID | MsFlags::MS_NODEV | MsFlags::MS_RELATIME,
+        Some("mode=755"),
+    )?;
+
+    // 9. /sys/fs/cgroup -- cgroup2 (best-effort, used for worker memory limits)
     mount_cgroup2().ok();
 
     Ok(())
@@ -185,6 +208,27 @@ mod tests {
             sysfs_pos < devpts_pos,
             "sysfs must be mounted before devpts"
         );
+    }
+
+    #[test]
+    fn test_tmpfs_mounts_after_dev_fd() {
+        // /tmp and /run tmpfs must come after /dev/fd symlink.
+        let source = include_str!("mount.rs");
+        let symlink_pos = source
+            .find("// 6. /dev/fd -> /proc/self/fd")
+            .expect("/dev/fd symlink comment not found");
+        let tmp_pos = source
+            .find("// 7. /tmp -- tmpfs")
+            .expect("/tmp mount comment not found");
+        let run_pos = source
+            .find("// 8. /run -- tmpfs")
+            .expect("/run mount comment not found");
+
+        assert!(
+            symlink_pos < tmp_pos,
+            "/dev/fd symlink must precede /tmp mount"
+        );
+        assert!(tmp_pos < run_pos, "/tmp must be mounted before /run");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Mount `/tmp` as tmpfs (`mode=1777`) so Unix domain sockets work inside the VM — the rootfs passthrough filesystem does not implement `mknod`
- Mount `/run` as tmpfs (`mode=755`) for runtime scratch space
- Add ordering test to ensure `/tmp` and `/run` mounts come after `/dev/fd` symlink

## Test plan
- [ ] `cargo test -p iii-init` passes (mount ordering tests)
- [ ] VM boots and Node/Python workers can create Unix domain sockets on `/tmp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * System initialization now properly mounts temporary filesystem directories with appropriate security configurations during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->