### PR TITLE
fix(iii-worker): DX overhaul + unblock binary worker auto-start

### DIFF
--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -90,6 +90,13 @@ pub enum Commands {
         /// Don't block waiting for the worker to report ready.
         #[arg(long)]
         no_wait: bool,
+
+        /// Engine WebSocket port the spawned worker connects back to. Defaults
+        /// to DEFAULT_PORT; the engine passes its configured
+        /// iii-worker-manager port when auto-spawning external workers so
+        /// non-default manager ports don't silently break connectivity.
+        #[arg(long, default_value_t = DEFAULT_PORT)]
+        port: u16,
     },
 
     /// Stop a managed worker container
@@ -110,6 +117,11 @@ pub enum Commands {
         /// Don't block waiting for the worker to report ready.
         #[arg(long)]
         no_wait: bool,
+
+        /// Engine WebSocket port the spawned worker connects back to. Same
+        /// semantics as `start --port`.
+        #[arg(long, default_value_t = DEFAULT_PORT)]
+        port: u16,
     },
 
     /// List all workers and their status

--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -43,13 +43,24 @@ pub enum Commands {
         /// Force re-download: delete existing artifacts before adding
         #[arg(long, short = 'f')]
         force: bool,
+
+        /// Don't block waiting for the engine to finish booting the sandbox.
+        /// By default `add` waits up to 120s for the worker to report ready.
+        #[arg(long)]
+        no_wait: bool,
     },
 
-    /// Remove one or more workers (stops and removes containers)
+    /// Remove one or more workers from config.yaml. The engine's file watcher
+    /// tears down any running sandbox. Artifacts under ~/.iii/managed/{name}/
+    /// remain; use `iii worker clear {name}` to delete them.
     Remove {
         /// Worker names to remove (e.g., "pdfkit")
         #[arg(value_name = "WORKER", required = true, num_args = 1..)]
         worker_names: Vec<String>,
+
+        /// Skip the confirmation prompt when a worker is currently running
+        #[arg(long, short = 'y')]
+        yes: bool,
     },
 
     /// Re-download a worker (equivalent to `add --force`; pass `--reset-config` to also clear config.yaml)
@@ -69,19 +80,16 @@ pub enum Commands {
         yes: bool,
     },
 
-    /// Start a previously stopped managed worker container
+    /// Start a previously stopped managed worker container.
+    /// By default waits up to 120s for the worker to report ready.
     Start {
         /// Worker name to start
         #[arg(value_name = "WORKER")]
         worker_name: String,
 
-        /// Engine host address
-        #[arg(long, default_value = "localhost")]
-        address: String,
-
-        /// Engine WebSocket port
-        #[arg(long, default_value_t = DEFAULT_PORT)]
-        port: u16,
+        /// Don't block waiting for the worker to report ready.
+        #[arg(long)]
+        no_wait: bool,
     },
 
     /// Stop a managed worker container
@@ -89,18 +97,36 @@ pub enum Commands {
         /// Worker name to stop
         #[arg(value_name = "WORKER")]
         worker_name: String,
+    },
 
-        /// Engine host address
-        #[arg(long, default_value = "localhost")]
-        address: String,
+    /// Restart a managed worker: stop if running, then start. Idempotent --
+    /// running workers get a clean cycle, stopped workers just start.
+    /// By default waits up to 120s for the worker to report ready.
+    Restart {
+        /// Worker name to restart
+        #[arg(value_name = "WORKER")]
+        worker_name: String,
 
-        /// Engine WebSocket port
-        #[arg(long, default_value_t = DEFAULT_PORT)]
-        port: u16,
+        /// Don't block waiting for the worker to report ready.
+        #[arg(long)]
+        no_wait: bool,
     },
 
     /// List all workers and their status
     List,
+
+    /// Show detailed status of one worker (config, sandbox, process, logs).
+    /// By default refreshes live in place until the worker reaches a terminal
+    /// phase (ready/missing). Pass --no-watch for a one-shot snapshot.
+    Status {
+        /// Worker name
+        #[arg(value_name = "WORKER")]
+        worker_name: String,
+
+        /// Print a one-shot snapshot and exit immediately (no live refresh)
+        #[arg(long)]
+        no_watch: bool,
+    },
 
     /// Show logs from a managed worker container
     Logs {

--- a/crates/iii-worker/src/cli/config_file.rs
+++ b/crates/iii-worker/src/cli/config_file.rs
@@ -11,6 +11,54 @@ use std::path::Path;
 
 const CONFIG_FILE: &str = "config.yaml";
 
+/// Resolve the engine's effective `iii-worker-manager` port from config.yaml.
+///
+/// Mirrors the engine-side resolution in
+/// `engine/src/workers/config.rs::EngineBuilder::build` so the CLI's
+/// liveness probe targets the same port the engine binds. Without this,
+/// `iii worker status` / `--wait` / `--watch` hardcode `DEFAULT_PORT` and
+/// silently report "engine stopped" whenever the user runs the engine on
+/// a non-default port (SDK integration tests, multi-engine dev setups).
+///
+/// Falls back to `DEFAULT_PORT` if:
+/// - config.yaml does not exist (fresh project, before first `worker add`)
+/// - config.yaml is unreadable or not valid YAML
+/// - no `iii-worker-manager` entry is present (mandatory-injection path
+///   uses `DEFAULT_PORT` engine-side too)
+/// - the entry has no `config.port` field, or the port is not a u16
+pub fn manager_port() -> u16 {
+    let path = Path::new(CONFIG_FILE);
+    if !path.exists() {
+        return super::app::DEFAULT_PORT;
+    }
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return super::app::DEFAULT_PORT;
+    };
+    manager_port_from(&content)
+}
+
+/// Pure extraction used by [`manager_port`] and exposed for unit tests so the
+/// YAML parsing doesn't need filesystem I/O to exercise.
+pub(crate) fn manager_port_from(content: &str) -> u16 {
+    let yaml: serde_yaml::Value = match serde_yaml::from_str(content) {
+        Ok(v) => v,
+        Err(_) => return super::app::DEFAULT_PORT,
+    };
+    let entry = yaml
+        .get("workers")
+        .and_then(|w| w.as_sequence())
+        .and_then(|seq| {
+            seq.iter()
+                .find(|w| w.get("name").and_then(|n| n.as_str()) == Some("iii-worker-manager"))
+        });
+    entry
+        .and_then(|w| w.get("config"))
+        .and_then(|c| c.get("port"))
+        .and_then(|p| p.as_u64())
+        .and_then(|p| u16::try_from(p).ok())
+        .unwrap_or(super::app::DEFAULT_PORT)
+}
+
 /// Canonical worker type resolved from config.yaml + filesystem.
 #[derive(Debug)]
 pub enum ResolvedWorkerType {
@@ -1267,5 +1315,62 @@ mod tests {
         assert_eq!(workers.len(), 1);
 
         let _ = std::fs::remove_file(path);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // manager_port resolution. Pins the contract that the CLI's engine-
+    // liveness probe targets the SAME port the engine resolves at build
+    // time — see engine_builder_resolves_custom_worker_manager_port_from_config
+    // in engine/src/workers/config.rs. Any drift here silently re-breaks
+    // --wait / status on non-default manager ports.
+    // ─────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn manager_port_from_picks_custom_port_when_configured() {
+        let yaml = r#"
+workers:
+  - name: iii-worker-manager
+    config:
+      host: 127.0.0.1
+      port: 49199
+"#;
+        assert_eq!(manager_port_from(yaml), 49199);
+    }
+
+    #[test]
+    fn manager_port_from_falls_back_to_default_when_entry_missing() {
+        let yaml = "workers:\n  - name: iii-http\n";
+        assert_eq!(manager_port_from(yaml), super::super::app::DEFAULT_PORT);
+    }
+
+    #[test]
+    fn manager_port_from_falls_back_to_default_on_missing_port_field() {
+        let yaml = r#"
+workers:
+  - name: iii-worker-manager
+    config:
+      host: 127.0.0.1
+"#;
+        assert_eq!(manager_port_from(yaml), super::super::app::DEFAULT_PORT);
+    }
+
+    #[test]
+    fn manager_port_from_rejects_out_of_range_port() {
+        // 99999 overflows u16; must not panic, must fall back.
+        let yaml = r#"
+workers:
+  - name: iii-worker-manager
+    config:
+      port: 99999
+"#;
+        assert_eq!(manager_port_from(yaml), super::super::app::DEFAULT_PORT);
+    }
+
+    #[test]
+    fn manager_port_from_returns_default_on_malformed_yaml() {
+        assert_eq!(
+            manager_port_from("not: valid: yaml: :"),
+            super::super::app::DEFAULT_PORT
+        );
     }
 }

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -493,9 +493,11 @@ pub async fn handle_local_add(
         );
 
         let started = std::time::Instant::now();
+        let port = super::config_file::manager_port();
         let final_status = super::status::watch_until_ready(
             &worker_name,
             Some(std::time::Duration::from_secs(120)),
+            port,
         )
         .await;
         let elapsed = started.elapsed();

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -326,12 +326,25 @@ pub fn resolve_worker_name(project_path: &Path) -> String {
 /// 4. Run setup+install scripts inside a libkrun VM
 /// 5. Extract default config from iii.worker.yaml
 /// 6. Append to config.yaml with `worker_path`
-pub async fn handle_local_add(path: &str, force: bool, reset_config: bool, brief: bool) -> i32 {
+pub async fn handle_local_add(
+    path: &str,
+    force: bool,
+    reset_config: bool,
+    brief: bool,
+    wait: bool,
+) -> i32 {
     // 1. Resolve path to absolute
     let project_path = match std::fs::canonicalize(path) {
         Ok(p) => p,
         Err(e) => {
-            eprintln!("{} Invalid path '{}': {}", "error:".red(), path, e);
+            eprintln!(
+                "{} Cannot resolve path '{}': {}\n  \
+                 Fix: pass a path that exists, e.g. `iii worker add ./my-worker`.\n  \
+                 If the directory should exist, check spelling and current working dir.",
+                "error:".red(),
+                path,
+                e
+            );
             return 1;
         }
     };
@@ -339,7 +352,8 @@ pub async fn handle_local_add(path: &str, force: bool, reset_config: bool, brief
     // 2. Validate directory exists
     if !project_path.is_dir() {
         eprintln!(
-            "{} '{}' is not a directory",
+            "{} '{}' exists but is not a directory.\n  \
+             Fix: point at the worker's project directory, not a file.",
             "error:".red(),
             project_path.display()
         );
@@ -351,8 +365,13 @@ pub async fn handle_local_add(path: &str, force: bool, reset_config: bool, brief
         Some(p) => p,
         None => {
             eprintln!(
-                "{} Could not detect project type in '{}'. \
-                 Add iii.worker.yaml or use package.json/Cargo.toml/pyproject.toml.",
+                "{} No project manifest detected in '{}'.\n  \
+                 Looked for: iii.worker.yaml, package.json, Cargo.toml, pyproject.toml.\n  \
+                 Fix: run from inside your worker project, or create iii.worker.yaml:\n      \
+                     name: my-worker\n      \
+                     runtime:\n        \
+                       language: typescript\n      \
+                     command: [\"node\", \"src/index.js\"]",
                 "error:".red(),
                 project_path.display()
             );
@@ -361,23 +380,29 @@ pub async fn handle_local_add(path: &str, force: bool, reset_config: bool, brief
     };
 
     if let Err(msg) = project.validate() {
-        eprintln!("{} {}", "error:".red(), msg);
+        eprintln!(
+            "{} Project manifest is invalid: {}\n  \
+             Fix: see https://motia.dev/docs/iii/worker-manifest for the schema.",
+            "error:".red(),
+            msg
+        );
         return 1;
     }
 
     // 4. Resolve worker name
     let worker_name = resolve_worker_name(&project_path);
 
-    if !brief {
-        eprintln!("  Adding local worker {}...", worker_name.bold());
-    }
-
     // 5. Check if already exists in config.yaml
     if super::config_file::worker_exists(&worker_name) {
         if !force {
             eprintln!(
-                "{} Worker '{}' already exists in config.yaml. Use --force to replace.",
+                "{} Worker '{}' is already in config.yaml.\n  \
+                 Fix options:\n    \
+                   - Keep it: `iii worker status {}` to see how it's doing.\n    \
+                   - Replace it: rerun with --force (stops VM, clears artifacts).\n    \
+                   - Wipe the config entry too: --force --reset-config.",
                 "error:".red(),
+                worker_name,
                 worker_name
             );
             return 1;
@@ -385,7 +410,7 @@ pub async fn handle_local_add(path: &str, force: bool, reset_config: bool, brief
         // --force: stop if running, clear artifacts
         if super::managed::is_worker_running(&worker_name) {
             eprintln!("  Stopping running worker {}...", worker_name.bold());
-            super::managed::handle_managed_stop(&worker_name, "0.0.0.0", 49134).await;
+            super::managed::handle_managed_stop(&worker_name).await;
         }
         let freed = super::managed::delete_worker_artifacts(&worker_name);
         if freed > 0 {
@@ -418,25 +443,112 @@ pub async fn handle_local_add(path: &str, force: bool, reset_config: bool, brief
         &abs_path_str,
         config_yaml.as_deref(),
     ) {
-        eprintln!("{} {}", "error:".red(), e);
+        eprintln!(
+            "{} Failed to update config.yaml: {}\n  \
+             Fix: check that config.yaml is writable and valid YAML.",
+            "error:".red(),
+            e
+        );
         return 1;
     }
 
-    // 8. Print success
+    // 8. Decide the output shape. The worker is queued in config.yaml but has
+    //    NOT booted yet — never claim success with ✓. Output depends on three
+    //    axes: brief (multi-add row), engine state, and whether the caller
+    //    asked us to --wait.
+    let engine_running = super::managed::is_engine_running();
+
     if brief {
-        eprintln!("        {} {}", "\u{2713}".green(), worker_name.bold());
+        // Multi-worker add: one short row per worker. ⟳ if the engine will
+        // pick it up, ⚠ if it won't.
+        let glyph = if engine_running {
+            "\u{27F3}"
+        } else {
+            "\u{26A0}"
+        };
+        eprintln!("        {} {}", glyph.cyan(), worker_name.bold());
+        return 0;
+    }
+
+    // 9. --wait: skip the "follow along" nudge entirely (we ARE following
+    //    along now), drop straight into the live snapshot, and print a
+    //    one-line closer with elapsed time.
+    if wait {
+        if !engine_running {
+            eprintln!(
+                "\n  {} Added {} ({}) to config.yaml, but the engine isn't running.\n  \
+                 --wait cannot observe it boot — run `iii start` in another terminal first.",
+                "\u{26A0}".yellow(),
+                worker_name.bold(),
+                "local".dimmed()
+            );
+            return 0;
+        }
+
+        eprintln!(
+            "\n  {} Adding {} ({})...",
+            "→".cyan(),
+            worker_name.bold(),
+            "local".dimmed()
+        );
+
+        let started = std::time::Instant::now();
+        let final_status = super::status::watch_until_ready(
+            &worker_name,
+            Some(std::time::Duration::from_secs(120)),
+        )
+        .await;
+        let elapsed = started.elapsed();
+
+        match final_status.phase {
+            super::status::Phase::Ready => {
+                eprintln!("  {} ready in {:.1}s", "✓".green(), elapsed.as_secs_f64());
+                return 0;
+            }
+            _ => {
+                eprintln!(
+                    "  {} not ready after {:.0}s (worker is still queued in config.yaml).\n  \
+                       Keep watching: iii worker status {}\n  \
+                       Check logs:    iii worker logs {} -f",
+                    "⚠".yellow(),
+                    elapsed.as_secs_f64(),
+                    worker_name,
+                    worker_name
+                );
+                return 2;
+            }
+        }
+    }
+
+    // 10. Non-wait path (user passed --no-wait): two-branch tight message
+    //     depending on engine state. Hints drop `--watch` because status
+    //     live-refreshes by default now.
+    if engine_running {
+        eprintln!(
+            "\n  {} Added {} ({}) — queued in config.yaml.\n  \
+             Watch it boot: iii worker status {}\n  \
+             Tail logs:     iii worker logs {} -f",
+            "→".cyan(),
+            worker_name.bold(),
+            "local".dimmed(),
+            worker_name,
+            worker_name
+        );
     } else {
         eprintln!(
-            "\n  {} Worker {} added to {}",
-            "\u{2713}".green(),
+            "\n  {} Added {} ({}) to config.yaml, but the engine isn't running.\n  \
+             Start it:  iii start\n  \
+             Then:      iii worker status {}",
+            "\u{26A0}".yellow(),
             worker_name.bold(),
-            "config.yaml".dimmed(),
+            "local".dimmed(),
+            worker_name
         );
-        eprintln!("  {}  {}", "Path".cyan().bold(), abs_path_str.bold());
-
-        // The engine's file watcher will detect the config change and
-        // reload automatically — no need to start the worker here.
     }
+
+    // Stash the absolute path in a debug-visible spot without cluttering the
+    // happy-path output. Users who need it can run `iii worker status`.
+    tracing::debug!(worker = %worker_name, path = %abs_path_str, "local worker queued");
 
     0
 }

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -1448,30 +1448,28 @@ pub async fn handle_managed_start(worker_name: &str, wait: bool) -> i32 {
 /// running just get started. We delegate to the existing stop/start paths
 /// rather than duplicating the libkrun teardown / pid-discovery logic.
 ///
-/// Stop failures are logged but do NOT abort the restart -- the most common
-/// reason stop fails here is "already not running," which is exactly the
-/// state start expects. Start's exit code becomes the command's exit code.
+/// Stop is invoked unconditionally so its three-tier PID discovery (OCI
+/// pidfile, binary pidfile, `ps` scan) can catch orphan processes whose
+/// pidfiles are missing or stale. `is_worker_running` only consults
+/// pidfiles, so gating on it would let those orphans slip through and
+/// start would then spawn a duplicate. Stop failures are logged but do
+/// NOT abort the restart -- the most common reason stop "fails" here is
+/// "already not running," which returns 0. Start's exit code becomes the
+/// command's exit code.
 pub async fn handle_managed_restart(worker_name: &str, wait: bool) -> i32 {
     if let Err(e) = super::registry::validate_worker_name(worker_name) {
         eprintln!("{} {}", "error:".red(), e);
         return 1;
     }
 
-    // Only stop if we see a live process. handle_managed_stop is tolerant of
-    // "not running" (it returns 0 with an "already stopped" message), but
-    // calling it unconditionally clutters the output with a redundant line.
-    if is_worker_running(worker_name) {
-        eprintln!("  Restarting {}...", worker_name.bold());
-        let stop_rc = handle_managed_stop(worker_name).await;
-        if stop_rc != 0 {
-            eprintln!(
-                "  {} stop exited {} -- continuing with start",
-                "warning:".yellow(),
-                stop_rc
-            );
-        }
-    } else {
-        eprintln!("  {} not running; starting fresh...", worker_name.bold());
+    eprintln!("  Restarting {}...", worker_name.bold());
+    let stop_rc = handle_managed_stop(worker_name).await;
+    if stop_rc != 0 {
+        eprintln!(
+            "  {} stop exited {} -- continuing with start",
+            "warning:".yellow(),
+            stop_rc
+        );
     }
 
     handle_managed_start(worker_name, wait).await

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -5,6 +5,23 @@
 // See LICENSE and PATENTS files for details.
 
 //! CLI command handlers for managing OCI-based workers.
+//!
+//! # Output contract
+//!
+//! - **stdout**: machine-readable worker name on success (one line). Scripts
+//!   pipe `iii worker start foo | xargs ...` and rely on this being the only
+//!   thing on stdout.
+//! - **stderr**: all human-facing status, progress, errors, prompts, and
+//!   decorative output. Every line here is cosmetic and may change between
+//!   releases without breaking anyone.
+//!
+//! Two implications:
+//! 1. Never `println!` anything that isn't the worker name. Use `eprintln!`
+//!    for everything else, including successes like "✓ ready in 3.2s".
+//! 2. Failures exit non-zero WITHOUT printing to stdout. Consumers of the
+//!    stdout contract check the exit code first.
+//!
+//! The same contract applies in `local_worker.rs` and `status.rs`.
 
 use colored::Colorize;
 
@@ -163,7 +180,10 @@ pub async fn handle_managed_add(
         .await;
     }
 
-    // --force: delete existing artifacts before re-downloading
+    // --force: stop if running, delete artifacts, then proceed with a fresh
+    // add. Before the fix this path errored out with "Stop it first" when a
+    // running worker was detected — which defeats the point of --force. The
+    // whole sequence (stop → clear → add) is what a user means by "force."
     if force {
         let (plain_name, _) = parse_worker_input(image_or_name);
 
@@ -175,12 +195,22 @@ pub async fn handle_managed_add(
 
         if is_worker_running(&plain_name) {
             eprintln!(
-                "{} Worker '{}' is currently running. Stop it first with `iii worker stop {}`",
-                "error:".red(),
-                plain_name,
-                plain_name,
+                "  {} {} is running, stopping first...",
+                "⟳".cyan(),
+                plain_name.bold()
             );
-            return 1;
+            let stop_rc = handle_managed_stop(&plain_name).await;
+            if stop_rc != 0 {
+                // Don't abort — artifacts will be wiped below anyway, and the
+                // most common "failure" is "already stopped between is_worker_running
+                // and the signal" which is benign. Surface it so a stuck worker
+                // doesn't silently confuse the user.
+                eprintln!(
+                    "  {} stop exited {} — continuing with force add anyway",
+                    "warning:".yellow(),
+                    stop_rc
+                );
+            }
         }
 
         if super::builtin_defaults::get_builtin_default(&plain_name).is_some() {
@@ -226,7 +256,8 @@ pub async fn handle_managed_add(
         if !brief {
             eprintln!("  {} Resolved to {}", "✓".green(), image_or_name.dimmed());
         }
-        return handle_oci_pull_and_add(name, image_or_name, brief).await;
+        let rc = handle_oci_pull_and_add(name, image_or_name, brief).await;
+        return finish_add(name, rc, wait, brief).await;
     }
 
     // Shorthand name — resolve via API
@@ -269,6 +300,9 @@ pub async fn handle_managed_add(
                 eprintln!("  Start the engine to run it, or edit config.yaml to customize.");
             }
         }
+        // Builtins run in-process with the engine; there is no detached VM
+        // or binary to watch. The Phase machinery would loop on Queued until
+        // timeout, so skip wait_for_ready for builtins even when wait=true.
         return 0;
     }
 
@@ -284,7 +318,7 @@ pub async fn handle_managed_add(
         }
     };
 
-    match response {
+    let rc = match response {
         WorkerInfoResponse::Binary(r) => handle_binary_add(&name, &r, brief).await,
         WorkerInfoResponse::Oci(r) => {
             if !brief {
@@ -292,7 +326,39 @@ pub async fn handle_managed_add(
             }
             handle_oci_pull_and_add(&r.name, &r.image_url, brief).await
         }
+    };
+    finish_add(&name, rc, wait, brief).await
+}
+
+/// Shared tail for every non-local `handle_managed_add` exit path.
+///
+/// `handle_managed_add` accepts `wait: bool` from the `--wait` / `--no-wait`
+/// flag (default wait=true per the CLI definition in app.rs). Before this
+/// helper, `wait` was only honored on the local-path branch — OCI/binary/
+/// registry adds silently dropped it, contradicting the `add` command's
+/// documented "waits up to 120s by default" contract. We also skip the
+/// wait when `rc != 0` (nothing to wait on if the add itself failed) and
+/// when `brief` is set (multi-worker `add-many` renders per-row status
+/// and a blocking wait per entry would produce confusing output).
+async fn finish_add(worker_name: &str, rc: i32, wait: bool, brief: bool) -> i32 {
+    if rc != 0 || !wait || brief {
+        return rc;
     }
+    let port = super::config_file::manager_port();
+    if !is_engine_running_on(port) {
+        // Engine down → no file watcher → config.yaml change won't be
+        // picked up. A wait would run to timeout. Tell the user instead.
+        eprintln!(
+            "\n  {} engine not running; start it to observe boot.\n  \
+               Start:         iii start\n  \
+               Then watch:    iii worker status {}",
+            "⚠".yellow(),
+            worker_name,
+        );
+        return rc;
+    }
+    wait_for_ready(worker_name, port).await;
+    rc
 }
 
 async fn handle_oci_pull_and_add(name: &str, image_ref: &str, brief: bool) -> i32 {
@@ -968,14 +1034,26 @@ pub fn is_worker_running(worker_name: &str) -> bool {
     false
 }
 
-/// Probes `127.0.0.1:DEFAULT_PORT` to check whether the engine is listening.
+/// Probes `127.0.0.1:{port}` to check whether the engine is listening.
 /// Uses a 200ms timeout to avoid blocking the CLI.
-pub fn is_engine_running() -> bool {
+///
+/// Callers that don't already know the port should resolve via
+/// `super::config_file::manager_port()`; those who already hold a port
+/// (e.g. after a user passed `--port`) should use it directly so an
+/// override isn't silently ignored.
+pub fn is_engine_running_on(port: u16) -> bool {
     std::net::TcpStream::connect_timeout(
-        &std::net::SocketAddr::from(([127, 0, 0, 1], super::app::DEFAULT_PORT)),
+        &std::net::SocketAddr::from(([127, 0, 0, 1], port)),
         std::time::Duration::from_millis(200),
     )
     .is_ok()
+}
+
+/// Convenience for call sites without a known port: resolves the
+/// `iii-worker-manager` port from config.yaml (or falls back to
+/// `DEFAULT_PORT`) and probes it.
+pub fn is_engine_running() -> bool {
+    is_engine_running_on(super::config_file::manager_port())
 }
 
 /// Deletes local artifacts for a worker (binary dir or OCI image dir).
@@ -1272,11 +1350,19 @@ async fn kill_pid_with_grace(pid: u32) {
 /// --no-wait. Same contract as `iii worker add --wait`: on timeout we do NOT
 /// fail the command (the process started successfully), we just inform the
 /// user and let them poll with `iii worker status {name}`.
-async fn wait_for_ready(worker_name: &str) {
+///
+/// `port` is the engine's configured `iii-worker-manager` port so the
+/// engine-liveness probe inside `watch_until_ready` targets the engine the
+/// worker is actually talking to. Without this, users on a non-default
+/// port would see "engine: stopped" until the wait timed out.
+async fn wait_for_ready(worker_name: &str, port: u16) {
     let started = std::time::Instant::now();
-    let final_status =
-        super::status::watch_until_ready(worker_name, Some(std::time::Duration::from_secs(120)))
-            .await;
+    let final_status = super::status::watch_until_ready(
+        worker_name,
+        Some(std::time::Duration::from_secs(120)),
+        port,
+    )
+    .await;
     let elapsed = started.elapsed();
     match final_status.phase {
         super::status::Phase::Ready => {
@@ -1341,31 +1427,25 @@ pub async fn handle_managed_start(worker_name: &str, wait: bool, port: u16) -> i
         println!("{}", worker_name);
         return 0;
     }
-    let start_rc = match super::config_file::resolve_worker_type(worker_name) {
+    let local_outcome = match super::config_file::resolve_worker_type(worker_name) {
         ResolvedWorkerType::Oci { image, env } => {
             let worker_def = WorkerDef::Managed {
                 image,
                 env,
                 resources: None,
             };
-            start_oci_worker(worker_name, &worker_def, port).await
+            StartOutcome::Exit(start_oci_worker(worker_name, &worker_def, port).await)
         }
-        ResolvedWorkerType::Local { worker_path } => {
-            super::local_worker::start_local_worker(worker_name, &worker_path, port).await
-        }
+        ResolvedWorkerType::Local { worker_path } => StartOutcome::Exit(
+            super::local_worker::start_local_worker(worker_name, &worker_path, port).await,
+        ),
         ResolvedWorkerType::Binary { binary_path } => {
-            start_binary_worker(worker_name, &binary_path).await
+            StartOutcome::Exit(start_binary_worker(worker_name, &binary_path).await)
         }
-        ResolvedWorkerType::Config => i32::MIN, // sentinel: fall through to registry
+        ResolvedWorkerType::Config => StartOutcome::FallThrough,
     };
-    if start_rc != i32::MIN {
-        if start_rc == 0 {
-            if wait {
-                wait_for_ready(worker_name).await;
-            }
-            println!("{}", worker_name);
-        }
-        return start_rc;
+    if let StartOutcome::Exit(rc) = local_outcome {
+        return finish_start(worker_name, rc, wait, port).await;
     }
 
     // Not found locally — try remote registry for auto-install
@@ -1403,13 +1483,7 @@ pub async fn handle_managed_start(worker_name: &str, wait: bool, port: u16) -> i
                 Ok(installed_path) => {
                     eprintln!("  {} Installed successfully", "✓".green());
                     let rc = start_binary_worker(worker_name, &installed_path).await;
-                    if rc == 0 {
-                        if wait {
-                            wait_for_ready(worker_name).await;
-                        }
-                        println!("{}", worker_name);
-                    }
-                    return rc;
+                    return finish_start(worker_name, rc, wait, port).await;
                 }
                 Err(e) => {
                     eprintln!(
@@ -1429,13 +1503,7 @@ pub async fn handle_managed_start(worker_name: &str, wait: bool, port: u16) -> i
                 resources: None,
             };
             let rc = start_oci_worker(worker_name, &worker_def, port).await;
-            if rc == 0 {
-                if wait {
-                    wait_for_ready(worker_name).await;
-                }
-                println!("{}", worker_name);
-            }
-            return rc;
+            return finish_start(worker_name, rc, wait, port).await;
         }
         Err(e) => {
             tracing::warn!("Failed to fetch worker info: {}", e);
@@ -1449,6 +1517,29 @@ pub async fn handle_managed_start(worker_name: &str, wait: bool, port: u16) -> i
         worker_name
     );
     1
+}
+
+/// Classifies what `handle_managed_start`'s local-resolution branch wants the
+/// caller to do next: either return an exit code straight to the user, or
+/// fall through to the remote-registry path. Introduced to replace an
+/// `i32::MIN` sentinel that overloaded the exit-code type as a control token.
+enum StartOutcome {
+    Exit(i32),
+    FallThrough,
+}
+
+/// Shared tail for every successful start path: wait (if requested) then
+/// emit the machine-readable worker name on stdout per the module output
+/// contract. Keeping this in one place prevents the stdout contract from
+/// drifting across the four call sites that used to inline it.
+async fn finish_start(worker_name: &str, rc: i32, wait: bool, port: u16) -> i32 {
+    if rc == 0 {
+        if wait {
+            wait_for_ready(worker_name, port).await;
+        }
+        println!("{}", worker_name);
+    }
+    rc
 }
 
 /// Stop (if running) and start a worker. Idempotent: workers that aren't

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -1296,12 +1296,19 @@ async fn wait_for_ready(worker_name: &str) {
     }
 }
 
-pub async fn handle_managed_start(worker_name: &str, wait: bool) -> i32 {
+/// Starts a managed worker, pointing it back at the engine on `port`.
+///
+/// `port` is the WebSocket port the spawned worker will connect to (used to
+/// build `III_ENGINE_URL` for VM-based workers and to probe engine liveness).
+/// Callers that don't know any better pass `DEFAULT_PORT`; the engine's
+/// auto-spawn path in `registry_worker::ExternalWorkerProcess::spawn` passes
+/// the configured `iii-worker-manager` port so non-default manager ports
+/// don't silently break connectivity for external workers.
+pub async fn handle_managed_start(worker_name: &str, wait: bool, port: u16) -> i32 {
     if let Err(e) = super::registry::validate_worker_name(worker_name) {
         eprintln!("{} {}", "error:".red(), e);
         return 1;
     }
-    let port = super::app::DEFAULT_PORT;
     // Builtin workers are served in-process by the iii engine (see
     // engine/src/workers/config.rs factory registry). They have no external
     // process to spawn and must not be resolved via the remote registry.
@@ -1456,7 +1463,7 @@ pub async fn handle_managed_start(worker_name: &str, wait: bool) -> i32 {
 /// NOT abort the restart -- the most common reason stop "fails" here is
 /// "already not running," which returns 0. Start's exit code becomes the
 /// command's exit code.
-pub async fn handle_managed_restart(worker_name: &str, wait: bool) -> i32 {
+pub async fn handle_managed_restart(worker_name: &str, wait: bool, port: u16) -> i32 {
     if let Err(e) = super::registry::validate_worker_name(worker_name) {
         eprintln!("{} {}", "error:".red(), e);
         return 1;
@@ -1472,7 +1479,7 @@ pub async fn handle_managed_restart(worker_name: &str, wait: bool) -> i32 {
         );
     }
 
-    handle_managed_start(worker_name, wait).await
+    handle_managed_start(worker_name, wait, port).await
 }
 
 async fn start_oci_worker(worker_name: &str, worker_def: &WorkerDef, port: u16) -> i32 {

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -114,7 +114,7 @@ pub async fn handle_binary_add(
     0
 }
 
-pub async fn handle_managed_add_many(worker_names: &[String]) -> i32 {
+pub async fn handle_managed_add_many(worker_names: &[String], wait: bool) -> i32 {
     let total = worker_names.len();
     let brief = total > 1;
     let mut fail_count = 0;
@@ -123,7 +123,7 @@ pub async fn handle_managed_add_many(worker_names: &[String]) -> i32 {
         if brief {
             eprintln!("  [{}/{}] Adding {}...", i + 1, total, name.bold());
         }
-        let result = handle_managed_add(name, brief, false, false).await;
+        let result = handle_managed_add(name, brief, false, false, wait).await;
         if result != 0 {
             fail_count += 1;
         }
@@ -149,11 +149,18 @@ pub async fn handle_managed_add(
     brief: bool,
     force: bool,
     reset_config: bool,
+    wait: bool,
 ) -> i32 {
     // Local path workers: starts with '.', '/', or '~'
     if super::local_worker::is_local_path(image_or_name) {
-        return super::local_worker::handle_local_add(image_or_name, force, reset_config, brief)
-            .await;
+        return super::local_worker::handle_local_add(
+            image_or_name,
+            force,
+            reset_config,
+            brief,
+            wait,
+        )
+        .await;
     }
 
     // --force: delete existing artifacts before re-downloading
@@ -389,10 +396,44 @@ async fn handle_oci_pull_and_add(name: &str, image_ref: &str, brief: bool) -> i3
     0
 }
 
-pub async fn handle_managed_remove_many(worker_names: &[String]) -> i32 {
+pub async fn handle_managed_remove_many(worker_names: &[String], yes: bool) -> i32 {
     let total = worker_names.len();
     let brief = total > 1;
     let mut fail_count = 0;
+
+    // Single batch confirmation for any names that are currently running. We
+    // gather them up-front so the user sees the whole blast radius once, not a
+    // prompt per worker.
+    if !yes {
+        let running: Vec<&String> = worker_names
+            .iter()
+            .filter(|n| is_worker_running(n))
+            .collect();
+        if !running.is_empty() {
+            let list = running
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            eprintln!(
+                "  {} {} currently running: {}",
+                "warning:".yellow(),
+                if running.len() == 1 {
+                    "worker is"
+                } else {
+                    "workers are"
+                },
+                list,
+            );
+            eprintln!(
+                "  Removing them from config.yaml triggers an engine reload that will tear the sandbox(es) down."
+            );
+            if !confirm_prompt("  Continue? [y/N] ") {
+                eprintln!("  Aborted.");
+                return 0;
+            }
+        }
+    }
 
     for (i, name) in worker_names.iter().enumerate() {
         if brief {
@@ -424,6 +465,17 @@ pub async fn handle_managed_remove(worker_name: &str, brief: bool) -> i32 {
         eprintln!("{} {}", "error:".red(), e);
         return 1;
     }
+    // Distinguish "config.yaml doesn't exist yet" from "worker isn't in it."
+    // The underlying remove_worker surfaces both as the same anyhow error,
+    // which misleads users into thinking their config file is missing.
+    if !super::config_file::worker_exists(worker_name) {
+        eprintln!(
+            "{} Worker '{}' is not in config.yaml. Run `iii worker list` to see known workers.",
+            "error:".red(),
+            worker_name,
+        );
+        return 1;
+    }
     if let Err(e) = super::config_file::remove_worker(worker_name) {
         eprintln!("{} {}", "error:".red(), e);
         return 1;
@@ -438,7 +490,22 @@ pub async fn handle_managed_remove(worker_name: &str, brief: bool) -> i32 {
             "config.yaml".dimmed(),
         );
     }
+    println!("{}", worker_name);
     0
+}
+
+/// Read a y/N answer from stdin. Mirrors `confirm_clear` but parameterized on
+/// the prompt so we can reuse it for `remove` and any future destructive ops.
+fn confirm_prompt(prompt: &str) -> bool {
+    use std::io::{Read, Write};
+    #[cfg(unix)]
+    super::local_worker::restore_terminal_cooked_mode();
+    let _ = std::io::stderr().write_all(prompt.as_bytes());
+    let _ = std::io::stderr().flush();
+    let mut buf = [0u8; 64];
+    let n = std::io::stdin().read(&mut buf).unwrap_or(0);
+    let input = std::str::from_utf8(&buf[..n]).unwrap_or("");
+    input.trim().eq_ignore_ascii_case("y")
 }
 
 pub fn handle_managed_clear(worker_name: Option<&str>, skip_confirm: bool) -> i32 {
@@ -464,6 +531,22 @@ fn clear_single_worker(worker_name: &str) -> i32 {
         return 1;
     }
 
+    // Distinguish "worker doesn't exist" from "already clean". The old path
+    // exited 0 on unknown names, which hid typos in automation. If we have no
+    // artifacts AND the name isn't in config.yaml, it's a typo -- exit 1.
+    let home = dirs::home_dir().unwrap_or_default();
+    let has_artifacts = home.join(".iii/workers").join(worker_name).exists()
+        || home.join(".iii/managed").join(worker_name).is_dir();
+    let in_config = super::config_file::worker_exists(worker_name);
+    if !has_artifacts && !in_config {
+        eprintln!(
+            "{} Worker '{}' not found. Run `iii worker list` to see known workers.",
+            "error:".red(),
+            worker_name,
+        );
+        return 1;
+    }
+
     let freed = delete_worker_artifacts(worker_name);
     if freed == 0 {
         eprintln!("  Nothing to clear for '{}'.", worker_name);
@@ -474,6 +557,7 @@ fn clear_single_worker(worker_name: &str) -> i32 {
             freed as f64 / 1_048_576.0,
             worker_name.bold(),
         );
+        println!("{}", worker_name);
     }
     0
 }
@@ -481,25 +565,7 @@ fn clear_single_worker(worker_name: &str) -> i32 {
 /// Prompts the user for confirmation before clearing all artifacts.
 /// Returns `true` if the user confirms with "y".
 fn confirm_clear() -> bool {
-    use std::io::{Read, Write};
-
-    // Restore canonical terminal mode in case a previous VM/worker session
-    // left the terminal in raw mode (no ICANON, no ECHO, no ICRNL).
-    #[cfg(unix)]
-    super::local_worker::restore_terminal_cooked_mode();
-
-    let _ = std::io::stderr()
-        .write_all(b"  This will remove all downloaded workers and images. Continue? [y/N] ");
-    let _ = std::io::stderr().flush();
-
-    // Use read() instead of read_line() so that both CR (\r) and LF (\n)
-    // terminate input.  read_line() only recognises LF, so if the terminal is
-    // in raw/non-canonical mode pressing Enter sends only CR and read_line
-    // blocks forever.
-    let mut buf = [0u8; 64];
-    let n = std::io::stdin().read(&mut buf).unwrap_or(0);
-    let input = std::str::from_utf8(&buf[..n]).unwrap_or("");
-    input.trim().eq_ignore_ascii_case("y")
+    confirm_prompt("  This will remove all downloaded workers and images. Continue? [y/N] ")
 }
 
 fn clear_all_workers(skip_confirm: bool) -> i32 {
@@ -578,14 +644,9 @@ fn clear_all_workers(skip_confirm: bool) -> i32 {
         }
     }
 
-    eprintln!(
-        "  {} Cleared {} worker(s) and {} image(s) ({:.1} MB freed)",
-        "✓".green(),
-        worker_count,
-        image_count,
-        total_freed as f64 / 1_048_576.0,
-    );
-
+    // Print skipped warnings FIRST so the final line the user sees is the
+    // success tally, not a "✓ success" followed by warnings (which reads as
+    // "everything worked, oh btw some didn't").
     for name in &skipped {
         eprintln!(
             "  {} Skipped {} (running). Stop it first with `iii worker stop {}`",
@@ -594,6 +655,14 @@ fn clear_all_workers(skip_confirm: bool) -> i32 {
             name,
         );
     }
+
+    eprintln!(
+        "  {} Cleared {} worker(s) and {} image(s) ({:.1} MB freed)",
+        "✓".green(),
+        worker_count,
+        image_count,
+        total_freed as f64 / 1_048_576.0,
+    );
 
     0
 }
@@ -1007,7 +1076,7 @@ fn dir_size(path: &std::path::Path) -> u64 {
     total
 }
 
-pub async fn handle_managed_stop(worker_name: &str, _address: &str, _port: u16) -> i32 {
+pub async fn handle_managed_stop(worker_name: &str) -> i32 {
     if let Err(e) = super::registry::validate_worker_name(worker_name) {
         eprintln!("{} {}", "error:".red(), e);
         return 1;
@@ -1016,14 +1085,26 @@ pub async fn handle_managed_stop(worker_name: &str, _address: &str, _port: u16) 
     let oci_pidfile = home.join(".iii/managed").join(worker_name).join("vm.pid");
     let bin_pidfile = home.join(".iii/pids").join(format!("{}.pid", worker_name));
 
+    // Is this name known at all? Check every evidence source we have: config,
+    // managed artifacts, binary workers dir, pidfiles. If none of those apply
+    // and no live process exists, it's a typo -- exit 1 with "not found" so
+    // automation doesn't confuse that with "already stopped."
+    let in_config_yaml = super::config_file::list_worker_names()
+        .iter()
+        .any(|n| n == worker_name);
+    let managed_dir_exists = home.join(".iii/managed").join(worker_name).is_dir();
+    let binary_exists = home.join(".iii/workers").join(worker_name).exists();
+    let worker_known = in_config_yaml
+        || managed_dir_exists
+        || binary_exists
+        || oci_pidfile.exists()
+        || bin_pidfile.exists();
+
     // Reject the well-defined "config worker explicitly listed in config.yaml"
     // case -- the engine owns those, the worker CLI cannot stop them. We only
     // reject when the name is genuinely listed in config; the resolver also
     // returns Config as the no-match fallthrough, which we want to treat as
     // an orphan candidate instead.
-    let in_config_yaml = super::config_file::list_worker_names()
-        .iter()
-        .any(|n| n == worker_name);
     if in_config_yaml
         && matches!(
             super::config_file::resolve_worker_type(worker_name),
@@ -1089,14 +1170,17 @@ pub async fn handle_managed_stop(worker_name: &str, _address: &str, _port: u16) 
                 pidfile: stale_pidfile,
             }
         }
-    } else {
+    } else if !worker_known {
         eprintln!(
-            "{} Worker '{}' is not running. Start it with 'iii worker start {}'",
+            "{} Worker '{}' not found. Run `iii worker list` to see known workers.",
             "error:".red(),
             worker_name,
-            worker_name
         );
         return 1;
+    } else {
+        eprintln!("  {} {} already stopped", "✓".green(), worker_name.bold());
+        println!("{}", worker_name);
+        return 0;
     };
 
     eprintln!("  Stopping {}...", worker_name.bold());
@@ -1118,6 +1202,7 @@ pub async fn handle_managed_stop(worker_name: &str, _address: &str, _port: u16) 
     }
 
     eprintln!("  {} {} stopped", "✓".green(), worker_name.bold());
+    println!("{}", worker_name);
     0
 }
 
@@ -1182,17 +1267,47 @@ async fn kill_pid_with_grace(pid: u32) {
     }
 }
 
-pub async fn handle_managed_start(worker_name: &str, _address: &str, port: u16) -> i32 {
+/// Block up to 120s waiting for the worker to report ready, printing a live
+/// status snapshot. Used by `iii worker start` when the user did not pass
+/// --no-wait. Same contract as `iii worker add --wait`: on timeout we do NOT
+/// fail the command (the process started successfully), we just inform the
+/// user and let them poll with `iii worker status {name}`.
+async fn wait_for_ready(worker_name: &str) {
+    let started = std::time::Instant::now();
+    let final_status =
+        super::status::watch_until_ready(worker_name, Some(std::time::Duration::from_secs(120)))
+            .await;
+    let elapsed = started.elapsed();
+    match final_status.phase {
+        super::status::Phase::Ready => {
+            eprintln!("  {} ready in {:.1}s", "✓".green(), elapsed.as_secs_f64());
+        }
+        _ => {
+            eprintln!(
+                "  {} not ready after {:.0}s.\n  \
+                 Keep watching: iii worker status {}\n  \
+                 Check logs:    iii worker logs {} -f",
+                "⚠".yellow(),
+                elapsed.as_secs_f64(),
+                worker_name,
+                worker_name
+            );
+        }
+    }
+}
+
+pub async fn handle_managed_start(worker_name: &str, wait: bool) -> i32 {
     if let Err(e) = super::registry::validate_worker_name(worker_name) {
         eprintln!("{} {}", "error:".red(), e);
         return 1;
     }
+    let port = super::app::DEFAULT_PORT;
     // Builtin workers are served in-process by the iii engine (see
     // engine/src/workers/config.rs factory registry). They have no external
     // process to spawn and must not be resolved via the remote registry.
     // Only treat this as success when the builtin is actually configured in
-    // config.yaml — otherwise the engine won't load it and the user would be
-    // misled by a 0 exit code.
+    // config.yaml AND the engine is running -- otherwise `start` is lying by
+    // returning 0 for a no-op and automation thinks something booted.
     if get_builtin_default(worker_name).is_some() {
         if !super::config_file::worker_exists(worker_name) {
             eprintln!(
@@ -1203,33 +1318,47 @@ pub async fn handle_managed_start(worker_name: &str, _address: &str, port: u16) 
             );
             return 1;
         }
+        if !is_engine_running() {
+            eprintln!(
+                "{} '{}' is a builtin served by the iii engine, but the engine isn't running.\n  \
+                 Start the engine:  iii start",
+                "error:".red(),
+                worker_name,
+            );
+            return 1;
+        }
         eprintln!(
             "  '{}' is a builtin worker — served by the iii engine process.",
             worker_name,
         );
-        if !is_engine_running() {
-            eprintln!("  Start the engine to run it.");
-        }
+        println!("{}", worker_name);
         return 0;
     }
-    match super::config_file::resolve_worker_type(worker_name) {
+    let start_rc = match super::config_file::resolve_worker_type(worker_name) {
         ResolvedWorkerType::Oci { image, env } => {
             let worker_def = WorkerDef::Managed {
                 image,
                 env,
                 resources: None,
             };
-            return start_oci_worker(worker_name, &worker_def, port).await;
+            start_oci_worker(worker_name, &worker_def, port).await
         }
         ResolvedWorkerType::Local { worker_path } => {
-            return super::local_worker::start_local_worker(worker_name, &worker_path, port).await;
+            super::local_worker::start_local_worker(worker_name, &worker_path, port).await
         }
         ResolvedWorkerType::Binary { binary_path } => {
-            return start_binary_worker(worker_name, &binary_path).await;
+            start_binary_worker(worker_name, &binary_path).await
         }
-        ResolvedWorkerType::Config => {
-            // Fall through to registry lookup below
+        ResolvedWorkerType::Config => i32::MIN, // sentinel: fall through to registry
+    };
+    if start_rc != i32::MIN {
+        if start_rc == 0 {
+            if wait {
+                wait_for_ready(worker_name).await;
+            }
+            println!("{}", worker_name);
         }
+        return start_rc;
     }
 
     // Not found locally — try remote registry for auto-install
@@ -1266,7 +1395,14 @@ pub async fn handle_managed_start(worker_name: &str, _address: &str, port: u16) 
             match binary_download::download_and_install_binary(worker_name, binary_info).await {
                 Ok(installed_path) => {
                     eprintln!("  {} Installed successfully", "✓".green());
-                    return start_binary_worker(worker_name, &installed_path).await;
+                    let rc = start_binary_worker(worker_name, &installed_path).await;
+                    if rc == 0 {
+                        if wait {
+                            wait_for_ready(worker_name).await;
+                        }
+                        println!("{}", worker_name);
+                    }
+                    return rc;
                 }
                 Err(e) => {
                     eprintln!(
@@ -1285,7 +1421,14 @@ pub async fn handle_managed_start(worker_name: &str, _address: &str, port: u16) 
                 env: std::collections::HashMap::new(),
                 resources: None,
             };
-            return start_oci_worker(worker_name, &worker_def, port).await;
+            let rc = start_oci_worker(worker_name, &worker_def, port).await;
+            if rc == 0 {
+                if wait {
+                    wait_for_ready(worker_name).await;
+                }
+                println!("{}", worker_name);
+            }
+            return rc;
         }
         Err(e) => {
             tracing::warn!("Failed to fetch worker info: {}", e);
@@ -1299,6 +1442,39 @@ pub async fn handle_managed_start(worker_name: &str, _address: &str, port: u16) 
         worker_name
     );
     1
+}
+
+/// Stop (if running) and start a worker. Idempotent: workers that aren't
+/// running just get started. We delegate to the existing stop/start paths
+/// rather than duplicating the libkrun teardown / pid-discovery logic.
+///
+/// Stop failures are logged but do NOT abort the restart -- the most common
+/// reason stop fails here is "already not running," which is exactly the
+/// state start expects. Start's exit code becomes the command's exit code.
+pub async fn handle_managed_restart(worker_name: &str, wait: bool) -> i32 {
+    if let Err(e) = super::registry::validate_worker_name(worker_name) {
+        eprintln!("{} {}", "error:".red(), e);
+        return 1;
+    }
+
+    // Only stop if we see a live process. handle_managed_stop is tolerant of
+    // "not running" (it returns 0 with an "already stopped" message), but
+    // calling it unconditionally clutters the output with a redundant line.
+    if is_worker_running(worker_name) {
+        eprintln!("  Restarting {}...", worker_name.bold());
+        let stop_rc = handle_managed_stop(worker_name).await;
+        if stop_rc != 0 {
+            eprintln!(
+                "  {} stop exited {} -- continuing with start",
+                "warning:".yellow(),
+                stop_rc
+            );
+        }
+    } else {
+        eprintln!("  {} not running; starting fresh...", worker_name.bold());
+    }
+
+    handle_managed_start(worker_name, wait).await
 }
 
 async fn start_oci_worker(worker_name: &str, worker_def: &WorkerDef, port: u16) -> i32 {
@@ -1408,11 +1584,15 @@ async fn start_binary_worker(worker_name: &str, binary_path: &std::path::Path) -
                         std::fs::set_permissions(&pid_path, std::fs::Permissions::from_mode(0o600));
                 }
             }
+            let pid_display = child
+                .id()
+                .map(|p| p.to_string())
+                .unwrap_or_else(|| "?".into());
             eprintln!(
-                "  {} {} started (pid: {:?})",
+                "  {} {} started (pid: {})",
                 "✓".green(),
                 worker_name.bold(),
-                child.id()
+                pid_display
             );
             0
         }
@@ -2388,7 +2568,7 @@ mod tests {
             std::fs::write(proj.join("package.json"), r#"{"name":"test"}"#).unwrap();
 
             let path_str = proj.to_string_lossy().to_string();
-            let exit_code = handle_managed_add(&path_str, false, false, false).await;
+            let exit_code = handle_managed_add(&path_str, false, false, false, false).await;
             assert_eq!(exit_code, 0, "should succeed for valid local path");
 
             let content = std::fs::read_to_string("config.yaml").unwrap();
@@ -2410,7 +2590,7 @@ mod tests {
     async fn handle_managed_add_local_path_rejects_nonexistent() {
         in_temp_dir_async(|_dir| async move {
             let exit_code =
-                handle_managed_add("./nonexistent-path-12345", false, false, false).await;
+                handle_managed_add("./nonexistent-path-12345", false, false, false, false).await;
             assert_eq!(exit_code, 1, "should fail for nonexistent local path");
         })
         .await;
@@ -2427,7 +2607,7 @@ mod tests {
             let path_str = proj.to_string_lossy().to_string();
 
             // First add
-            let exit_code = handle_managed_add(&path_str, false, false, false).await;
+            let exit_code = handle_managed_add(&path_str, false, false, false, false).await;
             assert_eq!(exit_code, 0);
             assert!(
                 std::fs::read_to_string("config.yaml")
@@ -2436,7 +2616,7 @@ mod tests {
             );
 
             // Force re-add
-            let exit_code = handle_managed_add(&path_str, false, true, false).await;
+            let exit_code = handle_managed_add(&path_str, false, true, false, false).await;
             assert_eq!(exit_code, 0, "force re-add should succeed");
 
             let content = std::fs::read_to_string("config.yaml").unwrap();

--- a/crates/iii-worker/src/cli/mod.rs
+++ b/crates/iii-worker/src/cli/mod.rs
@@ -15,5 +15,6 @@ pub mod managed;
 pub mod project;
 pub mod registry;
 pub mod rootfs;
+pub mod status;
 pub mod vm_boot;
 pub mod worker_manager;

--- a/crates/iii-worker/src/cli/status.rs
+++ b/crates/iii-worker/src/cli/status.rs
@@ -88,7 +88,29 @@ pub fn derive_phase(inputs: DeriveInputs) -> Phase {
     } = inputs;
 
     if is_binary {
-        return if running { Phase::Ready } else { Phase::Failed };
+        // Binary workers are host processes spawned by the engine's
+        // file-watcher pipeline: config.yaml change → reload →
+        // ExternalWorkerProcess::spawn → iii-worker start → child process
+        // writes ~/.iii/pids/{name}.pid. The config-to-pid window is
+        // typically 100ms-several-seconds depending on engine load.
+        //
+        // A missing pidfile during that window is NOT "Failed" — it's
+        // "engine hasn't spawned it yet." Returning `Failed` here used to
+        // make `iii worker add <binary> --wait` exit "failed after 0s"
+        // because Phase::Failed is terminal for wait, so watch_until_ready
+        // bailed before the engine even saw the config change.
+        //
+        // Use `Queued` when the engine is up (non-terminal → wait keeps
+        // polling until pid appears OR the 120s timeout fires) and
+        // `EngineDown` when it isn't (the engine has to come up first;
+        // same semantics as VM workers in that state).
+        return if running {
+            Phase::Ready
+        } else if engine_running {
+            Phase::Queued
+        } else {
+            Phase::EngineDown
+        };
     }
     if !engine_running {
         return Phase::EngineDown;
@@ -234,11 +256,18 @@ impl WorkerStatus {
                 "{} engine not running (start it with `iii start`)",
                 "⚠".yellow()
             ),
-            Phase::Queued => format!(
-                "{} {} queued — engine will boot its sandbox shortly",
-                "⟳".cyan(),
-                self.name.bold()
-            ),
+            Phase::Queued => {
+                // Binary workers don't have a sandbox; the engine spawns
+                // them as plain host processes. Tailor the message so we
+                // don't confuse the user into looking for a VM that will
+                // never exist.
+                let tail = if self.worker_type == Some("binary") {
+                    "engine will spawn it shortly"
+                } else {
+                    "engine will boot its sandbox shortly"
+                };
+                format!("{} {} queued — {}", "⟳".cyan(), self.name.bold(), tail)
+            }
             Phase::Preparing => {
                 if self.alive {
                     // VM kernel booted; init script is running setup/install
@@ -746,11 +775,12 @@ mod tests {
     }
 
     #[test]
-    fn derive_phase_binary_dead_engine_down_is_failed_not_engine_down() {
-        // A binary worker that hasn't started (or has crashed) is `Failed`,
-        // not `EngineDown`. The render() path still prints `engine: stopped`
-        // on its own row, so the user doesn't lose that information — we
-        // just stop letting it shadow the worker headline.
+    fn derive_phase_binary_engine_down_is_engine_down_not_failed() {
+        // Binary workers are spawned by the engine's file watcher; without
+        // a live engine nothing will spawn them. `EngineDown` is the honest
+        // signal here — the previous `Failed` classification conflated
+        // "engine not up" with "crashed after spawn" and led users to
+        // restart things that didn't actually need restarting.
         let p = derive_phase(DeriveInputs {
             engine_running: false,
             is_binary: true,
@@ -759,7 +789,53 @@ mod tests {
             prepared: false,
             managed_dir_exists: false,
         });
-        assert_eq!(p, Phase::Failed);
+        assert_eq!(p, Phase::EngineDown);
+    }
+
+    /// Regression for the reported bug where `iii worker add image-resize`
+    /// (a binary worker) printed "✗ image-resize failed" / "not ready
+    /// after 0s" the instant the `add --wait` path invoked the probe —
+    /// before the engine had a chance to pick up the config change and
+    /// spawn the worker.
+    ///
+    /// Root cause: binary + not running returned Phase::Failed
+    /// unconditionally. Phase::Failed is terminal for wait
+    /// (`is_terminal_for_wait`), so `watch_until_ready` exited immediately.
+    ///
+    /// Fix: binary + engine_running + not running = Phase::Queued
+    /// (non-terminal, wait keeps polling). The wait-loop's own 120s
+    /// timeout still bounds genuine crash loops.
+    #[test]
+    fn derive_phase_binary_waiting_for_engine_to_spawn_is_queued() {
+        let p = derive_phase(DeriveInputs {
+            engine_running: true,
+            is_binary: true,
+            is_local: false,
+            running: false,
+            prepared: false,
+            managed_dir_exists: false,
+        });
+        assert_eq!(p, Phase::Queued);
+        // Also assert non-terminal so a future change to is_terminal_for_wait
+        // can't silently re-introduce the "failed after 0s" UX.
+        let status = WorkerStatus {
+            name: "bin".into(),
+            phase: p,
+            engine_running: true,
+            worker_type: Some("binary"),
+            worker_path: None,
+            managed_dir_exists: false,
+            prepared: false,
+            pid: None,
+            alive: false,
+            logs_dir: None,
+            logs_last_modified: None,
+        };
+        assert!(
+            !status.is_terminal_for_wait(),
+            "binary worker pending spawn must NOT be terminal — \
+             otherwise watch_until_ready exits before the engine spawns."
+        );
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/status.rs
+++ b/crates/iii-worker/src/cli/status.rs
@@ -39,6 +39,65 @@ pub enum Phase {
     Failed,
 }
 
+/// Inputs to [`derive_phase`]. Pure-function boundary so the classification
+/// rules can be tested without touching disk or sockets.
+pub struct DeriveInputs {
+    pub engine_running: bool,
+    pub is_binary: bool,
+    pub running: bool,
+    pub prepared: bool,
+    pub managed_dir_exists: bool,
+}
+
+/// Classify a worker into a [`Phase`] given its observable state.
+///
+/// Binary workers are evaluated first because they are plain host processes:
+/// once the engine has spawned them, they run independently of the engine's
+/// TCP port. A live pid IS ready; a dead one means the process exited (or
+/// never started). Gating on `engine_running` would shadow binary workers as
+/// `EngineDown` during an engine restart even though the worker is alive,
+/// and would leave `iii worker add --wait <binary>` hanging because
+/// `EngineDown` is not a terminal wait phase.
+///
+/// For VM workers, `Ready` requires BOTH a live VM pid AND the
+/// `.iii-prepared` marker. The VM pid goes live the moment libkrun boots,
+/// but the in-guest init script then runs setup/install (which can take
+/// minutes on first boot with a cold dep cache). The marker is only written
+/// at the end of that script, so it's the honest signal the worker is
+/// actually ready to handle events, not just that the VM kernel is up.
+pub fn derive_phase(inputs: DeriveInputs) -> Phase {
+    let DeriveInputs {
+        engine_running,
+        is_binary,
+        running,
+        prepared,
+        managed_dir_exists,
+    } = inputs;
+
+    if is_binary {
+        return if running { Phase::Ready } else { Phase::Failed };
+    }
+    if !engine_running {
+        return Phase::EngineDown;
+    }
+    if running && prepared {
+        Phase::Ready
+    } else if running {
+        // VM is up, deps still installing. Surface as Preparing — the
+        // sandbox line already explains the detail.
+        Phase::Preparing
+    } else if prepared {
+        // Deps installed previously, VM restarting (e.g. after --force we
+        // wiped the managed dir, but this branch covers the "second boot on
+        // a warm cache" window).
+        Phase::Booting
+    } else if managed_dir_exists {
+        Phase::Preparing
+    } else {
+        Phase::Queued
+    }
+}
+
 /// Full snapshot of one worker at one point in time.
 pub struct WorkerStatus {
     pub name: String,
@@ -109,36 +168,13 @@ impl WorkerStatus {
                 .max()
         });
 
-        // Ready requires BOTH a live VM process AND the `.iii-prepared`
-        // marker. The VM pid goes live the moment libkrun boots, but the
-        // in-guest init script then runs setup/install (which can take
-        // minutes on first boot with a cold dep cache). The marker is only
-        // written at the end of that script, so it's the honest signal that
-        // the worker is actually ready to handle events — not just that the
-        // VM kernel is up.
-        let phase = if !engine_running {
-            Phase::EngineDown
-        } else if is_binary {
-            // Binary workers are plain host processes — no VM, no rootfs, no
-            // `.iii-prepared` marker. A live pid IS ready; a dead one means
-            // the process exited (or never started).
-            if running { Phase::Ready } else { Phase::Failed }
-        } else if running && prepared {
-            Phase::Ready
-        } else if running {
-            // VM is up, deps still installing. Surface as Preparing — the
-            // sandbox line already explains the detail.
-            Phase::Preparing
-        } else if prepared {
-            // Deps installed previously, VM restarting (e.g. after --force
-            // we wiped the managed dir, but this branch covers the "second
-            // boot on a warm cache" window).
-            Phase::Booting
-        } else if managed_dir_exists {
-            Phase::Preparing
-        } else {
-            Phase::Queued
-        };
+        let phase = derive_phase(DeriveInputs {
+            engine_running,
+            is_binary,
+            running,
+            prepared,
+            managed_dir_exists,
+        });
 
         Self {
             name: name.to_string(),
@@ -596,5 +632,127 @@ mod tests {
             "process row must NOT call a live pid stale, got:\n{}",
             text
         );
+    }
+
+    /// Regression for the classifier bug where binary workers reported
+    /// `Phase::EngineDown` whenever the engine's TCP port was down, even
+    /// though a binary worker's host process is independent of that port
+    /// once spawned. The consequences: the `status` headline would hide the
+    /// worker behind an "engine not running" banner, and
+    /// `iii worker add --wait <binary>` would hang forever because
+    /// `EngineDown` is not a terminal wait phase.
+    ///
+    /// Fix: evaluate `is_binary` before `engine_running` in `derive_phase`.
+    /// If either assertion flips (e.g., someone re-introduces the old gate),
+    /// `--wait` on binary workers will silently hang again.
+    #[test]
+    fn derive_phase_binary_alive_ignores_engine_down() {
+        let p = derive_phase(DeriveInputs {
+            engine_running: false,
+            is_binary: true,
+            running: true,
+            prepared: false,
+            managed_dir_exists: false,
+        });
+        assert_eq!(
+            p,
+            Phase::Ready,
+            "binary worker with a live pid must classify as Ready regardless of engine port state"
+        );
+    }
+
+    #[test]
+    fn derive_phase_binary_dead_engine_down_is_failed_not_engine_down() {
+        // A binary worker that hasn't started (or has crashed) is `Failed`,
+        // not `EngineDown`. The render() path still prints `engine: stopped`
+        // on its own row, so the user doesn't lose that information — we
+        // just stop letting it shadow the worker headline.
+        let p = derive_phase(DeriveInputs {
+            engine_running: false,
+            is_binary: true,
+            running: false,
+            prepared: false,
+            managed_dir_exists: false,
+        });
+        assert_eq!(p, Phase::Failed);
+    }
+
+    #[test]
+    fn derive_phase_vm_worker_engine_down_still_classifies_as_engine_down() {
+        // VM workers DO depend on the engine to boot libkrun, so the
+        // EngineDown gate is still load-bearing for them. If this flips,
+        // VM workers will be misclassified as Queued/Preparing during an
+        // engine restart and `--wait` will spin on a phase that can never
+        // advance.
+        let p = derive_phase(DeriveInputs {
+            engine_running: false,
+            is_binary: false,
+            running: false,
+            prepared: false,
+            managed_dir_exists: false,
+        });
+        assert_eq!(p, Phase::EngineDown);
+    }
+
+    #[test]
+    fn derive_phase_vm_worker_happy_path_is_ready_when_running_and_prepared() {
+        let p = derive_phase(DeriveInputs {
+            engine_running: true,
+            is_binary: false,
+            running: true,
+            prepared: true,
+            managed_dir_exists: true,
+        });
+        assert_eq!(p, Phase::Ready);
+    }
+
+    #[test]
+    fn derive_phase_vm_worker_running_without_marker_is_preparing() {
+        // The honest "installing deps inside VM" window: libkrun is up but
+        // the in-guest init script hasn't written `.iii-prepared` yet.
+        let p = derive_phase(DeriveInputs {
+            engine_running: true,
+            is_binary: false,
+            running: true,
+            prepared: false,
+            managed_dir_exists: true,
+        });
+        assert_eq!(p, Phase::Preparing);
+    }
+
+    #[test]
+    fn derive_phase_vm_worker_prepared_but_dead_is_booting() {
+        let p = derive_phase(DeriveInputs {
+            engine_running: true,
+            is_binary: false,
+            running: false,
+            prepared: true,
+            managed_dir_exists: true,
+        });
+        assert_eq!(p, Phase::Booting);
+    }
+
+    #[test]
+    fn derive_phase_vm_worker_managed_dir_without_marker_is_preparing() {
+        let p = derive_phase(DeriveInputs {
+            engine_running: true,
+            is_binary: false,
+            running: false,
+            prepared: false,
+            managed_dir_exists: true,
+        });
+        assert_eq!(p, Phase::Preparing);
+    }
+
+    #[test]
+    fn derive_phase_vm_worker_fresh_is_queued() {
+        let p = derive_phase(DeriveInputs {
+            engine_running: true,
+            is_binary: false,
+            running: false,
+            prepared: false,
+            managed_dir_exists: false,
+        });
+        assert_eq!(p, Phase::Queued);
     }
 }

--- a/crates/iii-worker/src/cli/status.rs
+++ b/crates/iii-worker/src/cli/status.rs
@@ -1,0 +1,600 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at support@motia.dev
+// See LICENSE and PATENTS files for details.
+
+//! `iii worker status` — inspect what's happening to a worker without
+//! context-switching to the engine terminal.
+//!
+//! Probes filesystem state (config.yaml entry, managed dir, prepared marker,
+//! pid file, logs freshness) and the engine's TCP port, then renders a
+//! human-readable snapshot. Supports `--watch` for a refreshing live view and
+//! is also the primitive that powers `iii worker add --wait`.
+
+use colored::Colorize;
+use std::time::{Duration, Instant, SystemTime};
+
+use super::config_file::{ResolvedWorkerType, resolve_worker_type, worker_exists};
+use super::managed::{is_engine_running, is_worker_running};
+
+/// Terminal phase for waiters — once we reach `Ready` or `Failed` we stop
+/// polling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Phase {
+    /// Worker absent from config.yaml.
+    NotInConfig,
+    /// In config.yaml but engine isn't running, so nothing will boot it.
+    EngineDown,
+    /// In config.yaml, engine up, but no managed dir yet.
+    Queued,
+    /// Managed dir exists, rootfs being prepared or deps installing.
+    Preparing,
+    /// `.iii-prepared` marker present but no live pid yet.
+    Booting,
+    /// Pid file points at a live process.
+    Ready,
+    /// Sentinel for callers that want to treat "engine up + worker unknown"
+    /// as a non-fatal intermediate state.
+    Failed,
+}
+
+/// Full snapshot of one worker at one point in time.
+pub struct WorkerStatus {
+    pub name: String,
+    pub phase: Phase,
+    pub engine_running: bool,
+    pub worker_type: Option<&'static str>,
+    pub worker_path: Option<String>,
+    pub managed_dir_exists: bool,
+    pub prepared: bool,
+    pub pid: Option<u32>,
+    /// True iff the VM process is responding to signal 0. Tracked separately
+    /// from phase so the render can distinguish "alive, deps still
+    /// installing" (Preparing) from "stale pidfile" (dead).
+    pub alive: bool,
+    pub logs_dir: Option<std::path::PathBuf>,
+    pub logs_last_modified: Option<SystemTime>,
+}
+
+impl WorkerStatus {
+    pub fn probe(name: &str) -> Self {
+        let engine_running = is_engine_running();
+        let exists_in_config = worker_exists(name);
+
+        if !exists_in_config {
+            return Self {
+                name: name.to_string(),
+                phase: Phase::NotInConfig,
+                engine_running,
+                worker_type: None,
+                worker_path: None,
+                managed_dir_exists: false,
+                prepared: false,
+                pid: None,
+                alive: false,
+                logs_dir: None,
+                logs_last_modified: None,
+            };
+        }
+
+        let resolved = resolve_worker_type(name);
+        let (worker_type, worker_path) = match &resolved {
+            ResolvedWorkerType::Local { worker_path } => ("local", Some(worker_path.clone())),
+            ResolvedWorkerType::Oci { .. } => ("oci", None),
+            ResolvedWorkerType::Binary { .. } => ("binary", None),
+            ResolvedWorkerType::Config => ("config", None),
+        };
+        let is_binary = matches!(resolved, ResolvedWorkerType::Binary { .. });
+
+        let home = dirs::home_dir().unwrap_or_default();
+        let managed_dir = home.join(".iii/managed").join(name);
+        let managed_dir_exists = managed_dir.is_dir();
+        let prepared = managed_dir.join("var").join(".iii-prepared").exists();
+
+        let pid = read_pid(name);
+        let running = is_worker_running(name);
+
+        let logs_dir_candidate = home.join(".iii/logs").join(name);
+        let logs_dir = if logs_dir_candidate.is_dir() {
+            Some(logs_dir_candidate.clone())
+        } else {
+            None
+        };
+        let logs_last_modified = logs_dir.as_ref().and_then(|d| {
+            ["stdout.log", "stderr.log"]
+                .iter()
+                .filter_map(|f| std::fs::metadata(d.join(f)).ok())
+                .filter_map(|m| m.modified().ok())
+                .max()
+        });
+
+        // Ready requires BOTH a live VM process AND the `.iii-prepared`
+        // marker. The VM pid goes live the moment libkrun boots, but the
+        // in-guest init script then runs setup/install (which can take
+        // minutes on first boot with a cold dep cache). The marker is only
+        // written at the end of that script, so it's the honest signal that
+        // the worker is actually ready to handle events — not just that the
+        // VM kernel is up.
+        let phase = if !engine_running {
+            Phase::EngineDown
+        } else if is_binary {
+            // Binary workers are plain host processes — no VM, no rootfs, no
+            // `.iii-prepared` marker. A live pid IS ready; a dead one means
+            // the process exited (or never started).
+            if running { Phase::Ready } else { Phase::Failed }
+        } else if running && prepared {
+            Phase::Ready
+        } else if running {
+            // VM is up, deps still installing. Surface as Preparing — the
+            // sandbox line already explains the detail.
+            Phase::Preparing
+        } else if prepared {
+            // Deps installed previously, VM restarting (e.g. after --force
+            // we wiped the managed dir, but this branch covers the "second
+            // boot on a warm cache" window).
+            Phase::Booting
+        } else if managed_dir_exists {
+            Phase::Preparing
+        } else {
+            Phase::Queued
+        };
+
+        Self {
+            name: name.to_string(),
+            phase,
+            engine_running,
+            worker_type: Some(worker_type),
+            worker_path,
+            managed_dir_exists,
+            prepared,
+            pid,
+            alive: running,
+            logs_dir,
+            logs_last_modified,
+        }
+    }
+
+    /// Human-readable one-line headline, used for --wait spinners and the
+    /// banner on `iii worker status`.
+    pub fn headline(&self) -> String {
+        match self.phase {
+            Phase::NotInConfig => format!("{} {} not in config.yaml", "✗".red(), self.name.bold()),
+            Phase::EngineDown => format!(
+                "{} engine not running (start it with `iii start`)",
+                "⚠".yellow()
+            ),
+            Phase::Queued => format!(
+                "{} {} queued — engine will boot its sandbox shortly",
+                "⟳".cyan(),
+                self.name.bold()
+            ),
+            Phase::Preparing => {
+                if self.alive {
+                    // VM kernel booted; init script is running setup/install
+                    // inside the guest. Surface the pid so the user knows
+                    // something is actually happening.
+                    format!(
+                        "{} {} installing deps inside VM (pid {})",
+                        "⟳".cyan(),
+                        self.name.bold(),
+                        self.pid.map(|p| p.to_string()).unwrap_or_default()
+                    )
+                } else {
+                    format!(
+                        "{} {} preparing sandbox (rootfs / deps)",
+                        "⟳".cyan(),
+                        self.name.bold()
+                    )
+                }
+            }
+            Phase::Booting => format!("{} {} booting VM", "⟳".cyan(), self.name.bold()),
+            Phase::Ready => format!(
+                "{} {} ready (pid {})",
+                "✓".green(),
+                self.name.bold(),
+                self.pid.map(|p| p.to_string()).unwrap_or_default()
+            ),
+            Phase::Failed => format!("{} {} failed", "✗".red(), self.name.bold()),
+        }
+    }
+
+    pub fn is_terminal_for_wait(&self) -> bool {
+        matches!(
+            self.phase,
+            Phase::Ready | Phase::NotInConfig | Phase::Failed
+        )
+    }
+
+    /// Render a detailed multi-line snapshot. Returns the number of lines
+    /// written so `--watch` knows how much to rewind.
+    pub fn render(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        out.push(String::new());
+        out.push(format!("  {}", self.headline()));
+        out.push(String::new());
+
+        let engine_line = if self.engine_running {
+            format!("{:>12}  {}", "engine:".dimmed(), "running".green())
+        } else {
+            format!(
+                "{:>12}  {} {}",
+                "engine:".dimmed(),
+                "stopped".red(),
+                "(run `iii start` in another terminal)".dimmed()
+            )
+        };
+        out.push(engine_line);
+
+        let config_line = if matches!(self.phase, Phase::NotInConfig) {
+            format!(
+                "{:>12}  {} {}",
+                "config:".dimmed(),
+                "missing".red(),
+                "(add with `iii worker add <path-or-name>`)".dimmed()
+            )
+        } else {
+            let ty = self.worker_type.unwrap_or("?");
+            let path = self
+                .worker_path
+                .as_deref()
+                .map(|p| format!(" ({})", p.dimmed()))
+                .unwrap_or_default();
+            format!(
+                "{:>12}  {} type={}{}",
+                "config:".dimmed(),
+                "present".green(),
+                ty,
+                path
+            )
+        };
+        out.push(config_line);
+
+        let sandbox_line = if self.worker_type == Some("binary") {
+            format!(
+                "{:>12}  {}",
+                "sandbox:".dimmed(),
+                "n/a (binary worker runs on host)".dimmed()
+            )
+        } else {
+            match (self.managed_dir_exists, self.prepared) {
+                (false, _) => format!(
+                    "{:>12}  {}",
+                    "sandbox:".dimmed(),
+                    "no managed dir yet".dimmed()
+                ),
+                (true, false) => format!(
+                    "{:>12}  {} (rootfs cloned, deps still installing)",
+                    "sandbox:".dimmed(),
+                    "preparing".yellow()
+                ),
+                (true, true) => format!(
+                    "{:>12}  {} (rootfs + deps cached)",
+                    "sandbox:".dimmed(),
+                    "prepared".green()
+                ),
+            }
+        };
+        out.push(sandbox_line);
+
+        let process_line = match (self.pid, self.alive) {
+            (Some(p), true) => {
+                format!("{:>12}  {} pid={}", "process:".dimmed(), "alive".green(), p)
+            }
+            (Some(p), false) => format!(
+                "{:>12}  {} pid={} (stale pidfile)",
+                "process:".dimmed(),
+                "dead".red(),
+                p
+            ),
+            (None, _) => format!("{:>12}  {}", "process:".dimmed(), "not started".dimmed()),
+        };
+        out.push(process_line);
+
+        let logs_line = match (&self.logs_dir, self.logs_last_modified) {
+            (Some(_), Some(_)) => format!(
+                "{:>12}  {} {}",
+                "logs:".dimmed(),
+                "available".green(),
+                format!("(tail with `iii worker logs {} -f`)", self.name).dimmed()
+            ),
+            (Some(_), None) => format!(
+                "{:>12}  {}",
+                "logs:".dimmed(),
+                "directory exists, no content yet".dimmed()
+            ),
+            (None, _) => format!("{:>12}  {}", "logs:".dimmed(), "none yet".dimmed()),
+        };
+        out.push(logs_line);
+        out.push(String::new());
+        out
+    }
+}
+
+fn read_pid(name: &str) -> Option<u32> {
+    let home = dirs::home_dir().unwrap_or_default();
+    let candidates = [
+        home.join(".iii/managed").join(name).join("vm.pid"),
+        home.join(".iii/pids").join(format!("{}.pid", name)),
+    ];
+    for path in candidates {
+        if let Ok(s) = std::fs::read_to_string(&path)
+            && let Ok(pid) = s.trim().parse::<u32>()
+        {
+            return Some(pid);
+        }
+    }
+    None
+}
+
+/// Entry point for `iii worker status`.
+pub async fn handle_worker_status(worker_name: &str, watch: bool) -> i32 {
+    if !watch {
+        let status = WorkerStatus::probe(worker_name);
+        for line in status.render() {
+            eprintln!("{}", line);
+        }
+        return match status.phase {
+            Phase::Ready => 0,
+            Phase::NotInConfig => 1,
+            _ => 0,
+        };
+    }
+
+    // --watch: live-redraw with no timeout (Ctrl-C to abort).
+    let final_status = watch_until_ready(worker_name, None).await;
+    match final_status.phase {
+        Phase::Ready => 0,
+        Phase::NotInConfig => 1,
+        _ => 0,
+    }
+}
+
+/// Live-redraw the snapshot in place every 500ms until the worker reaches a
+/// terminal wait phase (Ready / NotInConfig / Failed), `timeout` elapses, or
+/// the process is killed.
+///
+/// `timeout = None` means "wait forever" (used by `--watch`); `Some(d)` is
+/// used by `--wait` so the CLI doesn't hang on a stuck VM.
+///
+/// Returns the final status so callers can render a closing message.
+pub async fn watch_until_ready(worker_name: &str, timeout: Option<Duration>) -> WorkerStatus {
+    let started = Instant::now();
+    let mut first = true;
+    loop {
+        let status = WorkerStatus::probe(worker_name);
+        let lines = status.render();
+
+        if !first {
+            // `\x1b[{n}F` = move cursor up n lines to start of line,
+            // `\x1b[J` = clear from cursor to end of screen. This keeps the
+            // snapshot pinned in place even as line counts shrink.
+            let n = lines.len();
+            eprint!("\x1b[{}F\x1b[J", n);
+        }
+        first = false;
+
+        for line in &lines {
+            eprintln!("{}", line);
+        }
+
+        if status.is_terminal_for_wait() {
+            return status;
+        }
+        if let Some(t) = timeout
+            && started.elapsed() >= t
+        {
+            return status;
+        }
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn phase_is_terminal_for_wait_only_on_ready_or_missing_or_failed() {
+        // Building a WorkerStatus manually to avoid touching disk.
+        let base = WorkerStatus {
+            name: "t".into(),
+            phase: Phase::Ready,
+            engine_running: true,
+            worker_type: Some("local"),
+            worker_path: None,
+            managed_dir_exists: true,
+            prepared: true,
+            pid: Some(42),
+            alive: true,
+            logs_dir: None,
+            logs_last_modified: None,
+        };
+        assert!(base.is_terminal_for_wait());
+
+        let mut not_in = WorkerStatus {
+            phase: Phase::NotInConfig,
+            ..base
+        };
+        assert!(not_in.is_terminal_for_wait());
+
+        not_in.phase = Phase::Queued;
+        assert!(!not_in.is_terminal_for_wait());
+
+        not_in.phase = Phase::Preparing;
+        assert!(!not_in.is_terminal_for_wait());
+
+        not_in.phase = Phase::Booting;
+        assert!(!not_in.is_terminal_for_wait());
+
+        not_in.phase = Phase::EngineDown;
+        assert!(!not_in.is_terminal_for_wait());
+
+        not_in.phase = Phase::Failed;
+        assert!(not_in.is_terminal_for_wait());
+    }
+
+    #[test]
+    fn render_includes_all_major_sections() {
+        let s = WorkerStatus {
+            name: "demo".into(),
+            phase: Phase::Ready,
+            engine_running: true,
+            worker_type: Some("local"),
+            worker_path: Some("/abs/path".into()),
+            managed_dir_exists: true,
+            prepared: true,
+            pid: Some(123),
+            alive: true,
+            logs_dir: Some(std::path::PathBuf::from("/tmp/logs")),
+            logs_last_modified: Some(SystemTime::now()),
+        };
+        let text = s.render().join("\n");
+        assert!(text.contains("engine:"));
+        assert!(text.contains("config:"));
+        assert!(text.contains("sandbox:"));
+        assert!(text.contains("process:"));
+        assert!(text.contains("logs:"));
+        assert!(text.contains("demo"));
+    }
+
+    #[test]
+    fn headline_variants() {
+        let base = WorkerStatus {
+            name: "w".into(),
+            phase: Phase::NotInConfig,
+            engine_running: false,
+            worker_type: None,
+            worker_path: None,
+            managed_dir_exists: false,
+            prepared: false,
+            pid: None,
+            alive: false,
+            logs_dir: None,
+            logs_last_modified: None,
+        };
+        assert!(base.headline().contains("not in config.yaml"));
+
+        let s = WorkerStatus {
+            phase: Phase::EngineDown,
+            ..base
+        };
+        assert!(s.headline().contains("iii start"));
+    }
+
+    #[test]
+    fn preparing_headline_with_live_vm_mentions_deps_installing() {
+        // Regression: `--watch` used to close the moment the libkrun pid
+        // went alive, even though the in-guest init script was still
+        // running npm/pip/etc. The honest ready signal is pid alive AND
+        // .iii-prepared marker, so this intermediate state must render as
+        // "installing deps inside VM" not as Ready.
+        let s = WorkerStatus {
+            name: "todo-worker-python".into(),
+            phase: Phase::Preparing,
+            engine_running: true,
+            worker_type: Some("local"),
+            worker_path: None,
+            managed_dir_exists: true,
+            prepared: false,
+            pid: Some(16795),
+            alive: true,
+            logs_dir: None,
+            logs_last_modified: None,
+        };
+        let h = s.headline();
+        assert!(
+            h.contains("installing deps inside VM"),
+            "headline should say 'installing deps inside VM', got: {}",
+            h
+        );
+        assert!(
+            h.contains("16795"),
+            "headline should include pid, got: {}",
+            h
+        );
+        assert!(
+            !s.is_terminal_for_wait(),
+            "preparing-with-live-vm must NOT be terminal — --watch must keep running"
+        );
+    }
+
+    /// Regression: binary workers have no VM and no `.iii-prepared` marker.
+    /// The probe used to fall through to `Preparing` with the "installing deps
+    /// inside VM" headline and the status watcher would hang forever waiting
+    /// for a marker that would never appear. For binary workers: alive pid =
+    /// Ready, immediately.
+    #[test]
+    fn binary_worker_alive_headline_and_render() {
+        let s = WorkerStatus {
+            name: "image-resize".into(),
+            phase: Phase::Ready,
+            engine_running: true,
+            worker_type: Some("binary"),
+            worker_path: None,
+            managed_dir_exists: false,
+            prepared: false,
+            pid: Some(48350),
+            alive: true,
+            logs_dir: None,
+            logs_last_modified: None,
+        };
+        let h = s.headline();
+        assert!(
+            h.contains("ready"),
+            "binary+alive must headline as ready, got: {}",
+            h
+        );
+        assert!(
+            !h.contains("installing deps inside VM"),
+            "binary workers have no VM — this string must not appear, got: {}",
+            h
+        );
+        let text = s.render().join("\n");
+        assert!(
+            text.contains("n/a (binary worker runs on host)"),
+            "binary worker sandbox row must say n/a, got:\n{}",
+            text
+        );
+        assert!(
+            !text.contains("no managed dir yet"),
+            "sandbox row must not dangle 'no managed dir yet' for a binary worker"
+        );
+        assert!(
+            s.is_terminal_for_wait(),
+            "binary+alive must be terminal so --wait exits"
+        );
+    }
+
+    #[test]
+    fn process_line_shows_alive_based_on_alive_field_not_phase() {
+        // Regression: process row used to check `matches!(phase, Ready)`
+        // and would print "dead pid=X (stale pidfile)" for a genuinely
+        // alive pid whose phase was Preparing (deps still installing).
+        let s = WorkerStatus {
+            name: "w".into(),
+            phase: Phase::Preparing,
+            engine_running: true,
+            worker_type: Some("local"),
+            worker_path: None,
+            managed_dir_exists: true,
+            prepared: false,
+            pid: Some(16795),
+            alive: true,
+            logs_dir: None,
+            logs_last_modified: None,
+        };
+        let text = s.render().join("\n");
+        assert!(
+            text.contains("alive") && text.contains("16795"),
+            "process row must show 'alive pid=16795', got:\n{}",
+            text
+        );
+        assert!(
+            !text.contains("stale pidfile"),
+            "process row must NOT call a live pid stale, got:\n{}",
+            text
+        );
+    }
+}

--- a/crates/iii-worker/src/cli/status.rs
+++ b/crates/iii-worker/src/cli/status.rs
@@ -16,7 +16,7 @@ use colored::Colorize;
 use std::time::{Duration, Instant, SystemTime};
 
 use super::config_file::{ResolvedWorkerType, resolve_worker_type, worker_exists};
-use super::managed::{is_engine_running, is_worker_running};
+use super::managed::{is_engine_running_on, is_worker_running};
 
 /// Terminal phase for waiters — once we reach `Ready` or `Failed` we stop
 /// polling.
@@ -117,8 +117,15 @@ pub struct WorkerStatus {
 }
 
 impl WorkerStatus {
+    /// Probes using the configured `iii-worker-manager` port from
+    /// config.yaml. Prefer [`Self::probe_on`] at call sites that already
+    /// hold a port so a `--port` override isn't silently ignored.
     pub fn probe(name: &str) -> Self {
-        let engine_running = is_engine_running();
+        Self::probe_on(name, super::config_file::manager_port())
+    }
+
+    pub fn probe_on(name: &str, port: u16) -> Self {
+        let engine_running = is_engine_running_on(port);
         let exists_in_config = worker_exists(name);
 
         if !exists_in_config {
@@ -347,13 +354,29 @@ impl WorkerStatus {
     }
 }
 
-fn read_pid(name: &str) -> Option<u32> {
-    let home = dirs::home_dir().unwrap_or_default();
-    let candidates = [
-        home.join(".iii/managed").join(name).join("vm.pid"),
-        home.join(".iii/pids").join(format!("{}.pid", name)),
-    ];
-    for path in candidates {
+/// Candidate pidfile paths for `worker_name`, ordered by probe priority.
+///
+/// - OCI/VM workers: `~/.iii/managed/{name}/vm.pid`
+/// - Binary workers: `~/.iii/pids/{name}.pid`
+///
+/// MUST stay in sync with `engine/src/workers/registry_worker.rs::
+/// pid_file_candidates`. Engine and iii-worker are sibling crates with no
+/// shared dep; duplicating this function keeps the path convention single-
+/// sourced within each crate. If you add a third worker type or location
+/// here, mirror it there.
+pub(crate) fn pid_file_candidates(
+    home: &std::path::Path,
+    worker_name: &str,
+) -> [std::path::PathBuf; 2] {
+    [
+        home.join("managed").join(worker_name).join("vm.pid"),
+        home.join("pids").join(format!("{}.pid", worker_name)),
+    ]
+}
+
+pub(crate) fn read_pid(name: &str) -> Option<u32> {
+    let home = dirs::home_dir()?.join(".iii");
+    for path in pid_file_candidates(&home, name) {
         if let Ok(s) = std::fs::read_to_string(&path)
             && let Ok(pid) = s.trim().parse::<u32>()
         {
@@ -363,10 +386,13 @@ fn read_pid(name: &str) -> Option<u32> {
     None
 }
 
-/// Entry point for `iii worker status`.
+/// Entry point for `iii worker status`. Resolves the engine port from
+/// config.yaml; there is no CLI override for this command today (it has
+/// no `--port` flag) because `iii worker status` is a diagnostic.
 pub async fn handle_worker_status(worker_name: &str, watch: bool) -> i32 {
+    let port = super::config_file::manager_port();
     if !watch {
-        let status = WorkerStatus::probe(worker_name);
+        let status = WorkerStatus::probe_on(worker_name, port);
         for line in status.render() {
             eprintln!("{}", line);
         }
@@ -378,7 +404,7 @@ pub async fn handle_worker_status(worker_name: &str, watch: bool) -> i32 {
     }
 
     // --watch: live-redraw with no timeout (Ctrl-C to abort).
-    let final_status = watch_until_ready(worker_name, None).await;
+    let final_status = watch_until_ready(worker_name, None, port).await;
     match final_status.phase {
         Phase::Ready => 0,
         Phase::NotInConfig => 1,
@@ -391,14 +417,21 @@ pub async fn handle_worker_status(worker_name: &str, watch: bool) -> i32 {
 /// the process is killed.
 ///
 /// `timeout = None` means "wait forever" (used by `--watch`); `Some(d)` is
-/// used by `--wait` so the CLI doesn't hang on a stuck VM.
+/// used by `--wait` so the CLI doesn't hang on a stuck VM. `port` is the
+/// engine's `iii-worker-manager` port — each probe re-checks it so the
+/// "engine: running/stopped" line reflects the correct engine even when
+/// the user runs on a non-default port.
 ///
 /// Returns the final status so callers can render a closing message.
-pub async fn watch_until_ready(worker_name: &str, timeout: Option<Duration>) -> WorkerStatus {
+pub async fn watch_until_ready(
+    worker_name: &str,
+    timeout: Option<Duration>,
+    port: u16,
+) -> WorkerStatus {
     let started = Instant::now();
     let mut first = true;
     loop {
-        let status = WorkerStatus::probe(worker_name);
+        let status = WorkerStatus::probe_on(worker_name, port);
         let lines = status.render();
 
         if !first {
@@ -754,5 +787,218 @@ mod tests {
             managed_dir_exists: false,
         });
         assert_eq!(p, Phase::Queued);
+    }
+
+    // ---------------------------------------------------------------------
+    // read_pid + pid_file_candidates pure-function tests.
+    //
+    // These don't need HOME mutation — pid_file_candidates takes the `.iii`
+    // root as an argument, so we can exercise every malformed-pidfile path
+    // without racing other tests for a process-global env var.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn pid_file_candidates_orders_vm_then_binary() {
+        let home = std::path::Path::new("/fake/.iii");
+        let got = pid_file_candidates(home, "demo");
+        assert_eq!(got[0], home.join("managed/demo/vm.pid"));
+        assert_eq!(got[1], home.join("pids/demo.pid"));
+    }
+
+    /// read_pid must silently skip malformed pidfile contents. Any panic or
+    /// wrong-typed parse (e.g. i32 instead of u32) would bubble through to
+    /// the status renderer and either blow up `iii worker status` or mis-
+    /// display a pid. Cases drawn from malformed-file bugs we've hit in the
+    /// wild: trailing whitespace, empty files, race with a writer that
+    /// flushed an empty buffer, accidental negative numbers.
+    #[test]
+    fn read_pid_silently_skips_malformed_pidfiles() {
+        // Must serialize under PROBE_ENV_LOCK because HOME is process-global
+        // and every probe test mutates it. Without the guard, parallel
+        // probe_* tests win the race and read_pid sees the wrong HOME.
+        let _g = PROBE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = ProbeEnvGuard::new(tmp.path());
+
+        let pids = tmp.path().join(".iii/pids");
+        std::fs::create_dir_all(&pids).unwrap();
+
+        for (name, contents) in [
+            ("empty", ""),
+            ("garbage", "not-a-pid"),
+            ("negative", "-1"),
+            ("overflow", "9999999999999"),
+            ("whitespace-only", "   \n"),
+        ] {
+            std::fs::write(pids.join(format!("{}.pid", name)), contents).unwrap();
+            assert_eq!(
+                read_pid(name),
+                None,
+                "malformed pidfile content {:?} must yield None, not panic or mis-parse",
+                contents,
+            );
+        }
+
+        // Well-formed pidfile with surrounding whitespace still parses.
+        std::fs::write(pids.join("padded.pid"), "  12345  \n").unwrap();
+        assert_eq!(read_pid("padded"), Some(12345));
+    }
+
+    /// watch_until_ready must honor its timeout even when the worker never
+    /// reaches a terminal phase. A regression that ignores the timeout arg
+    /// would deadlock `iii worker add --wait` and any caller of
+    /// wait_for_ready. We build a scenario where probe repeatedly reports
+    /// a non-terminal phase (no config.yaml + empty HOME → NotInConfig is
+    /// terminal, so we stage a config.yaml entry but keep engine "down" via
+    /// a missing socket → Phase::EngineDown, non-terminal).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn watch_until_ready_honors_timeout() {
+        // Shares PROBE_ENV_LOCK with every other test that mutates
+        // HOME+CWD. Using a separate lock would let the tempdirs overlap
+        // and corrupt each other's filesystem view.
+        let _g = PROBE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = ProbeEnvGuard::new(tmp.path());
+
+        // Minimal config.yaml with one VM worker so probe() does not early-
+        // return NotInConfig (terminal). We leave the engine socket closed
+        // so probe classifies as EngineDown (non-terminal for VM workers).
+        std::fs::write(
+            tmp.path().join("config.yaml"),
+            "workers:\n  - name: pending-vm\n",
+        )
+        .unwrap();
+
+        let start = std::time::Instant::now();
+        // Port 1 is privileged and never bound by an engine, so
+        // is_engine_running_on returns false → Phase::EngineDown (non-terminal)
+        // regardless of what's actually running on the host. Pinning this
+        // makes the test self-contained — it doesn't flake if a real engine
+        // happens to be bound on DEFAULT_PORT when the test runs.
+        let status = watch_until_ready("pending-vm", Some(Duration::from_millis(200)), 1).await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "watch_until_ready must return within the timeout window, elapsed = {:?}",
+            elapsed
+        );
+        assert!(
+            !status.is_terminal_for_wait(),
+            "timeout path must return a non-terminal status (got {:?}); \
+             otherwise the function returned for the wrong reason",
+            status.phase
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // WorkerStatus::probe coverage. Builds a fake HOME + CWD with the
+    // filesystem layout probe() reads, then asserts the probe output. This
+    // is the gluing layer between disk state and Phase classification —
+    // previously exercised only indirectly through integration paths.
+    // ---------------------------------------------------------------------
+
+    /// Shared guard for tests that mutate HOME + CWD. HOME is process-global,
+    /// CWD is process-global, so any two tests that touch either must run
+    /// one at a time.
+    static PROBE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct ProbeEnvGuard {
+        home: Option<std::ffi::OsString>,
+        cwd: Option<std::path::PathBuf>,
+    }
+
+    impl ProbeEnvGuard {
+        fn new(home: &std::path::Path) -> Self {
+            let original_home = std::env::var_os("HOME");
+            let original_cwd = std::env::current_dir().ok();
+            // SAFETY: test-only, serialized via PROBE_ENV_LOCK.
+            unsafe { std::env::set_var("HOME", home) };
+            std::env::set_current_dir(home).unwrap();
+            Self {
+                home: original_home,
+                cwd: original_cwd,
+            }
+        }
+    }
+
+    impl Drop for ProbeEnvGuard {
+        fn drop(&mut self) {
+            if let Some(cwd) = &self.cwd {
+                let _ = std::env::set_current_dir(cwd);
+            }
+            // SAFETY: test-only, serialized via PROBE_ENV_LOCK.
+            unsafe {
+                match &self.home {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn probe_returns_not_in_config_when_worker_missing() {
+        let _g = PROBE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = ProbeEnvGuard::new(tmp.path());
+        // No config.yaml written — worker_exists returns false.
+        let s = WorkerStatus::probe("ghost");
+        assert_eq!(s.phase, Phase::NotInConfig);
+        assert!(!s.managed_dir_exists);
+        assert!(s.pid.is_none());
+        assert!(!s.alive);
+    }
+
+    /// Binary worker with a live pidfile must probe to Ready regardless of
+    /// engine port state. This is the end-to-end equivalent of
+    /// `derive_phase_binary_alive_ignores_engine_down` — ensures the probe
+    /// layer plumbs the binary flag correctly into derive_phase.
+    ///
+    /// `resolve_worker_type` classifies a worker as `Binary` only when a
+    /// file exists at `~/.iii/workers/{name}` (see `check_binary_fallback`
+    /// in config_file.rs); the config.yaml entry alone is insufficient.
+    #[test]
+    fn probe_binary_worker_with_live_pidfile_is_ready() {
+        let _g = PROBE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = ProbeEnvGuard::new(tmp.path());
+
+        let name = "bin-w";
+        std::fs::write(
+            tmp.path().join("config.yaml"),
+            format!("workers:\n  - name: {}\n", name),
+        )
+        .unwrap();
+
+        // Binary worker is detected by presence of the binary file under
+        // ~/.iii/workers/{name}. Staging an empty file is enough for the
+        // classifier — we don't execute it.
+        let workers_dir = tmp.path().join(".iii/workers");
+        std::fs::create_dir_all(&workers_dir).unwrap();
+        std::fs::write(workers_dir.join(name), b"").unwrap();
+
+        let pids = tmp.path().join(".iii/pids");
+        std::fs::create_dir_all(&pids).unwrap();
+        // Write OUR pid so kill(pid, 0) succeeds on the alive check.
+        std::fs::write(
+            pids.join(format!("{}.pid", name)),
+            std::process::id().to_string(),
+        )
+        .unwrap();
+
+        let s = WorkerStatus::probe(name);
+        assert_eq!(s.pid, Some(std::process::id()));
+        assert!(s.alive, "is_worker_running must see our live pidfile");
+        assert_eq!(
+            s.worker_type,
+            Some("binary"),
+            "binary workers must be classified as binary, not config; got {:?}",
+            s.worker_type
+        );
+        // Phase depends on engine liveness which we can't control from a
+        // unit test, but regardless of engine state a binary with a live
+        // pid MUST be Ready (that's the point of the classifier fix).
+        assert_eq!(s.phase, Phase::Ready);
     }
 }

--- a/crates/iii-worker/src/cli/status.rs
+++ b/crates/iii-worker/src/cli/status.rs
@@ -44,6 +44,14 @@ pub enum Phase {
 pub struct DeriveInputs {
     pub engine_running: bool,
     pub is_binary: bool,
+    /// Local-path workers run an in-VM deps-install script that terminates
+    /// by writing `/var/.iii-prepared` (see `build_libkrun_local_script` in
+    /// `local_worker.rs`). Only they produce or consume that marker. OCI
+    /// images bake their deps at build time, so the marker is meaningless
+    /// there — treating it as a readiness gate for OCI keeps workers stuck
+    /// in `Phase::Preparing` forever, even after they've connected to the
+    /// engine and registered functions.
+    pub is_local: bool,
     pub running: bool,
     pub prepared: bool,
     pub managed_dir_exists: bool,
@@ -51,24 +59,29 @@ pub struct DeriveInputs {
 
 /// Classify a worker into a [`Phase`] given its observable state.
 ///
-/// Binary workers are evaluated first because they are plain host processes:
-/// once the engine has spawned them, they run independently of the engine's
-/// TCP port. A live pid IS ready; a dead one means the process exited (or
-/// never started). Gating on `engine_running` would shadow binary workers as
-/// `EngineDown` during an engine restart even though the worker is alive,
-/// and would leave `iii worker add --wait <binary>` hanging because
-/// `EngineDown` is not a terminal wait phase.
+/// Worker-kind-specific gates, evaluated in order:
 ///
-/// For VM workers, `Ready` requires BOTH a live VM pid AND the
-/// `.iii-prepared` marker. The VM pid goes live the moment libkrun boots,
-/// but the in-guest init script then runs setup/install (which can take
-/// minutes on first boot with a cold dep cache). The marker is only written
-/// at the end of that script, so it's the honest signal the worker is
-/// actually ready to handle events, not just that the VM kernel is up.
+/// **Binary** — plain host processes, independent of the engine's TCP port
+/// once spawned. Live pid = Ready; dead = Failed. Gating on `engine_running`
+/// would shadow binary workers as `EngineDown` during an engine restart, and
+/// would leave `iii worker add --wait <binary>` hanging because `EngineDown`
+/// is not a terminal wait phase.
+///
+/// **OCI** — image has deps baked in; no in-VM install step runs. The
+/// `.iii-prepared` marker is never written (see `start_oci_worker`). For
+/// these, `running` alone is the honest ready signal: the worker process
+/// is up inside libkrun and has already connected to the engine.
+///
+/// **Local** — rootfs cloned, then an in-guest init script runs
+/// setup/install (which can take minutes on first boot with a cold dep
+/// cache). `Ready` requires BOTH a live VM pid AND `.iii-prepared`, because
+/// the VM pid goes live the moment libkrun boots — well before the deps
+/// install finishes.
 pub fn derive_phase(inputs: DeriveInputs) -> Phase {
     let DeriveInputs {
         engine_running,
         is_binary,
+        is_local,
         running,
         prepared,
         managed_dir_exists,
@@ -79,6 +92,18 @@ pub fn derive_phase(inputs: DeriveInputs) -> Phase {
     }
     if !engine_running {
         return Phase::EngineDown;
+    }
+    if !is_local {
+        // OCI (or builtin `Config`) paths: no deps-install marker lifecycle.
+        // Running is the honest ready signal; absence reverts to the boot
+        // staging signals we can still observe.
+        return if running {
+            Phase::Ready
+        } else if managed_dir_exists {
+            Phase::Preparing
+        } else {
+            Phase::Queued
+        };
     }
     if running && prepared {
         Phase::Ready
@@ -152,6 +177,7 @@ impl WorkerStatus {
             ResolvedWorkerType::Config => ("config", None),
         };
         let is_binary = matches!(resolved, ResolvedWorkerType::Binary { .. });
+        let is_local = matches!(resolved, ResolvedWorkerType::Local { .. });
 
         let home = dirs::home_dir().unwrap_or_default();
         let managed_dir = home.join(".iii/managed").join(name);
@@ -178,6 +204,7 @@ impl WorkerStatus {
         let phase = derive_phase(DeriveInputs {
             engine_running,
             is_binary,
+            is_local,
             running,
             prepared,
             managed_dir_exists,
@@ -299,6 +326,29 @@ impl WorkerStatus {
                 "sandbox:".dimmed(),
                 "n/a (binary worker runs on host)".dimmed()
             )
+        } else if self.worker_type == Some("oci") {
+            // OCI images bake deps at build time — no in-VM install, no
+            // `.iii-prepared` marker. The honest statuses here are:
+            //   - no managed dir yet (pre-boot)
+            //   - running (libkrun up, deps were in the image)
+            // Suppressing the local-only "deps still installing" line.
+            match (self.managed_dir_exists, self.alive) {
+                (false, _) => format!(
+                    "{:>12}  {}",
+                    "sandbox:".dimmed(),
+                    "no managed dir yet".dimmed()
+                ),
+                (true, true) => format!(
+                    "{:>12}  {} (image-baked deps)",
+                    "sandbox:".dimmed(),
+                    "running".green()
+                ),
+                (true, false) => format!(
+                    "{:>12}  {} (rootfs ready)",
+                    "sandbox:".dimmed(),
+                    "prepared".green()
+                ),
+            }
         } else {
             match (self.managed_dir_exists, self.prepared) {
                 (false, _) => format!(
@@ -683,6 +733,7 @@ mod tests {
         let p = derive_phase(DeriveInputs {
             engine_running: false,
             is_binary: true,
+            is_local: false,
             running: true,
             prepared: false,
             managed_dir_exists: false,
@@ -703,6 +754,7 @@ mod tests {
         let p = derive_phase(DeriveInputs {
             engine_running: false,
             is_binary: true,
+            is_local: false,
             running: false,
             prepared: false,
             managed_dir_exists: false,
@@ -720,6 +772,7 @@ mod tests {
         let p = derive_phase(DeriveInputs {
             engine_running: false,
             is_binary: false,
+            is_local: true,
             running: false,
             prepared: false,
             managed_dir_exists: false,
@@ -728,10 +781,11 @@ mod tests {
     }
 
     #[test]
-    fn derive_phase_vm_worker_happy_path_is_ready_when_running_and_prepared() {
+    fn derive_phase_local_worker_happy_path_is_ready_when_running_and_prepared() {
         let p = derive_phase(DeriveInputs {
             engine_running: true,
             is_binary: false,
+            is_local: true,
             running: true,
             prepared: true,
             managed_dir_exists: true,
@@ -740,12 +794,15 @@ mod tests {
     }
 
     #[test]
-    fn derive_phase_vm_worker_running_without_marker_is_preparing() {
+    fn derive_phase_local_worker_running_without_marker_is_preparing() {
         // The honest "installing deps inside VM" window: libkrun is up but
         // the in-guest init script hasn't written `.iii-prepared` yet.
+        // This only applies to local-path workers — OCI images don't
+        // have an install phase.
         let p = derive_phase(DeriveInputs {
             engine_running: true,
             is_binary: false,
+            is_local: true,
             running: true,
             prepared: false,
             managed_dir_exists: true,
@@ -754,10 +811,11 @@ mod tests {
     }
 
     #[test]
-    fn derive_phase_vm_worker_prepared_but_dead_is_booting() {
+    fn derive_phase_local_worker_prepared_but_dead_is_booting() {
         let p = derive_phase(DeriveInputs {
             engine_running: true,
             is_binary: false,
+            is_local: true,
             running: false,
             prepared: true,
             managed_dir_exists: true,
@@ -766,10 +824,11 @@ mod tests {
     }
 
     #[test]
-    fn derive_phase_vm_worker_managed_dir_without_marker_is_preparing() {
+    fn derive_phase_local_worker_managed_dir_without_marker_is_preparing() {
         let p = derive_phase(DeriveInputs {
             engine_running: true,
             is_binary: false,
+            is_local: true,
             running: false,
             prepared: false,
             managed_dir_exists: true,
@@ -778,15 +837,73 @@ mod tests {
     }
 
     #[test]
-    fn derive_phase_vm_worker_fresh_is_queued() {
+    fn derive_phase_local_worker_fresh_is_queued() {
         let p = derive_phase(DeriveInputs {
             engine_running: true,
             is_binary: false,
+            is_local: true,
             running: false,
             prepared: false,
             managed_dir_exists: false,
         });
         assert_eq!(p, Phase::Queued);
+    }
+
+    /// OCI regression: `iii worker add docker.io/foo/bar` images bake their
+    /// deps at build time — the in-VM install script that writes
+    /// `/var/.iii-prepared` never runs for these. Before the fix, the
+    /// probe treated a running-but-no-marker OCI worker as Preparing
+    /// forever, even after the worker had already connected to the engine
+    /// and registered its functions. This is the bug reported for
+    /// `todo-worker-python` (OCI image shows "preparing (rootfs cloned,
+    /// deps still installing)" with engine logs proving REGISTERED endpoints).
+    ///
+    /// Fix: a running OCI worker is Ready. The `.iii-prepared` marker
+    /// is a local-worker-only concept.
+    #[test]
+    fn derive_phase_oci_worker_running_is_ready_without_marker() {
+        let p = derive_phase(DeriveInputs {
+            engine_running: true,
+            is_binary: false,
+            is_local: false,
+            running: true,
+            prepared: false,
+            managed_dir_exists: true,
+        });
+        assert_eq!(
+            p,
+            Phase::Ready,
+            "OCI worker with a live VM pid must classify as Ready — \
+             deps are baked into the image, no in-VM install step runs."
+        );
+    }
+
+    #[test]
+    fn derive_phase_oci_worker_no_managed_dir_is_queued() {
+        let p = derive_phase(DeriveInputs {
+            engine_running: true,
+            is_binary: false,
+            is_local: false,
+            running: false,
+            prepared: false,
+            managed_dir_exists: false,
+        });
+        assert_eq!(p, Phase::Queued);
+    }
+
+    #[test]
+    fn derive_phase_oci_worker_managed_dir_but_not_running_is_preparing() {
+        // Intermediate state between "queued" and "running": rootfs was
+        // extracted, libkrun hasn't come up yet. Brief window during boot.
+        let p = derive_phase(DeriveInputs {
+            engine_running: true,
+            is_binary: false,
+            is_local: false,
+            running: false,
+            prepared: false,
+            managed_dir_exists: true,
+        });
+        assert_eq!(p, Phase::Preparing);
     }
 
     // ---------------------------------------------------------------------

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -19,7 +19,12 @@ async fn main() -> anyhow::Result<()> {
     let cli_args = Cli::parse();
 
     let exit_code = match cli_args.command {
-        Commands::Add { args, force } => {
+        Commands::Add {
+            args,
+            force,
+            no_wait,
+        } => {
+            let wait = !no_wait;
             if force {
                 // Force mode: process each worker individually with force logic
                 let mut fail_count = 0;
@@ -29,6 +34,7 @@ async fn main() -> anyhow::Result<()> {
                         false,
                         force,
                         args.reset_config,
+                        wait,
                     )
                     .await;
                     if result != 0 {
@@ -37,11 +43,11 @@ async fn main() -> anyhow::Result<()> {
                 }
                 if fail_count == 0 { 0 } else { 1 }
             } else {
-                iii_worker::cli::managed::handle_managed_add_many(&args.worker_names).await
+                iii_worker::cli::managed::handle_managed_add_many(&args.worker_names, wait).await
             }
         }
-        Commands::Remove { worker_names } => {
-            iii_worker::cli::managed::handle_managed_remove_many(&worker_names).await
+        Commands::Remove { worker_names, yes } => {
+            iii_worker::cli::managed::handle_managed_remove_many(&worker_names, yes).await
         }
         Commands::Reinstall { args } => {
             let mut fail_count = 0;
@@ -51,6 +57,7 @@ async fn main() -> anyhow::Result<()> {
                     false,
                     true,
                     args.reset_config,
+                    false,
                 )
                 .await;
                 if result != 0 {
@@ -64,15 +71,20 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Start {
             worker_name,
-            address,
-            port,
-        } => iii_worker::cli::managed::handle_managed_start(&worker_name, &address, port).await,
-        Commands::Stop {
+            no_wait,
+        } => iii_worker::cli::managed::handle_managed_start(&worker_name, !no_wait).await,
+        Commands::Stop { worker_name } => {
+            iii_worker::cli::managed::handle_managed_stop(&worker_name).await
+        }
+        Commands::Restart {
             worker_name,
-            address,
-            port,
-        } => iii_worker::cli::managed::handle_managed_stop(&worker_name, &address, port).await,
+            no_wait,
+        } => iii_worker::cli::managed::handle_managed_restart(&worker_name, !no_wait).await,
         Commands::List => iii_worker::cli::managed::handle_worker_list().await,
+        Commands::Status {
+            worker_name,
+            no_watch,
+        } => iii_worker::cli::status::handle_worker_status(&worker_name, !no_watch).await,
         Commands::Logs {
             worker_name,
             follow,

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -72,14 +72,16 @@ async fn main() -> anyhow::Result<()> {
         Commands::Start {
             worker_name,
             no_wait,
-        } => iii_worker::cli::managed::handle_managed_start(&worker_name, !no_wait).await,
+            port,
+        } => iii_worker::cli::managed::handle_managed_start(&worker_name, !no_wait, port).await,
         Commands::Stop { worker_name } => {
             iii_worker::cli::managed::handle_managed_stop(&worker_name).await
         }
         Commands::Restart {
             worker_name,
             no_wait,
-        } => iii_worker::cli::managed::handle_managed_restart(&worker_name, !no_wait).await,
+            port,
+        } => iii_worker::cli::managed::handle_managed_restart(&worker_name, !no_wait, port).await,
         Commands::List => iii_worker::cli::managed::handle_worker_list().await,
         Commands::Status {
             worker_name,

--- a/crates/iii-worker/tests/common/isolation.rs
+++ b/crates/iii-worker/tests/common/isolation.rs
@@ -10,12 +10,17 @@ use std::sync::Mutex;
 pub static CWD_LOCK: Mutex<()> = Mutex::new(());
 
 /// Run an async closure in a temp dir, restoring cwd afterward.
+///
+/// Uses `unwrap_or_else(into_inner)` for poison tolerance: when one test
+/// panics the mutex is poisoned, and without tolerance every subsequent
+/// sibling test also panics at the lock acquisition — turning a single
+/// genuine failure into N cascading failures that hide the real cause.
 pub async fn in_temp_dir_async<F, Fut>(f: F)
 where
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = ()>,
 {
-    let _guard = CWD_LOCK.lock().unwrap();
+    let _guard = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let dir = tempfile::tempdir().unwrap();
     let original = std::env::current_dir().unwrap();
     std::env::set_current_dir(dir.path()).unwrap();
@@ -25,7 +30,7 @@ where
 
 /// Run a closure in a temp dir, restoring cwd afterward.
 pub fn in_temp_dir<F: FnOnce()>(f: F) {
-    let _guard = CWD_LOCK.lock().unwrap();
+    let _guard = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let dir = tempfile::tempdir().unwrap();
     let original = std::env::current_dir().unwrap();
     std::env::set_current_dir(dir.path()).unwrap();

--- a/crates/iii-worker/tests/config_clear_integration.rs
+++ b/crates/iii-worker/tests/config_clear_integration.rs
@@ -13,11 +13,32 @@ mod common;
 use common::isolation::in_temp_dir_async;
 
 #[tokio::test]
-async fn handle_managed_clear_single_no_artifacts() {
+async fn handle_managed_clear_single_no_artifacts_for_known_worker() {
     in_temp_dir_async(|| async {
-        // Clear a worker that has no artifacts -- should succeed silently
-        let exit_code = iii_worker::cli::managed::handle_managed_clear(Some("pdfkit"), true);
-        assert_eq!(exit_code, 0);
+        // A worker that's registered (in config.yaml) but has no artifacts
+        // yet should succeed silently -- "already clean" is not an error.
+        let add_rc =
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, false, false, false)
+                .await;
+        assert_eq!(add_rc, 0, "precondition: add must succeed");
+        let exit_code = iii_worker::cli::managed::handle_managed_clear(Some("iii-http"), true);
+        assert_eq!(
+            exit_code, 0,
+            "clear of known-but-clean worker should succeed"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn handle_managed_clear_unknown_worker_exits_error() {
+    in_temp_dir_async(|| async {
+        // Clearing a worker that is neither in config.yaml nor on disk is
+        // almost certainly a typo. Exit 1 so automation catches it instead
+        // of silently saying "nothing to clear" and moving on.
+        let exit_code =
+            iii_worker::cli::managed::handle_managed_clear(Some("not-a-real-worker"), true);
+        assert_eq!(exit_code, 1, "clear of unknown worker should exit non-zero");
     })
     .await;
 }

--- a/crates/iii-worker/tests/config_force_integration.rs
+++ b/crates/iii-worker/tests/config_force_integration.rs
@@ -18,14 +18,16 @@ async fn handle_managed_add_force_builtin_re_adds() {
     in_temp_dir_async(|| async {
         // First add creates config
         let exit_code =
-            iii_worker::cli::managed::handle_managed_add("iii-http", false, false, false).await;
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, false, false, false)
+                .await;
         assert_eq!(exit_code, 0);
         let content = std::fs::read_to_string("config.yaml").unwrap();
         assert!(content.contains("- name: iii-http"));
 
         // Force re-add succeeds (builtins have no artifacts to delete)
         let exit_code =
-            iii_worker::cli::managed::handle_managed_add("iii-http", false, true, false).await;
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, true, false, false)
+                .await;
         assert_eq!(exit_code, 0);
         let content = std::fs::read_to_string("config.yaml").unwrap();
         assert!(content.contains("- name: iii-http"));
@@ -45,7 +47,7 @@ async fn handle_managed_add_force_reset_config_clears_overrides() {
 
         // Force with reset_config should clear user overrides and re-apply defaults
         let exit_code =
-            iii_worker::cli::managed::handle_managed_add("iii-http", false, true, true)
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, true, true, false)
                 .await;
         assert_eq!(exit_code, 0);
 
@@ -71,7 +73,7 @@ async fn handle_managed_add_force_without_reset_preserves_config() {
 
         // Force WITHOUT reset_config should preserve user overrides
         let exit_code =
-            iii_worker::cli::managed::handle_managed_add("iii-http", false, true, false)
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, true, false, false)
                 .await;
         assert_eq!(exit_code, 0);
 

--- a/crates/iii-worker/tests/config_managed_integration.rs
+++ b/crates/iii-worker/tests/config_managed_integration.rs
@@ -126,7 +126,12 @@ async fn handle_managed_start_builtin_short_circuits() {
         // is down, start returns 1 with a "start the engine" hint. Both are
         // valid; what we're really asserting is that we did NOT fall through
         // to the remote registry (which would produce a different error).
-        let start_rc = iii_worker::cli::managed::handle_managed_start("iii-http", false).await;
+        let start_rc = iii_worker::cli::managed::handle_managed_start(
+            "iii-http",
+            false,
+            iii_worker::DEFAULT_PORT,
+        )
+        .await;
         assert!(
             start_rc == 0 || start_rc == 1,
             "expected short-circuit (0 or 1), got {} -- suggests a registry fall-through",
@@ -148,7 +153,12 @@ async fn handle_managed_start_unconfigured_builtin_fails() {
             !iii_worker::cli::config_file::worker_exists("iii-http"),
             "precondition: iii-http must not be in config.yaml"
         );
-        let start_rc = iii_worker::cli::managed::handle_managed_start("iii-http", false).await;
+        let start_rc = iii_worker::cli::managed::handle_managed_start(
+            "iii-http",
+            false,
+            iii_worker::DEFAULT_PORT,
+        )
+        .await;
         assert_ne!(
             start_rc, 0,
             "handle_managed_start must fail for unconfigured builtin 'iii-http'"

--- a/crates/iii-worker/tests/config_managed_integration.rs
+++ b/crates/iii-worker/tests/config_managed_integration.rs
@@ -374,3 +374,182 @@ async fn handle_managed_add_binary_via_file_fixture() {
     })
     .await;
 }
+
+/// Restart must reject invalid worker names BEFORE calling stop or start.
+/// Otherwise name-validation bugs would silently cascade into whatever
+/// garbage-in behavior `iii worker stop <bad>` has today. The fast-fail also
+/// guarantees we never execute side effects against an unvalidated name.
+#[tokio::test]
+async fn handle_managed_restart_invalid_name_fails_fast() {
+    in_temp_dir_async(|| async {
+        let rc = iii_worker::cli::managed::handle_managed_restart(
+            "bad name with spaces",
+            false,
+            iii_worker::DEFAULT_PORT,
+        )
+        .await;
+        assert_eq!(
+            rc, 1,
+            "invalid worker name must return 1 before stop/start run"
+        );
+    })
+    .await;
+}
+
+/// Restart against a configured-but-not-running builtin must still invoke
+/// the stop path. The orphan-safety contract (`commit 5f3cfc27`) is:
+/// `handle_managed_restart` calls `handle_managed_stop` unconditionally so
+/// its three-tier PID discovery (OCI pidfile → binary pidfile → `ps` scan)
+/// can catch orphaned processes whose pidfiles are missing. If a future
+/// refactor gates stop on `is_worker_running`, this test should still pass
+/// because stop itself is a no-op for a not-running worker — but the intent
+/// it pins is: restart returns start's rc, never early-returns, never
+/// panics, regardless of whether anything is currently running.
+#[tokio::test]
+async fn handle_managed_restart_on_not_running_surfaces_start_rc() {
+    in_temp_dir_async(|| async {
+        // Add a builtin so start has something valid to resolve.
+        let add_rc =
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, false, false, false)
+                .await;
+        assert_eq!(add_rc, 0);
+
+        let restart_rc = iii_worker::cli::managed::handle_managed_restart(
+            "iii-http",
+            false,
+            iii_worker::DEFAULT_PORT,
+        )
+        .await;
+        // Builtin start short-circuits with rc=0 or rc=1 depending on whether
+        // the engine is actually running on DEFAULT_PORT. Either is valid
+        // here — we're asserting that restart did NOT panic or hit an
+        // unintended error path.
+        assert!(
+            restart_rc == 0 || restart_rc == 1,
+            "restart must surface start's rc; got {}",
+            restart_rc
+        );
+    })
+    .await;
+}
+
+/// Remove-many with `--yes` must bypass the running-worker confirmation
+/// prompt entirely. The new DX (commit b655977c) added a single batch
+/// prompt when any target is currently running. If this gate regresses
+/// (e.g., someone inverts the `!yes` check), automation that relies on
+/// `--yes` for unattended cleanup would hang forever on stdin.
+#[tokio::test]
+async fn handle_managed_remove_many_with_yes_bypasses_prompt() {
+    in_temp_dir_async(|| async {
+        let names = vec!["iii-http".to_string(), "iii-state".to_string()];
+        let add_rc = iii_worker::cli::managed::handle_managed_add_many(&names, false).await;
+        assert_eq!(add_rc, 0);
+
+        // Simulate a "running" worker by writing a live pidfile (our own PID)
+        // under the binary-worker path. `is_worker_running` reads pidfiles
+        // directly, so this is enough to trigger the prompt branch in
+        // handle_managed_remove_many — but --yes must skip it.
+        let home = dirs::home_dir().unwrap();
+        let pids = home.join(".iii/pids");
+        std::fs::create_dir_all(&pids).unwrap();
+        let pidfile = pids.join("iii-http.pid");
+        std::fs::write(&pidfile, std::process::id().to_string()).unwrap();
+
+        let rc = iii_worker::cli::managed::handle_managed_remove_many(&names, /*yes=*/ true).await;
+        // Cleanup the pidfile before asserting.
+        let _ = std::fs::remove_file(&pidfile);
+
+        assert_eq!(rc, 0, "--yes must bypass the prompt and succeed");
+        assert!(!iii_worker::cli::config_file::worker_exists("iii-http"));
+        assert!(!iii_worker::cli::config_file::worker_exists("iii-state"));
+    })
+    .await;
+}
+
+/// Regression: `iii worker add --force` used to error with "Worker is
+/// currently running. Stop it first with `iii worker stop`" instead of
+/// doing what --force implies — stop, clean, then re-add. The fix at
+/// `handle_managed_add` (managed.rs force branch) now invokes
+/// `handle_managed_stop` unconditionally when `is_worker_running` returns
+/// true, so the user doesn't have to run two commands for what reads like
+/// one destructive intent.
+///
+/// We prove the behavior by spawning a real sentinel process (copy of
+/// /bin/sleep at the binary-worker path so `handle_managed_stop`'s three-
+/// tier discovery recognizes it), writing its pid to the pidfile, and
+/// asserting that `--force` add returns 0 — no "Stop it first" error.
+/// We deliberately do NOT assert that the pidfile is removed: on platforms
+/// where `ps` lookup is flaky or the sentinel exits between spawn and
+/// stop, pidfile cleanup may or may not happen. The contract we care
+/// about is: --force doesn't refuse.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[tokio::test]
+async fn handle_managed_add_force_auto_stops_running_worker() {
+    in_temp_dir_async(|| async {
+        // Seed config.yaml with a builtin.
+        let add_rc =
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, false, false, false)
+                .await;
+        assert_eq!(add_rc, 0);
+
+        // Spawn a real sentinel process so the auto-stop path can signal a
+        // non-test-process PID. Staging our own PID would make stop attempt
+        // to SIGTERM the test runner itself — genuinely bad.
+        let home = dirs::home_dir().unwrap();
+        let pids = home.join(".iii/pids");
+        std::fs::create_dir_all(&pids).unwrap();
+        let mut child = std::process::Command::new("/bin/sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn sentinel");
+        let pidfile = pids.join("iii-http.pid");
+        std::fs::write(&pidfile, child.id().to_string()).unwrap();
+
+        // --force add: the fix makes this succeed without requiring the
+        // user to stop first. Before the fix this returned 1 with the
+        // "Stop it first" error.
+        let rc =
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, true, false, false)
+                .await;
+
+        // Always tear down the sentinel regardless of assertion outcome.
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = std::fs::remove_file(&pidfile);
+
+        assert_eq!(
+            rc, 0,
+            "--force add must not refuse when worker is running; got rc={}",
+            rc
+        );
+    })
+    .await;
+}
+
+/// Regression: `iii worker add` with wait=true used to only honor the wait
+/// flag on the local-path branch. OCI/builtin/binary paths silently
+/// dropped it. The fix routes all non-local paths through `finish_add`
+/// which applies the wait. For builtins specifically, we skip the wait
+/// (builtins run in-process with the engine and have no Phase::Ready
+/// state machine to watch). This test pins that skip: wait=true on a
+/// builtin returns quickly without hanging, even with no engine running.
+#[tokio::test]
+async fn handle_managed_add_wait_on_builtin_returns_without_hanging() {
+    in_temp_dir_async(|| async {
+        let started = std::time::Instant::now();
+        // wait=true (5th param). Engine is not running on the test machine's
+        // DEFAULT_PORT in the tempdir, but the builtin short-circuit must
+        // still return immediately — builtins have no boot to observe.
+        let rc =
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, false, false, true)
+                .await;
+        let elapsed = started.elapsed();
+        assert_eq!(rc, 0);
+        assert!(
+            elapsed < std::time::Duration::from_secs(10),
+            "builtin add with wait=true must not hang; elapsed = {:?}",
+            elapsed
+        );
+    })
+    .await;
+}

--- a/crates/iii-worker/tests/config_managed_integration.rs
+++ b/crates/iii-worker/tests/config_managed_integration.rs
@@ -17,7 +17,7 @@ use common::isolation::in_temp_dir_async;
 async fn add_many_builtin_workers() {
     in_temp_dir_async(|| async {
         let names = vec!["iii-http".to_string(), "iii-state".to_string()];
-        let exit_code = iii_worker::cli::managed::handle_managed_add_many(&names).await;
+        let exit_code = iii_worker::cli::managed::handle_managed_add_many(&names, false).await;
         assert_eq!(exit_code, 0, "all builtin workers should succeed");
 
         assert!(
@@ -39,7 +39,7 @@ async fn add_many_with_invalid_worker_returns_nonzero() {
             "iii-http".to_string(),
             "definitely-not-a-real-worker-xyz".to_string(),
         ];
-        let exit_code = iii_worker::cli::managed::handle_managed_add_many(&names).await;
+        let exit_code = iii_worker::cli::managed::handle_managed_add_many(&names, false).await;
         assert_ne!(exit_code, 0, "should fail when any worker fails");
 
         assert!(
@@ -54,7 +54,8 @@ async fn add_many_with_invalid_worker_returns_nonzero() {
 async fn handle_managed_add_builtin_creates_config() {
     in_temp_dir_async(|| async {
         let exit_code =
-            iii_worker::cli::managed::handle_managed_add("iii-http", false, false, false).await;
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, false, false, false)
+                .await;
         assert_eq!(
             exit_code, 0,
             "expected success exit code for builtin worker"
@@ -83,7 +84,7 @@ async fn handle_managed_add_builtin_merges_existing() {
         .unwrap();
 
         let exit_code =
-            iii_worker::cli::managed::handle_managed_add("iii-http", false, false, false)
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, false, false, false)
                 .await;
         assert_eq!(exit_code, 0, "expected success exit code for merge");
 
@@ -103,23 +104,33 @@ async fn handle_managed_add_builtin_merges_existing() {
 /// engine; they have no external process to spawn and are not published to the
 /// registry. Previously this path fell through to `fetch_worker_info`, which
 /// emitted "not found locally, checking registry..." and failed.
+///
+/// When the engine is NOT running, `start` for a builtin now exits non-zero
+/// (DX fix: exit 0 with a "start the engine" hint misled automation into
+/// thinking the builtin actually booted). This test exercises that path and
+/// asserts exit 1 -- which still proves the short-circuit, because a 1 here
+/// means we returned from the builtin branch rather than hitting the remote
+/// registry and producing a different error.
 #[tokio::test]
 async fn handle_managed_start_builtin_short_circuits() {
     in_temp_dir_async(|| async {
         // Add a builtin to config.yaml first.
         let add_rc =
-            iii_worker::cli::managed::handle_managed_add("iii-http", false, false, false).await;
+            iii_worker::cli::managed::handle_managed_add("iii-http", false, false, false, false)
+                .await;
         assert_eq!(add_rc, 0, "expected add to succeed for builtin");
 
-        // handle_managed_start must return 0 for a builtin without network I/O.
-        // We exercise this by forcing the engine port to a closed port via the
-        // default (engine-not-running case), which would normally fail for a
-        // non-builtin. For builtins it must succeed regardless.
-        let start_rc =
-            iii_worker::cli::managed::handle_managed_start("iii-http", "127.0.0.1", 0).await;
-        assert_eq!(
-            start_rc, 0,
-            "handle_managed_start must succeed (short-circuit) for builtin 'iii-http'"
+        // Builtin must short-circuit regardless of the local engine's port
+        // binding state. If the engine is up (port 49134 open on the host)
+        // start returns 0 with "served by the engine" message. If the engine
+        // is down, start returns 1 with a "start the engine" hint. Both are
+        // valid; what we're really asserting is that we did NOT fall through
+        // to the remote registry (which would produce a different error).
+        let start_rc = iii_worker::cli::managed::handle_managed_start("iii-http", false).await;
+        assert!(
+            start_rc == 0 || start_rc == 1,
+            "expected short-circuit (0 or 1), got {} -- suggests a registry fall-through",
+            start_rc
         );
     })
     .await;
@@ -137,8 +148,7 @@ async fn handle_managed_start_unconfigured_builtin_fails() {
             !iii_worker::cli::config_file::worker_exists("iii-http"),
             "precondition: iii-http must not be in config.yaml"
         );
-        let start_rc =
-            iii_worker::cli::managed::handle_managed_start("iii-http", "127.0.0.1", 0).await;
+        let start_rc = iii_worker::cli::managed::handle_managed_start("iii-http", false).await;
         assert_ne!(
             start_rc, 0,
             "handle_managed_start must fail for unconfigured builtin 'iii-http'"
@@ -154,7 +164,8 @@ async fn handle_managed_add_all_builtins_succeed() {
             let _ = std::fs::remove_file("config.yaml");
 
             let exit_code =
-                iii_worker::cli::managed::handle_managed_add(name, false, false, false).await;
+                iii_worker::cli::managed::handle_managed_add(name, false, false, false, false)
+                    .await;
             assert_eq!(exit_code, 0, "expected success for builtin '{}'", name);
 
             let content = std::fs::read_to_string("config.yaml").unwrap();
@@ -173,11 +184,11 @@ async fn remove_many_workers() {
     in_temp_dir_async(|| async {
         // Add two builtins first.
         let names = vec!["iii-http".to_string(), "iii-state".to_string()];
-        let exit_code = iii_worker::cli::managed::handle_managed_add_many(&names).await;
+        let exit_code = iii_worker::cli::managed::handle_managed_add_many(&names, false).await;
         assert_eq!(exit_code, 0);
 
         // Remove both at once.
-        let exit_code = iii_worker::cli::managed::handle_managed_remove_many(&names).await;
+        let exit_code = iii_worker::cli::managed::handle_managed_remove_many(&names, true).await;
         assert_eq!(exit_code, 0, "all removals should succeed");
 
         assert!(
@@ -197,12 +208,13 @@ async fn remove_many_with_missing_worker_returns_nonzero() {
     in_temp_dir_async(|| async {
         // Add one builtin.
         let add_names = vec!["iii-http".to_string()];
-        let exit_code = iii_worker::cli::managed::handle_managed_add_many(&add_names).await;
+        let exit_code = iii_worker::cli::managed::handle_managed_add_many(&add_names, false).await;
         assert_eq!(exit_code, 0);
 
         // Remove existing + nonexistent.
         let remove_names = vec!["iii-http".to_string(), "not-a-real-worker".to_string()];
-        let exit_code = iii_worker::cli::managed::handle_managed_remove_many(&remove_names).await;
+        let exit_code =
+            iii_worker::cli::managed::handle_managed_remove_many(&remove_names, true).await;
         assert_ne!(exit_code, 0, "should fail when any removal fails");
 
         // The valid one should still have been removed.
@@ -232,6 +244,7 @@ async fn handle_managed_add_oci_ref_passthrough() {
             false,
             false,
             false,
+            false,
         )
         .await;
         // Non-zero exit because pull fails, but it should NOT have tried the API
@@ -246,6 +259,7 @@ async fn handle_managed_add_oci_ref_with_colon_passthrough() {
     in_temp_dir_async(|| async {
         let result = iii_worker::cli::managed::handle_managed_add(
             "docker.io/org/image:latest",
+            false,
             false,
             false,
             false,
@@ -267,9 +281,14 @@ async fn handle_managed_add_plain_name_calls_api() {
     in_temp_dir_async(|| async {
         // Set III_API_URL to something that will fail quickly
         unsafe { std::env::set_var("III_API_URL", "http://127.0.0.1:1") };
-        let result =
-            iii_worker::cli::managed::handle_managed_add("nonexistent-worker", true, false, false)
-                .await;
+        let result = iii_worker::cli::managed::handle_managed_add(
+            "nonexistent-worker",
+            true,
+            false,
+            false,
+            false,
+        )
+        .await;
         unsafe { std::env::remove_var("III_API_URL") };
         // Should fail because API is unreachable
         assert_ne!(result, 0);
@@ -284,7 +303,8 @@ async fn handle_managed_add_builtin_skips_api() {
         // Set III_API_URL to something that will fail — if it tries the API, we'll know
         unsafe { std::env::set_var("III_API_URL", "http://127.0.0.1:1") };
         let result =
-            iii_worker::cli::managed::handle_managed_add("iii-http", true, false, false).await;
+            iii_worker::cli::managed::handle_managed_add("iii-http", true, false, false, false)
+                .await;
         unsafe { std::env::remove_var("III_API_URL") };
         // Should succeed because iii-http is a builtin — no API call needed
         assert_eq!(result, 0);
@@ -297,9 +317,14 @@ async fn handle_managed_add_builtin_skips_api() {
 async fn handle_managed_add_local_path_skips_api() {
     in_temp_dir_async(|| async {
         unsafe { std::env::set_var("III_API_URL", "http://127.0.0.1:1") };
-        let result =
-            iii_worker::cli::managed::handle_managed_add("./my-local-worker", true, false, false)
-                .await;
+        let result = iii_worker::cli::managed::handle_managed_add(
+            "./my-local-worker",
+            true,
+            false,
+            false,
+            false,
+        )
+        .await;
         unsafe { std::env::remove_var("III_API_URL") };
         // Will fail (path doesn't exist), but should NOT have called the API
         assert_ne!(result, 0);
@@ -324,9 +349,14 @@ async fn handle_managed_add_binary_via_file_fixture() {
 
         let url = format!("file://{}", path.display());
         unsafe { std::env::set_var("III_API_URL", &url) };
-        let result =
-            iii_worker::cli::managed::handle_managed_add("test-binary-worker", true, false, false)
-                .await;
+        let result = iii_worker::cli::managed::handle_managed_add(
+            "test-binary-worker",
+            true,
+            false,
+            false,
+            false,
+        )
+        .await;
         unsafe { std::env::remove_var("III_API_URL") };
         // Will fail because binaries map is empty (no platform match),
         // but it proves the API resolution path was taken and parsed correctly

--- a/crates/iii-worker/tests/local_worker_integration.rs
+++ b/crates/iii-worker/tests/local_worker_integration.rs
@@ -330,7 +330,8 @@ async fn handle_local_add_valid_path() {
         std::fs::create_dir_all(&project_dir).unwrap();
         std::fs::write(project_dir.join("package.json"), "{}").unwrap();
 
-        let result = handle_local_add(project_dir.to_str().unwrap(), false, false, true).await;
+        let result =
+            handle_local_add(project_dir.to_str().unwrap(), false, false, true, false).await;
         assert_eq!(result, 0, "handle_local_add should return 0 for valid path");
 
         // Without manifest, resolve_worker_name falls back to directory name
@@ -376,7 +377,7 @@ async fn handle_local_add_rejects_duplicate_without_force() {
             .build(&cwd);
 
         let result =
-            handle_local_add(project_dir.to_str().unwrap(), false, false, true).await;
+            handle_local_add(project_dir.to_str().unwrap(), false, false, true, false).await;
         assert_eq!(
             result, 1,
             "should return 1 when worker exists and force=false"
@@ -407,7 +408,7 @@ async fn handle_local_add_force_replaces_existing() {
             .build(&cwd);
 
         let result =
-            handle_local_add(project_dir.to_str().unwrap(), true, true, true).await;
+            handle_local_add(project_dir.to_str().unwrap(), true, true, true, false).await;
         assert_eq!(result, 0, "should return 0 with force=true");
 
         let stored_path = get_worker_path("my-worker");
@@ -441,7 +442,7 @@ async fn handle_local_add_canonicalizes_relative_path() {
         std::fs::create_dir_all(&project_dir).unwrap();
         std::fs::write(project_dir.join("package.json"), "{}").unwrap();
 
-        let result = handle_local_add("./rel-worker", false, false, true).await;
+        let result = handle_local_add("./rel-worker", false, false, true, false).await;
         assert_eq!(result, 0, "should succeed with relative path");
 
         // Without manifest, name falls back to directory name "rel-worker"
@@ -461,7 +462,8 @@ async fn handle_local_add_canonicalizes_relative_path() {
 #[tokio::test]
 async fn handle_local_add_invalid_path_returns_error() {
     in_temp_dir_async(|| async {
-        let result = handle_local_add("/nonexistent/path/to/worker", false, false, true).await;
+        let result =
+            handle_local_add("/nonexistent/path/to/worker", false, false, true, false).await;
         assert_eq!(result, 1, "should return 1 for nonexistent path");
     })
     .await;

--- a/crates/iii-worker/tests/worker_integration.rs
+++ b/crates/iii-worker/tests/worker_integration.rs
@@ -51,40 +51,78 @@ fn cli_parses_all_subcommands() {
     }
 }
 
-/// Engine/CLI IPC contract: the iii engine spawns `iii-worker start <name>`
-/// from engine/src/workers/registry_worker.rs::ExternalWorkerProcess::spawn
+/// Engine/CLI IPC contract: the iii engine spawns `iii-worker start <name>
+/// --port <N>` from engine/src/workers/registry_worker.rs::ExternalWorkerProcess::spawn
 /// whenever it encounters a worker in config.yaml that isn't a builtin or a
-/// legacy iii.toml module. If either side drifts (e.g. the engine starts
-/// passing `--port` again, or someone re-adds `--port` to the Start
-/// subcommand), clap will reject with exit 2 and every non-builtin worker
-/// silently fails to auto-start. These two tests lock both halves of the
-/// contract.
+/// legacy iii.toml module. The --port flag carries the engine's configured
+/// iii-worker-manager port so spawned workers connect back to the right
+/// place (previously hardcoded DEFAULT_PORT, silently breaking non-default
+/// manager ports). These tests lock both halves of the contract: (a) the
+/// bare-name form still parses for backward compat with direct CLI use, and
+/// (b) the engine's new --port form parses and surfaces the port correctly.
 #[test]
 fn start_subcommand_matches_engine_spawn_args() {
-    // Exact form the engine uses. Must parse cleanly.
+    // Bare-name form used when a human runs `iii-worker start <name>` from
+    // the terminal. Must still parse cleanly and default port to DEFAULT_PORT.
     let cli = Cli::try_parse_from(["iii-worker", "start", "image-resize"])
-        .expect("engine's spawn args must parse");
+        .expect("bare start form must parse");
     match cli.command {
         Commands::Start {
             worker_name,
             no_wait,
+            port,
         } => {
             assert_eq!(worker_name, "image-resize");
             assert!(!no_wait, "engine expects default wait behavior");
+            assert_eq!(
+                port,
+                iii_worker::DEFAULT_PORT,
+                "bare form must default to DEFAULT_PORT"
+            );
         }
         _ => panic!("expected Start"),
     }
 }
 
 #[test]
-fn start_subcommand_rejects_port_flag() {
-    // If someone re-introduces `--port` on Start (or on the engine's spawn
-    // call), this test fails loudly at the CLI side instead of at runtime.
-    let result = Cli::try_parse_from(["iii-worker", "start", "--port", "49134", "--", "x"]);
-    assert!(
-        result.is_err(),
-        "Start must not accept --port -- engine IPC contract depends on it"
-    );
+fn start_subcommand_accepts_port_flag_from_engine_spawn() {
+    // Exact form the engine's ExternalWorkerProcess::spawn emits when a
+    // non-default iii-worker-manager port is configured. If this ever stops
+    // parsing, clap rejects with exit 2 and every auto-spawned external
+    // worker on a non-default port silently fails to connect.
+    let cli = Cli::try_parse_from(["iii-worker", "start", "pdfkit", "--port", "49199"])
+        .expect("engine's --port spawn form must parse");
+    match cli.command {
+        Commands::Start {
+            worker_name,
+            no_wait,
+            port,
+        } => {
+            assert_eq!(worker_name, "pdfkit");
+            assert!(!no_wait, "engine expects default wait behavior");
+            assert_eq!(port, 49199, "--port must surface the custom port");
+        }
+        _ => panic!("expected Start"),
+    }
+}
+
+#[test]
+fn restart_subcommand_accepts_port_flag() {
+    // Restart funnels through handle_managed_start too, so a CLI user who
+    // runs `iii-worker restart foo --port 49199` against a non-default
+    // engine must see the port flow through. Otherwise the same silent-fail
+    // pattern returns via the restart path.
+    let cli = Cli::try_parse_from(["iii-worker", "restart", "pdfkit", "--port", "49199"])
+        .expect("restart --port must parse");
+    match cli.command {
+        Commands::Restart {
+            worker_name, port, ..
+        } => {
+            assert_eq!(worker_name, "pdfkit");
+            assert_eq!(port, 49199);
+        }
+        _ => panic!("expected Restart"),
+    }
 }
 
 /// `add` subcommand parses worker name and applies defaults.

--- a/crates/iii-worker/tests/worker_integration.rs
+++ b/crates/iii-worker/tests/worker_integration.rs
@@ -51,12 +51,48 @@ fn cli_parses_all_subcommands() {
     }
 }
 
+/// Engine/CLI IPC contract: the iii engine spawns `iii-worker start <name>`
+/// from engine/src/workers/registry_worker.rs::ExternalWorkerProcess::spawn
+/// whenever it encounters a worker in config.yaml that isn't a builtin or a
+/// legacy iii.toml module. If either side drifts (e.g. the engine starts
+/// passing `--port` again, or someone re-adds `--port` to the Start
+/// subcommand), clap will reject with exit 2 and every non-builtin worker
+/// silently fails to auto-start. These two tests lock both halves of the
+/// contract.
+#[test]
+fn start_subcommand_matches_engine_spawn_args() {
+    // Exact form the engine uses. Must parse cleanly.
+    let cli = Cli::try_parse_from(["iii-worker", "start", "image-resize"])
+        .expect("engine's spawn args must parse");
+    match cli.command {
+        Commands::Start {
+            worker_name,
+            no_wait,
+        } => {
+            assert_eq!(worker_name, "image-resize");
+            assert!(!no_wait, "engine expects default wait behavior");
+        }
+        _ => panic!("expected Start"),
+    }
+}
+
+#[test]
+fn start_subcommand_rejects_port_flag() {
+    // If someone re-introduces `--port` on Start (or on the engine's spawn
+    // call), this test fails loudly at the CLI side instead of at runtime.
+    let result = Cli::try_parse_from(["iii-worker", "start", "--port", "49134", "--", "x"]);
+    assert!(
+        result.is_err(),
+        "Start must not accept --port -- engine IPC contract depends on it"
+    );
+}
+
 /// `add` subcommand parses worker name and applies defaults.
 #[test]
 fn add_subcommand_fields() {
     let cli = Cli::parse_from(["iii-worker", "add", "ghcr.io/iii-hq/node:latest"]);
     match cli.command {
-        Commands::Add { args, force } => {
+        Commands::Add { args, force, .. } => {
             assert_eq!(
                 args.worker_names,
                 vec!["ghcr.io/iii-hq/node:latest".to_string()]
@@ -72,7 +108,7 @@ fn add_subcommand_fields() {
 fn add_subcommand_multiple_workers() {
     let cli = Cli::parse_from(["iii-worker", "add", "pdfkit", "iii-http", "iii-state"]);
     match cli.command {
-        Commands::Add { args, force } => {
+        Commands::Add { args, force, .. } => {
             assert_eq!(args.worker_names, vec!["pdfkit", "iii-http", "iii-state"]);
             assert!(!force);
         }
@@ -215,7 +251,7 @@ resources:
 fn add_force_flag() {
     let cli = Cli::parse_from(["iii-worker", "add", "pdfkit", "--force"]);
     match cli.command {
-        Commands::Add { args, force } => {
+        Commands::Add { args, force, .. } => {
             assert_eq!(args.worker_names, vec!["pdfkit"]);
             assert!(force);
             assert!(!args.reset_config);
@@ -229,7 +265,7 @@ fn add_force_flag() {
 fn add_force_reset_config() {
     let cli = Cli::parse_from(["iii-worker", "add", "pdfkit", "--force", "--reset-config"]);
     match cli.command {
-        Commands::Add { args, force } => {
+        Commands::Add { args, force, .. } => {
             assert!(force);
             assert!(args.reset_config);
         }
@@ -252,7 +288,7 @@ fn add_force_short_flag() {
 fn add_subcommand_accepts_local_path() {
     let cli = Cli::parse_from(["iii-worker", "add", "./my-worker"]);
     match cli.command {
-        Commands::Add { args, force } => {
+        Commands::Add { args, force, .. } => {
             assert_eq!(args.worker_names, vec!["./my-worker"]);
             assert!(!force);
         }
@@ -265,7 +301,7 @@ fn add_subcommand_accepts_local_path() {
 fn add_subcommand_accepts_absolute_path() {
     let cli = Cli::parse_from(["iii-worker", "add", "/tmp/my-worker"]);
     match cli.command {
-        Commands::Add { args, force } => {
+        Commands::Add { args, force, .. } => {
             assert_eq!(args.worker_names, vec!["/tmp/my-worker"]);
             assert!(!force);
         }
@@ -278,7 +314,7 @@ fn add_subcommand_accepts_absolute_path() {
 fn add_subcommand_local_path_with_force() {
     let cli = Cli::parse_from(["iii-worker", "add", "./my-worker", "--force"]);
     match cli.command {
-        Commands::Add { args, force } => {
+        Commands::Add { args, force, .. } => {
             assert_eq!(args.worker_names, vec!["./my-worker"]);
             assert!(force);
         }

--- a/crates/iii-worker/tests/worker_list_discovery_integration.rs
+++ b/crates/iii-worker/tests/worker_list_discovery_integration.rs
@@ -225,3 +225,75 @@ fn find_worker_pid_from_ps_returns_none_for_unknown_name() {
     let unique = format!("definitely-no-such-worker-{}", std::process::id());
     assert_eq!(find_worker_pid_from_ps(&unique), None);
 }
+
+/// Regression test for the restart-path duplicate-spawn bug in
+/// [`handle_managed_restart`] (`crates/iii-worker/src/cli/managed.rs`).
+///
+/// The old restart path gated stop on `is_worker_running`, which only reads
+/// pidfiles. When a worker's pidfile was deleted but the process kept running
+/// (orphan), the gate returned false, stop was skipped, and start spawned a
+/// duplicate. The fix now calls `handle_managed_stop` unconditionally, whose
+/// three-tier discovery (OCI pidfile → binary pidfile → `ps` scan) catches
+/// those orphans.
+///
+/// This test pins down the exact discovery asymmetry the fix relies on: stage
+/// a real live orphan process at the expected binary-worker path but leave
+/// **no pidfile on disk**, then assert that:
+///   1. `is_worker_running` is blind to it (proves the old gate short-circuited).
+///   2. `find_worker_pid_from_ps` (used by `handle_managed_stop`) still finds it
+///      (proves the new unconditional-stop path catches it).
+///
+/// If either assertion flips in the future — e.g., `is_worker_running` gains a
+/// `ps` fallback, or `find_worker_pid_from_ps` loses it — revisit whether the
+/// unconditional-stop pattern in `handle_managed_restart` is still load-bearing.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn restart_orphan_invisible_to_is_worker_running_but_visible_to_ps() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::new(tmp.path());
+
+    // Stage a binary-worker executable at the recognised path, but do NOT
+    // create the corresponding pidfile under ~/.iii/pids/{name}.pid.
+    let workers_dir = tmp.path().join(".iii/workers");
+    std::fs::create_dir_all(&workers_dir).unwrap();
+    let worker_name = format!("test-restart-orphan-{}", std::process::id());
+    let worker_bin = workers_dir.join(&worker_name);
+    std::fs::copy("/bin/sleep", &worker_bin).expect("/bin/sleep must exist on Unix");
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&worker_bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let mut child = std::process::Command::new(&worker_bin)
+        .arg("60")
+        .spawn()
+        .expect("spawn sentinel sleep process");
+
+    // Give the OS a moment to register the new process in /proc or ps.
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    let running_by_pidfile = is_worker_running(&worker_name);
+    let found_by_ps = find_worker_pid_from_ps(&worker_name);
+
+    // Always tear down before asserting.
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(
+        !running_by_pidfile,
+        "is_worker_running saw orphan {worker_name} without any pidfile on disk. \
+         If this is intentional (e.g., is_worker_running gained a ps fallback), \
+         the unconditional-stop pattern in handle_managed_restart may be redundant \
+         and should be reviewed."
+    );
+    assert_eq!(
+        found_by_ps,
+        Some(child.id()),
+        "handle_managed_stop's ps fallback failed to find live orphan \
+         {worker_name} (pid {}). The restart-path fix depends on this lookup \
+         working; if it has regressed, handle_managed_restart will once again \
+         risk spawning duplicate workers.",
+        child.id()
+    );
+}

--- a/crates/iii-worker/tests/worker_list_discovery_integration.rs
+++ b/crates/iii-worker/tests/worker_list_discovery_integration.rs
@@ -58,7 +58,7 @@ impl Drop for HomeGuard {
 /// assumption that the dirs always exist.
 #[test]
 fn discover_disk_worker_names_empty_home() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let tmp = tempfile::tempdir().unwrap();
     let _home = HomeGuard::new(tmp.path());
 
@@ -71,7 +71,7 @@ fn discover_disk_worker_names_empty_home() {
 /// function returns the union, sorted and deduplicated.
 #[test]
 fn discover_disk_worker_names_finds_managed_and_pids() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let tmp = tempfile::tempdir().unwrap();
     let _home = HomeGuard::new(tmp.path());
 
@@ -93,7 +93,7 @@ fn discover_disk_worker_names_finds_managed_and_pids() {
 /// guaranteed-alive sentinel, exercising the real signal-0 path.
 #[test]
 fn is_worker_running_true_for_alive_pid() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let tmp = tempfile::tempdir().unwrap();
     let _home = HomeGuard::new(tmp.path());
 
@@ -113,7 +113,7 @@ fn is_worker_running_true_for_alive_pid() {
 /// excludes a name from the orphan set if it is also missing from config.
 #[test]
 fn is_worker_running_false_for_dead_pid() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let tmp = tempfile::tempdir().unwrap();
     let _home = HomeGuard::new(tmp.path());
 
@@ -140,7 +140,7 @@ fn is_worker_running_false_for_dead_pid() {
 /// an empty Vec, which we accept.
 #[test]
 fn discover_running_from_ps_returns_some_processes() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let tmp = tempfile::tempdir().unwrap();
     let _home = HomeGuard::new(tmp.path());
 
@@ -170,16 +170,25 @@ fn discover_running_from_ps_returns_some_processes() {
 /// orphan binary workers whose pidfiles have been removed.
 ///
 /// Skipped on non-Unix and on platforms without `/bin/sleep`.
+///
+/// macOS caveat: `/var -> /private/var` is a symlink, and `tempfile::tempdir`
+/// lands under `$TMPDIR` which is typically `/var/folders/...`. Once a
+/// process is spawned, the kernel stores the canonicalized path, and
+/// `ps -o args=` emits `/private/var/folders/...`. Without canonicalizing
+/// the HOME we use for `workers_prefix`, `strip_prefix` misses the match
+/// and the test flakes as "expected pid, got None". Linux doesn't have
+/// this specific symlink but canonicalize is still the right call.
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn find_worker_pid_from_ps_locates_live_orphan_binary() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let tmp = tempfile::tempdir().unwrap();
-    let _home = HomeGuard::new(tmp.path());
+    let canonical_home = std::fs::canonicalize(tmp.path()).unwrap();
+    let _home = HomeGuard::new(&canonical_home);
 
     // Stage an executable at the exact path the scanner uses to recognise
     // binary workers. Copying /bin/sleep keeps this dependency-free.
-    let workers_dir = tmp.path().join(".iii/workers");
+    let workers_dir = canonical_home.join(".iii/workers");
     std::fs::create_dir_all(&workers_dir).unwrap();
     let worker_name = format!("test-orphan-{}", std::process::id());
     let worker_bin = workers_dir.join(&worker_name);
@@ -195,10 +204,19 @@ fn find_worker_pid_from_ps_locates_live_orphan_binary() {
         .spawn()
         .expect("spawn sentinel sleep process");
 
-    // Give the OS a moment to register the new process in /proc or ps.
-    std::thread::sleep(std::time::Duration::from_millis(200));
-
-    let found = find_worker_pid_from_ps(&worker_name);
+    // macOS `ps` has a non-deterministic window after fork/exec before a new
+    // process appears in the table — observed failures at 200ms with passes
+    // at 400-600ms under CI load. Poll with short sleeps instead of a single
+    // fixed sleep so the test is robust without slowing the happy path.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    let mut found = None;
+    while std::time::Instant::now() < deadline {
+        if let Some(pid) = find_worker_pid_from_ps(&worker_name) {
+            found = Some(pid);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
 
     // Always tear down the sentinel before asserting, so a failed assertion
     // doesn't leak a 60-second sleep.
@@ -208,7 +226,7 @@ fn find_worker_pid_from_ps_locates_live_orphan_binary() {
     assert_eq!(
         found,
         Some(child.id()),
-        "expected to find sentinel pid {}, got {found:?}",
+        "expected to find sentinel pid {} within 3s, got {found:?}",
         child.id()
     );
 }
@@ -218,7 +236,7 @@ fn find_worker_pid_from_ps_locates_live_orphan_binary() {
 /// unrelated process.
 #[test]
 fn find_worker_pid_from_ps_returns_none_for_unknown_name() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let tmp = tempfile::tempdir().unwrap();
     let _home = HomeGuard::new(tmp.path());
 
@@ -249,13 +267,17 @@ fn find_worker_pid_from_ps_returns_none_for_unknown_name() {
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn restart_orphan_invisible_to_is_worker_running_but_visible_to_ps() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let tmp = tempfile::tempdir().unwrap();
-    let _home = HomeGuard::new(tmp.path());
+    // Canonicalize — see the note in
+    // `find_worker_pid_from_ps_locates_live_orphan_binary` for the macOS
+    // `/var -> /private/var` reason.
+    let canonical_home = std::fs::canonicalize(tmp.path()).unwrap();
+    let _home = HomeGuard::new(&canonical_home);
 
     // Stage a binary-worker executable at the recognised path, but do NOT
     // create the corresponding pidfile under ~/.iii/pids/{name}.pid.
-    let workers_dir = tmp.path().join(".iii/workers");
+    let workers_dir = canonical_home.join(".iii/workers");
     std::fs::create_dir_all(&workers_dir).unwrap();
     let worker_name = format!("test-restart-orphan-{}", std::process::id());
     let worker_bin = workers_dir.join(&worker_name);
@@ -270,11 +292,20 @@ fn restart_orphan_invisible_to_is_worker_running_but_visible_to_ps() {
         .spawn()
         .expect("spawn sentinel sleep process");
 
-    // Give the OS a moment to register the new process in /proc or ps.
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    // macOS `ps` has a fork/exec registration window that varies under load
+    // (see find_worker_pid_from_ps_locates_live_orphan_binary). Poll briefly
+    // for the process to appear instead of a single fixed sleep.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    let mut found_by_ps = None;
+    while std::time::Instant::now() < deadline {
+        if let Some(pid) = find_worker_pid_from_ps(&worker_name) {
+            found_by_ps = Some(pid);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
 
     let running_by_pidfile = is_worker_running(&worker_name);
-    let found_by_ps = find_worker_pid_from_ps(&worker_name);
 
     // Always tear down before asserting.
     let _ = child.kill();

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -234,6 +234,12 @@ pub struct Engine {
     pub channel_manager: Arc<ChannelManager>,
     pub queue_module: Arc<tokio::sync::RwLock<Option<Arc<dyn QueueEnqueuer>>>>,
     pub(crate) active_scope: Arc<std::sync::Mutex<Option<crate::workers::reload::ScopeBuilder>>>,
+    /// Effective `iii-worker-manager` port, resolved from config at build
+    /// time. Set once by `EngineBuilder::build`; subsequent reads see the
+    /// same value for the engine's lifetime. Used by `registry_worker::
+    /// ExternalWorkerProcess::spawn` so externally-spawned workers connect
+    /// back to the actual configured port, not a hardcoded DEFAULT_PORT.
+    worker_manager_port: Arc<std::sync::OnceLock<u16>>,
 }
 
 impl Default for Engine {
@@ -254,11 +260,31 @@ impl Engine {
             channel_manager: Arc::new(ChannelManager::new()),
             queue_module: Arc::new(tokio::sync::RwLock::new(None)),
             active_scope,
+            worker_manager_port: Arc::new(std::sync::OnceLock::new()),
         }
     }
 
     pub async fn set_queue_module(&self, module: Arc<dyn QueueEnqueuer>) {
         *self.queue_module.write().await = Some(module);
+    }
+
+    /// Returns the effective `iii-worker-manager` port. Resolved from config
+    /// by `EngineBuilder::build` (see `set_worker_manager_port`); falls back
+    /// to `workers::worker::DEFAULT_PORT` if never set (direct `Engine::new`
+    /// paths used only by tests).
+    pub fn worker_manager_port(&self) -> u16 {
+        self.worker_manager_port
+            .get()
+            .copied()
+            .unwrap_or(crate::workers::worker::DEFAULT_PORT)
+    }
+
+    /// Records the effective port. Called once by `EngineBuilder::build`
+    /// after scanning the worker list for an `iii-worker-manager` entry.
+    /// Subsequent calls are ignored (OnceLock semantics) so the port cannot
+    /// drift mid-lifetime.
+    pub fn set_worker_manager_port(&self, port: u16) {
+        let _ = self.worker_manager_port.set(port);
     }
 
     /// Opens a scope so that registrations made between here and

--- a/engine/src/workers/config.rs
+++ b/engine/src/workers/config.rs
@@ -245,11 +245,14 @@ impl WorkerRegistry {
         }
 
         // 4. Delegate to iii-worker start (handles registry lookup, binary
-        //    download, OCI pull, and spawning autonomously). The CLI reads the
-        //    engine port from its own DEFAULT_PORT -- do not pass --port here,
-        //    the Start subcommand does not accept it.
-        tracing::info!(worker = %name, "Starting external worker via iii-worker");
-        let process = super::registry_worker::ExternalWorkerProcess::spawn(name)
+        //    download, OCI pull, and spawning autonomously). Pass the
+        //    engine's effective `iii-worker-manager` port so the spawned
+        //    VM-based worker connects back to the right place. `EngineBuilder::build`
+        //    pre-resolves this from config; direct `Engine::new` paths fall
+        //    back to DEFAULT_PORT via `worker_manager_port()`.
+        let port = engine.worker_manager_port();
+        tracing::info!(worker = %name, port = port, "Starting external worker via iii-worker");
+        let process = super::registry_worker::ExternalWorkerProcess::spawn(name, port)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to start worker '{}': {}", name, e))?;
         Ok(Box::new(
@@ -470,6 +473,24 @@ impl EngineBuilder {
         }
 
         assign_instance_ids(&mut workers);
+
+        // Resolve the effective `iii-worker-manager` port BEFORE creating
+        // workers so the step-4 delegation path in `WorkerRegistry::create_worker`
+        // can hand it to `ExternalWorkerProcess::spawn`. We pick the first
+        // `iii-worker-manager` entry whose config parses -- fixtures like
+        // `sdk/fixtures/config-test.yaml` sometimes declare two manager
+        // instances on different ports for test isolation, and there's no
+        // unambiguous "primary" beyond declaration order. Fall back to
+        // DEFAULT_PORT if no entry is present or its config is shaped
+        // unexpectedly; that matches the legacy hardcoded behavior.
+        let resolved_port = workers
+            .iter()
+            .find(|e| e.worker_type() == "iii-worker-manager")
+            .and_then(|e| e.config.clone())
+            .and_then(|v| serde_json::from_value::<super::worker::WorkerManagerConfig>(v).ok())
+            .map(|c| c.port)
+            .unwrap_or(super::worker::DEFAULT_PORT);
+        self.engine.set_worker_manager_port(resolved_port);
 
         for entry in workers {
             tracing::debug!("Creating worker: {}", entry.name);
@@ -1664,6 +1685,103 @@ workers:
         assert_eq!(
             config.workers[0].image.as_deref(),
             Some("ghcr.io/org/w:2.0.0")
+        );
+    }
+
+    // =========================================================================
+    // Engine worker_manager_port resolution
+    //
+    // Regression: `ExternalWorkerProcess::spawn` previously hardcoded
+    // DEFAULT_PORT (49134) when invoking `iii-worker start`, silently breaking
+    // auto-spawn for any engine running on a non-default `iii-worker-manager`
+    // port. The fix resolves the effective port at build time and stores it
+    // on `Engine`; these tests pin the resolution behavior.
+    // =========================================================================
+
+    #[test]
+    fn engine_worker_manager_port_defaults_to_default_port() {
+        // Direct `Engine::new` (used by test paths) must report DEFAULT_PORT
+        // until a builder sets it. Anything else would be a silent config
+        // regression masquerading as test isolation.
+        let engine = Engine::new();
+        assert_eq!(
+            engine.worker_manager_port(),
+            super::super::worker::DEFAULT_PORT,
+            "fresh Engine must default to DEFAULT_PORT"
+        );
+    }
+
+    #[tokio::test]
+    async fn engine_builder_resolves_custom_worker_manager_port_from_config() {
+        // The key regression: when config.yaml sets a non-default port for
+        // `iii-worker-manager`, `EngineBuilder::build` must surface that port
+        // on the Engine so the step-4 delegation path hands it to
+        // `ExternalWorkerProcess::spawn` instead of the hardcoded default.
+        //
+        // Pick a port no one else binds. 49199 matches the value used in
+        // `sdk/fixtures/config-test.yaml` -- if that fixture's port ever
+        // needs rewording, this test keeps the plumbing honest.
+        let custom_port: u16 = 49199;
+        let builder = EngineBuilder::new()
+            .add_worker(
+                "iii-worker-manager",
+                Some(serde_json::json!({
+                    "host": "127.0.0.1",
+                    "port": custom_port,
+                })),
+            )
+            .build()
+            .await
+            .expect("build with custom iii-worker-manager port");
+
+        assert_eq!(
+            builder.engine().worker_manager_port(),
+            custom_port,
+            "builder must resolve iii-worker-manager port from config"
+        );
+
+        builder.destroy().await.expect("destroy engine");
+    }
+
+    #[tokio::test]
+    async fn engine_builder_falls_back_to_default_when_no_manager_entry() {
+        // Edge: configs that don't declare `iii-worker-manager` still get
+        // one injected via the `mandatory` registration path. That entry
+        // has no custom config, so the port resolution must land on
+        // DEFAULT_PORT. Losing this fallback would regress every existing
+        // deployment that doesn't explicitly pin a port.
+        let builder = EngineBuilder::new()
+            .with_config(EngineConfig {
+                modules: Vec::new(),
+                workers: Vec::new(),
+            })
+            .build()
+            .await
+            .expect("build with no explicit workers");
+
+        assert_eq!(
+            builder.engine().worker_manager_port(),
+            super::super::worker::DEFAULT_PORT,
+            "absent/default iii-worker-manager must resolve to DEFAULT_PORT"
+        );
+
+        builder.destroy().await.expect("destroy engine");
+    }
+
+    #[test]
+    fn engine_worker_manager_port_is_set_once() {
+        // OnceLock semantics: first set wins. This guards against a future
+        // refactor that might try to mutate the port mid-lifetime (e.g. from
+        // a config hot-reload), which would silently drift external worker
+        // connections. If the port genuinely needs to change, the user
+        // should restart the engine.
+        let engine = Engine::new();
+        engine.set_worker_manager_port(49199);
+        engine.set_worker_manager_port(50000); // ignored
+        assert_eq!(
+            engine.worker_manager_port(),
+            49199,
+            "second set_worker_manager_port must be a no-op"
         );
     }
 }

--- a/engine/src/workers/config.rs
+++ b/engine/src/workers/config.rs
@@ -245,10 +245,11 @@ impl WorkerRegistry {
         }
 
         // 4. Delegate to iii-worker start (handles registry lookup, binary
-        //    download, OCI pull, and spawning autonomously)
+        //    download, OCI pull, and spawning autonomously). The CLI reads the
+        //    engine port from its own DEFAULT_PORT -- do not pass --port here,
+        //    the Start subcommand does not accept it.
         tracing::info!(worker = %name, "Starting external worker via iii-worker");
-        let port = crate::workers::worker::DEFAULT_PORT;
-        let process = super::registry_worker::ExternalWorkerProcess::spawn(name, port)
+        let process = super::registry_worker::ExternalWorkerProcess::spawn(name)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to start worker '{}': {}", name, e))?;
         Ok(Box::new(

--- a/engine/src/workers/registry_worker.rs
+++ b/engine/src/workers/registry_worker.rs
@@ -72,13 +72,16 @@ pub struct ExternalWorkerProcess {
 const SPAWN_GRACE: std::time::Duration = std::time::Duration::from_secs(30);
 
 impl ExternalWorkerProcess {
-    /// Spawns `iii-worker start <name>` as a detached child. The CLI reads the
-    /// engine port from its own `DEFAULT_PORT` constant (which must stay in
-    /// lockstep with the engine's), so we intentionally do NOT pass `--port`
-    /// here -- `iii worker start` does not expose that flag and clap will
-    /// reject it with exit 2, silently breaking auto-start for every
-    /// non-builtin worker.
-    pub async fn spawn(name: &str) -> Result<Self, String> {
+    /// Spawns `iii-worker start <name> --port <port>` as a detached child.
+    ///
+    /// `port` is the engine's configured `iii-worker-manager` port; the CLI
+    /// uses it to build the `III_ENGINE_URL` env var handed to the spawned
+    /// VM-based worker so it connects back to the right place. When the
+    /// engine runs on the default port this is equivalent to the pre-fix
+    /// behavior; when it runs on a non-default port (e.g. SDK integration
+    /// tests with multiple `iii-worker-manager` entries), the spawned worker
+    /// no longer silently connects to the wrong port.
+    pub async fn spawn(name: &str, port: u16) -> Result<Self, String> {
         let worker_binary = resolve_iii_worker_binary()
             .ok_or_else(|| {
                 "iii-worker binary not found. Install with `iii update worker` or place in ~/.local/bin/".to_string()
@@ -96,8 +99,9 @@ impl ExternalWorkerProcess {
         let stderr_file = std::fs::File::create(logs_dir.join("stderr.log"))
             .map_err(|e| format!("Failed to create stderr log: {}", e))?;
 
+        let port_str = port.to_string();
         let mut cmd = tokio::process::Command::new(&worker_binary);
-        cmd.args(["start", name])
+        cmd.args(["start", name, "--port", &port_str])
             .stdout(stdout_file)
             .stderr(stderr_file);
 
@@ -108,6 +112,7 @@ impl ExternalWorkerProcess {
         tracing::info!(
             worker = %name,
             pid = ?child.id(),
+            port = port,
             "Worker starting via iii-worker (logs: `iii worker logs {}`)", name
         );
 

--- a/engine/src/workers/registry_worker.rs
+++ b/engine/src/workers/registry_worker.rs
@@ -8,12 +8,64 @@
 //! All registry resolution, binary download, and OCI management is handled
 //! by `iii-worker` itself — the engine only manages the child process lifecycle.
 
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::{Arc, OnceLock},
+};
 
 use serde_json::Value;
 use tokio::sync::Mutex;
 
 use crate::{engine::Engine, workers::traits::Worker};
+
+// =============================================================================
+// Path helpers
+// =============================================================================
+
+/// `HOME`-relative `.iii` directory, or `None` when `HOME` cannot be resolved.
+///
+/// Returning `Option` lets callers distinguish "no HOME" from "path under HOME
+/// missing." The previous pattern — `dirs::home_dir().unwrap_or_default()` —
+/// silently collapsed an unresolvable HOME into `""`, which then joined to
+/// relative paths and produced file reads against the current working
+/// directory. In `is_alive`, that made every liveness probe fail on machines
+/// without a HOME, which the reload loop interprets as "dead → restart,"
+/// producing a restart storm.
+fn iii_home() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".iii"))
+}
+
+/// Candidate pidfile paths for `worker_name`, ordered by probe priority.
+///
+/// - OCI/VM workers: `~/.iii/managed/{name}/vm.pid`
+/// - Binary workers: `~/.iii/pids/{name}.pid`
+///
+/// MUST stay in sync with `crates/iii-worker/src/cli/status.rs::pid_file_candidates`.
+/// Engine and iii-worker are sibling crates with no shared dep; duplicating
+/// this function keeps the path convention single-sourced within each crate.
+/// If you add a third worker type or location here, mirror it there.
+fn pid_file_candidates(home: &std::path::Path, worker_name: &str) -> [PathBuf; 2] {
+    [
+        home.join("managed").join(worker_name).join("vm.pid"),
+        home.join("pids").join(format!("{}.pid", worker_name)),
+    ]
+}
+
+/// Build the argv handed to `iii-worker start` when the engine auto-spawns a
+/// non-builtin worker. Kept pure so the CLI/engine IPC contract can be
+/// regression-tested without spawning a real process (see tests).
+///
+/// Any drift here silently breaks the non-default `iii-worker-manager` port
+/// case — the exact bug this module exists to fix.
+fn spawn_args(worker_name: &str, port: u16) -> [String; 4] {
+    [
+        "start".into(),
+        worker_name.into(),
+        "--port".into(),
+        port.to_string(),
+    ]
+}
 
 // =============================================================================
 // iii-worker binary resolution
@@ -28,13 +80,11 @@ pub fn resolve_iii_worker_binary() -> Option<PathBuf> {
     };
 
     // Check ~/.local/bin/ (standard managed binary location)
-    let managed_path = dirs::home_dir()
-        .unwrap_or_default()
-        .join(".local")
-        .join("bin")
-        .join(exe_name);
-    if managed_path.exists() {
-        return Some(managed_path);
+    if let Some(home) = dirs::home_dir() {
+        let managed_path = home.join(".local").join("bin").join(exe_name);
+        if managed_path.exists() {
+            return Some(managed_path);
+        }
     }
 
     // Check system PATH
@@ -99,11 +149,9 @@ impl ExternalWorkerProcess {
         let stderr_file = std::fs::File::create(logs_dir.join("stderr.log"))
             .map_err(|e| format!("Failed to create stderr log: {}", e))?;
 
-        let port_str = port.to_string();
+        let args = spawn_args(name, port);
         let mut cmd = tokio::process::Command::new(&worker_binary);
-        cmd.args(["start", name, "--port", &port_str])
-            .stdout(stdout_file)
-            .stderr(stderr_file);
+        cmd.args(&args).stdout(stdout_file).stderr(stderr_file);
 
         let child = cmd
             .spawn()
@@ -125,41 +173,51 @@ impl ExternalWorkerProcess {
 
     /// Probes whether the detached worker process is still alive.
     ///
-    /// The real VM PID lives in `~/.iii/managed/{name}/vm.pid` — the tokio
-    /// `Child` handle is stale because `iii-worker start` exits immediately
-    /// after spawning the detached boot process.
+    /// The real PID lives in one of two places depending on worker type:
+    /// - OCI/VM workers: `~/.iii/managed/{name}/vm.pid`
+    /// - Binary workers: `~/.iii/pids/{name}.pid`
+    ///
+    /// The tokio `Child` handle is stale because `iii-worker start` exits
+    /// immediately after spawning the detached boot/worker process. Mirrors
+    /// the dual-candidate lookup used by `iii worker status` (`read_pid` in
+    /// `crates/iii-worker/src/cli/status.rs`).
     ///
     /// Returns:
-    /// - `true` if a pidfile exists and the PID responds to signal 0
-    /// - `true` if we're still inside the post-spawn grace window (VM might
+    /// - `true` if any candidate pidfile exists and its PID responds to signal 0
+    /// - `true` if we're still inside the post-spawn grace window (worker might
     ///   just be finishing boot and writing its pidfile)
     /// - `false` otherwise (crashed, force-stopped, or never booted)
     pub fn is_alive(&self) -> bool {
-        let pidfile = dirs::home_dir()
-            .unwrap_or_default()
-            .join(".iii/managed")
-            .join(&self.name)
-            .join("vm.pid");
+        // HOME-less machines can't observe pidfiles at all — skip the disk
+        // probe entirely and let the grace window handle the early-boot case.
+        // A permanent "unable to observe" state for a real worker will still
+        // surface later as a dead probe once grace elapses, rather than a
+        // false-positive restart storm triggered by nonsensical paths.
+        let Some(home) = iii_home() else {
+            return self.spawned_at.elapsed() < SPAWN_GRACE;
+        };
 
-        if let Ok(s) = std::fs::read_to_string(&pidfile)
-            && let Ok(pid) = s.trim().parse::<u32>()
-        {
-            #[cfg(unix)]
+        for pidfile in pid_file_candidates(&home, &self.name) {
+            if let Ok(s) = std::fs::read_to_string(&pidfile)
+                && let Ok(pid) = s.trim().parse::<u32>()
             {
-                use nix::sys::signal::kill;
-                use nix::unistd::Pid;
-                if kill(Pid::from_raw(pid as i32), None).is_ok() {
+                #[cfg(unix)]
+                {
+                    use nix::sys::signal::kill;
+                    use nix::unistd::Pid;
+                    if kill(Pid::from_raw(pid as i32), None).is_ok() {
+                        return true;
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    let _ = pid;
                     return true;
                 }
             }
-            #[cfg(not(unix))]
-            {
-                let _ = pid;
-                return true;
-            }
         }
 
-        // No pidfile (or stale/dead pid). Grant a grace window from spawn
+        // No live pidfile at either candidate. Grant a grace window from spawn
         // so we don't misread a still-booting worker as dead.
         self.spawned_at.elapsed() < SPAWN_GRACE
     }
@@ -209,9 +267,34 @@ pub struct ExternalWorkerWrapper {
     display_name: &'static str,
 }
 
+/// Intern a display name so the same worker name only ever leaks once.
+///
+/// The `Worker::name()` trait method returns `&'static str`, so the wrapper
+/// must materialize a `&'static str` somewhere. Pre-fix, every call to
+/// `ExternalWorkerWrapper::new` leaked a fresh boxed string, producing
+/// unbounded growth under hot-reload (config watcher recreates wrappers for
+/// every CHANGED/REVIVED entry). The intern cache caps the total leak at one
+/// allocation per unique worker name for the engine's lifetime, which is the
+/// natural upper bound of names the engine can legitimately reference.
+///
+/// Proper fix (changing `Worker::name` to return `&str` borrowed from `&self`)
+/// would cascade to every `impl Worker` in the workspace — out of scope here.
+fn intern_display_name(name: &str) -> &'static str {
+    static INTERNED: OnceLock<std::sync::Mutex<HashMap<String, &'static str>>> = OnceLock::new();
+    let cache = INTERNED.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
+    let mut guard = cache.lock().expect("intern cache poisoned");
+    if let Some(&existing) = guard.get(name) {
+        return existing;
+    }
+    let display = format!("ExternalWorker({})", name);
+    let leaked: &'static str = Box::leak(display.into_boxed_str());
+    guard.insert(name.to_string(), leaked);
+    leaked
+}
+
 impl ExternalWorkerWrapper {
     pub fn new(process: ExternalWorkerProcess) -> Self {
-        let display_name = Box::leak(format!("ExternalWorker({})", &process.name).into_boxed_str());
+        let display_name = intern_display_name(&process.name);
         Self {
             process,
             display_name,
@@ -276,6 +359,135 @@ mod tests {
         let _ = check;
     };
 
+    /// Serializes tests that mutate HOME. HOME is process-global, so any two
+    /// tests that override it must run one at a time. Uses `std::sync::Mutex`
+    /// (blocking) rather than the tokio re-export pulled in by `super::*`.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// RAII guard that overrides HOME for the duration of a test and restores
+    /// the original value (or removes the var if it was unset) on drop.
+    struct HomeGuard {
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl HomeGuard {
+        fn new(path: &std::path::Path) -> Self {
+            let original = std::env::var_os("HOME");
+            // SAFETY: test-only, serialized via ENV_LOCK.
+            unsafe {
+                std::env::set_var("HOME", path);
+            }
+            Self { original }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: test-only, serialized via ENV_LOCK.
+            unsafe {
+                match &self.original {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+        }
+    }
+
+    /// Builds a process with `spawned_at` set far enough in the past that the
+    /// grace-window fallback in `is_alive()` cannot mask a missing pidfile.
+    fn stale_process(name: &str) -> ExternalWorkerProcess {
+        let spawned_at = std::time::Instant::now()
+            .checked_sub(SPAWN_GRACE * 2)
+            .expect("clock has enough runway to subtract grace window");
+        ExternalWorkerProcess {
+            name: name.to_string(),
+            child: Arc::new(Mutex::new(None)),
+            spawned_at,
+        }
+    }
+
+    /// Binary workers write their pid to `~/.iii/pids/{name}.pid`. `is_alive`
+    /// must see it even when the VM pidfile is absent — the bug this guards
+    /// against is the reload loop restarting healthy binary workers after the
+    /// spawn grace window elapses.
+    #[test]
+    fn is_alive_finds_binary_worker_pidfile() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = HomeGuard::new(tmp.path());
+
+        let name = "bin-worker";
+        let pids_dir = tmp.path().join(".iii/pids");
+        std::fs::create_dir_all(&pids_dir).unwrap();
+        std::fs::write(
+            pids_dir.join(format!("{}.pid", name)),
+            std::process::id().to_string(),
+        )
+        .unwrap();
+
+        let process = stale_process(name);
+        assert!(
+            process.is_alive(),
+            "binary worker pidfile should keep is_alive true past the grace window"
+        );
+    }
+
+    /// VM/OCI workers write their pid to `~/.iii/managed/{name}/vm.pid`.
+    /// Ensures the dual-candidate refactor didn't break the original path.
+    #[test]
+    fn is_alive_finds_vm_worker_pidfile() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = HomeGuard::new(tmp.path());
+
+        let name = "vm-worker";
+        let managed_dir = tmp.path().join(".iii/managed").join(name);
+        std::fs::create_dir_all(&managed_dir).unwrap();
+        std::fs::write(managed_dir.join("vm.pid"), std::process::id().to_string()).unwrap();
+
+        let process = stale_process(name);
+        assert!(
+            process.is_alive(),
+            "vm.pid must still be honored after the dual-candidate refactor"
+        );
+    }
+
+    /// No pidfile at either candidate and the grace window has elapsed →
+    /// worker is dead. This is the signal `promote_dead_unchanged` uses to
+    /// force a restart on reload.
+    #[test]
+    fn is_alive_returns_false_when_no_pidfile_and_grace_elapsed() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = HomeGuard::new(tmp.path());
+
+        let process = stale_process("ghost-worker");
+        assert!(
+            !process.is_alive(),
+            "no pidfile + grace window elapsed should report dead"
+        );
+    }
+
+    /// Within the grace window, a missing pidfile is treated as "still
+    /// booting", not dead. This is what keeps fresh `iii-worker start` calls
+    /// from being immediately flagged for restart.
+    #[test]
+    fn is_alive_returns_true_within_grace_window() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = HomeGuard::new(tmp.path());
+
+        let process = ExternalWorkerProcess {
+            name: "booting-worker".to_string(),
+            child: Arc::new(Mutex::new(None)),
+            spawned_at: std::time::Instant::now(),
+        };
+        assert!(
+            process.is_alive(),
+            "freshly spawned worker with no pidfile yet must be alive during grace window"
+        );
+    }
+
     #[test]
     fn external_worker_wrapper_name_format() {
         let process = ExternalWorkerProcess {
@@ -316,5 +528,65 @@ mod tests {
         };
         let wrapper = ExternalWorkerWrapper::new(process);
         assert!(wrapper.destroy().await.is_ok());
+    }
+
+    /// The engine/CLI IPC contract: argv is `start <name> --port <port>` in
+    /// that exact order. `iii-worker`'s clap parser is matched to this shape
+    /// (see `crates/iii-worker/tests/worker_integration.rs::
+    /// start_subcommand_matches_engine_spawn_args`). Drift here silently
+    /// re-breaks non-default `iii-worker-manager` port setups — the exact
+    /// regression this whole module exists to fix.
+    #[test]
+    fn spawn_args_emit_start_name_port_in_order() {
+        let args = spawn_args("pdfkit", 49199);
+        assert_eq!(
+            args,
+            [
+                "start".to_string(),
+                "pdfkit".to_string(),
+                "--port".to_string(),
+                "49199".to_string()
+            ],
+        );
+    }
+
+    #[test]
+    fn spawn_args_default_port_serializes_as_digits() {
+        // Pin that port formatting is decimal digits, not something clap
+        // would reject like "0x1234". u16::MAX is the boundary case.
+        let args = spawn_args("x", u16::MAX);
+        assert_eq!(args[3], "65535");
+    }
+
+    /// Intern cache caps the Box::leak growth: the same worker name must
+    /// resolve to the same `&'static str` across wrappers. If this flips
+    /// (e.g. someone removes the HashMap lookup), every config reload will
+    /// leak a fresh string for the same name and the original unbounded-
+    /// growth bug returns.
+    #[test]
+    fn intern_display_name_returns_same_pointer_for_same_name() {
+        let a = intern_display_name("interned-worker");
+        let b = intern_display_name("interned-worker");
+        assert!(
+            std::ptr::eq(a.as_ptr(), b.as_ptr()),
+            "same name must intern to the same allocation"
+        );
+    }
+
+    #[test]
+    fn intern_display_name_differs_across_names() {
+        let a = intern_display_name("worker-a-unique");
+        let b = intern_display_name("worker-b-unique");
+        assert_ne!(a, b);
+        assert!(a.contains("worker-a-unique"));
+        assert!(b.contains("worker-b-unique"));
+    }
+
+    #[test]
+    fn pid_file_candidates_orders_vm_then_binary() {
+        let home = std::path::Path::new("/fake/home/.iii");
+        let got = pid_file_candidates(home, "demo");
+        assert_eq!(got[0], home.join("managed/demo/vm.pid"));
+        assert_eq!(got[1], home.join("pids/demo.pid"));
     }
 }

--- a/engine/src/workers/registry_worker.rs
+++ b/engine/src/workers/registry_worker.rs
@@ -55,10 +55,30 @@ pub fn resolve_iii_worker_binary() -> Option<PathBuf> {
 pub struct ExternalWorkerProcess {
     pub name: String,
     pub child: Arc<Mutex<Option<tokio::process::Child>>>,
+    /// When the process was spawned. `is_alive` grants a grace window from
+    /// this instant to cover the gap between `iii-worker start` exiting and
+    /// the detached VM writing its pidfile.
+    pub spawned_at: std::time::Instant,
 }
 
+/// How long after spawn we trust "still booting, no pidfile yet" as alive.
+///
+/// iii-worker start returns immediately after forking the detached VM boot
+/// process. The VM then provisions rootfs, installs deps, and writes
+/// `~/.iii/managed/{name}/vm.pid` only once libkrun is up. On a warm cache
+/// this is sub-second; a cold first-boot with dep install can take tens of
+/// seconds. 30s is conservative enough to avoid false-negative "dead" reads
+/// during boot without masking a genuine crash for long.
+const SPAWN_GRACE: std::time::Duration = std::time::Duration::from_secs(30);
+
 impl ExternalWorkerProcess {
-    pub async fn spawn(name: &str, port: u16) -> Result<Self, String> {
+    /// Spawns `iii-worker start <name>` as a detached child. The CLI reads the
+    /// engine port from its own `DEFAULT_PORT` constant (which must stay in
+    /// lockstep with the engine's), so we intentionally do NOT pass `--port`
+    /// here -- `iii worker start` does not expose that flag and clap will
+    /// reject it with exit 2, silently breaking auto-start for every
+    /// non-builtin worker.
+    pub async fn spawn(name: &str) -> Result<Self, String> {
         let worker_binary = resolve_iii_worker_binary()
             .ok_or_else(|| {
                 "iii-worker binary not found. Install with `iii update worker` or place in ~/.local/bin/".to_string()
@@ -77,7 +97,7 @@ impl ExternalWorkerProcess {
             .map_err(|e| format!("Failed to create stderr log: {}", e))?;
 
         let mut cmd = tokio::process::Command::new(&worker_binary);
-        cmd.args(["start", "--port", &port.to_string(), "--", name])
+        cmd.args(["start", name])
             .stdout(stdout_file)
             .stderr(stderr_file);
 
@@ -94,7 +114,49 @@ impl ExternalWorkerProcess {
         Ok(Self {
             name: name.to_string(),
             child: Arc::new(Mutex::new(Some(child))),
+            spawned_at: std::time::Instant::now(),
         })
+    }
+
+    /// Probes whether the detached worker process is still alive.
+    ///
+    /// The real VM PID lives in `~/.iii/managed/{name}/vm.pid` — the tokio
+    /// `Child` handle is stale because `iii-worker start` exits immediately
+    /// after spawning the detached boot process.
+    ///
+    /// Returns:
+    /// - `true` if a pidfile exists and the PID responds to signal 0
+    /// - `true` if we're still inside the post-spawn grace window (VM might
+    ///   just be finishing boot and writing its pidfile)
+    /// - `false` otherwise (crashed, force-stopped, or never booted)
+    pub fn is_alive(&self) -> bool {
+        let pidfile = dirs::home_dir()
+            .unwrap_or_default()
+            .join(".iii/managed")
+            .join(&self.name)
+            .join("vm.pid");
+
+        if let Ok(s) = std::fs::read_to_string(&pidfile)
+            && let Ok(pid) = s.trim().parse::<u32>()
+        {
+            #[cfg(unix)]
+            {
+                use nix::sys::signal::kill;
+                use nix::unistd::Pid;
+                if kill(Pid::from_raw(pid as i32), None).is_ok() {
+                    return true;
+                }
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = pid;
+                return true;
+            }
+        }
+
+        // No pidfile (or stale/dead pid). Grant a grace window from spawn
+        // so we don't misread a still-booting worker as dead.
+        self.spawned_at.elapsed() < SPAWN_GRACE
     }
 
     pub async fn stop(&self) {
@@ -187,6 +249,10 @@ impl Worker for ExternalWorkerWrapper {
         Ok(())
     }
 
+    async fn is_alive(&self) -> bool {
+        self.process.is_alive()
+    }
+
     fn register_functions(&self, _engine: Arc<Engine>) {
         // External workers register their own functions via the bridge protocol
     }
@@ -210,6 +276,7 @@ mod tests {
         let process = ExternalWorkerProcess {
             name: "test-worker".to_string(),
             child: Arc::new(Mutex::new(None)),
+            spawned_at: std::time::Instant::now(),
         };
         let wrapper = ExternalWorkerWrapper::new(process);
         assert_eq!(wrapper.name(), "ExternalWorker(test-worker)");
@@ -229,6 +296,7 @@ mod tests {
         let process = ExternalWorkerProcess {
             name: "init-test".to_string(),
             child: Arc::new(Mutex::new(None)),
+            spawned_at: std::time::Instant::now(),
         };
         let wrapper = ExternalWorkerWrapper::new(process);
         assert!(wrapper.initialize().await.is_ok());
@@ -239,6 +307,7 @@ mod tests {
         let process = ExternalWorkerProcess {
             name: "destroy-test".to_string(),
             child: Arc::new(Mutex::new(None)),
+            spawned_at: std::time::Instant::now(),
         };
         let wrapper = ExternalWorkerWrapper::new(process);
         assert!(wrapper.destroy().await.is_ok());

--- a/engine/src/workers/reload.rs
+++ b/engine/src/workers/reload.rs
@@ -141,6 +141,53 @@ impl ReloadManager {
         Ok(entries)
     }
 
+    /// Walks `diff.unchanged` and asks each tracked worker whether its
+    /// backing process is still alive. Dead ones get pulled out of
+    /// `unchanged` and pushed into `changed` so the commit step will
+    /// destroy + restart them.
+    ///
+    /// This fixes the class of bugs where the engine's `running` list
+    /// believes a worker is up but its detached VM / child process has died
+    /// or been reaped out of band — most commonly via
+    /// `iii worker add --force`, which wipes the managed dir and rewrites
+    /// config.yaml with a structurally identical entry, leaving diff with
+    /// nothing to do.
+    ///
+    /// Returns the list of names that were promoted so the caller can log
+    /// them (e.g. in the reload summary).
+    pub async fn promote_dead_unchanged(
+        diff: &mut ReloadDiff,
+        new_entries: &[WorkerEntry],
+        running: &[RunningWorker],
+    ) -> Vec<String> {
+        let new_by_name: HashMap<&str, &WorkerEntry> =
+            new_entries.iter().map(|e| (e.name.as_str(), e)).collect();
+        let mut promoted: Vec<String> = Vec::new();
+        let mut still_unchanged: Vec<String> = Vec::with_capacity(diff.unchanged.len());
+        for name in diff.unchanged.drain(..) {
+            let is_alive = match running.iter().find(|rw| rw.entry.name == name) {
+                Some(rw) => rw.worker.is_alive().await,
+                None => true, // no tracked worker — can't assess, leave alone
+            };
+            if is_alive {
+                still_unchanged.push(name);
+            } else if let Some(entry) = new_by_name.get(name.as_str()) {
+                tracing::warn!(
+                    worker = %name,
+                    "reload: tracked worker is dead, promoting to CHANGED for restart"
+                );
+                diff.changed.push((*entry).clone());
+                promoted.push(name);
+            } else {
+                // unchanged must appear in new_entries by construction of
+                // diff_entries; this branch is a defensive fallback.
+                still_unchanged.push(name);
+            }
+        }
+        diff.unchanged = still_unchanged;
+        promoted
+    }
+
     /// Refuse removal of mandatory workers.
     pub fn enforce_guards(diff: &ReloadDiff) -> anyhow::Result<()> {
         let mandatory_names: std::collections::HashSet<&'static str> =
@@ -301,12 +348,16 @@ impl ReloadManager {
         })?;
 
         let old_entries: Vec<WorkerEntry> = running.iter().map(|rw| rw.entry.clone()).collect();
-        let diff = diff_entries(&old_entries, &new_entries);
+        let mut diff = diff_entries(&old_entries, &new_entries);
+
+        let promoted = Self::promote_dead_unchanged(&mut diff, &new_entries, running).await;
+
         tracing::info!(
-            "reload: diff +{} added, -{} removed, ~{} changed, ={} unchanged",
+            "reload: diff +{} added, -{} removed, ~{} changed ({} revived), ={} unchanged",
             diff.added.len(),
             diff.removed.len(),
             diff.changed.len(),
+            promoted.len(),
             diff.unchanged.len(),
         );
 

--- a/engine/src/workers/reload.rs
+++ b/engine/src/workers/reload.rs
@@ -162,10 +162,14 @@ impl ReloadManager {
     ) -> Vec<String> {
         let new_by_name: HashMap<&str, &WorkerEntry> =
             new_entries.iter().map(|e| (e.name.as_str(), e)).collect();
+        let running_by_name: HashMap<&str, &RunningWorker> = running
+            .iter()
+            .map(|rw| (rw.entry.name.as_str(), rw))
+            .collect();
         let mut promoted: Vec<String> = Vec::new();
         let mut still_unchanged: Vec<String> = Vec::with_capacity(diff.unchanged.len());
         for name in diff.unchanged.drain(..) {
-            let is_alive = match running.iter().find(|rw| rw.entry.name == name) {
+            let is_alive = match running_by_name.get(name.as_str()) {
                 Some(rw) => rw.worker.is_alive().await,
                 None => true, // no tracked worker — can't assess, leave alone
             };

--- a/engine/src/workers/traits.rs
+++ b/engine/src/workers/traits.rs
@@ -73,6 +73,19 @@ pub trait Worker: Send + Sync {
         Ok(())
     }
 
+    /// Reports whether the backing process/state for this worker is still
+    /// alive. Used by the reloader to detect workers whose external VM or
+    /// child process died without the engine noticing — those get promoted
+    /// from `unchanged` to `changed` on the next config reload so they get
+    /// rebooted instead of being skipped.
+    ///
+    /// Default is `true`: built-in, in-process workers are alive as long as
+    /// the engine is alive. Override for workers that track out-of-process
+    /// state (e.g. detached VMs via pidfile).
+    async fn is_alive(&self) -> bool {
+        true
+    }
+
     /// Registers functions to the engine
     #[allow(unused_variables)]
     fn register_functions(&self, engine: Arc<Engine>) {

--- a/engine/tests/reload_manager_unit.rs
+++ b/engine/tests/reload_manager_unit.rs
@@ -1,8 +1,11 @@
 use std::io::Write;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use iii::EngineBuilder;
 use iii::workers::config::{EngineConfig, WorkerEntry};
-use iii::workers::reload::{ReloadDiff, ReloadManager};
+use iii::workers::reload::{ReloadDiff, ReloadManager, RunningWorker, WorkerRegistrations};
+use iii::workers::traits::Worker;
 
 fn write_config(contents: &str) -> tempfile::NamedTempFile {
     let mut f = tempfile::NamedTempFile::new().expect("tempfile");
@@ -177,4 +180,133 @@ fn enforce_guards_allows_removing_non_mandatory_workers() {
 #[test]
 fn enforce_guards_allows_empty_diff() {
     assert!(ReloadManager::enforce_guards(&ReloadDiff::default()).is_ok());
+}
+
+// -----------------------------------------------------------------------------
+// Test helpers: a bare-minimum Worker that reports a configurable is_alive
+// value so we can drive promote_dead_unchanged deterministically.
+// -----------------------------------------------------------------------------
+
+struct TestWorker {
+    alive: AtomicBool,
+}
+
+#[async_trait::async_trait]
+impl Worker for TestWorker {
+    fn name(&self) -> &'static str {
+        "test-worker"
+    }
+
+    async fn create(
+        _engine: Arc<iii::engine::Engine>,
+        _config: Option<serde_json::Value>,
+    ) -> anyhow::Result<Box<dyn Worker>>
+    where
+        Self: Sized,
+    {
+        Err(anyhow::anyhow!("TestWorker::create not used in unit tests"))
+    }
+
+    async fn initialize(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::Relaxed)
+    }
+}
+
+fn running_worker(name: &str, alive: bool) -> RunningWorker {
+    let entry = WorkerEntry {
+        name: name.to_string(),
+        image: None,
+        config: None,
+    };
+    let worker: Arc<dyn Worker> = Arc::new(TestWorker {
+        alive: AtomicBool::new(alive),
+    });
+    let (shutdown_tx, _) = tokio::sync::watch::channel(false);
+    RunningWorker {
+        entry,
+        worker,
+        shutdown_tx,
+        registrations: WorkerRegistrations::default(),
+    }
+}
+
+#[tokio::test]
+async fn promote_dead_unchanged_leaves_live_workers_alone() {
+    let running = vec![running_worker("alive-worker", true)];
+    let new_entries = vec![WorkerEntry {
+        name: "alive-worker".into(),
+        image: None,
+        config: None,
+    }];
+    let mut diff = ReloadDiff {
+        unchanged: vec!["alive-worker".into()],
+        ..Default::default()
+    };
+
+    let promoted = ReloadManager::promote_dead_unchanged(&mut diff, &new_entries, &running).await;
+
+    assert_eq!(promoted, Vec::<String>::new(), "nothing should be promoted");
+    assert_eq!(diff.unchanged, vec!["alive-worker".to_string()]);
+    assert!(diff.changed.is_empty());
+}
+
+#[tokio::test]
+async fn promote_dead_unchanged_revives_dead_worker() {
+    // This is the regression test for `iii worker add ./w --force` not
+    // restarting the VM: the CLI rewrites config.yaml with the same entry,
+    // the diff says unchanged, but the tracked worker is dead. The reloader
+    // must promote it to `changed` so commit() destroys + restarts.
+    let running = vec![
+        running_worker("alive-worker", true),
+        running_worker("dead-worker", false),
+    ];
+    let new_entries = vec![
+        WorkerEntry {
+            name: "alive-worker".into(),
+            image: None,
+            config: None,
+        },
+        WorkerEntry {
+            name: "dead-worker".into(),
+            image: None,
+            config: None,
+        },
+    ];
+    let mut diff = ReloadDiff {
+        unchanged: vec!["alive-worker".into(), "dead-worker".into()],
+        ..Default::default()
+    };
+
+    let promoted = ReloadManager::promote_dead_unchanged(&mut diff, &new_entries, &running).await;
+
+    assert_eq!(promoted, vec!["dead-worker".to_string()]);
+    assert_eq!(diff.unchanged, vec!["alive-worker".to_string()]);
+    assert_eq!(diff.changed.len(), 1);
+    assert_eq!(diff.changed[0].name, "dead-worker");
+}
+
+#[tokio::test]
+async fn promote_dead_unchanged_skips_entries_without_a_tracked_worker() {
+    // Defensive: if diff.unchanged contains a name not in `running`, we
+    // cannot assess liveness. Leave it alone rather than dropping it.
+    let running: Vec<RunningWorker> = Vec::new();
+    let new_entries = vec![WorkerEntry {
+        name: "orphan".into(),
+        image: None,
+        config: None,
+    }];
+    let mut diff = ReloadDiff {
+        unchanged: vec!["orphan".into()],
+        ..Default::default()
+    };
+
+    let promoted = ReloadManager::promote_dead_unchanged(&mut diff, &new_entries, &running).await;
+
+    assert!(promoted.is_empty());
+    assert_eq!(diff.unchanged, vec!["orphan".to_string()]);
+    assert!(diff.changed.is_empty());
 }


### PR DESCRIPTION
## Summary

Two problems on one branch:

1. **Binary workers never auto-started when `iii start` booted the engine.** The DX review on `feat/workspace-live-sync` removed `--port`/`--address` from `iii worker start`, but `engine/src/workers/registry_worker.rs` was still spawning `iii-worker start --port <n> -- <name>`. Clap rejected with exit 2, engine ignored the exit code (detached spawn), and every non-builtin worker silently failed to come up. Fix: drop `--port` from the spawn args and simplify the function signature.
2. **The CLI DX for `start`/`stop`/`remove`/`clear` was rough.** Unknown workers and already-stopped workers produced the same output, the status watcher hung forever on binary workers hunting for a `.iii-prepared` marker that would never be written, `start` leaked `pid: Some(48350)` from Option debug formatting, and `remove` had no batch confirmation.

### What changed

**CLI**
- New: `iii worker restart <name>` (stop-if-running, then start; idempotent).
- `start`/`stop`/`remove`/`clear` disambiguate unknown-vs-already-stopped and emit the worker name on stdout so the output is pipeable.
- `start` drops unused `--address`/`--port`. `stop` drops the same.
- `remove` adds `--yes` and a batch confirmation when any target is running.
- Status: binary workers go `Ready` when alive (no VM, no marker to wait for). Sandbox row shows `n/a (binary worker runs on host)`. Headline never bleeds "installing deps inside VM" for a host process.
- `start <binary>` now prints `pid: N` instead of `pid: Some(N)`.

**Engine**
- `ExternalWorkerProcess::spawn` drops `--port` and the now-dead `port` parameter.

**Tests**
- Lock the engine ↔ CLI IPC contract so this can't silently break again:
  - `start_subcommand_matches_engine_spawn_args` (positive)
  - `start_subcommand_rejects_port_flag` (fail loud if anyone re-adds `--port`)
- `binary_worker_alive_headline_and_render` regression for the status rendering.
- `config_managed`/`config_clear`/`config_force` suites updated for the new disambiguation rules and short-circuit exit codes.

**Result:** 2152 tests pass across 46 suites (iii + iii-worker).

## Test plan

- [x] `cargo test -p iii -p iii-worker` — 2152 passed, 9 ignored
- [x] Reproduced the original bug: `iii-worker start --port 49134 -- image-resize` → `error: unexpected argument '--port' found` (exit 2) before fix
- [x] Verified post-fix: `iii-worker start image-resize` → `✓ image-resize started (pid: 86185)`
- [x] `iii worker status image-resize` on a running binary now terminates on `ready` instead of spinning forever
- [ ] Smoke test end-to-end: `iii worker add image-resize`, `iii start`, confirm worker comes up automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-blocking flags for add/start/restart (run without waiting)
  * --yes/-y on remove to skip confirmations
  * restart subcommand (stop-then-start) and status subcommand with one-shot vs live watch

* **Bug Fixes**
  * Clearer, more actionable error and confirmation messaging
  * More accurate, observable worker liveness and status reporting; improved start/stop/reload behavior and CLI output semantics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->