### PR TITLE
fix: drop extra slash in REST endpoint registration log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "iii"
-version = "0.11.0-next.8"
+version = "0.11.0-next.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "iii-console"
-version = "0.11.0-next.8"
+version = "0.11.0-next.10"
 dependencies = [
  "anyhow",
  "axum",
@@ -2537,7 +2537,7 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.11.0-next.8"
+version = "0.11.0-next.10"
 dependencies = [
  "async-trait",
  "ctor",

--- a/engine/src/workers/rest_api/api_core.rs
+++ b/engine/src/workers/rest_api/api_core.rs
@@ -354,7 +354,7 @@ impl HttpWorker {
         tracing::info!(
             "{} Endpoint {} → {}",
             "[REGISTERED]".green(),
-            format!("{} /{}", method, http_path).bright_yellow().bold(),
+            format!("{} {}", method, http_path).bright_yellow().bold(),
             function_id.purple()
         );
 


### PR DESCRIPTION
## Summary
- Removed the literal `/` in the `[REGISTERED] Endpoint` log format so paths that already start with `/` no longer render as `//math/add-two-numbers`.

## Test plan
- [ ] Register a REST endpoint and confirm the log now prints `POST /math/add-two-numbers` (single slash).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved logging output formatting for endpoint registration messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->