### PR TITLE
docs: update worker configuration to use 'exec' 

### DIFF
--- a/docs/changelog/0-11-0/migrating-from-motia-js.mdx
+++ b/docs/changelog/0-11-0/migrating-from-motia-js.mdx
@@ -564,7 +564,8 @@ Replace Motia's dev command with a direct `bun` watcher. In your `config.yaml`, 
 workers:
   - name: iii-exec
     config:
-      command: bun run --watch src/main.ts
+      exec:
+        - bun run --watch src/main.ts
 ```
 
 Run the engine, and it will start your worker process with file watching built in.
@@ -620,7 +621,8 @@ Update your production config to run the bundled output:
 workers:
   - name: iii-exec
     config:
-      command: bun run --enable-source-maps dist/index-production.js
+      exec: 
+        - bun run --enable-source-maps dist/index-production.js
 ```
 
 ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration guide examples to reflect the new worker configuration format, changing from `command` string syntax to `exec` array syntax for worker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->