### PR TITLE
fix(sdk): graceful shutdown to close dev-loop worker-reload race

### DIFF
--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -767,7 +767,18 @@ class Sdk implements ISdk {
           ws.removeAllListeners()
           resolve()
         }
-        const timer = setTimeout(done, 500)
+        const timer = setTimeout(() => {
+          // Close handshake didn't complete in time. Force-close the
+          // underlying socket so it doesn't linger half-open until the
+          // OS TCP timeout — long-lived hosts that call shutdown()
+          // without exiting would otherwise leak the socket.
+          try {
+            ws.terminate()
+          } catch {
+            // Already closed.
+          }
+          done()
+        }, 500)
         timer.unref()
         ws.once('close', () => {
           clearTimeout(timer)

--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -114,6 +114,21 @@ export type InitOptions = {
   otel?: Omit<OtelConfig, 'engineWsUrl'>
   /** Custom HTTP headers sent during the WebSocket handshake. */
   headers?: Record<string, string>
+  /**
+   * Auto-install `SIGTERM` and `SIGINT` handlers that call {@link ISdk.shutdown}
+   * and then `process.exit(128 + signal_number)`. Defaults to `true`.
+   *
+   * Without this, `SIGTERM` takes Node's default action (immediate termination)
+   * and the WebSocket dies without a Close frame. The engine then races between
+   * cleaning up the old worker's registrations and processing the new worker's
+   * register messages, which produces spurious "function is already registered,
+   * Overwriting" warnings in the engine log and, rarely, wipes the fresh
+   * registrations entirely.
+   *
+   * Set to `false` if you want to own signal handling (for example, to drain
+   * in-flight work before calling `shutdown()` yourself).
+   */
+  autoShutdown?: boolean
   /** @internal */
   telemetry?: TelemetryOptions
 }
@@ -138,6 +153,7 @@ class Sdk implements ISdk {
   private reconnectAttempt = 0
   private connectionState: IIIConnectionState = 'disconnected'
   private isShuttingDown = false
+  private signalHandlers?: Array<{ signal: NodeJS.Signals; handler: () => void }>
 
   constructor(
     private readonly address: string,
@@ -155,6 +171,52 @@ class Sdk implements ISdk {
     initOtel({ ...options?.otel, engineWsUrl: this.address })
 
     this.connect()
+
+    // Auto-install signal handlers so dev-loop supervisors (e.g. iii-worker's
+    // SIGTERM-based fast restart) get a clean WebSocket close before the
+    // process dies. See InitOptions.autoShutdown for rationale.
+    if (options?.autoShutdown !== false) {
+      this.installSignalHandlers()
+    }
+  }
+
+  /**
+   * Install SIGTERM/SIGINT handlers that call {@link shutdown} and then exit
+   * with the conventional `128 + signal_number` status. Stored so they can
+   * be removed by {@link shutdown} (avoid `process.exit` being called after
+   * an explicit shutdown) and on re-install (avoid listener leaks).
+   */
+  private installSignalHandlers(): void {
+    const targets: Array<{ signal: NodeJS.Signals; code: number }> = [
+      { signal: 'SIGTERM', code: 15 },
+      { signal: 'SIGINT', code: 2 },
+    ]
+
+    this.signalHandlers = targets.map(({ signal, code }) => {
+      const handler = () => {
+        // shutdown() is idempotent via isShuttingDown; awaiting it ensures the
+        // WS Close frame is flushed before the process exits so the engine's
+        // cleanup_worker runs before the next worker connects.
+        this.shutdown()
+          .catch(() => {
+            // swallow — we're exiting anyway; shutdown errors shouldn't mask
+            // the signal-code exit
+          })
+          .finally(() => {
+            process.exit(128 + code)
+          })
+      }
+      process.on(signal, handler)
+      return { signal, handler }
+    })
+  }
+
+  private removeSignalHandlers(): void {
+    if (!this.signalHandlers) return
+    for (const { signal, handler } of this.signalHandlers) {
+      process.off(signal, handler)
+    }
+    this.signalHandlers = undefined
   }
 
   /**
@@ -652,7 +714,18 @@ class Sdk implements ISdk {
    * Gracefully shutdown the iii, cleaning up all resources.
    */
   shutdown = async (): Promise<void> => {
+    // Idempotent: a second SIGTERM mid-shutdown, or an explicit shutdown()
+    // call after an auto-shutdown handler has already started, must not
+    // re-enter and double-flush OTel / re-iterate cleared invocations.
+    if (this.isShuttingDown) {
+      return
+    }
     this.isShuttingDown = true
+
+    // Release signal handlers synchronously, BEFORE any awaits. If something
+    // further down (OTel exporter flush, WS close) hangs or throws, the
+    // process still won't trip our auto-shutdown handler on a second signal.
+    this.removeSignalHandlers()
 
     this.stopMetricsReporting()
 
@@ -672,9 +745,40 @@ class Sdk implements ISdk {
     this.invocations.clear()
 
     // Close WebSocket
+    //
+    // Await the close handshake instead of fire-and-forget. Without this
+    // await the signal-handler caller runs process.exit() before the
+    // close frame hits the wire; the engine only notices our
+    // disappearance via eventual TCP timeout, by which point the NEXT
+    // worker (spawned by iii-worker's fast-restart) has already
+    // registered its functions. The engine's cleanup_worker for the
+    // old connection then fires late and removes function registrations
+    // that the new worker has already overwritten — which is exactly
+    // the "change a file and registrations don't get unregistered"
+    // symptom in the bug report.
+    //
+    // 500ms safety timeout so shutdown() can't hang forever if the peer
+    // is unreachable or TCP is wedged. On a healthy localhost the close
+    // handshake completes in <10ms.
     if (this.ws) {
-      this.ws.removeAllListeners()
-      this.ws.close()
+      const ws = this.ws
+      await new Promise<void>((resolve) => {
+        const done = () => {
+          ws.removeAllListeners()
+          resolve()
+        }
+        const timer = setTimeout(done, 500)
+        timer.unref()
+        ws.once('close', () => {
+          clearTimeout(timer)
+          done()
+        })
+        try {
+          ws.close()
+        } catch {
+          // Already closing/closed — just wait for the event or timeout.
+        }
+      })
       this.ws = undefined
     }
 

--- a/sdk/packages/node/iii/tests/auto-shutdown.test.ts
+++ b/sdk/packages/node/iii/tests/auto-shutdown.test.ts
@@ -1,0 +1,214 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WebSocketServer } from 'ws'
+import { registerWorker } from '../src/index'
+import { iii } from './utils'
+import { bridgeIII } from './bridge-utils'
+
+// Neutralise the shared SDK instances created by setup.ts. They're wired to
+// real bridge URLs that aren't running in this test file; without this the
+// global afterAll hook hangs for 30s trying to close their reconnecting
+// WebSockets. Same trick used in exports.test.ts.
+beforeAll(() => {
+  vi.spyOn(iii, 'shutdown').mockResolvedValue(undefined)
+  vi.spyOn(bridgeIII, 'shutdown').mockResolvedValue(undefined)
+})
+
+// The SDK's shutdown() calls `ws.removeAllListeners()` before `ws.close()`,
+// so if a CONNECTING socket hasn't opened yet, the `ws` library emits an
+// unhandled "WebSocket was closed before the connection was established"
+// error. That's pre-existing behaviour unrelated to signal handling; silence
+// it here so the test file's exit status reflects our assertions, not that
+// library quirk. The ws lib emits this via EventEmitter, which surfaces as
+// an uncaughtException (NOT a promise rejection) when no listener is
+// attached after removeAllListeners().
+const wsCloseEarlyRegex = /WebSocket was closed before the connection was established/
+const swallowWsEarlyClose = (err: unknown) => {
+  if (err instanceof Error && wsCloseEarlyRegex.test(err.message)) return
+  throw err
+}
+beforeAll(() => {
+  process.on('unhandledRejection', swallowWsEarlyClose)
+  process.on('uncaughtException', swallowWsEarlyClose)
+})
+afterAll(() => {
+  process.off('unhandledRejection', swallowWsEarlyClose)
+  process.off('uncaughtException', swallowWsEarlyClose)
+})
+
+// Run a throwaway WebSocket server on 127.0.0.1 so the Sdk's connect()
+// can complete cleanly. Using a real server instead of mocking `ws`
+// dodges vitest's module-hoist ordering (setupFiles pre-load the SDK,
+// which caches the real `ws` before any per-file vi.mock can swap it).
+// The server accepts connections and ignores their payloads — we don't
+// care about transport behaviour here, only about signal-handler wiring.
+let server: WebSocketServer
+let serverUrl: string
+
+beforeAll(async () => {
+  server = new WebSocketServer({ host: '127.0.0.1', port: 0 })
+  // Port 0 gives us an OS-assigned port, but the listener isn't ready to
+  // report its address synchronously — wait for the 'listening' event.
+  await new Promise<void>((resolve, reject) => {
+    server.on('listening', resolve)
+    server.on('error', reject)
+  })
+  const addr = server.address()
+  if (typeof addr === 'string' || addr === null) {
+    throw new Error('WebSocketServer failed to bind to an AF_INET port')
+  }
+  serverUrl = `ws://127.0.0.1:${addr.port}`
+  // Accept connections without doing anything — enough for the Sdk's
+  // connect() to succeed and for shutdown() to close cleanly.
+  server.on('connection', () => {})
+})
+
+afterAll(() => {
+  // Tests fire-and-forget shutdown() on multiple Sdk instances; those WS
+  // connections may still be half-open on the server side. Terminate them
+  // before close() so server.close doesn't block waiting for clean closes.
+  for (const client of server.clients) client.terminate()
+  return new Promise<void>((resolve) => server.close(() => resolve()))
+})
+
+describe('auto-shutdown', () => {
+  // Snapshot listener counts before each test so we can assert our SDK
+  // instance added exactly the listeners we expect, without false positives
+  // from Vitest's own or Node's built-in handlers.
+  let baseline: { SIGTERM: number; SIGINT: number }
+
+  beforeEach(() => {
+    baseline = {
+      SIGTERM: process.listenerCount('SIGTERM'),
+      SIGINT: process.listenerCount('SIGINT'),
+    }
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+  })
+
+  it('installs SIGTERM and SIGINT listeners by default', async () => {
+    const sdk = registerWorker(serverUrl, { otel: { enabled: false } })
+    try {
+      expect(process.listenerCount('SIGTERM')).toBe(baseline.SIGTERM + 1)
+      expect(process.listenerCount('SIGINT')).toBe(baseline.SIGINT + 1)
+    } finally {
+      // Listeners are released synchronously at the top of shutdown(), so
+      // we don't need to await the rest of the async teardown (OTel exporter
+      // flush, WS close) which can drag for seconds under test conditions.
+      sdk.shutdown().catch(() => {})
+    }
+  })
+
+  it('does not install listeners when autoShutdown is false', async () => {
+    const sdk = registerWorker(serverUrl, { autoShutdown: false, otel: { enabled: false } })
+    try {
+      expect(process.listenerCount('SIGTERM')).toBe(baseline.SIGTERM)
+      expect(process.listenerCount('SIGINT')).toBe(baseline.SIGINT)
+    } finally {
+      // Listeners are released synchronously at the top of shutdown(), so
+      // we don't need to await the rest of the async teardown (OTel exporter
+      // flush, WS close) which can drag for seconds under test conditions.
+      sdk.shutdown().catch(() => {})
+    }
+  })
+
+  it('removes its listeners on explicit shutdown()', async () => {
+    const sdk = registerWorker(serverUrl, { otel: { enabled: false } })
+    expect(process.listenerCount('SIGTERM')).toBe(baseline.SIGTERM + 1)
+    expect(process.listenerCount('SIGINT')).toBe(baseline.SIGINT + 1)
+
+    // Fire shutdown but don't await — listener removal is the very first
+    // thing shutdown() does, synchronously. If we awaited the full chain
+    // we'd block on OTel/WS teardown, which can hang under test conditions.
+    sdk.shutdown().catch(() => {})
+
+    // If shutdown() doesn't release them, an explicit graceful cleanup
+    // would still trip process.exit() on the next signal — which would be
+    // both surprising and racy for users who wire their own handlers.
+    expect(process.listenerCount('SIGTERM')).toBe(baseline.SIGTERM)
+    expect(process.listenerCount('SIGINT')).toBe(baseline.SIGINT)
+  })
+
+  it('SIGTERM handler calls shutdown then process.exit(143)', async () => {
+    // Intercept process.exit so the test doesn't actually kill the runner.
+    // Throw inside the mock to halt the handler's synchronous tail and
+    // surface timing to the test.
+    // Record the exit call without throwing or actually exiting. The
+    // handler's promise chain (`shutdown().finally(exit)`) will resolve
+    // normally and we assert on the recorded call below.
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => undefined) as never)
+
+    const sdk = registerWorker(serverUrl, { otel: { enabled: false } })
+    const shutdownSpy = vi.spyOn(sdk, 'shutdown')
+
+    // Pick the SIGTERM handler we just installed. It's the last attached
+    // listener (baseline + 1); indexing by position is stable within this
+    // test because beforeEach captured the snapshot right before we
+    // constructed the Sdk.
+    const listeners = process.listeners('SIGTERM') as Array<(signal: NodeJS.Signals) => void>
+    const ourHandler = listeners[listeners.length - 1]
+
+    // Fire it. The handler awaits shutdown() then calls process.exit(143).
+    // We need to wait long enough for the async chain to reach exit; a
+    // microtask flush via `await Promise.resolve()` after invoking isn't
+    // quite enough because shutdown() has its own awaits, so we wait on
+    // the exit spy having been called via a short polling loop.
+    ourHandler('SIGTERM')
+
+    // Drain the microtask queue a few times. shutdown() only awaits
+    // synchronous work here (no network), so 20ms is plenty.
+    const deadline = Date.now() + 1000
+    while (Date.now() < deadline && !exitSpy.mock.calls.length) {
+      await new Promise((r) => setTimeout(r, 10))
+    }
+
+    expect(shutdownSpy).toHaveBeenCalled()
+    expect(exitSpy).toHaveBeenCalledWith(128 + 15)
+  })
+
+  it('SIGINT handler uses exit code 130 (128 + 2)', async () => {
+    // Record the exit call without throwing or actually exiting. The
+    // handler's promise chain (`shutdown().finally(exit)`) will resolve
+    // normally and we assert on the recorded call below.
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => undefined) as never)
+
+    const sdk = registerWorker(serverUrl, { otel: { enabled: false } })
+    vi.spyOn(sdk, 'shutdown')
+
+    const listeners = process.listeners('SIGINT') as Array<(signal: NodeJS.Signals) => void>
+    const ourHandler = listeners[listeners.length - 1]
+    ourHandler('SIGINT')
+
+    const deadline = Date.now() + 1000
+    while (Date.now() < deadline && !exitSpy.mock.calls.length) {
+      await new Promise((r) => setTimeout(r, 10))
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(128 + 2)
+  })
+
+  it('shutdown failures do not block the exit path', async () => {
+    // Record the exit call without throwing or actually exiting. The
+    // handler's promise chain (`shutdown().finally(exit)`) will resolve
+    // normally and we assert on the recorded call below.
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => undefined) as never)
+
+    const sdk = registerWorker(serverUrl, { otel: { enabled: false } })
+    // Force shutdown to reject. The handler's .catch() must swallow this
+    // and still call process.exit — otherwise a misbehaving shutdown would
+    // leave the worker process hanging on signal, defeating the whole point
+    // of auto-shutdown in dev workflows.
+    vi.spyOn(sdk, 'shutdown').mockRejectedValue(new Error('boom'))
+
+    const listeners = process.listeners('SIGTERM') as Array<(signal: NodeJS.Signals) => void>
+    listeners[listeners.length - 1]('SIGTERM')
+
+    const deadline = Date.now() + 1000
+    while (Date.now() < deadline && !exitSpy.mock.calls.length) {
+      await new Promise((r) => setTimeout(r, 10))
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(128 + 15)
+  })
+})

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -168,6 +168,18 @@ class III:
         for signum in (signal.SIGTERM, signal.SIGINT):
             try:
                 previous = signal.signal(signum, self._on_shutdown_signal)
+                # Collapse chains of III handlers: if `previous` is another
+                # III instance's _on_shutdown_signal, recording it directly
+                # would mean restoring a live peer's handler when WE remove
+                # ours. Walk to that peer's recorded predecessor instead so
+                # the chain unwinds to the host's original handler.
+                if (
+                    getattr(previous, "__func__", None)
+                    is getattr(self._on_shutdown_signal, "__func__", None)
+                    and getattr(previous, "__self__", None) is not self
+                ):
+                    other = previous.__self__
+                    previous = other._signal_handlers.get(signum, signal.SIG_DFL)
                 self._signal_handlers[signum] = previous
             except (ValueError, OSError) as exc:
                 # ValueError: not main thread. OSError: unsupported platform.
@@ -186,6 +198,16 @@ class III:
             return
         for signum, previous in self._signal_handlers.items():
             try:
+                # Only restore if our handler is still the active one. If
+                # something else (a newer III instance, host code) installed
+                # a handler after us, restoring `previous` would clobber it.
+                current = signal.getsignal(signum)
+                if not (
+                    getattr(current, "__func__", None)
+                    is getattr(self._on_shutdown_signal, "__func__", None)
+                    and getattr(current, "__self__", None) is self
+                ):
+                    continue
                 signal.signal(signum, previous)
             except (ValueError, OSError):
                 pass

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -6,6 +6,7 @@ import logging
 import os
 import platform
 import random
+import signal
 import threading
 import traceback
 import uuid
@@ -131,9 +132,77 @@ class III:
         self._thread = threading.Thread(target=self._loop.run_forever, daemon=False)
         self._thread.start()
 
+        # Idempotency guard: a second SIGTERM mid-shutdown, or an explicit
+        # shutdown() after the auto-shutdown handler already started, must
+        # not re-enter and re-cancel tasks / re-flush OTel / re-stop the
+        # event loop.
+        self._shutdown_started = False
+
         # Auto-connect (non-blocking, matches Node.js constructor behavior)
         self._connected_event = threading.Event()
         self._schedule_on_loop(self.connect_async())
+
+        # Signal handlers: store previous handlers so shutdown() can restore
+        # them and so we don't replace a handler the host app deliberately
+        # set. Only the main thread can install signal handlers in CPython;
+        # if we're constructed from a worker thread the install is skipped
+        # with a debug log.
+        self._signal_handlers: dict[int, Any] = {}
+        if self._options.auto_shutdown:
+            self._install_signal_handlers()
+
+    def _install_signal_handlers(self) -> None:
+        """Install SIGTERM/SIGINT handlers that call :meth:`shutdown` and then
+        exit with ``128 + signum``.
+
+        The in-VM iii-worker supervisor sends SIGTERM to cycle the worker on
+        source edits; without this, Python takes its default action (immediate
+        termination) and the WebSocket dies without a Close frame, which
+        causes the engine to double-register functions on the next start.
+        """
+        if threading.current_thread() is not threading.main_thread():
+            log.debug(
+                "auto_shutdown: skipping signal handler install (not on main thread)"
+            )
+            return
+        for signum in (signal.SIGTERM, signal.SIGINT):
+            try:
+                previous = signal.signal(signum, self._on_shutdown_signal)
+                self._signal_handlers[signum] = previous
+            except (ValueError, OSError) as exc:
+                # ValueError: not main thread. OSError: unsupported platform.
+                log.debug(
+                    "auto_shutdown: could not install handler for %s: %s",
+                    signum,
+                    exc,
+                )
+
+    def _remove_signal_handlers(self) -> None:
+        """Restore previously-installed signal handlers. Safe to call twice."""
+        if not self._signal_handlers:
+            return
+        if threading.current_thread() is not threading.main_thread():
+            # Can't modify handlers off the main thread; leave them in place.
+            return
+        for signum, previous in self._signal_handlers.items():
+            try:
+                signal.signal(signum, previous)
+            except (ValueError, OSError):
+                pass
+        self._signal_handlers.clear()
+
+    def _on_shutdown_signal(self, signum: int, _frame: Any) -> None:
+        """Triggered by SIGTERM/SIGINT when auto_shutdown is enabled."""
+        # Best effort: close the WS via the blocking shutdown() path from the
+        # main thread, then os._exit with the conventional signal exit code.
+        # We use os._exit rather than sys.exit to avoid re-entrancy issues
+        # with the non-daemon background event-loop thread during a signal
+        # handler.
+        try:
+            self.shutdown()
+        except Exception:
+            pass
+        os._exit(128 + signum)
 
     def _run_on_loop(self, coro: Coroutine[Any, Any, TResult]) -> TResult:
         if threading.current_thread() is self._thread:
@@ -173,6 +242,14 @@ class III:
             >>> # ... do work ...
             >>> iii.shutdown()
         """
+        if self._shutdown_started:
+            return
+        # Restore signal handlers on the caller's thread — signal.signal()
+        # can only be called from the main thread, so doing it inside
+        # shutdown_async (which runs on the background event-loop thread)
+        # silently no-ops. Do it first so we never leave our handler
+        # attached after an explicit shutdown.
+        self._remove_signal_handlers()
         self._run_on_loop(self.shutdown_async())
         self._loop.call_soon_threadsafe(self._loop.stop)
         self._thread.join(timeout=5)
@@ -213,6 +290,9 @@ class III:
             >>> # ... do work ...
             >>> await iii.shutdown_async()
         """
+        if self._shutdown_started:
+            return
+        self._shutdown_started = True
         self._running = False
 
         for task in [self._reconnect_task, self._receiver_task]:

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -173,13 +173,14 @@ class III:
                 # would mean restoring a live peer's handler when WE remove
                 # ours. Walk to that peer's recorded predecessor instead so
                 # the chain unwinds to the host's original handler.
+                prev_func = getattr(previous, "__func__", None)
+                prev_self = getattr(previous, "__self__", None)
                 if (
-                    getattr(previous, "__func__", None)
-                    is getattr(self._on_shutdown_signal, "__func__", None)
-                    and getattr(previous, "__self__", None) is not self
+                    prev_func is getattr(self._on_shutdown_signal, "__func__", None)
+                    and prev_self is not None
+                    and prev_self is not self
                 ):
-                    other = previous.__self__
-                    previous = other._signal_handlers.get(signum, signal.SIG_DFL)
+                    previous = prev_self._signal_handlers.get(signum, signal.SIG_DFL)
                 self._signal_handlers[signum] = previous
             except (ValueError, OSError) as exc:
                 # ValueError: not main thread. OSError: unsupported platform.

--- a/sdk/packages/python/iii/src/iii/iii_constants.py
+++ b/sdk/packages/python/iii/src/iii/iii_constants.py
@@ -71,6 +71,16 @@ class InitOptions:
         reconnection_config: WebSocket reconnection behavior.
         otel: OpenTelemetry configuration. Enabled by default.
             Set ``{'enabled': False}`` or env ``OTEL_ENABLED=false`` to disable.
+        auto_shutdown: Auto-install ``SIGTERM`` and ``SIGINT`` handlers that
+            call :meth:`III.shutdown` and then ``os._exit(128 + signal_number)``.
+            Default ``True``. Without this, ``SIGTERM`` takes Python's default
+            (immediate termination) and the WebSocket dies without a Close
+            frame. The engine then races between cleaning up the old worker's
+            registrations and processing the new worker's register messages,
+            producing spurious ``function is already registered. Overwriting``
+            warnings in the engine log. Set ``False`` to own signal handling
+            yourself (common when embedding the SDK inside a larger service
+            that already traps signals).
         telemetry: Internal telemetry metadata.
     """
 
@@ -80,4 +90,5 @@ class InitOptions:
     reconnection_config: ReconnectionConfig | None = None
     otel: OtelConfig | dict[str, Any] | None = None
     headers: dict[str, str] | None = None
+    auto_shutdown: bool = True
     telemetry: TelemetryOptions | None = None

--- a/sdk/packages/python/iii/tests/test_auto_shutdown.py
+++ b/sdk/packages/python/iii/tests/test_auto_shutdown.py
@@ -1,0 +1,154 @@
+"""Tests for the auto-installed SIGTERM/SIGINT handlers in III.__init__.
+
+Background: the in-VM supervisor (iii-worker) cycles dev-mode workers by
+sending SIGTERM. Without a handler, Python takes its default termination
+action and the WebSocket dies without a Close frame — which leaves the
+engine overwriting stale registrations on each restart. These tests verify
+the handler is installed by default, can be opted out, is cleaned up on
+shutdown, and actually calls shutdown() + os._exit on delivery.
+"""
+
+from __future__ import annotations
+
+import signal
+import threading
+from typing import Any
+from unittest import mock
+
+from iii import InitOptions
+from iii.iii import III
+
+
+def _fake_do_connect_factory() -> Any:
+    """Return a no-op replacement for III._do_connect so tests don't open
+    real sockets. Connection state is still transitioned by connect_async
+    but no network happens.
+    """
+
+    async def fake_do_connect(self: III) -> None:
+        return None
+
+    return fake_do_connect
+
+
+def _build_client(monkeypatch: Any, **init_kwargs: Any) -> III:
+    """Construct an III instance with networking stubbed out. Tests are
+    pure — they only care about signal wiring, not wire protocol.
+    """
+    monkeypatch.setattr(III, "_do_connect", _fake_do_connect_factory())
+
+    # Stub OTel to avoid background metric exporters + their own sockets.
+    import iii.telemetry as telemetry
+
+    monkeypatch.setattr(telemetry, "init_otel", lambda **_kw: None)
+    monkeypatch.setattr(telemetry, "attach_event_loop", lambda *_a, **_kw: None)
+
+    async def fake_shutdown_otel_async() -> None:
+        return None
+
+    monkeypatch.setattr(telemetry, "shutdown_otel_async", fake_shutdown_otel_async)
+
+    return III("ws://127.0.0.1:1/never-binds", options=InitOptions(**init_kwargs))
+
+
+class TestAutoShutdown:
+    def test_installs_sigterm_and_sigint_handlers_by_default(
+        self, monkeypatch: Any
+    ) -> None:
+        """Default init path should replace the SIGTERM and SIGINT handlers
+        with our shutdown signal handler.
+        """
+        if threading.current_thread() is not threading.main_thread():
+            # signal.signal only works on the main thread in CPython; skip in
+            # weird environments that host pytest on a worker thread.
+            return
+
+        client = _build_client(monkeypatch)
+        try:
+            assert (
+                signal.getsignal(signal.SIGTERM) == client._on_shutdown_signal
+            ), "SIGTERM handler should be installed by default"
+            assert (
+                signal.getsignal(signal.SIGINT) == client._on_shutdown_signal
+            ), "SIGINT handler should be installed by default"
+        finally:
+            # shutdown restores previous handlers so subsequent tests aren't
+            # affected.
+            client.shutdown()
+
+    def test_does_not_install_handlers_when_auto_shutdown_is_false(
+        self, monkeypatch: Any
+    ) -> None:
+        before_term = signal.getsignal(signal.SIGTERM)
+        before_int = signal.getsignal(signal.SIGINT)
+
+        client = _build_client(monkeypatch, auto_shutdown=False)
+        try:
+            assert signal.getsignal(signal.SIGTERM) == before_term
+            assert signal.getsignal(signal.SIGINT) == before_int
+        finally:
+            client.shutdown()
+
+    def test_shutdown_restores_previous_signal_handlers(
+        self, monkeypatch: Any
+    ) -> None:
+        """Explicit shutdown() must restore the handlers that were in place
+        before the SDK installed its own. Otherwise a worker that cleans up
+        cleanly would still exit the process on the next signal — surprising
+        for anyone who later wires their own handler.
+        """
+        if threading.current_thread() is not threading.main_thread():
+            return
+
+        sentinel_term = signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        sentinel_int = signal.signal(signal.SIGINT, signal.SIG_DFL)
+        try:
+            client = _build_client(monkeypatch)
+            # SDK installs its handler...
+            assert signal.getsignal(signal.SIGTERM) == client._on_shutdown_signal
+            assert signal.getsignal(signal.SIGINT) == client._on_shutdown_signal
+
+            client.shutdown()
+
+            # ...and shutdown restores what was there before.
+            assert signal.getsignal(signal.SIGTERM) == signal.SIG_DFL
+            assert signal.getsignal(signal.SIGINT) == signal.SIG_DFL
+        finally:
+            # Restore original so the test suite doesn't leak state.
+            signal.signal(signal.SIGTERM, sentinel_term)
+            signal.signal(signal.SIGINT, sentinel_int)
+
+    def test_signal_handler_calls_shutdown_then_exits(self) -> None:
+        """Delivering SIGTERM through our handler should call shutdown() and
+        then os._exit with the conventional 128 + signum code.
+
+        Exercised on a duck-typed stand-in rather than a real III instance.
+        A real III spins up a non-daemon background event-loop thread that
+        a mocked shutdown() would never tear down, and would keep pytest
+        alive forever. The handler only touches ``self.shutdown`` and the
+        module-level ``os._exit``, so a SimpleNamespace exercises it
+        faithfully.
+        """
+        from types import SimpleNamespace
+
+        shutdown_mock = mock.MagicMock()
+        stand_in = SimpleNamespace(shutdown=shutdown_mock)
+
+        with mock.patch("iii.iii.os._exit") as exit_mock:
+            III._on_shutdown_signal(stand_in, signal.SIGTERM, None)  # type: ignore[arg-type]
+            shutdown_mock.assert_called_once()
+            exit_mock.assert_called_once_with(128 + int(signal.SIGTERM))
+
+    def test_signal_handler_exits_even_when_shutdown_raises(self) -> None:
+        """If shutdown() blows up, we still want os._exit to fire — otherwise
+        a misbehaving shutdown path would leave the worker process hanging
+        on SIGTERM, defeating the whole point of auto-shutdown in dev.
+        """
+        from types import SimpleNamespace
+
+        shutdown_mock = mock.MagicMock(side_effect=RuntimeError("boom"))
+        stand_in = SimpleNamespace(shutdown=shutdown_mock)
+
+        with mock.patch("iii.iii.os._exit") as exit_mock:
+            III._on_shutdown_signal(stand_in, signal.SIGINT, None)  # type: ignore[arg-type]
+            exit_mock.assert_called_once_with(128 + int(signal.SIGINT))

--- a/sdk/packages/rust/iii/Cargo.toml
+++ b/sdk/packages/rust/iii/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = "0.8"
 thiserror = "2"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "net"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "net", "signal"] }
 tokio-tungstenite = { version = "0.28", features = ["rustls-tls-native-roots"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -1575,6 +1575,18 @@ impl III {
                             Ok(Outbound::Message(msg)) => queue.push(msg),
                             Ok(Outbound::Shutdown) => {
                                 self.inner.running.store(false, Ordering::SeqCst);
+                                // Mirror the inner-loop Shutdown arm: send a
+                                // clean Close frame so the engine sees a
+                                // graceful disconnect instead of having to
+                                // detect the drop via TCP timeout. Without
+                                // this, a Shutdown that lands between
+                                // connect_async returning and the inner loop
+                                // starting (rare but reachable in tests doing
+                                // rapid connect+shutdown) would reproduce the
+                                // exact bug the inner-loop fix was meant to
+                                // close.
+                                let _ = ws_tx.send(WsMessage::Close(None)).await;
+                                let _ = ws_tx.close().await;
                                 return;
                             }
                             Err(_) => break,

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -645,6 +645,81 @@ impl RegisterFunction {
     }
 }
 
+/// Conventional Unix signal numbers used by the shutdown handler. Hard-
+/// coded so we don't pull in `libc` directly; these values are stable
+/// across every supported platform.
+const SIGTERM_NUM: i32 = 15;
+const SIGINT_NUM: i32 = 2;
+
+/// How long the handler waits between sending `Outbound::Shutdown` to
+/// `run_connection` and forcibly `process::exit`-ing. Matches the
+/// equivalent grace window used by the in-VM supervisor's
+/// `terminate_gracefully` (iii-supervisor::child::SHUTDOWN_GRACE) so
+/// either side bottoming out independently produces the same observed
+/// timing. 500ms is plenty for `run_connection`'s Shutdown branch to
+/// flush the WS Close frame on a healthy localhost.
+const AUTO_SHUTDOWN_GRACE_MS: u64 = 500;
+
+/// Trap SIGTERM/SIGINT and turn the first one into a clean shutdown:
+/// signal `run_connection` to drain (which sends a WS Close frame),
+/// wait briefly for the close to flush, then `process::exit(128 +
+/// signum)`.
+///
+/// Runs on the connection thread's tokio runtime so it can use
+/// `tokio::signal::unix::signal` without spinning up a new runtime
+/// or pulling in `signal-hook`. Does NOT call `III::shutdown` — that
+/// would `join()` the connection thread, but we are running ON that
+/// thread, so the join would deadlock.
+#[cfg(unix)]
+async fn run_auto_shutdown_handler(iii: III) {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let Ok(mut sigterm) = signal(SignalKind::terminate()) else {
+        tracing::warn!("iii: failed to install SIGTERM handler; auto-shutdown disabled");
+        return;
+    };
+    let Ok(mut sigint) = signal(SignalKind::interrupt()) else {
+        tracing::warn!("iii: failed to install SIGINT handler; auto-shutdown disabled");
+        return;
+    };
+
+    let signum = tokio::select! {
+        _ = sigterm.recv() => SIGTERM_NUM,
+        _ = sigint.recv() => SIGINT_NUM,
+    };
+
+    finish_auto_shutdown(iii, signum).await;
+}
+
+/// Windows variant: tokio::signal::unix is unavailable. Trap Ctrl-C only;
+/// no SIGTERM equivalent exists in the same form. Behavior parity with
+/// the Unix path on Ctrl-C; SIGTERM-style supervisor termination on
+/// Windows still falls back to the OS default.
+#[cfg(not(unix))]
+async fn run_auto_shutdown_handler(iii: III) {
+    if tokio::signal::ctrl_c().await.is_err() {
+        tracing::warn!("iii: failed to install Ctrl-C handler; auto-shutdown disabled");
+        return;
+    }
+    finish_auto_shutdown(iii, SIGINT_NUM).await;
+}
+
+async fn finish_auto_shutdown(iii: III, signum: i32) {
+    iii.inner.running.store(false, Ordering::SeqCst);
+    let _ = iii.inner.outbound.send(Outbound::Shutdown);
+
+    // Yield long enough for `run_connection` to pick up Outbound::Shutdown
+    // off the mpsc, send the WS Close frame, and have the bytes leave the
+    // outbound socket buffer.
+    sleep(Duration::from_millis(AUTO_SHUTDOWN_GRACE_MS)).await;
+
+    // process::exit terminates immediately and skips Drop. That's OK —
+    // we already signalled `run_connection` to wind down, and the
+    // 500ms grace covered the close-frame flush. Any other resources
+    // (file handles, sockets) get reclaimed by the kernel on exit.
+    std::process::exit(128 + signum);
+}
+
 struct IIIInner {
     address: String,
     outbound: mpsc::UnboundedSender<Outbound>,
@@ -665,6 +740,11 @@ struct IIIInner {
     functions_available_trigger: Mutex<Option<Trigger>>,
     headers: Mutex<Option<HashMap<String, String>>>,
     otel_config: Mutex<Option<OtelConfig>>,
+    /// When true, `connect()` spawns a task that traps SIGTERM/SIGINT
+    /// and triggers a clean shutdown + `process::exit(128 + signum)`.
+    /// Mirrors Python's `auto_shutdown: bool = True` and Node's
+    /// `autoShutdown: boolean = true`. Default `true`.
+    auto_shutdown: AtomicBool,
 }
 
 /// WebSocket client for communication with the III Engine.
@@ -728,6 +808,7 @@ impl III {
             functions_available_trigger: Mutex::new(None),
             headers: Mutex::new(None),
             otel_config: Mutex::new(None),
+            auto_shutdown: AtomicBool::new(true),
         };
         Self {
             inner: Arc::new(inner),
@@ -752,6 +833,13 @@ impl III {
     /// Set OpenTelemetry configuration (call before connect)
     pub fn set_otel_config(&self, config: OtelConfig) {
         *self.inner.otel_config.lock_or_recover() = Some(config);
+    }
+
+    /// Toggle the auto-installed SIGTERM/SIGINT handler. See
+    /// [`InitOptions::auto_shutdown`](crate::InitOptions::auto_shutdown).
+    /// Call before `connect()` (typically via `register_worker`).
+    pub fn set_auto_shutdown(&self, value: bool) {
+        self.inner.auto_shutdown.store(value, Ordering::SeqCst);
     }
 
     pub(crate) fn connect(&self) {
@@ -784,6 +872,8 @@ impl III {
         // In Rust, a spawned thread does not keep the process alive on its own;
         // call shutdown() to signal the thread and join connection_thread so
         // run_connection() can exit cleanly before main() returns.
+        let auto_shutdown = self.inner.auto_shutdown.load(Ordering::SeqCst);
+
         let handle = std::thread::Builder::new()
             .name("iii-connection".into())
             .spawn(move || {
@@ -794,6 +884,24 @@ impl III {
 
                 rt.block_on(async move {
                     let otel_active = telemetry::init_otel(otel_config).await;
+
+                    // Spawn the auto-shutdown signal trap inside the
+                    // connection runtime. Doing it here (instead of from
+                    // a separate thread) lets us use `tokio::signal::unix`
+                    // without bringing in extra dependencies, and keeps
+                    // the signal-driven shutdown path on the same runtime
+                    // that's draining `outbound`. Without this, a SIGTERM
+                    // from the in-VM supervisor's fast-restart kills the
+                    // process before any WS Close frame is sent — the
+                    // engine sees the disconnect via TCP timeout (slow,
+                    // racy), and the next worker's registration arrives
+                    // before cleanup_worker has run.
+                    if auto_shutdown {
+                        let iii_for_signal = iii.clone();
+                        tokio::spawn(async move {
+                            run_auto_shutdown_handler(iii_for_signal).await;
+                        });
+                    }
 
                     iii.run_connection(rx).await;
 
@@ -1453,6 +1561,26 @@ impl III {
                     self.set_connection_state(IIIConnectionState::Connected);
                     let (mut ws_tx, mut ws_rx) = stream.split();
 
+                    // Drain anything the caller buffered on the outbound mpsc
+                    // BEFORE connect (e.g. the RegisterFunction message that
+                    // `register_function_inner` sends synchronously). Without
+                    // this drain, `collect_registrations` would produce a
+                    // second copy for every pre-connect registration and the
+                    // engine would log `Function ... is already registered.
+                    // Overwriting.` for each one. `dedupe_registrations` below
+                    // only helps if both copies live in the same `queue`, so
+                    // the drain has to happen here, not in the inner loop.
+                    loop {
+                        match rx.try_recv() {
+                            Ok(Outbound::Message(msg)) => queue.push(msg),
+                            Ok(Outbound::Shutdown) => {
+                                self.inner.running.store(false, Ordering::SeqCst);
+                                return;
+                            }
+                            Err(_) => break,
+                        }
+                    }
+
                     queue.extend(self.collect_registrations());
                     Self::dedupe_registrations(&mut queue);
                     if let Err(err) = self.flush_queue(&mut ws_tx, &mut queue).await {
@@ -1479,6 +1607,22 @@ impl III {
                                     }
                                     Some(Outbound::Shutdown) => {
                                         self.inner.running.store(false, Ordering::SeqCst);
+                                        // Send a clean WebSocket Close frame so the
+                                        // engine sees a graceful disconnect and runs
+                                        // cleanup_worker promptly. Without this, the
+                                        // engine has to detect the drop via TCP-level
+                                        // EOF, which on a fast restart can race the
+                                        // next worker's registration arrival — leaving
+                                        // the engine logging "Function … is already
+                                        // registered. Overwriting." and (worse)
+                                        // deleting the new worker's registrations when
+                                        // the late cleanup eventually fires.
+                                        //
+                                        // Errors are intentionally ignored: if the WS
+                                        // is already half-closed we just want to exit
+                                        // the loop and let the connection drop.
+                                        let _ = ws_tx.send(WsMessage::Close(None)).await;
+                                        let _ = ws_tx.close().await;
                                         return;
                                     }
                                     None => {

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -53,7 +53,7 @@ pub use serde_json::Value;
 ///
 /// let iii = register_worker("ws://localhost:49134", InitOptions::default());
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct InitOptions {
     /// Custom worker metadata. Auto-detected if `None`.
     pub metadata: Option<WorkerMetadata>,
@@ -61,6 +61,34 @@ pub struct InitOptions {
     pub headers: Option<std::collections::HashMap<String, String>>,
     /// OpenTelemetry configuration.
     pub otel: Option<crate::telemetry::types::OtelConfig>,
+    /// Auto-install `SIGTERM` and `SIGINT` handlers that send a clean
+    /// WebSocket Close frame to the engine, then `process::exit(128 +
+    /// signal_number)`. Default `true`.
+    ///
+    /// Without this, `SIGTERM` takes the default disposition (immediate
+    /// process termination) and the WebSocket connection drops without
+    /// a Close frame. The engine then relies on TCP-level disconnect
+    /// detection, which on a fast restart can race the next worker's
+    /// registration — producing spurious `Function ... is already
+    /// registered. Overwriting.` warnings and (worse) deleting the new
+    /// worker's fresh registrations when the late cleanup finally
+    /// fires.
+    ///
+    /// Set `false` to own signal handling yourself (common when
+    /// embedding the SDK inside a larger service that already traps
+    /// signals).
+    pub auto_shutdown: bool,
+}
+
+impl Default for InitOptions {
+    fn default() -> Self {
+        Self {
+            metadata: None,
+            headers: None,
+            otel: None,
+            auto_shutdown: true,
+        }
+    }
 }
 
 /// Create and return a connected SDK instance. The WebSocket connection is
@@ -91,6 +119,7 @@ pub fn register_worker(address: &str, options: InitOptions) -> III {
         metadata,
         headers,
         otel,
+        auto_shutdown,
     } = options;
 
     let iii = if let Some(metadata) = metadata {
@@ -107,6 +136,7 @@ pub fn register_worker(address: &str, options: InitOptions) -> III {
         iii.set_otel_config(cfg);
     }
 
+    iii.set_auto_shutdown(auto_shutdown);
     iii.connect();
 
     iii

--- a/sdk/packages/rust/iii/tests/register_function_no_duplicate_test.rs
+++ b/sdk/packages/rust/iii/tests/register_function_no_duplicate_test.rs
@@ -1,0 +1,173 @@
+//! Regression test for the Rust SDK double-register bug.
+//!
+//! Background: `register_function_inner` both inserts into `self.inner.functions`
+//! AND pushes a `RegisterFunction` message onto the outbound mpsc. On the first
+//! connect, `run_connection` called `collect_registrations()` (which rebuilds
+//! messages from `self.inner.functions`) then entered the inner loop where
+//! `rx.recv()` pulled the pre-connect-buffered copy and sent it again. The engine
+//! saw the same RegisterFunction twice and logged:
+//!
+//! ```text
+//! [REGISTERED] Function foo::bar
+//! [WARN] Function already exists in service
+//! [REGISTERED] Function foo::bar
+//! [WARN] Function foo::bar is already registered. Overwriting.
+//! ```
+//!
+//! Fix: drain the outbound mpsc into the local queue BEFORE
+//! `dedupe_registrations` runs, so the dedupe pass can collapse the two copies.
+//! This test wires a minimal in-process WS server, counts incoming
+//! `RegisterFunction` frames per id, and asserts the count is exactly 1 for a
+//! function registered before the connect handshake completes. Without the fix
+//! the count is 2.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use iii_sdk::{InitOptions, OtelConfig, RegisterFunction, register_worker};
+use serde::Deserialize;
+use serde_json::Value;
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+use tokio_tungstenite::accept_async;
+
+/// Spawns a tiny WebSocket server on 127.0.0.1:0 that records every
+/// `RegisterFunction` frame it receives. Returns the server URL and a handle to
+/// the counts map. The server accepts a single connection and reads until the
+/// client disconnects.
+async fn spawn_counting_server() -> (String, Arc<Mutex<HashMap<String, u32>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind 127.0.0.1:0");
+    let addr = listener.local_addr().expect("local_addr");
+    let url = format!("ws://{}", addr);
+
+    let counts: Arc<Mutex<HashMap<String, u32>>> = Arc::new(Mutex::new(HashMap::new()));
+    let counts_for_task = counts.clone();
+
+    tokio::spawn(async move {
+        // Accept exactly one client (the SDK under test). Anything after that
+        // we ignore — this keeps the server simple and deterministic.
+        eprintln!("[test-server] listening, awaiting accept...");
+        let (stream, peer) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(e) => {
+                eprintln!("[test-server] accept failed: {e}");
+                return;
+            }
+        };
+        eprintln!("[test-server] tcp accept from {peer}");
+        let ws = match accept_async(stream).await {
+            Ok(ws) => ws,
+            Err(e) => {
+                eprintln!("[test-server] accept_async failed: {e}");
+                return;
+            }
+        };
+        eprintln!("[test-server] ws handshake complete");
+        let (_write, mut read) = ws.split();
+
+        while let Some(msg) = read.next().await {
+            let msg = match msg {
+                Ok(m) => m,
+                Err(e) => {
+                    eprintln!("[test-server] read error: {e}");
+                    break;
+                }
+            };
+            let text = match msg {
+                tokio_tungstenite::tungstenite::Message::Text(t) => t.to_string(),
+                tokio_tungstenite::tungstenite::Message::Binary(b) => {
+                    String::from_utf8_lossy(&b).to_string()
+                }
+                tokio_tungstenite::tungstenite::Message::Close(_) => break,
+                _ => continue,
+            };
+            eprintln!("[test-server] frame: {}", &text[..text.len().min(200)]);
+
+            // Wire format serializes the message_type enum as lowercase
+            // concatenated (no underscore): "registerfunction". See
+            // sdk/packages/rust/iii/src/types.rs.
+            if let Ok(parsed) = serde_json::from_str::<Value>(&text)
+                && parsed.get("type").and_then(|v| v.as_str()) == Some("registerfunction")
+                && let Some(id) = parsed.get("id").and_then(|v| v.as_str())
+            {
+                let mut c = counts_for_task.lock().await;
+                *c.entry(id.to_string()).or_insert(0) += 1;
+                eprintln!("[test-server] register_function observed: {id}");
+            }
+        }
+        eprintln!("[test-server] loop exit");
+    });
+
+    (url, counts)
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct EchoInput {
+    msg: String,
+}
+
+fn echo(input: EchoInput) -> Result<String, String> {
+    Ok(input.msg)
+}
+
+/// Pre-connect registration should send exactly one RegisterFunction on the
+/// wire, not two. This is the core regression guard for the double-send bug.
+#[tokio::test]
+async fn register_function_before_connect_is_not_duplicated() {
+    let (url, counts) = spawn_counting_server().await;
+
+    // Disable OTel so the telemetry-system doesn't open a second ws that the
+    // tiny counting server can't service — it accepts one connection and quits.
+    // The bug only affects the main iii connection anyway.
+    let opts = InitOptions {
+        otel: Some(OtelConfig {
+            enabled: Some(false),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let iii = register_worker(&url, opts);
+
+    // This is the typical user pattern: synchronously register a function
+    // immediately after construction, before the connect handshake has had a
+    // chance to complete. `register_function_inner` inserts into
+    // `self.inner.functions` AND pushes onto the outbound mpsc. Pre-fix, both
+    // copies survived dedupe and the server received two frames.
+    let _fn_ref =
+        iii.register_function(RegisterFunction::new("regression::echo", echo).description("ech"));
+
+    // Poll the server's count for up to 3s so the SDK's independent thread
+    // has time to init OTel, connect, and flush the register queue. OTel init
+    // runs before `run_connection` even when disabled, so the wall-clock is
+    // dominated by that rather than the handshake.
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    let mut got = 0u32;
+    while std::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let c = counts.lock().await;
+        got = c.get("regression::echo").copied().unwrap_or(0);
+        // Stop as soon as we see >=1 so we can also catch a spurious second
+        // send before the deadline (bug-era behaviour was 2 back-to-back sends
+        // within ~1ms of the handshake, so a 100ms pause is plenty).
+        if got >= 1 {
+            drop(c);
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let c2 = counts.lock().await;
+            got = c2.get("regression::echo").copied().unwrap_or(0);
+            break;
+        }
+    }
+
+    assert_eq!(
+        got, 1,
+        "expected exactly one RegisterFunction for regression::echo, got {}",
+        got
+    );
+
+    iii.shutdown();
+}

--- a/sdk/packages/rust/iii/tests/shutdown_close_frame_test.rs
+++ b/sdk/packages/rust/iii/tests/shutdown_close_frame_test.rs
@@ -1,0 +1,123 @@
+//! Regression test for the Rust SDK shutdown bug.
+//!
+//! Background: pre-fix, `run_connection`'s `Outbound::Shutdown` branch
+//! just returned without sending a WebSocket Close frame. The engine
+//! had to detect the disconnect via TCP-level EOF, which on a fast
+//! restart raced the next worker's registration arrival — leaving the
+//! engine logging spurious `Function ... is already registered.
+//! Overwriting.` warnings and (worse) deleting the new worker's fresh
+//! registrations when the late cleanup_worker fired.
+//!
+//! Fix: in the inner-loop Shutdown branch, send `WsMessage::Close(None)`
+//! and call `ws_tx.close()` before returning. This test wires a minimal
+//! in-process WS server, asserts the server observes a Close frame
+//! after `iii.shutdown()` is called. Without the fix, the server only
+//! sees the TCP drop (no Close frame) and the assertion fails.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use iii_sdk::{InitOptions, OtelConfig, register_worker};
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+use tokio_tungstenite::accept_async;
+
+/// Spawns a tiny WebSocket server on 127.0.0.1:0 that records whether
+/// it received a WebSocket Close frame from its single client. Returns
+/// the server URL and a flag handle. The server accepts exactly one
+/// connection.
+async fn spawn_close_observing_server() -> (String, Arc<Mutex<bool>>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind 127.0.0.1:0");
+    let addr = listener.local_addr().expect("local_addr");
+    let url = format!("ws://{}", addr);
+
+    let saw_close: Arc<Mutex<bool>> = Arc::new(Mutex::new(false));
+    let saw_close_task = saw_close.clone();
+
+    tokio::spawn(async move {
+        // Accept exactly one client. Anything after is ignored.
+        let (stream, _peer) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(_) => return,
+        };
+        let ws = match accept_async(stream).await {
+            Ok(ws) => ws,
+            Err(_) => return,
+        };
+        let (_write, mut read) = ws.split();
+
+        // Drain frames until we observe a Close OR the stream errors.
+        // The pre-fix codepath dropped TCP without a Close frame, so
+        // `read.next()` returns either `Some(Err(...))` or `None`
+        // depending on the lib's interpretation of the abrupt drop.
+        // Either way, we DON'T see `Ok(Message::Close(_))`.
+        while let Some(msg) = read.next().await {
+            match msg {
+                Ok(tokio_tungstenite::tungstenite::Message::Close(_)) => {
+                    *saw_close_task.lock().await = true;
+                    break;
+                }
+                Ok(_) => continue,
+                Err(_) => break,
+            }
+        }
+    });
+
+    (url, saw_close)
+}
+
+/// `iii.shutdown()` should trigger `run_connection` to send a clean
+/// WebSocket Close frame to the engine before the connection drops.
+/// Pre-fix the Shutdown branch just `return`-ed and the engine had to
+/// infer the disconnect from a TCP-level EOF — the slow path that
+/// races fast-restart re-registration on the engine side.
+#[tokio::test]
+async fn shutdown_sends_websocket_close_frame() {
+    let (url, saw_close) = spawn_close_observing_server().await;
+
+    // OTel disabled — the telemetry system tries to open a SECOND ws
+    // connection that the single-accept server can't service, and any
+    // failure noise there isn't relevant to this test. auto_shutdown
+    // also disabled because we want to drive shutdown() explicitly
+    // from the test rather than via a real signal (which would
+    // process::exit and kill the test runner).
+    let opts = InitOptions {
+        otel: Some(OtelConfig {
+            enabled: Some(false),
+            ..Default::default()
+        }),
+        auto_shutdown: false,
+        ..Default::default()
+    };
+
+    let iii = register_worker(&url, opts);
+
+    // Wait for the connection to be live before triggering shutdown,
+    // otherwise the Shutdown branch we want to exercise is the
+    // pre-connect one (which has no `ws_tx` to send Close on and is
+    // intentionally a bare `return`). 1.5s is comfortably above the
+    // OTel init + handshake budget seen in the sibling
+    // register_function_no_duplicate test.
+    tokio::time::sleep(Duration::from_millis(1_500)).await;
+
+    iii.shutdown();
+
+    // Give the close handshake a moment to round-trip from the SDK to
+    // our test server. The Shutdown branch sends the frame
+    // synchronously (`.send(...).await`) before returning, so the
+    // server-side `read.next()` should observe it within tens of ms;
+    // 500ms is generous.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let observed = *saw_close.lock().await;
+    assert!(
+        observed,
+        "expected a WebSocket Close frame after shutdown(), got none — \
+         pre-fix the SDK dropped TCP without sending a close frame, \
+         which makes engine-side cleanup_worker run after the next \
+         worker has already registered"
+    );
+}


### PR DESCRIPTION
## Summary

- On a fast dev-loop restart, the SDK was tearing down the WebSocket without sending a Close frame. The engine had to detect the disconnect via TCP-level EOF, which on a fast restart raced the next worker's registration — the "change a file, endpoint stops working" symptom.
- SDK-side half of the fix, across all three SDKs in parity. Pairs with the engine-side ownership check in **#1502**.

## Changes (per SDK)

- **Node** (`iii.ts`): `shutdown()` awaits the `close` event with a 500ms timeout; on timeout, force-closes via `ws.terminate()` so the socket can't linger half-open. `isShuttingDown` guard makes `shutdown()` idempotent across signal + explicit invocations. Regression tests: `tests/auto-shutdown.test.ts`.
- **Rust** (`iii.rs`, `lib.rs`, `Cargo.toml`): new `InitOptions.auto_shutdown` field (default `true`); tokio `signal` feature; `run_auto_shutdown_handler` installs SIGTERM/SIGINT handlers that send `Outbound::Shutdown` and then `process::exit(128 + signum)`. Handler is `#[cfg(unix)]` with a `tokio::signal::ctrl_c()` fallback on Windows so the crate compiles cross-platform. Both the inner-loop `Outbound::Shutdown` arm AND the pre-loop drain arm emit a `Close(None)` frame before returning. Regression tests: `shutdown_close_frame_test.rs`, `register_function_no_duplicate_test.rs`.
- **Python** (`iii.py`, `iii_constants.py`): `_shutdown_started` guard makes `shutdown()` / `shutdown_async()` idempotent. SIGTERM/SIGINT handler hardening: `_install_signal_handlers` collapses chains when the previous handler is another III instance's handler; `_remove_signal_handlers` only restores when `getsignal` confirms our bound method is still installed (so a newer III or host-installed handler isn't clobbered). Parity regression tests: `tests/test_auto_shutdown.py`.

## Test plan

- [x] `cargo test -p iii-sdk --test shutdown_close_frame_test`
- [x] `cargo test -p iii-sdk --test register_function_no_duplicate_test`
- [x] Node: `pnpm vitest run tests/auto-shutdown.test.ts` (6/6 pass)
- [x] Python: `pytest tests/test_auto_shutdown.py` (5/5 pass) + `mypy src` clean
- [x] Node: `tsc --noEmit` clean
- [x] Rust: `cargo check` clean
- [ ] Manual: `iii worker` → edit a source file → confirm endpoint keeps working after reload.
- [ ] Manual: tail engine logs during reload; confirm graceful-disconnect path (no TCP-EOF fallback).

## User-visible impact

- Engine sees a clean disconnect on worker reload instead of waiting for TCP timeout.
- `shutdown()` is safe to call multiple times (explicit + signal).
- Rust SDK compiles on Windows.

## Related

Engine-side ownership fix: **#1502**. Either PR reduces the race window; both together close it. Can land in either order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic graceful shutdown on system termination signals (SIGTERM/SIGINT) is now enabled by default across all SDKs, with an option to disable if needed.

* **Tests**
  * Added comprehensive test coverage validating signal handling and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->