### PR TITLE
fix(iii-worker): surface and stop orphan workers

### DIFF
--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -691,6 +691,240 @@ pub async fn kill_stale_worker(worker_name: &str) {
     }
 }
 
+/// Returns worker names discovered from on-disk runtime state under `~/.iii`.
+///
+/// Sources scanned:
+/// - `~/.iii/managed/{name}/`     -- OCI/VM and local-path workers
+/// - `~/.iii/pids/{name}.pid`     -- binary workers
+///
+/// Names are returned sorted and deduplicated. This is the union of every
+/// worker the local runtime has touched, regardless of which `config.yaml`
+/// declared them. Used by `iii worker list` to surface orphan workers whose
+/// project folder has moved or been deleted.
+pub fn discover_disk_worker_names() -> Vec<String> {
+    let home = dirs::home_dir().unwrap_or_default();
+    discover_disk_worker_names_in(&home.join(".iii/managed"), &home.join(".iii/pids"))
+}
+
+/// Path-injectable variant of [`discover_disk_worker_names`] for testing.
+fn discover_disk_worker_names_in(
+    managed_dir: &std::path::Path,
+    pids_dir: &std::path::Path,
+) -> Vec<String> {
+    use std::collections::BTreeSet;
+    let mut names = BTreeSet::new();
+
+    if let Ok(entries) = std::fs::read_dir(managed_dir) {
+        for entry in entries.flatten() {
+            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false)
+                && let Some(name) = entry.file_name().to_str()
+            {
+                names.insert(name.to_string());
+            }
+        }
+    }
+
+    if let Ok(entries) = std::fs::read_dir(pids_dir) {
+        for entry in entries.flatten() {
+            if let Some(file_name) = entry.file_name().to_str()
+                && let Some(name) = file_name.strip_suffix(".pid")
+                && !name.is_empty()
+            {
+                names.insert(name.to_string());
+            }
+        }
+    }
+
+    names.into_iter().collect()
+}
+
+/// Discovers worker names by inspecting live process command lines for
+/// processes spawned by iii-worker. Catches the case where a worker is alive
+/// but its on-disk PID file has been removed (project folder moved/deleted,
+/// manual cleanup, or a crashed `iii worker stop`).
+///
+/// Two process patterns are recognised:
+/// 1. Binary workers — executable is `~/.iii/workers/{name}`.
+/// 2. OCI/VM workers — `iii-worker __vm-boot --pid-file ~/.iii/managed/{name}/vm.pid ...`.
+///
+/// Sources by platform:
+/// - Linux: walks `/proc/*/cmdline` (works on every kernel including
+///   Alpine/busybox where `ps -o args=` is unreliable).
+/// - macOS: shells out to `ps -axww -o pid=,args=`.
+/// - Other platforms: returns empty (best-effort supplement to disk discovery).
+pub fn discover_running_worker_names_from_ps() -> Vec<String> {
+    let processes = collect_processes();
+    if processes.is_empty() {
+        return Vec::new();
+    }
+    let home = dirs::home_dir().unwrap_or_default();
+    let workers_prefix = home.join(".iii/workers");
+    let managed_prefix = home.join(".iii/managed");
+    let cmdlines: Vec<String> = processes.into_iter().map(|(_, c)| c).collect();
+    discover_running_worker_names_from_ps_output(
+        &cmdlines.join("\n"),
+        &workers_prefix,
+        &managed_prefix,
+    )
+}
+
+/// Returns the live PID of the iii-worker process associated with `name`, by
+/// scanning live process command lines. Used by `iii worker stop` to terminate
+/// orphan workers whose pidfiles have been removed.
+///
+/// Returns `None` when no matching process exists, when the platform has no
+/// process enumeration support, or when `ps`/`/proc` access is denied.
+pub fn find_worker_pid_from_ps(name: &str) -> Option<u32> {
+    let processes = collect_processes();
+    if processes.is_empty() {
+        return None;
+    }
+    let home = dirs::home_dir().unwrap_or_default();
+    let workers_prefix = home.join(".iii/workers");
+    let managed_prefix = home.join(".iii/managed");
+    find_worker_pid_in_processes(&processes, name, &workers_prefix, &managed_prefix)
+}
+
+/// Linux: read every numeric `/proc/<pid>/cmdline`. Each is NUL-separated
+/// argv0\0argv1\0...\0; we replace NULs with spaces so the shared parser
+/// can tokenise it the same way as `ps` output.
+#[cfg(target_os = "linux")]
+fn collect_processes() -> Vec<(u32, String)> {
+    let mut out = Vec::new();
+    let entries = match std::fs::read_dir("/proc") {
+        Ok(e) => e,
+        Err(_) => return out,
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = match name.to_str() {
+            Some(s) => s,
+            None => continue,
+        };
+        let pid: u32 = match name_str.parse() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        let bytes = match std::fs::read(entry.path().join("cmdline")) {
+            Ok(b) if !b.is_empty() => b,
+            _ => continue,
+        };
+        let line = String::from_utf8_lossy(&bytes).replace('\0', " ");
+        let trimmed = line.trim_end();
+        if !trimmed.is_empty() {
+            out.push((pid, trimmed.to_string()));
+        }
+    }
+    out
+}
+
+/// macOS: BSD `ps` exposes full argv via `-o args=`; `-axww` selects all
+/// processes and disables column truncation. `pid=` keeps the pid column
+/// without a header so we can split the first whitespace-separated token off.
+#[cfg(target_os = "macos")]
+fn collect_processes() -> Vec<(u32, String)> {
+    let output = match std::process::Command::new("ps")
+        .args(["-axww", "-o", "pid=,args="])
+        .output()
+    {
+        Ok(o) if o.status.success() => o.stdout,
+        _ => return Vec::new(),
+    };
+    String::from_utf8_lossy(&output)
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim_start();
+            let mut split = line.splitn(2, char::is_whitespace);
+            let pid: u32 = split.next()?.parse().ok()?;
+            let args = split.next()?.trim();
+            if args.is_empty() {
+                None
+            } else {
+                Some((pid, args.to_string()))
+            }
+        })
+        .collect()
+}
+
+/// Other platforms: no cross-platform process enumeration without a new dep.
+/// Disk discovery still runs; we just lose the alive-but-no-pidfile fallback.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn collect_processes() -> Vec<(u32, String)> {
+    Vec::new()
+}
+
+/// From a single process's `argv`-joined cmdline, return the worker name it
+/// represents (if any). Shared between name discovery and PID lookup so both
+/// match against the exact same recognition rules.
+fn extract_worker_name_from_cmdline(
+    cmdline: &str,
+    workers_prefix: &std::path::Path,
+    managed_prefix: &std::path::Path,
+) -> Option<String> {
+    let mut tokens = cmdline.split_whitespace();
+    let exe = tokens.next()?;
+    let exe_path = std::path::Path::new(exe);
+
+    // Pattern 1: binary worker -- executable lives under ~/.iii/workers/{name}
+    if let Ok(rel) = exe_path.strip_prefix(workers_prefix)
+        && let Some(name) = rel.iter().next().and_then(|c| c.to_str())
+        && !name.is_empty()
+    {
+        return Some(name.to_string());
+    }
+
+    // Pattern 2: iii-worker __vm-boot --pid-file <...>/managed/{name}/vm.pid
+    if exe_path.file_name().and_then(|s| s.to_str()) == Some("iii-worker")
+        && tokens.next() == Some("__vm-boot")
+    {
+        let rest: Vec<&str> = tokens.collect();
+        for i in 0..rest.len().saturating_sub(1) {
+            if rest[i] == "--pid-file"
+                && let Ok(rel) = std::path::Path::new(rest[i + 1]).strip_prefix(managed_prefix)
+                && let Some(name) = rel.iter().next().and_then(|c| c.to_str())
+                && !name.is_empty()
+            {
+                return Some(name.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Pure parser used by [`discover_running_worker_names_from_ps`]. Exposed for
+/// testing with synthetic cmdline output and arbitrary path prefixes. Each
+/// input line is one process's argv joined by spaces.
+fn discover_running_worker_names_from_ps_output(
+    ps_output: &str,
+    workers_prefix: &std::path::Path,
+    managed_prefix: &std::path::Path,
+) -> Vec<String> {
+    use std::collections::BTreeSet;
+    let mut names = BTreeSet::new();
+    for line in ps_output.lines() {
+        if let Some(name) = extract_worker_name_from_cmdline(line, workers_prefix, managed_prefix) {
+            names.insert(name);
+        }
+    }
+    names.into_iter().collect()
+}
+
+/// Pure parser used by [`find_worker_pid_from_ps`]. Returns the first PID
+/// whose cmdline resolves to `name`. Exposed for testing.
+fn find_worker_pid_in_processes(
+    processes: &[(u32, String)],
+    name: &str,
+    workers_prefix: &std::path::Path,
+    managed_prefix: &std::path::Path,
+) -> Option<u32> {
+    processes.iter().find_map(|(pid, cmdline)| {
+        match extract_worker_name_from_cmdline(cmdline, workers_prefix, managed_prefix) {
+            Some(n) if n == name => Some(*pid),
+            _ => None,
+        }
+    })
+}
+
 /// Returns `true` if the worker has a valid PID file and the process is alive.
 pub fn is_worker_running(worker_name: &str) -> bool {
     let home = dirs::home_dir().unwrap_or_default();
@@ -835,76 +1069,138 @@ pub async fn handle_managed_stop(worker_name: &str, _address: &str, _port: u16) 
         return 1;
     }
     let home = dirs::home_dir().unwrap_or_default();
+    let oci_pidfile = home.join(".iii/managed").join(worker_name).join("vm.pid");
+    let bin_pidfile = home.join(".iii/pids").join(format!("{}.pid", worker_name));
 
-    let (pid_file, is_oci) = match super::config_file::resolve_worker_type(worker_name) {
-        ResolvedWorkerType::Oci { .. } | ResolvedWorkerType::Local { .. } => {
-            let f = home.join(".iii/managed").join(worker_name).join("vm.pid");
-            if !f.exists() {
+    // Reject the well-defined "config worker explicitly listed in config.yaml"
+    // case -- the engine owns those, the worker CLI cannot stop them. We only
+    // reject when the name is genuinely listed in config; the resolver also
+    // returns Config as the no-match fallthrough, which we want to treat as
+    // an orphan candidate instead.
+    let in_config_yaml = super::config_file::list_worker_names()
+        .iter()
+        .any(|n| n == worker_name);
+    if in_config_yaml
+        && matches!(
+            super::config_file::resolve_worker_type(worker_name),
+            ResolvedWorkerType::Config
+        )
+    {
+        eprintln!(
+            "{} Cannot stop '{}': config workers run inside the engine and cannot be stopped individually",
+            "error:".red(),
+            worker_name
+        );
+        return 1;
+    }
+
+    // Locate the worker's PID via three evidence tiers, in order:
+    // 1. ~/.iii/managed/{name}/vm.pid       (OCI/VM/local-path)
+    // 2. ~/.iii/pids/{name}.pid             (binary)
+    // 3. live `ps` scan                     (orphan with cleaned-up pidfile)
+    let mode = if oci_pidfile.exists() {
+        match read_pid(&oci_pidfile) {
+            Some(pid) => StopMode::Managed {
+                pid,
+                pidfile: Some(oci_pidfile),
+            },
+            None => {
                 eprintln!("{} Worker '{}' is not running", "error:".red(), worker_name);
                 return 1;
             }
-            (f, true)
         }
-        ResolvedWorkerType::Config => {
-            eprintln!(
-                "{} Cannot stop '{}': config workers run inside the engine and cannot be stopped individually",
-                "error:".red(),
-                worker_name
-            );
-            return 1;
-        }
-        ResolvedWorkerType::Binary { .. } => {
-            let f = home.join(".iii/pids").join(format!("{}.pid", worker_name));
-            if !f.exists() {
-                eprintln!(
-                    "{} Worker '{}' is not running. Start it with 'iii worker start {}'",
-                    "error:".red(),
-                    worker_name,
-                    worker_name
-                );
+    } else if bin_pidfile.exists() {
+        match read_pid(&bin_pidfile) {
+            Some(pid) => StopMode::Binary {
+                pid,
+                pidfile: Some(bin_pidfile),
+            },
+            None => {
+                eprintln!("{} Worker '{}' is not running", "error:".red(), worker_name);
                 return 1;
             }
-            (f, false)
         }
+    } else if let Some(pid) = find_worker_pid_from_ps(worker_name) {
+        // No pidfile, but a live process matches this name — orphan worker.
+        // Treat as Managed if we still have the managed/ dir, else Binary.
+        let is_managed = home.join(".iii/managed").join(worker_name).is_dir();
+        if is_managed {
+            StopMode::Managed { pid, pidfile: None }
+        } else {
+            StopMode::Binary { pid, pidfile: None }
+        }
+    } else {
+        eprintln!(
+            "{} Worker '{}' is not running. Start it with 'iii worker start {}'",
+            "error:".red(),
+            worker_name,
+            worker_name
+        );
+        return 1;
     };
 
-    match std::fs::read_to_string(&pid_file) {
-        Ok(pid_str) => {
-            let pid = pid_str.trim();
-            eprintln!("  Stopping {}...", worker_name.bold());
-            if is_oci {
-                let adapter = super::worker_manager::create_adapter("libkrun");
-                let _ = adapter.stop(pid, 10).await;
-            } else {
-                // Kill binary worker process directly
-                if let Ok(pid_num) = pid.parse::<i32>() {
-                    #[cfg(unix)]
-                    {
-                        use nix::sys::signal::{Signal, kill};
-                        use nix::unistd::Pid;
-                        let _ = kill(Pid::from_raw(pid_num), Signal::SIGTERM);
-                        // Wait briefly then SIGKILL if still alive
-                        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-                        let _ = kill(Pid::from_raw(pid_num), Signal::SIGKILL);
-                    }
-                    #[cfg(not(unix))]
-                    {
-                        let _ = pid_num; // suppress unused warning
-                        eprintln!(
-                            "{} Binary worker stop not supported on this platform",
-                            "error:".red()
-                        );
-                    }
-                }
+    eprintln!("  Stopping {}...", worker_name.bold());
+
+    match mode {
+        StopMode::Managed { pid, pidfile } => {
+            let adapter = super::worker_manager::create_adapter("libkrun");
+            let _ = adapter.stop(&pid.to_string(), 10).await;
+            if let Some(f) = pidfile {
+                let _ = std::fs::remove_file(&f);
             }
-            let _ = std::fs::remove_file(&pid_file);
-            eprintln!("  {} {} stopped", "✓".green(), worker_name.bold());
-            0
         }
-        Err(_) => {
-            eprintln!("{} Worker '{}' is not running", "error:".red(), worker_name);
-            1
+        StopMode::Binary { pid, pidfile } => {
+            kill_pid_with_grace(pid).await;
+            if let Some(f) = pidfile {
+                let _ = std::fs::remove_file(&f);
+            }
         }
+    }
+
+    eprintln!("  {} {} stopped", "✓".green(), worker_name.bold());
+    0
+}
+
+/// Internal stop dispatch. The path the PID was discovered through dictates
+/// how we terminate it (libkrun adapter for VMs, raw signals for binaries) and
+/// whether we have an on-disk pidfile to clean up afterwards.
+enum StopMode {
+    Managed {
+        pid: u32,
+        pidfile: Option<std::path::PathBuf>,
+    },
+    Binary {
+        pid: u32,
+        pidfile: Option<std::path::PathBuf>,
+    },
+}
+
+/// Reads a PID file, returning `Some(pid)` when contents parse as `u32`.
+fn read_pid(path: &std::path::Path) -> Option<u32> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+}
+
+/// SIGTERM, brief grace period, then SIGKILL. Mirrors the original
+/// binary-worker stop semantics. No-op on platforms without nix signals.
+async fn kill_pid_with_grace(pid: u32) {
+    #[cfg(unix)]
+    {
+        use nix::sys::signal::{Signal, kill};
+        use nix::unistd::Pid;
+        let target = Pid::from_raw(pid as i32);
+        let _ = kill(target, Signal::SIGTERM);
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        let _ = kill(target, Signal::SIGKILL);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        eprintln!(
+            "{} Direct PID stop not supported on this platform",
+            "error:".red()
+        );
     }
 }
 
@@ -1125,9 +1421,29 @@ async fn start_binary_worker(worker_name: &str, binary_path: &std::path::Path) -
 }
 
 pub async fn handle_worker_list() -> i32 {
-    let names = super::config_file::list_worker_names();
+    let config_names = super::config_file::list_worker_names();
 
-    if names.is_empty() {
+    // Discovery union: on-disk PID files + on-disk managed dirs + live process
+    // table (catches workers whose pidfiles were removed but the process kept
+    // running -- the actual repro from the user's bug report).
+    let disk_names = discover_disk_worker_names();
+    let ps_names = discover_running_worker_names_from_ps();
+    let ps_set: std::collections::HashSet<String> = ps_names.iter().cloned().collect();
+    let config_set: std::collections::HashSet<&str> =
+        config_names.iter().map(String::as_str).collect();
+
+    // Orphan = not in current ./config.yaml AND demonstrably alive (either via
+    // pidfile signal-0 check or because we just saw it in `ps`). Dead disk-only
+    // entries are stale runtime state, not what the user is asking about.
+    let candidate_names: std::collections::BTreeSet<String> =
+        disk_names.into_iter().chain(ps_names.into_iter()).collect();
+    let orphan_names: Vec<String> = candidate_names
+        .into_iter()
+        .filter(|n| !config_set.contains(n.as_str()))
+        .filter(|n| ps_set.contains(n) || is_worker_running(n))
+        .collect();
+
+    if config_names.is_empty() && orphan_names.is_empty() {
         eprintln!("  No workers. Use `iii worker add` to get started.");
         return 0;
     }
@@ -1148,7 +1464,7 @@ pub async fn handle_worker_list() -> i32 {
         "------".dimmed()
     );
 
-    for name in &names {
+    for name in &config_names {
         let worker_type = match super::config_file::resolve_worker_type(name) {
             ResolvedWorkerType::Local { .. } => "local",
             ResolvedWorkerType::Oci { .. } => "oci",
@@ -1166,8 +1482,54 @@ pub async fn handle_worker_list() -> i32 {
 
         eprintln!("  {:25} {:10} {}", name, worker_type.dimmed(), running);
     }
+
+    // Orphans: alive on this machine but absent from the current ./config.yaml.
+    // The TYPE column is inferred from the on-disk evidence we found the worker
+    // through (managed dir vs binary pidfile/exe). Falls back to "?" only when
+    // a worker was discovered solely via `ps` and no on-disk artifact remains.
+    for name in &orphan_names {
+        let home = dirs::home_dir().unwrap_or_default();
+        let worker_type = resolve_orphan_type(
+            name,
+            &home.join(".iii/managed"),
+            &home.join(".iii/pids"),
+            &home.join(".iii/workers"),
+        );
+        eprintln!(
+            "  {:25} {:10} {}",
+            name,
+            worker_type.dimmed(),
+            "orphan".yellow()
+        );
+    }
+
     eprintln!();
     0
+}
+
+/// Infers the TYPE label for an orphan worker from on-disk evidence alone.
+///
+/// We can't rebuild the `ResolvedWorkerType` enum without a config entry, but
+/// we can tell `managed` (OCI/VM/local-path -- shares a directory shape) from
+/// `binary` (single executable + sidecar pidfile) just from where the artifact
+/// lives. Returns "?" when only a `ps` match exists and every artifact has been
+/// cleaned up under it -- the honest answer.
+///
+/// Path arguments are injected to keep the function unit-testable against a
+/// tempdir without an env override.
+fn resolve_orphan_type(
+    name: &str,
+    managed_dir: &std::path::Path,
+    pids_dir: &std::path::Path,
+    workers_dir: &std::path::Path,
+) -> &'static str {
+    if managed_dir.join(name).is_dir() {
+        return "managed";
+    }
+    if pids_dir.join(format!("{}.pid", name)).is_file() || workers_dir.join(name).is_file() {
+        return "binary";
+    }
+    "?"
 }
 
 /// Pick the log directory with the most recently modified, non-empty log file.
@@ -1568,6 +1930,215 @@ mod tests {
         std::fs::write(dir.path().join("a.txt"), "hello").unwrap(); // 5 bytes
         std::fs::write(dir.path().join("b.txt"), "world!").unwrap(); // 6 bytes
         assert_eq!(dir_size(dir.path()), 11);
+    }
+
+    #[test]
+    fn discover_disk_worker_names_unions_managed_and_pids() {
+        let dir = tempfile::tempdir().unwrap();
+        let managed = dir.path().join("managed");
+        let pids = dir.path().join("pids");
+        std::fs::create_dir_all(managed.join("alpha")).unwrap();
+        std::fs::create_dir_all(managed.join("beta")).unwrap();
+        std::fs::create_dir_all(&pids).unwrap();
+        std::fs::write(pids.join("gamma.pid"), "1234").unwrap();
+        // Overlap: same name appears in both sources -> deduped.
+        std::fs::write(pids.join("alpha.pid"), "5678").unwrap();
+
+        let names = discover_disk_worker_names_in(&managed, &pids);
+        assert_eq!(names, vec!["alpha", "beta", "gamma"]);
+    }
+
+    #[test]
+    fn discover_disk_worker_names_handles_missing_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let names = discover_disk_worker_names_in(
+            &dir.path().join("nope-managed"),
+            &dir.path().join("nope-pids"),
+        );
+        assert!(names.is_empty());
+    }
+
+    #[test]
+    fn discover_disk_worker_names_skips_non_pid_files_and_loose_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let managed = dir.path().join("managed");
+        let pids = dir.path().join("pids");
+        std::fs::create_dir_all(managed.join("alpha")).unwrap();
+        // Loose file under managed/ is not a worker dir, must be skipped.
+        std::fs::write(managed.join("README.md"), "").unwrap();
+        std::fs::create_dir_all(&pids).unwrap();
+        std::fs::write(pids.join("beta.pid"), "1").unwrap();
+        // Non-.pid files under pids/ must be skipped.
+        std::fs::write(pids.join("notes.txt"), "").unwrap();
+        // Empty-name guard: a bare ".pid" file must not yield "".
+        std::fs::write(pids.join(".pid"), "").unwrap();
+
+        let names = discover_disk_worker_names_in(&managed, &pids);
+        assert_eq!(names, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn discover_running_from_ps_finds_binary_workers() {
+        let workers = std::path::PathBuf::from("/home/u/.iii/workers");
+        let managed = std::path::PathBuf::from("/home/u/.iii/managed");
+        let ps = "\
+/home/u/.iii/workers/image-resize\n\
+/usr/bin/zsh\n\
+/home/u/.iii/workers/another-binary --flag\n";
+        let names = discover_running_worker_names_from_ps_output(ps, &workers, &managed);
+        assert_eq!(names, vec!["another-binary", "image-resize"]);
+    }
+
+    #[test]
+    fn discover_running_from_ps_finds_vm_boot_workers() {
+        let workers = std::path::PathBuf::from("/home/u/.iii/workers");
+        let managed = std::path::PathBuf::from("/home/u/.iii/managed");
+        // Real-world cmdline shape from ~/.local/bin/iii-worker __vm-boot.
+        let ps = "\
+/home/u/.local/bin/iii-worker __vm-boot --rootfs /home/u/.iii/managed/todo-worker-python/rootfs --exec todo-worker --workdir /app --pid-file /home/u/.iii/managed/todo-worker-python/vm.pid --env FOO=bar\n\
+/home/u/.local/bin/iii-worker __vm-boot --pid-file /home/u/.iii/managed/postgres/vm.pid --rootfs /home/u/.iii/managed/postgres/rootfs\n";
+        let names = discover_running_worker_names_from_ps_output(ps, &workers, &managed);
+        assert_eq!(names, vec!["postgres", "todo-worker-python"]);
+    }
+
+    #[test]
+    fn discover_running_from_ps_dedups_across_patterns() {
+        let workers = std::path::PathBuf::from("/h/.iii/workers");
+        let managed = std::path::PathBuf::from("/h/.iii/managed");
+        // Same name via both binary and vm-boot patterns -> single entry.
+        let ps = "\
+/h/.iii/workers/dual\n\
+/h/.local/bin/iii-worker __vm-boot --pid-file /h/.iii/managed/dual/vm.pid\n";
+        let names = discover_running_worker_names_from_ps_output(ps, &workers, &managed);
+        assert_eq!(names, vec!["dual"]);
+    }
+
+    #[test]
+    fn discover_running_from_ps_ignores_unrelated_processes_and_malformed_input() {
+        let workers = std::path::PathBuf::from("/h/.iii/workers");
+        let managed = std::path::PathBuf::from("/h/.iii/managed");
+        let ps = "\
+\n\
+   \n\
+/usr/bin/python\n\
+/h/.local/bin/iii-worker __serve\n\
+/h/.local/bin/iii-worker __vm-boot --rootfs /h/.iii/managed/x/rootfs\n\
+/h/.local/bin/iii-worker __vm-boot --pid-file\n\
+/h/.local/bin/iii-worker __vm-boot --pid-file /elsewhere/vm.pid\n";
+        // No `--pid-file <path>` matching managed prefix → no orphans found.
+        let names = discover_running_worker_names_from_ps_output(ps, &workers, &managed);
+        assert!(names.is_empty(), "got unexpected names: {names:?}");
+    }
+
+    #[test]
+    fn discover_running_from_proc_style_cmdlines() {
+        // Simulates Linux /proc/<pid>/cmdline shape: NULs → spaces → joined
+        // with newlines exactly the way collect_cmdlines() produces. Verifies
+        // the parser is identical regardless of source platform.
+        let workers = std::path::PathBuf::from("/h/.iii/workers");
+        let managed = std::path::PathBuf::from("/h/.iii/managed");
+        let proc_like = [
+            "/h/.iii/workers/image-resize",
+            "/h/.local/bin/iii-worker __vm-boot --pid-file /h/.iii/managed/todo/vm.pid --rootfs /h/.iii/managed/todo/rootfs",
+            "/usr/bin/python3 server.py",
+        ]
+        .join("\n");
+        let names = discover_running_worker_names_from_ps_output(&proc_like, &workers, &managed);
+        assert_eq!(names, vec!["image-resize", "todo"]);
+    }
+
+    #[test]
+    fn find_worker_pid_returns_first_matching_process() {
+        let workers = std::path::PathBuf::from("/h/.iii/workers");
+        let managed = std::path::PathBuf::from("/h/.iii/managed");
+        let processes = vec![
+            (12, "/usr/bin/zsh".to_string()),
+            (
+                42,
+                "/h/.local/bin/iii-worker __vm-boot --pid-file /h/.iii/managed/todo/vm.pid"
+                    .to_string(),
+            ),
+            (77, "/h/.iii/workers/image-resize".to_string()),
+        ];
+        assert_eq!(
+            find_worker_pid_in_processes(&processes, "todo", &workers, &managed),
+            Some(42)
+        );
+        assert_eq!(
+            find_worker_pid_in_processes(&processes, "image-resize", &workers, &managed),
+            Some(77)
+        );
+        assert_eq!(
+            find_worker_pid_in_processes(&processes, "no-such-worker", &workers, &managed),
+            None
+        );
+    }
+
+    #[test]
+    fn find_worker_pid_returns_none_for_empty_input() {
+        let workers = std::path::PathBuf::from("/h/.iii/workers");
+        let managed = std::path::PathBuf::from("/h/.iii/managed");
+        assert_eq!(
+            find_worker_pid_in_processes(&[], "anything", &workers, &managed),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_orphan_type_managed_takes_priority() {
+        let tmp = tempfile::tempdir().unwrap();
+        let managed = tmp.path().join("managed");
+        let pids = tmp.path().join("pids");
+        let workers = tmp.path().join("workers");
+        std::fs::create_dir_all(managed.join("dual")).unwrap();
+        std::fs::create_dir_all(&pids).unwrap();
+        std::fs::write(pids.join("dual.pid"), "1").unwrap();
+        // managed/ wins because the directory shape carries more information
+        // (rootfs, logs, etc.) than a bare pidfile.
+        assert_eq!(
+            resolve_orphan_type("dual", &managed, &pids, &workers),
+            "managed"
+        );
+    }
+
+    #[test]
+    fn resolve_orphan_type_binary_via_pidfile() {
+        let tmp = tempfile::tempdir().unwrap();
+        let managed = tmp.path().join("managed");
+        let pids = tmp.path().join("pids");
+        let workers = tmp.path().join("workers");
+        std::fs::create_dir_all(&pids).unwrap();
+        std::fs::write(pids.join("img-resize.pid"), "1234").unwrap();
+        assert_eq!(
+            resolve_orphan_type("img-resize", &managed, &pids, &workers),
+            "binary"
+        );
+    }
+
+    #[test]
+    fn resolve_orphan_type_binary_via_workers_executable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let managed = tmp.path().join("managed");
+        let pids = tmp.path().join("pids");
+        let workers = tmp.path().join("workers");
+        std::fs::create_dir_all(&workers).unwrap();
+        std::fs::write(workers.join("img-resize"), b"#!/bin/sh\n").unwrap();
+        // No pidfile, only the executable -- still recognisable as binary.
+        assert_eq!(
+            resolve_orphan_type("img-resize", &managed, &pids, &workers),
+            "binary"
+        );
+    }
+
+    #[test]
+    fn resolve_orphan_type_unknown_when_only_ps_evidence() {
+        let tmp = tempfile::tempdir().unwrap();
+        let managed = tmp.path().join("managed");
+        let pids = tmp.path().join("pids");
+        let workers = tmp.path().join("workers");
+        // Nothing on disk under any of the three roots: a worker that is alive
+        // in ps but has had every artifact cleaned up. Honest answer is "?".
+        assert_eq!(resolve_orphan_type("ghost", &managed, &pids, &workers), "?");
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -1097,37 +1097,53 @@ pub async fn handle_managed_stop(worker_name: &str, _address: &str, _port: u16) 
     // Locate the worker's PID via three evidence tiers, in order:
     // 1. ~/.iii/managed/{name}/vm.pid       (OCI/VM/local-path)
     // 2. ~/.iii/pids/{name}.pid             (binary)
-    // 3. live `ps` scan                     (orphan with cleaned-up pidfile)
-    let mode = if oci_pidfile.exists() {
-        match read_pid(&oci_pidfile) {
-            Some(pid) => StopMode::Managed {
-                pid,
-                pidfile: Some(oci_pidfile),
-            },
-            None => {
-                eprintln!("{} Worker '{}' is not running", "error:".red(), worker_name);
-                return 1;
-            }
+    // 3. live `ps` scan                     (orphan, or stale pidfile)
+    //
+    // Pidfiles are only trusted when the recorded PID is actually alive. A
+    // stale pidfile (process crashed without cleanup, or PID got recycled)
+    // must fall through to the ps scan — otherwise we'd either signal an
+    // unrelated recycled PID or miss a restarted orphan worker.
+    let oci_live_pid = oci_pidfile
+        .exists()
+        .then(|| read_pid(&oci_pidfile).filter(|&p| is_pid_alive(p)))
+        .flatten();
+    let bin_live_pid = bin_pidfile
+        .exists()
+        .then(|| read_pid(&bin_pidfile).filter(|&p| is_pid_alive(p)))
+        .flatten();
+
+    let mode = if let Some(pid) = oci_live_pid {
+        StopMode::Managed {
+            pid,
+            pidfile: Some(oci_pidfile),
         }
-    } else if bin_pidfile.exists() {
-        match read_pid(&bin_pidfile) {
-            Some(pid) => StopMode::Binary {
-                pid,
-                pidfile: Some(bin_pidfile),
-            },
-            None => {
-                eprintln!("{} Worker '{}' is not running", "error:".red(), worker_name);
-                return 1;
-            }
+    } else if let Some(pid) = bin_live_pid {
+        StopMode::Binary {
+            pid,
+            pidfile: Some(bin_pidfile),
         }
     } else if let Some(pid) = find_worker_pid_from_ps(worker_name) {
-        // No pidfile, but a live process matches this name — orphan worker.
-        // Treat as Managed if we still have the managed/ dir, else Binary.
+        // Either no pidfile on disk, or the pidfile is stale (dead PID).
+        // Either way, ps found a live process for this worker — treat as
+        // orphan. Carry any stale pidfile along so it gets cleaned up.
+        let stale_pidfile = if oci_pidfile.exists() {
+            Some(oci_pidfile)
+        } else if bin_pidfile.exists() {
+            Some(bin_pidfile)
+        } else {
+            None
+        };
         let is_managed = home.join(".iii/managed").join(worker_name).is_dir();
         if is_managed {
-            StopMode::Managed { pid, pidfile: None }
+            StopMode::Managed {
+                pid,
+                pidfile: stale_pidfile,
+            }
         } else {
-            StopMode::Binary { pid, pidfile: None }
+            StopMode::Binary {
+                pid,
+                pidfile: stale_pidfile,
+            }
         }
     } else {
         eprintln!(
@@ -1180,6 +1196,24 @@ fn read_pid(path: &std::path::Path) -> Option<u32> {
     std::fs::read_to_string(path)
         .ok()
         .and_then(|s| s.trim().parse::<u32>().ok())
+}
+
+/// Returns `true` if `pid` refers to a live process. Uses signal 0 as a
+/// non-destructive existence probe on Unix; assumes alive on platforms
+/// without nix signals (the stop path will discover failure on real kill).
+///
+/// Used by the stop path to distinguish fresh pidfiles from stale ones so
+/// a dead/recycled PID cannot short-circuit the `ps` orphan scan.
+#[cfg(unix)]
+fn is_pid_alive(pid: u32) -> bool {
+    use nix::sys::signal::kill;
+    use nix::unistd::Pid;
+    kill(Pid::from_raw(pid as i32), None).is_ok()
+}
+
+#[cfg(not(unix))]
+fn is_pid_alive(_pid: u32) -> bool {
+    true
 }
 
 /// SIGTERM, brief grace period, then SIGKILL. Mirrors the original

--- a/crates/iii-worker/tests/worker_list_discovery_integration.rs
+++ b/crates/iii-worker/tests/worker_list_discovery_integration.rs
@@ -1,0 +1,227 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at support@motia.dev
+// See LICENSE and PATENTS files for details.
+
+//! Integration tests for orphan-worker discovery in `iii worker list`.
+//!
+//! These tests exercise the public discovery functions
+//! ([`discover_disk_worker_names`], [`discover_running_worker_names_from_ps`])
+//! and the liveness check ([`is_worker_running`]) against a real filesystem
+//! tree under a temporary HOME, using the current test process's PID as a
+//! known-alive sentinel. This is the regression coverage for the bug where
+//! `iii worker list` missed workers whose project folders had moved or whose
+//! PID files had been removed while the process kept running.
+
+use iii_worker::cli::managed::{
+    discover_disk_worker_names, discover_running_worker_names_from_ps, find_worker_pid_from_ps,
+    is_worker_running,
+};
+use std::sync::Mutex;
+
+/// Serializes tests that mutate the HOME env var. HOME is process-global, so
+/// any two tests in this file that override it must run one at a time.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// RAII guard that overrides HOME for the duration of a test and restores the
+/// original value (or removes the var if it was unset) on drop, even if the
+/// test panics.
+struct HomeGuard {
+    original: Option<std::ffi::OsString>,
+}
+
+impl HomeGuard {
+    fn new(path: &std::path::Path) -> Self {
+        let original = std::env::var_os("HOME");
+        // SAFETY: test-only, serialized via ENV_LOCK.
+        unsafe {
+            std::env::set_var("HOME", path);
+        }
+        Self { original }
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        // SAFETY: test-only, serialized via ENV_LOCK.
+        unsafe {
+            match &self.original {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+}
+
+/// Empty `~/.iii` tree → discovery returns nothing. Guards against any latent
+/// assumption that the dirs always exist.
+#[test]
+fn discover_disk_worker_names_empty_home() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::new(tmp.path());
+
+    let names = discover_disk_worker_names();
+    assert!(names.is_empty(), "expected no workers, got {names:?}");
+}
+
+/// Populates a fake `~/.iii` with the two real on-disk shapes
+/// (`managed/{name}/` and `pids/{name}.pid`) and asserts the discovery
+/// function returns the union, sorted and deduplicated.
+#[test]
+fn discover_disk_worker_names_finds_managed_and_pids() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::new(tmp.path());
+
+    // Two OCI/VM-style workers (managed dirs).
+    std::fs::create_dir_all(tmp.path().join(".iii/managed/oci-one")).unwrap();
+    std::fs::create_dir_all(tmp.path().join(".iii/managed/oci-two")).unwrap();
+    // Two binary-style workers (pidfiles), one overlapping with managed/oci-one.
+    let pids_dir = tmp.path().join(".iii/pids");
+    std::fs::create_dir_all(&pids_dir).unwrap();
+    std::fs::write(pids_dir.join("bin-only.pid"), "1234").unwrap();
+    std::fs::write(pids_dir.join("oci-one.pid"), "5678").unwrap();
+
+    let names = discover_disk_worker_names();
+    assert_eq!(names, vec!["bin-only", "oci-one", "oci-two"]);
+}
+
+/// `is_worker_running` must return `true` when the pidfile holds a PID that
+/// is actually alive. The current test process's PID is the simplest
+/// guaranteed-alive sentinel, exercising the real signal-0 path.
+#[test]
+fn is_worker_running_true_for_alive_pid() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::new(tmp.path());
+
+    let pids_dir = tmp.path().join(".iii/pids");
+    std::fs::create_dir_all(&pids_dir).unwrap();
+    let my_pid = std::process::id();
+    std::fs::write(pids_dir.join("alive-worker.pid"), my_pid.to_string()).unwrap();
+
+    assert!(
+        is_worker_running("alive-worker"),
+        "expected alive-worker (pid {my_pid}, this process) to be detected as running"
+    );
+}
+
+/// `is_worker_running` must return `false` for an unmistakably dead PID.
+/// This is the case that produces "stopped" status in `iii worker list` and
+/// excludes a name from the orphan set if it is also missing from config.
+#[test]
+fn is_worker_running_false_for_dead_pid() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::new(tmp.path());
+
+    let pids_dir = tmp.path().join(".iii/pids");
+    std::fs::create_dir_all(&pids_dir).unwrap();
+    // PID well above any plausible live pid on Linux/macOS (PID_MAX defaults
+    // are 32k or 4M; 2_000_000_000 is reliably dead).
+    std::fs::write(pids_dir.join("dead-worker.pid"), "2000000000").unwrap();
+
+    assert!(
+        !is_worker_running("dead-worker"),
+        "expected dead-worker (pid 2_000_000_000) to be detected as stopped"
+    );
+}
+
+/// End-to-end orphan discovery on Linux/macOS: this test process is one of
+/// the live `ps`/`/proc` entries, so its own argv0 should surface through
+/// the cmdline scanner when we point HOME at a fake tree where that argv0
+/// lives under `~/.iii/workers/{name}`.
+///
+/// We don't relocate the binary; we just verify the scanner is wired up and
+/// returns *something* non-empty in normal environments. On platforms with
+/// no implementation (anything other than Linux/macOS) the function returns
+/// an empty Vec, which we accept.
+#[test]
+fn discover_running_from_ps_returns_some_processes() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::new(tmp.path());
+
+    let result = discover_running_worker_names_from_ps();
+
+    if cfg!(any(target_os = "linux", target_os = "macos")) {
+        // Result may be empty if no live processes match the iii-worker
+        // patterns under our fresh fake HOME — that is the correct outcome
+        // for an isolated test environment. The contract under test is that
+        // the call succeeds without panicking and returns a sorted Vec.
+        let mut sorted = result.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(result, sorted, "discovery output must be sorted & deduped");
+    } else {
+        assert!(
+            result.is_empty(),
+            "non-Linux/macOS platforms should return empty, got {result:?}"
+        );
+    }
+}
+
+/// End-to-end orphan PID lookup: stages a real executable at the path the
+/// scanner expects (`<tmp HOME>/.iii/workers/{name}`), spawns it as a child
+/// with a long sleep, and asserts `find_worker_pid_from_ps` returns the
+/// child's PID. This is the regression coverage for `iii worker stop` of
+/// orphan binary workers whose pidfiles have been removed.
+///
+/// Skipped on non-Unix and on platforms without `/bin/sleep`.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn find_worker_pid_from_ps_locates_live_orphan_binary() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::new(tmp.path());
+
+    // Stage an executable at the exact path the scanner uses to recognise
+    // binary workers. Copying /bin/sleep keeps this dependency-free.
+    let workers_dir = tmp.path().join(".iii/workers");
+    std::fs::create_dir_all(&workers_dir).unwrap();
+    let worker_name = format!("test-orphan-{}", std::process::id());
+    let worker_bin = workers_dir.join(&worker_name);
+    std::fs::copy("/bin/sleep", &worker_bin).expect("/bin/sleep must exist on Unix");
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&worker_bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    // Spawn the sentinel with a long-enough sleep to outlive this test.
+    let mut child = std::process::Command::new(&worker_bin)
+        .arg("60")
+        .spawn()
+        .expect("spawn sentinel sleep process");
+
+    // Give the OS a moment to register the new process in /proc or ps.
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    let found = find_worker_pid_from_ps(&worker_name);
+
+    // Always tear down the sentinel before asserting, so a failed assertion
+    // doesn't leak a 60-second sleep.
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert_eq!(
+        found,
+        Some(child.id()),
+        "expected to find sentinel pid {}, got {found:?}",
+        child.id()
+    );
+}
+
+/// Sanity check: if no matching process exists for a fresh, unique name, the
+/// PID lookup must return `None` rather than confidently misidentifying some
+/// unrelated process.
+#[test]
+fn find_worker_pid_from_ps_returns_none_for_unknown_name() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::new(tmp.path());
+
+    let unique = format!("definitely-no-such-worker-{}", std::process::id());
+    assert_eq!(find_worker_pid_from_ps(&unique), None);
+}


### PR DESCRIPTION
## Summary

- `iii worker list` now surfaces workers running on this machine that aren't in the current `./config.yaml` — including the case where their pidfile was removed but the process kept running (parented to init, visible in `ps`, invisible to every prior `list` invocation).
- `iii worker stop <name>` now works on those orphans. No more misleading _"config workers cannot be stopped individually"_ for anything that isn't actually in `config.yaml`.

## Why

The enumeration and lifecycle layers had split sources of truth: `list` read cwd-relative `./config.yaml`, but state lived at machine-global `~/.iii/managed/{name}/` and `~/.iii/pids/{name}.pid`. If you moved or deleted a project folder, its workers vanished from `list` but kept running. `stop` couldn't reach them either.

## What changed

**list** — union discovery:
1. `./config.yaml` (existing)
2. `~/.iii/managed/*/` directories
3. `~/.iii/pids/*.pid` files
4. Live process scan (Linux `/proc/*/cmdline`, macOS `ps -axww -o pid=,args=`)

Orphans (alive but not in current config) render below regular rows with inferred `TYPE` (`managed` / `binary` / `?`) and `STATUS` `orphan`.

**stop** — three-tier evidence resolution:
1. `~/.iii/managed/{name}/vm.pid` → libkrun adapter
2. `~/.iii/pids/{name}.pid` → SIGTERM/grace/SIGKILL
3. Live `ps` scan for the PID → same termination path appropriate to worker kind

Only rejects _"config workers cannot be stopped"_ when the name is **actually listed in `config.yaml`**, not on resolver fallthrough.

Platform handling for the process scan: `/proc` on Linux (works everywhere including Alpine/busybox), `ps` on macOS, empty no-op elsewhere. No new deps.

## Test plan

- [x] `cargo test -p iii-worker` — 476 passed, 22 suites
- [x] Unit tests (9 new): parsers for ps and `/proc` shapes, type resolver, PID lookup, dedup, malformed input
- [x] Integration tests (7 new) in `crates/iii-worker/tests/worker_list_discovery_integration.rs`:
  - HOME-overridden filesystem + signal-0 PID liveness against this test process
  - Real sentinel process spawn to verify `find_worker_pid_from_ps` against live `ps`/`/proc`
- [x] Live macOS verify: `iii-worker list` from `/tmp` surfaces both `image-resize` (binary) and `todo-worker-python` (managed, pidfile missing) as orphans with correct TYPE labels
- [ ] Live verify `iii worker stop` against an actual orphan (didn't run destructively before PR)

## Not included

- Engine's `engine::workers::list` view (WS-only RPC, would need a new client dep or a new HTTP endpoint). Followups already tracked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved worker discovery: detects workers from disk and by scanning running processes.
  * Worker list now shows orphan workers, their inferred type, and live status.
  * Stop command improved to more reliably locate and terminate workers (including orphaned cases).

* **Tests**
  * Added integration and unit tests covering discovery, live PID checks, orphan inference, and process lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->