### PR TITLE
fix: use `topic` not `queue` in durable:subscriber trigger configs

### DIFF
--- a/skills/references/dead-letter-queues.js
+++ b/skills/references/dead-letter-queues.js
@@ -50,7 +50,7 @@ iii.registerFunction('payments::charge', async (data) => {
 iii.registerTrigger({
   type: 'durable:subscriber',
   function_id: 'payments::charge',
-  config: { queue: 'payment' },
+  config: { topic: 'payment' },
 })
 
 // ---------------------------------------------------------------------------

--- a/skills/references/dead-letter-queues.py
+++ b/skills/references/dead-letter-queues.py
@@ -57,7 +57,7 @@ iii.register_function("payments::charge", payments_charge)
 iii.register_trigger({
     "type": "durable:subscriber",
     "function_id": "payments::charge",
-    "config": {"queue": "payment"},
+    "config": {"topic": "payment"},
 })
 
 # ---

--- a/skills/references/functions-and-triggers.js
+++ b/skills/references/functions-and-triggers.js
@@ -52,7 +52,7 @@ iii.registerFunction('orders::fulfill', async (data) => {
 iii.registerTrigger({
   type: 'durable:subscriber',
   function_id: 'orders::fulfill',
-  config: { queue: 'fulfillment' },
+  config: { topic: 'fulfillment' },
 })
 
 // ---------------------------------------------------------------------------

--- a/skills/references/functions-and-triggers.py
+++ b/skills/references/functions-and-triggers.py
@@ -57,7 +57,7 @@ iii.register_function("orders::fulfill", fulfill_order)
 iii.register_trigger({
     "type": "durable:subscriber",
     "function_id": "orders::fulfill",
-    "config": {"queue": "fulfillment"},
+    "config": {"topic": "fulfillment"},
 })
 
 # ---------------------------------------------------------------------------

--- a/skills/references/trigger-conditions.js
+++ b/skills/references/trigger-conditions.js
@@ -115,7 +115,7 @@ iii.registerTrigger({
   type: 'durable:subscriber',
   function_id: 'orders::on-placed',
   config: {
-    queue: 'order-events',
+    topic: 'order-events',
     condition_function_id: 'conditions::is-order-placed',
   },
 })

--- a/skills/references/trigger-conditions.py
+++ b/skills/references/trigger-conditions.py
@@ -138,7 +138,7 @@ iii.register_trigger({
     "type": "durable:subscriber",
     "function_id": "orders::on-placed",
     "config": {
-        "queue": "order-events",
+        "topic": "order-events",
         "condition_function_id": "conditions::is-order-placed",
     },
 })


### PR DESCRIPTION
The engine's QueueTriggerConfig expects `topic` as the config key, but six skill reference files used `queue` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated durable subscriber trigger configurations in reference examples to use topic-based binding instead of queue-based binding for message destination routing.
  * Changes applied across multiple subscriber trigger scenarios to reflect updated messaging subscription patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->