### PR TITLE
feat(engine+sdk): route OTEL telemetry to dedicated /otel endpoint

### DIFF
--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -1390,6 +1390,80 @@ impl Engine {
         Ok(())
     }
 
+    /// Handles OTEL-only WebSocket connections.
+    ///
+    /// SDKs open a second WS exclusively for OpenTelemetry (OTLP/MTRC/LOGS
+    /// binary frames). Routing that traffic through `handle_worker` would
+    /// pollute `worker_registry` with ghost rows that have no metadata, no
+    /// functions, and no pid — doubling the worker count, inflating the
+    /// `workers_active` metric, and adding noise to `Worker registered`
+    /// logs. This handler performs the same RBAC handshake as a normal
+    /// worker connection but skips `worker_registry.register_worker`, and
+    /// only accepts telemetry binary frames on the inbound side.
+    pub async fn handle_otel(
+        &self,
+        socket: WebSocket,
+        peer: SocketAddr,
+        uri: Uri,
+        headers: HeaderMap,
+        config: Arc<WorkerManagerConfig>,
+        mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    ) -> anyhow::Result<()> {
+        tracing::debug!(peer = %peer, "OTEL connection opened");
+        let (mut ws_tx, mut ws_rx) = socket.split();
+
+        // Reuse the worker RBAC gate so OTEL traffic can't bypass auth.
+        if let Err(err) =
+            rbac_session::handle_session(peer, Arc::new(self.clone()), config, uri, headers).await
+        {
+            let error_msg = serde_json::json!({
+                "type": "error",
+                "error": { "code": err.code, "message": err.message }
+            });
+            let _ = ws_tx
+                .send(WsMessage::Text(error_msg.to_string().into()))
+                .await;
+            let _ = ws_tx.send(WsMessage::Close(None)).await;
+            return Ok(());
+        }
+
+        loop {
+            tokio::select! {
+                frame = ws_rx.next() => {
+                    match frame {
+                        Some(Ok(WsMessage::Binary(bytes))) => {
+                            if !handle_telemetry_frame(&bytes, &peer).await {
+                                tracing::warn!(peer = %peer, "Unrecognized binary frame on /otel (dropping)");
+                            }
+                        }
+                        Some(Ok(WsMessage::Text(_))) => {
+                            // /otel is binary-only. Text frames here are a
+                            // protocol mistake — ignore rather than crash.
+                            tracing::debug!(peer = %peer, "Ignoring text frame on /otel");
+                        }
+                        Some(Ok(WsMessage::Close(_))) => {
+                            tracing::debug!(peer = %peer, "OTEL peer closed");
+                            break;
+                        }
+                        Some(Ok(WsMessage::Ping(payload))) => {
+                            let _ = ws_tx.send(WsMessage::Pong(payload)).await;
+                        }
+                        Some(Ok(WsMessage::Pong(_))) => {}
+                        Some(Err(_)) | None => break,
+                    }
+                }
+                _ = shutdown_rx.changed() => {
+                    tracing::debug!(peer = %peer, "Shutdown signal received, closing OTEL connection");
+                    let _ = ws_tx.send(WsMessage::Close(None)).await;
+                    break;
+                }
+            }
+        }
+
+        tracing::debug!(peer = %peer, "OTEL connection closed");
+        Ok(())
+    }
+
     async fn cleanup_worker(&self, worker: &WorkerConnection) {
         let regular_functions = worker.get_regular_function_ids().await;
         let external_functions = worker.get_external_function_ids().await;

--- a/engine/src/workers/worker/mod.rs
+++ b/engine/src/workers/worker/mod.rs
@@ -112,6 +112,7 @@ impl Worker for WorkerManager {
             // Setup router
             let app = Router::new()
                 .route("/", get(ws_handler))
+                .route("/otel", get(otel_ws_handler))
                 .route("/ws/channels/{channel_id}", get(channel_ws_upgrade))
                 .with_state(state);
 
@@ -193,6 +194,30 @@ async fn ws_handler(
             .await
         {
             tracing::error!(addr = %addr, error = ?err, "worker error");
+        }
+    })
+}
+
+/// WS upgrade handler for the OTEL-only endpoint (`/otel`).
+///
+/// Keeps telemetry traffic off the worker registry. See
+/// `Engine::handle_otel` for the rationale.
+async fn otel_ws_handler(
+    State(state): State<AppState>,
+    ws: WebSocketUpgrade,
+    uri: Uri,
+    headers: HeaderMap,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+) -> impl IntoResponse {
+    let engine = state.engine.clone();
+    let config = state.config.clone();
+
+    ws.on_upgrade(move |socket| async move {
+        if let Err(err) = engine
+            .handle_otel(socket, addr, uri, headers, config, state.shutdown_rx)
+            .await
+        {
+            tracing::error!(addr = %addr, error = ?err, "otel connection error");
         }
     })
 }

--- a/engine/tests/otel_ws_no_worker_registration_test.rs
+++ b/engine/tests/otel_ws_no_worker_registration_test.rs
@@ -74,10 +74,9 @@ async fn otel_path_skips_worker_registry_registration() {
     // Step 1: connect a normal worker socket to `/`. This should register
     // exactly one WorkerConnection, proving the test harness is wired
     // correctly (and that the default route behavior is unchanged).
-    let (mut normal_ws, _) =
-        tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{}/", port))
-            .await
-            .expect("connect to / should succeed");
+    let (mut normal_ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{}/", port))
+        .await
+        .expect("connect to / should succeed");
 
     // The engine's `handle_worker` sends a `WorkerRegistered` message
     // synchronously after `register_worker`, so once the client observes

--- a/engine/tests/otel_ws_no_worker_registration_test.rs
+++ b/engine/tests/otel_ws_no_worker_registration_test.rs
@@ -1,0 +1,135 @@
+//! Regression test for the OTEL WS routing fix.
+//!
+//! Pre-fix: every WebSocket connection hitting the engine — including
+//! the secondary OTEL-only socket opened by the SDK for traces, metrics,
+//! and logs — was handed to `handle_worker`, which unconditionally
+//! called `worker_registry.register_worker`. The OTEL socket never sent
+//! a `RegisterWorker` function call, so it sat in the registry with null
+//! name/os/runtime/pid: a ghost worker alongside every real one. That
+//! doubled `workers::list` output, inflated `workers_active` metrics,
+//! and produced two `Worker registered` log lines per worker startup.
+//!
+//! Fix: the engine now exposes a dedicated `/otel` route. SDKs connect
+//! their telemetry socket there. The new route runs the same RBAC
+//! handshake as `/` but does NOT touch `worker_registry`, and only
+//! accepts binary telemetry frames on the inbound side.
+//!
+//! This test boots the full `WorkerManager` axum router on a random
+//! port, connects one WS client to `/` and one to `/otel`, and asserts:
+//!   1. `/` produces exactly 1 registry entry.
+//!   2. `/otel` produces ZERO additional registry entries.
+//! Without the fix, `/otel` would 404 (pre-route) OR register the
+//! telemetry socket (pre-path-routing), both of which this test catches.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::SinkExt;
+use iii::engine::Engine;
+use iii::workers::traits::Worker;
+use iii::workers::worker::{WorkerManager, WorkerManagerConfig};
+use serde_json::json;
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+/// Boots a `WorkerManager` on a random port and returns the port + engine
+/// handle so the test can later inspect `worker_registry`. The worker
+/// manager runs in a background task for the duration of the test.
+async fn spawn_engine() -> (u16, Arc<Engine>) {
+    // Pre-bind to discover an available port so the test avoids racing
+    // against CI parallelism on 49134.
+    let probe = TcpListener::bind("127.0.0.1:0").await.expect("bind probe");
+    let port = probe.local_addr().expect("local_addr").port();
+    drop(probe);
+
+    let engine = Arc::new(Engine::new());
+    let config = json!({ "port": port, "host": "127.0.0.1" });
+    let worker = WorkerManager::create(engine.clone(), Some(config))
+        .await
+        .expect("create WorkerManager");
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    worker
+        .start_background_tasks(shutdown_rx, shutdown_tx)
+        .await
+        .expect("start WorkerManager");
+
+    // Give axum a moment to bind.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    (port, engine)
+}
+
+#[tokio::test]
+async fn otel_path_skips_worker_registry_registration() {
+    let (port, engine) = spawn_engine().await;
+
+    // Baseline: registry starts empty.
+    assert_eq!(
+        engine.worker_registry.list_workers().len(),
+        0,
+        "registry should start empty"
+    );
+
+    // Step 1: connect a normal worker socket to `/`. This should register
+    // exactly one WorkerConnection, proving the test harness is wired
+    // correctly (and that the default route behavior is unchanged).
+    let (mut normal_ws, _) =
+        tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{}/", port))
+            .await
+            .expect("connect to / should succeed");
+
+    // The engine's `handle_worker` sends a `WorkerRegistered` message
+    // synchronously after `register_worker`, so once the client observes
+    // any inbound message the registry insert is guaranteed to have
+    // happened. Wait up to 500ms to stay well clear of CI jitter.
+    tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            if engine.worker_registry.list_workers().len() >= 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("`/` should register a worker within 500ms");
+
+    let after_normal = engine.worker_registry.list_workers().len();
+    assert_eq!(
+        after_normal, 1,
+        "`/` connection should add exactly one registry entry"
+    );
+
+    // Step 2: connect an OTEL-only socket to `/otel`. This must NOT add
+    // a registry entry, even after sending a telemetry binary frame.
+    let (mut otel_ws, _) =
+        tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{}/otel", port))
+            .await
+            .expect("connect to /otel should succeed");
+
+    // Send a synthetic OTLP frame. `OTLP` prefix + empty JSON object is
+    // the minimum the engine's `handle_telemetry_frame` will accept as a
+    // recognized telemetry frame.
+    let mut frame = b"OTLP".to_vec();
+    frame.extend_from_slice(b"{}");
+    otel_ws
+        .send(WsMessage::Binary(frame.into()))
+        .await
+        .expect("send OTLP frame");
+
+    // Give the engine a generous window to process the frame. If a
+    // regression reintroduced the bug, `register_worker` would have
+    // fired on connect (before any frame was sent), so 200ms is plenty.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let after_otel = engine.worker_registry.list_workers().len();
+    assert_eq!(
+        after_otel, 1,
+        "`/otel` connection must NOT add a worker registry entry \
+         (got {after_otel}, expected 1 from the `/` connection above)"
+    );
+
+    // Cleanup: drop sockets so the engine background task doesn't leak.
+    let _ = normal_ws.close(None).await;
+    let _ = otel_ws.close(None).await;
+}

--- a/sdk/packages/node/iii/src/telemetry-system/index.ts
+++ b/sdk/packages/node/iii/src/telemetry-system/index.ts
@@ -53,8 +53,10 @@ export * from './context'
  * up as a ghost null-metadata worker).
  */
 function appendOtelPath(base: string): string {
-  const trimmed = base.replace(/\/+$/, '')
-  return trimmed.endsWith('/otel') ? trimmed : `${trimmed}/otel`
+  const url = new URL(base)
+  const path = url.pathname.replace(/\/+$/, '')
+  url.pathname = path.endsWith('/otel') ? path : `${path}/otel`
+  return url.toString()
 }
 
 // Module-level state

--- a/sdk/packages/node/iii/src/telemetry-system/index.ts
+++ b/sdk/packages/node/iii/src/telemetry-system/index.ts
@@ -46,6 +46,17 @@ import { parseIntegerEnv, parseNumberEnv } from './utils'
 export * from './types'
 export * from './context'
 
+/**
+ * Normalize an engine WebSocket URL into the dedicated OTEL endpoint.
+ * The engine exposes `/otel` for telemetry-only WS connections; routing
+ * there keeps this socket out of the worker registry (otherwise it shows
+ * up as a ghost null-metadata worker).
+ */
+function appendOtelPath(base: string): string {
+  const trimmed = base.replace(/\/+$/, '')
+  return trimmed.endsWith('/otel') ? trimmed : `${trimmed}/otel`
+}
+
 // Module-level state
 let sharedConnection: SharedEngineConnection | null = null
 let tracerProvider: NodeTracerProvider | null = null
@@ -88,8 +99,11 @@ export function initOtel(config: OtelConfig = {}): void {
   }
   const resource = new Resource(resourceAttributes)
 
-  // Create shared WebSocket connection
-  sharedConnection = new SharedEngineConnection(engineWsUrl, config.reconnectionConfig)
+  // Create shared WebSocket connection.
+  // OTEL always connects to the engine's dedicated `/otel` endpoint so
+  // the telemetry socket doesn't get registered in `worker_registry` as
+  // a ghost null-metadata worker alongside the real worker.
+  sharedConnection = new SharedEngineConnection(appendOtelPath(engineWsUrl), config.reconnectionConfig)
 
   // Initialize tracer
   const spanExporter = new EngineSpanExporter(sharedConnection)

--- a/sdk/packages/python/iii/src/iii/telemetry.py
+++ b/sdk/packages/python/iii/src/iii/telemetry.py
@@ -31,12 +31,16 @@ def _append_otel_path(base: str) -> str:
 
     The engine exposes ``/otel`` for telemetry-only WS connections; routing
     there keeps this socket out of ``worker_registry`` (otherwise it shows
-    up as a ghost null-metadata worker alongside the real worker).
+    up as a ghost null-metadata worker alongside the real worker). Query
+    strings and fragments are preserved.
     """
-    trimmed = base.rstrip("/")
-    if trimmed.endswith("/otel"):
-        return trimmed
-    return f"{trimmed}/otel"
+    from urllib.parse import urlsplit, urlunsplit
+
+    parts = urlsplit(base)
+    path = parts.path.rstrip("/")
+    if not path.endswith("/otel"):
+        path = f"{path}/otel"
+    return urlunsplit((parts.scheme, parts.netloc, path, parts.query, parts.fragment))
 
 
 def init_otel(

--- a/sdk/packages/python/iii/src/iii/telemetry.py
+++ b/sdk/packages/python/iii/src/iii/telemetry.py
@@ -26,6 +26,19 @@ _fetch_patched: bool = False
 _DEFAULT_SERVICE_NAME = "iii-python-sdk"
 
 
+def _append_otel_path(base: str) -> str:
+    """Normalize an engine WS URL into the dedicated ``/otel`` endpoint.
+
+    The engine exposes ``/otel`` for telemetry-only WS connections; routing
+    there keeps this socket out of ``worker_registry`` (otherwise it shows
+    up as a ghost null-metadata worker alongside the real worker).
+    """
+    trimmed = base.rstrip("/")
+    if trimmed.endswith("/otel"):
+        return trimmed
+    return f"{trimmed}/otel"
+
+
 def init_otel(
     config: OtelConfig | None = None,
     loop: asyncio.AbstractEventLoop | None = None,
@@ -81,7 +94,10 @@ def init_otel(
     from .telemetry_exporters import EngineSpanExporter, SharedEngineConnection
 
     ws_url = cfg.engine_ws_url or os.environ.get("III_URL") or "ws://localhost:49134"
-    _connection = SharedEngineConnection(ws_url)
+    # Route OTEL to the engine's dedicated `/otel` endpoint so the
+    # telemetry socket doesn't get registered in `worker_registry` as a
+    # ghost null-metadata worker alongside every real worker.
+    _connection = SharedEngineConnection(_append_otel_path(ws_url))
     if loop is not None:
         _connection.start(loop)
 

--- a/sdk/packages/rust/iii/src/telemetry/mod.rs
+++ b/sdk/packages/rust/iii/src/telemetry/mod.rs
@@ -51,15 +51,20 @@ fn get_otel_lock() -> &'static Mutex<Option<OtelState>> {
 ///
 /// The engine exposes `/otel` for telemetry-only WS connections. Appending
 /// the path here means the SDK never shows up in `worker_registry` as a
-/// ghost null-metadata worker. Handles trailing slashes and is idempotent
-/// when the URL already ends in `/otel`. Callers must not pass URLs that
-/// include a query string — this helper does not split path from query.
+/// ghost null-metadata worker. Handles trailing slashes, is idempotent
+/// when the URL already ends in `/otel`, and preserves query strings and
+/// fragments by inserting `/otel` into the path segment only.
 fn append_otel_path(base: &str) -> String {
-    let trimmed = base.trim_end_matches('/');
+    let split_idx = base
+        .find(|c: char| c == '?' || c == '#')
+        .unwrap_or(base.len());
+    let (prefix, suffix) = base.split_at(split_idx);
+    let trimmed = prefix.trim_end_matches('/');
     if trimmed.ends_with("/otel") {
-        return trimmed.to_string();
+        format!("{trimmed}{suffix}")
+    } else {
+        format!("{trimmed}/otel{suffix}")
     }
-    format!("{trimmed}/otel")
 }
 
 #[cfg(test)]
@@ -87,6 +92,38 @@ mod otel_path_tests {
         assert_eq!(
             append_otel_path("ws://localhost:49134/otel"),
             "ws://localhost:49134/otel"
+        );
+    }
+
+    #[test]
+    fn preserves_query_string() {
+        assert_eq!(
+            append_otel_path("ws://localhost:49134?token=abc"),
+            "ws://localhost:49134/otel?token=abc"
+        );
+    }
+
+    #[test]
+    fn preserves_query_string_when_already_otel() {
+        assert_eq!(
+            append_otel_path("ws://localhost:49134/otel?token=abc"),
+            "ws://localhost:49134/otel?token=abc"
+        );
+    }
+
+    #[test]
+    fn preserves_fragment() {
+        assert_eq!(
+            append_otel_path("ws://localhost:49134#frag"),
+            "ws://localhost:49134/otel#frag"
+        );
+    }
+
+    #[test]
+    fn strips_trailing_slash_before_query() {
+        assert_eq!(
+            append_otel_path("ws://localhost:49134/otel/?token=abc"),
+            "ws://localhost:49134/otel?token=abc"
         );
     }
 }

--- a/sdk/packages/rust/iii/src/telemetry/mod.rs
+++ b/sdk/packages/rust/iii/src/telemetry/mod.rs
@@ -47,6 +47,49 @@ fn get_otel_lock() -> &'static Mutex<Option<OtelState>> {
     OTEL_STATE.get_or_init(|| Mutex::new(None))
 }
 
+/// Normalize an engine WebSocket URL into the dedicated OTEL endpoint.
+///
+/// The engine exposes `/otel` for telemetry-only WS connections. Appending
+/// the path here means the SDK never shows up in `worker_registry` as a
+/// ghost null-metadata worker. Handles trailing slashes, existing query
+/// strings, and URLs that already point at a path.
+fn append_otel_path(base: &str) -> String {
+    let trimmed = base.trim_end_matches('/');
+    if trimmed.ends_with("/otel") {
+        return trimmed.to_string();
+    }
+    format!("{trimmed}/otel")
+}
+
+#[cfg(test)]
+mod otel_path_tests {
+    use super::append_otel_path;
+
+    #[test]
+    fn appends_otel_path() {
+        assert_eq!(
+            append_otel_path("ws://localhost:49134"),
+            "ws://localhost:49134/otel"
+        );
+    }
+
+    #[test]
+    fn strips_trailing_slash_before_appending() {
+        assert_eq!(
+            append_otel_path("ws://localhost:49134/"),
+            "ws://localhost:49134/otel"
+        );
+    }
+
+    #[test]
+    fn is_idempotent() {
+        assert_eq!(
+            append_otel_path("ws://localhost:49134/otel"),
+            "ws://localhost:49134/otel"
+        );
+    }
+}
+
 /// Initialize OpenTelemetry with the given configuration.
 ///
 /// Sets up distributed tracing, optional metrics, and optional log export
@@ -92,10 +135,17 @@ pub async fn init_otel(config: OtelConfig) -> bool {
         .service_instance_id
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
-    let ws_url = config
-        .engine_ws_url
-        .or_else(|| std::env::var("III_URL").ok())
-        .unwrap_or_else(|| "ws://localhost:49134".to_string());
+    let ws_url = {
+        let base = config
+            .engine_ws_url
+            .or_else(|| std::env::var("III_URL").ok())
+            .unwrap_or_else(|| "ws://localhost:49134".to_string());
+        // Route OTEL to the dedicated `/otel` endpoint so the engine
+        // doesn't register this connection in `worker_registry`. The
+        // telemetry socket would otherwise show up as a ghost worker
+        // (null name/os/pid/runtime) alongside every real worker.
+        append_otel_path(&base)
+    };
 
     let reconnection_config = config.reconnection_config.unwrap_or_default();
 

--- a/sdk/packages/rust/iii/src/telemetry/mod.rs
+++ b/sdk/packages/rust/iii/src/telemetry/mod.rs
@@ -51,8 +51,9 @@ fn get_otel_lock() -> &'static Mutex<Option<OtelState>> {
 ///
 /// The engine exposes `/otel` for telemetry-only WS connections. Appending
 /// the path here means the SDK never shows up in `worker_registry` as a
-/// ghost null-metadata worker. Handles trailing slashes, existing query
-/// strings, and URLs that already point at a path.
+/// ghost null-metadata worker. Handles trailing slashes and is idempotent
+/// when the URL already ends in `/otel`. Callers must not pass URLs that
+/// include a query string — this helper does not split path from query.
 fn append_otel_path(base: &str) -> String {
     let trimmed = base.trim_end_matches('/');
     if trimmed.ends_with("/otel") {

--- a/sdk/packages/rust/iii/src/telemetry/mod.rs
+++ b/sdk/packages/rust/iii/src/telemetry/mod.rs
@@ -55,9 +55,7 @@ fn get_otel_lock() -> &'static Mutex<Option<OtelState>> {
 /// when the URL already ends in `/otel`, and preserves query strings and
 /// fragments by inserting `/otel` into the path segment only.
 fn append_otel_path(base: &str) -> String {
-    let split_idx = base
-        .find(|c: char| c == '?' || c == '#')
-        .unwrap_or(base.len());
+    let split_idx = base.find(['?', '#']).unwrap_or(base.len());
     let (prefix, suffix) = base.split_at(split_idx);
     let trimmed = prefix.trim_end_matches('/');
     if trimmed.ends_with("/otel") {


### PR DESCRIPTION
## Summary

- Every WebSocket connection to the engine was being treated as a worker and inserted into `worker_registry`. The SDKs open a second WS exclusively for OTEL (OTLP/MTRC/LOGS binary frames); that secondary socket never sends a `RegisterWorker` call, so it sat in the registry with null `name`/`os`/`runtime`/`pid` — a ghost worker alongside every real one. Result: `workers::list` returned 2N rows, the `workers_active` metric was 2x real, and two `Worker registered` log lines fired per startup.
- Engine change: new `/otel` route handled by `Engine::handle_otel`. Runs the same RBAC handshake as `handle_worker` but skips `worker_registry.register_worker`, only accepts binary telemetry frames via `handle_telemetry_frame`, and skips `cleanup_worker` on disconnect. Default `/` route unchanged.
- SDK change: Node/Python/Rust each gain a small idempotent helper (`appendOtelPath` / `_append_otel_path` / `append_otel_path`) that routes the shared telemetry WS to `/otel`. Rust ships three unit tests on the helper.

## Backwards compatibility

- **Old SDK + new engine**: OTEL still works. Binary frames on `/` still flow through `handle_telemetry_frame`, and the ghost-worker row returns for that connection only (matching pre-fix behavior). No regression.
- **New SDK + old engine**: `/otel` 404s and OTEL silently stops. Downgrade-only breakage. For external SDK consumers pinning older engine versions, either add SDK-side fallback (try `/otel`, fall back to `/` on upgrade failure) or document an engine-version floor.

## Test plan

- [x] `cargo test -p iii --test otel_ws_no_worker_registration_test` — asserts `/` registers one worker and `/otel` adds zero entries even after a synthetic OTLP frame.
- [x] `cargo test -p iii-sdk` — Rust `append_otel_path` unit tests (3 cases: bare URL, trailing slash, already-has-otel).
- [ ] Manual: boot engine + one Node SDK + one Python SDK + one Rust SDK; run `iii trigger --function-id='engine::workers::list'`; confirm N rows (not 2N) and no null-metadata entries.
- [ ] Manual: tail engine logs during worker startup; confirm one `Worker registered` line per worker (not two).
- [ ] Manual: pin an old SDK against this engine; confirm OTEL still reaches the engine via `/` and ghost row reappears (expected compat behavior).

## Engine-visible impact after deploy

- `workers::list` drops from 2N rows to N.
- `workers_active` metric is accurate.
- Spurious `Function ... already registered. Overwriting.` warnings go away on reload (they were caused by the OTEL-socket race rather than real duplicates).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated telemetry WebSocket endpoint; SDKs now connect to it automatically.

* **Bug Fixes**
  * Telemetry connections no longer register workers.
  * Telemetry handler processes binary OTEL frames, ignores text frames, supports ping/pong, and closes promptly on shutdown.

* **Tests**
  * Added integration and unit tests validating telemetry routing and URL normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->