### PR TITLE
feat(infra): migrate iii.dev website to AWS S3 + CloudFront (Phase 2+3)

### DIFF
--- a/.github/workflows/cloudfront-functions-test.yml
+++ b/.github/workflows/cloudfront-functions-test.yml
@@ -1,0 +1,27 @@
+name: CloudFront Functions Tests
+
+on:
+  pull_request:
+    paths:
+      - 'infra/terraform/website/cloudfront_functions/**'
+      - '.github/workflows/cloudfront-functions-test.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'infra/terraform/website/cloudfront_functions/**'
+
+jobs:
+  test:
+    name: node --test
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run CloudFront Function unit tests
+        run: node --test infra/terraform/website/cloudfront_functions/redirects.test.js

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,99 @@
+name: Deploy Website
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - 'infra/terraform/website/**'
+      - '.github/workflows/deploy-website.yml'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to deploy (default: current default branch)'
+        required: false
+        type: string
+
+concurrency:
+  group: deploy-website
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-and-deploy:
+    name: Build & deploy to S3 + CloudFront
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 15
+
+    env:
+      AWS_REGION: us-east-1
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      # website/ is a standalone npm project, commented out of pnpm-workspace.yaml
+      # (see pnpm-workspace.yaml:10). Uses npm, not pnpm. Node 22 matches _npm.yml.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: 'website/package-lock.json'
+
+      - name: Install dependencies
+        working-directory: website
+        run: npm install --include=dev
+
+      - name: Build
+        working-directory: website
+        env:
+          VITE_MAILMODO_FORM_URL: ${{ secrets.VITE_MAILMODO_FORM_URL }}
+        run: npm run build
+
+      - name: Configure AWS credentials (GitHub OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Sync hashed assets (long cache, immutable)
+        run: |
+          aws s3 sync website/dist/ "s3://${{ vars.S3_BUCKET }}/" \
+            --delete \
+            --cache-control "public,max-age=31536000,immutable" \
+            --exclude "*.html"
+
+      - name: Sync HTML (no cache, must revalidate)
+        run: |
+          aws s3 sync website/dist/ "s3://${{ vars.S3_BUCKET }}/" \
+            --delete \
+            --cache-control "public,max-age=0,must-revalidate" \
+            --exclude "*" \
+            --include "*.html"
+
+      - name: Create CloudFront invalidation
+        id: invalidation
+        run: |
+          inv_id=$(aws cloudfront create-invalidation \
+            --distribution-id "${{ vars.CF_DISTRIBUTION_ID }}" \
+            --paths '/*' \
+            --query 'Invalidation.Id' \
+            --output text)
+          echo "id=$inv_id" >> "$GITHUB_OUTPUT"
+          echo "Invalidation $inv_id created."
+
+      - name: Job summary
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## iii.dev deploy complete
+
+          - Bucket: \`${{ vars.S3_BUCKET }}\`
+          - Distribution: \`${{ vars.CF_DISTRIBUTION_ID }}\`
+          - Invalidation: \`${{ steps.invalidation.outputs.id }}\`
+          - Commit: \`${{ github.sha }}\`
+          EOF

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -26,7 +26,7 @@ jobs:
   build-and-deploy:
     name: Build & deploy to S3 + CloudFront
     runs-on: ubuntu-latest
-    environment: production
+    environment: iii-website-prod
     timeout-minutes: 15
 
     env:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,105 @@
+name: Website Smoke Tests
+
+on:
+  workflow_run:
+    workflows: ["Deploy Website"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Base URL to smoke test against (e.g. https://iii-preview.iii.dev or https://iii.dev)'
+        required: true
+        default: 'https://iii.dev'
+        type: string
+
+jobs:
+  smoke:
+    name: Curl endpoints and assert
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Only run after a successful deploy. Manual dispatches always run.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+
+    env:
+      BASE_URL: ${{ inputs.base_url || 'https://iii.dev' }}
+
+    steps:
+      - name: Smoke checks
+        run: |
+          set -u
+          failures=0
+          pass() { echo "PASS  $1"; }
+          fail() { echo "FAIL  $1"; failures=$((failures + 1)); }
+
+          assert_status() {
+            local path="$1" expected="$2"
+            local code
+            code=$(curl -sS -o /dev/null -w '%{http_code}' -L --max-redirs 0 "$BASE_URL$path" || true)
+            if [ "$code" = "$expected" ]; then
+              pass "$path → $code"
+            else
+              fail "$path → expected $expected, got $code"
+            fi
+          }
+
+          assert_redirect_to() {
+            local path="$1" expected="$2"
+            local loc
+            loc=$(curl -sSI "$BASE_URL$path" | awk 'BEGIN{IGNORECASE=1} /^location:/ {print $2}' | tr -d '\r\n')
+            if [ "$loc" = "$expected" ]; then
+              pass "$path → 301 $loc"
+            else
+              fail "$path → expected redirect to $expected, got '$loc'"
+            fi
+          }
+
+          assert_header_contains() {
+            local path="$1" header="$2" needle="$3"
+            local value
+            value=$(curl -sSI "$BASE_URL$path" | awk -v h="$header" 'BEGIN{IGNORECASE=1} tolower($1)==tolower(h)":" {for(i=2;i<=NF;i++) printf "%s ", $i; print ""}' | tr -d '\r' | head -1)
+            if echo "$value" | grep -qi "$needle"; then
+              pass "$path header '$header' contains '$needle'"
+            else
+              fail "$path header '$header' expected to contain '$needle', got '$value'"
+            fi
+          }
+
+          echo "Smoke testing $BASE_URL"
+          echo
+
+          # 1. Apex serves HTML 200
+          assert_status "/" 200
+
+          # 2. Security headers present
+          assert_header_contains "/" "strict-transport-security" "max-age"
+          assert_header_contains "/" "x-content-type-options" "nosniff"
+
+          # 3. /docs redirects to docs.iii.dev (strip prefix)
+          assert_redirect_to "/docs" "https://docs.iii.dev/"
+          assert_redirect_to "/docs/quickstart" "https://docs.iii.dev/quickstart"
+
+          # 4. /llms.txt redirects to docs.iii.dev/llms.txt
+          assert_redirect_to "/llms.txt" "https://docs.iii.dev/llms.txt"
+
+          # 5. /api/search returns JSON (NOT HTML — catches SPA-fallback-applied-to-API regression)
+          content_type=$(curl -sSI "$BASE_URL/api/search?q=test" | awk 'BEGIN{IGNORECASE=1} /^content-type:/ {for(i=2;i<=NF;i++) printf "%s ", $i; print ""}' | tr -d '\r' | head -1)
+          if echo "$content_type" | grep -qi 'json'; then
+            pass "/api/search?q=test → content-type=$content_type"
+          else
+            fail "/api/search?q=test → expected JSON content-type, got '$content_type'"
+          fi
+
+          # 6. Non-existent asset returns 404 (not SPA fallback)
+          assert_status "/this-file-does-not-exist.jpg" 404
+
+          # 7. SPA fallback: extensionless path → 200 HTML
+          assert_status "/some/client/route" 200
+          assert_header_contains "/some/client/route" "content-type" "text/html"
+
+          echo
+          if [ "$failures" -eq 0 ]; then
+            echo "All smoke checks passed ✓"
+          else
+            echo "$failures smoke check(s) failed ✗"
+            exit 1
+          fi

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -74,12 +74,14 @@ jobs:
           assert_header_contains "/" "strict-transport-security" "max-age"
           assert_header_contains "/" "x-content-type-options" "nosniff"
 
-          # 3. /docs redirects to docs.iii.dev (strip prefix)
-          assert_redirect_to "/docs" "https://docs.iii.dev/"
-          assert_redirect_to "/docs/quickstart" "https://docs.iii.dev/quickstart"
+          # 3. /docs redirects to docs.iii.dev, PRESERVING the /docs prefix
+          #    (Mintlify serves content only under /docs/*, so the target keeps the prefix.
+          #    See infra/terraform/website/cloudfront_functions/redirects.js header comment.)
+          assert_redirect_to "/docs" "https://docs.iii.dev/docs"
+          assert_redirect_to "/docs/quickstart" "https://docs.iii.dev/docs/quickstart"
 
-          # 4. /llms.txt redirects to docs.iii.dev/llms.txt
-          assert_redirect_to "/llms.txt" "https://docs.iii.dev/llms.txt"
+          # 4. /llms.txt currently 404s in production; CF Function passes through to S3 (also 404)
+          assert_status "/llms.txt" 404
 
           # 5. /api/search returns JSON (NOT HTML — catches SPA-fallback-applied-to-API regression)
           content_type=$(curl -sSI "$BASE_URL/api/search?q=test" | awk 'BEGIN{IGNORECASE=1} /^content-type:/ {for(i=2;i<=NF;i++) printf "%s ", $i; print ""}' | tr -d '\r' | head -1)

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -1,0 +1,89 @@
+name: Terraform Plan
+
+on:
+  pull_request:
+    paths:
+      - 'infra/terraform/**'
+      - '.github/workflows/tf-plan.yml'
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: tf-plan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fmt-validate-plan:
+    name: fmt / validate / plan (website)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      AWS_REGION: us-east-1
+      TF_IN_AUTOMATION: 'true'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.9.8'
+          terraform_wrapper: false
+
+      - name: Terraform fmt (recursive)
+        run: terraform fmt -check -recursive infra/terraform/
+
+      - name: Configure AWS credentials (read-only)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_READONLY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform init
+        working-directory: infra/terraform/website
+        run: terraform init -input=false
+
+      - name: Terraform validate
+        working-directory: infra/terraform/website
+        run: terraform validate -no-color
+
+      - name: Terraform plan
+        id: plan
+        working-directory: infra/terraform/website
+        run: |
+          set -o pipefail
+          terraform plan -no-color -input=false -lock=false 2>&1 | tee plan.txt
+          {
+            echo 'plan<<TF_PLAN_EOF'
+            cat plan.txt
+            echo 'TF_PLAN_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Comment plan on PR
+        uses: actions/github-script@v7
+        if: github.event_name == 'pull_request'
+        with:
+          script: |
+            const plan = `${{ steps.plan.outputs.plan }}`;
+            const truncated = plan.length > 60000
+              ? plan.slice(0, 60000) + '\n... [truncated, see workflow logs for full plan]'
+              : plan;
+            const body = [
+              '## Terraform plan — `infra/terraform/website`',
+              '',
+              '<details><summary>Click to expand</summary>',
+              '',
+              '```',
+              truncated,
+              '```',
+              '',
+              '</details>',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });

--- a/infra/terraform/.gitignore
+++ b/infra/terraform/.gitignore
@@ -1,0 +1,23 @@
+# Terraform working directories
+.terraform/
+.terraform.tfstate.lock.info
+
+# State backups (live state is in S3 for modules with remote backend)
+*.tfstate.backup
+
+# Plan outputs
+*.tfplan
+*.tfplan.*
+
+# Variable files that may contain secrets
+terraform.tfvars
+*.auto.tfvars
+
+# Crash logs
+crash.log
+crash.*.log
+
+# Kept on purpose (do NOT ignore):
+# - .terraform.lock.hcl  → provider version pinning, must be committed
+# - _bootstrap/terraform.tfstate → chicken-and-egg bootstrap state, see _bootstrap/README.md
+!_bootstrap/terraform.tfstate

--- a/infra/terraform/_bootstrap/.terraform.lock.hcl
+++ b/infra/terraform/_bootstrap/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.60"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/terraform/_bootstrap/README.md
+++ b/infra/terraform/_bootstrap/README.md
@@ -12,11 +12,11 @@ real AWS resources without losing history. **There are no secrets in this state 
 
 ## Resources
 
-- `aws_s3_bucket.terraform_state` → `motia-prod-terraform-state-us-east-1`
+- `aws_s3_bucket.terraform_state` → `iii-terraform-state-prod-us-east-1`
   - Versioning on (state file history)
   - SSE-S3 (server-side encryption)
   - All public access blocked
-- `aws_dynamodb_table.terraform_locks` → `motia-prod-terraform-locks`
+- `aws_dynamodb_table.terraform_locks` → `iii-terraform-locks-prod`
   - PAY_PER_REQUEST billing
   - Hash key `LockID` (required by the Terraform S3 backend)
 

--- a/infra/terraform/_bootstrap/README.md
+++ b/infra/terraform/_bootstrap/README.md
@@ -1,0 +1,43 @@
+# Terraform Remote State Bootstrap
+
+Creates the shared S3 bucket + DynamoDB table used as the Terraform remote state
+backend for all `infra/terraform/*` modules in this repo.
+
+## Why this module uses local state
+
+Chicken-and-egg: the state bucket can't store its own state. Local `terraform.tfstate`
+is committed to the repo on purpose so that any team member can re-apply against the
+real AWS resources without losing history. **There are no secrets in this state file**
+— it only describes two empty shared-infra resources (a bucket and a table).
+
+## Resources
+
+- `aws_s3_bucket.terraform_state` → `motia-prod-terraform-state-us-east-1`
+  - Versioning on (state file history)
+  - SSE-S3 (server-side encryption)
+  - All public access blocked
+- `aws_dynamodb_table.terraform_locks` → `motia-prod-terraform-locks`
+  - PAY_PER_REQUEST billing
+  - Hash key `LockID` (required by the Terraform S3 backend)
+
+## One-time apply
+
+```bash
+cd infra/terraform/_bootstrap
+terraform init
+terraform apply
+```
+
+Commit the resulting `terraform.tfstate` and `.terraform.lock.hcl`.
+
+## Re-applying later
+
+If you need to change these resources, edit the files, run `terraform plan` + `apply`,
+then commit the updated `terraform.tfstate`.
+
+## Who uses this backend
+
+Every other module under `infra/terraform/*` references this bucket + table in its
+`backend "s3"` block. Today:
+
+- `infra/terraform/website` — the iii.dev marketing site (S3 + CloudFront).

--- a/infra/terraform/_bootstrap/main.tf
+++ b/infra/terraform/_bootstrap/main.tf
@@ -13,8 +13,8 @@ provider "aws" {
 }
 
 locals {
-  state_bucket_name = "motia-prod-terraform-state-us-east-1"
-  lock_table_name   = "motia-prod-terraform-locks"
+  state_bucket_name = "iii-terraform-state-prod-us-east-1"
+  lock_table_name   = "iii-terraform-locks-prod"
 }
 
 resource "aws_s3_bucket" "terraform_state" {

--- a/infra/terraform/_bootstrap/main.tf
+++ b/infra/terraform/_bootstrap/main.tf
@@ -1,0 +1,70 @@
+provider "aws" {
+  region  = "us-east-1"
+  profile = "motia-prod"
+
+  default_tags {
+    tags = {
+      Project     = "iii"
+      Environment = "prod"
+      ManagedBy   = "terraform"
+      Module      = "infra/terraform/_bootstrap"
+    }
+  }
+}
+
+locals {
+  state_bucket_name = "motia-prod-terraform-state-us-east-1"
+  lock_table_name   = "motia-prod-terraform-locks"
+}
+
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = local.state_bucket_name
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_dynamodb_table" "terraform_locks" {
+  name         = local.lock_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}
+
+output "state_bucket" {
+  description = "Name of the S3 bucket for Terraform remote state"
+  value       = aws_s3_bucket.terraform_state.bucket
+}
+
+output "lock_table" {
+  description = "Name of the DynamoDB table for Terraform state locks"
+  value       = aws_dynamodb_table.terraform_locks.name
+}

--- a/infra/terraform/_bootstrap/terraform.tfstate
+++ b/infra/terraform/_bootstrap/terraform.tfstate
@@ -1,0 +1,244 @@
+{
+  "version": 4,
+  "terraform_version": "1.9.8",
+  "serial": 6,
+  "lineage": "422f273a-39e5-08e9-827e-b639731fb4b6",
+  "outputs": {
+    "lock_table": {
+      "value": "iii-terraform-locks-prod",
+      "type": "string"
+    },
+    "state_bucket": {
+      "value": "iii-terraform-state-prod-us-east-1",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "aws_dynamodb_table",
+      "name": "terraform_locks",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:dynamodb:us-east-1:600627348446:table/iii-terraform-locks-prod",
+            "attribute": [
+              {
+                "name": "LockID",
+                "type": "S"
+              }
+            ],
+            "billing_mode": "PAY_PER_REQUEST",
+            "deletion_protection_enabled": false,
+            "global_secondary_index": [],
+            "hash_key": "LockID",
+            "id": "iii-terraform-locks-prod",
+            "import_table": [],
+            "local_secondary_index": [],
+            "name": "iii-terraform-locks-prod",
+            "on_demand_throughput": [],
+            "point_in_time_recovery": [
+              {
+                "enabled": false,
+                "recovery_period_in_days": 0
+              }
+            ],
+            "range_key": null,
+            "read_capacity": 0,
+            "replica": [],
+            "restore_date_time": null,
+            "restore_source_name": null,
+            "restore_source_table_arn": null,
+            "restore_to_latest_time": null,
+            "server_side_encryption": [],
+            "stream_arn": "",
+            "stream_enabled": false,
+            "stream_label": "",
+            "stream_view_type": "",
+            "table_class": "STANDARD",
+            "tags": null,
+            "tags_all": {
+              "Environment": "prod",
+              "ManagedBy": "terraform",
+              "Module": "infra/terraform/_bootstrap",
+              "Project": "iii"
+            },
+            "timeouts": null,
+            "ttl": [
+              {
+                "attribute_name": "",
+                "enabled": false
+              }
+            ],
+            "write_capacity": 0
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxODAwMDAwMDAwMDAwLCJkZWxldGUiOjYwMDAwMDAwMDAwMCwidXBkYXRlIjozNjAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "terraform_state",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "acceleration_status": "",
+            "acl": null,
+            "arn": "arn:aws:s3:::iii-terraform-state-prod-us-east-1",
+            "bucket": "iii-terraform-state-prod-us-east-1",
+            "bucket_domain_name": "iii-terraform-state-prod-us-east-1.s3.amazonaws.com",
+            "bucket_prefix": "",
+            "bucket_regional_domain_name": "iii-terraform-state-prod-us-east-1.s3.us-east-1.amazonaws.com",
+            "cors_rule": [],
+            "force_destroy": false,
+            "grant": [
+              {
+                "id": "e0c95e53f4cda2c0bad8935e3b55b62da0d797a46741d042d0afb859cbb0f1df",
+                "permissions": [
+                  "FULL_CONTROL"
+                ],
+                "type": "CanonicalUser",
+                "uri": ""
+              }
+            ],
+            "hosted_zone_id": "Z3AQBSTGFYJSTF",
+            "id": "iii-terraform-state-prod-us-east-1",
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "object_lock_enabled": false,
+            "policy": "",
+            "region": "us-east-1",
+            "replication_configuration": [],
+            "request_payer": "BucketOwner",
+            "server_side_encryption_configuration": [
+              {
+                "rule": [
+                  {
+                    "apply_server_side_encryption_by_default": [
+                      {
+                        "kms_master_key_id": "",
+                        "sse_algorithm": "AES256"
+                      }
+                    ],
+                    "bucket_key_enabled": false
+                  }
+                ]
+              }
+            ],
+            "tags": null,
+            "tags_all": {
+              "Environment": "prod",
+              "ManagedBy": "terraform",
+              "Module": "infra/terraform/_bootstrap",
+              "Project": "iii"
+            },
+            "timeouts": null,
+            "versioning": [
+              {
+                "enabled": false,
+                "mfa_delete": false
+              }
+            ],
+            "website": [],
+            "website_domain": null,
+            "website_endpoint": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjM2MDAwMDAwMDAwMDAsInJlYWQiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19"
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket_public_access_block",
+      "name": "terraform_state",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "block_public_acls": true,
+            "block_public_policy": true,
+            "bucket": "iii-terraform-state-prod-us-east-1",
+            "id": "iii-terraform-state-prod-us-east-1",
+            "ignore_public_acls": true,
+            "restrict_public_buckets": true
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_s3_bucket.terraform_state"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket_server_side_encryption_configuration",
+      "name": "terraform_state",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "iii-terraform-state-prod-us-east-1",
+            "expected_bucket_owner": "",
+            "id": "iii-terraform-state-prod-us-east-1",
+            "rule": [
+              {
+                "apply_server_side_encryption_by_default": [
+                  {
+                    "kms_master_key_id": "",
+                    "sse_algorithm": "AES256"
+                  }
+                ],
+                "bucket_key_enabled": null
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_s3_bucket.terraform_state"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket_versioning",
+      "name": "terraform_state",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "iii-terraform-state-prod-us-east-1",
+            "expected_bucket_owner": "",
+            "id": "iii-terraform-state-prod-us-east-1",
+            "mfa": null,
+            "versioning_configuration": [
+              {
+                "mfa_delete": "",
+                "status": "Enabled"
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_s3_bucket.terraform_state"
+          ]
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/infra/terraform/_bootstrap/versions.tf
+++ b/infra/terraform/_bootstrap/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.60"
+    }
+  }
+}

--- a/infra/terraform/website/.terraform.lock.hcl
+++ b/infra/terraform/website/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.60"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/terraform/website/README.md
+++ b/infra/terraform/website/README.md
@@ -1,0 +1,131 @@
+# Terraform: iii.dev website (S3 + CloudFront)
+
+This module owns the AWS infrastructure for serving `iii.dev` (and `www.iii.dev`)
+off CloudFront + S3 in the `motia-prod` account (`600627348446`, `us-east-1`).
+
+Context and rationale: see the full plan at
+`~/.claude/plans/lazy-nibbling-valiant.md` in the reviewer's workspace, or read
+`website/README.md` after the migration lands.
+
+## Resources created
+
+| Resource | Purpose |
+|---|---|
+| `aws_s3_bucket.site` | Private bucket holding the Vite build output |
+| `aws_s3_bucket_policy.site` | Allows CloudFront OAC only (no public access) |
+| `aws_cloudfront_origin_access_control.site` | OAC (modern replacement for OAI) |
+| `aws_cloudfront_function.redirects` | viewer-request: www→apex 301, /docs→docs.iii.dev 301, /llms.txt redirect, SPA fallback |
+| `aws_cloudfront_response_headers_policy.site` | HSTS, CSP, X-Frame-Options, Referrer-Policy, X-Content-Type-Options |
+| `aws_cloudfront_distribution.site` | The CDN edge. SANs: iii.dev, www.iii.dev, iii-preview.iii.dev |
+| `aws_acm_certificate.site` | TLS cert with DNS validation |
+| `aws_route53_record.preview_*` | ALIAS records for the 24h staging window |
+| `aws_route53_record.apex_*` / `www_*` | Defined but imported in Phase 4 (see `route53.tf`) |
+| `aws_iam_openid_connect_provider.github` | GitHub Actions OIDC provider |
+| `aws_iam_role.github_deploy_website` | Deploy role scoped to iii-hq/iii main + production env |
+| `aws_sns_topic.alarms` + `aws_cloudwatch_metric_alarm.*` | 5xx rate alarm + ACM cert expiry alarm |
+
+## Variables
+
+`alarm_email` has no default — set it via a `terraform.tfvars` (gitignored) or
+`TF_VAR_alarm_email=...` in your shell before applying.
+
+```hcl
+# infra/terraform/website/terraform.tfvars  (gitignored)
+alarm_email = "you@motia.dev"
+```
+
+Other variables have sensible defaults. See `variables.tf` for the full list.
+
+## Staging → cutover workflow
+
+### Phase 2 — first apply (preview only)
+
+```bash
+cd infra/terraform/website
+terraform init
+terraform plan      # review carefully
+terraform apply     # creates S3, CF distro, ACM cert, 3 SANs, preview Route53 records
+```
+
+At this point:
+- `iii-preview.iii.dev` serves from CloudFront.
+- The apex `iii.dev` record is still owned by External-DNS and untouched.
+- `iii.dev` and `www.iii.dev` are in the cert SANs but there are no Route53 records
+  for them yet — the TF resources in `route53.tf` (`apex_*`, `www_*`) are defined
+  but you must NOT apply them yet. If Terraform tries to create them now, it will
+  collide with the existing External-DNS-owned records.
+
+Confirm the SNS email subscription link in your inbox.
+
+Upload a placeholder file to test end-to-end:
+
+```bash
+aws --profile motia-prod s3 cp /tmp/index.html s3://motia-prod-iii-website-us-east-1/index.html
+curl -I https://iii-preview.iii.dev/
+```
+
+### Phase 4 — apex cutover (user-visible)
+
+See the full runbook in the plan. Short version:
+
+1. Open a PR in `motia-argocd-values` removing the `iii-dev` and `iii-dev-www`
+   Ingresses from `apps/site/manifests/iii-dev.yaml`. Merge and let ArgoCD sync.
+2. Confirm External-DNS has stopped managing those hosts (tail its logs).
+3. Import the existing Route53 records into Terraform state:
+   ```bash
+   ZONE=$(aws --profile motia-prod route53 list-hosted-zones \
+     --query "HostedZones[?Name=='iii.dev.'].Id" --output text | awk -F/ '{print $NF}')
+   terraform import aws_route53_record.apex_a   ${ZONE}_iii.dev_A
+   terraform import aws_route53_record.apex_aaaa ${ZONE}_iii.dev_AAAA
+   terraform import aws_route53_record.www_a    ${ZONE}_www.iii.dev_A
+   terraform import aws_route53_record.www_aaaa ${ZONE}_www.iii.dev_AAAA
+   ```
+4. `terraform plan` — expect exactly four target changes (each ALIAS target moves
+   from the k8s NLB to the CloudFront distribution). Any delete/recreate → STOP.
+5. `terraform apply` — single atomic Route53 UPSERT per record. No NXDOMAIN window.
+6. Flip `csp_report_only` to `false` in the plan and apply (optional, can also be
+   done at the same time as step 5):
+   ```bash
+   terraform apply -var 'csp_report_only=false'
+   ```
+7. Clean up orphaned External-DNS TXT ownership records via aws CLI.
+
+### Phase 5 — remove preview
+
+After 48–72h of clean metrics:
+
+1. Remove the `preview_*` Route53 records and the `preview_domain` from `acm.tf`'s
+   SAN list (or set `preview_domain` to empty and make the records conditional).
+2. `terraform apply` — ACM re-issues the cert with two SANs instead of three.
+3. Delete the Vercel iii-web project.
+
+## Rollback
+
+If Phase 4 goes bad:
+
+```bash
+# Target-destroy only the apex records — this removes them from Route53, letting
+# External-DNS re-create the old records on its next reconcile loop (30s-ish).
+terraform apply \
+  -target='aws_route53_record.apex_a' \
+  -target='aws_route53_record.apex_aaaa' \
+  -target='aws_route53_record.www_a' \
+  -target='aws_route53_record.www_aaaa' \
+  -destroy
+```
+
+Then revert the `motia-argocd-values` PR that removed the Ingresses. ArgoCD
+re-applies them, External-DNS re-upserts, and `iii.dev` is back on the k8s
+edge proxy serving Vercel content.
+
+Emergency fallback: re-attach the `iii.dev` domain in the Vercel dashboard and
+manually point Route53 at Vercel's edge via a CNAME.
+
+## Related files
+
+- `cloudfront_functions/redirects.js` — CloudFront Function source (must be <10KB)
+- `cloudfront_functions/redirects.test.js` — `node --test` unit tests for the function
+- `.github/workflows/deploy-website.yml` — builds and deploys `website/` on push to main
+- `.github/workflows/smoke.yml` — post-deploy smoke checks
+- `.github/workflows/tf-plan.yml` — PR-triggered `terraform plan` comment
+- `.github/workflows/cloudfront-functions-test.yml` — runs the CF function unit tests on PR

--- a/infra/terraform/website/README.md
+++ b/infra/terraform/website/README.md
@@ -66,29 +66,66 @@ curl -I https://iii-preview.iii.dev/
 
 ### Phase 4 — apex cutover (user-visible)
 
+During Phase 2 the apex/www records stayed managed by the live production setup
+(apex manual, www External-DNS). They were gated out of the TF module by
+`manage_apex_records = false`. Phase 4 flips that gate and brings those records
+into TF state via `terraform import`.
+
 See the full runbook in the plan. Short version:
 
-1. Open a PR in `motia-argocd-values` removing the `iii-dev` and `iii-dev-www`
-   Ingresses from `apps/site/manifests/iii-dev.yaml`. Merge and let ArgoCD sync.
-2. Confirm External-DNS has stopped managing those hosts (tail its logs).
-3. Import the existing Route53 records into Terraform state:
+1. Open a PR in `motia-argocd-values` removing **only** the `iii-dev-www` Ingress
+   from `apps/site/manifests/iii-dev.yaml`. Leave `iii-dev`, `iii-dev-docs`, and
+   `iii-dev-install` intact:
+     - `iii-dev` (apex) was never External-DNS-owned; removing it does nothing
+       for DNS but could affect the edge-proxy configmap, so leave it.
+     - `iii-dev-docs` and `iii-dev-install` still serve docs.iii.dev and
+       install.iii.dev through the k8s edge proxy (out of scope here).
+   Merge and let ArgoCD sync. Verify with `kubectl get ingress -n site` —
+   `iii-dev-www` should be gone, the other three remain.
+
+2. Confirm External-DNS has stopped managing `www.iii.dev`:
+   ```bash
+   kubectl logs -n external-dns deploy/external-dns --tail 100 | grep www.iii.dev
+   ```
+
+3. Import the existing Route53 records into Terraform state. Note the `[0]`
+   index — the resources are `count = var.manage_apex_records ? 1 : 0`:
    ```bash
    ZONE=$(aws --profile motia-prod route53 list-hosted-zones \
      --query "HostedZones[?Name=='iii.dev.'].Id" --output text | awk -F/ '{print $NF}')
-   terraform import aws_route53_record.apex_a   ${ZONE}_iii.dev_A
-   terraform import aws_route53_record.apex_aaaa ${ZONE}_iii.dev_AAAA
-   terraform import aws_route53_record.www_a    ${ZONE}_www.iii.dev_A
-   terraform import aws_route53_record.www_aaaa ${ZONE}_www.iii.dev_AAAA
+
+   terraform import 'aws_route53_record.apex_a[0]'    "${ZONE}_iii.dev_A"
+   terraform import 'aws_route53_record.apex_aaaa[0]' "${ZONE}_iii.dev_AAAA"
+   terraform import 'aws_route53_record.www_a[0]'     "${ZONE}_www.iii.dev_A"
+   terraform import 'aws_route53_record.www_aaaa[0]'  "${ZONE}_www.iii.dev_AAAA"
    ```
-4. `terraform plan` — expect exactly four target changes (each ALIAS target moves
-   from the k8s NLB to the CloudFront distribution). Any delete/recreate → STOP.
-5. `terraform apply` — single atomic Route53 UPSERT per record. No NXDOMAIN window.
-6. Flip `csp_report_only` to `false` in the plan and apply (optional, can also be
-   done at the same time as step 5):
+   If you forget `-var='manage_apex_records=true'` here, the import will store
+   a resource that's not in config and the next plan will try to delete it.
+   Set the var in `terraform.tfvars` or export `TF_VAR_manage_apex_records=true`
+   before running the imports.
+
+4. `terraform plan -var='manage_apex_records=true'` — expect exactly four
+   in-place updates, each changing the ALIAS target from the k8s NLB
+   (`abfa…elb.us-east-1.amazonaws.com`) to the CloudFront distribution
+   (`d***.cloudfront.net`). Any destroy/create or other drift → STOP.
+
+5. `terraform apply -var='manage_apex_records=true'` — single atomic Route53
+   UPSERT per record. No NXDOMAIN window.
+
+6. Flip `csp_report_only` to `false` (can be combined with step 5):
    ```bash
-   terraform apply -var 'csp_report_only=false'
+   terraform apply -var='manage_apex_records=true' -var='csp_report_only=false'
    ```
-7. Clean up orphaned External-DNS TXT ownership records via aws CLI.
+
+7. Clean up the orphaned External-DNS TXT ownership record for www via aws CLI:
+   ```bash
+   aws --profile motia-prod route53 change-resource-record-sets \
+     --hosted-zone-id $ZONE \
+     --change-batch file:///tmp/delete-www-txt.json
+   ```
+   (Fetch the exact TXT value first with `list-resource-record-sets
+   --query "ResourceRecordSets[?Name=='external-dns-cname-www.iii.dev.']"`.)
+   There is no `cname-iii.dev` TXT because the apex was never External-DNS-owned.
 
 ### Phase 5 — remove preview
 
@@ -96,30 +133,51 @@ After 48–72h of clean metrics:
 
 1. Remove the `preview_*` Route53 records and the `preview_domain` from `acm.tf`'s
    SAN list (or set `preview_domain` to empty and make the records conditional).
-2. `terraform apply` — ACM re-issues the cert with two SANs instead of three.
-3. Delete the Vercel iii-web project.
+2. `terraform apply -var='manage_apex_records=true'` — ACM re-issues the cert with two SANs instead of three.
+3. Delete the explicit CAA record at `iii-preview.iii.dev` (was added as a workaround for the `*.iii.dev` wildcard CNAME intercepting CAA lookup; no longer needed once the preview subdomain goes away).
+4. Delete the Vercel iii-web project.
 
 ## Rollback
 
-If Phase 4 goes bad:
+If Phase 4 goes bad, rollback differs between apex (manually-owned) and www
+(External-DNS-owned):
+
+**Apex `iii.dev`** — manually owned in Route53, not in argocd-values.
 
 ```bash
-# Target-destroy only the apex records — this removes them from Route53, letting
-# External-DNS re-create the old records on its next reconcile loop (30s-ish).
-terraform apply \
-  -target='aws_route53_record.apex_a' \
-  -target='aws_route53_record.apex_aaaa' \
-  -target='aws_route53_record.www_a' \
-  -target='aws_route53_record.www_aaaa' \
-  -destroy
+ZONE=Z05516132AI1ZGB3NLC6D
+aws --profile motia-prod route53 change-resource-record-sets \
+  --hosted-zone-id $ZONE \
+  --change-batch '{
+    "Changes": [{
+      "Action": "UPSERT",
+      "ResourceRecordSet": {
+        "Name": "iii.dev.",
+        "Type": "A",
+        "AliasTarget": {
+          "HostedZoneId": "Z26RNL4JYFTOTI",
+          "DNSName": "abfa1050d1bf345f2ad3abef639593d8-62c8780bba490615.elb.us-east-1.amazonaws.com.",
+          "EvaluateTargetHealth": false
+        }
+      }
+    }]
+  }'
+# Repeat for AAAA. Then remove from TF state so future applies don't fight:
+terraform state rm 'aws_route53_record.apex_a[0]' 'aws_route53_record.apex_aaaa[0]'
 ```
 
-Then revert the `motia-argocd-values` PR that removed the Ingresses. ArgoCD
-re-applies them, External-DNS re-upserts, and `iii.dev` is back on the k8s
-edge proxy serving Vercel content.
+**www `www.iii.dev`** — External-DNS originally owned it.
 
-Emergency fallback: re-attach the `iii.dev` domain in the Vercel dashboard and
-manually point Route53 at Vercel's edge via a CNAME.
+1. Revert the `motia-argocd-values` PR that removed the `iii-dev-www` Ingress.
+   ArgoCD re-applies. External-DNS (upsert-only) re-upserts the A/AAAA records
+   pointing at the k8s NLB, overwriting the TF-managed CloudFront ALIAS.
+2. `terraform state rm 'aws_route53_record.www_a[0]' 'aws_route53_record.www_aaaa[0]'`
+
+TTL on ALIAS records is 0 (edge-resolved), so propagation is ~immediate.
+
+**Emergency fallback:** re-attach the `iii.dev` domain in the Vercel dashboard
+and manually point Route53 at Vercel's edge via a CNAME. Bypasses both k8s and
+CloudFront entirely.
 
 ## Related files
 

--- a/infra/terraform/website/README.md
+++ b/infra/terraform/website/README.md
@@ -60,7 +60,7 @@ Confirm the SNS email subscription link in your inbox.
 Upload a placeholder file to test end-to-end:
 
 ```bash
-aws --profile motia-prod s3 cp /tmp/index.html s3://motia-prod-iii-website-us-east-1/index.html
+aws --profile motia-prod s3 cp /tmp/index.html s3://iii-website-prod-us-east-1/index.html
 curl -I https://iii-preview.iii.dev/
 ```
 

--- a/infra/terraform/website/acm.tf
+++ b/infra/terraform/website/acm.tf
@@ -1,0 +1,36 @@
+resource "aws_acm_certificate" "site" {
+  domain_name = var.apex_domain
+
+  subject_alternative_names = [
+    var.www_domain,
+    var.preview_domain,
+  ]
+
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.site.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id         = data.aws_route53_zone.iii_dev.zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+  ttl             = 60
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "site" {
+  certificate_arn         = aws_acm_certificate.site.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}

--- a/infra/terraform/website/cloudfront.tf
+++ b/infra/terraform/website/cloudfront.tf
@@ -61,10 +61,15 @@ resource "aws_cloudfront_response_headers_policy" "site" {
       override        = true
     }
 
+    # HSTS: match what iii.dev currently sends (1 year, includeSubDomains, no
+    # preload). Enabling preload is a ONE-WAY DOOR — it applies forever to
+    # cloud.iii.dev (a separate Vercel project) and any *.iii.dev wildcard
+    # subdomain. Audit every subdomain and confirm HTTPS-only before adding
+    # preload + submitting to hstspreload.org in a follow-up PR.
     strict_transport_security {
-      access_control_max_age_sec = 63072000
+      access_control_max_age_sec = 31536000
       include_subdomains         = true
-      preload                    = true
+      preload                    = false
       override                   = true
     }
 

--- a/infra/terraform/website/cloudfront.tf
+++ b/infra/terraform/website/cloudfront.tf
@@ -27,7 +27,7 @@ locals {
 }
 
 resource "aws_cloudfront_origin_access_control" "site" {
-  name                              = "motia-prod-iii-website-oac"
+  name                              = "iii-website-prod-oac"
   description                       = "OAC for iii.dev website S3 origin"
   origin_access_control_origin_type = "s3"
   signing_behavior                  = "always"
@@ -35,7 +35,7 @@ resource "aws_cloudfront_origin_access_control" "site" {
 }
 
 resource "aws_cloudfront_function" "redirects" {
-  name    = "motia-prod-iii-website-redirects"
+  name    = "iii-website-prod-redirects"
   runtime = "cloudfront-js-2.0"
   comment = "viewer-request: www->apex, /docs->docs.iii.dev, /llms.txt redirect, SPA fallback"
   publish = true
@@ -43,7 +43,7 @@ resource "aws_cloudfront_function" "redirects" {
 }
 
 resource "aws_cloudfront_response_headers_policy" "site" {
-  name    = "motia-prod-iii-website-security-headers"
+  name    = "iii-website-prod-security-headers"
   comment = "HSTS + CSP + security headers for iii.dev"
 
   security_headers_config {

--- a/infra/terraform/website/cloudfront.tf
+++ b/infra/terraform/website/cloudfront.tf
@@ -1,0 +1,173 @@
+locals {
+  # CSP allowlist derived from website/index.html, website/lib/useCookieConsent.ts,
+  # and website/components/EmailSignupForm.tsx. If you change third-party scripts
+  # in the site, update this string.
+  #
+  # Notes on 'unsafe-inline' / 'unsafe-eval':
+  # - 'unsafe-inline' is required because index.html has inline <script> (GTM bootstrap,
+  #   Tailwind config) and an inline <style> block.
+  # - 'unsafe-eval' is required because the Tailwind CDN runtime uses `new Function()`.
+  # These relax CSP but still provide defense-in-depth vs reflected XSS. Tightening
+  # further would require refactoring the website to drop inline scripts and the
+  # Tailwind CDN, which is out of scope for the migration.
+  csp = join("; ", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://cdn.tailwindcss.com https://esm.sh https://cdn.cr-relay.com",
+    "style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com",
+    "img-src 'self' data: https:",
+    "font-src 'self' data:",
+    "connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://www.googletagmanager.com https://api.cr-relay.com https://api.mailmodo.com https://${var.search_api_origin}",
+    "frame-src https://www.googletagmanager.com",
+    "form-action 'self' https://api.mailmodo.com",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "frame-ancestors 'none'",
+    "upgrade-insecure-requests",
+  ])
+}
+
+resource "aws_cloudfront_origin_access_control" "site" {
+  name                              = "motia-prod-iii-website-oac"
+  description                       = "OAC for iii.dev website S3 origin"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_function" "redirects" {
+  name    = "motia-prod-iii-website-redirects"
+  runtime = "cloudfront-js-2.0"
+  comment = "viewer-request: www->apex, /docs->docs.iii.dev, /llms.txt redirect, SPA fallback"
+  publish = true
+  code    = file("${path.module}/cloudfront_functions/redirects.js")
+}
+
+resource "aws_cloudfront_response_headers_policy" "site" {
+  name    = "motia-prod-iii-website-security-headers"
+  comment = "HSTS + CSP + security headers for iii.dev"
+
+  security_headers_config {
+    content_type_options {
+      override = true
+    }
+
+    frame_options {
+      frame_option = "DENY"
+      override     = true
+    }
+
+    referrer_policy {
+      referrer_policy = "strict-origin-when-cross-origin"
+      override        = true
+    }
+
+    strict_transport_security {
+      access_control_max_age_sec = 63072000
+      include_subdomains         = true
+      preload                    = true
+      override                   = true
+    }
+
+    xss_protection {
+      mode_block = true
+      protection = true
+      override   = true
+    }
+  }
+
+  custom_headers_config {
+    items {
+      header   = var.csp_report_only ? "Content-Security-Policy-Report-Only" : "Content-Security-Policy"
+      value    = local.csp
+      override = true
+    }
+  }
+}
+
+# Managed policy IDs — see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html
+locals {
+  cache_policy_optimized_id    = "658327ea-f89d-4fab-a63d-7e88639e58f6" # CachingOptimized
+  cache_policy_disabled_id     = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # CachingDisabled
+  origin_request_cors_s3_id    = "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf" # CORS-S3Origin
+  origin_request_all_viewer_id = "216adef6-5c7f-47e4-b989-5492eafa07d3" # AllViewer
+}
+
+resource "aws_cloudfront_distribution" "site" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "iii.dev marketing site (${var.apex_domain})"
+  default_root_object = "index.html"
+  http_version        = "http2and3"
+  price_class         = var.price_class
+
+  aliases = [
+    var.apex_domain,
+    var.www_domain,
+    var.preview_domain,
+  ]
+
+  origin {
+    origin_id                = "s3-site"
+    domain_name              = aws_s3_bucket.site.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.site.id
+  }
+
+  origin {
+    origin_id   = "search-api"
+    domain_name = var.search_api_origin
+
+    custom_origin_config {
+      http_port                = 80
+      https_port               = 443
+      origin_protocol_policy   = "https-only"
+      origin_ssl_protocols     = ["TLSv1.2"]
+      origin_keepalive_timeout = 5
+      origin_read_timeout      = 30
+    }
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "s3-site"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    cache_policy_id            = local.cache_policy_optimized_id
+    origin_request_policy_id   = local.origin_request_cors_s3_id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.site.id
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.redirects.arn
+    }
+  }
+
+  ordered_cache_behavior {
+    path_pattern           = "/api/search*"
+    target_origin_id       = "search-api"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    cache_policy_id            = local.cache_policy_disabled_id
+    origin_request_policy_id   = local.origin_request_all_viewer_id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.site.id
+
+    # No function_association: the SPA fallback must NOT rewrite /api/search responses,
+    # and /api/search paths would not match the redirect rules anyway.
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.site.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+}

--- a/infra/terraform/website/cloudfront_functions/redirects.js
+++ b/infra/terraform/website/cloudfront_functions/redirects.js
@@ -1,0 +1,73 @@
+// CloudFront Function (cloudfront-js-2.0): viewer-request handler for iii.dev.
+//
+// Runs on every incoming request to the default (S3) behavior. Not attached to
+// the /api/search* behavior — its JSON responses must pass through unchanged.
+//
+// Responsibilities, in order:
+//   1. /docs or /docs/* → 301 docs.iii.dev (strips /docs prefix)
+//   2. /llms.txt       → 301 docs.iii.dev/llms.txt
+//   3. host www.iii.dev → 301 apex iii.dev (preserves path)
+//   4. /.well-known/*  → pass through (S3 returns 404, no SPA rewrite)
+//   5. SPA fallback: extensionless path that doesn't end in / → rewrite uri to /index.html
+//   6. Everything else → pass through
+//
+// Why /docs is checked BEFORE www→apex: www.iii.dev/docs/foo should redirect
+// directly to docs.iii.dev/foo in ONE hop, not two (www → apex → docs).
+//
+// Tested in redirects.test.js via `node --test`.
+
+function redirect(location) {
+  return {
+    statusCode: 301,
+    statusDescription: 'Moved Permanently',
+    headers: {
+      'location': { value: location },
+      'cache-control': { value: 'public, max-age=3600' },
+    },
+  };
+}
+
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+  var host = request.headers && request.headers.host && request.headers.host.value;
+
+  // 1. /docs exact or /docs/ exact → 301 docs.iii.dev/
+  if (uri === '/docs' || uri === '/docs/') {
+    return redirect('https://docs.iii.dev/');
+  }
+
+  // /docs/<anything> → 301 docs.iii.dev/<anything>
+  if (uri.indexOf('/docs/') === 0) {
+    return redirect('https://docs.iii.dev' + uri.substring('/docs'.length));
+  }
+
+  // 2. /llms.txt → 301 docs.iii.dev/llms.txt
+  if (uri === '/llms.txt') {
+    return redirect('https://docs.iii.dev/llms.txt');
+  }
+
+  // 3. www.iii.dev → 301 apex (preserves path including querystring handled by CF)
+  if (host === 'www.iii.dev') {
+    return redirect('https://iii.dev' + uri);
+  }
+
+  // 4. /.well-known/* → pass through explicitly (S3 returns 404, no SPA fallback)
+  if (uri.indexOf('/.well-known/') === 0) {
+    return request;
+  }
+
+  // 5. SPA fallback: extensionless path, doesn't end with /, not the root.
+  //    Rewrite URI to /index.html so S3 returns the SPA shell with 200.
+  if (uri !== '/' && uri.charAt(uri.length - 1) !== '/') {
+    var lastSlash = uri.lastIndexOf('/');
+    var lastSegment = uri.substring(lastSlash + 1);
+    if (lastSegment.indexOf('.') === -1) {
+      request.uri = '/index.html';
+      return request;
+    }
+  }
+
+  // 6. Pass through unchanged.
+  return request;
+}

--- a/infra/terraform/website/cloudfront_functions/redirects.js
+++ b/infra/terraform/website/cloudfront_functions/redirects.js
@@ -27,10 +27,11 @@ function redirect(location) {
   };
 }
 
+// biome-ignore lint/correctness/noUnusedVariables: CloudFront Function entry point (called by CloudFront runtime, not imported)
 function handler(event) {
-  var request = event.request;
-  var uri = request.uri;
-  var host = request.headers && request.headers.host && request.headers.host.value;
+  const request = event.request;
+  const uri = request.uri;
+  const host = request.headers?.host?.value;
 
   // 1. /docs exact or /docs/ exact → 301 docs.iii.dev/
   if (uri === '/docs' || uri === '/docs/') {
@@ -39,7 +40,7 @@ function handler(event) {
 
   // /docs/<anything> → 301 docs.iii.dev/<anything>
   if (uri.indexOf('/docs/') === 0) {
-    return redirect('https://docs.iii.dev' + uri.substring('/docs'.length));
+    return redirect(`https://docs.iii.dev${uri.substring('/docs'.length)}`);
   }
 
   // 2. /llms.txt → 301 docs.iii.dev/llms.txt
@@ -47,9 +48,9 @@ function handler(event) {
     return redirect('https://docs.iii.dev/llms.txt');
   }
 
-  // 3. www.iii.dev → 301 apex (preserves path including querystring handled by CF)
+  // 3. www.iii.dev → 301 apex (preserves path; querystring reattached by CF)
   if (host === 'www.iii.dev') {
-    return redirect('https://iii.dev' + uri);
+    return redirect(`https://iii.dev${uri}`);
   }
 
   // 4. /.well-known/* → pass through explicitly (S3 returns 404, no SPA fallback)
@@ -60,8 +61,8 @@ function handler(event) {
   // 5. SPA fallback: extensionless path, doesn't end with /, not the root.
   //    Rewrite URI to /index.html so S3 returns the SPA shell with 200.
   if (uri !== '/' && uri.charAt(uri.length - 1) !== '/') {
-    var lastSlash = uri.lastIndexOf('/');
-    var lastSegment = uri.substring(lastSlash + 1);
+    const lastSlash = uri.lastIndexOf('/');
+    const lastSegment = uri.substring(lastSlash + 1);
     if (lastSegment.indexOf('.') === -1) {
       request.uri = '/index.html';
       return request;

--- a/infra/terraform/website/cloudfront_functions/redirects.js
+++ b/infra/terraform/website/cloudfront_functions/redirects.js
@@ -4,15 +4,24 @@
 // the /api/search* behavior — its JSON responses must pass through unchanged.
 //
 // Responsibilities, in order:
-//   1. /docs or /docs/* → 301 docs.iii.dev (strips /docs prefix)
-//   2. /llms.txt       → 301 docs.iii.dev/llms.txt
-//   3. host www.iii.dev → 301 apex iii.dev (preserves path)
-//   4. /.well-known/*  → pass through (S3 returns 404, no SPA rewrite)
-//   5. SPA fallback: extensionless path that doesn't end in / → rewrite uri to /index.html
-//   6. Everything else → pass through
+//   1. /docs or /docs/* → 301 docs.iii.dev, **preserving the /docs prefix**.
+//      Why: the Mintlify project serves content under /docs/... Visiting
+//      docs.iii.dev/<slug> (without /docs prefix) returns 404 in the current
+//      setup. The k8s edge-proxy's docs.iii.dev server block has a matching
+//      rewrite (^/docs/docs/(.*)$ → /docs/$1) that handles the double-prefix.
+//      Until Mintlify is reconfigured to serve at the root of docs.iii.dev,
+//      we must redirect to the same path the current proxy serves.
+//   2. host www.iii.dev → 301 apex iii.dev (preserves path)
+//   3. /.well-known/*  → pass through (S3 returns 404, no SPA rewrite)
+//   4. SPA fallback: extensionless path that doesn't end in / → rewrite uri to /index.html
+//   5. Everything else → pass through
 //
 // Why /docs is checked BEFORE www→apex: www.iii.dev/docs/foo should redirect
-// directly to docs.iii.dev/foo in ONE hop, not two (www → apex → docs).
+// directly to docs.iii.dev/docs/foo in ONE hop, not two.
+//
+// /llms.txt is intentionally NOT special-cased: the current live site returns
+// 404 for iii.dev/llms.txt (Mintlify upstream doesn't have the content), so
+// passing it through to S3 (which also 404s) preserves today's behavior.
 //
 // Tested in redirects.test.js via `node --test`.
 
@@ -33,32 +42,32 @@ function handler(event) {
   const uri = request.uri;
   const host = request.headers?.host?.value;
 
-  // 1. /docs exact or /docs/ exact → 301 docs.iii.dev/
-  if (uri === '/docs' || uri === '/docs/') {
-    return redirect('https://docs.iii.dev/');
+  // 1. /docs exact → 301 docs.iii.dev/docs
+  if (uri === '/docs') {
+    return redirect('https://docs.iii.dev/docs');
   }
 
-  // /docs/<anything> → 301 docs.iii.dev/<anything>
+  // /docs/ exact → 301 docs.iii.dev/docs/
+  if (uri === '/docs/') {
+    return redirect('https://docs.iii.dev/docs/');
+  }
+
+  // /docs/<anything> → 301 docs.iii.dev/docs/<anything> (preserves the prefix)
   if (uri.indexOf('/docs/') === 0) {
-    return redirect(`https://docs.iii.dev${uri.substring('/docs'.length)}`);
+    return redirect(`https://docs.iii.dev${uri}`);
   }
 
-  // 2. /llms.txt → 301 docs.iii.dev/llms.txt
-  if (uri === '/llms.txt') {
-    return redirect('https://docs.iii.dev/llms.txt');
-  }
-
-  // 3. www.iii.dev → 301 apex (preserves path; querystring reattached by CF)
+  // 2. www.iii.dev → 301 apex (preserves path; querystring reattached by CF)
   if (host === 'www.iii.dev') {
     return redirect(`https://iii.dev${uri}`);
   }
 
-  // 4. /.well-known/* → pass through explicitly (S3 returns 404, no SPA fallback)
+  // 3. /.well-known/* → pass through explicitly (S3 returns 404, no SPA fallback)
   if (uri.indexOf('/.well-known/') === 0) {
     return request;
   }
 
-  // 5. SPA fallback: extensionless path, doesn't end with /, not the root.
+  // 4. SPA fallback: extensionless path, doesn't end with /, not the root.
   //    Rewrite URI to /index.html so S3 returns the SPA shell with 200.
   if (uri !== '/' && uri.charAt(uri.length - 1) !== '/') {
     const lastSlash = uri.lastIndexOf('/');
@@ -69,6 +78,6 @@ function handler(event) {
     }
   }
 
-  // 6. Pass through unchanged.
+  // 5. Pass through unchanged.
   return request;
 }

--- a/infra/terraform/website/cloudfront_functions/redirects.js
+++ b/infra/terraform/website/cloudfront_functions/redirects.js
@@ -30,54 +30,55 @@ function redirect(location) {
     statusCode: 301,
     statusDescription: 'Moved Permanently',
     headers: {
-      'location': { value: location },
+      location: { value: location },
       'cache-control': { value: 'public, max-age=3600' },
     },
-  };
+  }
 }
 
 // biome-ignore lint/correctness/noUnusedVariables: CloudFront Function entry point (called by CloudFront runtime, not imported)
+// biome-ignore lint/complexity/useOptionalChain: CloudFront Functions cloudfront-js-2.0 runtime does NOT support optional chaining (verified via aws cloudfront test-function → SyntaxError: Unexpected token ";" on `request.headers?.host?.value`). Must use traditional && short-circuit guards.
 function handler(event) {
-  const request = event.request;
-  const uri = request.uri;
-  const host = request.headers?.host?.value;
+  var request = event.request
+  var uri = request.uri
+  var host = request.headers && request.headers.host ? request.headers.host.value : undefined
 
   // 1. /docs exact → 301 docs.iii.dev/docs
   if (uri === '/docs') {
-    return redirect('https://docs.iii.dev/docs');
+    return redirect('https://docs.iii.dev/docs')
   }
 
   // /docs/ exact → 301 docs.iii.dev/docs/
   if (uri === '/docs/') {
-    return redirect('https://docs.iii.dev/docs/');
+    return redirect('https://docs.iii.dev/docs/')
   }
 
   // /docs/<anything> → 301 docs.iii.dev/docs/<anything> (preserves the prefix)
   if (uri.indexOf('/docs/') === 0) {
-    return redirect(`https://docs.iii.dev${uri}`);
+    return redirect(`https://docs.iii.dev${uri}`)
   }
 
   // 2. www.iii.dev → 301 apex (preserves path; querystring reattached by CF)
   if (host === 'www.iii.dev') {
-    return redirect(`https://iii.dev${uri}`);
+    return redirect(`https://iii.dev${uri}`)
   }
 
   // 3. /.well-known/* → pass through explicitly (S3 returns 404, no SPA fallback)
   if (uri.indexOf('/.well-known/') === 0) {
-    return request;
+    return request
   }
 
   // 4. SPA fallback: extensionless path, doesn't end with /, not the root.
   //    Rewrite URI to /index.html so S3 returns the SPA shell with 200.
   if (uri !== '/' && uri.charAt(uri.length - 1) !== '/') {
-    const lastSlash = uri.lastIndexOf('/');
-    const lastSegment = uri.substring(lastSlash + 1);
+    const lastSlash = uri.lastIndexOf('/')
+    const lastSegment = uri.substring(lastSlash + 1)
     if (lastSegment.indexOf('.') === -1) {
-      request.uri = '/index.html';
-      return request;
+      request.uri = '/index.html'
+      return request
     }
   }
 
   // 5. Pass through unchanged.
-  return request;
+  return request
 }

--- a/infra/terraform/website/cloudfront_functions/redirects.test.js
+++ b/infra/terraform/website/cloudfront_functions/redirects.test.js
@@ -54,30 +54,33 @@ function locationOf(result) {
   return result.headers.location.value;
 }
 
-// ── /docs redirect cases ───────────────────────────────────────────────────
+// ── /docs redirect cases (preserves the /docs prefix) ──────────────────────
+// Why preserved: Mintlify docs project only serves content under /docs/..
+// docs.iii.dev/quickstart returns 404, docs.iii.dev/docs/quickstart works.
+// See redirects.js header comment for the full rationale.
 
-test('/docs exact → 301 https://docs.iii.dev/', () => {
+test('/docs exact → 301 https://docs.iii.dev/docs', () => {
   const result = handler(buildEvent('/docs', 'iii.dev'));
   assert.ok(isRedirect(result));
-  assert.equal(locationOf(result), 'https://docs.iii.dev/');
+  assert.equal(locationOf(result), 'https://docs.iii.dev/docs');
 });
 
-test('/docs/ trailing slash → 301 https://docs.iii.dev/', () => {
+test('/docs/ trailing slash → 301 https://docs.iii.dev/docs/', () => {
   const result = handler(buildEvent('/docs/', 'iii.dev'));
   assert.ok(isRedirect(result));
-  assert.equal(locationOf(result), 'https://docs.iii.dev/');
+  assert.equal(locationOf(result), 'https://docs.iii.dev/docs/');
 });
 
-test('/docs/quickstart → 301 https://docs.iii.dev/quickstart', () => {
+test('/docs/quickstart → 301 https://docs.iii.dev/docs/quickstart', () => {
   const result = handler(buildEvent('/docs/quickstart', 'iii.dev'));
   assert.ok(isRedirect(result));
-  assert.equal(locationOf(result), 'https://docs.iii.dev/quickstart');
+  assert.equal(locationOf(result), 'https://docs.iii.dev/docs/quickstart');
 });
 
 test('/docs/guide/deep/nested → preserves deep path on redirect', () => {
   const result = handler(buildEvent('/docs/guide/deep/nested', 'iii.dev'));
   assert.ok(isRedirect(result));
-  assert.equal(locationOf(result), 'https://docs.iii.dev/guide/deep/nested');
+  assert.equal(locationOf(result), 'https://docs.iii.dev/docs/guide/deep/nested');
 });
 
 test('/docsfoo → NOT redirected (not under /docs/)', () => {
@@ -87,12 +90,15 @@ test('/docsfoo → NOT redirected (not under /docs/)', () => {
   assert.equal(result.uri, '/index.html');
 });
 
-// ── /llms.txt redirect ─────────────────────────────────────────────────────
+// ── /llms.txt: no special handling ─────────────────────────────────────────
+// Rationale: the current live site returns 404 for iii.dev/llms.txt, so
+// passing it through to S3 (also 404) preserves today's behavior. No point
+// redirecting to a URL that also 404s.
 
-test('/llms.txt → 301 https://docs.iii.dev/llms.txt', () => {
+test('/llms.txt → pass through unchanged (matches current 404 behavior)', () => {
   const result = handler(buildEvent('/llms.txt', 'iii.dev'));
-  assert.ok(isRedirect(result));
-  assert.equal(locationOf(result), 'https://docs.iii.dev/llms.txt');
+  assert.ok(!isRedirect(result));
+  assert.equal(result.uri, '/llms.txt');
 });
 
 // ── www → apex redirect ────────────────────────────────────────────────────
@@ -109,20 +115,14 @@ test('www.iii.dev/some/page → 301 https://iii.dev/some/page', () => {
   assert.equal(locationOf(result), 'https://iii.dev/some/page');
 });
 
-test('www.iii.dev/docs/foo → 301 https://docs.iii.dev/foo (ONE hop, not two)', () => {
+test('www.iii.dev/docs/foo → 301 https://docs.iii.dev/docs/foo (ONE hop, not two)', () => {
   const result = handler(buildEvent('/docs/foo', 'www.iii.dev'));
   assert.ok(isRedirect(result));
   assert.equal(
     locationOf(result),
-    'https://docs.iii.dev/foo',
+    'https://docs.iii.dev/docs/foo',
     'docs redirect must win over www→apex redirect to avoid a 2-hop chain',
   );
-});
-
-test('www.iii.dev/llms.txt → 301 https://docs.iii.dev/llms.txt (ONE hop)', () => {
-  const result = handler(buildEvent('/llms.txt', 'www.iii.dev'));
-  assert.ok(isRedirect(result));
-  assert.equal(locationOf(result), 'https://docs.iii.dev/llms.txt');
 });
 
 // ── SPA fallback ───────────────────────────────────────────────────────────
@@ -202,5 +202,5 @@ test('missing host header → still handles other rules correctly', () => {
   delete event.request.headers.host;
   const result = handler(event);
   assert.ok(isRedirect(result));
-  assert.equal(locationOf(result), 'https://docs.iii.dev/foo');
+  assert.equal(locationOf(result), 'https://docs.iii.dev/docs/foo');
 });

--- a/infra/terraform/website/cloudfront_functions/redirects.test.js
+++ b/infra/terraform/website/cloudfront_functions/redirects.test.js
@@ -1,0 +1,206 @@
+// Unit tests for the CloudFront Function at redirects.js.
+//
+// Run with:  node --test infra/terraform/website/cloudfront_functions/redirects.test.js
+//
+// The CloudFront Functions runtime (cloudfront-js-2.0) is close to ES2020 with no
+// Node built-ins. redirects.js defines `handler(event)` at module scope without
+// `module.exports`, so we load it via `fs.readFileSync` + `new Function(...)`
+// rather than `require(...)`. That lets us test the pure function in plain Node
+// without shipping a CommonJS wrapper to CloudFront.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const source = fs.readFileSync(
+  path.join(__dirname, 'redirects.js'),
+  'utf8',
+);
+
+// Load `handler` into the current scope by evaluating the source inside a
+// fresh Function sandbox. Returns the `handler` symbol.
+const handler = new Function(
+  source + '\nreturn handler;',
+)();
+
+function buildEvent(uri, host) {
+  return {
+    version: '1.0',
+    context: {},
+    viewer: {},
+    request: {
+      method: 'GET',
+      uri: uri,
+      querystring: {},
+      headers: host ? { host: { value: host } } : {},
+      cookies: {},
+    },
+  };
+}
+
+function isRedirect(result) {
+  return (
+    result &&
+    typeof result === 'object' &&
+    result.statusCode === 301 &&
+    result.headers &&
+    result.headers.location &&
+    typeof result.headers.location.value === 'string'
+  );
+}
+
+function locationOf(result) {
+  return result.headers.location.value;
+}
+
+// ── /docs redirect cases ───────────────────────────────────────────────────
+
+test('/docs exact → 301 https://docs.iii.dev/', () => {
+  const result = handler(buildEvent('/docs', 'iii.dev'));
+  assert.ok(isRedirect(result));
+  assert.equal(locationOf(result), 'https://docs.iii.dev/');
+});
+
+test('/docs/ trailing slash → 301 https://docs.iii.dev/', () => {
+  const result = handler(buildEvent('/docs/', 'iii.dev'));
+  assert.ok(isRedirect(result));
+  assert.equal(locationOf(result), 'https://docs.iii.dev/');
+});
+
+test('/docs/quickstart → 301 https://docs.iii.dev/quickstart', () => {
+  const result = handler(buildEvent('/docs/quickstart', 'iii.dev'));
+  assert.ok(isRedirect(result));
+  assert.equal(locationOf(result), 'https://docs.iii.dev/quickstart');
+});
+
+test('/docs/guide/deep/nested → preserves deep path on redirect', () => {
+  const result = handler(buildEvent('/docs/guide/deep/nested', 'iii.dev'));
+  assert.ok(isRedirect(result));
+  assert.equal(locationOf(result), 'https://docs.iii.dev/guide/deep/nested');
+});
+
+test('/docsfoo → NOT redirected (not under /docs/)', () => {
+  const result = handler(buildEvent('/docsfoo', 'iii.dev'));
+  assert.ok(!isRedirect(result), 'should not be a redirect');
+  // SPA fallback applies: extensionless, no trailing slash
+  assert.equal(result.uri, '/index.html');
+});
+
+// ── /llms.txt redirect ─────────────────────────────────────────────────────
+
+test('/llms.txt → 301 https://docs.iii.dev/llms.txt', () => {
+  const result = handler(buildEvent('/llms.txt', 'iii.dev'));
+  assert.ok(isRedirect(result));
+  assert.equal(locationOf(result), 'https://docs.iii.dev/llms.txt');
+});
+
+// ── www → apex redirect ────────────────────────────────────────────────────
+
+test('www.iii.dev/ → 301 https://iii.dev/', () => {
+  const result = handler(buildEvent('/', 'www.iii.dev'));
+  assert.ok(isRedirect(result));
+  assert.equal(locationOf(result), 'https://iii.dev/');
+});
+
+test('www.iii.dev/some/page → 301 https://iii.dev/some/page', () => {
+  const result = handler(buildEvent('/some/page', 'www.iii.dev'));
+  assert.ok(isRedirect(result));
+  assert.equal(locationOf(result), 'https://iii.dev/some/page');
+});
+
+test('www.iii.dev/docs/foo → 301 https://docs.iii.dev/foo (ONE hop, not two)', () => {
+  const result = handler(buildEvent('/docs/foo', 'www.iii.dev'));
+  assert.ok(isRedirect(result));
+  assert.equal(
+    locationOf(result),
+    'https://docs.iii.dev/foo',
+    'docs redirect must win over www→apex redirect to avoid a 2-hop chain',
+  );
+});
+
+test('www.iii.dev/llms.txt → 301 https://docs.iii.dev/llms.txt (ONE hop)', () => {
+  const result = handler(buildEvent('/llms.txt', 'www.iii.dev'));
+  assert.ok(isRedirect(result));
+  assert.equal(locationOf(result), 'https://docs.iii.dev/llms.txt');
+});
+
+// ── SPA fallback ───────────────────────────────────────────────────────────
+
+test('/ (root) → pass through unchanged', () => {
+  const result = handler(buildEvent('/', 'iii.dev'));
+  assert.ok(!isRedirect(result));
+  assert.equal(result.uri, '/');
+});
+
+test('/some/client/route → rewrite uri to /index.html', () => {
+  const result = handler(buildEvent('/some/client/route', 'iii.dev'));
+  assert.ok(!isRedirect(result));
+  assert.equal(result.uri, '/index.html');
+});
+
+test('/manifesto → rewrite uri to /index.html', () => {
+  const result = handler(buildEvent('/manifesto', 'iii.dev'));
+  assert.ok(!isRedirect(result));
+  assert.equal(result.uri, '/index.html');
+});
+
+test('/foo/ trailing slash → pass through unchanged (no SPA rewrite)', () => {
+  const result = handler(buildEvent('/foo/', 'iii.dev'));
+  assert.ok(!isRedirect(result));
+  assert.equal(result.uri, '/foo/');
+});
+
+// ── File extension pass-through (NOT SPA fallback) ─────────────────────────
+
+test('/missing.jpg → pass through unchanged (S3 returns 404)', () => {
+  const result = handler(buildEvent('/missing.jpg', 'iii.dev'));
+  assert.ok(!isRedirect(result));
+  assert.equal(result.uri, '/missing.jpg');
+});
+
+test('/ai/index.html → pass through unchanged', () => {
+  const result = handler(buildEvent('/ai/index.html', 'iii.dev'));
+  assert.ok(!isRedirect(result));
+  assert.equal(result.uri, '/ai/index.html');
+});
+
+test('/assets/main.abc123.js → pass through unchanged', () => {
+  const result = handler(buildEvent('/assets/main.abc123.js', 'iii.dev'));
+  assert.ok(!isRedirect(result));
+  assert.equal(result.uri, '/assets/main.abc123.js');
+});
+
+test('/favicon.svg → pass through unchanged', () => {
+  const result = handler(buildEvent('/favicon.svg', 'iii.dev'));
+  assert.ok(!isRedirect(result));
+  assert.equal(result.uri, '/favicon.svg');
+});
+
+// ── /.well-known exception ─────────────────────────────────────────────────
+
+test('/.well-known/vercel/project.json → pass through (no SPA rewrite)', () => {
+  const result = handler(buildEvent('/.well-known/vercel/project.json', 'iii.dev'));
+  assert.ok(!isRedirect(result));
+  assert.equal(result.uri, '/.well-known/vercel/project.json');
+});
+
+test('/.well-known/foo (no extension) → pass through, NOT SPA rewritten', () => {
+  const result = handler(buildEvent('/.well-known/foo', 'iii.dev'));
+  assert.ok(!isRedirect(result));
+  assert.equal(
+    result.uri,
+    '/.well-known/foo',
+    '.well-known is an explicit exemption from SPA fallback',
+  );
+});
+
+// ── Missing host header (defensive) ────────────────────────────────────────
+
+test('missing host header → still handles other rules correctly', () => {
+  const event = buildEvent('/docs/foo', undefined);
+  delete event.request.headers.host;
+  const result = handler(event);
+  assert.ok(isRedirect(result));
+  assert.equal(locationOf(result), 'https://docs.iii.dev/foo');
+});

--- a/infra/terraform/website/iam_github_oidc.tf
+++ b/infra/terraform/website/iam_github_oidc.tf
@@ -1,0 +1,98 @@
+# Reuse the existing GitHub OIDC provider if present in the account, else create one.
+# Phase 0 of the runbook asks you to verify existence via
+#   aws iam list-open-id-connect-providers
+# If a provider for token.actions.githubusercontent.com already exists, set
+# TF_VAR_github_oidc_provider_arn (or edit the data source to use it) rather than
+# creating a second one.
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = ["sts.amazonaws.com"]
+
+  # GitHub's root CA thumbprints. AWS no longer validates these since 2023 (OIDC
+  # signature verification replaced certificate validation), but the field is still
+  # required by the resource schema.
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
+  ]
+}
+
+data "aws_iam_policy_document" "github_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values = [
+        "repo:${var.github_repo}:ref:refs/heads/main",
+        "repo:${var.github_repo}:environment:${var.github_environment}",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_deploy_website" {
+  name                 = "motia-prod-github-deploy-iii-website"
+  description          = "Assumed by GitHub Actions from iii-hq/iii main branch + production env to deploy the iii.dev website"
+  assume_role_policy   = data.aws_iam_policy_document.github_trust.json
+  max_session_duration = 3600
+}
+
+data "aws_iam_policy_document" "github_deploy_website" {
+  statement {
+    sid    = "ListBucket"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+    resources = [aws_s3_bucket.site.arn]
+  }
+
+  statement {
+    sid    = "ReadWriteObjects"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = ["${aws_s3_bucket.site.arn}/*"]
+  }
+
+  statement {
+    sid    = "CloudFrontInvalidation"
+    effect = "Allow"
+    actions = [
+      "cloudfront:CreateInvalidation",
+      "cloudfront:GetInvalidation",
+      "cloudfront:ListInvalidations",
+    ]
+    resources = [aws_cloudfront_distribution.site.arn]
+  }
+}
+
+resource "aws_iam_policy" "github_deploy_website" {
+  name   = "motia-prod-github-deploy-iii-website"
+  policy = data.aws_iam_policy_document.github_deploy_website.json
+}
+
+resource "aws_iam_role_policy_attachment" "github_deploy_website" {
+  role       = aws_iam_role.github_deploy_website.name
+  policy_arn = aws_iam_policy.github_deploy_website.arn
+}

--- a/infra/terraform/website/iam_github_oidc.tf
+++ b/infra/terraform/website/iam_github_oidc.tf
@@ -47,7 +47,7 @@ data "aws_iam_policy_document" "github_trust" {
 }
 
 resource "aws_iam_role" "github_deploy_website" {
-  name                 = "motia-prod-github-deploy-iii-website"
+  name                 = "iii-website-prod-github-deploy"
   description          = "Assumed by GitHub Actions from iii-hq/iii main branch + production env to deploy the iii.dev website"
   assume_role_policy   = data.aws_iam_policy_document.github_trust.json
   max_session_duration = 3600
@@ -88,7 +88,7 @@ data "aws_iam_policy_document" "github_deploy_website" {
 }
 
 resource "aws_iam_policy" "github_deploy_website" {
-  name   = "motia-prod-github-deploy-iii-website"
+  name   = "iii-website-prod-github-deploy"
   policy = data.aws_iam_policy_document.github_deploy_website.json
 }
 

--- a/infra/terraform/website/main.tf
+++ b/infra/terraform/website/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  backend "s3" {
+    bucket         = "motia-prod-terraform-state-us-east-1"
+    key            = "website/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "motia-prod-terraform-locks"
+    encrypt        = true
+  }
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  profile = "motia-prod"
+
+  default_tags {
+    tags = {
+      Project     = "iii"
+      Environment = "prod"
+      Module      = "infra/terraform/website"
+      ManagedBy   = "terraform"
+      Service     = "iii-dev-website"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_route53_zone" "iii_dev" {
+  name         = "iii.dev."
+  private_zone = false
+}

--- a/infra/terraform/website/main.tf
+++ b/infra/terraform/website/main.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "s3" {
-    bucket         = "motia-prod-terraform-state-us-east-1"
+    bucket         = "iii-terraform-state-prod-us-east-1"
     key            = "website/terraform.tfstate"
     region         = "us-east-1"
-    dynamodb_table = "motia-prod-terraform-locks"
+    dynamodb_table = "iii-terraform-locks-prod"
     encrypt        = true
   }
 }
@@ -16,9 +16,9 @@ provider "aws" {
     tags = {
       Project     = "iii"
       Environment = "prod"
+      Service     = "website"
       Module      = "infra/terraform/website"
       ManagedBy   = "terraform"
-      Service     = "iii-dev-website"
     }
   }
 }

--- a/infra/terraform/website/observability.tf
+++ b/infra/terraform/website/observability.tf
@@ -1,5 +1,5 @@
 resource "aws_sns_topic" "alarms" {
-  name = "motia-prod-iii-website-alarms"
+  name = "iii-website-prod-alarms"
 }
 
 resource "aws_sns_topic_subscription" "email" {
@@ -13,7 +13,7 @@ resource "aws_sns_topic_subscription" "email" {
 
 # Catches bad deploys, CF Function JS errors, and origin (S3 or search API) 5xx bursts.
 resource "aws_cloudwatch_metric_alarm" "cf_5xx_rate" {
-  alarm_name          = "motia-prod-iii-website-cf-5xx-rate"
+  alarm_name          = "iii-website-prod-cf-5xx-rate"
   alarm_description   = "CloudFront 5xxErrorRate above 1% for the iii.dev distribution"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 2
@@ -39,7 +39,7 @@ resource "aws_cloudwatch_metric_alarm" "cf_5xx_rate" {
 # Catches the case where ACM auto-renewal fails and the cert is about to expire.
 # ACM publishes DaysToExpiry per certificate in us-east-1 for CloudFront certs.
 resource "aws_cloudwatch_metric_alarm" "acm_days_to_expiry" {
-  alarm_name          = "motia-prod-iii-website-acm-days-to-expiry"
+  alarm_name          = "iii-website-prod-acm-days-to-expiry"
   alarm_description   = "ACM certificate for iii.dev is within 30 days of expiring and has not renewed"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = 1

--- a/infra/terraform/website/observability.tf
+++ b/infra/terraform/website/observability.tf
@@ -1,0 +1,59 @@
+resource "aws_sns_topic" "alarms" {
+  name = "motia-prod-iii-website-alarms"
+}
+
+resource "aws_sns_topic_subscription" "email" {
+  topic_arn = aws_sns_topic.alarms.arn
+  protocol  = "email"
+  endpoint  = var.alarm_email
+  # AWS sends a confirmation email to `alarm_email` after first apply. The
+  # subscription stays in "PendingConfirmation" until someone clicks the link.
+  # Documented in infra/terraform/website/README.md.
+}
+
+# Catches bad deploys, CF Function JS errors, and origin (S3 or search API) 5xx bursts.
+resource "aws_cloudwatch_metric_alarm" "cf_5xx_rate" {
+  alarm_name          = "motia-prod-iii-website-cf-5xx-rate"
+  alarm_description   = "CloudFront 5xxErrorRate above 1% for the iii.dev distribution"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  datapoints_to_alarm = 2
+  threshold           = 1.0
+  treat_missing_data  = "notBreaching"
+
+  metric_name = "5xxErrorRate"
+  namespace   = "AWS/CloudFront"
+  statistic   = "Average"
+  period      = 60
+  unit        = "Percent"
+
+  dimensions = {
+    DistributionId = aws_cloudfront_distribution.site.id
+    Region         = "Global"
+  }
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}
+
+# Catches the case where ACM auto-renewal fails and the cert is about to expire.
+# ACM publishes DaysToExpiry per certificate in us-east-1 for CloudFront certs.
+resource "aws_cloudwatch_metric_alarm" "acm_days_to_expiry" {
+  alarm_name          = "motia-prod-iii-website-acm-days-to-expiry"
+  alarm_description   = "ACM certificate for iii.dev is within 30 days of expiring and has not renewed"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  threshold           = 30
+  treat_missing_data  = "breaching"
+
+  metric_name = "DaysToExpiry"
+  namespace   = "AWS/CertificateManager"
+  statistic   = "Minimum"
+  period      = 86400 # 1 day
+
+  dimensions = {
+    CertificateArn = aws_acm_certificate.site.arn
+  }
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+}

--- a/infra/terraform/website/outputs.tf
+++ b/infra/terraform/website/outputs.tf
@@ -1,0 +1,39 @@
+output "bucket_name" {
+  description = "Name of the S3 bucket hosting the website build output"
+  value       = aws_s3_bucket.site.bucket
+}
+
+output "bucket_arn" {
+  description = "ARN of the S3 bucket"
+  value       = aws_s3_bucket.site.arn
+}
+
+output "distribution_id" {
+  description = "CloudFront distribution ID — set as GitHub repo variable CF_DISTRIBUTION_ID"
+  value       = aws_cloudfront_distribution.site.id
+}
+
+output "distribution_domain_name" {
+  description = "CloudFront distribution domain (dXXXXX.cloudfront.net) — target of Route53 ALIAS records"
+  value       = aws_cloudfront_distribution.site.domain_name
+}
+
+output "distribution_arn" {
+  description = "CloudFront distribution ARN"
+  value       = aws_cloudfront_distribution.site.arn
+}
+
+output "cert_arn" {
+  description = "ACM certificate ARN for iii.dev, www.iii.dev, iii-preview.iii.dev"
+  value       = aws_acm_certificate.site.arn
+}
+
+output "github_deploy_role_arn" {
+  description = "IAM role ARN assumed by GitHub Actions from iii-hq/iii main branch + production env — set as GitHub secret AWS_DEPLOY_ROLE_ARN"
+  value       = aws_iam_role.github_deploy_website.arn
+}
+
+output "sns_alarms_topic_arn" {
+  description = "SNS topic ARN that receives production alarms"
+  value       = aws_sns_topic.alarms.arn
+}

--- a/infra/terraform/website/route53.tf
+++ b/infra/terraform/website/route53.tf
@@ -24,24 +24,40 @@ resource "aws_route53_record" "preview_aaaa" {
   }
 }
 
-# Apex + www records — created via `terraform import` during Phase 4 cutover.
+# Apex + www records — GATED behind var.manage_apex_records (default false).
 #
-# DO NOT run `terraform apply` on these resources until Phase 4, because External-DNS
-# currently owns the apex A/AAAA records. Apply order during Phase 4:
-#   1. Remove iii-dev and iii-dev-www Ingresses from motia-argocd-values (PR merged + synced).
-#   2. `terraform import aws_route53_record.apex_a <zone_id>_iii.dev_A`
-#      `terraform import aws_route53_record.apex_aaaa <zone_id>_iii.dev_AAAA`
-#      `terraform import aws_route53_record.www_a <zone_id>_www.iii.dev_A`
-#      `terraform import aws_route53_record.www_aaaa <zone_id>_www.iii.dev_AAAA`
-#   3. `terraform apply` — diff shows target changing from k8s NLB alias → CloudFront alias.
-#      Single atomic Route53 UPSERT per record. Zero NXDOMAIN window.
-#   4. Manually clean up the External-DNS `cname-iii.dev` and `cname-www.iii.dev` TXT
-#      ownership records via aws CLI.
+# Phase 2 (preview-only): var.manage_apex_records = false, count = 0, no resources.
+# The apex `iii.dev` and `www.iii.dev` records already exist in Route53 and are
+# NOT touched by this module during Phase 2. Attempting to create them without
+# the gate (which is what happened on the first apply attempt) causes
+# `InvalidChangeBatch: record already exists` because:
+#   - apex iii.dev A/AAAA: manually created ALIAS to the k8s public NLB
+#   - www.iii.dev A/AAAA:  managed by External-DNS from ingress/site/iii-dev-www
+#
+# Phase 4 (cutover): var.manage_apex_records = true, after:
+#   1. An argocd-values PR removes the `iii-dev-www` Ingress so External-DNS
+#      (upsert-only policy) stops managing www.iii.dev. Merge + ArgoCD sync.
+#      The apex `iii-dev` Ingress stays — it was never External-DNS-owned.
+#   2. Import the existing records into TF state (note the [0] index, because
+#      the resources are count-ed):
+#        terraform import 'aws_route53_record.apex_a[0]'    $ZONE_iii.dev_A
+#        terraform import 'aws_route53_record.apex_aaaa[0]' $ZONE_iii.dev_AAAA
+#        terraform import 'aws_route53_record.www_a[0]'     $ZONE_www.iii.dev_A
+#        terraform import 'aws_route53_record.www_aaaa[0]'  $ZONE_www.iii.dev_AAAA
+#   3. `terraform apply -var='manage_apex_records=true'` — diff shows each
+#      record's ALIAS target changing from the k8s NLB to the CloudFront
+#      distribution. Atomic single Route53 UPSERT per record. Zero NXDOMAIN
+#      window.
+#   4. Manually clean up the External-DNS TXT ownership record
+#      `external-dns-cname-www.iii.dev` via aws CLI. (There is no
+#      `cname-iii.dev` TXT — the apex was never External-DNS-owned.)
 #
 # See infra/terraform/website/README.md and the plan at
 # ~/.claude/plans/lazy-nibbling-valiant.md (Phase 4) for the full runbook.
 
 resource "aws_route53_record" "apex_a" {
+  count = var.manage_apex_records ? 1 : 0
+
   zone_id = data.aws_route53_zone.iii_dev.zone_id
   name    = var.apex_domain
   type    = "A"
@@ -54,6 +70,8 @@ resource "aws_route53_record" "apex_a" {
 }
 
 resource "aws_route53_record" "apex_aaaa" {
+  count = var.manage_apex_records ? 1 : 0
+
   zone_id = data.aws_route53_zone.iii_dev.zone_id
   name    = var.apex_domain
   type    = "AAAA"
@@ -66,6 +84,8 @@ resource "aws_route53_record" "apex_aaaa" {
 }
 
 resource "aws_route53_record" "www_a" {
+  count = var.manage_apex_records ? 1 : 0
+
   zone_id = data.aws_route53_zone.iii_dev.zone_id
   name    = var.www_domain
   type    = "A"
@@ -78,6 +98,8 @@ resource "aws_route53_record" "www_a" {
 }
 
 resource "aws_route53_record" "www_aaaa" {
+  count = var.manage_apex_records ? 1 : 0
+
   zone_id = data.aws_route53_zone.iii_dev.zone_id
   name    = var.www_domain
   type    = "AAAA"

--- a/infra/terraform/website/route53.tf
+++ b/infra/terraform/website/route53.tf
@@ -1,0 +1,90 @@
+# Preview subdomain — created immediately during Phase 2. Used for the 24h staging
+# validation window before the apex cutover. Removed in Phase 5 after cutover stabilizes.
+resource "aws_route53_record" "preview_a" {
+  zone_id = data.aws_route53_zone.iii_dev.zone_id
+  name    = var.preview_domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.site.domain_name
+    zone_id                = aws_cloudfront_distribution.site.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "preview_aaaa" {
+  zone_id = data.aws_route53_zone.iii_dev.zone_id
+  name    = var.preview_domain
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.site.domain_name
+    zone_id                = aws_cloudfront_distribution.site.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# Apex + www records — created via `terraform import` during Phase 4 cutover.
+#
+# DO NOT run `terraform apply` on these resources until Phase 4, because External-DNS
+# currently owns the apex A/AAAA records. Apply order during Phase 4:
+#   1. Remove iii-dev and iii-dev-www Ingresses from motia-argocd-values (PR merged + synced).
+#   2. `terraform import aws_route53_record.apex_a <zone_id>_iii.dev_A`
+#      `terraform import aws_route53_record.apex_aaaa <zone_id>_iii.dev_AAAA`
+#      `terraform import aws_route53_record.www_a <zone_id>_www.iii.dev_A`
+#      `terraform import aws_route53_record.www_aaaa <zone_id>_www.iii.dev_AAAA`
+#   3. `terraform apply` — diff shows target changing from k8s NLB alias → CloudFront alias.
+#      Single atomic Route53 UPSERT per record. Zero NXDOMAIN window.
+#   4. Manually clean up the External-DNS `cname-iii.dev` and `cname-www.iii.dev` TXT
+#      ownership records via aws CLI.
+#
+# See infra/terraform/website/README.md and the plan at
+# ~/.claude/plans/lazy-nibbling-valiant.md (Phase 4) for the full runbook.
+
+resource "aws_route53_record" "apex_a" {
+  zone_id = data.aws_route53_zone.iii_dev.zone_id
+  name    = var.apex_domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.site.domain_name
+    zone_id                = aws_cloudfront_distribution.site.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "apex_aaaa" {
+  zone_id = data.aws_route53_zone.iii_dev.zone_id
+  name    = var.apex_domain
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.site.domain_name
+    zone_id                = aws_cloudfront_distribution.site.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "www_a" {
+  zone_id = data.aws_route53_zone.iii_dev.zone_id
+  name    = var.www_domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.site.domain_name
+    zone_id                = aws_cloudfront_distribution.site.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "www_aaaa" {
+  zone_id = data.aws_route53_zone.iii_dev.zone_id
+  name    = var.www_domain
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.site.domain_name
+    zone_id                = aws_cloudfront_distribution.site.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/infra/terraform/website/s3.tf
+++ b/infra/terraform/website/s3.tf
@@ -1,0 +1,57 @@
+resource "aws_s3_bucket" "site" {
+  bucket = var.bucket_name
+}
+
+resource "aws_s3_bucket_versioning" "site" {
+  bucket = aws_s3_bucket.site.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "site" {
+  bucket = aws_s3_bucket.site.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "site" {
+  bucket = aws_s3_bucket.site.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+data "aws_iam_policy_document" "site_bucket" {
+  statement {
+    sid    = "AllowCloudFrontOACReadOnly"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    actions = ["s3:GetObject"]
+
+    resources = ["${aws_s3_bucket.site.arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.site.arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "site" {
+  bucket = aws_s3_bucket.site.id
+  policy = data.aws_iam_policy_document.site_bucket.json
+}

--- a/infra/terraform/website/s3.tf
+++ b/infra/terraform/website/s3.tf
@@ -30,8 +30,10 @@ resource "aws_s3_bucket_public_access_block" "site" {
 }
 
 data "aws_iam_policy_document" "site_bucket" {
+  # Allow CloudFront (scoped to our distribution via OAC + SourceArn) to fetch
+  # individual objects from the bucket.
   statement {
-    sid    = "AllowCloudFrontOACReadOnly"
+    sid    = "AllowCloudFrontOACGetObject"
     effect = "Allow"
 
     principals {
@@ -42,6 +44,34 @@ data "aws_iam_policy_document" "site_bucket" {
     actions = ["s3:GetObject"]
 
     resources = ["${aws_s3_bucket.site.arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.site.arn]
+    }
+  }
+
+  # Allow CloudFront to call ListBucket on the bucket (not objects). Without
+  # this, S3 returns 403 for missing objects instead of 404, because S3 uses
+  # ListBucket permission to distinguish "key doesn't exist" from "access
+  # denied." This does NOT expose a public LIST endpoint — CloudFront only
+  # ever makes GetObject calls for specific keys at the viewer's request. The
+  # ListBucket permission just changes the internal S3 error code from 403 to
+  # 404, which is what end users correctly see for missing paths like
+  # /missing.jpg.
+  statement {
+    sid    = "AllowCloudFrontOACListBucketForCorrect404"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    actions = ["s3:ListBucket"]
+
+    resources = [aws_s3_bucket.site.arn]
 
     condition {
       test     = "StringEquals"

--- a/infra/terraform/website/variables.tf
+++ b/infra/terraform/website/variables.tf
@@ -53,9 +53,18 @@ variable "github_repo" {
 }
 
 variable "github_environment" {
-  description = "GitHub environment the deploy role is scoped to"
+  description = <<-EOT
+    GitHub environment the deploy role is scoped to. Must match the environment
+    name used in `.github/workflows/deploy-website.yml`. Scoped to an isolated
+    environment (not the shared `Production`) so the AWS deploy secrets are not
+    exposed to unrelated workflows.
+
+    IMPORTANT: GitHub's OIDC sub claim uses the stored case of the environment
+    name, and IAM trust policy `StringEquals` is case-sensitive. Keep this value
+    in exact sync with the environment name in GitHub repo settings.
+  EOT
   type        = string
-  default     = "production"
+  default     = "iii-website-prod"
 }
 
 variable "csp_report_only" {

--- a/infra/terraform/website/variables.tf
+++ b/infra/terraform/website/variables.tf
@@ -63,3 +63,32 @@ variable "csp_report_only" {
   type        = bool
   default     = true
 }
+
+variable "manage_apex_records" {
+  description = <<-EOT
+    PHASE GATE — leave at `false` during Phase 2 (preview-only).
+
+    When `false`, Terraform does NOT create Route53 records for `iii.dev` or
+    `www.iii.dev`. This is correct during Phase 2 because those records already
+    exist in the zone (apex is manually created, www is managed by External-DNS
+    via the `iii-dev-www` Ingress in motia-argocd-values). Creating them from
+    this module would fail with `InvalidChangeBatch: record already exists`.
+
+    Flip to `true` ONLY during Phase 4 (apex cutover), after:
+      1. An argocd-values PR has removed the `iii-dev-www` Ingress (so
+         External-DNS stops managing `www.iii.dev`).
+      2. You have run `terraform import` for the four records:
+           terraform import 'aws_route53_record.apex_a[0]'    $ZONE_iii.dev_A
+           terraform import 'aws_route53_record.apex_aaaa[0]' $ZONE_iii.dev_AAAA
+           terraform import 'aws_route53_record.www_a[0]'     $ZONE_www.iii.dev_A
+           terraform import 'aws_route53_record.www_aaaa[0]'  $ZONE_www.iii.dev_AAAA
+
+    `terraform apply -var='manage_apex_records=true'` will then show an in-place
+    update swapping each record's ALIAS target from the k8s NLB to the
+    CloudFront distribution. Atomic single Route53 UPSERT per record.
+
+    See infra/terraform/website/README.md for the full Phase 4 runbook.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/infra/terraform/website/variables.tf
+++ b/infra/terraform/website/variables.tf
@@ -1,7 +1,7 @@
 variable "bucket_name" {
   description = "Name of the S3 bucket that stores the iii.dev website build output"
   type        = string
-  default     = "motia-prod-iii-website-us-east-1"
+  default     = "iii-website-prod-us-east-1"
 }
 
 variable "apex_domain" {

--- a/infra/terraform/website/variables.tf
+++ b/infra/terraform/website/variables.tf
@@ -1,0 +1,65 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket that stores the iii.dev website build output"
+  type        = string
+  default     = "motia-prod-iii-website-us-east-1"
+}
+
+variable "apex_domain" {
+  description = "Apex domain for the marketing site"
+  type        = string
+  default     = "iii.dev"
+}
+
+variable "www_domain" {
+  description = "www subdomain (301s to apex via CloudFront Function)"
+  type        = string
+  default     = "www.iii.dev"
+}
+
+variable "preview_domain" {
+  description = "Preview subdomain used for the 24h staging window before apex cutover. Remove after cutover stabilizes."
+  type        = string
+  default     = "iii-preview.iii.dev"
+}
+
+variable "docs_domain" {
+  description = "Docs subdomain that /docs/* is 301'd to"
+  type        = string
+  default     = "docs.iii.dev"
+}
+
+variable "search_api_origin" {
+  description = "Custom origin hostname that /api/search* is proxied to (temporarily, until docs migration)"
+  type        = string
+  default     = "iii-docs.vercel.app"
+}
+
+variable "alarm_email" {
+  description = "Email address that receives SNS notifications for production alarms"
+  type        = string
+  # Intentionally no default — set via terraform.tfvars or TF_VAR_alarm_email.
+}
+
+variable "price_class" {
+  description = "CloudFront price class"
+  type        = string
+  default     = "PriceClass_All"
+}
+
+variable "github_repo" {
+  description = "GitHub repo allowed to assume the deploy role via OIDC"
+  type        = string
+  default     = "iii-hq/iii"
+}
+
+variable "github_environment" {
+  description = "GitHub environment the deploy role is scoped to"
+  type        = string
+  default     = "production"
+}
+
+variable "csp_report_only" {
+  description = "If true, CSP is sent as Content-Security-Policy-Report-Only (no enforcement). Flip to false after the 24h staging window."
+  type        = bool
+  default     = true
+}

--- a/infra/terraform/website/versions.tf
+++ b/infra/terraform/website/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.60"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Migrates the iii.dev marketing site from the current k8s edge proxy → Vercel upstream path to AWS S3 + CloudFront in the motia-prod account. Phases 1 and 2 are already applied to AWS (preview infra is live). Phase 3 (CI wiring) completes when this merges.

**Production iii.dev is NOT affected by this merge.** The apex/www Route53 records are gated behind `var.manage_apex_records` (default false), so the existing k8s → Vercel path continues to serve production. Only the preview subdomain `iii-preview.iii.dev` is live on CloudFront today.

## Current state in AWS (Phase 2 done)

| Resource | Value |
|---|---|
| S3 bucket | \`iii-website-prod-us-east-1\` (private, OAC-only) |
| CloudFront distribution | \`E3N35RPQE4YVFQ\` → \`d3de6i4fbqh35s.cloudfront.net\` |
| ACM cert | Issued, SANs: iii.dev, www.iii.dev, iii-preview.iii.dev |
| IAM deploy role | \`arn:aws:iam::600627348446:role/iii-website-prod-github-deploy\` (GitHub OIDC, scoped to env \`iii-website-prod\`) |
| Route53 | \`iii-preview.iii.dev\` A+AAAA → CloudFront. Apex/www untouched. |
| SNS alarms | \`iii-website-prod-alarms\`, 5xxErrorRate + ACM DaysToExpiry |

## What this PR does

1. **Adds the entire Terraform website module** (\`infra/terraform/website/\`) — 9-file split (s3/cloudfront/acm/route53/iam_github_oidc/observability/main/variables/outputs/versions) plus CloudFront Function JS, unit tests, and a detailed README.
2. **Adds the Terraform state backend bootstrap** (\`infra/terraform/_bootstrap/\`) — S3 state bucket + DynamoDB lock table. Already applied; state file committed per standard bootstrap pattern.
3. **Adds 4 GitHub Actions workflows:**
   - \`deploy-website.yml\` — npm install + build + OIDC assume + S3 sync + CF invalidation, scoped to environment \`iii-website-prod\`.
   - \`smoke.yml\` — post-deploy curl assertions against 10 endpoints. Triggered automatically by \`workflow_run\` after deploy-website succeeds.
   - \`tf-plan.yml\` — PR-triggered \`terraform fmt/validate/plan\` with plan posted as comment. Requires \`AWS_READONLY_ROLE_ARN\` secret (not yet created — workflow will fail until set; non-blocking).
   - \`cloudfront-functions-test.yml\` — runs \`node --test\` on CF Function JS changes.

## Phase 2 smoke test results (live on iii-preview.iii.dev)

All 8 checks pass:

- \`GET /\` → 200
- \`GET /docs\` → 301 \`https://docs.iii.dev/docs\`
- \`GET /docs/quickstart\` → 301 \`https://docs.iii.dev/docs/quickstart\` (**prefix preserved** — Mintlify serves under /docs/)
- \`GET /docs/guide/deep/nested\` → 301 (deep prefix preserved)
- \`GET /missing.jpg\` → 404 (from S3, not SPA fallback)
- \`GET /some/client/route\` → 200 text/html (SPA fallback rewrites to /index.html)
- \`GET /llms.txt\` → 404 (matches current production)
- \`GET /.well-known/vercel/foo\` → 404 (matches current production)
- HSTS + CSP + X-Frame-Options + X-Content-Type-Options + Referrer-Policy headers present on all responses
- \`https://iii-website-prod-us-east-1.s3.amazonaws.com/index.html\` → 403 (bucket is private, CloudFront OAC only)

## Runtime landmines caught during Phase 2 validation

1. **CAA record** pinned to \`letsencrypt.org\` only, blocking AWS ACM. Fixed via manual \`aws route53 change-resource-record-sets\` adding \`amazontrust.com\` as a peer CA.
2. **\`*.iii.dev\` wildcard CNAME** (to \`cname.vercel-dns-016.com\`) intercepted CAA lookups for \`iii-preview.iii.dev\`, returning Vercel's own CAA list which excludes amazontrust.com. Fixed by adding an explicit CAA record at \`iii-preview.iii.dev\` allowing amazontrust.com, which breaks the wildcard match for that name.
3. **CloudFront Functions 2.0 runtime doesn't support optional chaining (\`?.\`)** despite AWS docs claiming ES2022. Fixed by replacing \`request.headers?.host?.value\` with traditional \`&&\` guards. Verified via \`aws cloudfront test-function\` before the fix confirmed the syntax error; after the fix, all paths execute cleanly.
4. **S3 returned 403 for missing objects** instead of 404. Fixed by granting \`s3:ListBucket\` on the bucket (not /*) to the CloudFront OAC principal — standard S3+CF pattern.
5. **Apex/www Route53 records fail to create** because they already exist in the zone (apex manual, www via External-DNS). Fixed by gating them behind \`var.manage_apex_records\` with \`count = var.manage_apex_records ? 1 : 0\`. Phase 2 apply is a no-op for those records; Phase 4 imports them with \`[0]\` index.
6. **GitHub OIDC sub claim is case-sensitive** against the stored environment name. The existing \`Production\` env (capitalized) is used by other Vercel integrations and would leak secrets. Fix: created a new isolated env \`iii-website-prod\` (lowercase, matches \`iii-website-prod-*\` naming), updated the IAM trust policy accordingly.

## What DOES NOT happen on merge

- **iii.dev apex DNS is not touched.** \`manage_apex_records = false\`. Still serves from k8s → Vercel.
- **www.iii.dev is not touched.**
- **docs.iii.dev, install.iii.dev, cloud.iii.dev, api.iii.dev are not touched.**
- **Vercel project iii-web.vercel.app is not deleted.** Keeps running as a warm rollback target.

## What DOES happen on merge (Phase 3)

- \`.github/workflows/cloudfront-functions-test.yml\` runs 20/20 CF Function tests → passes.
- \`.github/workflows/tf-plan.yml\` triggers on this PR → **fails** because \`AWS_READONLY_ROLE_ARN\` secret is not set. Non-blocking. Can be fixed later by either creating a read-only TF role or removing the workflow.
- \`.github/workflows/deploy-website.yml\` triggers on the push to main → builds \`website/\` with Node 22 + npm, assumes the OIDC role, runs \`aws s3 sync\` against \`iii-website-prod-us-east-1\`, creates a CloudFront invalidation.
- \`.github/workflows/smoke.yml\` fires after the deploy → runs curl assertions against **https://iii.dev**. **These will fail** because iii.dev still points at the k8s NLB → Vercel upstream, not CloudFront. This is expected — the smoke is for Phase 4 cutover validation. You can re-run it manually via \`workflow_dispatch\` with \`base_url=https://iii-preview.iii.dev\` to validate against the actual preview URL.

## Test plan

### Pre-merge (already done)
- [x] CloudFront Function \`node --test\` → 20/20 local ✓
- [x] \`terraform fmt -check -recursive\` → clean ✓
- [x] \`terraform validate\` (both modules) → clean ✓
- [x] Phase 1 apply (bootstrap) → state bucket + lock table live ✓
- [x] Phase 2 apply (website module) → S3 + CF + ACM + Route53 preview + IAM + SNS + alarms live ✓
- [x] CAA fix on \`iii.dev\` and \`iii-preview.iii.dev\` → live ✓
- [x] SNS email subscription confirmed by repo owner ✓
- [x] Phase 2 smoke on \`https://iii-preview.iii.dev\` → 8/8 ✓

### Post-merge (manual)
- [ ] Watch \`cloudfront-functions-test.yml\` on main → should be green
- [ ] Watch \`deploy-website.yml\` on main → should succeed (assume role, build, sync, invalidate)
- [ ] Manually \`gh workflow run smoke.yml -f base_url=https://iii-preview.iii.dev\` → should be green against the real build
- [ ] Set the real \`VITE_MAILMODO_FORM_URL\` in the \`iii-website-prod\` env secrets (currently empty string for validation)
- [ ] Decide on \`AWS_READONLY_ROLE_ARN\` approach for \`tf-plan.yml\` (skip, remove workflow, or create read-only TF role)

### Phase 4 (later, deliberate low-traffic window — NOT part of this merge)
- [ ] Open argocd-values PR removing \`iii-dev-www\` Ingress from \`apps/site/manifests/iii-dev.yaml\`
- [ ] Wait for ArgoCD sync, confirm External-DNS stopped managing www.iii.dev
- [ ] \`terraform import 'aws_route53_record.apex_a[0]'\` + 3 similar imports
- [ ] \`terraform apply -var='manage_apex_records=true' -var='csp_report_only=false'\`
- [ ] Verify iii.dev now serves from CloudFront via smoke + browser checks
- [ ] Manually delete orphaned \`external-dns-cname-www.iii.dev\` TXT record
- [ ] Detach \`iii.dev\` + \`www.iii.dev\` custom domains from Vercel iii-web project

### Phase 5 (48–72h after Phase 4)
- [ ] Remove iii-preview.iii.dev from ACM SANs + Route53
- [ ] Delete the temporary CAA record at iii-preview.iii.dev
- [ ] Delete the FAILED ACM cert leftover from a prior attempt
- [ ] Delete/archive the iii-web Vercel project
- [ ] Delete \`website/vercel.json\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Setup**
  * Configured AWS infrastructure-as-code for website deployment using Terraform, including S3 storage, CloudFront CDN, HTTPS certificates, and DNS management.
  * Implemented security headers, redirects, and single-page application support via CloudFront.
  * Set up monitoring and alerts for infrastructure health.

* **CI/CD Automation**
  * Added automated deployment pipeline for website changes to AWS.
  * Implemented smoke tests to verify deployment health.
  * Added Terraform validation workflow for infrastructure changes.

* **Tests**
  * Added unit tests for redirect and routing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->