### PR TITLE
feat(engine): wire OTEL logs config and improve passthrough rendering

### DIFF
--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -280,9 +280,8 @@ impl Engine {
             scope.is_none(),
             "begin_worker_scope called while a scope was already active"
         );
-        *scope = Some(crate::workers::reload::ScopeBuilder::new(
-            worker_name.to_string(),
-        ));
+        tracing::trace!(worker = %worker_name, "begin_worker_scope");
+        *scope = Some(crate::workers::reload::ScopeBuilder::new());
     }
 
     /// Closes the current scope and returns the registrations captured inside

--- a/engine/src/logging.rs
+++ b/engine/src/logging.rs
@@ -23,7 +23,9 @@ use tracing_subscriber::{
 use crate::telemetry::{ExporterType, OtelConfig, init_otel};
 use crate::workers::config::EngineConfig;
 use crate::workers::observability::logs_layer::OtelLogsLayer;
-use crate::workers::observability::otel::{get_log_storage, get_otel_config, init_log_storage};
+use crate::workers::observability::otel::{
+    OTEL_PASSTHROUGH_TARGET, get_log_storage, get_otel_config, init_log_storage, logs_enabled,
+};
 
 /// Collected field from tracing event
 #[derive(Debug, Clone)]
@@ -57,14 +59,95 @@ impl FieldCollector {
         self.function.as_deref()
     }
 
-    /// Get fields excluding the "function" field (since it's shown in the header)
-    fn get_display_fields(&self) -> Vec<(&String, &FieldValue)> {
+    /// Get fields excluding the "function" field (always hidden since it's
+    /// shown in the header). When `is_passthrough` is true, also hides the
+    /// "service" and "function_name" fields (rendered as the header) and
+    /// any "data" field whose string value is empty (would otherwise render
+    /// as `""`).
+    fn get_display_fields_filtered(&self, is_passthrough: bool) -> Vec<(&String, &FieldValue)> {
         self.fields
             .iter()
-            .filter(|(name, _)| name != "function")
+            .filter(|(name, value)| {
+                if name == "function" {
+                    return false;
+                }
+                if is_passthrough {
+                    if name == "service" || name == "function_name" {
+                        return false;
+                    }
+                    if name == "data"
+                        && matches!(value, FieldValue::String(s) if s.is_empty())
+                    {
+                        return false;
+                    }
+                }
+                true
+            })
             .map(|(name, value)| (name, value))
             .collect()
     }
+
+    /// Look up a field by name and return its value as a plain string.
+    fn field_as_string(&self, key: &str) -> Option<String> {
+        self.fields.iter().find_map(|(name, value)| {
+            if name != key {
+                return None;
+            }
+            Some(match value {
+                FieldValue::String(s) => s.clone(),
+                FieldValue::Debug(s) => s.trim_matches('"').to_string(),
+                FieldValue::I64(n) => n.to_string(),
+                FieldValue::U64(n) => n.to_string(),
+                FieldValue::F64(n) => n.to_string(),
+                FieldValue::Bool(b) => b.to_string(),
+            })
+        })
+    }
+}
+
+/// The worker (service) name and step (service.name) name for an OTEL
+/// passthrough event, each optional. Extracted from tracing fields emitted by
+/// `emit_log_to_console`.
+#[derive(Debug, Default)]
+struct PassthroughNames {
+    /// Worker service name, e.g. `todo-worker-python`.
+    worker: Option<String>,
+    /// Step/function name, e.g. `api.get./todos`. Parsed out of the `data`
+    /// JSON blob under the `service.name` attribute.
+    step: Option<String>,
+}
+
+impl PassthroughNames {
+    fn is_empty(&self) -> bool {
+        self.worker.is_none() && self.step.is_none()
+    }
+}
+
+/// Extract the passthrough worker + step names from the collected fields.
+///
+/// Primary source: the `function_name` field emitted directly by
+/// `emit_log_to_console`. Falls back to parsing `service.name` out of the
+/// `data` JSON blob for events produced before the `function_name` field
+/// was added.
+fn extract_passthrough_names(collector: &FieldCollector) -> PassthroughNames {
+    let worker = collector
+        .field_as_string("service")
+        .filter(|s| !s.is_empty());
+
+    let step = collector
+        .field_as_string("function_name")
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            collector.field_as_string("data").and_then(|data| {
+                let parsed: serde_json::Value = serde_json::from_str(&data).ok()?;
+                parsed
+                    .get("service.name")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            })
+        });
+
+    PassthroughNames { worker, step }
 }
 
 impl Visit for FieldCollector {
@@ -255,17 +338,41 @@ where
         };
         write!(writer, "[{}] ", level_str)?;
 
-        // Use "function" field if present, otherwise use target (module path)
-        let display_name = collector.get_function().unwrap_or(meta.target());
-        write!(writer, "{} ", display_name.cyan().bold())?;
+        // For OTEL-ingested logs from SDK workers, render two separately-
+        // colored header tokens: worker (blue) and step/service.name
+        // (purple). Falls back gracefully when one or both are missing.
+        let is_passthrough = meta.target() == OTEL_PASSTHROUGH_TARGET;
+        let passthrough = if is_passthrough {
+            extract_passthrough_names(&collector)
+        } else {
+            PassthroughNames::default()
+        };
+
+        if is_passthrough && !passthrough.is_empty() {
+            if let Some(w) = passthrough.worker.as_deref() {
+                write!(writer, "{} ", w.blue().bold())?;
+            }
+            if let Some(s) = passthrough.step.as_deref() {
+                write!(writer, "{} ", s.purple().bold())?;
+            }
+        } else {
+            let display_name = if is_passthrough {
+                OTEL_PASSTHROUGH_TARGET
+            } else {
+                collector.get_function().unwrap_or(meta.target())
+            };
+            write!(writer, "{} ", display_name.cyan().bold())?;
+        }
 
         // Write message if present
         if let Some(msg) = &collector.message {
             write!(writer, "{}", msg.white())?;
         }
 
-        // Render fields as tree (excluding "function" since it's in the header)
-        let display_fields = collector.get_display_fields();
+        // Render fields as tree. Hide "function" always; hide "service" and
+        // empty "data" on passthrough events since they're already in the
+        // header / vestigial after service.name stripping in emit_log_to_console.
+        let display_fields = collector.get_display_fields_filtered(is_passthrough);
         let tree = render_fields_tree(&display_fields);
         write!(writer, "{}", tree)?;
 
@@ -400,7 +507,7 @@ fn init_prod_log(log_level: &str, otel_cfg: &OtelConfig) {
         let otel_trace_layer = init_otel(otel_cfg);
 
         // Initialize OTEL logs layer if enabled
-        let otel_logs_layer = if otel_cfg.enabled {
+        let otel_logs_layer = if otel_cfg.enabled && logs_enabled(get_otel_config()) {
             // Get max logs from global config (if set) or use default
             let max_logs = get_otel_config()
                 .and_then(|cfg| cfg.logs_max_count)
@@ -436,7 +543,7 @@ fn init_local_log(log_level: &str, otel_cfg: &OtelConfig) {
         let otel_trace_layer = init_otel(otel_cfg);
 
         // Initialize OTEL logs layer if enabled
-        let otel_logs_layer = if otel_cfg.enabled {
+        let otel_logs_layer = if otel_cfg.enabled && logs_enabled(get_otel_config()) {
             // Get max logs from global config (if set) or use default
             let max_logs = get_otel_config()
                 .and_then(|cfg| cfg.logs_max_count)
@@ -614,9 +721,9 @@ mod tests {
         let f_other = fs.field("other").unwrap();
         collector.record_i64(&f_other, 7);
 
-        let display = collector.get_display_fields();
+        let display = collector.get_display_fields_filtered(false);
         // "function" is stored on the dedicated field, not in `fields`,
-        // so get_display_fields() just returns whatever is in `fields`.
+        // so the filtered view just returns whatever is in `fields`.
         assert_eq!(display.len(), 2);
         assert_eq!(display[0].0, "extra");
         assert_eq!(display[1].0, "other");
@@ -971,5 +1078,121 @@ modules:
         let _ = std::fs::remove_file(&path);
 
         assert!(TRACING.get().is_some());
+    }
+
+    // =========================================================================
+    // OTEL passthrough header tests
+    // =========================================================================
+
+    #[test]
+    fn test_extract_passthrough_names_reads_function_name_field_directly() {
+        let mut collector = FieldCollector::new();
+        let fs = make_fields!("service", "function_name", "data");
+
+        collector.record_str(&fs.field("service").unwrap(), "todo-worker-python");
+        collector.record_str(&fs.field("function_name").unwrap(), "api.get./todos");
+        collector.record_str(&fs.field("data").unwrap(), r#"{"log.data":{"count":0}}"#);
+
+        let names = extract_passthrough_names(&collector);
+        assert_eq!(names.worker.as_deref(), Some("todo-worker-python"));
+        assert_eq!(names.step.as_deref(), Some("api.get./todos"));
+        assert!(!names.is_empty());
+    }
+
+    #[test]
+    fn test_extract_passthrough_names_falls_back_to_parsing_data() {
+        let mut collector = FieldCollector::new();
+        let fs = make_fields!("service", "function_name", "data");
+
+        collector.record_str(&fs.field("service").unwrap(), "todo-worker-python");
+        // function_name field present but empty (what emit_log_to_console
+        // emits when the `service.name` attribute isn't set).
+        collector.record_str(&fs.field("function_name").unwrap(), "");
+        // Legacy: function name lives only in the data JSON.
+        collector.record_str(
+            &fs.field("data").unwrap(),
+            r#"{"service.name":"api.legacy"}"#,
+        );
+
+        let names = extract_passthrough_names(&collector);
+        assert_eq!(names.worker.as_deref(), Some("todo-worker-python"));
+        assert_eq!(names.step.as_deref(), Some("api.legacy"));
+    }
+
+    #[test]
+    fn test_extract_passthrough_names_step_only_when_worker_missing() {
+        let mut collector = FieldCollector::new();
+        let fs = make_fields!("data");
+
+        collector.record_str(
+            &fs.field("data").unwrap(),
+            r#"{"service.name":"api.get./todos"}"#,
+        );
+
+        let names = extract_passthrough_names(&collector);
+        assert!(names.worker.is_none());
+        assert_eq!(names.step.as_deref(), Some("api.get./todos"));
+    }
+
+    #[test]
+    fn test_extract_passthrough_names_empty_when_nothing_present() {
+        let collector = FieldCollector::new();
+        let names = extract_passthrough_names(&collector);
+        assert!(names.is_empty());
+        assert!(names.worker.is_none());
+        assert!(names.step.is_none());
+    }
+
+    #[test]
+    fn test_get_display_fields_filtered_hides_header_fields_and_empty_data_on_passthrough() {
+        let mut collector = FieldCollector::new();
+        let fs = make_fields!("service", "function_name", "data", "function", "extra");
+
+        collector.record_str(&fs.field("service").unwrap(), "worker");
+        collector.record_str(&fs.field("function_name").unwrap(), "api.get./todos");
+        // Empty string — mirrors the case where emit_log_to_console stripped
+        // the only attribute (`service.name`) leaving nothing to render.
+        collector.record_str(&fs.field("data").unwrap(), "");
+        collector.record_str(&fs.field("function").unwrap(), "fn-name");
+        collector.record_str(&fs.field("extra").unwrap(), "keep");
+
+        // Non-passthrough case: only "function" is hidden.
+        let visible: Vec<&String> = collector
+            .get_display_fields_filtered(false)
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        assert!(visible.iter().any(|n| *n == "service"));
+        assert!(visible.iter().any(|n| *n == "function_name"));
+        assert!(visible.iter().any(|n| *n == "data"));
+        assert!(visible.iter().any(|n| *n == "extra"));
+        assert!(!visible.iter().any(|n| *n == "function"));
+
+        // Passthrough case: function, service, function_name, AND empty data hidden.
+        let visible: Vec<&String> = collector
+            .get_display_fields_filtered(true)
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        assert!(!visible.iter().any(|n| *n == "service"));
+        assert!(!visible.iter().any(|n| *n == "function_name"));
+        assert!(!visible.iter().any(|n| *n == "function"));
+        assert!(!visible.iter().any(|n| *n == "data"));
+        assert!(visible.iter().any(|n| *n == "extra"));
+    }
+
+    #[test]
+    fn test_get_display_fields_filtered_keeps_nonempty_data_on_passthrough() {
+        let mut collector = FieldCollector::new();
+        let fs = make_fields!("data");
+
+        collector.record_str(&fs.field("data").unwrap(), r#"{"log.data":"x"}"#);
+
+        let visible: Vec<&String> = collector
+            .get_display_fields_filtered(true)
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        assert!(visible.iter().any(|n| *n == "data"));
     }
 }

--- a/engine/src/logging.rs
+++ b/engine/src/logging.rs
@@ -75,9 +75,7 @@ impl FieldCollector {
                     if name == "service" || name == "function_name" {
                         return false;
                     }
-                    if name == "data"
-                        && matches!(value, FieldValue::String(s) if s.is_empty())
-                    {
+                    if name == "data" && matches!(value, FieldValue::String(s) if s.is_empty()) {
                         return false;
                     }
                 }

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -2190,7 +2190,11 @@ mod tests {
         storage.apply_retention(one_hour_ns);
 
         let logs = storage.get_logs();
-        assert_eq!(logs.len(), 1, "backdated entry must be evicted even when trapped behind a newer one");
+        assert_eq!(
+            logs.len(),
+            1,
+            "backdated entry must be evicted even when trapped behind a newer one"
+        );
         assert_eq!(logs[0].body, "recent");
     }
 

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -2166,6 +2166,84 @@ mod tests {
     }
 
     #[test]
+    fn test_log_storage_apply_retention_falls_back_to_observed_timestamp_when_event_time_zero() {
+        // Regression test: OTLP logs spec allows time_unix_nano == 0 to mean
+        // "unknown event time". Receivers must fall back to
+        // observed_time_unix_nano. Without the fallback, such logs are
+        // evicted on the first retention tick despite a valid observation
+        // time.
+        let storage = otel::InMemoryLogStorage::new(100);
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64;
+        let one_hour_ns: u64 = 3600 * 1_000_000_000;
+        let recent_observed = now_ns.saturating_sub(60 * 1_000_000_000); // 1m ago
+
+        // Hand-craft a log with timestamp_unix_nano == 0 but a recent
+        // observed_timestamp_unix_nano — the exact shape produced by
+        // ingest_otlp_logs when the SDK sends time_unix_nano=0.
+        let log = otel::StoredLog {
+            timestamp_unix_nano: 0,
+            observed_timestamp_unix_nano: recent_observed,
+            severity_number: 9,
+            severity_text: "INFO".to_string(),
+            body: "observed-only".to_string(),
+            attributes: HashMap::new(),
+            trace_id: None,
+            span_id: None,
+            resource: HashMap::new(),
+            service_name: "svc".to_string(),
+            instrumentation_scope_name: None,
+            instrumentation_scope_version: None,
+        };
+        storage.store(log);
+        assert_eq!(storage.len(), 1);
+
+        storage.apply_retention(one_hour_ns);
+
+        let logs = storage.get_logs();
+        assert_eq!(
+            logs.len(),
+            1,
+            "log with zero event timestamp must be preserved via observed timestamp"
+        );
+        assert_eq!(logs[0].body, "observed-only");
+    }
+
+    #[test]
+    fn test_log_storage_apply_retention_evicts_when_both_timestamps_expired() {
+        // Complement to the fallback test: if BOTH timestamps are expired,
+        // the log must still be evicted.
+        let storage = otel::InMemoryLogStorage::new(100);
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64;
+        let one_hour_ns: u64 = 3600 * 1_000_000_000;
+        let old_observed = now_ns.saturating_sub(2 * one_hour_ns); // 2h ago
+
+        let log = otel::StoredLog {
+            timestamp_unix_nano: 0,
+            observed_timestamp_unix_nano: old_observed,
+            severity_number: 9,
+            severity_text: "INFO".to_string(),
+            body: "stale-observed".to_string(),
+            attributes: HashMap::new(),
+            trace_id: None,
+            span_id: None,
+            resource: HashMap::new(),
+            service_name: "svc".to_string(),
+            instrumentation_scope_name: None,
+            instrumentation_scope_version: None,
+        };
+        storage.store(log);
+        storage.apply_retention(one_hour_ns);
+
+        assert_eq!(storage.get_logs().len(), 0);
+    }
+
+    #[test]
     fn test_log_storage_apply_retention_scans_whole_buffer_for_out_of_order() {
         // Regression test: logs are stored in arrival order, not timestamp
         // order. An older-timestamped log that lands AFTER a newer one must

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -448,6 +448,11 @@ impl ObservabilityWorker {
         severity_text: &str,
         severity_number: i32,
     ) {
+        // Respect logs_enabled: if explicitly disabled, skip storage/emit entirely.
+        if !otel::logs_enabled(otel::get_otel_config()) {
+            return;
+        }
+
         // Check sampling ratio before storing
         let should_sample = {
             let ratio = otel::get_otel_config()
@@ -460,9 +465,9 @@ impl ObservabilityWorker {
             return;
         }
 
-        // Initialize storage if not already done
+        // Initialize storage if not already done, honoring the configured cap.
         if otel::get_log_storage().is_none() {
-            otel::init_log_storage(None);
+            otel::init_log_storage(self._config.logs_max_count);
         }
 
         let service_name = input
@@ -1016,8 +1021,12 @@ impl ObservabilityWorker {
                 FunctionResult::Success(Some(response))
             }
             None => {
-                // Initialize storage if not already done and return empty result
-                otel::init_log_storage(None);
+                // Honor logs_enabled: do NOT lazily revive storage when logs
+                // are disabled at config time. Return an empty result so API
+                // consumers get a consistent shape.
+                if otel::logs_enabled(Some(&self._config)) {
+                    otel::init_log_storage(self._config.logs_max_count);
+                }
                 let response = serde_json::json!({
                     "logs": [],
                     "total": 0,
@@ -1435,8 +1444,15 @@ impl Worker for ObservabilityWorker {
             let _ = metrics::get_engine_metrics();
         }
 
-        // Initialize log storage
-        otel::init_log_storage(None);
+        // Initialize log storage only when logs are enabled
+        if otel::logs_enabled(Some(&self._config)) {
+            otel::init_log_storage(self._config.logs_max_count);
+        } else {
+            tracing::info!(
+                "{} OTEL logs disabled via logs_enabled=false; skipping log storage",
+                "[OTEL]".cyan()
+            );
+        }
 
         // Initialize rollup storage for multi-level metric aggregation
         metrics::init_rollup_storage();
@@ -1531,6 +1547,41 @@ impl Worker for ObservabilityWorker {
                     );
                 }
             });
+        }
+
+        // Spawn background task for log retention cleanup
+        if let Some(retention_seconds) = self._config.logs_retention_seconds
+            && retention_seconds > 0
+            && let Some(log_storage) = otel::get_log_storage()
+        {
+            let retention_ns = match retention_seconds.checked_mul(1_000_000_000) {
+                Some(ns) => ns,
+                None => {
+                    tracing::warn!(
+                        "logs_retention_seconds overflow when converting to nanoseconds; disabling log retention task"
+                    );
+                    0
+                }
+            };
+            if retention_ns > 0 {
+                let mut shutdown_rx = shutdown_rx.clone();
+                tokio::spawn(async move {
+                    let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(60));
+                    loop {
+                        tokio::select! {
+                            result = shutdown_rx.changed() => {
+                                if result.is_err() || *shutdown_rx.borrow() {
+                                    tracing::debug!("[ObservabilityWorker] Log retention task shutting down");
+                                    break;
+                                }
+                            }
+                            _ = interval.tick() => {
+                                log_storage.apply_retention(retention_ns);
+                            }
+                        }
+                    }
+                });
+            }
         }
 
         // Spawn background task for metrics retention cleanup and rollup processing
@@ -2088,6 +2139,59 @@ mod tests {
         let storage = otel::InMemoryLogStorage::new(100);
         assert!(storage.is_empty());
         assert_eq!(storage.len(), 0);
+    }
+
+    #[test]
+    fn test_log_storage_apply_retention_drops_old_and_keeps_recent() {
+        let storage = otel::InMemoryLogStorage::new(100);
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64;
+
+        let one_hour_ns: u64 = 3600 * 1_000_000_000;
+        let old_ts = now_ns.saturating_sub(2 * one_hour_ns); // 2h ago
+        let recent_ts = now_ns.saturating_sub(60 * 1_000_000_000); // 1m ago
+
+        storage.store(make_log(None, None, "INFO", 9, "old", "svc", old_ts));
+        storage.store(make_log(None, None, "INFO", 9, "recent", "svc", recent_ts));
+        assert_eq!(storage.len(), 2);
+
+        // Retain only last hour: old entry must be dropped, recent kept.
+        storage.apply_retention(one_hour_ns);
+
+        let logs = storage.get_logs();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].body, "recent");
+    }
+
+    #[test]
+    fn test_log_storage_apply_retention_scans_whole_buffer_for_out_of_order() {
+        // Regression test: logs are stored in arrival order, not timestamp
+        // order. An older-timestamped log that lands AFTER a newer one must
+        // still be evicted by retention. Proves apply_retention scans the
+        // entire buffer rather than stopping at the first non-expired front.
+        let storage = otel::InMemoryLogStorage::new(100);
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64;
+
+        let one_hour_ns: u64 = 3600 * 1_000_000_000;
+        let old_ts = now_ns.saturating_sub(2 * one_hour_ns); // 2h ago, expired
+        let recent_ts = now_ns.saturating_sub(60 * 1_000_000_000); // 1m ago, fresh
+
+        // Arrival order puts the fresh log FIRST, then a backdated log
+        // (simulates clock skew / SDK batch flushing older records).
+        storage.store(make_log(None, None, "INFO", 9, "recent", "svc", recent_ts));
+        storage.store(make_log(None, None, "INFO", 9, "backdated", "svc", old_ts));
+        assert_eq!(storage.len(), 2);
+
+        storage.apply_retention(one_hour_ns);
+
+        let logs = storage.get_logs();
+        assert_eq!(logs.len(), 1, "backdated entry must be evicted even when trapped behind a newer one");
+        assert_eq!(logs[0].body, "recent");
     }
 
     #[test]

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -2243,13 +2243,20 @@ impl InMemoryLogStorage {
         self.tx.subscribe()
     }
 
-    /// Drop logs whose `timestamp_unix_nano` is older than `retention_ns` from now.
+    /// Drop logs whose effective timestamp is older than `retention_ns` from now.
     ///
     /// Scans the entire buffer rather than popping from the front: logs are
     /// stored in arrival order, which does not match timestamp order when
     /// SDK workers batch backdated records, clocks skew across workers, or
     /// sampling interleaves late arrivals. An older-timestamped log trapped
     /// behind a newer one would otherwise survive retention.
+    ///
+    /// The effective timestamp is `timestamp_unix_nano` when non-zero,
+    /// falling back to `observed_timestamp_unix_nano`. Per the OTLP logs
+    /// spec, a `time_unix_nano` of 0 means "unknown" and receivers must use
+    /// `observed_time_unix_nano` instead; without this fallback, logs
+    /// emitted without an event timestamp would be evicted on the very
+    /// first retention tick despite a valid observation time.
     pub fn apply_retention(&self, retention_ns: u64) {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -2258,7 +2265,14 @@ impl InMemoryLogStorage {
         let cutoff = now.saturating_sub(retention_ns);
 
         let mut logs = self.logs.write().unwrap();
-        logs.retain(|log| log.timestamp_unix_nano >= cutoff);
+        logs.retain(|log| {
+            let effective = if log.timestamp_unix_nano != 0 {
+                log.timestamp_unix_nano
+            } else {
+                log.observed_timestamp_unix_nano
+            };
+            effective >= cutoff
+        });
     }
 }
 

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -64,6 +64,13 @@ pub fn get_otel_config() -> Option<&'static ObservabilityWorkerConfig> {
     GLOBAL_OTEL_CONFIG.get()
 }
 
+/// Decide whether OTEL logs storage / emission should be active, given an
+/// optional config. Defaults to `true` when the config (or field) is absent
+/// — matches "opt-out" semantics: logs on unless explicitly disabled.
+pub fn logs_enabled(cfg: Option<&ObservabilityWorkerConfig>) -> bool {
+    cfg.and_then(|c| c.logs_enabled).unwrap_or(true)
+}
+
 /// Exporter type for OpenTelemetry traces.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub enum ExporterType {
@@ -2235,6 +2242,24 @@ impl InMemoryLogStorage {
     pub fn subscribe(&self) -> broadcast::Receiver<StoredLog> {
         self.tx.subscribe()
     }
+
+    /// Drop logs whose `timestamp_unix_nano` is older than `retention_ns` from now.
+    ///
+    /// Scans the entire buffer rather than popping from the front: logs are
+    /// stored in arrival order, which does not match timestamp order when
+    /// SDK workers batch backdated records, clocks skew across workers, or
+    /// sampling interleaves late arrivals. An older-timestamped log trapped
+    /// behind a newer one would otherwise survive retention.
+    pub fn apply_retention(&self, retention_ns: u64) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+        let cutoff = now.saturating_sub(retention_ns);
+
+        let mut logs = self.logs.write().unwrap();
+        logs.retain(|log| log.timestamp_unix_nano >= cutoff);
+    }
 }
 
 /// Global in-memory log storage.
@@ -2298,12 +2323,50 @@ pub(crate) const OTEL_PASSTHROUGH_TARGET: &str = "iii::otel_passthrough";
 ///
 /// Uses [`OTEL_PASSTHROUGH_TARGET`] so `OtelLogsLayer` skips these events
 /// and avoids storing them a second time (they are already stored by `ingest_otlp_logs`).
-fn emit_log_to_console(log: &StoredLog) {
+/// Build the (data_json, function_name) pair that `emit_log_to_console`
+/// passes to the tracing macros for a passthrough log record.
+///
+/// - `function_name` is read from the `service.name` attribute (empty
+///   string when absent).
+/// - `data_json` is the JSON-serialized attribute map with `service.name`
+///   stripped out (empty string when the map is empty or has only
+///   `service.name`).
+pub(crate) fn build_console_log_fields(log: &StoredLog) -> (String, &str) {
+    let function_name = log
+        .attributes
+        .get("service.name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
     let data = if log.attributes.is_empty() {
         String::new()
     } else {
-        serde_json::to_string(&log.attributes).unwrap_or_default()
+        let filtered: std::collections::BTreeMap<&str, &serde_json::Value> = log
+            .attributes
+            .iter()
+            .filter(|(k, _)| k.as_str() != "service.name")
+            .map(|(k, v)| (k.as_str(), v))
+            .collect();
+        if filtered.is_empty() {
+            String::new()
+        } else {
+            serde_json::to_string(&filtered).unwrap_or_default()
+        }
     };
+
+    (data, function_name)
+}
+
+fn emit_log_to_console(log: &StoredLog) {
+    // Extract the function name from the `service.name` attribute before it
+    // gets stripped from the rendered blob. This is emitted as its own
+    // tracing field (`function_name`) so the console formatter can render
+    // it as a distinct token without having to re-parse `data`.
+    // `service.name` is also excluded from the rendered attribute blob: it
+    // is redundant with the resource-level service name (rendered separately
+    // as the passthrough header by the console formatter) and clutters the
+    // tree.
+    let (data, function_name) = build_console_log_fields(log);
 
     let service = &log.service_name;
     let body = &log.body;
@@ -2311,22 +2374,22 @@ fn emit_log_to_console(log: &StoredLog) {
     // OTEL severity numbers: TRACE=1-4, DEBUG=5-8, INFO=9-12, WARN=13-16, ERROR=17-20, FATAL=21-24
     match log.severity_number {
         1..=4 => {
-            tracing::trace!(target: OTEL_PASSTHROUGH_TARGET, service = %service, data = %data, "{}", body)
+            tracing::trace!(target: OTEL_PASSTHROUGH_TARGET, service = %service, function_name = %function_name, data = %data, "{}", body)
         }
         5..=8 => {
-            tracing::debug!(target: OTEL_PASSTHROUGH_TARGET, service = %service, data = %data, "{}", body)
+            tracing::debug!(target: OTEL_PASSTHROUGH_TARGET, service = %service, function_name = %function_name, data = %data, "{}", body)
         }
         9..=12 => {
-            tracing::info!(target: OTEL_PASSTHROUGH_TARGET, service = %service, data = %data, "{}", body)
+            tracing::info!(target: OTEL_PASSTHROUGH_TARGET, service = %service, function_name = %function_name, data = %data, "{}", body)
         }
         13..=16 => {
-            tracing::warn!(target: OTEL_PASSTHROUGH_TARGET, service = %service, data = %data, "{}", body)
+            tracing::warn!(target: OTEL_PASSTHROUGH_TARGET, service = %service, function_name = %function_name, data = %data, "{}", body)
         }
         17..=24 => {
-            tracing::error!(target: OTEL_PASSTHROUGH_TARGET, service = %service, data = %data, "{}", body)
+            tracing::error!(target: OTEL_PASSTHROUGH_TARGET, service = %service, function_name = %function_name, data = %data, "{}", body)
         }
         _ => {
-            tracing::info!(target: OTEL_PASSTHROUGH_TARGET, service = %service, data = %data, "{}", body)
+            tracing::info!(target: OTEL_PASSTHROUGH_TARGET, service = %service, function_name = %function_name, data = %data, "{}", body)
         }
     }
 }
@@ -2348,6 +2411,14 @@ pub async fn ingest_otlp_logs(json_str: &str) -> anyhow::Result<()> {
         "Received OTLP logs from Node SDK"
     );
 
+    // Honor logs_enabled: silently drop incoming OTLP logs when logs are
+    // disabled at config time. Otherwise a Node/Python SDK worker posting
+    // logs would lazily revive the storage that `initialize()` deliberately
+    // did not create.
+    if !logs_enabled(get_otel_config()) {
+        return Ok(());
+    }
+
     // Parse the OTLP logs JSON
     let request: OtlpExportLogsServiceRequest = serde_json::from_str(json_str)
         .map_err(|e| anyhow::anyhow!("Failed to parse OTLP logs JSON: {}", e))?;
@@ -2356,8 +2427,12 @@ pub async fn ingest_otlp_logs(json_str: &str) -> anyhow::Result<()> {
     let storage = match get_log_storage() {
         Some(s) => s,
         None => {
-            // Initialize storage if not already done
-            init_log_storage(None);
+            // Initialize storage with the configured cap. Only reached when
+            // logs_enabled=true but initialize() hasn't run yet (e.g.,
+            // worker starts receiving OTLP before ObservabilityWorker's
+            // initialize() runs).
+            let max_logs = get_otel_config().and_then(|c| c.logs_max_count);
+            init_log_storage(max_logs);
             get_log_storage().ok_or_else(|| anyhow::anyhow!("Failed to initialize log storage"))?
         }
     };
@@ -5372,5 +5447,110 @@ mod tests {
             attr_map["exception.stacktrace"].contains("test_fn"),
             "stacktrace should contain function name"
         );
+    }
+
+    // =========================================================================
+    // logs_enabled() decision helper
+    // =========================================================================
+
+    fn cfg_with_logs_enabled(value: Option<bool>) -> ObservabilityWorkerConfig {
+        ObservabilityWorkerConfig {
+            logs_enabled: value,
+            ..ObservabilityWorkerConfig::default()
+        }
+    }
+
+    #[test]
+    fn test_logs_enabled_defaults_true_when_config_absent() {
+        assert!(logs_enabled(None));
+    }
+
+    #[test]
+    fn test_logs_enabled_defaults_true_when_field_absent() {
+        let cfg = cfg_with_logs_enabled(None);
+        assert!(logs_enabled(Some(&cfg)));
+    }
+
+    #[test]
+    fn test_logs_enabled_true_when_explicit_true() {
+        let cfg = cfg_with_logs_enabled(Some(true));
+        assert!(logs_enabled(Some(&cfg)));
+    }
+
+    #[test]
+    fn test_logs_enabled_false_when_explicit_false() {
+        let cfg = cfg_with_logs_enabled(Some(false));
+        assert!(!logs_enabled(Some(&cfg)));
+    }
+
+    // =========================================================================
+    // build_console_log_fields() — service.name strip + function_name extract
+    // =========================================================================
+
+    fn log_with_attributes(attrs: Vec<(&str, serde_json::Value)>) -> StoredLog {
+        StoredLog {
+            timestamp_unix_nano: 0,
+            observed_timestamp_unix_nano: 0,
+            severity_number: 9,
+            severity_text: "INFO".to_string(),
+            body: "body".to_string(),
+            attributes: attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+            trace_id: None,
+            span_id: None,
+            resource: HashMap::new(),
+            service_name: "test-service".to_string(),
+            instrumentation_scope_name: None,
+            instrumentation_scope_version: None,
+        }
+    }
+
+    #[test]
+    fn test_build_console_log_fields_extracts_function_name_and_strips_it() {
+        let log = log_with_attributes(vec![
+            ("service.name", serde_json::json!("api.get./todos")),
+            ("log.data", serde_json::json!({"count": 0})),
+        ]);
+
+        let (data, function_name) = build_console_log_fields(&log);
+
+        assert_eq!(function_name, "api.get./todos");
+        // data must be non-empty JSON and must NOT contain "service.name"
+        let parsed: serde_json::Value = serde_json::from_str(&data).unwrap();
+        assert!(parsed.get("service.name").is_none());
+        assert!(parsed.get("log.data").is_some());
+    }
+
+    #[test]
+    fn test_build_console_log_fields_empty_when_only_service_name_attribute() {
+        let log = log_with_attributes(vec![(
+            "service.name",
+            serde_json::json!("api.get./todos"),
+        )]);
+
+        let (data, function_name) = build_console_log_fields(&log);
+
+        assert_eq!(function_name, "api.get./todos");
+        assert!(
+            data.is_empty(),
+            "stripping the only attribute must produce empty data"
+        );
+    }
+
+    #[test]
+    fn test_build_console_log_fields_empty_when_no_attributes() {
+        let log = log_with_attributes(vec![]);
+        let (data, function_name) = build_console_log_fields(&log);
+        assert!(function_name.is_empty());
+        assert!(data.is_empty());
+    }
+
+    #[test]
+    fn test_build_console_log_fields_missing_service_name_returns_empty_function_name() {
+        let log = log_with_attributes(vec![("log.data", serde_json::json!({"k": 1}))]);
+        let (data, function_name) = build_console_log_fields(&log);
+        assert!(function_name.is_empty());
+        assert!(!data.is_empty());
+        let parsed: serde_json::Value = serde_json::from_str(&data).unwrap();
+        assert!(parsed.get("log.data").is_some());
     }
 }

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -5522,10 +5522,7 @@ mod tests {
 
     #[test]
     fn test_build_console_log_fields_empty_when_only_service_name_attribute() {
-        let log = log_with_attributes(vec![(
-            "service.name",
-            serde_json::json!("api.get./todos"),
-        )]);
+        let log = log_with_attributes(vec![("service.name", serde_json::json!("api.get./todos"))]);
 
         let (data, function_name) = build_console_log_fields(&log);
 

--- a/engine/src/workers/reload.rs
+++ b/engine/src/workers/reload.rs
@@ -33,14 +33,12 @@ pub struct WorkerRegistrations {
 /// mutate, and consume these.
 #[derive(Debug, Default)]
 pub(crate) struct ScopeBuilder {
-    pub worker_name: String,
     pub function_ids: Vec<String>,
 }
 
 impl ScopeBuilder {
-    pub fn new(worker_name: String) -> Self {
+    pub fn new() -> Self {
         Self {
-            worker_name,
             function_ids: Vec::new(),
         }
     }


### PR DESCRIPTION
## Summary

Observability config was advertising knobs the engine never read and producing SDK-sourced console logs that hid which worker and function emitted them. This PR wires the missing config and cleans up the rendering without changing storage fidelity or any public API.

### Config wiring

- **`logs_enabled`** now gates `OtelLogsLayer`, `InMemoryLogStorage` init, and `store_and_emit_log`. When false the engine skips log storage and emits an informational notice. Decision logic is centralized in a new `otel::logs_enabled(cfg)` helper used by all three call sites.
- **`logs_retention_seconds`** now enforces time-based pruning via a new 60s-tick retention task that mirrors the existing metrics retention task (with `checked_mul` overflow protection). `InMemoryLogStorage` gains `apply_retention(retention_ns)` which drops entries older than the cutoff via `pop_front` on the ring buffer.

### Console rendering for SDK-sourced logs

Before (dedupe target leaked into output, function name buried in `data`):
```
[09:22:48.482 PM] [INFO] iii::otel_passthrough Listing todos
    ├ service: todo-worker-python
    └ data: { └ service.name: "api::get::todos" }
```

After (worker blue, function purple, message white, no redundant `service.name`):
```
[11:04:54.688 AM] [INFO] todo-worker-python api::get::todos Listing todos
    └ data: { └ log.data: { └ count: 0 } }
```

- Replaces the dedupe-only `iii::otel_passthrough` target in the header with two colored tokens.
- Emits the function name as a dedicated `function_name` tracing field from `emit_log_to_console` so the formatter doesn't have to parse JSON; falls back to `data."service.name"` for legacy events.
- Strips `service.name` from the console-rendered attribute tree since it duplicates the header. **Storage, OTLP export, triggers, and log API queries still see the full attribute set** — only console rendering changes.
- Suppresses empty `data` and header-duplicate fields for passthrough events.
- `build_console_log_fields()` and `extract_passthrough_names()` are pure helpers to keep the logic unit-testable.

### Dead-code cleanup

Drops the unused `worker_name` field from `ScopeBuilder`. Public `Engine::begin_worker_scope(worker_name)` API is unchanged; the name is now logged via `tracing::trace!` so the parameter has an observable use.

## Test plan

- [x] `cargo test --lib` — 1813 pass / 1 ignored / 0 failed
- [x] New: 4 tests for `otel::logs_enabled()` (default-true, field-absent, explicit true/false)
- [x] New: 4 tests for `otel::build_console_log_fields()` (strip with mixed attributes, strip when only `service.name`, empty map, missing `service.name`)
- [x] New: `InMemoryLogStorage::apply_retention` eviction test (2h-old dropped, 1m-old kept under 1h retention)
- [x] New: 4 tests for `extract_passthrough_names` (primary `function_name` field, legacy `data.service.name` fallback, worker-missing, all-empty)
- [x] New: 2 tests for `get_display_fields_filtered` covering the passthrough field-hiding rules
- [ ] Manual: run a Python SDK worker → confirm header renders as `worker function Listing...` with expected colors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic log retention: expired logs are periodically cleaned based on your retention setting.

* **Improvements**
  * Richer OTEL/console headers: multi-token headers show clearer worker/service and step context.
  * Conditional log storage: storage now initializes only when logs are enabled; incoming OTLP logs are dropped if logging is disabled.
  * Cleaner log field presentation: better extraction and stripping of function/service names and empty data.

* **Bug Fixes**
  * Worker startup now emits a trace-level log when a worker scope begins; retention overflow logs a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->