### PR TITLE
ci(release): sync Cargo.lock in version bump, unblock bench-release

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -253,6 +253,10 @@ jobs:
           sed -i "0,/^version = \".*\"/{s/^version = \".*\"/version = \"${NEW_VERSION}\"/}" console/packages/console-rust/Cargo.toml
           echo "Updated console/packages/console-rust/Cargo.toml to $NEW_VERSION"
 
+      - name: Sync Cargo.lock
+        if: inputs.target == 'iii' && inputs.dry_run != true
+        run: cargo update --workspace
+
       - name: Update motia manifests
         if: inputs.target == 'motia' && inputs.dry_run != true
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "iii"
-version = "0.11.0-next.10"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "iii-console"
-version = "0.11.0-next.10"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2537,7 +2537,7 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.11.0-next.10"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "ctor",


### PR DESCRIPTION
## Summary

- `create-tag.yml` bumps workspace `Cargo.toml` versions but never regenerates `Cargo.lock`, so the release commit ships with a stale lockfile.
- On the release tag, `bench-release.yml` runs `cargo bench`, which rewrites `Cargo.lock` in place. The `benchmark-action/github-action-benchmark@v1` step then tries `git switch gh-pages` and aborts because uncommitted Cargo.lock changes would be overwritten (see [failed run](https://github.com/iii-hq/iii/actions/runs/24428708903/job/71368282285)).

## Changes

- Add a `cargo update --workspace` step to `create-tag.yml` right after the Cargo.toml bumps. It only touches workspace-member entries (no dep upgrades), so the refreshed lockfile is picked up by the existing `git add -A && git commit`.
- Sync `Cargo.lock` on `main` as a one-shot: workspace members (`iii`, `iii-console`, `iii-sdk`) go from `0.11.0-next.10` → `0.11.0` to match the already-released `7a97fadf`.

## Test plan

- [ ] Manually re-run the failed `bench-release` workflow on the `iii/v0.11.0` tag (or cut a dry-run tag) and confirm the `Store benchmark result` step no longer aborts on `git switch gh-pages`.
- [ ] On next real release, confirm the version-bump commit includes `Cargo.lock` alongside the Cargo.toml changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal CI workflow processes to maintain consistency during version releases.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->