### PR TITLE
feat(website): serve iii.dev/docs in place instead of 301-redirecting

### DIFF
--- a/infra/terraform/website/cloudfront.tf
+++ b/infra/terraform/website/cloudfront.tf
@@ -28,7 +28,7 @@ resource "aws_cloudfront_origin_access_control" "site" {
 resource "aws_cloudfront_function" "redirects" {
   name    = "iii-website-prod-redirects"
   runtime = "cloudfront-js-2.0"
-  comment = "viewer-request: www->apex, /docs->docs.iii.dev, /llms.txt redirect, SPA fallback"
+  comment = "viewer-request (default behavior only): www->apex, SPA fallback. /docs* is on its own behavior -> docs-nlb origin."
   publish = true
   code    = file("${path.module}/cloudfront_functions/redirects.js")
 }
@@ -118,6 +118,31 @@ resource "aws_cloudfront_distribution" "site" {
     }
   }
 
+  # docs-nlb: serves iii.dev/docs* in place instead of redirecting to docs.iii.dev.
+  # COUPLING: origin domain_name is var.docs_domain (docs.iii.dev) because CloudFront
+  # uses it for origin TLS SNI, and ingress-nginx serves the iii-dev-tls-docs cert for
+  # that SNI. The viewer's Host header (iii.dev) is forwarded via the AllViewer origin
+  # request policy on the /docs* cache behaviors below, so ingress-nginx routes the
+  # request via the iii-dev Ingress → iii-edge-proxy default server block → /docs
+  # location → motiadev.mintlify.dev.
+  #
+  # IMPORTANT: when docs.iii.dev migrates off the k8s NLB to a Mintlify custom domain
+  # (see infra/terraform/website/NEXT-STEPS.md item 13), this origin must be repointed
+  # in the same change or iii.dev/docs will break.
+  origin {
+    origin_id   = "docs-nlb"
+    domain_name = var.docs_domain
+
+    custom_origin_config {
+      http_port                = 80
+      https_port               = 443
+      origin_protocol_policy   = "https-only"
+      origin_ssl_protocols     = ["TLSv1.2"]
+      origin_keepalive_timeout = 5
+      origin_read_timeout      = 30
+    }
+  }
+
   default_cache_behavior {
     target_origin_id       = "s3-site"
     viewer_protocol_policy = "redirect-to-https"
@@ -148,6 +173,45 @@ resource "aws_cloudfront_distribution" "site" {
     response_headers_policy_id = aws_cloudfront_response_headers_policy.site.id
 
     # No function_association: SPA fallback must not rewrite /api/search responses.
+  }
+
+  # /docs (exact) and /docs/* → docs-nlb. Two behaviors are required because CloudFront
+  # path patterns are literal: `/docs` matches only the exact path, `/docs/*` matches
+  # everything under it.
+  #
+  # No function_association: the redirects function's SPA fallback would rewrite
+  # /docs/quickstart to /index.html and the www→apex redirect is intentionally
+  # skipped here (see redirects.test.js note — www.iii.dev/docs/foo reaches Mintlify
+  # without canonicalization, accepted trade-off).
+  #
+  # No response_headers_policy: Mintlify emits its own Cache-Control and security
+  # headers; the site CSP would break Mintlify's inline scripts.
+  #
+  # cache_policy_disabled mirrors search-api: predictable "no stale docs" story,
+  # at the cost of every request round-tripping to the origin. Revisit once we
+  # have a signal on traffic / origin cost.
+  ordered_cache_behavior {
+    path_pattern           = "/docs"
+    target_origin_id       = "docs-nlb"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    cache_policy_id          = local.cache_policy_disabled_id
+    origin_request_policy_id = local.origin_request_all_viewer_id
+  }
+
+  ordered_cache_behavior {
+    path_pattern           = "/docs/*"
+    target_origin_id       = "docs-nlb"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    cache_policy_id          = local.cache_policy_disabled_id
+    origin_request_policy_id = local.origin_request_all_viewer_id
   }
 
   viewer_certificate {

--- a/infra/terraform/website/cloudfront.tf
+++ b/infra/terraform/website/cloudfront.tf
@@ -28,7 +28,7 @@ resource "aws_cloudfront_origin_access_control" "site" {
 resource "aws_cloudfront_function" "redirects" {
   name    = "iii-website-prod-redirects"
   runtime = "cloudfront-js-2.0"
-  comment = "viewer-request (default behavior only): www->apex, SPA fallback. /docs* is on its own behavior -> docs-nlb origin."
+  comment = "viewer-request (default behavior only): www->apex, SPA fallback"
   publish = true
   code    = file("${path.module}/cloudfront_functions/redirects.js")
 }
@@ -118,17 +118,9 @@ resource "aws_cloudfront_distribution" "site" {
     }
   }
 
-  # docs-nlb: serves iii.dev/docs* in place instead of redirecting to docs.iii.dev.
-  # COUPLING: origin domain_name is var.docs_domain (docs.iii.dev) because CloudFront
-  # uses it for origin TLS SNI, and ingress-nginx serves the iii-dev-tls-docs cert for
-  # that SNI. The viewer's Host header (iii.dev) is forwarded via the AllViewer origin
-  # request policy on the /docs* cache behaviors below, so ingress-nginx routes the
-  # request via the iii-dev Ingress → iii-edge-proxy default server block → /docs
-  # location → motiadev.mintlify.dev.
-  #
-  # IMPORTANT: when docs.iii.dev migrates off the k8s NLB to a Mintlify custom domain
-  # (see infra/terraform/website/NEXT-STEPS.md item 13), this origin must be repointed
-  # in the same change or iii.dev/docs will break.
+  # domain_name is docs.iii.dev so origin TLS SNI matches iii-dev-tls-docs at
+  # ingress-nginx; the /docs* behaviors forward Host: iii.dev via AllViewer.
+  # Coupled to docs.iii.dev staying on the k8s NLB (see NEXT-STEPS.md item 13).
   origin {
     origin_id   = "docs-nlb"
     domain_name = var.docs_domain
@@ -175,21 +167,11 @@ resource "aws_cloudfront_distribution" "site" {
     # No function_association: SPA fallback must not rewrite /api/search responses.
   }
 
-  # /docs (exact) and /docs/* → docs-nlb. Two behaviors are required because CloudFront
-  # path patterns are literal: `/docs` matches only the exact path, `/docs/*` matches
-  # everything under it.
-  #
+  # Two behaviors because CloudFront path patterns are literal: /docs matches
+  # only the exact path, /docs/* matches everything under it.
   # No function_association: the redirects function's SPA fallback would rewrite
-  # /docs/quickstart to /index.html and the www→apex redirect is intentionally
-  # skipped here (see redirects.test.js note — www.iii.dev/docs/foo reaches Mintlify
-  # without canonicalization, accepted trade-off).
-  #
-  # No response_headers_policy: Mintlify emits its own Cache-Control and security
-  # headers; the site CSP would break Mintlify's inline scripts.
-  #
-  # cache_policy_disabled mirrors search-api: predictable "no stale docs" story,
-  # at the cost of every request round-tripping to the origin. Revisit once we
-  # have a signal on traffic / origin cost.
+  # /docs/quickstart to /index.html.
+  # No response_headers_policy: the site CSP would break Mintlify's inline scripts.
   ordered_cache_behavior {
     path_pattern           = "/docs"
     target_origin_id       = "docs-nlb"

--- a/infra/terraform/website/cloudfront_functions/redirects.js
+++ b/infra/terraform/website/cloudfront_functions/redirects.js
@@ -1,6 +1,4 @@
 // Viewer-request handler for the default (S3) behavior. Tested in redirects.test.js.
-// /docs* is handled by its own ordered cache behavior against the docs-nlb origin
-// (see cloudfront.tf), so it never reaches this function.
 
 function redirect(location) {
   return {

--- a/infra/terraform/website/cloudfront_functions/redirects.js
+++ b/infra/terraform/website/cloudfront_functions/redirects.js
@@ -1,5 +1,6 @@
 // Viewer-request handler for the default (S3) behavior. Tested in redirects.test.js.
-// /docs redirects preserve the /docs prefix because Mintlify serves content under /docs/...
+// /docs* is handled by its own ordered cache behavior against the docs-nlb origin
+// (see cloudfront.tf), so it never reaches this function.
 
 function redirect(location) {
   return {
@@ -18,10 +19,6 @@ function handler(event) {
   var request = event.request
   var uri = request.uri
   var host = request.headers && request.headers.host ? request.headers.host.value : undefined
-
-  if (uri === '/docs') return redirect('https://docs.iii.dev/docs')
-  if (uri === '/docs/') return redirect('https://docs.iii.dev/docs/')
-  if (uri.indexOf('/docs/') === 0) return redirect(`https://docs.iii.dev${uri}`)
 
   if (host === 'www.iii.dev') return redirect(`https://iii.dev${uri}`)
 

--- a/infra/terraform/website/cloudfront_functions/redirects.test.js
+++ b/infra/terraform/website/cloudfront_functions/redirects.test.js
@@ -39,28 +39,24 @@ function locationOf(result) {
   return result.headers.location.value
 }
 
-test('/docs exact → 301 https://docs.iii.dev/docs', () => {
+// NOTE: /docs and /docs/* paths are handled by dedicated ordered_cache_behaviors
+// against the docs-nlb origin (see cloudfront.tf) and never reach this function in
+// production. These tests document that the function no longer rewrites or
+// redirects anything under /docs so a future regression is caught immediately.
+
+test('/docs → function does not redirect (handled by docs-nlb behavior in prod)', () => {
   const result = handler(buildEvent('/docs', 'iii.dev'))
-  assert.ok(isRedirect(result))
-  assert.equal(locationOf(result), 'https://docs.iii.dev/docs')
+  assert.ok(!isRedirect(result), 'must not be a 301 — /docs is served from the NLB origin')
+  // /docs has no dot in the last segment and no trailing slash, so SPA fallback kicks in.
+  // In production this function isn't attached to the /docs behavior, so it's moot — but
+  // we pin the current function-level behavior to catch accidental reintroductions.
+  assert.equal(result.uri, '/index.html')
 })
 
-test('/docs/ trailing slash → 301 https://docs.iii.dev/docs/', () => {
-  const result = handler(buildEvent('/docs/', 'iii.dev'))
-  assert.ok(isRedirect(result))
-  assert.equal(locationOf(result), 'https://docs.iii.dev/docs/')
-})
-
-test('/docs/quickstart → 301 https://docs.iii.dev/docs/quickstart', () => {
+test('/docs/quickstart → function does not redirect (handled by docs-nlb behavior in prod)', () => {
   const result = handler(buildEvent('/docs/quickstart', 'iii.dev'))
-  assert.ok(isRedirect(result))
-  assert.equal(locationOf(result), 'https://docs.iii.dev/docs/quickstart')
-})
-
-test('/docs/guide/deep/nested → preserves deep path on redirect', () => {
-  const result = handler(buildEvent('/docs/guide/deep/nested', 'iii.dev'))
-  assert.ok(isRedirect(result))
-  assert.equal(locationOf(result), 'https://docs.iii.dev/docs/guide/deep/nested')
+  assert.ok(!isRedirect(result), 'must not be a 301 — /docs/* is served from the NLB origin')
+  assert.equal(result.uri, '/index.html')
 })
 
 test('/docsfoo → NOT redirected (not under /docs/)', () => {
@@ -87,14 +83,15 @@ test('www.iii.dev/some/page → 301 https://iii.dev/some/page', () => {
   assert.equal(locationOf(result), 'https://iii.dev/some/page')
 })
 
-test('www.iii.dev/docs/foo → 301 https://docs.iii.dev/docs/foo (ONE hop, not two)', () => {
+test('www.iii.dev/docs/foo → 301 https://iii.dev/docs/foo (www→apex canonicalization)', () => {
+  // With /docs* moved off this function and onto the docs-nlb cache behavior, the
+  // www→apex redirect is the only rule left that touches www.iii.dev. In production
+  // the /docs* ordered behavior has no function_association, so www.iii.dev/docs/foo
+  // flows straight to the NLB without canonicalization — that's an accepted
+  // trade-off documented alongside the behavior in cloudfront.tf.
   const result = handler(buildEvent('/docs/foo', 'www.iii.dev'))
   assert.ok(isRedirect(result))
-  assert.equal(
-    locationOf(result),
-    'https://docs.iii.dev/docs/foo',
-    'docs redirect must win over www→apex redirect to avoid a 2-hop chain',
-  )
+  assert.equal(locationOf(result), 'https://iii.dev/docs/foo')
 })
 
 test('/ (root) → pass through unchanged', () => {
@@ -157,10 +154,10 @@ test('/.well-known/foo (no extension) → pass through, NOT SPA rewritten', () =
   assert.equal(result.uri, '/.well-known/foo', '.well-known is an explicit exemption from SPA fallback')
 })
 
-test('missing host header → still handles other rules correctly', () => {
-  const event = buildEvent('/docs/foo', undefined)
+test('missing host header → SPA fallback still applies for extensionless paths', () => {
+  const event = buildEvent('/some/page', undefined)
   delete event.request.headers.host
   const result = handler(event)
-  assert.ok(isRedirect(result))
-  assert.equal(locationOf(result), 'https://docs.iii.dev/docs/foo')
+  assert.ok(!isRedirect(result))
+  assert.equal(result.uri, '/index.html')
 })

--- a/infra/terraform/website/cloudfront_functions/redirects.test.js
+++ b/infra/terraform/website/cloudfront_functions/redirects.test.js
@@ -39,23 +39,15 @@ function locationOf(result) {
   return result.headers.location.value
 }
 
-// NOTE: /docs and /docs/* paths are handled by dedicated ordered_cache_behaviors
-// against the docs-nlb origin (see cloudfront.tf) and never reach this function in
-// production. These tests document that the function no longer rewrites or
-// redirects anything under /docs so a future regression is caught immediately.
-
-test('/docs → function does not redirect (handled by docs-nlb behavior in prod)', () => {
+test('/docs → function does not redirect', () => {
   const result = handler(buildEvent('/docs', 'iii.dev'))
-  assert.ok(!isRedirect(result), 'must not be a 301 — /docs is served from the NLB origin')
-  // /docs has no dot in the last segment and no trailing slash, so SPA fallback kicks in.
-  // In production this function isn't attached to the /docs behavior, so it's moot — but
-  // we pin the current function-level behavior to catch accidental reintroductions.
+  assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/index.html')
 })
 
-test('/docs/quickstart → function does not redirect (handled by docs-nlb behavior in prod)', () => {
+test('/docs/quickstart → function does not redirect', () => {
   const result = handler(buildEvent('/docs/quickstart', 'iii.dev'))
-  assert.ok(!isRedirect(result), 'must not be a 301 — /docs/* is served from the NLB origin')
+  assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/index.html')
 })
 
@@ -83,12 +75,7 @@ test('www.iii.dev/some/page → 301 https://iii.dev/some/page', () => {
   assert.equal(locationOf(result), 'https://iii.dev/some/page')
 })
 
-test('www.iii.dev/docs/foo → 301 https://iii.dev/docs/foo (www→apex canonicalization)', () => {
-  // With /docs* moved off this function and onto the docs-nlb cache behavior, the
-  // www→apex redirect is the only rule left that touches www.iii.dev. In production
-  // the /docs* ordered behavior has no function_association, so www.iii.dev/docs/foo
-  // flows straight to the NLB without canonicalization — that's an accepted
-  // trade-off documented alongside the behavior in cloudfront.tf.
+test('www.iii.dev/docs/foo → 301 https://iii.dev/docs/foo', () => {
   const result = handler(buildEvent('/docs/foo', 'www.iii.dev'))
   assert.ok(isRedirect(result))
   assert.equal(locationOf(result), 'https://iii.dev/docs/foo')


### PR DESCRIPTION
## Summary

- Adds a `docs-nlb` CloudFront custom origin (reusing `var.docs_domain` so origin TLS SNI resolves against the existing `iii-dev-tls-docs` cert at ingress-nginx) and two `ordered_cache_behavior`s (`/docs` + `/docs/*`) that forward the viewer `Host` header via the `AllViewer` origin request policy.
- Drops the `/docs*` 301 rules from the CloudFront Function (`redirects.js`) — they're replaced by the new cache behaviors and the function is only on the default (S3) behavior now.
- Updates `redirects.test.js`: pins the new function-level expectation that `/docs*` is not a 301, and updates the `www.iii.dev/docs/foo` test to reflect the accepted trade-off.

## Why

On the 2026-04-15 cutover (#1470), `iii.dev` / `www.iii.dev` were moved onto CloudFront → S3. As a shortcut, the CF Function 301-redirects any hit to `iii.dev/docs*` off to `docs.iii.dev/docs*`, so users lose the `iii.dev/docs/...` URL shape that worked pre-cutover.

The `iii-dev` Ingress (`host: iii.dev`) in `motia-argocd-values` was never removed during cutover — only `iii-dev-www` was. And `iii-edge-proxy`'s nginx ConfigMap still has `location = /docs` and `location ^~ /docs/` rules in its default server block proxying to `motiadev.mintlify.dev`. The k8s side is already wired; we just need CloudFront to forward `/docs*` to the NLB with `Host: iii.dev` preserved.

## How it routes

```
curl https://iii.dev/docs/quickstart
  → CloudFront distribution E3N35RPQE4YVFQ
    → path match /docs/* → docs-nlb cache behavior
      → origin: docs.iii.dev (SNI-only; cert = iii-dev-tls-docs)
        DNS still resolves docs.iii.dev → k8s NLB
      → AllViewer origin request policy forwards Host: iii.dev
    → ingress-nginx terminates TLS on iii-dev-tls-docs
    → routes by HTTP Host: iii.dev → iii-dev Ingress
    → iii-edge-proxy default server block → /docs location
    → https://motiadev.mintlify.dev/docs/quickstart
```

## Coupling / risks

- **`docs.iii.dev` → NLB dependency.** The `docs-nlb` origin's `domain_name` is `var.docs_domain`, which currently resolves to the k8s NLB. When `docs.iii.dev` migrates to a Mintlify custom domain (see `infra/terraform/website/NEXT-STEPS.md` item 13), this origin must be repointed in the same change or `iii.dev/docs` will break. A code comment on the origin block calls this out.
- **No www→apex canonicalization for `/docs*`.** The `/docs*` behaviors intentionally have no `function_association` because attaching the redirects function would pull in the SPA fallback and rewrite `/docs/quickstart` → `/index.html`. Effect: `www.iii.dev/docs/foo` reaches Mintlify without canonicalization. Trade-off is documented in `redirects.test.js`. Marketing nav links all use the apex host already.
- **Mintlify link leak (possible follow-up).** The `iii-edge-proxy` default server block's `/docs` locations have `proxy_redirect` (for `Location:` headers) but no `sub_filter` (for response body HTML). If Mintlify emits absolute `motiadev.mintlify.dev` links in the body, a follow-up argocd-values PR adds `sub_filter` rules mirroring the `docs.iii.dev` server block at lines 242–243 of `iii-dev.yaml`. Detection: post-apply `curl -sL https://iii.dev/docs/quickstart | grep motiadev.mintlify.dev` should return 0 hits.

## Test plan

Post-merge, from the deploy workflow run:

- [ ] `terraform plan` from `infra/terraform/website/` shows: 1 in-place `aws_cloudfront_function.redirects` (code), 1 in-place `aws_cloudfront_distribution.site` (new origin + 2 new behaviors + function comment). Zero destroys.
- [ ] `node infra/terraform/website/cloudfront_functions/redirects.test.js` → 18/18 pass (ran locally, green).
- [ ] `terraform apply`, wait for CloudFront `Deployed` (~5 min).
- [ ] `curl -sI https://iii.dev/docs` → `HTTP/2 200` (not 301).
- [ ] `curl -sI https://iii.dev/docs/` → `HTTP/2 200`.
- [ ] `curl -sI https://iii.dev/docs/quickstart` → `HTTP/2 200`.
- [ ] `curl -sL https://iii.dev/docs/quickstart | grep -c 'motiadev.mintlify.dev'` → `0`. If non-zero, open a follow-up argocd-values PR to add `sub_filter` to the `/docs` nginx locations.
- [ ] `curl -sI https://iii.dev/` → 200 via S3, `server: CloudFront`, `x-cache: Hit/Miss from cloudfront`.
- [ ] `curl -sI https://www.iii.dev/` → 301 → `https://iii.dev/` (unchanged).
- [ ] `curl -sI https://iii.dev/api/search?q=hello` → 200 via `search-api` origin (unchanged).
- [ ] Open `https://iii.dev/docs/quickstart` in Chrome: Mintlify sidebar/search/nav all work, no console CSP errors from the site CSP (`/docs*` intentionally skips the site response-headers policy — Mintlify's own headers apply).
- [ ] Watch CloudWatch alarm `iii-website-prod-cf-5xx-rate` for 15 minutes. Must stay `OK`.

## Rollback

Revert this PR and `terraform apply`. Two behaviors + origin destroyed, `redirects.js` restored. ~5 min of edge propagation. No DNS touch, no k8s touch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure & Performance**
  * Docs paths now route to a dedicated origin with explicit caching behavior, improving load reliability and avoiding previous redirect overhead.
* **Bug Fixes**
  * Removed automatic redirects for /docs paths so deep docs URLs are served directly and fall back to the site SPA when appropriate.
* **Tests**
  * Updated redirect tests to reflect the new docs routing and SPA fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->