### PR TITLE
fix(iii-worker): review follow-ups + rootfs FHS-marker guard

### DIFF
--- a/crates/iii-init/src/network.rs
+++ b/crates/iii-init/src/network.rs
@@ -80,6 +80,15 @@ pub fn configure_network() -> Result<(), InitError> {
     // Write /etc/hosts mapping localhost to the gateway IP so DNS resolution
     // of "localhost" returns the gateway (reachable via the virtual network)
     // instead of 127.0.0.1 (unreachable guest loopback).
+    //
+    // Defensive create_dir_all: most rootfs images ship /etc, but a
+    // half-populated managed_dir (see local_worker.rs rootfs-clone path)
+    // can have the VM booting against a tree where /etc hasn't been
+    // created yet. Matches the pattern in `write_resolv_conf` above so
+    // both network writes behave consistently. Swallow errors — we're
+    // in best-effort territory and the subsequent write warning is the
+    // real diagnostic.
+    let _ = std::fs::create_dir_all("/etc");
     if let Err(e) = std::fs::write("/etc/hosts", format!("{gw}\tlocalhost\n")) {
         eprintln!("iii-init: warning: failed to write /etc/hosts: {e}");
     }

--- a/crates/iii-supervisor/src/child.rs
+++ b/crates/iii-supervisor/src/child.rs
@@ -11,8 +11,28 @@
 //! control-channel decoding live in sibling modules.
 
 use std::process::{Child, Command, Stdio};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
+
+/// Acquire the state lock without poisoning the whole VM on panic.
+///
+/// `Mutex::lock()` returns `Err` when a previous holder panicked while
+/// the guard was live. `.expect(...)` turns that into a fresh panic,
+/// which on PID-1 terminates the VM. The state behind the mutex is
+/// small (`Child` handle + restart counter) and the supervisor is
+/// already designed to tolerate out-of-band child reaping, so recovering
+/// the inner data is strictly better than crashing: at worst we observe
+/// partially-updated state for one RPC, which the host either retries
+/// or escalates to a full VM restart.
+fn lock_or_recover<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
+    match m.lock() {
+        Ok(g) => g,
+        Err(poisoned) => {
+            tracing::error!("inner mutex was poisoned; recovering");
+            poisoned.into_inner()
+        }
+    }
+}
 
 /// Grace period between SIGTERM and SIGKILL when cycling the worker.
 ///
@@ -35,6 +55,13 @@ const SHUTDOWN_GRACE: Duration = Duration::from_millis(500);
 /// syscall, ~µs) while giving up to 50 chances to catch a fast exit
 /// before escalating to SIGKILL.
 const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Delay between the initial spawn attempt and the retry in
+/// `spawn_with_one_retry`. Short enough that the host-side
+/// `supervisor_ctl` 500ms read timeout does not fire while a single
+/// transient EAGAIN/ENOMEM is being absorbed, long enough that the
+/// kernel has a fair chance to free a fork-table slot.
+const RESPAWN_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 /// Configuration captured once at supervisor startup. Immutable after.
 #[derive(Debug, Clone)]
@@ -77,8 +104,19 @@ impl State {
     /// supervisor boot, before entering the control loop. Returns an
     /// error if spawn fails; supervisor should exit in that case so the
     /// host can observe the VM going down and fall back.
+    ///
+    /// Intentionally does NOT retry on transient errors — boot-time
+    /// spawn failure already escalates to the host by way of the
+    /// supervisor exiting, and the host's full-VM restart path provides
+    /// its own retry layer. Masking boot-time EAGAIN here would hide a
+    /// real "wrong run_cmd / workdir / binary missing" class of bug
+    /// under a 50ms stall. The restart-time path
+    /// (`kill_and_respawn` → `spawn_with_one_retry`) retries because
+    /// the cost of escalation — a full VM teardown that breaks the
+    /// dev-loop — is disproportionate to a single transient fork
+    /// failure.
     pub fn spawn_initial(&self) -> anyhow::Result<u32> {
-        let mut guard = self.inner.lock().expect("inner mutex poisoned");
+        let mut guard = lock_or_recover(&self.inner);
         let child = Self::spawn_child(&self.config)?;
         let pid = child.id();
         guard.child = Some(child);
@@ -97,15 +135,78 @@ impl State {
     /// [`SHUTDOWN_GRACE`], escalate to SIGKILL if the child is still
     /// alive. See [`terminate_gracefully`] for the rationale.
     pub fn kill_and_respawn(&self) -> anyhow::Result<u32> {
-        let mut guard = self.inner.lock().expect("inner mutex poisoned");
-        if let Some(mut old) = guard.child.take() {
-            terminate_gracefully(&mut old);
+        // Terminate the old child under the lock so no concurrent
+        // reader observes a torn `Inner { child: Some(old), … }` state.
+        {
+            let mut guard = lock_or_recover(&self.inner);
+            if let Some(mut old) = guard.child.take() {
+                terminate_gracefully(&mut old);
+            }
         }
-        let child = Self::spawn_child(&self.config)?;
+
+        // Spawn the replacement WITHOUT holding the lock. The retry
+        // path below sleeps up to `RESPAWN_RETRY_DELAY` between
+        // attempts — if that sleep happened under the mutex, every
+        // concurrent `Status`/`Ping`/`Restart` RPC would block for
+        // the sleep duration. Since the host-side `supervisor_ctl`
+        // has a 500ms read timeout, a chained retry under real
+        // fork-table pressure could trip that timeout and escalate
+        // to a full VM teardown — exactly the outcome the retry is
+        // meant to avoid.
+        let child = Self::spawn_with_one_retry(&self.config)?;
         let pid = child.id();
+
+        // Re-acquire the lock to insert the new child. Because the
+        // control loop is single-threaded and the only other writers
+        // are `spawn_initial` (called once at boot) and
+        // `kill_for_shutdown` (terminal), no racing writer can have
+        // re-populated `child` in the window above. Assert that
+        // invariant defensively: if we ever grow concurrent writers,
+        // we'd rather fail loud here than silently leak the child we
+        // just spawned.
+        let mut guard = lock_or_recover(&self.inner);
+        debug_assert!(
+            guard.child.is_none(),
+            "kill_and_respawn: racing writer re-populated child during respawn"
+        );
         guard.child = Some(child);
         guard.restarts = guard.restarts.saturating_add(1);
         Ok(pid)
+    }
+
+    /// Spawn the worker with a single retry after `RESPAWN_RETRY_DELAY`.
+    ///
+    /// Retries transient spawn failures (EAGAIN under fork storms,
+    /// ENOMEM under memory pressure). A persistent failure still
+    /// propagates: the PID-1 reap loop sees `state.pid() == None`,
+    /// marks the exit terminal, and the VM goes down so the host
+    /// watcher can fall back to a full restart. Bounded retry lets a
+    /// dev-loop edit survive brief fork-table exhaustion without a
+    /// teardown cycle.
+    ///
+    /// Factored out of `kill_and_respawn` so the retry contract can
+    /// be regression-tested without mocking the state machine (see
+    /// `spawn_with_one_retry_retries_once_then_succeeds` and
+    /// `spawn_with_one_retry_propagates_persistent_failure`).
+    fn spawn_with_one_retry(config: &Config) -> anyhow::Result<Child> {
+        match Self::spawn_child(config) {
+            Ok(c) => Ok(c),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "spawn_child failed during restart; retrying once after {}ms",
+                    RESPAWN_RETRY_DELAY.as_millis()
+                );
+                std::thread::sleep(RESPAWN_RETRY_DELAY);
+                Self::spawn_child(config).map_err(|e2| {
+                    tracing::error!(
+                        error = %e2,
+                        "spawn_child retry also failed; VM will exit and host will full-restart"
+                    );
+                    e2
+                })
+            }
+        }
     }
 
     /// Kill the current child, do NOT respawn, mark supervisor as
@@ -116,7 +217,7 @@ impl State {
     /// dev-time shutdowns should still give the worker a chance to
     /// flush stdio and close sockets before hard-killing it.
     pub fn kill_for_shutdown(&self) -> anyhow::Result<()> {
-        let mut guard = self.inner.lock().expect("inner mutex poisoned");
+        let mut guard = lock_or_recover(&self.inner);
         if let Some(mut old) = guard.child.take() {
             terminate_gracefully(&mut old);
         }
@@ -127,10 +228,16 @@ impl State {
     /// after an unexpected child exit that `kill_and_respawn` hasn't yet
     /// been called to recover from.
     pub fn pid(&self) -> Option<u32> {
-        let mut guard = self.inner.lock().expect("inner mutex poisoned");
+        let mut guard = lock_or_recover(&self.inner);
         // Check if the stored child has died on its own. `try_wait`
         // non-destructively reaps dead children so we don't report a
-        // stale pid.
+        // stale pid. On `Err(ECHILD)` the child was reaped by someone
+        // else (typically the PID-1 `waitpid(-1)` loop in supervisor
+        // mode) — the handle is stale and the kernel may have already
+        // recycled the pid, so returning `child.id()` would lie about
+        // liveness (and could coincide with an unrelated same-uid
+        // process). Treat any try_wait error as "handle is stale" and
+        // drop it.
         if let Some(child) = guard.child.as_mut() {
             match child.try_wait() {
                 Ok(Some(_)) => {
@@ -138,7 +245,10 @@ impl State {
                     return None;
                 }
                 Ok(None) => return Some(child.id()),
-                Err(_) => return Some(child.id()),
+                Err(_) => {
+                    guard.child = None;
+                    return None;
+                }
             }
         }
         None
@@ -146,7 +256,7 @@ impl State {
 
     /// Total restart count since supervisor boot.
     pub fn restarts(&self) -> u32 {
-        self.inner.lock().expect("inner mutex poisoned").restarts
+        lock_or_recover(&self.inner).restarts
     }
 
     fn spawn_child(config: &Config) -> anyhow::Result<Child> {
@@ -309,6 +419,97 @@ mod tests {
         // Give the child a moment to exit.
         thread::sleep(Duration::from_millis(100));
         assert_eq!(state.pid(), None, "exited child must not report a pid");
+    }
+
+    #[test]
+    fn pid_clears_handle_when_child_reaped_out_of_band() {
+        // Regression for the stale-dead-pid bug: in supervisor mode the
+        // PID-1 `waitpid(-1)` loop reaps the child before `State::pid()`
+        // is queried. `try_wait()` on a reaped child returns `Err(ECHILD)`;
+        // we must treat that as "handle is stale" and return None,
+        // rather than falling through to `child.id()` and reporting a
+        // pid the kernel may have already recycled.
+        let state = State::new(Config {
+            run_cmd: "true".to_string(),
+            workdir: "/tmp".to_string(),
+        });
+        let pid = state.spawn_initial().unwrap();
+        // Reap the child from the outside so the stored Rust handle
+        // becomes stale — mirrors what the PID-1 waitpid(-1) loop does.
+        use nix::sys::wait::{WaitPidFlag, waitpid};
+        use nix::unistd::Pid;
+        let deadline = std::time::Instant::now() + Duration::from_millis(1000);
+        loop {
+            match waitpid(Pid::from_raw(pid as i32), Some(WaitPidFlag::WNOHANG)) {
+                Ok(nix::sys::wait::WaitStatus::StillAlive) => {}
+                Ok(_) => break,
+                Err(nix::Error::ECHILD) => break,
+                Err(e) => panic!("waitpid: {e}"),
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "child {pid} never exited"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+        // Now the internal Child handle references a reaped pid. pid()
+        // must not lie by returning the stale value.
+        assert_eq!(
+            state.pid(),
+            None,
+            "stale reaped child must not report a live pid"
+        );
+    }
+
+    #[test]
+    fn spawn_with_one_retry_returns_ok_without_sleeping_on_happy_path() {
+        // When the first spawn succeeds the helper must not sleep at
+        // all. A regression that unconditionally slept would double the
+        // dev-loop restart latency.
+        let start = Instant::now();
+        let mut child = State::spawn_with_one_retry(&sleep_config()).unwrap();
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < RESPAWN_RETRY_DELAY / 2,
+            "happy path must not sleep, elapsed = {:?}",
+            elapsed
+        );
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn spawn_with_one_retry_retries_exactly_once_on_persistent_failure() {
+        // Bad workdir makes `Command::spawn` fail at chdir-in-child
+        // time: the stdlib's exec-failure pipe returns the errno from
+        // the child before `.spawn()` returns, so the parent observes
+        // a proper Err. Every attempt with this config fails the same
+        // way, which lets us pin the retry contract:
+        //   - exactly one retry (not zero, not two)
+        //   - sleep of RESPAWN_RETRY_DELAY between attempts
+        //   - final error propagates
+        let bad = Config {
+            run_cmd: "true".to_string(),
+            workdir: "/nonexistent/__iii_supervisor_retry_test__".to_string(),
+        };
+
+        let start = Instant::now();
+        let result = State::spawn_with_one_retry(&bad);
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err(), "persistent spawn failure must propagate");
+        assert!(
+            elapsed >= RESPAWN_RETRY_DELAY,
+            "persistent failure must sleep at least the retry delay, elapsed = {:?}",
+            elapsed
+        );
+        // Upper bound: well under 2 * delay so a refactor that loops
+        // forever or adds a second retry trips this.
+        assert!(
+            elapsed < RESPAWN_RETRY_DELAY * 3,
+            "persistent failure must NOT retry more than once, elapsed = {:?}",
+            elapsed
+        );
     }
 
     #[test]

--- a/crates/iii-supervisor/src/control.rs
+++ b/crates/iii-supervisor/src/control.rs
@@ -49,7 +49,7 @@ pub fn find_virtio_port_by_name(target: &str) -> Option<PathBuf> {
 
 /// Dispatch a single request against the supervisor's state, returning
 /// the response to send back. Pure function of `(state, req)` — no I/O.
-pub fn dispatch(state: &State, req: Request) -> (Response, bool) {
+pub fn dispatch(state: &State, req: &Request) -> (Response, bool) {
     match req {
         Request::Ping => (
             Response::Alive {
@@ -153,7 +153,7 @@ where
         match protocol::decode_request(&line) {
             Ok(req) => {
                 tracing::debug!(request = ?req, "dispatching");
-                let (resp, should_exit) = dispatch(&state, req.clone());
+                let (resp, should_exit) = dispatch(&state, &req);
                 writeln!(writer, "{}", protocol::encode_response(&resp))?;
                 writer.flush()?;
                 on_dispatch(&req, &resp, &state);
@@ -190,7 +190,7 @@ mod tests {
     #[test]
     fn dispatch_ping_returns_alive_with_pid_zero_when_no_child() {
         let state = sleep_state();
-        let (resp, exit) = dispatch(&state, Request::Ping);
+        let (resp, exit) = dispatch(&state, &Request::Ping);
         assert!(!exit);
         assert!(matches!(resp, Response::Alive { pid: 0 }));
     }
@@ -199,7 +199,7 @@ mod tests {
     fn dispatch_ping_returns_alive_with_running_pid() {
         let state = sleep_state();
         let pid = state.spawn_initial().unwrap();
-        let (resp, _) = dispatch(&state, Request::Ping);
+        let (resp, _) = dispatch(&state, &Request::Ping);
         assert_eq!(resp, Response::Alive { pid });
         state.kill_for_shutdown().unwrap();
     }
@@ -210,7 +210,7 @@ mod tests {
         state.spawn_initial().unwrap();
         state.kill_and_respawn().unwrap();
         state.kill_and_respawn().unwrap();
-        let (resp, _) = dispatch(&state, Request::Status);
+        let (resp, _) = dispatch(&state, &Request::Status);
         match resp {
             Response::Status { restarts, pid } => {
                 assert_eq!(restarts, 2);
@@ -225,7 +225,7 @@ mod tests {
     fn dispatch_restart_bumps_counter() {
         let state = sleep_state();
         state.spawn_initial().unwrap();
-        let (resp, exit) = dispatch(&state, Request::Restart);
+        let (resp, exit) = dispatch(&state, &Request::Restart);
         assert_eq!(resp, Response::Ok);
         assert!(!exit);
         assert_eq!(state.restarts(), 1);
@@ -236,7 +236,7 @@ mod tests {
     fn dispatch_shutdown_requests_exit() {
         let state = sleep_state();
         state.spawn_initial().unwrap();
-        let (resp, exit) = dispatch(&state, Request::Shutdown);
+        let (resp, exit) = dispatch(&state, &Request::Shutdown);
         assert_eq!(resp, Response::Ok);
         assert!(exit, "shutdown must request loop exit");
         assert_eq!(state.pid(), None);

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -402,6 +402,25 @@ pub async fn handle_local_add(
     // 4. Resolve worker name
     let worker_name = resolve_worker_name(&project_path);
 
+    // Defense in depth: the manifest's `name:` field is attacker-
+    // reachable via a hand-edited or copy-pasted iii.worker.yaml, and
+    // it flows into filesystem operations below (delete_worker_artifacts
+    // does remove_dir_all on ~/.iii/workers/<name> and ~/.iii/managed/<name>).
+    // `Path::join` preserves `..` components, so a name like
+    // `../../../some_dir` produces a real traversal path. The primary
+    // validator at `append_worker_with_path` normally blocks such names
+    // from entering config.yaml, but re-validate here so a stale or
+    // malicious manifest can't slip past on the --force path.
+    if let Err(msg) = super::registry::validate_worker_name(&worker_name) {
+        eprintln!(
+            "{} Worker name from manifest is invalid: {}\n  \
+             Names must be single path segments with no `/`, `\\`, `..`, or shell metachars.",
+            "error:".red(),
+            msg
+        );
+        return 1;
+    }
+
     // 5. Check if already exists in config.yaml
     if super::config_file::worker_exists(&worker_name) {
         if !force {
@@ -791,38 +810,12 @@ pub async fn start_local_worker(worker_name: &str, worker_path: &str, port: u16)
     exit_code
 }
 
-/// Write the sidecar PID to `pid_file` with symlink-replace defense.
-///
-/// On Unix, opens with `O_NOFOLLOW` + mode `0o600` so a local attacker
-/// with dir-traverse access can't pre-plant a symlink at `watch.pid`
-/// pointing at a sensitive file (e.g. `~/.ssh/authorized_keys`) and
-/// have our write clobber it. Matches the hardening already applied to
-/// the watcher log file immediately above.
-///
-/// On non-Unix, falls back to `std::fs::write`. Failures are logged and
-/// swallowed — a missing pidfile only degrades stop-path reaping, not
-/// correctness of a running watcher.
-fn write_pid_file(pid_file: &std::path::Path, pid: u32) {
-    let mut opts = std::fs::OpenOptions::new();
-    opts.create(true).write(true).truncate(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        opts.custom_flags(nix::libc::O_NOFOLLOW);
-        opts.mode(0o600);
-    }
-    match opts.open(pid_file) {
-        Ok(mut f) => {
-            use std::io::Write;
-            if let Err(e) = write!(f, "{}", pid) {
-                tracing::warn!(path = %pid_file.display(), error = %e, "failed to write pidfile");
-            }
-        }
-        Err(e) => {
-            tracing::warn!(path = %pid_file.display(), error = %e, "failed to open pidfile");
-        }
-    }
-}
+// Sidecar pidfile writes delegate to super::pidfile::write_pid_file for
+// unified hardening across all managed-dir pidfiles. See that module
+// for rationale; in short, O_NOFOLLOW + 0o600 on Unix so a symlink
+// pre-planted at watch.pid can't redirect our write to a sensitive
+// target.
+use super::pidfile::write_pid_file;
 
 /// Spawn the hidden `__watch-source` sidecar process, detached, with
 /// its PID recorded so `kill_stale_worker` can reap it on stop.
@@ -1146,39 +1139,6 @@ resources:
         assert_eq!(memory, 4096);
     }
 
-    #[cfg(unix)]
-    #[test]
-    fn write_pid_file_refuses_to_follow_symlink() {
-        // Attacker (or stale state) pre-plants watch.pid as a symlink
-        // pointing at a sensitive file. write_pid_file must fail open
-        // instead of clobbering the symlink target.
-        let dir = tempfile::tempdir().unwrap();
-        let target = dir.path().join("sensitive-target");
-        std::fs::write(&target, "DO-NOT-OVERWRITE").unwrap();
-
-        let pid_file = dir.path().join("watch.pid");
-        std::os::unix::fs::symlink(&target, &pid_file).unwrap();
-
-        write_pid_file(&pid_file, 42);
-
-        // Target must be untouched.
-        let contents = std::fs::read_to_string(&target).unwrap();
-        assert_eq!(contents, "DO-NOT-OVERWRITE");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn write_pid_file_creates_file_with_owner_only_mode() {
-        use std::os::unix::fs::PermissionsExt;
-        let dir = tempfile::tempdir().unwrap();
-        let pid_file = dir.path().join("watch.pid");
-
-        write_pid_file(&pid_file, 1234);
-
-        let meta = std::fs::metadata(&pid_file).unwrap();
-        // Mask off file-type bits, keep permission bits only.
-        let mode = meta.permissions().mode() & 0o777;
-        assert_eq!(mode, 0o600, "pidfile must be 0o600, got {mode:o}");
-        assert_eq!(std::fs::read_to_string(&pid_file).unwrap(), "1234");
-    }
+    // Symlink-defense + 0o600 mode tests moved to super::pidfile where
+    // the shared implementation lives.
 }

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -584,6 +584,23 @@ pub async fn handle_local_add(
     0
 }
 
+/// Return `true` when `managed_dir` needs a rootfs clone before VM boot.
+///
+/// The predicate is `!managed_dir.join("bin").exists()` — every OCI base
+/// image we ship populates `/bin`, and none of the failure-mode artifacts
+/// (iii-init runtime mkdirs for /dev /proc /sys /etc /tmp /run, our own
+/// side-effect writes under /opt /workspace, stray vm.pid / watch.pid, a
+/// leftover `/rootfs` subdir from an older codepath) do. Plain
+/// `!managed_dir.exists()` is insufficient: a half-start that created
+/// runtime mountpoints then died would falsely register as "already
+/// prepared" and surface as a confusing `supervisor spawn_initial failed:
+/// No such file or directory` from iii-init once the VM tried to exec
+/// `/bin/sh`. Extracted as a named helper so the regression tests can
+/// exercise the exact predicate the start path uses.
+fn needs_rootfs_clone(managed_dir: &std::path::Path) -> bool {
+    !managed_dir.join("bin").exists()
+}
+
 /// Start a local-path worker VM.
 ///
 /// Re-copies project files, builds env, and runs via libkrun.
@@ -648,8 +665,41 @@ pub async fn start_local_worker(worker_name: &str, worker_path: &str, port: u16)
         }
     };
 
-    if !managed_dir.exists() {
+    // Detect "managed_dir exists but the rootfs was never cloned here"
+    // by probing for `/bin` — every OCI base image we ship has it, and
+    // neither iii-init's runtime mount dirs (/dev, /proc, /sys, /etc,
+    // /tmp, /run) nor our own side-effect writes (/opt, /workspace,
+    // vm.pid, watch.pid, /rootfs from an older codepath) populate it.
+    //
+    // Matches the `path.join("bin").exists()` idiom in
+    // `worker_manager/oci.rs::prepare_rootfs`. A plain `managed_dir.exists()`
+    // check is too weak: any prior half-start (VM booted, iii-init mkdir'd
+    // /dev/proc/sys, then died before finishing) leaves the dir present
+    // but FHS-less, so the next start would skip the clone and boot a VM
+    // with no `/bin/sh` — which surfaces as a confusing
+    // "supervisor spawn_initial failed: No such file or directory" from
+    // iii-init rather than a clear "rootfs never got populated" error.
+    //
+    // Self-heal: if the marker is missing but the dir exists, wipe it
+    // first so `cp -c -a SRC DEST` (rootfs::clone_rootfs) creates DEST
+    // fresh as a copy of SRC. Without the wipe, cp's "copy INTO existing
+    // dir" semantics would nest the rootfs at `managed_dir/python/`
+    // instead of at `managed_dir/`. Anything the user cares about under
+    // managed_dir is regenerated on boot (logs, vm.pid, dep caches come
+    // back after pip install / npm install).
+    if needs_rootfs_clone(&managed_dir) {
         eprintln!("  Preparing sandbox...");
+        if managed_dir.exists()
+            && let Err(e) = std::fs::remove_dir_all(&managed_dir)
+        {
+            eprintln!(
+                "{} Failed to clear stale managed dir {}: {}",
+                "error:".red(),
+                managed_dir.display(),
+                e
+            );
+            return 1;
+        }
         let base_rootfs = match super::worker_manager::oci::prepare_rootfs(language).await {
             Ok(p) => p,
             Err(e) => {
@@ -1141,4 +1191,84 @@ resources:
 
     // Symlink-defense + 0o600 mode tests moved to super::pidfile where
     // the shared implementation lives.
+
+    /// Regression test for the "managed_dir exists but is missing /bin"
+    /// failure mode. A half-populated managed_dir — created by a prior
+    /// iii-init boot that mkdir'd /dev/proc/sys but died before the
+    /// rootfs was cloned, or by an older codepath that placed the
+    /// rootfs at `managed_dir/rootfs/` rather than at `managed_dir/` —
+    /// must be detected as "needs re-clone" by `needs_rootfs_clone`.
+    ///
+    /// The pre-fix guard (`!managed_dir.exists()`) skipped the clone
+    /// and let the VM boot against an FHS-less rootfs, surfacing as a
+    /// confusing `supervisor spawn_initial failed: No such file or
+    /// directory (os error 2)` from iii-init because `/bin/sh` didn't
+    /// exist. This test calls the extracted helper so a refactor that
+    /// weakens the predicate back to `!managed_dir.exists()` — or any
+    /// other too-permissive check — fails here.
+    #[test]
+    fn needs_rootfs_clone_true_for_half_populated_managed_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let managed = tmp.path().join("todo-worker-python");
+
+        // Simulate iii-init-style runtime dirs (created on prior boot)
+        // + a stale /rootfs subdir from an older codepath — the exact
+        // layout the user hit in the wild.
+        for d in [
+            "dev",
+            "proc",
+            "sys",
+            "etc",
+            "tmp",
+            "run",
+            "opt",
+            "workspace",
+            "rootfs/bin",
+            "rootfs/usr",
+        ] {
+            std::fs::create_dir_all(managed.join(d)).unwrap();
+        }
+        std::fs::write(managed.join("vm.pid"), "12345").unwrap();
+        std::fs::write(managed.join("watch.pid"), "12346").unwrap();
+
+        // Dir exists — the old too-weak guard would skip the clone.
+        assert!(managed.exists());
+        // But the helper must flag this as "rootfs never got populated
+        // here, must re-clone" — otherwise the VM boots against an
+        // FHS-less tree and iii-init dies trying to exec /bin/sh.
+        assert!(
+            needs_rootfs_clone(&managed),
+            "half-populated managed_dir must register as `needs clone`"
+        );
+    }
+
+    /// Complement: a fully-cloned managed_dir (with `/bin` present)
+    /// must be recognized as ready so we don't nuke a healthy sandbox
+    /// on every start and pay the re-clone cost. Exercises the helper
+    /// directly for the same reason as the sibling test above.
+    #[test]
+    fn needs_rootfs_clone_false_for_fully_cloned_managed_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let managed = tmp.path().join("todo-worker-python");
+        std::fs::create_dir_all(managed.join("bin")).unwrap();
+        std::fs::create_dir_all(managed.join("usr")).unwrap();
+        assert!(
+            !needs_rootfs_clone(&managed),
+            "fully-cloned managed_dir must NOT trigger a re-clone"
+        );
+    }
+
+    /// Absence case: `needs_rootfs_clone(nonexistent_path)` must be true.
+    /// Covers the first-start path where the parent `~/.iii/managed/`
+    /// exists but the per-worker subdir has never been created.
+    #[test]
+    fn needs_rootfs_clone_true_when_managed_dir_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let managed = tmp.path().join("never-started");
+        assert!(!managed.exists());
+        assert!(
+            needs_rootfs_clone(&managed),
+            "absent managed_dir must register as `needs clone`"
+        );
+    }
 }

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -1362,44 +1362,13 @@ enum StopMode {
 
 /// Reads a PID file, returning `Some(pid)` when contents parse as `u32`.
 ///
-/// On Unix, opens with `O_NOFOLLOW` + verifies the opened file is a
-/// regular file owned by the current euid before reading. Defends
-/// against symlink-replace attacks: a local attacker who can write
-/// into the managed dir can't redirect the read elsewhere, and can't
-/// trick us into treating a file they own as a valid pid marker that
-/// we then `kill()` on. On non-Unix platforms falls back to plain
-/// read_to_string.
+/// Thin alias for [`super::pidfile::read_pid`] — the hardened reader
+/// lives in the shared module alongside `write_pid_file` so every
+/// pidfile I/O path goes through the same O_NOFOLLOW + uid-ownership
+/// check. See the `pidfile` module docstring for the full attacker
+/// model.
 fn read_pid(path: &std::path::Path) -> Option<u32> {
-    #[cfg(unix)]
-    {
-        use std::io::Read;
-        use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
-
-        let mut file = std::fs::OpenOptions::new()
-            .read(true)
-            .custom_flags(nix::libc::O_NOFOLLOW)
-            .open(path)
-            .ok()?;
-        let meta = file.metadata().ok()?;
-        if !meta.file_type().is_file() {
-            return None;
-        }
-        let our_uid = unsafe { nix::libc::geteuid() };
-        if meta.uid() != our_uid {
-            return None;
-        }
-        // Cap at a few bytes — a PID is at most 10 decimal digits.
-        let mut buf = [0u8; 32];
-        let n = file.read(&mut buf).ok()?;
-        let s = std::str::from_utf8(&buf[..n]).ok()?;
-        return s.trim().parse::<u32>().ok();
-    }
-    #[cfg(not(unix))]
-    {
-        std::fs::read_to_string(path)
-            .ok()
-            .and_then(|s| s.trim().parse::<u32>().ok())
-    }
+    super::pidfile::read_pid(path)
 }
 
 /// Returns `true` if `pid` refers to a live process. Uses signal 0 as a

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -556,7 +556,6 @@ pub async fn handle_managed_remove(worker_name: &str, brief: bool) -> i32 {
             "config.yaml".dimmed(),
         );
     }
-    println!("{}", worker_name);
     0
 }
 
@@ -623,7 +622,6 @@ fn clear_single_worker(worker_name: &str) -> i32 {
             freed as f64 / 1_048_576.0,
             worker_name.bold(),
         );
-        println!("{}", worker_name);
     }
     0
 }
@@ -1084,7 +1082,21 @@ pub fn is_engine_running() -> bool {
 
 /// Deletes local artifacts for a worker (binary dir or OCI image dir).
 /// Returns the number of bytes freed, or 0 if nothing was found.
+///
+/// Defense-in-depth: `worker_name` is joined into `~/.iii/...` paths
+/// that get `remove_dir_all`'d. `Path::join` preserves `..` components,
+/// so an unvalidated traversal name would delete attacker-chosen
+/// directories under the user's HOME. Callers are expected to have
+/// validated, but we re-check here so the sink itself is safe.
 pub fn delete_worker_artifacts(worker_name: &str) -> u64 {
+    if let Err(msg) = super::registry::validate_worker_name(worker_name) {
+        eprintln!(
+            "  {} refusing to delete artifacts for invalid worker name: {}",
+            "warning:".yellow(),
+            msg
+        );
+        return 0;
+    }
     let home = dirs::home_dir().unwrap_or_default();
     let mut freed: u64 = 0;
 
@@ -1289,7 +1301,6 @@ pub async fn handle_managed_stop(worker_name: &str) -> i32 {
         // reporting "already stopped."
         reap_source_watcher(worker_name).await;
         eprintln!("  {} {} already stopped", "✓".green(), worker_name.bold());
-        println!("{}", worker_name);
         return 0;
     };
 
@@ -1332,7 +1343,6 @@ pub async fn handle_managed_stop(worker_name: &str) -> i32 {
     }
 
     eprintln!("  {} {} stopped", "✓".green(), worker_name.bold());
-    println!("{}", worker_name);
     0
 }
 
@@ -1511,7 +1521,6 @@ pub async fn handle_managed_start(worker_name: &str, wait: bool, port: u16) -> i
             "  '{}' is a builtin worker — served by the iii engine process.",
             worker_name,
         );
-        println!("{}", worker_name);
         return 0;
     }
     let local_outcome = match super::config_file::resolve_worker_type(worker_name) {
@@ -1620,11 +1629,8 @@ enum StartOutcome {
 /// contract. Keeping this in one place prevents the stdout contract from
 /// drifting across the four call sites that used to inline it.
 async fn finish_start(worker_name: &str, rc: i32, wait: bool, port: u16) -> i32 {
-    if rc == 0 {
-        if wait {
-            wait_for_ready(worker_name, port).await;
-        }
-        println!("{}", worker_name);
+    if rc == 0 && wait {
+        wait_for_ready(worker_name, port).await;
     }
     rc
 }
@@ -1760,13 +1766,12 @@ async fn start_binary_worker(worker_name: &str, binary_path: &std::path::Path) -
             }
             if let Some(pid) = child.id() {
                 let pid_path = pid_dir.join(format!("{}.pid", worker_name));
-                let _ = std::fs::write(&pid_path, pid.to_string());
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    let _ =
-                        std::fs::set_permissions(&pid_path, std::fs::Permissions::from_mode(0o600));
-                }
+                // Route through the shared hardened writer: O_NOFOLLOW +
+                // atomic 0o600 mode at O_CREAT. A plain fs::write here
+                // would follow a pre-planted symlink at the target and
+                // a post-hoc set_permissions leaves a create/chmod
+                // TOCTOU window. See cli/pidfile.rs for rationale.
+                super::pidfile::write_pid_file(&pid_path, pid);
             }
             let pid_display = child
                 .id()
@@ -2052,21 +2057,11 @@ pub async fn handle_managed_logs(
     if has_new_logs {
         let mut found_content = false;
 
-        if let Ok(contents) = std::fs::read_to_string(&stdout_path)
-            && !contents.is_empty()
-        {
-            found_content = true;
-            let lines: Vec<&str> = contents.lines().collect();
-            let start = if lines.len() > 100 {
-                lines.len() - 100
-            } else {
-                0
-            };
-            for line in &lines[start..] {
-                println!("{}", line);
-            }
-        }
-
+        // Read stderr.log first: it holds the host vm-boot subprocess's own
+        // eprintln! output (e.g. "  Booting VM...") which fires BEFORE the
+        // VM enters, so those lines are chronologically the oldest. stdout.log
+        // is the VM's --console-output stream, which only starts producing
+        // content once the guest is actually running.
         if let Ok(contents) = std::fs::read_to_string(&stderr_path)
             && !contents.is_empty()
         {
@@ -2079,6 +2074,21 @@ pub async fn handle_managed_logs(
             };
             for line in &lines[start..] {
                 eprintln!("{}", line);
+            }
+        }
+
+        if let Ok(contents) = std::fs::read_to_string(&stdout_path)
+            && !contents.is_empty()
+        {
+            found_content = true;
+            let lines: Vec<&str> = contents.lines().collect();
+            let start = if lines.len() > 100 {
+                lines.len() - 100
+            } else {
+                0
+            };
+            for line in &lines[start..] {
+                println!("{}", line);
             }
         }
 

--- a/crates/iii-worker/src/cli/mod.rs
+++ b/crates/iii-worker/src/cli/mod.rs
@@ -12,11 +12,14 @@ pub mod firmware;
 pub mod lifecycle;
 pub mod local_worker;
 pub mod managed;
+pub mod pidfile;
 pub mod project;
 pub mod registry;
 pub mod rootfs;
 pub mod source_watcher;
 pub mod status;
 pub mod supervisor_ctl;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub mod vm_boot;
 pub mod worker_manager;

--- a/crates/iii-worker/src/cli/pidfile.rs
+++ b/crates/iii-worker/src/cli/pidfile.rs
@@ -6,31 +6,41 @@
 
 //! Shared hardened pidfile I/O.
 //!
-//! Every pidfile a worker writes MUST go through this module — no
-//! direct `fs::write` + `set_permissions`. Sites today:
+//! Every pidfile a worker writes OR reads MUST go through this module —
+//! no direct `fs::write` + `set_permissions`, no bare `fs::read_to_string`
+//! on `.pid` paths. Sites today:
 //!   - `~/.iii/managed/<name>/watch.pid` — source-watcher sidecar
 //!     (`local_worker.rs`)
 //!   - `~/.iii/managed/<name>/vm.pid` — libkrun VM
 //!     (`worker_manager/libkrun.rs`)
 //!   - `~/.iii/pids/<name>.pid` — binary workers (`managed.rs`)
 //!
+//! Reads in the engine crate (`engine/src/workers/registry_worker.rs`)
+//! are a sibling concern; that crate has no dep on iii-worker, so it
+//! re-implements the same O_NOFOLLOW + uid check inline and tests are
+//! mirrored there.
+//!
 //! A local attacker with write access to any of these directories can
 //! pre-plant the target path as a symlink pointing at a sensitive file
 //! (e.g. `~/.ssh/authorized_keys`); a naive `std::fs::write` follows
-//! the symlink and clobbers the target with a PID string.
+//! the symlink and clobbers the target with a PID string. A naive
+//! `fs::read_to_string` on a symlink-planted pidfile lets the attacker
+//! redirect the read to arbitrary numeric-looking content, making
+//! `is_alive(pid)` return true forever and wedging the restart loop.
 //!
-//! `write_pid_file` opens with `O_NOFOLLOW` on Unix so symlink-planted
-//! pre-images cause the open to fail rather than propagate the write to
-//! the target. Mode is locked to `0o600` so neighboring same-uid
-//! attackers can't race the permissions after creation. Falls back to
-//! `std::fs::write` on non-Unix.
+//! `write_pid_file` / `read_pid` open with `O_NOFOLLOW` on Unix so
+//! symlink-planted pre-images cause the open to fail rather than
+//! propagate the operation to the target. Writes lock mode to `0o600`;
+//! reads verify the file is regular and owned by the current euid,
+//! rejecting attacker-planted files even if the attacker won the
+//! first-write race. Falls back to plain `std::fs` on non-Unix.
 //!
-//! Failures are logged and swallowed at call sites that treat pidfile
-//! writes as best-effort (the sidecar's PID helps stop-path reaping but
-//! isn't required for the watcher itself to work). Callers that need
-//! hard-fail semantics (e.g. libkrun's `vm.pid` — we kill the spawned
-//! child if the write fails so we don't leak an untracked VM) should
-//! use the `_strict` variant which returns `io::Result`.
+//! Write failures are logged and swallowed at call sites that treat
+//! pidfile writes as best-effort (the sidecar's PID helps stop-path
+//! reaping but isn't required for the watcher itself to work). Callers
+//! that need hard-fail semantics (e.g. libkrun's `vm.pid` — we kill
+//! the spawned child if the write fails so we don't leak an untracked
+//! VM) should use the `_strict` variant which returns `io::Result`.
 
 use std::path::Path;
 
@@ -66,6 +76,54 @@ pub fn write_pid_file_strict(path: &Path, pid: u32) -> std::io::Result<()> {
 pub fn write_pid_file(path: &Path, pid: u32) {
     if let Err(e) = write_pid_file_strict(path, pid) {
         tracing::warn!(path = %path.display(), error = %e, "failed to write pidfile");
+    }
+}
+
+/// Read `path` as a pidfile, returning `Some(pid)` when contents parse as `u32`.
+///
+/// On Unix, opens with `O_NOFOLLOW`, requires the opened file to be a
+/// regular file owned by the current euid, and reads at most 32 bytes
+/// (a PID is at most 10 decimal digits). Defends against the read-side
+/// symlink-replace attack: a local attacker who planted `path` as a
+/// symlink to `/etc/hostname`, `/proc/1/sched`, or any attacker-owned
+/// file cannot trick us into treating its contents as a valid pid
+/// marker that we then `kill()` or probe with `kill(pid, 0)`.
+///
+/// Returns `None` on any failure (open, metadata, ownership mismatch,
+/// non-regular file, parse failure). Callers treat pidfile absence as
+/// equivalent to pidfile invalidity, so silent `None` is correct.
+///
+/// On non-Unix platforms falls back to plain `read_to_string`.
+pub fn read_pid(path: &Path) -> Option<u32> {
+    #[cfg(unix)]
+    {
+        use std::io::Read;
+        use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+        let mut file = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(nix::libc::O_NOFOLLOW)
+            .open(path)
+            .ok()?;
+        let meta = file.metadata().ok()?;
+        if !meta.file_type().is_file() {
+            return None;
+        }
+        let our_uid = unsafe { nix::libc::geteuid() };
+        if meta.uid() != our_uid {
+            return None;
+        }
+        // Cap at a few bytes — a PID is at most 10 decimal digits.
+        let mut buf = [0u8; 32];
+        let n = file.read(&mut buf).ok()?;
+        let s = std::str::from_utf8(&buf[..n]).ok()?;
+        s.trim().parse::<u32>().ok()
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|s| s.trim().parse::<u32>().ok())
     }
 }
 
@@ -109,5 +167,97 @@ mod tests {
         let bad = dir.path().join("does_not_exist").join("vm.pid");
         write_pid_file(&bad, 42);
         assert!(!bad.exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn read_pid_refuses_to_follow_symlink() {
+        // Attacker plants the pidfile as a symlink to a file they
+        // control whose contents parse as a PID. A naive `read_to_string`
+        // would return Some(pid) and let the attacker influence
+        // liveness probes; `read_pid` must refuse to follow and return None.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("planted_pid");
+        std::fs::write(&target, "1234\n").unwrap();
+        let pid_file = dir.path().join("vm.pid");
+        std::os::unix::fs::symlink(&target, &pid_file).unwrap();
+
+        assert_eq!(
+            read_pid(&pid_file),
+            None,
+            "O_NOFOLLOW must refuse to follow symlinked pidfile"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn read_pid_round_trips_well_formed_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("vm.pid");
+        write_pid_file_strict(&pid_file, 1234).unwrap();
+        assert_eq!(read_pid(&pid_file), Some(1234));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn read_pid_rejects_malformed_contents() {
+        // Matches the cases the status::tests module exercises, but
+        // pinned here so future callers can't accidentally weaken the
+        // shared parser: empty, garbage, negative, overflow, whitespace.
+        let dir = tempfile::tempdir().unwrap();
+        for (name, contents) in [
+            ("empty", ""),
+            ("garbage", "not-a-pid"),
+            ("negative", "-1"),
+            ("overflow", "9999999999999"),
+            ("whitespace-only", "   \n"),
+        ] {
+            let p = dir.path().join(format!("{}.pid", name));
+            std::fs::write(&p, contents).unwrap();
+            assert_eq!(
+                read_pid(&p),
+                None,
+                "malformed pidfile content {:?} must yield None",
+                contents
+            );
+        }
+        // Surrounding whitespace is tolerated.
+        let padded = dir.path().join("padded.pid");
+        std::fs::write(&padded, "  12345  \n").unwrap();
+        assert_eq!(read_pid(&padded), Some(12345));
+    }
+
+    /// Enforce the module invariant: known pidfile call sites must route
+    /// through this module rather than reimplementing the hardening
+    /// inline. This is a grep-style positive check — a future refactor
+    /// that drops the `pidfile::*` reference in any of these files will
+    /// trip the test and surface the regression at `cargo test` time,
+    /// without needing a separate CI lint pass.
+    #[test]
+    fn known_call_sites_route_through_module() {
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        let cases: &[(&str, &str)] = &[
+            ("src/cli/local_worker.rs", "pidfile::write_pid_file"),
+            ("src/cli/managed.rs", "pidfile::write_pid_file"),
+            (
+                "src/cli/worker_manager/libkrun.rs",
+                "pidfile::write_pid_file_strict",
+            ),
+            ("src/cli/managed.rs", "pidfile::read_pid"),
+            ("src/cli/status.rs", "pidfile::read_pid"),
+        ];
+        for (rel_path, token) in cases {
+            let p = std::path::Path::new(manifest).join(rel_path);
+            let contents =
+                std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {:?}: {}", p, e));
+            assert!(
+                contents.contains(token),
+                "{} must reference `{}` (pidfile module invariant — do not \
+                 reimplement the hardening inline; if this call site was \
+                 removed, drop it from this test)",
+                rel_path,
+                token,
+            );
+        }
     }
 }

--- a/crates/iii-worker/src/cli/pidfile.rs
+++ b/crates/iii-worker/src/cli/pidfile.rs
@@ -1,0 +1,113 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at support@motia.dev
+// See LICENSE and PATENTS files for details.
+
+//! Shared hardened pidfile I/O.
+//!
+//! Every pidfile a worker writes MUST go through this module — no
+//! direct `fs::write` + `set_permissions`. Sites today:
+//!   - `~/.iii/managed/<name>/watch.pid` — source-watcher sidecar
+//!     (`local_worker.rs`)
+//!   - `~/.iii/managed/<name>/vm.pid` — libkrun VM
+//!     (`worker_manager/libkrun.rs`)
+//!   - `~/.iii/pids/<name>.pid` — binary workers (`managed.rs`)
+//!
+//! A local attacker with write access to any of these directories can
+//! pre-plant the target path as a symlink pointing at a sensitive file
+//! (e.g. `~/.ssh/authorized_keys`); a naive `std::fs::write` follows
+//! the symlink and clobbers the target with a PID string.
+//!
+//! `write_pid_file` opens with `O_NOFOLLOW` on Unix so symlink-planted
+//! pre-images cause the open to fail rather than propagate the write to
+//! the target. Mode is locked to `0o600` so neighboring same-uid
+//! attackers can't race the permissions after creation. Falls back to
+//! `std::fs::write` on non-Unix.
+//!
+//! Failures are logged and swallowed at call sites that treat pidfile
+//! writes as best-effort (the sidecar's PID helps stop-path reaping but
+//! isn't required for the watcher itself to work). Callers that need
+//! hard-fail semantics (e.g. libkrun's `vm.pid` — we kill the spawned
+//! child if the write fails so we don't leak an untracked VM) should
+//! use the `_strict` variant which returns `io::Result`.
+
+use std::path::Path;
+
+/// Open a pidfile for writing with symlink-replace defense.
+///
+/// Unix: `O_NOFOLLOW | O_CREAT | O_WRONLY | O_TRUNC`, mode `0o600`.
+/// Non-Unix: plain `OpenOptions::create+write+truncate`.
+fn open_pid_file(path: &Path) -> std::io::Result<std::fs::File> {
+    let mut opts = std::fs::OpenOptions::new();
+    opts.create(true).write(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.custom_flags(nix::libc::O_NOFOLLOW);
+        opts.mode(0o600);
+    }
+    opts.open(path)
+}
+
+/// Write `pid` to `path` with symlink defense. Returns the io::Result
+/// so callers that care (e.g. VM spawn, where a failed pidfile means we
+/// must kill the just-spawned child) can react.
+pub fn write_pid_file_strict(path: &Path, pid: u32) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut f = open_pid_file(path)?;
+    write!(f, "{}", pid)?;
+    Ok(())
+}
+
+/// Write `pid` to `path` with symlink defense. Errors are logged at
+/// warn level and swallowed — use when the pidfile is a reap hint
+/// rather than a correctness requirement (sidecar watchers, etc).
+pub fn write_pid_file(path: &Path, pid: u32) {
+    if let Err(e) = write_pid_file_strict(path, pid) {
+        tracing::warn!(path = %path.display(), error = %e, "failed to write pidfile");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(unix)]
+    fn strict_refuses_to_follow_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("secret");
+        std::fs::write(&target, "original").unwrap();
+        let pid_file = dir.path().join("vm.pid");
+        std::os::unix::fs::symlink(&target, &pid_file).unwrap();
+
+        let res = write_pid_file_strict(&pid_file, 42);
+        assert!(res.is_err(), "O_NOFOLLOW must refuse symlinked pidfile");
+        // Target must be untouched.
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "original");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn strict_creates_file_with_owner_only_mode() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("vm.pid");
+        write_pid_file_strict(&pid_file, 1234).unwrap();
+        let meta = std::fs::metadata(&pid_file).unwrap();
+        let mode = meta.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "pidfile must be 0o600, got {:o}", mode);
+        assert_eq!(std::fs::read_to_string(&pid_file).unwrap(), "1234");
+    }
+
+    #[test]
+    fn lossy_swallows_errors() {
+        // Path with a non-existent parent should fail on open but not
+        // panic; just observe no file was created.
+        let dir = tempfile::tempdir().unwrap();
+        let bad = dir.path().join("does_not_exist").join("vm.pid");
+        write_pid_file(&bad, 42);
+        assert!(!bad.exists());
+    }
+}

--- a/crates/iii-worker/src/cli/source_watcher.rs
+++ b/crates/iii-worker/src/cli/source_watcher.rs
@@ -316,6 +316,18 @@ fn register_new_dirs(
             Ok(md) if md.file_type().is_dir() => {}
             _ => continue,
         }
+        // Defense-in-depth bounds check: reject any path that isn't
+        // under the canonicalized project root before calling
+        // `watcher.watch()`. The existing defenses (ignore-filter +
+        // symlink rejection) already close today's attack paths, but
+        // if a future notify refactor ever surfaces an out-of-root
+        // event path (e.g. FSEvents resolving a mount alias), the
+        // filter wouldn't catch it. `starts_with` is O(segments) and
+        // uses canonical equality since `root` is already canonical
+        // (`root_for_filter`); no additional syscall cost.
+        if !p.starts_with(root) {
+            continue;
+        }
         match watcher.watch(p, RecursiveMode::NonRecursive) {
             Ok(()) => {
                 registered.insert(p.clone());
@@ -427,7 +439,16 @@ where
     // .git — thousands of watch descriptors on a large project, and
     // per-event post-delivery filtering. NonRecursive on pruned
     // directories avoids both costs.
-    watch_pruned(&mut watcher, &project_path, &mut registered_dirs)?;
+    //
+    // Seed with `root_for_filter` (canonicalized) rather than the raw
+    // `project_path` so `registered_dirs` and the burst-time paths
+    // emitted by notify live in the same canonical namespace. On macOS
+    // FSEvents always reports canonical `/private/var/...` event paths
+    // even when the watch was registered on a symlinked ancestor, so
+    // seeding with the raw path makes `register_new_dirs` miss the
+    // dedup-set lookup and redo `lstat` + `inotify_add_watch` on every
+    // burst for already-watched parents. Canonical seed keeps dedup O(1).
+    watch_pruned(&mut watcher, &root_for_filter, &mut registered_dirs)?;
 
     tracing::info!(
         worker = %worker_name,
@@ -1155,5 +1176,99 @@ mod tests {
         );
 
         handle.abort();
+    }
+
+    /// Regression lock for the `starts_with(root)` bounds check added
+    /// at `register_new_dirs` (line ~328). If a path outside the
+    /// canonical project root sneaks through the earlier filters
+    /// (ignore-set + symlink-metadata), the bounds check MUST still
+    /// reject it before `watcher.watch()` is called — otherwise a
+    /// future notify-layer refactor could surface cross-root event
+    /// paths (e.g. FSEvents resolving a mount alias) and silently
+    /// register watches outside the project tree.
+    #[test]
+    fn register_new_dirs_rejects_out_of_root_paths() {
+        // Two independent tempdirs. `root` is the project; `stranger`
+        // simulates any path notify might hand us that is a real
+        // directory but outside the tree we meant to watch.
+        let proj = tempfile::tempdir().unwrap();
+        let stranger_tmp = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(proj.path()).unwrap();
+        let stranger = std::fs::canonicalize(stranger_tmp.path()).unwrap();
+
+        // Sanity: stranger is NOT under root (the whole point of the
+        // fixture). If this fires the tempdir layout changed.
+        assert!(!stranger.starts_with(&root));
+
+        let mut watcher = notify::recommended_watcher(|_| {}).unwrap();
+        let mut registered: HashSet<PathBuf> = HashSet::new();
+        register_new_dirs(&mut watcher, &[stranger.clone()], &root, &mut registered);
+
+        assert!(
+            !registered.contains(&stranger),
+            "out-of-root path must be rejected by the bounds check; \
+             if this fires, the `starts_with(root)` guard at \
+             source_watcher.rs:~328 was weakened or removed"
+        );
+        assert!(
+            registered.is_empty(),
+            "no watches should be registered for an out-of-root burst"
+        );
+    }
+
+    /// Complement: an in-root path (real directory, not ignored) must
+    /// still register. Guards against the bounds check being
+    /// accidentally inverted or over-tightened.
+    #[test]
+    fn register_new_dirs_accepts_in_root_paths() {
+        let proj = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(proj.path()).unwrap();
+        let child = root.join("src");
+        std::fs::create_dir_all(&child).unwrap();
+
+        let mut watcher = notify::recommended_watcher(|_| {}).unwrap();
+        let mut registered: HashSet<PathBuf> = HashSet::new();
+        register_new_dirs(&mut watcher, &[child.clone()], &root, &mut registered);
+
+        assert!(
+            registered.contains(&child),
+            "in-root directory must register; got registered set: {:?}",
+            registered
+        );
+    }
+
+    /// Regression lock for the canonical-root seed: `watch_pruned` is
+    /// called with `&root_for_filter` (canonicalized) rather than the
+    /// raw user-supplied `project_path`, so the paths inserted into
+    /// `registered_dirs` match the canonical form that notify's
+    /// per-burst `register_new_dirs` lookup expects. On macOS FSEvents
+    /// always emits canonical `/private/var/...` event paths even when
+    /// the watch was registered on a symlinked ancestor; seeding with
+    /// the raw (non-canonical) path would make every burst miss the
+    /// dedup-set and redo `lstat` + `inotify_add_watch` on parents we
+    /// already watched.
+    ///
+    /// Strategy: walk a canonicalized tempdir tree, then verify that
+    /// `registered_dirs` contains the canonical root path (not a
+    /// symlinked alias). On filesystems where tempdir() paths are
+    /// already canonical this degenerates to a presence check — still
+    /// useful as a regression fence against any refactor that seeds
+    /// with a non-canonical argument.
+    #[test]
+    fn watch_pruned_seeds_registered_with_canonical_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let canonical_root = std::fs::canonicalize(tmp.path()).unwrap();
+
+        let mut watcher = notify::recommended_watcher(|_| {}).unwrap();
+        let mut registered: HashSet<PathBuf> = HashSet::new();
+        watch_pruned(&mut watcher, &canonical_root, &mut registered).unwrap();
+
+        assert!(
+            registered.contains(&canonical_root),
+            "watch_pruned must seed `registered` with the canonical root \
+             so burst-time lookups from notify hit the dedup set; \
+             got registered set: {:?}",
+            registered
+        );
     }
 }

--- a/crates/iii-worker/src/cli/source_watcher.rs
+++ b/crates/iii-worker/src/cli/source_watcher.rs
@@ -187,20 +187,58 @@ pub fn should_ignore_path(path: &Path, project_root: &Path) -> bool {
 ///
 /// Best-effort: permission errors on subdirs are logged and skipped,
 /// not propagated. The watcher stays online for the rest of the tree.
-fn watch_pruned(watcher: &mut notify::RecommendedWatcher, root: &Path) -> anyhow::Result<()> {
+fn watch_pruned(
+    watcher: &mut notify::RecommendedWatcher,
+    root: &Path,
+    registered: &mut HashSet<PathBuf>,
+) -> anyhow::Result<()> {
     use std::collections::VecDeque;
 
     let mut queue: VecDeque<PathBuf> = VecDeque::new();
     queue.push_back(root.to_path_buf());
 
     while let Some(dir) = queue.pop_front() {
-        if let Err(e) = watcher.watch(&dir, RecursiveMode::NonRecursive) {
-            tracing::debug!(
-                path = %dir.display(),
-                error = %e,
-                "watch_pruned: skipping unwatchable dir"
-            );
-            continue;
+        match watcher.watch(&dir, RecursiveMode::NonRecursive) {
+            Ok(()) => {
+                registered.insert(dir.clone());
+            }
+            Err(e) => {
+                // Detect inotify ENOSPC (io::ErrorKind::StorageFull on
+                // stable) and call it out once with an actionable
+                // remediation. notify wraps the OS error in its own
+                // variants so we match on the error string rather than
+                // plumbing through a platform-specific check.
+                //
+                // ENOSPC is terminal: the kernel's inotify budget is
+                // a per-user counter, so every remaining `inotify_add_watch`
+                // for this user will fail the same way. Continuing the
+                // walk would burn one syscall per dir on large trees
+                // (tens of thousands on a monorepo). Abort the walk —
+                // the watcher stays online for already-registered dirs,
+                // and the user now has an actionable log line.
+                let msg = e.to_string();
+                if msg.contains("No space left on device")
+                    || msg.contains("watch limit")
+                    || msg.contains("ENOSPC")
+                {
+                    tracing::warn!(
+                        path = %dir.display(),
+                        error = %e,
+                        "source watcher: inotify watch budget exhausted — file changes in \
+                         some directories will go undetected. Raise the limit with: \
+                         `sudo sysctl fs.inotify.max_user_watches=524288` (persist via \
+                         /etc/sysctl.d/). Aborting the rest of the walk to avoid a storm \
+                         of failing syscalls."
+                    );
+                    return Ok(());
+                }
+                tracing::debug!(
+                    path = %dir.display(),
+                    error = %e,
+                    "watch_pruned: skipping unwatchable dir"
+                );
+                continue;
+            }
         }
 
         let read = match std::fs::read_dir(&dir) {
@@ -248,26 +286,47 @@ fn watch_pruned(watcher: &mut notify::RecommendedWatcher, root: &Path) -> anyhow
 ///
 /// macOS FSEvents is inherently recursive and auto-covers new subdirs
 /// already, so this call is a no-op there aside from the logging cost.
-fn register_new_dirs(watcher: &mut notify::RecommendedWatcher, paths: &[PathBuf], root: &Path) {
+fn register_new_dirs(
+    watcher: &mut notify::RecommendedWatcher,
+    paths: &[PathBuf],
+    root: &Path,
+    registered: &mut HashSet<PathBuf>,
+) {
+    // `registered` persists across bursts: it's seeded from `watch_pruned`
+    // and grown each time we successfully register a new dir. Skipping
+    // already-registered paths collapses per-burst work to O(new unique
+    // dirs) instead of O(events) — crucial under IDE-save-heavy loops
+    // where the same parent directories appear in every burst.
     for p in paths {
+        if registered.contains(p) {
+            continue;
+        }
         // Cheap rejection first — ignored subtrees (node_modules etc.)
         // must never be watched even if they were just created.
         if should_ignore_path(p, root) {
             continue;
         }
-        // Skip non-directories. `is_dir` follows symlinks, which is
-        // fine here: a user-placed symlink-to-dir is legitimately
-        // something they want reloaded on edit. Errors from stat (file
-        // already gone, permission denied) make is_dir return false.
-        if !p.is_dir() {
-            continue;
+        // Use `symlink_metadata` so a user-placed symlink-to-dir in
+        // the project doesn't silently register a watch outside the
+        // project root. `watch_pruned` already skips symlinks on the
+        // initial walk; match its policy here. Errors from stat
+        // (file already gone, permission denied, race with delete)
+        // are treated as "not a watchable dir".
+        match std::fs::symlink_metadata(p) {
+            Ok(md) if md.file_type().is_dir() => {}
+            _ => continue,
         }
-        if let Err(e) = watcher.watch(p, RecursiveMode::NonRecursive) {
-            tracing::debug!(
-                path = %p.display(),
-                error = %e,
-                "source watcher: could not register new dir, skipping"
-            );
+        match watcher.watch(p, RecursiveMode::NonRecursive) {
+            Ok(()) => {
+                registered.insert(p.clone());
+            }
+            Err(e) => {
+                tracing::debug!(
+                    path = %p.display(),
+                    error = %e,
+                    "source watcher: could not register new dir, skipping"
+                );
+            }
         }
     }
 }
@@ -304,6 +363,9 @@ where
     // preserves today's behavior.
     let root_for_filter =
         std::fs::canonicalize(&project_path).unwrap_or_else(|_| project_path.clone());
+    // Clone for the closure — the outer scope still needs its copy to
+    // pass into register_new_dirs below.
+    let root_for_closure = root_for_filter.clone();
     let mut watcher = notify::RecommendedWatcher::new(
         move |res: Result<notify::Event, notify::Error>| {
             // Backend-level errors (inotify queue overflow on Linux,
@@ -342,7 +404,7 @@ where
             let has_relevant_path = event
                 .paths
                 .iter()
-                .any(|p| !should_ignore_path(p, &root_for_filter) && p != &root_for_filter);
+                .any(|p| !should_ignore_path(p, &root_for_closure) && p != &root_for_closure);
             if !has_relevant_path {
                 return;
             }
@@ -351,13 +413,21 @@ where
         notify::Config::default(),
     )?;
 
+    // Persistent registry of directories the watcher has a live watch
+    // descriptor on. Seeded by `watch_pruned`, grown by
+    // `register_new_dirs` on each burst. Lets the burst-time registrar
+    // skip redundant `lstat` + `watcher.watch` calls for dirs that are
+    // already watched — matters on IDE-save-heavy loops where the same
+    // parents appear in every burst.
+    let mut registered_dirs: HashSet<PathBuf> = HashSet::new();
+
     // Walk the project once and register watches on directories that
     // aren't in the ignore list. notify's RecursiveMode::Recursive
     // otherwise registers inotify watches inside node_modules/target/
     // .git — thousands of watch descriptors on a large project, and
     // per-event post-delivery filtering. NonRecursive on pruned
     // directories avoids both costs.
-    watch_pruned(&mut watcher, &project_path)?;
+    watch_pruned(&mut watcher, &project_path, &mut registered_dirs)?;
 
     tracing::info!(
         worker = %worker_name,
@@ -393,7 +463,17 @@ where
         // Files written between `mkdir` and this registration are
         // inherently missed — matches inotify's own semantics and is
         // best-effort by design.
-        register_new_dirs(&mut watcher, &burst_paths, &project_path);
+        // Use the canonicalized root for the ignore filter — event
+        // paths may be canonical (macOS FSEvents) while project_path
+        // is not, so strip_prefix would mismatch and the filter would
+        // fail. watch_and_restart already computed root_for_filter
+        // above; we pass it through here for symmetry.
+        register_new_dirs(
+            &mut watcher,
+            &burst_paths,
+            &root_for_filter,
+            &mut registered_dirs,
+        );
 
         let kind = if burst_paths.iter().any(|p| is_dep_manifest(p)) {
             ChangeKind::DepManifest
@@ -465,6 +545,20 @@ fn try_fast_restart(worker_name: &str) -> anyhow::Result<()> {
     super::supervisor_ctl::request_restart_blocking(worker_name)
 }
 
+/// Build the argv handed to `iii-worker start` in the full-VM restart
+/// path. Factored out of `restart_via_full_vm` so the contract can be
+/// regression-tested without spawning a real process.
+///
+/// `--no-wait` is load-bearing: the watcher runs with stdout/stderr
+/// redirected to `watcher.log` (see `spawn_source_watcher`), so any
+/// output the child emits gets appended to that file. The default
+/// wait path prints the 500ms status-panel redraw loop plus
+/// "✓ started / ✓ ready / <name>" lines, all of which would pollute
+/// watcher.log on every slow-path restart.
+pub(crate) fn full_vm_restart_args(worker_name: &str) -> [&str; 3] {
+    ["start", worker_name, "--no-wait"]
+}
+
 /// Slow path — spawn `iii-worker start <name>` which internally calls
 /// `kill_stale_worker` (killing the old VM + watcher sidecar) and
 /// boots a fresh VM. Taken when the supervisor is unreachable or when
@@ -478,12 +572,15 @@ fn restart_via_full_vm(worker_name: &str) {
         }
     };
 
+    // Discard the child's stdout/stderr. Inheriting here would pipe the
+    // child's chatter into `watcher.log` (the watcher's own redirected
+    // stdout/stderr). The watcher only cares about exit status for the
+    // tracing::info!/warn! below, which is captured separately.
     let output = std::process::Command::new(&self_exe)
-        .arg("start")
-        .arg(worker_name)
+        .args(full_vm_restart_args(worker_name))
         .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
         .output();
 
     match output {
@@ -517,6 +614,23 @@ mod tests {
 
     fn root() -> PathBuf {
         PathBuf::from("/proj")
+    }
+
+    /// Regression lock: the watcher's slow-path restart MUST pass
+    /// `--no-wait`. Without it, the child spawned by `restart_via_full_vm`
+    /// blocks on `watch_until_ready`, which eprintln's the 500ms status
+    /// panel redraw loop. The watcher's stderr is redirected to
+    /// `~/.iii/logs/<name>/watcher.log`, so that loop would append the
+    /// panel (ANSI redraw escapes and all) to watcher.log on every slow
+    /// path restart.
+    #[test]
+    fn full_vm_restart_args_include_no_wait() {
+        let args = full_vm_restart_args("my-worker");
+        assert_eq!(args, ["start", "my-worker", "--no-wait"]);
+        assert!(
+            args.iter().any(|a| *a == "--no-wait"),
+            "watcher slow-path restart must pass --no-wait to avoid polluting watcher.log"
+        );
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/status.rs
+++ b/crates/iii-worker/src/cli/status.rs
@@ -1091,10 +1091,12 @@ mod tests {
     // previously exercised only indirectly through integration paths.
     // ---------------------------------------------------------------------
 
-    /// Shared guard for tests that mutate HOME + CWD. HOME is process-global,
-    /// CWD is process-global, so any two tests that touch either must run
-    /// one at a time.
-    static PROBE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    /// Shared guard for tests that mutate HOME + CWD. Aliased to the
+    /// crate-wide test lock at `super::super::test_support::TEST_HOME_LOCK`
+    /// so tests across modules (supervisor_ctl, etc.) that read HOME
+    /// via `dirs::home_dir()` don't race against HOME mutations
+    /// here and pick up a tempdir path that breaches SUN_LEN.
+    use super::super::test_support::TEST_HOME_LOCK as PROBE_ENV_LOCK;
 
     struct ProbeEnvGuard {
         home: Option<std::ffi::OsString>,

--- a/crates/iii-worker/src/cli/status.rs
+++ b/crates/iii-worker/src/cli/status.rs
@@ -456,9 +456,11 @@ pub(crate) fn pid_file_candidates(
 pub(crate) fn read_pid(name: &str) -> Option<u32> {
     let home = dirs::home_dir()?.join(".iii");
     for path in pid_file_candidates(&home, name) {
-        if let Ok(s) = std::fs::read_to_string(&path)
-            && let Ok(pid) = s.trim().parse::<u32>()
-        {
+        // Route through the shared hardened reader so the status CLI
+        // can't be tricked by a symlink-planted pidfile into displaying
+        // or waiting on an attacker-chosen PID. See `pidfile` module
+        // docstring for the attacker model.
+        if let Some(pid) = super::pidfile::read_pid(&path) {
             return Some(pid);
         }
     }
@@ -1006,10 +1008,10 @@ mod tests {
     /// flushed an empty buffer, accidental negative numbers.
     #[test]
     fn read_pid_silently_skips_malformed_pidfiles() {
-        // Must serialize under PROBE_ENV_LOCK because HOME is process-global
+        // Must serialize under test_support::lock_home because HOME is process-global
         // and every probe test mutates it. Without the guard, parallel
         // probe_* tests win the race and read_pid sees the wrong HOME.
-        let _g = PROBE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = lock_home();
         let tmp = tempfile::tempdir().unwrap();
         let _env = ProbeEnvGuard::new(tmp.path());
 
@@ -1046,10 +1048,10 @@ mod tests {
     /// a missing socket → Phase::EngineDown, non-terminal).
     #[tokio::test(flavor = "multi_thread")]
     async fn watch_until_ready_honors_timeout() {
-        // Shares PROBE_ENV_LOCK with every other test that mutates
+        // Shares test_support::lock_home with every other test that mutates
         // HOME+CWD. Using a separate lock would let the tempdirs overlap
         // and corrupt each other's filesystem view.
-        let _g = PROBE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = lock_home();
         let tmp = tempfile::tempdir().unwrap();
         let _env = ProbeEnvGuard::new(tmp.path());
 
@@ -1091,12 +1093,15 @@ mod tests {
     // previously exercised only indirectly through integration paths.
     // ---------------------------------------------------------------------
 
-    /// Shared guard for tests that mutate HOME + CWD. Aliased to the
-    /// crate-wide test lock at `super::super::test_support::TEST_HOME_LOCK`
-    /// so tests across modules (supervisor_ctl, etc.) that read HOME
-    /// via `dirs::home_dir()` don't race against HOME mutations
-    /// here and pick up a tempdir path that breaches SUN_LEN.
-    use super::super::test_support::TEST_HOME_LOCK as PROBE_ENV_LOCK;
+    /// Shared guard for tests that mutate HOME + CWD. Delegates to
+    /// the crate-wide `test_support::lock_home` so tests across modules
+    /// (supervisor_ctl, etc.) that read HOME via `dirs::home_dir()`
+    /// don't race against HOME mutations here and pick up a tempdir
+    /// path that breaches SUN_LEN. Using the helper (rather than
+    /// open-coding `.lock().unwrap_or_else(…)` at each call site)
+    /// centralizes the poison-recovery contract in one place and keeps
+    /// the pattern discoverable for future tests.
+    use super::super::test_support::lock_home;
 
     struct ProbeEnvGuard {
         home: Option<std::ffi::OsString>,
@@ -1107,7 +1112,7 @@ mod tests {
         fn new(home: &std::path::Path) -> Self {
             let original_home = std::env::var_os("HOME");
             let original_cwd = std::env::current_dir().ok();
-            // SAFETY: test-only, serialized via PROBE_ENV_LOCK.
+            // SAFETY: test-only, serialized via test_support::lock_home.
             unsafe { std::env::set_var("HOME", home) };
             std::env::set_current_dir(home).unwrap();
             Self {
@@ -1122,7 +1127,7 @@ mod tests {
             if let Some(cwd) = &self.cwd {
                 let _ = std::env::set_current_dir(cwd);
             }
-            // SAFETY: test-only, serialized via PROBE_ENV_LOCK.
+            // SAFETY: test-only, serialized via test_support::lock_home.
             unsafe {
                 match &self.home {
                     Some(v) => std::env::set_var("HOME", v),
@@ -1134,7 +1139,7 @@ mod tests {
 
     #[test]
     fn probe_returns_not_in_config_when_worker_missing() {
-        let _g = PROBE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = lock_home();
         let tmp = tempfile::tempdir().unwrap();
         let _env = ProbeEnvGuard::new(tmp.path());
         // No config.yaml written — worker_exists returns false.
@@ -1155,7 +1160,7 @@ mod tests {
     /// in config_file.rs); the config.yaml entry alone is insufficient.
     #[test]
     fn probe_binary_worker_with_live_pidfile_is_ready() {
-        let _g = PROBE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = lock_home();
         let tmp = tempfile::tempdir().unwrap();
         let _env = ProbeEnvGuard::new(tmp.path());
 

--- a/crates/iii-worker/src/cli/supervisor_ctl.rs
+++ b/crates/iii-worker/src/cli/supervisor_ctl.rs
@@ -312,8 +312,21 @@ mod tests {
         format!("__iii_test_supervisor_ctl_{}__", std::process::id())
     }
 
+    /// Guard that locks the process-global HOME so other tests in the
+    /// crate (notably `status::tests` which temporarily points HOME at
+    /// a long `/var/folders/...` tempdir) can't make our resolved
+    /// socket path breach macOS's 104-byte SUN_LEN limit while this
+    /// test is mid-run. Thin wrapper over
+    /// [`crate::cli::test_support::lock_home`] — the shared helper
+    /// keeps the invariant documented in one place and gives any new
+    /// test module an obvious entry point.
+    fn lock_home() -> std::sync::MutexGuard<'static, ()> {
+        super::super::test_support::lock_home()
+    }
+
     #[tokio::test]
     async fn request_restart_blocking_succeeds_from_within_tokio_context() {
+        let _h = lock_home();
         // The motivating bug: watcher's sync callback runs inside a
         // tokio runtime and cannot spin up a nested one. This test
         // proves that request_restart_blocking is safe to call from a
@@ -336,6 +349,7 @@ mod tests {
 
     #[test]
     fn request_restart_blocking_errors_on_missing_socket() {
+        let _h = lock_home();
         // No stub running. Blocking connect should fail fast with
         // ENOENT or ECONNREFUSED. Caller maps this to "fall back to
         // full VM restart" and carries on.
@@ -352,6 +366,7 @@ mod tests {
 
     #[tokio::test]
     async fn request_restart_succeeds_on_ok_response() {
+        let _h = lock_home();
         let worker = sandbox_worker_name();
         stub_server(control_socket_path(&worker).unwrap(), r#"{"result":"ok"}"#).await;
         request_restart(&worker).await.expect("restart ok");
@@ -362,6 +377,7 @@ mod tests {
 
     #[tokio::test]
     async fn request_restart_propagates_error_response() {
+        let _h = lock_home();
         let worker = format!("{}_err", sandbox_worker_name());
         stub_server(
             control_socket_path(&worker).unwrap(),
@@ -377,6 +393,7 @@ mod tests {
 
     #[tokio::test]
     async fn ping_reports_pid_from_alive_response() {
+        let _h = lock_home();
         let worker = format!("{}_ping", sandbox_worker_name());
         stub_server(
             control_socket_path(&worker).unwrap(),
@@ -392,6 +409,7 @@ mod tests {
 
     #[tokio::test]
     async fn round_trip_fails_fast_when_socket_missing() {
+        let _h = lock_home();
         let worker = format!("{}_missing", sandbox_worker_name());
         // Don't start a server — the socket doesn't exist.
         let err = ping(&worker).await.expect_err("should fail");

--- a/crates/iii-worker/src/cli/test_support.rs
+++ b/crates/iii-worker/src/cli/test_support.rs
@@ -1,0 +1,43 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at support@motia.dev
+// See LICENSE and PATENTS files for details.
+
+//! Test-only helpers shared across `cli/` test modules.
+//!
+//! Anything in here is gated on `#[cfg(test)]` at the module
+//! declaration site (`cli/mod.rs`) so it never ships in production
+//! binaries.
+//!
+//! The central primitive is [`TEST_HOME_LOCK`], a process-wide mutex
+//! that every test mutating or reading `HOME` (or `CWD`, which on
+//! macOS is derived from `HOME` in several of our resolution paths)
+//! must take before entering its body. Without it, `cargo test
+//! -- --test-threads=N` lets one test override `HOME` to a long
+//! `/var/folders/...` tempdir while another concurrently resolves
+//! `dirs::home_dir()` — the concurrent reader then derives a path
+//! that blows past macOS's 104-byte `SUN_LEN` limit for Unix socket
+//! addresses and the test fails with a misleading bind error.
+//!
+//! Use [`lock_home`] rather than taking the mutex directly: it
+//! transparently recovers from poisoned state (a prior test
+//! panicking while holding the lock leaves the mutex poisoned; that
+//! is not a correctness problem for our callers, since the lock
+//! protects an `()` and is only there to serialize env mutations).
+//!
+//! Any new test that reads or mutates `HOME` must call `lock_home()`
+//! for the whole body — missing the call reintroduces the race.
+
+/// Process-global lock serializing tests that read or mutate
+/// `HOME` / `CWD`. See the module docstring for the full rationale.
+pub(crate) static TEST_HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Acquire [`TEST_HOME_LOCK`], transparently recovering from a
+/// poisoned mutex. Tests should bind the returned guard to `_g` for
+/// the whole body so the lock is released on scope exit.
+pub(crate) fn lock_home() -> std::sync::MutexGuard<'static, ()> {
+    TEST_HOME_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}

--- a/crates/iii-worker/src/cli/vm_boot.rs
+++ b/crates/iii-worker/src/cli/vm_boot.rs
@@ -317,7 +317,30 @@ fn spawn_control_proxy(
     }
     let _ = std::fs::remove_file(&sock_path);
 
-    let listener = match UnixListener::bind(&sock_path) {
+    // Narrow umask around the bind so the socket inode is created with
+    // 0o600 mode from the start, rather than born with the process
+    // umask (typically 0o002 / 0o022) and chmod'd afterwards. The prior
+    // `set_permissions` approach left a narrow TOCTOU window where a
+    // same-uid attacker could `connect()` before we locked the perms;
+    // SO_PEERCRED would reject cross-uid clients but not same-uid ones.
+    // umask(0o077) yields 0o600 files (default mode 0o666 & !0o077 = 0o600),
+    // closing the window. Restore the prior umask immediately after bind.
+    //
+    // Kept for defense-in-depth: SO_PEERCRED (below) remains the primary
+    // authz check and the parent dir is already 0o700 from line ~316.
+    //
+    // Caveat: `umask` is process-global, not per-thread. If a concurrent
+    // Tokio task (or any other thread) happens to create a file between
+    // the `umask(0o077)` and restore call, that file also inherits 0o077.
+    // The window is a few syscalls wide and `iii worker start` is
+    // effectively serial at this point in boot, so the practical risk is
+    // low; the `set_permissions` follow-up below catches the rare miss.
+    let prev_umask = unsafe { nix::libc::umask(0o077) };
+    let bind_result = UnixListener::bind(&sock_path);
+    unsafe {
+        nix::libc::umask(prev_umask);
+    }
+    let listener = match bind_result {
         Ok(l) => l,
         Err(e) => {
             eprintln!(
@@ -327,10 +350,10 @@ fn spawn_control_proxy(
             return None;
         }
     };
-    // Lock the socket file to 0o600 (owner rw only). Combined with
-    // SO_PEERCRED checks below, this is defense-in-depth: without the
-    // peer uid check a local user whose uid != ours could still use
-    // a stolen fd, but fs perms block the typical unprivileged path.
+    // Belt-and-suspenders: some platforms or `nix` versions of `umask`
+    // might not influence Unix-socket inode creation mode. The
+    // `set_permissions` call here is a no-op when bind already produced
+    // 0o600 (the common case), and a corrective chmod otherwise.
     let _ = std::fs::set_permissions(&sock_path, std::fs::Permissions::from_mode(0o600));
 
     // Capture (dev, ino) of the just-bound socket so the on_exit hook

--- a/crates/iii-worker/src/cli/vm_boot.rs
+++ b/crates/iii-worker/src/cli/vm_boot.rs
@@ -204,6 +204,38 @@ pub fn rewrite_localhost(s: &str, gateway_ip: &str) -> String {
         .replace("://127.0.0.1:", &format!("://{}:", gateway_ip))
 }
 
+/// Identity of a bound control socket: path plus (dev, ino) of the
+/// filesystem entry that `UnixListener::bind` produced. Captured at
+/// bind time and consulted by the VM-exit cleanup hook so we only
+/// unlink the socket we created — never a replacement someone else
+/// bound at the same path in the meantime.
+#[cfg(unix)]
+#[derive(Debug, Clone)]
+struct SocketFingerprint {
+    path: String,
+    dev: u64,
+    ino: u64,
+}
+
+#[cfg(unix)]
+impl SocketFingerprint {
+    /// Remove the socket file iff its (dev, ino) still match what we
+    /// captured at bind time. Silently does nothing if the path has
+    /// been replaced (another VM rebinding), is gone, or can't be
+    /// stat'd — all three are benign at VM-exit time.
+    fn remove_if_unchanged(&self) {
+        use std::os::unix::fs::MetadataExt;
+        match std::fs::metadata(&self.path) {
+            Ok(m) if m.dev() == self.dev && m.ino() == self.ino => {
+                let _ = std::fs::remove_file(&self.path);
+            }
+            _ => {
+                // Replaced, gone, or unstatable — leave it alone.
+            }
+        }
+    }
+}
+
 /// Create a unix stream `socketpair` for the control channel. The guest
 /// fd will be handed to `ConsoleBuilder::port` and must remain open for
 /// the lifetime of the VM; we deliberately `forget` the owned wrapper
@@ -247,15 +279,17 @@ fn setup_control_socketpair() -> Result<(std::os::unix::net::UnixStream, i32), S
 /// one in flight at a time).
 ///
 /// The listener is bound to a fresh unix socket — any stale file at
-/// `sock_path` is unlinked first. The socket is NOT unlinked on exit;
-/// the caller's `on_exit` hook (which already deletes the pid file
-/// and similar) is the right place for that. In practice the socket
-/// file becomes inert when the __vm-boot process dies, and any
-/// subsequent `iii worker start` overwrites it via the same unlink
-/// step at the top of this function.
+/// `sock_path` is unlinked first. The `on_exit` hook in the caller
+/// unlinks it again on VM shutdown so stop leaves a tidy managed dir.
+/// Even without that cleanup the file becomes inert when the
+/// __vm-boot process dies, and any subsequent `iii worker start`
+/// overwrites it via the same unlink step below.
 #[cfg(unix)]
-fn spawn_control_proxy(sock_path: String, host_end: std::os::unix::net::UnixStream) {
-    use std::os::unix::fs::PermissionsExt;
+fn spawn_control_proxy(
+    sock_path: String,
+    host_end: std::os::unix::net::UnixStream,
+) -> Option<SocketFingerprint> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
     use std::os::unix::net::{UnixListener, UnixStream};
     use std::path::PathBuf;
     use std::sync::{Arc, Mutex};
@@ -290,7 +324,7 @@ fn spawn_control_proxy(sock_path: String, host_end: std::os::unix::net::UnixStre
                 "warning: control proxy bind({sock_path}) failed: {e}. \
                  Fast-path restart is disabled; full VM restarts still work."
             );
-            return;
+            return None;
         }
     };
     // Lock the socket file to 0o600 (owner rw only). Combined with
@@ -298,6 +332,20 @@ fn spawn_control_proxy(sock_path: String, host_end: std::os::unix::net::UnixStre
     // peer uid check a local user whose uid != ours could still use
     // a stolen fd, but fs perms block the typical unprivileged path.
     let _ = std::fs::set_permissions(&sock_path, std::fs::Permissions::from_mode(0o600));
+
+    // Capture (dev, ino) of the just-bound socket so the on_exit hook
+    // can refuse to unlink if the file at `sock_path` has since been
+    // replaced — a fast `stop → start` race can let the new VM bind
+    // the same path before the old VM's on_exit fires; without this
+    // fingerprint check the stale hook would nuke the live socket
+    // and silently downgrade fast-path restart to a full-VM cycle.
+    let fingerprint = std::fs::metadata(&sock_path)
+        .ok()
+        .map(|m| SocketFingerprint {
+            path: sock_path.clone(),
+            dev: m.dev(),
+            ino: m.ino(),
+        });
 
     // Cap how long any single read from the VM end can block. A wedged
     // supervisor otherwise pins the mutex forever and every subsequent
@@ -432,6 +480,8 @@ fn spawn_control_proxy(sock_path: String, host_end: std::os::unix::net::UnixStre
             false
         }
     }
+
+    fingerprint
 }
 
 /// Boot the VM. Called from `main()` when `__vm-boot` is parsed.
@@ -588,9 +638,10 @@ fn boot_vm(args: &VmBootArgs) -> Result<std::convert::Infallible, String> {
     // is exactly the lifetime of the control channel.
     let console_output_path = args.console_output.clone();
     let mut guest_control_fd: Option<i32> = None;
+    let mut control_sock_fingerprint: Option<SocketFingerprint> = None;
     if let Some(sock_path) = args.control_sock.clone() {
         let (host_end, guest_fd) = setup_control_socketpair()?;
-        spawn_control_proxy(sock_path, host_end);
+        control_sock_fingerprint = spawn_control_proxy(sock_path, host_end);
         guest_control_fd = Some(guest_fd);
     }
 
@@ -604,10 +655,30 @@ fn boot_vm(args: &VmBootArgs) -> Result<std::convert::Infallible, String> {
         c
     });
 
-    if let Some(ref pid_path) = args.pid_file {
-        let path = pid_path.clone();
+    // Register VM-exit cleanup for pidfile and control socket
+    // independently — they're separate resources and may be enabled
+    // independently of each other (a future caller may want a control
+    // socket without a persistent pidfile, or vice versa). Coupling
+    // them inside `if let Some(pid_file)` would silently regress the
+    // socket-cleanup path for such callers.
+    //
+    // libkrun's Builder::on_exit replaces the previous hook, so we
+    // fold everything into a single closure that checks each resource
+    // independently.
+    let pid_path_for_exit = args.pid_file.clone();
+    let sock_fingerprint_for_exit = control_sock_fingerprint.clone();
+    if pid_path_for_exit.is_some() || sock_fingerprint_for_exit.is_some() {
         builder = builder.on_exit(move |exit_code| {
-            let _ = std::fs::remove_file(&path);
+            if let Some(ref p) = pid_path_for_exit {
+                let _ = std::fs::remove_file(p);
+            }
+            // Only unlink the control socket if it's still the one we
+            // bound — a fast `stop → start` can let a new VM rebind
+            // the same path before this hook fires. The fingerprint
+            // check makes stale unlinks a no-op.
+            if let Some(ref fp) = sock_fingerprint_for_exit {
+                fp.remove_if_unchanged();
+            }
             if exit_code != 0 {
                 eprintln!("  VM exited with code {}", exit_code);
             }

--- a/crates/iii-worker/src/cli/worker_manager/libkrun.rs
+++ b/crates/iii-worker/src/cli/worker_manager/libkrun.rs
@@ -132,11 +132,14 @@ pub async fn run_dev(
 
     match cmd.spawn() {
         Ok(mut child) => {
-            // Write PID file so is_worker_running / stop / kill_stale_worker can find us
+            // Write PID file so is_worker_running / stop / kill_stale_worker can find us.
+            // Use the hardened writer: O_NOFOLLOW + 0o600 on Unix so a
+            // symlink pre-planted at vm.pid can't redirect our write to
+            // a sensitive file. Matches the watch.pid hardening.
             let pid_file = rootfs.join("vm.pid");
             let pid = child.id().unwrap_or(0);
             if pid > 0
-                && let Err(e) = std::fs::write(&pid_file, pid.to_string())
+                && let Err(e) = crate::cli::pidfile::write_pid_file_strict(&pid_file, pid)
             {
                 eprintln!(
                     "{} Failed to write PID file {}: {}",
@@ -465,7 +468,7 @@ This image likely does not publish arm64. Rebuild/push a multi-arch image (linux
         let child = cmd.spawn().context("failed to spawn VM boot process")?;
 
         let pid = child.id();
-        std::fs::write(Self::pid_file(&spec.name), pid.to_string())?;
+        crate::cli::pidfile::write_pid_file_strict(&Self::pid_file(&spec.name), pid)?;
 
         tracing::info!(name = %spec.name, pid = pid, "started libkrun VM");
 

--- a/crates/iii-worker/tests/worker_integration.rs
+++ b/crates/iii-worker/tests/worker_integration.rs
@@ -64,6 +64,8 @@ fn cli_parses_all_subcommands() {
 fn start_subcommand_matches_engine_spawn_args() {
     // Bare-name form used when a human runs `iii-worker start <name>` from
     // the terminal. Must still parse cleanly and default port to DEFAULT_PORT.
+    // Humans DO expect the wait-for-ready status panel here; only the engine
+    // auto-spawn path opts out via --no-wait.
     let cli = Cli::try_parse_from(["iii-worker", "start", "image-resize"])
         .expect("bare start form must parse");
     match cli.command {
@@ -73,7 +75,7 @@ fn start_subcommand_matches_engine_spawn_args() {
             port,
         } => {
             assert_eq!(worker_name, "image-resize");
-            assert!(!no_wait, "engine expects default wait behavior");
+            assert!(!no_wait, "bare human invocation keeps default wait=true");
             assert_eq!(
                 port,
                 iii_worker::DEFAULT_PORT,
@@ -90,8 +92,19 @@ fn start_subcommand_accepts_port_flag_from_engine_spawn() {
     // non-default iii-worker-manager port is configured. If this ever stops
     // parsing, clap rejects with exit 2 and every auto-spawned external
     // worker on a non-default port silently fails to connect.
-    let cli = Cli::try_parse_from(["iii-worker", "start", "pdfkit", "--port", "49199"])
-        .expect("engine's --port spawn form must parse");
+    //
+    // `--no-wait` is part of that contract now: without it, the child blocks
+    // on the 500ms status-panel redraw loop and floods stderr.log with ANSI
+    // redraw noise that bleeds into `iii worker logs -f`.
+    let cli = Cli::try_parse_from([
+        "iii-worker",
+        "start",
+        "pdfkit",
+        "--port",
+        "49199",
+        "--no-wait",
+    ])
+    .expect("engine's --port --no-wait spawn form must parse");
     match cli.command {
         Commands::Start {
             worker_name,
@@ -99,7 +112,7 @@ fn start_subcommand_accepts_port_flag_from_engine_spawn() {
             port,
         } => {
             assert_eq!(worker_name, "pdfkit");
-            assert!(!no_wait, "engine expects default wait behavior");
+            assert!(no_wait, "engine auto-spawn must pass --no-wait");
             assert_eq!(port, 49199, "--port must surface the custom port");
         }
         _ => panic!("expected Start"),

--- a/engine/src/workers/registry_worker.rs
+++ b/engine/src/workers/registry_worker.rs
@@ -58,12 +58,19 @@ fn pid_file_candidates(home: &std::path::Path, worker_name: &str) -> [PathBuf; 2
 ///
 /// Any drift here silently breaks the non-default `iii-worker-manager` port
 /// case — the exact bug this module exists to fix.
-fn spawn_args(worker_name: &str, port: u16) -> [String; 4] {
+fn spawn_args(worker_name: &str, port: u16) -> [String; 5] {
+    // `--no-wait` keeps the child process short-lived. Without it the default
+    // `wait=true` path pulls `wait_for_ready` → `watch_until_ready`, which
+    // eprintln's a 500ms status-panel redraw loop into the engine-redirected
+    // stderr.log. `iii worker logs -f` then tails that noise interleaved with
+    // the VM's actual console output. The engine already probes liveness via
+    // `is_alive`, so blocking the child on the panel loop is pure pollution.
     [
         "start".into(),
         worker_name.into(),
         "--port".into(),
         port.to_string(),
+        "--no-wait".into(),
     ]
 }
 
@@ -545,8 +552,21 @@ mod tests {
                 "start".to_string(),
                 "pdfkit".to_string(),
                 "--port".to_string(),
-                "49199".to_string()
+                "49199".to_string(),
+                "--no-wait".to_string(),
             ],
+        );
+    }
+
+    /// Regression lock: the engine auto-spawn MUST pass `--no-wait`.
+    /// Dropping it resurrects the status-panel redraw loop that poisons
+    /// `~/.iii/logs/<name>/stderr.log` (visible via `iii worker logs -f`).
+    #[test]
+    fn spawn_args_always_passes_no_wait() {
+        let args = spawn_args("anything", 1234);
+        assert!(
+            args.iter().any(|a| a == "--no-wait"),
+            "engine spawn must include --no-wait to avoid polluting stderr.log"
         );
     }
 

--- a/engine/src/workers/registry_worker.rs
+++ b/engine/src/workers/registry_worker.rs
@@ -52,6 +52,54 @@ fn pid_file_candidates(home: &std::path::Path, worker_name: &str) -> [PathBuf; 2
     ]
 }
 
+/// Hardened pidfile read. Mirrors `iii-worker::cli::pidfile::read_pid`;
+/// engine has no dep on iii-worker so the check is duplicated inline
+/// alongside `pid_file_candidates`.
+///
+/// Defends against a local-user pidfile planting attack: without
+/// O_NOFOLLOW + ownership check, an attacker with write access to
+/// `~/.iii/pids/` (or `~/.iii/managed/<name>/`) can symlink a worker's
+/// pidfile to any numeric-content file (e.g. `/proc/1/sched`, an
+/// attacker-owned file with "1\n"). The engine then reads a wrong PID
+/// and either (a) `kill(pid, 0)` succeeds against an unrelated live
+/// process, making `is_alive` return true forever so the real worker
+/// never gets restarted, or (b) in worst-case future uses, signals the
+/// wrong PID. Requiring euid-ownership rejects planted files.
+///
+/// Returns `None` on any failure — the caller (`is_alive`) treats
+/// unreadable pidfiles as "no live pidfile" and falls through to the
+/// grace window, which is the correct conservative behavior.
+#[cfg(unix)]
+fn read_pid_hardened(path: &std::path::Path) -> Option<u32> {
+    use std::io::Read;
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(nix::libc::O_NOFOLLOW)
+        .open(path)
+        .ok()?;
+    let meta = file.metadata().ok()?;
+    if !meta.file_type().is_file() {
+        return None;
+    }
+    let our_uid = unsafe { nix::libc::geteuid() };
+    if meta.uid() != our_uid {
+        return None;
+    }
+    let mut buf = [0u8; 32];
+    let n = file.read(&mut buf).ok()?;
+    let s = std::str::from_utf8(&buf[..n]).ok()?;
+    s.trim().parse::<u32>().ok()
+}
+
+#[cfg(not(unix))]
+fn read_pid_hardened(path: &std::path::Path) -> Option<u32> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+}
+
 /// Build the argv handed to `iii-worker start` when the engine auto-spawns a
 /// non-builtin worker. Kept pure so the CLI/engine IPC contract can be
 /// regression-tested without spawning a real process (see tests).
@@ -205,9 +253,10 @@ impl ExternalWorkerProcess {
         };
 
         for pidfile in pid_file_candidates(&home, &self.name) {
-            if let Ok(s) = std::fs::read_to_string(&pidfile)
-                && let Ok(pid) = s.trim().parse::<u32>()
-            {
+            // `read_pid_hardened` uses O_NOFOLLOW + euid-ownership check
+            // to reject attacker-planted symlinks or foreign-owned files;
+            // see its docstring for the attacker model.
+            if let Some(pid) = read_pid_hardened(&pidfile) {
                 #[cfg(unix)]
                 {
                     use nix::sys::signal::kill;
@@ -608,5 +657,35 @@ mod tests {
         let got = pid_file_candidates(home, "demo");
         assert_eq!(got[0], home.join("managed/demo/vm.pid"));
         assert_eq!(got[1], home.join("pids/demo.pid"));
+    }
+
+    /// Engine-side mirror of iii-worker's
+    /// `pidfile::tests::known_call_sites_route_through_module`. Pins the
+    /// three hardening invariants in `read_pid_hardened` so a future
+    /// refactor can't silently drop O_NOFOLLOW, the uid-ownership check,
+    /// or the regular-file check and regress the attacker model.
+    /// Engine has no dep on iii-worker, so the hardening is duplicated
+    /// inline above — this grep-style test is the only thing preventing
+    /// the duplicate from drifting out of sync with the canonical copy.
+    #[test]
+    #[cfg(unix)]
+    fn read_pid_hardened_retains_hardening_tokens() {
+        // `file!()` is relative to the crate root, so anchor via
+        // `CARGO_MANIFEST_DIR` for reliable lookup under any `cargo test`
+        // invocation (workspace-relative vs crate-relative cwd).
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        let path = std::path::Path::new(manifest).join("src/workers/registry_worker.rs");
+        let src = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {:?} for self-grep: {}", path, e));
+        for token in ["O_NOFOLLOW", "meta.uid()", "file_type().is_file()"] {
+            assert!(
+                src.contains(token),
+                "read_pid_hardened must reference `{}` — dropping it regresses the pidfile \
+                 attacker model (see iii-worker::cli::pidfile docstring). If you genuinely \
+                 need to remove this check, reproduce the security rationale in the commit \
+                 message and update this test.",
+                token,
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Two rounds of code-review follow-ups on the hot-reload PR (#1498), plus a fix for the live VM-boot regression surfaced by `iii worker start` failing with `supervisor spawn_initial failed: No such file or directory`.

**Pidfile hardening — writes (round 1) + reads (round 2).** Every write now goes through `pidfile::write_pid_file` (`O_NOFOLLOW` + `O_CREAT` + `0o600`). Reads now go through `pidfile::read_pid` (`O_NOFOLLOW` + euid ownership + regular-file check + 32-byte cap). Engine has no dep on `iii-worker`, so it carries an inline duplicate guarded by a self-grep test. The iii-worker invariant test (`known_call_sites_route_through_module`) locks the canonical call sites so a future refactor can't silently re-open either side of the symlink-replace attack.

**Rootfs FHS-marker guard (the live fix).** Previously `!managed_dir.exists()` was used to decide whether to clone the rootfs. A half-populated `managed_dir` (iii-init runtime mkdirs for `/dev /proc /sys /etc /tmp /run`, stray `vm.pid` / `watch.pid`, legacy `managed_dir/rootfs/` subdir from an older codepath) slipped through, the VM booted against an FHS-less tree, and iii-init died trying to exec `/bin/sh`. New guard: `needs_rootfs_clone(&Path) = !managed_dir.join("bin").exists()`. Self-heals on mismatch by wiping `managed_dir` before `cp -c -a` so the clone lands at `managed_dir/` instead of being nested at `managed_dir/python/`.

**Socket TOCTOU refinement (round 1, tightened in round 2).** `UnixListener::bind` in `spawn_control_proxy` is now wrapped by `umask(0o077)` so the socket inode is born 0o600 rather than chmod'd after the fact. Closes the same-uid `connect()` window `SO_PEERCRED` doesn't cover. `set_permissions` follow-up kept as belt-and-suspenders.

**Source watcher tightening.** `register_new_dirs` now performs a `starts_with(root)` bounds check before `watcher.watch()`. `watch_pruned` is seeded with the canonicalized root so macOS FSEvents' `/private/var/...` event paths dedup-hit the `registered_dirs` set on every burst.

**iii-init defensive `/etc` mkdir** before writing `/etc/hosts`, matching the pattern already in `write_resolv_conf`. Half-populated managed_dirs without `/etc` no longer surface as a confusing warning during boot.

**Other round-1 nits:** watcher slow-path restart passes `--no-wait` (stops the status-panel redraw loop from polluting `watcher.log`); engine auto-spawn passes `--no-wait` for the same reason; watcher inotify ENOSPC surfaces as an actionable warning; `register_new_dirs` dedup + symlink-safe + canonical root; shared `HOME` lock between status and supervisor_ctl tests.

## Test plan

- [x] `cargo test -p iii-worker --lib` → 334 passed (+6 new: pidfile read hardening ×4, source_watcher bounds ×2 + canonical seed, needs_rootfs_clone fixtures ×3)
- [x] `cargo test -p iii --lib workers::` → 1100 passed (+1 new: `read_pid_hardened_retains_hardening_tokens` self-grep)
- [x] `cargo test -p iii-init` → 13 passed
- [x] `cargo fmt --all` clean; `cargo check -p iii -p iii-worker` clean; clippy clean on touched files (pre-existing warnings in unrelated engine files untouched)
- [ ] Live smoke: `make sandbox && iii worker start todo-worker-python` on a managed_dir with the half-populated layout — expect one "Preparing sandbox..." print, clean boot thereafter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Centralized PID file management with symlink protection on Unix systems
  * Socket fingerprinting for improved control socket cleanup and security
  * Respawn retry mechanism for transient spawn failures

* **Bug Fixes**
  * Fixed stale process handle references when child processes exit unexpectedly
  * Corrected log output ordering for managed worker operations
  * Improved resilience when system resources are temporarily unavailable

* **Reliability & Security**
  * Enhanced PID file I/O hardening against symlink attacks
  * Improved socket creation security with proper permission handling
  * Strengthened worker name validation across operations
  * Better error recovery from corrupted/unsafe process state
  * Added bounds checking for directory watching operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->