### PR TITLE
feat(iii-worker): live workspace sync via virtiofs + VM-local dep bind-mounts

### DIFF
--- a/crates/iii-init/src/lib.rs
+++ b/crates/iii-init/src/lib.rs
@@ -8,8 +8,12 @@
 pub mod error;
 #[cfg(target_os = "linux")]
 pub mod mount;
+
+// Pure parsers — compiled on every platform so they can be unit-tested
+// on the build host (iii-init itself is a Linux-guest binary).
 #[cfg(target_os = "linux")]
 pub mod network;
+pub mod parse;
 #[cfg(target_os = "linux")]
 pub mod rlimit;
 #[cfg(target_os = "linux")]

--- a/crates/iii-init/src/main.rs
+++ b/crates/iii-init/src/main.rs
@@ -17,6 +17,7 @@ fn main() {
 #[cfg(target_os = "linux")]
 fn run() -> Result<(), iii_init::InitError> {
     iii_init::mount::mount_filesystems()?;
+    iii_init::mount::mount_virtiofs_shares();
     iii_init::rlimit::raise_nofile()?;
     iii_init::network::configure_network()?;
     if let Err(e) = iii_init::network::write_resolv_conf() {

--- a/crates/iii-init/src/mount.rs
+++ b/crates/iii-init/src/mount.rs
@@ -136,6 +136,57 @@ pub fn mount_filesystems() -> Result<(), InitError> {
     Ok(())
 }
 
+/// Recursively `mkdir -p` a guest path, ignoring `EEXIST` at each level.
+fn mkdir_p(path: &str) -> Result<(), InitError> {
+    let mut acc = String::new();
+    for segment in path.trim_start_matches('/').split('/') {
+        if segment.is_empty() {
+            continue;
+        }
+        acc.push('/');
+        acc.push_str(segment);
+        mkdir_ignore_exists(&acc)?;
+    }
+    Ok(())
+}
+
+/// Mount virtiofs shares passed via the `III_VIRTIOFS_MOUNTS` env var.
+///
+/// Format: `tag1=/guest/path1;tag2=/guest/path2`. The tag matches the virtiofs
+/// source tag attached in vm_boot. Each guest path is created with `mkdir -p`
+/// before mounting. Failures on individual mounts log a warning and continue
+/// so a bad share cannot wedge worker startup.
+pub fn mount_virtiofs_shares() {
+    let spec = match std::env::var("III_VIRTIOFS_MOUNTS") {
+        Ok(s) if !s.is_empty() => s,
+        _ => return,
+    };
+
+    let pairs = crate::parse::parse_virtiofs_spec(&spec, |entry| {
+        eprintln!("iii-init: warning: malformed virtiofs mount entry: {entry}");
+    });
+
+    for (tag, guest_path) in pairs {
+        if let Err(e) = mkdir_p(&guest_path) {
+            eprintln!("iii-init: warning: mkdir {guest_path} failed: {e}");
+            continue;
+        }
+
+        match mount(
+            Some(tag.as_str()),
+            guest_path.as_str(),
+            Some("virtiofs"),
+            MsFlags::empty(),
+            None::<&str>,
+        ) {
+            Ok(()) | Err(nix::Error::EBUSY) => {}
+            Err(e) => {
+                eprintln!("iii-init: warning: mount virtiofs {tag} -> {guest_path} failed: {e}");
+            }
+        }
+    }
+}
+
 /// Mount cgroup2 and create a memory-limited worker cgroup.
 ///
 /// Reads `III_WORKER_MEM_BYTES` to set `memory.max` on the worker cgroup.

--- a/crates/iii-init/src/parse.rs
+++ b/crates/iii-init/src/parse.rs
@@ -1,0 +1,129 @@
+//! Pure parsers used by iii-init, compiled on all platforms so they can be
+//! unit-tested from the build host (iii-init itself is a Linux-guest binary).
+
+/// Parse the `III_VIRTIOFS_MOUNTS` env-var spec into `(tag, guest_path)` pairs.
+///
+/// Format: `tag1=/guest/path1;tag2=/guest/path2`. Empty segments and segments
+/// without a valid `tag=path` split are dropped (the caller prints a warning
+/// via `report` when a malformed entry is encountered). An empty spec yields
+/// an empty vec.
+///
+/// `report` receives each rejected entry verbatim so callers can log without
+/// this function needing access to stderr.
+pub fn parse_virtiofs_spec<F: FnMut(&str)>(spec: &str, mut report: F) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for entry in spec.split(';') {
+        if entry.is_empty() {
+            continue;
+        }
+        match entry.split_once('=') {
+            Some((tag, guest_path)) if !tag.is_empty() && !guest_path.is_empty() => {
+                out.push((tag.to_string(), guest_path.to_string()));
+            }
+            _ => report(entry),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(spec: &str) -> (Vec<(String, String)>, Vec<String>) {
+        let mut rejected = Vec::new();
+        let parsed = parse_virtiofs_spec(spec, |e| rejected.push(e.to_string()));
+        (parsed, rejected)
+    }
+
+    #[test]
+    fn empty_spec_yields_empty_vec() {
+        let (parsed, rejected) = parse("");
+        assert!(parsed.is_empty());
+        assert!(rejected.is_empty());
+    }
+
+    #[test]
+    fn single_entry_parses() {
+        let (parsed, rejected) = parse("virtiofs_0=/workspace");
+        assert_eq!(
+            parsed,
+            vec![("virtiofs_0".to_string(), "/workspace".to_string())]
+        );
+        assert!(rejected.is_empty());
+    }
+
+    #[test]
+    fn multiple_entries_preserve_order() {
+        let (parsed, _) = parse("virtiofs_0=/workspace;virtiofs_1=/data;virtiofs_2=/cache");
+        assert_eq!(parsed.len(), 3);
+        assert_eq!(
+            parsed[0],
+            ("virtiofs_0".to_string(), "/workspace".to_string())
+        );
+        assert_eq!(parsed[1], ("virtiofs_1".to_string(), "/data".to_string()));
+        assert_eq!(parsed[2], ("virtiofs_2".to_string(), "/cache".to_string()));
+    }
+
+    #[test]
+    fn trailing_semicolon_is_tolerated() {
+        let (parsed, rejected) = parse("virtiofs_0=/workspace;");
+        assert_eq!(parsed.len(), 1);
+        assert!(rejected.is_empty());
+    }
+
+    #[test]
+    fn leading_semicolon_is_tolerated() {
+        let (parsed, rejected) = parse(";virtiofs_0=/workspace");
+        assert_eq!(parsed.len(), 1);
+        assert!(rejected.is_empty());
+    }
+
+    #[test]
+    fn consecutive_semicolons_are_tolerated() {
+        let (parsed, _) = parse("virtiofs_0=/a;;virtiofs_1=/b");
+        assert_eq!(parsed.len(), 2);
+    }
+
+    #[test]
+    fn missing_equals_is_rejected() {
+        let (parsed, rejected) = parse("virtiofs_0/workspace");
+        assert!(parsed.is_empty());
+        assert_eq!(rejected, vec!["virtiofs_0/workspace".to_string()]);
+    }
+
+    #[test]
+    fn empty_tag_is_rejected() {
+        let (parsed, rejected) = parse("=/workspace");
+        assert!(parsed.is_empty());
+        assert_eq!(rejected, vec!["=/workspace".to_string()]);
+    }
+
+    #[test]
+    fn empty_path_is_rejected() {
+        let (parsed, rejected) = parse("virtiofs_0=");
+        assert!(parsed.is_empty());
+        assert_eq!(rejected, vec!["virtiofs_0=".to_string()]);
+    }
+
+    #[test]
+    fn extra_equals_in_path_is_kept_as_path() {
+        // Paths don't contain `=` on Linux, but if one does, split_once
+        // keeps the first `=` as the separator — second `=` stays in the value.
+        let (parsed, rejected) = parse("virtiofs_0=/path=with=equals");
+        assert_eq!(
+            parsed,
+            vec![("virtiofs_0".to_string(), "/path=with=equals".to_string())]
+        );
+        assert!(rejected.is_empty());
+    }
+
+    #[test]
+    fn malformed_and_valid_entries_coexist() {
+        let (parsed, rejected) = parse("virtiofs_0=/workspace;garbage;virtiofs_1=/data;=/bad");
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].0, "virtiofs_0");
+        assert_eq!(parsed[1].0, "virtiofs_1");
+        assert_eq!(rejected, vec!["garbage".to_string(), "=/bad".to_string()]);
+    }
+}

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -187,11 +187,17 @@ pub fn build_libkrun_local_script(project: &ProjectInfo, prepared: bool) -> Stri
     // the target to exist. If the host repo doesn't already have one of
     // these dirs, an empty directory appears on the host (standard
     // .gitignore entry in every dev setup).
+    // Verify /workspace is an actual virtiofs mountpoint, not just a bare
+    // directory. iii-init's mount_virtiofs_shares() calls mkdir_p on the
+    // guest path before mounting and swallows mount failures as warnings,
+    // so a silent virtiofs failure leaves /workspace existing-but-unmounted.
+    // A plain `-d` check would pass and we'd bind-mount deps onto an empty
+    // rootfs dir -- writes would leak onto rootfs instead of the host repo.
     parts.push(
-        r#"if [ ! -d /workspace ]; then
-  echo "iii: ERROR /workspace is not a directory (virtiofs share missing)" >&2
+        r#"if ! { mountpoint -q /workspace 2>/dev/null || awk '$5 == "/workspace" && / - virtiofs /' /proc/self/mountinfo | grep -q .; }; then
+  echo "iii: ERROR /workspace is not a virtiofs mountpoint (share missing or mount failed)" >&2
   echo "--- III_VIRTIOFS_MOUNTS=${III_VIRTIOFS_MOUNTS:-<unset>} ---" >&2
-  cat /proc/mounts >&2 2>/dev/null || mount >&2
+  cat /proc/self/mountinfo >&2 2>/dev/null || cat /proc/mounts >&2 2>/dev/null || mount >&2
   exit 1
 fi
 DEPS_ROOT=/var/iii/deps
@@ -219,7 +225,8 @@ echo "iii: workspace ready; deps mounted VM-local from $DEPS_ROOT" >&2"#
     parts.push("export CHOKIDAR_INTERVAL=${CHOKIDAR_INTERVAL:-300}".to_string());
     parts.push("export WATCHPACK_POLLING=true".to_string());
     parts.push("export WATCHFILES_FORCE_POLLING=true".to_string());
-    parts.push("export TSC_WATCHFILE=UseFsEventsOnParentDirectory".to_string());
+    parts.push("export TSC_WATCHFILE=DynamicPriorityPolling".to_string());
+    parts.push("export TSC_WATCHDIRECTORY=DynamicPriorityPolling".to_string());
 
     if !prepared {
         if !project.setup_cmd.is_empty() {

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -167,10 +167,59 @@ pub fn build_libkrun_local_script(project: &ProjectInfo, prepared: bool) -> Stri
     let env_exports = build_env_exports(&project.env);
     let mut parts: Vec<String> = Vec::new();
 
+    parts.push("set -e".to_string());
     parts.push("export HOME=${HOME:-/root}".to_string());
     parts.push("export PATH=/usr/local/bin:/usr/bin:/bin:$PATH".to_string());
     parts.push("export LANG=${LANG:-C.UTF-8}".to_string());
+
+    // Workspace strategy: host project is mounted live at /workspace via
+    // virtiofs (by iii-init from III_VIRTIOFS_MOUNTS). Source edits flow
+    // through naturally. Language dep dirs (node_modules, .venv, target,
+    // etc.) are bind-mounted from the rootfs so their writes stay VM-local
+    // and never hit the host repo. The rootfs-backed bind targets persist
+    // across VM restarts, so npm install / pip install caches survive.
+    //
+    // We tried overlayfs with virtiofs as lower and hit errno 102 (kernel
+    // copy-up path fails for PassthroughFs reads). Bind-mounts sidestep
+    // that entirely.
+    //
+    // Tradeoff: each dep dir becomes a mountpoint, and mount(2) requires
+    // the target to exist. If the host repo doesn't already have one of
+    // these dirs, an empty directory appears on the host (standard
+    // .gitignore entry in every dev setup).
+    parts.push(
+        r#"if [ ! -d /workspace ]; then
+  echo "iii: ERROR /workspace is not a directory (virtiofs share missing)" >&2
+  echo "--- III_VIRTIOFS_MOUNTS=${III_VIRTIOFS_MOUNTS:-<unset>} ---" >&2
+  cat /proc/mounts >&2 2>/dev/null || mount >&2
+  exit 1
+fi
+DEPS_ROOT=/var/iii/deps
+for d in node_modules .venv target dist __pycache__ .pytest_cache .next; do
+  mkdir -p "$DEPS_ROOT/$d"
+  if [ ! -e "/workspace/$d" ]; then
+    mkdir "/workspace/$d"
+  elif [ ! -d "/workspace/$d" ]; then
+    echo "iii: WARN /workspace/$d exists but is not a directory, skipping bind" >&2
+    continue
+  fi
+  mount --bind "$DEPS_ROOT/$d" "/workspace/$d"
+done
+cd /workspace
+echo "iii: workspace ready; deps mounted VM-local from $DEPS_ROOT" >&2"#
+            .to_string(),
+    );
+
     parts.push("echo $$ > /sys/fs/cgroup/worker/cgroup.procs 2>/dev/null || true".to_string());
+
+    // Force polling for common file watchers. Overlayfs does not propagate
+    // inotify events from lower-layer (host) changes, so without polling
+    // `tsx watch`, watchfiles, cargo-watch etc. never fire on host edits.
+    parts.push("export CHOKIDAR_USEPOLLING=true".to_string());
+    parts.push("export CHOKIDAR_INTERVAL=${CHOKIDAR_INTERVAL:-300}".to_string());
+    parts.push("export WATCHPACK_POLLING=true".to_string());
+    parts.push("export WATCHFILES_FORCE_POLLING=true".to_string());
+    parts.push("export TSC_WATCHFILE=UseFsEventsOnParentDirectory".to_string());
 
     if !prepared {
         if !project.setup_cmd.is_empty() {
@@ -182,7 +231,7 @@ pub fn build_libkrun_local_script(project: &ProjectInfo, prepared: bool) -> Stri
         parts.push("mkdir -p /var && touch /var/.iii-prepared".to_string());
     }
 
-    parts.push(format!("{} && {}", env_exports, project.run_cmd));
+    parts.push(format!("{} && exec {}", env_exports, project.run_cmd));
     parts.join("\n")
 }
 
@@ -226,6 +275,16 @@ pub fn build_local_env(
 // ──────────────────────────────────────────────────────────────────────────────
 // New functions for local-path worker support
 // ──────────────────────────────────────────────────────────────────────────────
+
+/// Build the virtiofs mount list for a local-path worker: the host project
+/// dir is shared live at guest `/workspace`. Returns `(host_path, guest_path)`
+/// pairs suitable for `libkrun::run_dev`.
+pub fn build_local_mounts(project_path: &Path) -> Vec<(String, String)> {
+    vec![(
+        project_path.to_string_lossy().into_owned(),
+        "/workspace".to_string(),
+    )]
+}
 
 /// Returns `true` if `input` looks like a local filesystem path rather than
 /// a registry name or OCI reference.
@@ -454,31 +513,23 @@ pub async fn start_local_worker(worker_name: &str, worker_path: &str, port: u16)
         }
     }
 
-    // 5. Re-copy project files to workspace (fresh source each start)
-    //    Preserve installed dependency dirs (node_modules, target, .venv)
-    //    so setup/install doesn't re-run every time.
-    let workspace = managed_dir.join("workspace");
-    let ws = workspace.clone();
-    let pp = project_path.to_path_buf();
-    let copy_result = tokio::task::spawn_blocking(move || {
-        if ws.exists() {
-            clean_workspace_preserving_deps(&ws);
-        }
-        std::fs::create_dir_all(&ws).ok();
-        copy_dir_contents(&pp, &ws)
-    })
-    .await;
-
-    match copy_result {
-        Ok(Ok(())) => {}
-        Ok(Err(e)) => {
-            eprintln!("{} Failed to copy project to rootfs: {}", "error:".red(), e);
-            return 1;
-        }
-        Err(e) => {
-            eprintln!("{} Copy task panicked: {}", "error:".red(), e);
-            return 1;
-        }
+    // 5. Host project dir is shared live into the VM via virtiofs at
+    //    /mnt/host-workspace; /workspace is assembled inside the VM as an
+    //    overlay on top of that (see build_libkrun_local_script). No copy
+    //    step — host edits flow through immediately, VM-side writes never
+    //    touch the host.
+    //
+    //    Ensure the overlay mountpoint dir exists in the rootfs so the init
+    //    doesn't fail cd-ing into it before the overlay is assembled.
+    let workspace_dir = managed_dir.join("workspace");
+    if let Err(e) = std::fs::create_dir_all(&workspace_dir) {
+        eprintln!(
+            "{} Failed to create workspace dir {}: {}",
+            "error:".red(),
+            workspace_dir.display(),
+            e
+        );
+        return 1;
     }
 
     // 5. Check .iii-prepared marker
@@ -562,10 +613,15 @@ pub async fn start_local_worker(worker_name: &str, worker_path: &str, port: u16)
     let (vcpus, ram) = parse_manifest_resources(&manifest_path);
 
     let exec_path = "/bin/sh";
+    // The script sets up the overlay at /workspace; no pre-cd needed (and
+    // /workspace is empty until overlay mounts, so cd-before-exec would be
+    // racy).
     let args = vec![
         "-c".to_string(),
-        "cd /workspace && exec bash /opt/iii/dev-run.sh".to_string(),
+        "exec bash /opt/iii/dev-run.sh".to_string(),
     ];
+
+    let mounts = build_local_mounts(project_path);
 
     super::worker_manager::libkrun::run_dev(
         language,
@@ -578,6 +634,7 @@ pub async fn start_local_worker(worker_name: &str, worker_path: &str, port: u16)
         managed_dir,
         true,
         worker_name,
+        &mounts,
     )
     .await
 }
@@ -589,6 +646,23 @@ pub async fn start_local_worker(worker_name: &str, worker_path: &str, port: u16)
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn build_local_mounts_maps_project_to_workspace() {
+        let mounts = build_local_mounts(Path::new("/abs/host/project"));
+        assert_eq!(mounts.len(), 1);
+        assert_eq!(mounts[0].0, "/abs/host/project");
+        assert_eq!(mounts[0].1, "/workspace");
+    }
+
+    #[test]
+    fn build_local_mounts_preserves_relative_path_string() {
+        // Path stringification is lossy on non-UTF8, but for typical macOS/Linux
+        // paths we round-trip exactly. Documents intended behavior.
+        let mounts = build_local_mounts(Path::new("./relative/path"));
+        assert_eq!(mounts[0].0, "./relative/path");
+        assert_eq!(mounts[0].1, "/workspace");
+    }
 
     #[test]
     fn is_local_path_detects_relative() {
@@ -646,6 +720,10 @@ mod tests {
         assert!(script.contains("npm install"));
         assert!(script.contains("node server.js"));
         assert!(script.contains(".iii-prepared"));
+        assert!(script.contains("mount --bind"));
+        assert!(script.contains("/var/iii/deps"));
+        assert!(script.contains("node_modules"));
+        assert!(script.contains("CHOKIDAR_USEPOLLING=true"));
     }
 
     #[test]
@@ -662,6 +740,7 @@ mod tests {
         assert!(!script.contains("apt-get install nodejs"));
         assert!(!script.contains("npm install"));
         assert!(script.contains("node server.js"));
+        assert!(script.contains("mount --bind"));
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/vm_boot.rs
+++ b/crates/iii-worker/src/cli/vm_boot.rs
@@ -59,6 +59,58 @@ pub struct VmBootArgs {
     pub slot: u64,
 }
 
+/// One `--mount host:guest` CLI arg, expanded into the virtiofs attach plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VirtiofsMountEntry {
+    pub tag: String,
+    pub host_path: String,
+    pub guest_path: String,
+}
+
+/// Output of [`build_virtiofs_mount_plan`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VirtiofsMountPlan {
+    /// Virtio-fs attach entries, in CLI arg order. Each gets a `virtiofs_N` tag.
+    pub entries: Vec<VirtiofsMountEntry>,
+    /// Value of `III_VIRTIOFS_MOUNTS` to pass into the guest env:
+    /// `tag1=/guest/path1;tag2=/guest/path2`.
+    pub env_var: String,
+}
+
+/// Parse `--mount host:guest` CLI args into a virtiofs attach plan and the
+/// matching `III_VIRTIOFS_MOUNTS` env string the guest (iii-init) will consume.
+///
+/// Returns `Err` on the first malformed entry so a bad CLI arg fails the VM
+/// boot instead of producing a partial attach plan.
+pub fn build_virtiofs_mount_plan(mounts: &[String]) -> Result<VirtiofsMountPlan, String> {
+    let mut entries = Vec::with_capacity(mounts.len());
+    let mut env_var = String::new();
+    for (i, mount_str) in mounts.iter().enumerate() {
+        let (host_path, guest_path) = match mount_str.split_once(':') {
+            Some((h, g)) if !h.is_empty() && !g.is_empty() => (h.to_string(), g.to_string()),
+            _ => {
+                return Err(format!(
+                    "Invalid mount format '{}'. Expected host:guest",
+                    mount_str
+                ));
+            }
+        };
+        let tag = format!("virtiofs_{}", i);
+        if !env_var.is_empty() {
+            env_var.push(';');
+        }
+        env_var.push_str(&tag);
+        env_var.push('=');
+        env_var.push_str(&guest_path);
+        entries.push(VirtiofsMountEntry {
+            tag,
+            host_path,
+            guest_path,
+        });
+    }
+    Ok(VirtiofsMountPlan { entries, env_var })
+}
+
 /// Compose the full libkrunfw file path from the resolved directory and platform filename.
 pub fn resolve_krunfw_file_path() -> Option<std::path::PathBuf> {
     let dir = crate::cli::firmware::resolve::resolve_libkrunfw_dir()?;
@@ -207,17 +259,12 @@ fn boot_vm(args: &VmBootArgs) -> Result<std::convert::Infallible, String> {
         })
         .fs(move |fs| fs.tag("/dev/root").custom(Box::new(passthrough_fs)));
 
-    for (i, mount_str) in args.mount.iter().enumerate() {
-        let parts: Vec<&str> = mount_str.splitn(2, ':').collect();
-        if parts.len() != 2 {
-            return Err(format!(
-                "Invalid mount format '{}'. Expected host:guest",
-                mount_str
-            ));
-        }
-        let tag = format!("virtiofs_{}", i);
-        let path = parts[0].to_string();
-        builder = builder.fs(move |fs| fs.tag(&tag).path(&path));
+    let mount_plan = build_virtiofs_mount_plan(&args.mount)?;
+    let virtiofs_mount_env = mount_plan.env_var.clone();
+    for entry in mount_plan.entries {
+        let tag = entry.tag.clone();
+        let host_path = entry.host_path.clone();
+        builder = builder.fs(move |fs| fs.tag(&tag).path(&host_path));
     }
 
     let tokio_rt = tokio::runtime::Builder::new_multi_thread()
@@ -250,6 +297,9 @@ fn boot_vm(args: &VmBootArgs) -> Result<std::convert::Infallible, String> {
         e = e.env("III_INIT_GW", &gateway_ip);
         e = e.env("III_INIT_CIDR", "30");
         e = e.env("III_WORKER_MEM_BYTES", &worker_heap_bytes.to_string());
+        if !virtiofs_mount_env.is_empty() {
+            e = e.env("III_VIRTIOFS_MOUNTS", &virtiofs_mount_env);
+        }
 
         for env_str in &args.env {
             if let Some((key, value)) = env_str.split_once('=') {
@@ -354,6 +404,55 @@ mod tests {
             build_worker_cmd("/usr/bin/node", &args),
             "/usr/bin/node script.js --port 3000"
         );
+    }
+
+    #[test]
+    fn build_virtiofs_mount_plan_empty() {
+        let plan = build_virtiofs_mount_plan(&[]).unwrap();
+        assert!(plan.entries.is_empty());
+        assert!(plan.env_var.is_empty());
+    }
+
+    #[test]
+    fn build_virtiofs_mount_plan_single() {
+        let plan = build_virtiofs_mount_plan(&["/host/proj:/workspace".to_string()]).unwrap();
+        assert_eq!(plan.entries.len(), 1);
+        assert_eq!(plan.entries[0].tag, "virtiofs_0");
+        assert_eq!(plan.entries[0].host_path, "/host/proj");
+        assert_eq!(plan.entries[0].guest_path, "/workspace");
+        assert_eq!(plan.env_var, "virtiofs_0=/workspace");
+    }
+
+    #[test]
+    fn build_virtiofs_mount_plan_multiple_preserves_order_and_indexes_tags() {
+        let plan = build_virtiofs_mount_plan(&["/host/a:/b".to_string(), "/host/c:/d".to_string()])
+            .unwrap();
+        assert_eq!(plan.entries.len(), 2);
+        assert_eq!(plan.entries[0].tag, "virtiofs_0");
+        assert_eq!(plan.entries[0].host_path, "/host/a");
+        assert_eq!(plan.entries[0].guest_path, "/b");
+        assert_eq!(plan.entries[1].tag, "virtiofs_1");
+        assert_eq!(plan.entries[1].host_path, "/host/c");
+        assert_eq!(plan.entries[1].guest_path, "/d");
+        assert_eq!(plan.env_var, "virtiofs_0=/b;virtiofs_1=/d");
+    }
+
+    #[test]
+    fn build_virtiofs_mount_plan_rejects_missing_colon() {
+        let err = build_virtiofs_mount_plan(&["/host/noguest".to_string()]).unwrap_err();
+        assert!(err.contains("Invalid mount format"));
+    }
+
+    #[test]
+    fn build_virtiofs_mount_plan_rejects_empty_host() {
+        let err = build_virtiofs_mount_plan(&[":/guest".to_string()]).unwrap_err();
+        assert!(err.contains("Invalid mount format"));
+    }
+
+    #[test]
+    fn build_virtiofs_mount_plan_rejects_empty_guest() {
+        let err = build_virtiofs_mount_plan(&["/host:".to_string()]).unwrap_err();
+        assert!(err.contains("Invalid mount format"));
     }
 
     // --- 6.1: check_kvm_nonexistent_path (Linux only) ---

--- a/crates/iii-worker/src/cli/worker_manager/libkrun.rs
+++ b/crates/iii-worker/src/cli/worker_manager/libkrun.rs
@@ -42,6 +42,7 @@ pub async fn run_dev(
     rootfs: PathBuf,
     background: bool,
     worker_name: &str,
+    mounts: &[(String, String)],
 ) -> i32 {
     let self_exe = match std::env::current_exe() {
         Ok(p) => p,
@@ -71,6 +72,10 @@ pub async fn run_dev(
 
     for (key, value) in &env {
         cmd.arg("--env").arg(format!("{}={}", key, value));
+    }
+
+    for (host, guest) in mounts {
+        cmd.arg("--mount").arg(format!("{}:{}", host, guest));
     }
 
     for arg in args {

--- a/engine/src/workers/observability/metrics.rs
+++ b/engine/src/workers/observability/metrics.rs
@@ -3461,7 +3461,10 @@ mod tests {
         assert!(acc.first_user_success_fn.get().is_none());
 
         let _ = acc.first_user_success_fn.set("math::add".to_string());
-        assert_eq!(acc.first_user_success_fn.get(), Some(&"math::add".to_string()));
+        assert_eq!(
+            acc.first_user_success_fn.get(),
+            Some(&"math::add".to_string())
+        );
 
         let _ = acc.first_user_success_fn.set("math::multiply".to_string());
         assert_eq!(
@@ -3477,7 +3480,10 @@ mod tests {
         assert!(acc.first_user_failure_fn.get().is_none());
 
         let _ = acc.first_user_failure_fn.set("math::add".to_string());
-        assert_eq!(acc.first_user_failure_fn.get(), Some(&"math::add".to_string()));
+        assert_eq!(
+            acc.first_user_failure_fn.get(),
+            Some(&"math::add".to_string())
+        );
 
         let _ = acc.first_user_failure_fn.set("other::fn".to_string());
         assert_eq!(
@@ -3493,8 +3499,14 @@ mod tests {
         let _ = acc.first_user_success_fn.set("math::add".to_string());
         let _ = acc.first_user_failure_fn.set("math::divide".to_string());
 
-        assert_eq!(acc.first_user_success_fn.get(), Some(&"math::add".to_string()));
-        assert_eq!(acc.first_user_failure_fn.get(), Some(&"math::divide".to_string()));
+        assert_eq!(
+            acc.first_user_success_fn.get(),
+            Some(&"math::add".to_string())
+        );
+        assert_eq!(
+            acc.first_user_failure_fn.get(),
+            Some(&"math::divide".to_string())
+        );
     }
 
     // =========================================================================

--- a/engine/tests/builtin_functions_e2e.rs
+++ b/engine/tests/builtin_functions_e2e.rs
@@ -2,11 +2,7 @@ use std::time::Duration;
 
 use serde_json::json;
 
-use iii::{
-    engine::EngineTrait,
-    workers::telemetry::is_iii_builtin_function_id,
-    EngineBuilder,
-};
+use iii::{EngineBuilder, engine::EngineTrait, workers::telemetry::is_iii_builtin_function_id};
 
 /// Boots the engine with all default modules (ephemeral ports to avoid
 /// conflicts), calls `engine::functions::list` with `include_internal: true`,


### PR DESCRIPTION
## Summary

- Host project dir mounts live at guest `/workspace` via virtiofs. `tsx watch` / `watchfiles` / `cargo-watch` now see host edits without a VM restart.
- Language dep dirs (`node_modules`, `.venv`, `target`, `dist`, `__pycache__`, `.pytest_cache`, `.next`) bind-mount from the rootfs at `/var/iii/deps/<name>`, so VM writes never touch the user's repo and persist across VM restarts.
- Drops the per-start `copy_dir_contents` of the project into the managed dir — source is now zero-copy.

## Why bind-mounts and not overlayfs

Tried overlayfs first. Two dead ends:

1. **Rootfs upper rejected**: `mount -t overlay` returns `wrong fs type, bad option, bad superblock` when upperdir lives on PassthroughFs (virtiofs-backed rootfs). PassthroughFs doesn't expose the xattr semantics overlayfs needs for upper.
2. **Tmpfs upper + virtiofs lower fails on copy-up**: install succeeds for pure-upper writes (new `node_modules`), but the moment npm tries to update an existing lower file (`package-lock.json`), the virtiofs→tmpfs copy-up path returns errno 102 (bubbles up as `Unknown system error -102` in node).

Bind-mounts sidestep the overlay copy-up path entirely: source files are read/written directly through virtiofs; dep paths shadow with plain bind mounts.

File watchers use polling (`CHOKIDAR_USEPOLLING`, `WATCHPACK_POLLING`, `WATCHFILES_FORCE_POLLING`, `TSC_WATCHFILE`) because virtiofs doesn't propagate inotify events from host edits.

## Plumbing

| File | Change |
|------|--------|
| `iii-init/src/parse.rs` | NEW. Pure, cross-platform `parse_virtiofs_spec` — extracted so it's unit-testable on macOS build hosts. |
| `iii-init/src/mount.rs` | `mount_virtiofs_shares()` reads `III_VIRTIOFS_MOUNTS` env, calls `mkdir -p`, mounts each share as `virtiofs`. |
| `iii-init/src/main.rs` | Calls `mount_virtiofs_shares()` right after base filesystem mounts. |
| `iii-worker/src/cli/vm_boot.rs` | New `build_virtiofs_mount_plan` produces both the virtio-fs attach entries and the `III_VIRTIOFS_MOUNTS` guest env string. |
| `iii-worker/src/cli/worker_manager/libkrun.rs` | `run_dev` takes `mounts: &[(String, String)]`, emits `--mount host:guest` args to `__vm-boot`. |
| `iii-worker/src/cli/local_worker.rs` | `build_local_mounts` maps `project_path -> /workspace`; `start_local_worker` drops the copy step and assembles the overlay-less `dev-run.sh`. |

## Tradeoff to call out

Bind-mount targets must exist. If the user's repo doesn't already have one of the dep dir names (`node_modules`, `.venv`, `target`, etc.), an empty directory appears on the host when the VM starts. All of these are already standard `.gitignore` entries in every dev setup.

## Test coverage (new)

- `parse_virtiofs_spec`: 11 cases (empty, single, multiple w/ order preserved, leading / trailing / consecutive semicolons, missing `=`, empty tag, empty path, `=` in path, mixed valid+malformed).
- `build_virtiofs_mount_plan`: 6 cases (empty, single, multiple w/ indexed tags + env string exact match, rejects missing colon / empty host / empty guest).
- `build_local_mounts`: 2 cases (absolute path, relative path round-trip).
- `build_libkrun_local_script`: asserts emitted script contains `mount --bind`, `/var/iii/deps`, `CHOKIDAR_USEPOLLING=true`.

Not covered by unit tests (flagged for follow-up): the actual `mount(2)` virtiofs call in iii-init (needs a Linux VM), `run_dev` CLI arg emission, and end-to-end VM boot. Verified manually against both `todo-worker` (TypeScript + `tsx watch`) and `todo-worker-python` (`watchfiles`).

## Test plan

- [ ] `cargo test -p iii-init --lib` — 11 parse tests pass on the build host
- [ ] `cargo test -p iii-worker --lib -- vm_boot local_worker` — 31 tests pass
- [ ] `cargo test --test local_worker_integration` — 24 legacy tests still pass
- [ ] Manual: `iii worker start todo-worker` (Node), edit `src/index.ts` on host, confirm `tsx watch` restarts inside the VM
- [ ] Manual: `iii worker start todo-worker-python`, edit `src/main.py` on host, confirm `watchfiles` restarts
- [ ] Manual: confirm host repo has no `node_modules` contents after `npm install` runs in VM (only an empty dir if one didn't exist)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added virtiofs filesystem mounting support and runtime mounting of configured virtiofs shares
  * Exposed host-to-guest mount planning for VM boots and local worker mounts

* **Improvements**
  * Switched local dev workspace to bind-mount/deps-root approach instead of file copying
  * Improved parsing and validation of virtiofs mount specs; more robust mount creation and error reporting

* **Tests**
  * Added unit tests for mount planning and spec parsing; refined existing test assertions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->