### PR TITLE
fix(observability): accept quoted int64 for asInt in OTLP metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "iii"
-version = "0.11.0-next.10"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "iii-console"
-version = "0.11.0-next.10"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2537,7 +2537,7 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.11.0-next.10"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "ctor",

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -1815,7 +1815,7 @@ struct OtlpNumberDataPoint {
     time_unix_nano: OtlpNumericString,
     #[serde(default)]
     as_double: Option<f64>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_int64_string_or_number")]
     as_int: Option<i64>,
 }
 
@@ -3124,6 +3124,62 @@ mod tests {
             Some("iii-py")
         );
         assert_eq!(metrics[0].instrumentation_scope_version, None);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_ingest_otlp_metrics_asint_as_string() {
+        // Regression: OTLP protobuf int64 fields are encoded as JSON strings
+        // (because JS cannot safely represent all 64-bit integers). The Python
+        // SDK emits `"asInt": "2048"` rather than `"asInt": 2048`, so the Rust
+        // NumberDataPoint deserializer must accept both forms.
+        crate::workers::observability::metrics::init_metric_storage(Some(100), Some(3600));
+        if let Some(storage) = crate::workers::observability::metrics::get_metric_storage() {
+            storage.clear();
+        }
+
+        let otlp_json = r#"{
+            "resourceMetrics": [{
+                "resource": {
+                    "attributes": [{
+                        "key": "service.name",
+                        "value": {"stringValue": "iii-py"}
+                    }]
+                },
+                "scopeMetrics": [{
+                    "scope": {"name": "iii-py", "version": ""},
+                    "metrics": [{
+                        "name": "iii.worker.memory.rss",
+                        "description": "",
+                        "unit": "bytes",
+                        "gauge": {
+                            "dataPoints": [{
+                                "attributes": [],
+                                "timeUnixNano": "1704067200000000000",
+                                "asInt": "2048"
+                            }]
+                        }
+                    }]
+                }]
+            }]
+        }"#;
+
+        let result = ingest_otlp_metrics(otlp_json).await;
+        assert!(
+            result.is_ok(),
+            "asInt encoded as a quoted string should parse: {result:?}"
+        );
+
+        let storage = crate::workers::observability::metrics::get_metric_storage().unwrap();
+        let metrics = storage.get_metrics();
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics[0].name, "iii.worker.memory.rss");
+        match &metrics[0].data_points[0] {
+            crate::workers::observability::metrics::StoredDataPoint::Number(dp) => {
+                assert_eq!(dp.value, 2048.0);
+            }
+            _ => panic!("expected number data point"),
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Follow-up to #1479. A new variant of the same class of bug was still firing in production:

```
[WARN] iii::engine Metrics ingestion error
    ├ peer: 127.0.0.1:58952
    └ error: Failed to parse OTLP metrics JSON: invalid type: string "2048", expected i64 at line 1 column 1092
```

## Root cause

OTLP JSON encodes int64 fields as quoted strings to preserve full precision across JavaScript runtimes (where `Number.MAX_SAFE_INTEGER` is `2^53 - 1`). This is the same reason `timeUnixNano` is a string. The Python SDK's `_serialize_metrics` follows this convention at `sdk/packages/python/iii/src/iii/telemetry_exporters.py:359`:

```python
if isinstance(val, int):
    dp["asInt"] = str(val)
```

So integer counters and gauges like `iii.worker.memory.rss` emit `"asInt": "2048"` on the wire.

The Rust engine already has a `deserialize_int64_string_or_number` helper (used for `OtlpAnyValue.int_value`) that accepts both JSON number and quoted-string forms. But `OtlpNumberDataPoint.as_int: Option<i64>` at `engine/src/workers/observability/otel.rs:1819` only had `#[serde(default)]` — no custom deserializer — so raw serde rejected the string form with the warning above.

## Fix

Wire the existing helper to `as_int`:

```rust
#[serde(default, deserialize_with = "deserialize_int64_string_or_number")]
as_int: Option<i64>,
```

No Python changes — the Python serializer is already OTLP-spec-compliant; the Rust side was the non-compliant end.

## Test plan

- [x] New regression test `test_ingest_otlp_metrics_asint_as_string` that feeds an OTLP JSON payload with `"asInt": "2048"` and asserts ingestion succeeds with `dp.value == 2048.0`. Verified RED before the fix, GREEN after.
- [x] `cargo test -p iii --lib workers::observability::otel::tests` — 97 passed, 0 failed.
- [x] `cargo fmt --all -- --check` — clean.

## Incidental

`Cargo.lock` updated to catch up to the `0.11.0` version bump from `7a97fadf` (that commit only touched `Cargo.toml` files), required so the engine tests still build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTLP metrics ingestion to handle integer values in multiple formats (JSON numbers and quoted strings), enabling compatibility with a wider range of metric data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->