### PR TITLE
docs: motia deprecation

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -8,7 +8,7 @@ description: "Product updates and announcements for iii."
 
   **Breaking.** The Motia framework is deprecated in favor of using `iii-sdk` directly. Moving to the SDK unlocks multi-worker orchestration, browser connectivity via `iii-browser-sdk` with RBAC, and a direct understanding of iii's three primitives — Workers, Functions, and Triggers. Your existing Motia project becomes one worker in a larger iii deployment instead of a standalone monolith.
 
-  [Read the migration guide &rarr;](/changelog/0-11-0/migrating-from-motia)
+  [Node / TypeScript migration guide &rarr;](/changelog/0-11-0/migrating-from-motia-js) &middot; [Python migration guide &rarr;](/changelog/0-11-0/migrating-from-motia-py)
 
   ## Worker RBAC
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -4,6 +4,12 @@ description: "Product updates and announcements for iii."
 ---
 
 <Update label="0.11.0 (next)" description="April 2026">
+  ## Migrating from Motia
+
+  **Breaking.** The Motia framework is deprecated in favor of using `iii-sdk` directly. Motia's abstractions — automatic file scanning, magic middleware wiring, and opaque bundling — helped early adoption but increasingly limited what developers could do with iii's multi-worker orchestration, remote function triggering, and custom build pipelines. Moving to `iii-sdk` gives you full control while keeping a thin `fn()` helper to smooth the transition.
+
+  [Read the migration guide &rarr;](/changelog/0-11-0/migrating-from-motia)
+
   ## Worker RBAC
 
   The **iii-worker-manager** now supports role-based access control. Configure auth functions that validate WebSocket upgrade requests, attach per-session allow/deny lists for functions, control trigger registration, and auto-prefix function IDs for namespace isolation. An optional middleware function lets you intercept every invocation for audit logging, rate limiting, or payload enrichment.

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -6,7 +6,7 @@ description: "Product updates and announcements for iii."
 <Update label="0.11.0 (next)" description="April 2026">
   ## Migrating from Motia
 
-  **Breaking.** The Motia framework is deprecated in favor of using `iii-sdk` directly. Motia's abstractions — automatic file scanning, magic middleware wiring, and opaque bundling — helped early adoption but increasingly limited what developers could do with iii's multi-worker orchestration, remote function triggering, and custom build pipelines. Moving to `iii-sdk` gives you full control while keeping a thin `fn()` helper to smooth the transition.
+  **Breaking.** The Motia framework is deprecated in favor of using `iii-sdk` directly. Moving to the SDK unlocks multi-worker orchestration, browser connectivity via `iii-browser-sdk` with RBAC, and a direct understanding of iii's three primitives — Workers, Functions, and Triggers. Your existing Motia project becomes one worker in a larger iii deployment instead of a standalone monolith.
 
   [Read the migration guide &rarr;](/changelog/0-11-0/migrating-from-motia)
 

--- a/docs/changelog/0-11-0/migrating-from-motia-js.mdx
+++ b/docs/changelog/0-11-0/migrating-from-motia-js.mdx
@@ -1,11 +1,18 @@
 ---
-title: 'Migrating from Motia'
-description: 'How to move from the Motia framework to iii-sdk directly.'
+title: 'Migrating from Motia (Node.js)'
+description: 'How to move from the Motia framework to iii-sdk directly in Node.js.'
 ---
 
-Motia was a higher-level framework built on top of `iii-sdk`. It handled file scanning, middleware wiring, trigger registration, and production bundling automatically. These conveniences came at a cost: they hid iii's primitives behind opaque abstractions that made multi-worker orchestration, remote function triggering, and custom build pipelines difficult or impossible to use.
+Motia was a higher-level framework built on top of `iii-sdk`. It handled file scanning, middleware wiring, trigger registration, and production bundling automatically. These conveniences came at a cost: they hid iii's three core primitives — **Workers**, **Functions**, and **Triggers** — behind opaque abstractions that limited what you could build.
 
-With `iii-sdk` directly, you register functions and triggers explicitly, structure your project however you want, and own your build pipeline end to end.
+By moving to `iii-sdk` directly, you unlock the full power of the engine:
+
+- **Add new workers** that register their own functions and triggers, enabling multi-worker orchestration across services, languages, and runtimes.
+- **Connect from the browser** using `iii-browser-sdk` with [Worker RBAC](/how-to/worker-rbac) for secure, real-time frontends — no REST layer needed. See [Use iii in the browser](/how-to/use-iii-in-the-browser).
+- **Treat Motia as one worker among many** instead of a standalone monolith. Your existing Motia code becomes just another worker in a larger iii deployment.
+- **Understand the primitives directly.** Working with `registerFunction`, `registerTrigger`, and `registerWorker` builds a mental model that transfers across all iii SDKs and documentation.
+
+<Callout type="tip">Before diving into this migration, we recommend reading the [iii documentation](/) to understand Workers, Functions, and Triggers. The [quickstart](/quickstart) and [Everything is a Worker](/changelog/0-11-0/everything-is-a-worker) pages are good starting points.</Callout>
 
 ---
 

--- a/docs/changelog/0-11-0/migrating-from-motia-py.mdx
+++ b/docs/changelog/0-11-0/migrating-from-motia-py.mdx
@@ -1,0 +1,502 @@
+---
+title: 'Migrating from Motia (Python)'
+description: 'How to move from the Motia framework to iii-sdk directly in Python.'
+---
+
+Motia was a higher-level framework built on top of `iii-sdk`. It handled file scanning, middleware wiring, trigger registration, and production packaging automatically. These conveniences came at a cost: they hid iii's three core primitives — **Workers**, **Functions**, and **Triggers** — behind opaque abstractions that limited what you could build.
+
+By moving to `iii-sdk` directly, you unlock the full power of the engine:
+
+- **Add new workers** that register their own functions and triggers, enabling multi-worker orchestration across services, languages, and runtimes.
+- **Connect from the browser** using `iii-browser-sdk` with [Worker RBAC](/how-to/worker-rbac) for secure, real-time frontends — no REST layer needed. See [Use iii in the browser](/how-to/use-iii-in-the-browser).
+- **Treat Motia as one worker among many** instead of a standalone monolith. Your existing Motia code becomes just another worker in a larger iii deployment.
+- **Understand the primitives directly.** Working with `register_function`, `register_trigger`, and `register_worker` builds a mental model that transfers across all iii SDKs and documentation.
+
+<Callout type="tip">Before diving into this migration, we recommend reading the [iii documentation](/) to understand Workers, Functions, and Triggers. The [quickstart](/quickstart) and [Everything is a Worker](/changelog/0-11-0/everything-is-a-worker) pages are good starting points.</Callout>
+
+<Callout type="info">For the Node / TypeScript migration, see [Migrating from Motia (Node.js)](/changelog/0-11-0/migrating-from-motia-js).</Callout>
+
+---
+
+## Step 1 — Update dependencies
+
+Remove `motia` and add `iii-sdk`.
+
+```bash
+pip uninstall motia
+pip install iii-sdk==0.11.0
+```
+
+| Before (Motia) | After (iii-sdk) |
+|---|---|
+| `motia` (pip) | `iii-sdk==0.11.0` (pip) |
+| `motia build` | `python -m build` or a container image |
+| `motia dev` | `python -m src.main` with a file watcher |
+
+<Callout type="info">The Python package is distributed as `iii-sdk` on PyPI but imported as `iii` (e.g., `from iii import register_worker`).</Callout>
+
+---
+
+## Step 2 — Initialize the SDK
+
+Create `src/lib/iii_client.py`. This replaces the implicit connection that Motia managed for you.
+
+```python
+import os
+from iii import Logger, register_worker, InitOptions
+
+iii = register_worker(
+    address=os.environ.get("III_URL", "ws://localhost:49134"),
+    options=InitOptions(worker_name="api-worker"),
+)
+
+logger = Logger()
+```
+
+Every `from motia import logger` in your codebase changes to `from src.lib.iii_client import logger`.
+
+---
+
+## Step 3 — Register functions and triggers directly
+
+Motia auto-registered functions and triggers from exported `config` objects. With `iii-sdk` Python, you call `iii.register_function` and `iii.register_trigger` directly at module scope — there's no helper to build. Each handler module registers its function and trigger(s) when imported. This mirrors the Motia `config` + `handler` structure without the implicit discovery.
+
+Continue to Step 4 to see the handler patterns.
+
+<Callout type="info">`iii-sdk` Python supports engine-native HTTP middleware via `middleware_function_ids`. See [Use HTTP middleware](/how-to/use-http-middleware) for the full pattern.</Callout>
+
+---
+
+## Step 4 — Migrate handlers
+
+### HTTP
+
+<Tabs>
+<Tab title="Motia">
+```python
+from motia import http, ApiRequest, ApiResponse
+
+config = {
+    "name": "Health",
+    "description": "Health check",
+    "triggers": [http("GET", "/health")],
+    "enqueues": [],
+}
+
+def handler(_request: ApiRequest) -> ApiResponse:
+    return ApiResponse(status=200, body={"ok": True})
+```
+</Tab>
+<Tab title="iii-sdk">
+```python
+def health(_data):
+    return {"statusCode": 200, "body": {"ok": True}}
+
+iii.register_function("health", health)
+iii.register_trigger({
+    "type": "http",
+    "function_id": "health",
+    "config": {"api_path": "/health", "http_method": "GET"},
+})
+```
+</Tab>
+</Tabs>
+
+### HTTP with middleware
+
+<Tabs>
+<Tab title="Motia">
+```python
+from motia import http, ApiRequest, ApiResponse
+
+def require_auth(request: ApiRequest) -> bool:
+    return request.headers.get("authorization") is not None
+
+config = {
+    "name": "ListTags",
+    "description": "List tags",
+    "triggers": [http("GET", "/tag", middleware=[require_auth])],
+    "enqueues": [],
+}
+
+def handler(request: ApiRequest) -> ApiResponse:
+    org_id = request.headers.get("x-org-id")
+    return ApiResponse(status=200, body={"tags": list_tags_for_org(org_id)})
+```
+</Tab>
+<Tab title="iii-sdk">
+```python
+from src.middleware.auth import require_auth  # registers "middleware::require-auth"
+
+def list_tags(data):
+    headers = data.get("headers") or {}
+    org_id = headers.get("x-org-id")
+    return {"statusCode": 200, "body": {"tags": list_tags_for_org(org_id)}}
+
+iii.register_function("list-tags", list_tags)
+iii.register_trigger({
+    "type": "http",
+    "function_id": "list-tags",
+    "config": {
+        "api_path": "/tag",
+        "http_method": "GET",
+        "middleware_function_ids": ["middleware::require-auth"],
+    },
+})
+```
+</Tab>
+</Tabs>
+
+<Callout type="info">`iii-sdk` Python uses engine-native middleware registered as regular functions with a `middleware::` prefix. See [Use HTTP middleware](/how-to/use-http-middleware) for the full pattern.</Callout>
+
+### Cron
+
+<Tabs>
+<Tab title="Motia">
+```python
+from motia import cron, logger
+
+config = {
+    "name": "DailyReport",
+    "description": "Generate daily report",
+    "triggers": [cron("0 0 9 * * * *")],
+    "enqueues": [],
+}
+
+def handler(input: None) -> None:
+    generate_report()
+```
+</Tab>
+<Tab title="iii-sdk">
+```python
+def daily_report(_data) -> None:
+    generate_report()
+
+iii.register_function("daily-report", daily_report)
+iii.register_trigger({
+    "type": "cron",
+    "function_id": "daily-report",
+    "config": {"expression": "0 0 9 * * * *"},
+})
+```
+</Tab>
+</Tabs>
+
+### Queue (durable subscriber)
+
+<Tabs>
+<Tab title="Motia">
+```python
+from motia import queue, logger
+from typing import Any
+
+config = {
+    "name": "ProcessOrder",
+    "description": "Process created orders",
+    "triggers": [queue("order.created")],
+    "enqueues": [],
+}
+
+def handler(input: Any) -> None:
+    process_order(input)
+```
+</Tab>
+<Tab title="iii-sdk">
+```python
+def process_order(data) -> None:
+    process_order_impl(data)
+
+iii.register_function("process-order", process_order)
+iii.register_trigger({
+    "type": "durable:subscriber",
+    "function_id": "process-order",
+    "config": {"topic": "order.created"},
+})
+```
+</Tab>
+</Tabs>
+
+To publish to a topic, use `iii.trigger` instead of Motia's `enqueue`:
+
+```python
+iii.trigger({
+    "function_id": "iii::durable::publish",
+    "payload": {"topic": "order.created", "data": order_payload},
+})
+```
+
+### State
+
+<Tabs>
+<Tab title="Motia">
+```python
+from motia import StateTriggerInput, state, logger
+
+config = {
+    "name": "OnStateChange",
+    "description": "React to state changes",
+    "triggers": [state()],
+    "enqueues": [],
+}
+
+def handler(input: StateTriggerInput) -> None:
+    handle_state_change(input)
+```
+</Tab>
+<Tab title="iii-sdk">
+```python
+def on_state_change(data) -> None:
+    handle_state_change(data)
+
+iii.register_function("on-state-change", on_state_change)
+iii.register_trigger({
+    "type": "state",
+    "function_id": "on-state-change",
+    "config": {},
+})
+```
+</Tab>
+</Tabs>
+
+### Stream
+
+<Tabs>
+<Tab title="Motia">
+```python
+from motia import StreamTriggerInput, stream, logger
+
+config = {
+    "name": "ChatMessage",
+    "description": "Handle chat messages",
+    "triggers": [stream("chat", group_id="room-1")],
+    "enqueues": [],
+}
+
+def handler(input: StreamTriggerInput) -> None:
+    handle_chat_message(input)
+```
+</Tab>
+<Tab title="iii-sdk">
+```python
+def chat_message(data) -> None:
+    handle_chat_message(data)
+
+iii.register_function("chat-message", chat_message)
+iii.register_trigger({
+    "type": "stream",
+    "function_id": "chat-message",
+    "config": {"stream_name": "chat", "group_id": "room-1"},
+})
+```
+</Tab>
+</Tabs>
+
+### Multiple triggers on one function
+
+A function can be driven by multiple triggers. This was possible in Motia via the `triggers` array, and maps directly to multiple `register_trigger` calls for the same `function_id`:
+
+```python
+def order_handler(data) -> None:
+    handle_order(data)
+
+iii.register_function("order-handler", order_handler)
+iii.register_trigger({
+    "type": "http",
+    "function_id": "order-handler",
+    "config": {"api_path": "/orders", "http_method": "POST"},
+})
+iii.register_trigger({
+    "type": "durable:subscriber",
+    "function_id": "order-handler",
+    "config": {"topic": "order.retry"},
+})
+```
+
+---
+
+## Step 5 — Update request and response shapes
+
+### Request properties
+
+Motia wrapped `iii-sdk`'s HTTP request into friendlier property names. With `iii-sdk` you receive the raw shape.
+
+| Property | Motia (`input.*`) | iii-sdk (`input.*`) |
+|---|---|---|
+| Route params | `params` | `path_params` |
+| Query string | `query` | `query_params` |
+| JSON body | `body` | `body` |
+| Headers | `headers` | `headers` |
+| HTTP method | `method` | `method` |
+| Request stream | `requestBody` | `request_body` |
+| Response stream | `response` | `response` |
+
+Motia Python's `ApiRequest` already exposed `path_params`, `query_params`, `body`, `headers`, `method`. When switching to `iii-sdk`, handlers receive those fields in a **plain dict** instead of a Pydantic model, so attribute access (`request.path_params`) becomes dict-key access (`data["path_params"]`).
+
+```python
+# Before (Motia — Pydantic model, attribute access)
+folder_id = request.path_params.get("folderId")
+parent_folder_id = request.query_params.get("parentFolderId")
+
+# After (iii-sdk — raw dict, key access)
+folder_id = (data.get("path_params") or {}).get("folderId")
+parent_folder_id = (data.get("query_params") or {}).get("parentFolderId")
+```
+
+### `query_params` value types
+
+In `iii-sdk`, `query_params` values are `str | list[str]`. Use a helper to safely extract the first value:
+
+```python
+def first_query_param(data: dict, name: str) -> str | None:
+    value = (data.get("query_params") or {}).get(name)
+    if value is None:
+        return None
+    return value[0] if isinstance(value, list) else value
+```
+
+### Response shape
+
+`iii-sdk` uses `statusCode` instead of `status`. This applies to every handler return and middleware response.
+
+```python
+# Before (Motia)
+return ApiResponse(status=200, body={"tags": all_tags})
+return ApiResponse(status=404, body={"error": "Not found"})
+
+# After (iii-sdk)
+return {"statusCode": 200, "body": {"tags": all_tags}}
+return {"statusCode": 404, "body": {"error": "Not found"}}
+```
+
+---
+
+## Step 6 — Set up the entry point
+
+Motia discovered `*_step.py` files automatically. With `iii-sdk` Python, create `src/main.py` that imports every handler module as a side effect.
+
+```python
+# src/main.py
+import signal
+import time
+
+from src.lib.iii_client import iii  # noqa: F401 — connects on import
+
+# Import every handler module; each registers its function + trigger at import time.
+from src.handlers import health  # noqa: F401
+from src.handlers import auth  # noqa: F401
+from src.handlers.orders import create_order  # noqa: F401
+from src.handlers.orders import list_orders  # noqa: F401
+from src.handlers.reports import daily_report  # noqa: F401
+# ... import every handler module
+
+
+def _shutdown(*_args) -> None:
+    iii.shutdown()
+    raise SystemExit(0)
+
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGINT, _shutdown)
+    signal.signal(signal.SIGTERM, _shutdown)
+    while True:
+        time.sleep(1)
+```
+
+Each import executes the `register_function` and `register_trigger` calls at the module level, registering the function and its triggers with the engine.
+
+### File renaming
+
+Rename all `*_step.py` files to remove the `_step` suffix:
+
+```
+src/steps/health_step.py  →  src/handlers/health.py
+src/steps/auth_step.py    →  src/handlers/auth.py
+```
+
+The directory structure is yours to decide — `handlers/`, `routes/`, `rest/`, or any layout that fits your project.
+
+---
+
+## Step 7 — Development workflow
+
+The `iii-exec` worker has a built-in file watcher. In your `config.yaml`, declare `watch` globs alongside the `exec` command — no extra dependencies, no wrapper process:
+
+```yaml
+workers:
+  - name: iii-exec
+    config:
+      watch:
+        - src/**/*.py
+      exec:
+        - python
+        - -m
+        - src.main
+```
+
+Any change matching a `watch` glob restarts the `exec` pipeline.
+
+---
+
+## Step 8 — Production build
+
+Python has no direct `esbuild` equivalent. The recommended production path is a virtualenv (or container image) with pinned dependencies.
+
+Add to `pyproject.toml`:
+
+```toml
+[project]
+name = "my-worker"
+version = "0.1.0"
+dependencies = [
+    "iii-sdk==0.11.0",
+]
+```
+
+Build and run:
+
+```bash
+pip install .
+python -m src.main
+```
+
+For containerized deploys, a minimal `Dockerfile`:
+
+```dockerfile
+FROM python:3.11-slim
+WORKDIR /app
+COPY pyproject.toml ./
+RUN pip install --no-cache-dir .
+COPY src ./src
+CMD ["python", "-m", "src.main"]
+```
+
+Update your production config to run the installed module (omit `watch` in production):
+
+```yaml
+workers:
+  - name: iii-exec
+    config:
+      exec:
+        - python
+        - -m
+        - src.main
+```
+
+<Callout type="info">Unlike `esbuild`, you do not bundle Python sources — the runtime imports modules directly. Ship your source tree (or a wheel) rather than a single file.</Callout>
+
+---
+
+## Migration checklist
+
+- [ ] Remove `motia` from `requirements.txt` / `pyproject.toml`, add `iii-sdk==0.11.0`
+- [ ] Create `src/lib/iii_client.py` with `register_worker` and `Logger`
+- [ ] Rename all `*_step.py` files to drop the `_step` suffix
+- [ ] Replace all `from motia import ...` with `from iii import ...` (and `from src.lib.iii_client import ...` for `iii` / `logger`)
+- [ ] Convert every `config` dict + `handler` function to `iii.register_function(...)` + `iii.register_trigger(...)` calls
+- [ ] Replace `ApiResponse(status=...)` with plain dicts using `statusCode` (e.g., `{"statusCode": 200, "body": ...}`)
+- [ ] Replace `request.path_params` / `request.query_params` attribute access with dict-key access on the raw payload (`data["path_params"]`, `data.get("query_params")`)
+- [ ] Replace `requestBody` with `request_body` in streaming handlers
+- [ ] Create `src/main.py` with side-effect imports for every handler module
+- [ ] Replace `motia dev` with an `iii-exec` worker using `watch` + `exec` in your `config.yaml`
+- [ ] Replace `motia build` with `pip install .` (and a `Dockerfile` for containerized deploys)
+- [ ] Test all endpoints, cron jobs, queue subscribers, and stream handlers

--- a/docs/changelog/0-11-0/migrating-from-motia.mdx
+++ b/docs/changelog/0-11-0/migrating-from-motia.mdx
@@ -1,0 +1,571 @@
+---
+title: 'Migrating from Motia'
+description: 'How to move from the Motia framework to iii-sdk directly.'
+---
+
+Motia was a higher-level framework built on top of `iii-sdk`. It handled file scanning, middleware wiring, trigger registration, and production bundling automatically. These conveniences came at a cost: they hid iii's primitives behind opaque abstractions that made multi-worker orchestration, remote function triggering, and custom build pipelines difficult or impossible to use.
+
+With `iii-sdk` directly, you register functions and triggers explicitly, structure your project however you want, and own your build pipeline end to end.
+
+---
+
+## Step 1 — Update dependencies
+
+Remove `motia` and add `iii-sdk`. If you need a production bundler, add `esbuild` as a dev dependency.
+
+```bash
+pnpm remove motia
+pnpm add iii-sdk@0.11.0
+pnpm add -D esbuild
+```
+
+| Before (Motia) | After (iii-sdk) |
+|---|---|
+| `motia` | `iii-sdk@0.11.0` |
+| `motia build` | `esbuild` via `bun run esbuild.config.ts` |
+| `motia dev && bun run dist/index.js` | `bun run --watch src/main.ts` |
+
+---
+
+## Step 2 — Initialize the SDK
+
+Create `src/lib/iii.ts`. This replaces the implicit connection that Motia managed for you.
+
+```typescript
+import { Logger, registerWorker } from 'iii-sdk'
+
+export const iii = registerWorker(process.env.III_URL ?? 'ws://localhost:49134', {
+  workerName: 'api-worker',
+})
+
+export const logger = new Logger()
+```
+
+Every `import { logger } from 'motia'` in your codebase changes to `import { logger } from '@/lib/iii'`.
+
+---
+
+## Step 3 — Create the `fn()` helper
+
+Motia auto-registered functions and triggers from exported `config` objects. With iii-sdk you call `registerFunction` and `registerTrigger` directly. The `fn()` helper below gives you a chainable API that keeps handler files concise while remaining fully explicit.
+
+Create `src/lib/iii-helpers.ts`:
+
+```typescript
+import type { RemoteFunctionHandler, Trigger, HttpRequest } from 'iii-sdk'
+import { iii } from './iii'
+
+export type Middleware = (input: HttpRequest) => Promise<any | void> | any | void
+
+export interface HttpOptions {
+  middleware?: Middleware[]
+}
+
+export interface QueueOptions {
+  config?: {
+    type?: 'fifo' | 'standard'
+    maxRetries?: number
+    visibilityTimeout?: number
+    delaySeconds?: number
+    concurrency?: number
+    backoffType?: string
+    backoffDelayMs?: number
+  }
+}
+
+export interface StreamOptions {
+  groupId?: string
+  itemId?: string
+}
+
+export interface FnOptions {
+  description?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface FnRegistration {
+  http(method: string, path: string, options?: HttpOptions): FnRegistration
+  cron(expression: string): FnRegistration
+  queue(topic: string, options?: QueueOptions): FnRegistration
+  state(): FnRegistration
+  stream(streamName: string, options?: StreamOptions): FnRegistration
+  unregister(): void
+}
+
+export function fn(
+  id: string,
+  handler: RemoteFunctionHandler,
+  options?: FnOptions,
+): FnRegistration {
+  let ref = iii.registerFunction(id, handler, options)
+  const triggers: Trigger[] = []
+
+  const registration: FnRegistration = {
+    http(method, path, httpOptions?) {
+      if (httpOptions?.middleware?.length) {
+        const originalHandler = handler
+
+        const wrappedHandler: RemoteFunctionHandler = async (input) => {
+          for (const mw of httpOptions.middleware!) {
+            const result = await mw(input)
+            if (result && typeof result === 'object' && 'status_code' in result) return result
+          }
+          return originalHandler(input)
+        }
+        ref.unregister()
+        ref = iii.registerFunction(id, wrappedHandler, options)
+      }
+
+      triggers.push(
+        iii.registerTrigger({
+          type: 'http',
+          function_id: ref.id,
+          config: { api_path: path, http_method: method },
+        }),
+      )
+      return registration
+    },
+
+    cron(expression) {
+      triggers.push(
+        iii.registerTrigger({
+          type: 'cron',
+          function_id: ref.id,
+          config: { expression },
+        }),
+      )
+      return registration
+    },
+
+    queue(topic, queueOptions?) {
+      triggers.push(
+        iii.registerTrigger({
+          type: 'durable:subscriber',
+          function_id: ref.id,
+          config: {
+            topic,
+            ...(queueOptions?.config ? { queue_config: queueOptions.config } : {}),
+          },
+        }),
+      )
+      return registration
+    },
+
+    state() {
+      triggers.push(
+        iii.registerTrigger({
+          type: 'state',
+          function_id: ref.id,
+          config: {},
+        }),
+      )
+      return registration
+    },
+
+    stream(streamName, streamOptions?) {
+      triggers.push(
+        iii.registerTrigger({
+          type: 'stream',
+          function_id: ref.id,
+          config: {
+            stream_name: streamName,
+            ...(streamOptions?.groupId ? { group_id: streamOptions.groupId } : {}),
+            ...(streamOptions?.itemId ? { item_id: streamOptions.itemId } : {}),
+          },
+        }),
+      )
+      return registration
+    },
+
+    unregister() {
+      for (const t of triggers) t.unregister()
+      ref.unregister()
+    },
+  }
+
+  return registration
+}
+```
+
+<Callout type="info">The `fn()` helper handles middleware by wrapping the handler at registration time. iii also supports engine-native HTTP middleware via `middleware_function_ids`. See [Use HTTP middleware](/how-to/use-http-middleware) for details.</Callout>
+
+---
+
+## Step 4 — Migrate handlers
+
+### HTTP
+
+<Tabs>
+<Tab title="Motia">
+```typescript
+import { type Handlers, http, type StepConfig } from 'motia'
+import { z } from 'zod'
+
+export const config = {
+  name: 'Health',
+  triggers: [http('GET', '/health', { responseSchema: { 200: z.object({ ok: z.boolean() }) } })],
+  enqueues: [],
+} as const satisfies StepConfig
+
+export const handler: Handlers<typeof config> = async (_input, _ctx) => {
+  return { status: 200, body: { ok: true } }
+}
+```
+</Tab>
+<Tab title="iii-sdk">
+```typescript
+import { fn } from '@/lib/iii-helpers'
+
+fn('health', async () => {
+  return { status_code: 200, body: { ok: true } }
+}).http('GET', '/health')
+```
+</Tab>
+</Tabs>
+
+### HTTP with middleware
+
+<Tabs>
+<Tab title="Motia">
+```typescript
+import { type Handlers, http, type StepConfig } from 'motia'
+
+export const config = {
+  name: 'List Tags',
+  triggers: [http('GET', '/tag', { middleware: [requireAuth] })],
+  enqueues: [],
+} as const satisfies StepConfig
+
+export const handler: Handlers<typeof config> = async (input, ctx) => {
+  const { sub: userId, orgId } = input.tokenInfo
+  return { status: 200, body: { tags: allTags } }
+}
+```
+</Tab>
+<Tab title="iii-sdk">
+```typescript
+import { fn } from '@/lib/iii-helpers'
+import { auth } from '@/middleware/auth'
+
+fn('list-tags', async (input) => {
+  const { sub: userId, orgId } = input.tokenInfo
+  return { status_code: 200, body: { tags: allTags } }
+}).http('GET', '/tag', { middleware: [auth({ required: true })] })
+```
+</Tab>
+</Tabs>
+
+### Cron
+
+<Tabs>
+<Tab title="Motia">
+```typescript
+import { cron, type Handlers, type StepConfig } from 'motia'
+
+export const config = {
+  name: 'Daily Report',
+  triggers: [cron('0 0 9 * * * *')],
+  enqueues: [],
+} as const satisfies StepConfig
+
+export const handler: Handlers<typeof config> = async (_input, _ctx) => {
+  await generateReport()
+}
+```
+</Tab>
+<Tab title="iii-sdk">
+```typescript
+import { fn } from '@/lib/iii-helpers'
+
+fn('daily-report', async () => {
+  await generateReport()
+}).cron('0 0 9 * * * *')
+```
+</Tab>
+</Tabs>
+
+### Queue (durable subscriber)
+
+<Tabs>
+<Tab title="Motia">
+```typescript
+import { type Handlers, queue, type StepConfig } from 'motia'
+
+export const config = {
+  name: 'Process Order',
+  triggers: [queue('order.created')],
+  enqueues: [],
+} as const satisfies StepConfig
+
+export const handler: Handlers<typeof config> = async (input, _ctx) => {
+  await processOrder(input)
+}
+```
+</Tab>
+<Tab title="iii-sdk">
+```typescript
+import { fn } from '@/lib/iii-helpers'
+
+fn('process-order', async (input) => {
+  await processOrder(input)
+}).queue('order.created')
+```
+</Tab>
+</Tabs>
+
+To publish to a topic, use `iii.trigger` instead of Motia's `enqueue`:
+
+```typescript
+import { iii } from '@/lib/iii'
+
+iii.trigger({
+  function_id: 'iii::durable::publish',
+  payload: { topic: 'order.created', data: orderPayload },
+})
+```
+
+### State
+
+<Tabs>
+<Tab title="Motia">
+```typescript
+import { type Handlers, state, type StepConfig } from 'motia'
+
+export const config = {
+  name: 'On State Change',
+  triggers: [state()],
+  enqueues: [],
+} as const satisfies StepConfig
+
+export const handler: Handlers<typeof config> = async (input, _ctx) => {
+  await handleStateChange(input)
+}
+```
+</Tab>
+<Tab title="iii-sdk">
+```typescript
+import { fn } from '@/lib/iii-helpers'
+
+fn('on-state-change', async (input) => {
+  await handleStateChange(input)
+}).state()
+```
+</Tab>
+</Tabs>
+
+### Stream
+
+<Tabs>
+<Tab title="Motia">
+```typescript
+import { type Handlers, stream, type StepConfig } from 'motia'
+
+export const config = {
+  name: 'Chat Message',
+  triggers: [stream('chat', { groupId: 'room-1' })],
+  enqueues: [],
+} as const satisfies StepConfig
+
+export const handler: Handlers<typeof config> = async (input, _ctx) => {
+  await handleChatMessage(input)
+}
+```
+</Tab>
+<Tab title="iii-sdk">
+```typescript
+import { fn } from '@/lib/iii-helpers'
+
+fn('chat-message', async (input) => {
+  await handleChatMessage(input)
+}).stream('chat', { groupId: 'room-1' })
+```
+</Tab>
+</Tabs>
+
+### Multiple triggers on one function
+
+A function can chain multiple triggers. This was possible in Motia via the `triggers` array, and maps directly to chained calls:
+
+```typescript
+fn('order-handler', async (input) => {
+  await handleOrder(input)
+})
+  .http('POST', '/orders')
+  .queue('order.retry')
+```
+
+---
+
+## Step 5 — Update request and response shapes
+
+### Request properties
+
+Motia wrapped iii-sdk's HTTP request into friendlier property names. With iii-sdk you receive the raw shape.
+
+| Property | Motia (`input.*`) | iii-sdk (`input.*`) |
+|---|---|---|
+| Route params | `params` | `path_params` |
+| Query string | `query` | `query_params` |
+| JSON body | `body` | `body` |
+| Headers | `headers` | `headers` |
+| HTTP method | `method` | `method` |
+| Request stream | `requestBody` | `request_body` |
+| Response stream | `response` | `response` |
+
+```typescript
+// Before (Motia)
+const { folderId } = input.params || {}
+const parentFolderId = input.query?.parentFolderId
+
+// After (iii-sdk)
+const { folderId } = input.path_params || {}
+const parentFolderId = input.query_params?.parentFolderId
+```
+
+### `query_params` value types
+
+In iii-sdk, `query_params` values are `string | string[]`. Use a helper to safely extract the first value:
+
+```typescript
+function firstQueryParam(
+  queryParams: Record<string, string | string[]> | undefined,
+  name: string,
+): string | undefined {
+  const v = queryParams?.[name]
+  if (v === undefined) return undefined
+  return Array.isArray(v) ? v[0] : v
+}
+```
+
+### Response shape
+
+iii-sdk uses `status_code` instead of `status`. This applies to every handler return and middleware response.
+
+```typescript
+// Before (Motia)
+return { status: 200, body: { tags: allTags } }
+return { status: 404, body: { error: 'Not found' } }
+
+// After (iii-sdk)
+return { status_code: 200, body: { tags: allTags } }
+return { status_code: 404, body: { error: 'Not found' } }
+```
+
+---
+
+## Step 6 — Set up the entry point
+
+Motia discovered `.step.ts` files automatically. With iii-sdk, you create a single entry point that imports all handler files as side effects.
+
+Create `src/main.ts`:
+
+```typescript
+import './lib/iii'
+import './handlers/health'
+import './handlers/auth'
+import './handlers/orders/create-order'
+import './handlers/orders/list-orders'
+import './handlers/reports/daily-report'
+// ... import every handler file
+```
+
+Each import executes the `fn()` call at the module level, registering the function and its triggers with the engine.
+
+### File renaming
+
+Rename all `*.step.ts` files to `*.ts`:
+
+```
+src/steps/health.step.ts  →  src/handlers/health.ts
+src/steps/auth.step.ts    →  src/handlers/auth.ts
+```
+
+The directory structure is yours to decide — `handlers/`, `routes/`, `rest/`, or any layout that fits your project.
+
+---
+
+## Step 7 — Development workflow
+
+Replace Motia's dev command with a direct `bun` watcher. In your `config.yaml`, configure the worker under `iii-exec`:
+
+```yaml
+workers:
+  - name: iii-exec
+    config:
+      command: bun run --watch src/main.ts
+```
+
+Run the engine, and it will start your worker process with file watching built in.
+
+---
+
+## Step 8 — Production build
+
+Motia had `motia build`. Replace it with a plain esbuild config.
+
+Add to `package.json`:
+
+```json
+{
+  "scripts": {
+    "build": "bun run esbuild.config.ts"
+  }
+}
+```
+
+Create `esbuild.config.ts`:
+
+```typescript
+import * as esbuild from 'esbuild'
+
+esbuild.build({
+  entryPoints: ['src/main.ts'],
+  outfile: 'dist/index-production.js',
+  bundle: true,
+  platform: 'node',
+  target: ['node22'],
+  format: 'esm',
+  minify: true,
+  sourcemap: true,
+  external: ['ws'],
+}).catch((err) => {
+  console.error(err)
+  process.exit(1)
+})
+```
+
+Key decisions:
+
+- **`bundle: true`** — all application code and npm dependencies are bundled into a single file.
+- **`external: ['ws']`** — the `ws` package has native addons and must remain in `node_modules` at runtime.
+- **`sourcemap: true`** — run production with `bun run --enable-source-maps dist/index-production.js` so stack traces map back to TypeScript source.
+- **`platform: 'node'`** — Node.js built-ins (`fs`, `path`, `crypto`, etc.) are treated as external.
+- **`format: 'esm'`** — matches `"type": "module"` in your `package.json`.
+
+Update your production config to run the bundled output:
+
+```yaml
+workers:
+  - name: iii-exec
+    config:
+      command: bun run --enable-source-maps dist/index-production.js
+```
+
+---
+
+## Migration checklist
+
+- [ ] Remove `motia` from dependencies, add `iii-sdk@0.11.0`
+- [ ] Add `esbuild` as a dev dependency
+- [ ] Create `src/lib/iii.ts` with `registerWorker` and `Logger`
+- [ ] Create `src/lib/iii-helpers.ts` with the `fn()` helper
+- [ ] Rename all `*.step.ts` files to `*.ts`
+- [ ] Replace all `import { ... } from 'motia'` with iii-sdk imports
+- [ ] Convert every `config` + `handler` export to a `fn()` call with chained triggers
+- [ ] Replace `status` with `status_code` in every handler return
+- [ ] Replace `params` with `path_params` and `query` with `query_params`
+- [ ] Replace `requestBody` with `request_body` in streaming handlers
+- [ ] Create `src/main.ts` with side-effect imports for every handler
+- [ ] Replace `motia dev` with `bun run --watch src/main.ts` in your dev config
+- [ ] Replace `motia build` with an esbuild config
+- [ ] Test all endpoints, cron jobs, queue subscribers, and stream handlers

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -297,7 +297,7 @@
                 "group": "0.11.0",
                 "pages": [
                   "changelog/0-11-0/everything-is-a-worker",
-                  "changelog/0-11-0/migrating-from-motia"
+                  "changelog/0-11-0/migrating-from-motia-js"
                 ]
               }
             ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -295,7 +295,10 @@
               },
               {
                 "group": "0.11.0",
-                "pages": ["changelog/0-11-0/everything-is-a-worker"]
+                "pages": [
+                  "changelog/0-11-0/everything-is-a-worker",
+                  "changelog/0-11-0/migrating-from-motia"
+                ]
               }
             ]
           }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -297,7 +297,8 @@
                 "group": "0.11.0",
                 "pages": [
                   "changelog/0-11-0/everything-is-a-worker",
-                  "changelog/0-11-0/migrating-from-motia-js"
+                  "changelog/0-11-0/migrating-from-motia-js",
+                  "changelog/0-11-0/migrating-from-motia-py"
                 ]
               }
             ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Motia framework marked as Breaking/deprecated in v0.11.0; users should migrate to iii-sdk
  * New step-by-step migration guides added for JavaScript and Python to help move existing projects to iii-sdk
  * Changelog and site navigation updated to surface the migration guidance and include a migration checklist
<!-- end of auto-generated comment: release notes by coderabbit.ai -->