### PR TITLE
fix(observability): tolerate null string fields in OTLP metrics ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "iii"
-version = "0.11.0-next.8"
+version = "0.11.0-next.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "iii-console"
-version = "0.11.0-next.8"
+version = "0.11.0-next.10"
 dependencies = [
  "anyhow",
  "axum",
@@ -2537,7 +2537,7 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.11.0-next.8"
+version = "0.11.0-next.10"
 dependencies = [
  "async-trait",
  "ctor",

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -1164,6 +1164,43 @@ impl OtlpArrayValue {
     }
 }
 
+/// Deserialize a String that may arrive as a JSON string or null, mapping null to empty string.
+/// OTLP JSON senders sometimes emit `null` for optional scope/metric string fields.
+fn deserialize_string_or_null<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct StringOrNullVisitor;
+
+    impl<'de> de::Visitor<'de> for StringOrNullVisitor {
+        type Value = String;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a string or null")
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+            Ok(v.to_owned())
+        }
+
+        fn visit_string<E: de::Error>(self, v: String) -> Result<Self::Value, E> {
+            Ok(v)
+        }
+
+        fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(String::new())
+        }
+
+        fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(String::new())
+        }
+    }
+
+    deserializer.deserialize_any(StringOrNullVisitor)
+}
+
 /// Deserialize an i64 that may arrive as a JSON number or a quoted string (OTLP protobuf int64).
 fn deserialize_int64_string_or_number<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
 where
@@ -1714,19 +1751,20 @@ struct OtlpScopeMetrics {
 #[serde(rename_all = "camelCase")]
 #[allow(dead_code)]
 struct OtlpScope {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_string_or_null")]
     name: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_string_or_null")]
     version: String,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct OtlpMetric {
+    #[serde(default, deserialize_with = "deserialize_string_or_null")]
     name: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_string_or_null")]
     description: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_string_or_null")]
     unit: String,
     #[serde(default)]
     gauge: Option<OtlpGauge>,
@@ -3028,6 +3066,58 @@ mod tests {
         } else {
             panic!("Expected histogram data point");
         }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_ingest_otlp_metrics_null_scope_and_metric_strings() {
+        // Regression: Python SDK emits `"version": null` when a meter is created
+        // without a version, and other senders may emit null for description/unit.
+        // The ingestion path must tolerate these without failing.
+        crate::workers::observability::metrics::init_metric_storage(Some(100), Some(3600));
+        if let Some(storage) = crate::workers::observability::metrics::get_metric_storage() {
+            storage.clear();
+        }
+
+        let otlp_json = r#"{
+            "resourceMetrics": [{
+                "resource": {
+                    "attributes": [{
+                        "key": "service.name",
+                        "value": {"stringValue": "iii-py"}
+                    }]
+                },
+                "scopeMetrics": [{
+                    "scope": {"name": "iii-py", "version": null},
+                    "metrics": [{
+                        "name": "test.counter",
+                        "description": null,
+                        "unit": null,
+                        "sum": {
+                            "isMonotonic": true,
+                            "aggregationTemporality": 2,
+                            "dataPoints": [{
+                                "attributes": [],
+                                "timeUnixNano": "1704067200000000000",
+                                "asDouble": 1.0
+                            }]
+                        }
+                    }]
+                }]
+            }]
+        }"#;
+
+        let result = ingest_otlp_metrics(otlp_json).await;
+        assert!(result.is_ok(), "null string fields should parse: {result:?}");
+
+        let storage = crate::workers::observability::metrics::get_metric_storage().unwrap();
+        let metrics = storage.get_metrics();
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics[0].name, "test.counter");
+        assert_eq!(metrics[0].description, "");
+        assert_eq!(metrics[0].unit, "");
+        assert_eq!(metrics[0].instrumentation_scope_name.as_deref(), Some("iii-py"));
+        assert_eq!(metrics[0].instrumentation_scope_version, None);
     }
 
     #[tokio::test]

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -3108,7 +3108,10 @@ mod tests {
         }"#;
 
         let result = ingest_otlp_metrics(otlp_json).await;
-        assert!(result.is_ok(), "null string fields should parse: {result:?}");
+        assert!(
+            result.is_ok(),
+            "null string fields should parse: {result:?}"
+        );
 
         let storage = crate::workers::observability::metrics::get_metric_storage().unwrap();
         let metrics = storage.get_metrics();
@@ -3116,7 +3119,10 @@ mod tests {
         assert_eq!(metrics[0].name, "test.counter");
         assert_eq!(metrics[0].description, "");
         assert_eq!(metrics[0].unit, "");
-        assert_eq!(metrics[0].instrumentation_scope_name.as_deref(), Some("iii-py"));
+        assert_eq!(
+            metrics[0].instrumentation_scope_name.as_deref(),
+            Some("iii-py")
+        );
         assert_eq!(metrics[0].instrumentation_scope_version, None);
     }
 

--- a/sdk/packages/python/iii/src/iii/telemetry_exporters.py
+++ b/sdk/packages/python/iii/src/iii/telemetry_exporters.py
@@ -395,8 +395,8 @@ def _serialize_metrics(metrics_data: Any) -> bytes:
             scope_metrics_json.append(
                 {
                     "scope": {
-                        "name": scope.name if scope else "",
-                        "version": scope.version if scope else "",
+                        "name": (scope.name if scope else "") or "",
+                        "version": (scope.version if scope else "") or "",
                     },
                     "metrics": metrics_json,
                 }

--- a/sdk/packages/python/iii/tests/test_telemetry_exporters.py
+++ b/sdk/packages/python/iii/tests/test_telemetry_exporters.py
@@ -179,6 +179,32 @@ def test_pre_start_buffer_drops_oldest_when_full():
     assert last == str(SharedEngineConnection.MAX_QUEUE).encode()
 
 
+def test_serialize_metrics_emits_empty_string_for_missing_scope_version():
+    """Regression: meter_provider.get_meter(name) produces scope.version=None in
+    the Python OTel SDK. The serializer must emit "" (not JSON null) so the Rust
+    engine's String deserializer doesn't reject the payload.
+    """
+    from iii.telemetry_exporters import _serialize_metrics
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+    from opentelemetry.sdk.resources import Resource
+
+    reader = InMemoryMetricReader()
+    resource = Resource.create({"service.name": "iii-py-test"})
+    provider = MeterProvider(resource=resource, metric_readers=[reader])
+    meter = provider.get_meter("iii-py-test")  # no version argument
+    counter = meter.create_counter("test.counter")
+    counter.add(1, {"k": "v"})
+
+    payload = _serialize_metrics(reader.get_metrics_data()).decode()
+    parsed = json.loads(payload)
+
+    scope = parsed["resourceMetrics"][0]["scopeMetrics"][0]["scope"]
+    assert scope["name"] == "iii-py-test"
+    assert scope["version"] == ""
+    assert scope["version"] is not None
+
+
 @pytest.mark.asyncio
 async def test_start_drains_pre_start_buffer_into_queue():
     """start() moves buffered frames into the asyncio queue."""


### PR DESCRIPTION
## Summary

Python workers were logging this warning on every metrics flush:

```
[WARN] iii::engine Metrics ingestion error
    ├ peer: 127.0.0.1:51379
    └ error: Failed to parse OTLP metrics JSON: invalid type: null, expected a string at line 1 column 572
```

Root cause chain:

1. `sdk/packages/python/iii/src/iii/telemetry.py:131` calls `meter_provider.get_meter(service_name)` with **no version argument**.
2. In the Python OTel SDK, that leaves `InstrumentationScope.version = None` (verified against opentelemetry-sdk 1.39).
3. `_serialize_metrics` in `telemetry_exporters.py` wrote the scope as `{"name": scope.name, "version": scope.version}`. `description` and `unit` already had `or ""` fallbacks; `version` did not. `json.dumps(None)` → `null`.
4. Rust engine `OtlpScope.version: String` with `#[serde(default)]` only applies the default for **missing** fields. An explicit JSON `null` still fails deserialization, producing the warning at the exact column where the `null` token appears (col 572 with production-sized resource attributes; verified by local reproduction at col 512 with minimal attributes).

## Changes

**Python (primary fix) — `sdk/packages/python/iii/src/iii/telemetry_exporters.py`**
- `scope.name` and `scope.version` coerced to `""` via `or ""`, matching how `description`/`unit` are already handled.

**Rust (defense in depth) — `engine/src/workers/observability/otel.rs`**
- New `deserialize_string_or_null` helper that accepts string, null, or absent and yields a `String` (empty on null/absent).
- Applied to `OtlpScope.{name, version}` and `OtlpMetric.{name, description, unit}` so any future null-happy sender (Node, Rust, third-party OTLP collectors) cannot trigger the same warning.

**Tests**
- `tests/test_telemetry_exporters.py::test_serialize_metrics_emits_empty_string_for_missing_scope_version` — exercises `_serialize_metrics` with a meter created without a version and asserts no `null` leaks into the payload.
- `otel.rs::test_ingest_otlp_metrics_null_scope_and_metric_strings` — feeds an OTLP JSON payload with `"version": null`, `"description": null`, `"unit": null` and asserts ingestion succeeds and the metric stores empty-string defaults.

**Incidental**
- `Cargo.lock` updated to catch up to the `0.11.0-next.10` bumps from `c5be6725` (the bump commit only touched `Cargo.toml` files). Required so the engine tests still build.

## Test plan

- [x] `cargo test -p iii --lib workers::observability::otel::tests::test_ingest_otlp_metrics` — 6 passed
- [x] `cargo test -p iii --lib workers::observability::otel::tests::test_ingest_otlp_metrics_null_scope_and_metric_strings` — 1 passed
- [x] `pytest sdk/packages/python/iii/tests/test_telemetry_exporters.py::test_serialize_metrics_emits_empty_string_for_missing_scope_version` — 1 passed
- [x] Python repro of `_serialize_metrics` post-fix confirms no `null` tokens in the serialized output.

## Known related bug (not fixed here)

`_serialize_metrics` at `telemetry_exporters.py:359` emits integer counter values as JSON strings (`dp["asInt"] = str(val)`), but `OtlpNumberDataPoint.as_int: Option<i64>` in Rust expects a raw number. Any Python `Counter`/`UpDownCounter` carrying an int value will hit `invalid type: string "1", expected i64`. Happy to address in a follow-up PR; flagged here so it doesn't get lost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OpenTelemetry metrics ingestion and serialization now treat null or missing string fields (scope name/version and metric name/description/unit) as empty strings, preventing ingestion failures and ensuring consistent stored values.
* **Tests**
  * Added regression tests that verify ingestion succeeds with null scope/metric strings and that serialized metrics emit empty strings for missing scope versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->