### PR TITLE
docs: update migration guide for iii-sdk, replacing fn() helper with …

### DIFF
--- a/docs/changelog/0-11-0/migrating-from-motia-js.mdx
+++ b/docs/changelog/0-11-0/migrating-from-motia-js.mdx
@@ -310,9 +310,7 @@ iii.registerTrigger({
 
 ### Stream and State operations
 
-In Motia, you used the `Stream` class and `stateManager` to read and write data. Under the hood, these called `iii.trigger()` with built-in function IDs (`stream::get`, `state::set`, etc.). With iii-sdk, you can call `iii.trigger()` directly or create your own wrapper classes.
-
-#### Calling `iii.trigger()` directly
+In Motia, you used the `Stream` class and `stateManager` to read and write data. Under the hood, these called `iii.trigger()` with built-in function IDs (`stream::get`, `state::set`, etc.). With iii-sdk, you call `iii.trigger()` directly. See the [Stream](/workers/iii-stream) and [State](/workers/iii-state) worker docs for the full list of operations.
 
 <Tabs>
 <Tab title="Stream">
@@ -368,84 +366,6 @@ const allSettings = await iii.trigger({
 </Tabs>
 
 <Callout type="info">Additional function IDs: `stream::update`, `stream::list_groups`, `stream::send` for streams; `state::update`, `state::list_groups` for state.</Callout>
-
-#### Creating wrapper classes
-
-If you prefer the ergonomics Motia's `Stream` and `StateManager` provided, create thin wrappers around `iii.trigger()`:
-
-```typescript title="@/lib/stream"
-import { iii } from '@/lib/iii'
-
-export class Stream {
-  constructor(private name: string) {}
-
-  async get<T>(groupId: string, itemId: string): Promise<T | null> {
-    return iii.trigger({
-      function_id: 'stream::get',
-      payload: { stream_name: this.name, group_id: groupId, item_id: itemId },
-    }) as Promise<T | null>
-  }
-
-  async set<T>(groupId: string, itemId: string, data: T) {
-    return iii.trigger({
-      function_id: 'stream::set',
-      payload: { stream_name: this.name, group_id: groupId, item_id: itemId, data },
-    })
-  }
-
-  async delete(groupId: string, itemId: string) {
-    return iii.trigger({
-      function_id: 'stream::delete',
-      payload: { stream_name: this.name, group_id: groupId, item_id: itemId },
-    })
-  }
-
-  async list<T>(groupId: string): Promise<T[]> {
-    return iii.trigger({
-      function_id: 'stream::list',
-      payload: { stream_name: this.name, group_id: groupId },
-    }) as Promise<T[]>
-  }
-}
-```
-
-```typescript title="@/lib/state"
-import { iii } from '@/lib/iii'
-
-export class StateManager {
-  async get<T>(scope: string, key: string): Promise<T | null> {
-    return iii.trigger({ function_id: 'state::get', payload: { scope, key } }) as Promise<T | null>
-  }
-
-  async set<T>(scope: string, key: string, value: T) {
-    return iii.trigger({ function_id: 'state::set', payload: { scope, key, value } })
-  }
-
-  async delete(scope: string, key: string) {
-    return iii.trigger({ function_id: 'state::delete', payload: { scope, key } })
-  }
-
-  async list<T>(scope: string): Promise<T[]> {
-    return iii.trigger({ function_id: 'state::list', payload: { scope } }) as Promise<T[]>
-  }
-}
-
-export const stateManager = new StateManager()
-```
-
-Usage is then the same as it was in Motia:
-
-```typescript
-import { Stream } from '@/lib/stream'
-import { stateManager } from '@/lib/state'
-
-const todoStream = new Stream('todos')
-const todo = await todoStream.get('user-1', 'todo-1')
-await todoStream.set('user-1', 'todo-1', { title: 'Buy milk' })
-
-const theme = await stateManager.get('settings', 'theme')
-await stateManager.set('settings', 'theme', 'dark')
-```
 
 ### Stream lifecycle hooks (`onJoin` / `onLeave`)
 

--- a/docs/changelog/0-11-0/migrating-from-motia-js.mdx
+++ b/docs/changelog/0-11-0/migrating-from-motia-js.mdx
@@ -308,6 +308,244 @@ iii.registerTrigger({
 })
 ```
 
+### Stream and State operations
+
+In Motia, you used the `Stream` class and `stateManager` to read and write data. Under the hood, these called `iii.trigger()` with built-in function IDs (`stream::get`, `state::set`, etc.). With iii-sdk, you can call `iii.trigger()` directly or create your own wrapper classes.
+
+#### Calling `iii.trigger()` directly
+
+<Tabs>
+<Tab title="Stream">
+```typescript
+import { iii } from '@/lib/iii'
+
+const todo = await iii.trigger({
+  function_id: 'stream::get',
+  payload: { stream_name: 'todos', group_id: 'user-1', item_id: 'todo-1' },
+})
+
+await iii.trigger({
+  function_id: 'stream::set',
+  payload: { stream_name: 'todos', group_id: 'user-1', item_id: 'todo-1', data: { title: 'Buy milk' } },
+})
+
+await iii.trigger({
+  function_id: 'stream::delete',
+  payload: { stream_name: 'todos', group_id: 'user-1', item_id: 'todo-1' },
+})
+
+const items = await iii.trigger({
+  function_id: 'stream::list',
+  payload: { stream_name: 'todos', group_id: 'user-1' },
+})
+```
+</Tab>
+<Tab title="State">
+```typescript
+import { iii } from '@/lib/iii'
+
+const theme = await iii.trigger({
+  function_id: 'state::get',
+  payload: { scope: 'settings', key: 'theme' },
+})
+
+await iii.trigger({
+  function_id: 'state::set',
+  payload: { scope: 'settings', key: 'theme', value: 'dark' },
+})
+
+await iii.trigger({
+  function_id: 'state::delete',
+  payload: { scope: 'settings', key: 'theme' },
+})
+
+const allSettings = await iii.trigger({
+  function_id: 'state::list',
+  payload: { scope: 'settings' },
+})
+```
+</Tab>
+</Tabs>
+
+<Callout type="info">Additional function IDs: `stream::update`, `stream::list_groups`, `stream::send` for streams; `state::update`, `state::list_groups` for state.</Callout>
+
+#### Creating wrapper classes
+
+If you prefer the ergonomics Motia's `Stream` and `StateManager` provided, create thin wrappers around `iii.trigger()`:
+
+```typescript title="@/lib/stream"
+import { iii } from '@/lib/iii'
+
+export class Stream {
+  constructor(private name: string) {}
+
+  async get<T>(groupId: string, itemId: string): Promise<T | null> {
+    return iii.trigger({
+      function_id: 'stream::get',
+      payload: { stream_name: this.name, group_id: groupId, item_id: itemId },
+    }) as Promise<T | null>
+  }
+
+  async set<T>(groupId: string, itemId: string, data: T) {
+    return iii.trigger({
+      function_id: 'stream::set',
+      payload: { stream_name: this.name, group_id: groupId, item_id: itemId, data },
+    })
+  }
+
+  async delete(groupId: string, itemId: string) {
+    return iii.trigger({
+      function_id: 'stream::delete',
+      payload: { stream_name: this.name, group_id: groupId, item_id: itemId },
+    })
+  }
+
+  async list<T>(groupId: string): Promise<T[]> {
+    return iii.trigger({
+      function_id: 'stream::list',
+      payload: { stream_name: this.name, group_id: groupId },
+    }) as Promise<T[]>
+  }
+}
+```
+
+```typescript title="@/lib/state"
+import { iii } from '@/lib/iii'
+
+export class StateManager {
+  async get<T>(scope: string, key: string): Promise<T | null> {
+    return iii.trigger({ function_id: 'state::get', payload: { scope, key } }) as Promise<T | null>
+  }
+
+  async set<T>(scope: string, key: string, value: T) {
+    return iii.trigger({ function_id: 'state::set', payload: { scope, key, value } })
+  }
+
+  async delete(scope: string, key: string) {
+    return iii.trigger({ function_id: 'state::delete', payload: { scope, key } })
+  }
+
+  async list<T>(scope: string): Promise<T[]> {
+    return iii.trigger({ function_id: 'state::list', payload: { scope } }) as Promise<T[]>
+  }
+}
+
+export const stateManager = new StateManager()
+```
+
+Usage is then the same as it was in Motia:
+
+```typescript
+import { Stream } from '@/lib/stream'
+import { stateManager } from '@/lib/state'
+
+const todoStream = new Stream('todos')
+const todo = await todoStream.get('user-1', 'todo-1')
+await todoStream.set('user-1', 'todo-1', { title: 'Buy milk' })
+
+const theme = await stateManager.get('settings', 'theme')
+await stateManager.set('settings', 'theme', 'dark')
+```
+
+### Stream lifecycle hooks (`onJoin` / `onLeave`)
+
+In Motia, `*.stream.ts` files could define `onJoin` and `onLeave` callbacks inside the `StreamConfig`. The framework registered a single shared function for each hook and dispatched by stream name internally.
+
+With iii-sdk, you register these as regular functions with `stream:join` and `stream:leave` triggers. The handler receives a `StreamJoinLeaveEvent` with `{ stream_name, group_id, id, context }`.
+
+<Tabs>
+<Tab title="Motia">
+```typescript
+import { type StreamConfig } from 'motia'
+
+export const config: StreamConfig = {
+  name: 'todo',
+  schema: todoSchema,
+  baseConfig: { storageType: 'default' },
+
+  onJoin: async (subscription, _context, authContext) => {
+    return { unauthorized: false }
+  },
+
+  onLeave: async (subscription, _context, authContext) => {
+    // cleanup logic
+  },
+}
+```
+</Tab>
+<Tab title="iii-sdk">
+```typescript
+import { iii } from '@/lib/iii'
+
+iii.registerFunction('stream::on-join', async (event) => {
+  const { stream_name, group_id, id, context } = event
+  return { unauthorized: false }
+})
+
+iii.registerTrigger({
+  type: 'stream:join',
+  function_id: 'stream::on-join',
+  config: {},
+})
+
+iii.registerFunction('stream::on-leave', async (event) => {
+  const { stream_name, group_id, id, context } = event
+  // cleanup logic
+})
+
+iii.registerTrigger({
+  type: 'stream:leave',
+  function_id: 'stream::on-leave',
+  config: {},
+})
+```
+</Tab>
+</Tabs>
+
+<Callout type="info">If you had multiple streams with different `onJoin` / `onLeave` logic, dispatch by `event.stream_name` inside the handler or register separate function IDs per stream.</Callout>
+
+### Stream authentication (`authenticateStream`)
+
+In Motia, `motia.config.ts` exported an `authenticateStream` function that ran during WebSocket upgrade. With iii-sdk, you register a function directly and reference its ID in the engine's stream module config.
+
+<Tabs>
+<Tab title="Motia">
+```typescript
+// motia.config.ts
+import type { AuthenticateStream } from 'motia'
+
+export const authenticateStream: AuthenticateStream = async (req, context) => {
+  return { context: { userId: 'sergio' } }
+}
+```
+</Tab>
+<Tab title="iii-sdk">
+```typescript
+import { iii } from '@/lib/iii'
+
+iii.registerFunction('stream::authenticate', async (input) => {
+  const { headers, path, query_params, addr } = input
+  return { context: { userId: 'sergio' } }
+})
+```
+</Tab>
+</Tabs>
+
+The engine calls this function during WebSocket upgrade. Reference the function ID in your `config.yaml`:
+
+```yaml
+workers:
+  - name: iii-stream
+    config:
+      auth_function: stream::authenticate
+```
+
+Key differences:
+
+- Motia used `queryParams` (camelCase); iii-sdk uses `query_params` (snake_case).
+- No trigger registration is needed for auth — it is config-driven via `auth_function`.
+- The `motia.config.ts` file is no longer needed; delete it.
+
 ---
 
 ## Step 4 — Update request and response shapes
@@ -478,6 +716,10 @@ workers:
 - [ ] Replace `status` with `status_code` in every handler return
 - [ ] Replace `params` with `path_params` and `query` with `query_params`
 - [ ] Replace `requestBody` with `request_body` in streaming handlers
+- [ ] Replace `Stream` and `stateManager` usage with `iii.trigger()` calls or custom wrappers
+- [ ] Migrate stream `onJoin` / `onLeave` hooks to `registerFunction` + `registerTrigger` (`stream:join` / `stream:leave`)
+- [ ] Migrate `authenticateStream` from `motia.config.ts` to a registered function and set `auth_function` in `config.yaml`
+- [ ] Delete `motia.config.ts`
 - [ ] Create `src/main.ts` with side-effect imports for every handler
 - [ ] Replace `motia dev` with `bun run --watch src/main.ts` in your dev config
 - [ ] Replace `motia build` with an esbuild config

--- a/docs/changelog/0-11-0/migrating-from-motia-js.mdx
+++ b/docs/changelog/0-11-0/migrating-from-motia-js.mdx
@@ -38,7 +38,7 @@ pnpm add -D esbuild
 
 Create `src/lib/iii.ts`. This replaces the implicit connection that Motia managed for you.
 
-```typescript
+```typescript title="@/lib/iii"
 import { Logger, registerWorker } from 'iii-sdk'
 
 export const iii = registerWorker(process.env.III_URL ?? 'ws://localhost:49134', {

--- a/docs/changelog/0-11-0/migrating-from-motia-js.mdx
+++ b/docs/changelog/0-11-0/migrating-from-motia-js.mdx
@@ -52,153 +52,9 @@ Every `import { logger } from 'motia'` in your codebase changes to `import { log
 
 ---
 
-## Step 3 — Create the `fn()` helper
+## Step 3 — Migrate handlers
 
-Motia auto-registered functions and triggers from exported `config` objects. With iii-sdk you call `registerFunction` and `registerTrigger` directly. The `fn()` helper below gives you a chainable API that keeps handler files concise while remaining fully explicit.
-
-Create `src/lib/iii-helpers.ts`:
-
-```typescript
-import type { RemoteFunctionHandler, Trigger, HttpRequest } from 'iii-sdk'
-import { iii } from './iii'
-
-export type Middleware = (input: HttpRequest) => Promise<any | void> | any | void
-
-export interface HttpOptions {
-  middleware?: Middleware[]
-}
-
-export interface QueueOptions {
-  config?: {
-    type?: 'fifo' | 'standard'
-    maxRetries?: number
-    visibilityTimeout?: number
-    delaySeconds?: number
-    concurrency?: number
-    backoffType?: string
-    backoffDelayMs?: number
-  }
-}
-
-export interface StreamOptions {
-  groupId?: string
-  itemId?: string
-}
-
-export interface FnOptions {
-  description?: string
-  metadata?: Record<string, unknown>
-}
-
-export interface FnRegistration {
-  http(method: string, path: string, options?: HttpOptions): FnRegistration
-  cron(expression: string): FnRegistration
-  queue(topic: string, options?: QueueOptions): FnRegistration
-  state(): FnRegistration
-  stream(streamName: string, options?: StreamOptions): FnRegistration
-  unregister(): void
-}
-
-export function fn(
-  id: string,
-  handler: RemoteFunctionHandler,
-  options?: FnOptions,
-): FnRegistration {
-  let ref = iii.registerFunction(id, handler, options)
-  const triggers: Trigger[] = []
-
-  const registration: FnRegistration = {
-    http(method, path, httpOptions?) {
-      if (httpOptions?.middleware?.length) {
-        const originalHandler = handler
-
-        const wrappedHandler: RemoteFunctionHandler = async (input) => {
-          for (const mw of httpOptions.middleware!) {
-            const result = await mw(input)
-            if (result && typeof result === 'object' && 'status_code' in result) return result
-          }
-          return originalHandler(input)
-        }
-        ref.unregister()
-        ref = iii.registerFunction(id, wrappedHandler, options)
-      }
-
-      triggers.push(
-        iii.registerTrigger({
-          type: 'http',
-          function_id: ref.id,
-          config: { api_path: path, http_method: method },
-        }),
-      )
-      return registration
-    },
-
-    cron(expression) {
-      triggers.push(
-        iii.registerTrigger({
-          type: 'cron',
-          function_id: ref.id,
-          config: { expression },
-        }),
-      )
-      return registration
-    },
-
-    queue(topic, queueOptions?) {
-      triggers.push(
-        iii.registerTrigger({
-          type: 'durable:subscriber',
-          function_id: ref.id,
-          config: {
-            topic,
-            ...(queueOptions?.config ? { queue_config: queueOptions.config } : {}),
-          },
-        }),
-      )
-      return registration
-    },
-
-    state() {
-      triggers.push(
-        iii.registerTrigger({
-          type: 'state',
-          function_id: ref.id,
-          config: {},
-        }),
-      )
-      return registration
-    },
-
-    stream(streamName, streamOptions?) {
-      triggers.push(
-        iii.registerTrigger({
-          type: 'stream',
-          function_id: ref.id,
-          config: {
-            stream_name: streamName,
-            ...(streamOptions?.groupId ? { group_id: streamOptions.groupId } : {}),
-            ...(streamOptions?.itemId ? { item_id: streamOptions.itemId } : {}),
-          },
-        }),
-      )
-      return registration
-    },
-
-    unregister() {
-      for (const t of triggers) t.unregister()
-      ref.unregister()
-    },
-  }
-
-  return registration
-}
-```
-
-<Callout type="info">The `fn()` helper handles middleware by wrapping the handler at registration time. iii also supports engine-native HTTP middleware via `middleware_function_ids`. See [Use HTTP middleware](/how-to/use-http-middleware) for details.</Callout>
-
----
-
-## Step 4 — Migrate handlers
+Motia auto-registered functions and triggers from exported `config` objects. With iii-sdk you call `registerFunction` and `registerTrigger` directly.
 
 ### HTTP
 
@@ -221,11 +77,17 @@ export const handler: Handlers<typeof config> = async (_input, _ctx) => {
 </Tab>
 <Tab title="iii-sdk">
 ```typescript
-import { fn } from '@/lib/iii-helpers'
+import { iii } from '@/lib/iii'
 
-fn('health', async () => {
+const ref = iii.registerFunction('health', async () => {
   return { status_code: 200, body: { ok: true } }
-}).http('GET', '/health')
+})
+
+iii.registerTrigger({
+  type: 'http',
+  function_id: ref.id,
+  config: { api_path: '/health', http_method: 'GET' },
+})
 ```
 </Tab>
 </Tabs>
@@ -251,14 +113,25 @@ export const handler: Handlers<typeof config> = async (input, ctx) => {
 </Tab>
 <Tab title="iii-sdk">
 ```typescript
-import { fn } from '@/lib/iii-helpers'
-import { auth } from '@/middleware/auth'
+import { iii } from '@/lib/iii'
 
-fn('list-tags', async (input) => {
+const ref = iii.registerFunction('list-tags', async (input) => {
   const { sub: userId, orgId } = input.tokenInfo
   return { status_code: 200, body: { tags: allTags } }
-}).http('GET', '/tag', { middleware: [auth({ required: true })] })
+})
+
+iii.registerTrigger({
+  type: 'http',
+  function_id: ref.id,
+  config: {
+    api_path: '/tag',
+    http_method: 'GET',
+    middleware_function_ids: ['middleware::auth'],
+  },
+})
 ```
+
+<Callout type="info">Middleware functions must be registered separately with `registerFunction`. See [Use HTTP middleware](/how-to/use-http-middleware) for details.</Callout>
 </Tab>
 </Tabs>
 
@@ -282,11 +155,17 @@ export const handler: Handlers<typeof config> = async (_input, _ctx) => {
 </Tab>
 <Tab title="iii-sdk">
 ```typescript
-import { fn } from '@/lib/iii-helpers'
+import { iii } from '@/lib/iii'
 
-fn('daily-report', async () => {
+const ref = iii.registerFunction('daily-report', async () => {
   await generateReport()
-}).cron('0 0 9 * * * *')
+})
+
+iii.registerTrigger({
+  type: 'cron',
+  function_id: ref.id,
+  config: { expression: '0 0 9 * * * *' },
+})
 ```
 </Tab>
 </Tabs>
@@ -311,11 +190,17 @@ export const handler: Handlers<typeof config> = async (input, _ctx) => {
 </Tab>
 <Tab title="iii-sdk">
 ```typescript
-import { fn } from '@/lib/iii-helpers'
+import { iii } from '@/lib/iii'
 
-fn('process-order', async (input) => {
+const ref = iii.registerFunction('process-order', async (input) => {
   await processOrder(input)
-}).queue('order.created')
+})
+
+iii.registerTrigger({
+  type: 'durable:subscriber',
+  function_id: ref.id,
+  config: { topic: 'order.created' },
+})
 ```
 </Tab>
 </Tabs>
@@ -351,11 +236,17 @@ export const handler: Handlers<typeof config> = async (input, _ctx) => {
 </Tab>
 <Tab title="iii-sdk">
 ```typescript
-import { fn } from '@/lib/iii-helpers'
+import { iii } from '@/lib/iii'
 
-fn('on-state-change', async (input) => {
+const ref = iii.registerFunction('on-state-change', async (input) => {
   await handleStateChange(input)
-}).state()
+})
+
+iii.registerTrigger({
+  type: 'state',
+  function_id: ref.id,
+  config: {},
+})
 ```
 </Tab>
 </Tabs>
@@ -380,30 +271,46 @@ export const handler: Handlers<typeof config> = async (input, _ctx) => {
 </Tab>
 <Tab title="iii-sdk">
 ```typescript
-import { fn } from '@/lib/iii-helpers'
+import { iii } from '@/lib/iii'
 
-fn('chat-message', async (input) => {
+const ref = iii.registerFunction('chat-message', async (input) => {
   await handleChatMessage(input)
-}).stream('chat', { groupId: 'room-1' })
+})
+
+iii.registerTrigger({
+  type: 'stream',
+  function_id: ref.id,
+  config: { stream_name: 'chat', group_id: 'room-1' },
+})
 ```
 </Tab>
 </Tabs>
 
 ### Multiple triggers on one function
 
-A function can chain multiple triggers. This was possible in Motia via the `triggers` array, and maps directly to chained calls:
+A function can have multiple triggers. This was possible in Motia via the `triggers` array, and maps directly to multiple `registerTrigger` calls sharing the same `function_id`:
 
 ```typescript
-fn('order-handler', async (input) => {
+const ref = iii.registerFunction('order-handler', async (input) => {
   await handleOrder(input)
 })
-  .http('POST', '/orders')
-  .queue('order.retry')
+
+iii.registerTrigger({
+  type: 'http',
+  function_id: ref.id,
+  config: { api_path: '/orders', http_method: 'POST' },
+})
+
+iii.registerTrigger({
+  type: 'durable:subscriber',
+  function_id: ref.id,
+  config: { topic: 'order.retry' },
+})
 ```
 
 ---
 
-## Step 5 — Update request and response shapes
+## Step 4 — Update request and response shapes
 
 ### Request properties
 
@@ -460,7 +367,7 @@ return { status_code: 404, body: { error: 'Not found' } }
 
 ---
 
-## Step 6 — Set up the entry point
+## Step 5 — Set up the entry point
 
 Motia discovered `.step.ts` files automatically. With iii-sdk, you create a single entry point that imports all handler files as side effects.
 
@@ -476,7 +383,7 @@ import './handlers/reports/daily-report'
 // ... import every handler file
 ```
 
-Each import executes the `fn()` call at the module level, registering the function and its triggers with the engine.
+Each import executes the `registerFunction` and `registerTrigger` calls at the module level, registering the function and its triggers with the engine.
 
 ### File renaming
 
@@ -491,7 +398,7 @@ The directory structure is yours to decide — `handlers/`, `routes/`, `rest/`, 
 
 ---
 
-## Step 7 — Development workflow
+## Step 6 — Development workflow
 
 Replace Motia's dev command with a direct `bun` watcher. In your `config.yaml`, configure the worker under `iii-exec`:
 
@@ -506,7 +413,7 @@ Run the engine, and it will start your worker process with file watching built i
 
 ---
 
-## Step 8 — Production build
+## Step 7 — Production build
 
 Motia had `motia build`. Replace it with a plain esbuild config.
 
@@ -565,10 +472,9 @@ workers:
 - [ ] Remove `motia` from dependencies, add `iii-sdk@0.11.0`
 - [ ] Add `esbuild` as a dev dependency
 - [ ] Create `src/lib/iii.ts` with `registerWorker` and `Logger`
-- [ ] Create `src/lib/iii-helpers.ts` with the `fn()` helper
 - [ ] Rename all `*.step.ts` files to `*.ts`
 - [ ] Replace all `import { ... } from 'motia'` with iii-sdk imports
-- [ ] Convert every `config` + `handler` export to a `fn()` call with chained triggers
+- [ ] Convert every `config` + `handler` export to `registerFunction` + `registerTrigger` calls
 - [ ] Replace `status` with `status_code` in every handler return
 - [ ] Replace `params` with `path_params` and `query` with `query_params`
 - [ ] Replace `requestBody` with `request_body` in streaming handlers

--- a/docs/changelog/0-11-0/migrating-from-motia-py.mdx
+++ b/docs/changelog/0-11-0/migrating-from-motia-py.mdx
@@ -312,6 +312,241 @@ iii.register_trigger({
 })
 ```
 
+### Stream and State operations
+
+In Motia, you used the `Stream` class and `stateManager` singleton to read and write data. Under the hood, these called `iii.trigger()` with built-in function IDs (`stream::get`, `state::set`, etc.). With iii-sdk, you can call `iii.trigger()` directly or create your own wrapper classes.
+
+#### Calling `iii.trigger()` directly
+
+<Tabs>
+<Tab title="Stream">
+```python
+from src.lib.iii_client import iii
+
+todo = iii.trigger({
+    "function_id": "stream::get",
+    "payload": {"stream_name": "todos", "group_id": "user-1", "item_id": "todo-1"},
+})
+
+iii.trigger({
+    "function_id": "stream::set",
+    "payload": {"stream_name": "todos", "group_id": "user-1", "item_id": "todo-1", "data": {"title": "Buy milk"}},
+})
+
+iii.trigger({
+    "function_id": "stream::delete",
+    "payload": {"stream_name": "todos", "group_id": "user-1", "item_id": "todo-1"},
+})
+
+items = iii.trigger({
+    "function_id": "stream::list",
+    "payload": {"stream_name": "todos", "group_id": "user-1"},
+})
+```
+</Tab>
+<Tab title="State">
+```python
+from src.lib.iii_client import iii
+
+theme = iii.trigger({
+    "function_id": "state::get",
+    "payload": {"scope": "settings", "key": "theme"},
+})
+
+iii.trigger({
+    "function_id": "state::set",
+    "payload": {"scope": "settings", "key": "theme", "value": "dark"},
+})
+
+iii.trigger({
+    "function_id": "state::delete",
+    "payload": {"scope": "settings", "key": "theme"},
+})
+
+all_settings = iii.trigger({
+    "function_id": "state::list",
+    "payload": {"scope": "settings"},
+})
+```
+</Tab>
+</Tabs>
+
+<Callout type="info">Additional function IDs: `stream::update`, `stream::list_groups`, `stream::send` for streams; `state::update`, `state::list_groups` for state.</Callout>
+
+#### Creating wrapper classes
+
+If you prefer the ergonomics Motia's `Stream` and `stateManager` provided, create thin wrappers around `iii.trigger()`:
+
+```python title="src/lib/stream.py"
+from src.lib.iii_client import iii
+
+
+class Stream:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def get(self, group_id: str, item_id: str):
+        return iii.trigger({
+            "function_id": "stream::get",
+            "payload": {"stream_name": self.name, "group_id": group_id, "item_id": item_id},
+        })
+
+    def set(self, group_id: str, item_id: str, data):
+        return iii.trigger({
+            "function_id": "stream::set",
+            "payload": {"stream_name": self.name, "group_id": group_id, "item_id": item_id, "data": data},
+        })
+
+    def delete(self, group_id: str, item_id: str):
+        return iii.trigger({
+            "function_id": "stream::delete",
+            "payload": {"stream_name": self.name, "group_id": group_id, "item_id": item_id},
+        })
+
+    def list(self, group_id: str):
+        return iii.trigger({
+            "function_id": "stream::list",
+            "payload": {"stream_name": self.name, "group_id": group_id},
+        })
+```
+
+```python title="src/lib/state.py"
+from src.lib.iii_client import iii
+
+
+class StateManager:
+    def get(self, scope: str, key: str):
+        return iii.trigger({"function_id": "state::get", "payload": {"scope": scope, "key": key}})
+
+    def set(self, scope: str, key: str, value):
+        return iii.trigger({"function_id": "state::set", "payload": {"scope": scope, "key": key, "value": value}})
+
+    def delete(self, scope: str, key: str):
+        return iii.trigger({"function_id": "state::delete", "payload": {"scope": scope, "key": key}})
+
+    def list(self, scope: str):
+        return iii.trigger({"function_id": "state::list", "payload": {"scope": scope}})
+
+
+state_manager = StateManager()
+```
+
+Usage is then the same as it was in Motia:
+
+```python
+from src.lib.stream import Stream
+from src.lib.state import state_manager
+
+todo_stream = Stream("todos")
+todo = todo_stream.get("user-1", "todo-1")
+todo_stream.set("user-1", "todo-1", {"title": "Buy milk"})
+
+theme = state_manager.get("settings", "theme")
+state_manager.set("settings", "theme", "dark")
+```
+
+### Stream lifecycle hooks (`onJoin` / `onLeave`)
+
+In Motia, stream files could define `onJoin` and `onLeave` callbacks inside the stream config. The framework registered a single shared function for each hook and dispatched by stream name internally.
+
+With iii-sdk, you register these as regular functions with `stream:join` and `stream:leave` triggers. The handler receives a dict with `stream_name`, `group_id`, `id`, and `context`.
+
+<Tabs>
+<Tab title="Motia">
+```python
+config = {
+    "name": "todo",
+    "schema": todo_schema,
+    "base_config": {"storage_type": "default"},
+}
+
+def on_join(subscription, context, auth_context):
+    return {"unauthorized": False}
+
+def on_leave(subscription, context, auth_context):
+    pass  # cleanup logic
+```
+</Tab>
+<Tab title="iii-sdk">
+```python
+from src.lib.iii_client import iii
+
+def stream_on_join(event):
+    stream_name = event.get("stream_name")
+    group_id = event.get("group_id")
+    item_id = event.get("id")
+    context = event.get("context")
+    return {"unauthorized": False}
+
+iii.register_function("stream::on-join", stream_on_join)
+iii.register_trigger({
+    "type": "stream:join",
+    "function_id": "stream::on-join",
+    "config": {},
+})
+
+def stream_on_leave(event):
+    stream_name = event.get("stream_name")
+    group_id = event.get("group_id")
+    item_id = event.get("id")
+    context = event.get("context")
+    # cleanup logic
+
+iii.register_function("stream::on-leave", stream_on_leave)
+iii.register_trigger({
+    "type": "stream:leave",
+    "function_id": "stream::on-leave",
+    "config": {},
+})
+```
+</Tab>
+</Tabs>
+
+<Callout type="info">If you had multiple streams with different `onJoin` / `onLeave` logic, dispatch by `event["stream_name"]` inside the handler or register separate function IDs per stream.</Callout>
+
+### Stream authentication (`authenticateStream`)
+
+In Motia, `motia_config.py` (or `motia.config.ts` for JS projects) exported an authentication function that ran during WebSocket upgrade. With iii-sdk, you register a function directly and reference its ID in the engine's stream module config.
+
+<Tabs>
+<Tab title="Motia">
+```python
+# motia_config.py
+def authenticate_stream(req, context):
+    return {"context": {"userId": "sergio"}}
+```
+</Tab>
+<Tab title="iii-sdk">
+```python
+from src.lib.iii_client import iii
+
+def stream_authenticate(data):
+    headers = data.get("headers")
+    path = data.get("path")
+    query_params = data.get("query_params")
+    addr = data.get("addr")
+    return {"context": {"userId": "sergio"}}
+
+iii.register_function("stream::authenticate", stream_authenticate)
+```
+</Tab>
+</Tabs>
+
+The engine calls this function during WebSocket upgrade. Reference the function ID in your `config.yaml`:
+
+```yaml
+workers:
+  - name: iii-stream
+    config:
+      auth_function: stream::authenticate
+```
+
+Key differences:
+
+- Motia used `queryParams` (camelCase); iii-sdk uses `query_params` (snake_case).
+- No trigger registration is needed for auth — it is config-driven via `auth_function`.
+- The `motia_config.py` file is no longer needed; delete it.
+
 ---
 
 ## Step 5 — Update request and response shapes
@@ -496,6 +731,10 @@ workers:
 - [ ] Replace `ApiResponse(status=...)` with plain dicts using `statusCode` (e.g., `{"statusCode": 200, "body": ...}`)
 - [ ] Replace `request.path_params` / `request.query_params` attribute access with dict-key access on the raw payload (`data["path_params"]`, `data.get("query_params")`)
 - [ ] Replace `requestBody` with `request_body` in streaming handlers
+- [ ] Replace `Stream` and `stateManager` usage with `iii.trigger()` calls or custom wrappers
+- [ ] Migrate stream `on_join` / `on_leave` hooks to `register_function` + `register_trigger` (`stream:join` / `stream:leave`)
+- [ ] Migrate `authenticate_stream` from `motia_config.py` to a registered function and set `auth_function` in `config.yaml`
+- [ ] Delete `motia_config.py`
 - [ ] Create `src/main.py` with side-effect imports for every handler module
 - [ ] Replace `motia dev` with an `iii-exec` worker using `watch` + `exec` in your `config.yaml`
 - [ ] Replace `motia build` with `pip install .` (and a `Dockerfile` for containerized deploys)

--- a/docs/changelog/0-11-0/migrating-from-motia-py.mdx
+++ b/docs/changelog/0-11-0/migrating-from-motia-py.mdx
@@ -314,9 +314,7 @@ iii.register_trigger({
 
 ### Stream and State operations
 
-In Motia, you used the `Stream` class and `stateManager` singleton to read and write data. Under the hood, these called `iii.trigger()` with built-in function IDs (`stream::get`, `state::set`, etc.). With iii-sdk, you can call `iii.trigger()` directly or create your own wrapper classes.
-
-#### Calling `iii.trigger()` directly
+In Motia, you used the `Stream` class and `stateManager` singleton to read and write data. Under the hood, these called `iii.trigger()` with built-in function IDs (`stream::get`, `state::set`, etc.). With iii-sdk, you call `iii.trigger()` directly. See the [Stream](/workers/iii-stream) and [State](/workers/iii-state) worker docs for the full list of operations.
 
 <Tabs>
 <Tab title="Stream">
@@ -372,78 +370,6 @@ all_settings = iii.trigger({
 </Tabs>
 
 <Callout type="info">Additional function IDs: `stream::update`, `stream::list_groups`, `stream::send` for streams; `state::update`, `state::list_groups` for state.</Callout>
-
-#### Creating wrapper classes
-
-If you prefer the ergonomics Motia's `Stream` and `stateManager` provided, create thin wrappers around `iii.trigger()`:
-
-```python title="src/lib/stream.py"
-from src.lib.iii_client import iii
-
-
-class Stream:
-    def __init__(self, name: str) -> None:
-        self.name = name
-
-    def get(self, group_id: str, item_id: str):
-        return iii.trigger({
-            "function_id": "stream::get",
-            "payload": {"stream_name": self.name, "group_id": group_id, "item_id": item_id},
-        })
-
-    def set(self, group_id: str, item_id: str, data):
-        return iii.trigger({
-            "function_id": "stream::set",
-            "payload": {"stream_name": self.name, "group_id": group_id, "item_id": item_id, "data": data},
-        })
-
-    def delete(self, group_id: str, item_id: str):
-        return iii.trigger({
-            "function_id": "stream::delete",
-            "payload": {"stream_name": self.name, "group_id": group_id, "item_id": item_id},
-        })
-
-    def list(self, group_id: str):
-        return iii.trigger({
-            "function_id": "stream::list",
-            "payload": {"stream_name": self.name, "group_id": group_id},
-        })
-```
-
-```python title="src/lib/state.py"
-from src.lib.iii_client import iii
-
-
-class StateManager:
-    def get(self, scope: str, key: str):
-        return iii.trigger({"function_id": "state::get", "payload": {"scope": scope, "key": key}})
-
-    def set(self, scope: str, key: str, value):
-        return iii.trigger({"function_id": "state::set", "payload": {"scope": scope, "key": key, "value": value}})
-
-    def delete(self, scope: str, key: str):
-        return iii.trigger({"function_id": "state::delete", "payload": {"scope": scope, "key": key}})
-
-    def list(self, scope: str):
-        return iii.trigger({"function_id": "state::list", "payload": {"scope": scope}})
-
-
-state_manager = StateManager()
-```
-
-Usage is then the same as it was in Motia:
-
-```python
-from src.lib.stream import Stream
-from src.lib.state import state_manager
-
-todo_stream = Stream("todos")
-todo = todo_stream.get("user-1", "todo-1")
-todo_stream.set("user-1", "todo-1", {"title": "Buy milk"})
-
-theme = state_manager.get("settings", "theme")
-state_manager.set("settings", "theme", "dark")
-```
 
 ### Stream lifecycle hooks (`onJoin` / `onLeave`)
 


### PR DESCRIPTION
…direct registerFunction and registerTrigger calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Migration guides revised to remove the deprecated chainable helper pattern and show explicit function registration plus separate trigger registrations.
  * HTTP examples updated to register middleware and triggers separately; multiple triggers now shown via repeated trigger registrations for one function.
  * New Stream & State sections with built-in trigger examples, lifecycle hook migration, and auth migration notes (including camelCase→snake_case param difference).
  * Migration checklist and step ordering updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->