### PR TITLE
fix(iii-worker): strip setuid/setgid bits during OCI layer extraction

### DIFF
--- a/crates/iii-worker/src/cli/worker_manager/oci.rs
+++ b/crates/iii-worker/src/cli/worker_manager/oci.rs
@@ -203,9 +203,17 @@ pub fn extract_layer_with_limits(
         let entry_type = entry.header().entry_type();
         let header_mode = entry.header().mode().unwrap_or(0);
 
-        entry
+        let unpacked = entry
             .unpack_in(dest)
             .with_context(|| format!("Failed to extract: {}", path.display()))?;
+
+        // `unpack_in` returns Ok(false) when it intentionally skips an entry
+        // (e.g. path traversal, no parent). Don't touch the dest path in
+        // that case — the file wasn't written and the resolved path could
+        // point outside the rootfs.
+        if !unpacked {
+            continue;
+        }
 
         // Strip setuid/setgid from regular files. See function doc for why.
         // Symlinks are skipped: chmod on a symlink path follows to the

--- a/crates/iii-worker/src/cli/worker_manager/oci.rs
+++ b/crates/iii-worker/src/cli/worker_manager/oci.rs
@@ -221,7 +221,13 @@ pub fn extract_layer_with_limits(
                 if current & SETID_BITS != 0 {
                     let mut perms = meta.permissions();
                     perms.set_mode(current & !SETID_BITS);
-                    let _ = std::fs::set_permissions(&target, perms);
+                    if let Err(e) = std::fs::set_permissions(&target, perms) {
+                        tracing::warn!(
+                            path = %target.display(),
+                            error = %e,
+                            "failed to strip setuid/setgid bits; setuid binaries will drop PID-1 privileges inside the guest",
+                        );
+                    }
                 }
             }
         }

--- a/crates/iii-worker/src/cli/worker_manager/oci.rs
+++ b/crates/iii-worker/src/cli/worker_manager/oci.rs
@@ -81,7 +81,26 @@ pub async fn prepare_rootfs(language: &str) -> Result<PathBuf> {
     Ok(rootfs_dir)
 }
 
+/// Setuid + setgid bit mask.
+///
+/// Both bits combined (0o4000 | 0o2000). Applied with a bitwise-NOT to
+/// clear them: `mode & !SETID_BITS`. Stripped during OCI extraction — see
+/// [`extract_layer_with_limits`] for the rationale.
+const SETID_BITS: u32 = 0o6000;
+
 /// Extract a single OCI layer with safety limits.
+///
+/// Setuid and setgid bits are stripped from every regular file as it lands.
+/// The microVM rootfs is served read-only through PassthroughFs with no UID
+/// translation: host ownership surfaces verbatim inside the guest. When the
+/// extracting user is not root (the common case), setuid binaries carry the
+/// host user's UID + setuid bit, and the guest kernel's setuid semantics
+/// *drop* the caller from euid=0 to that non-zero UID on exec — the classic
+/// example being `/bin/mount` refusing to run with "must be superuser".
+/// Stripping setuid/setgid at extraction time lets these binaries inherit
+/// the PID-1 euid (root) on exec, which is what a single-tenant microVM
+/// guest actually wants. There is no privilege boundary *inside* the VM
+/// for setuid to defend, so removing the bit is strictly a fix.
 pub fn extract_layer_with_limits(
     data: &[u8],
     dest: &std::path::Path,
@@ -89,6 +108,8 @@ pub fn extract_layer_with_limits(
     layer_count: usize,
     total_size: &mut u64,
 ) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
     let decoder = flate2::read::GzDecoder::new(data);
     let mut archive = tar::Archive::new(decoder);
     archive.set_preserve_permissions(true);
@@ -179,9 +200,31 @@ pub fn extract_layer_with_limits(
             continue;
         }
 
+        let entry_type = entry.header().entry_type();
+        let header_mode = entry.header().mode().unwrap_or(0);
+
         entry
             .unpack_in(dest)
             .with_context(|| format!("Failed to extract: {}", path.display()))?;
+
+        // Strip setuid/setgid from regular files. See function doc for why.
+        // Symlinks are skipped: chmod on a symlink path follows to the
+        // target, which may live outside the rootfs.
+        if matches!(
+            entry_type,
+            tar::EntryType::Regular | tar::EntryType::Continuous
+        ) && header_mode & SETID_BITS != 0
+        {
+            let target = dest.join(&path);
+            if let Ok(meta) = std::fs::metadata(&target) {
+                let current = meta.permissions().mode();
+                if current & SETID_BITS != 0 {
+                    let mut perms = meta.permissions();
+                    perms.set_mode(current & !SETID_BITS);
+                    let _ = std::fs::set_permissions(&target, perms);
+                }
+            }
+        }
     }
 
     Ok(())

--- a/crates/iii-worker/tests/oci_worker_integration.rs
+++ b/crates/iii-worker/tests/oci_worker_integration.rs
@@ -145,7 +145,11 @@ fn extract_layer_strips_setuid_and_setgid_bits() {
 
     assert_eq!(mode("bin/mount") & 0o6000, 0, "setuid bit must be stripped");
     assert_eq!(mode("bin/wall") & 0o6000, 0, "setgid bit must be stripped");
-    assert_eq!(mode("bin/odd") & 0o6000, 0, "setuid+setgid must be stripped");
+    assert_eq!(
+        mode("bin/odd") & 0o6000,
+        0,
+        "setuid+setgid must be stripped"
+    );
     assert_eq!(mode("bin/plain") & 0o777, 0o755, "plain perms survive");
 }
 
@@ -164,19 +168,25 @@ fn extract_layer_does_not_chmod_symlinks() {
 
     let dir = tempfile::tempdir().unwrap();
 
+    // Pre-create the target file with setid bits set on disk. If the
+    // symlink guard breaks, set_permissions("bin/link", ...) would follow
+    // the link and strip setid from this sentinel. Without the setid bits
+    // here, the inner `current & SETID_BITS != 0` gate would short-circuit
+    // before the chmod — so the test would pass even with a broken guard.
+    // The sentinel is NOT in the tarball (extraction would overwrite its
+    // mode with the header's 0o755), so we create it manually first.
+    std::fs::create_dir_all(dir.path().join("bin")).unwrap();
+    std::fs::write(dir.path().join("bin/real"), b"data").unwrap();
+    std::fs::set_permissions(
+        dir.path().join("bin/real"),
+        std::fs::Permissions::from_mode(0o6755),
+    )
+    .unwrap();
+
     let layer = {
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
         {
             let mut archive = tar::Builder::new(&mut encoder);
-
-            // Target: a regular file, mode 0o755, no setid bits.
-            let mut target_header = tar::Header::new_gnu();
-            target_header.set_path("bin/real").unwrap();
-            target_header.set_size(4);
-            target_header.set_mode(0o755);
-            target_header.set_entry_type(tar::EntryType::Regular);
-            target_header.set_cksum();
-            archive.append(&target_header, &b"data"[..]).unwrap();
 
             // Symlink: header claims setuid+setgid. If the guard breaks,
             // chmod would follow `link` to `real` and strip its perms.
@@ -205,17 +215,20 @@ fn extract_layer_does_not_chmod_symlinks() {
     let link_target = std::fs::read_link(dir.path().join("bin/link")).unwrap();
     assert_eq!(link_target.to_str(), Some("real"));
 
-    // The target regular file must be unchanged. If the symlink guard
-    // broke, set_permissions on `link` would have followed to `real` and
-    // stripped the setid bits from a file whose header had no setid bits
-    // set in the first place — a silent corruption path.
+    // The sentinel target must still have its setid bits. If the symlink
+    // guard broke, set_permissions on `link` would have followed to `real`
+    // and stripped them.
     let target_mode = std::fs::metadata(dir.path().join("bin/real"))
         .unwrap()
         .permissions()
         .mode()
         & 0o7777;
-    assert_eq!(target_mode & 0o777, 0o755, "target perms unchanged");
-    assert_eq!(target_mode & 0o6000, 0, "target has no setid bits");
+    assert_eq!(
+        target_mode & 0o6000,
+        0o6000,
+        "sentinel target must retain setid bits; a broken symlink guard would have stripped them"
+    );
+    assert_eq!(target_mode & 0o777, 0o755, "target base perms unchanged");
 }
 
 #[test]

--- a/crates/iii-worker/tests/oci_worker_integration.rs
+++ b/crates/iii-worker/tests/oci_worker_integration.rs
@@ -149,6 +149,75 @@ fn extract_layer_strips_setuid_and_setgid_bits() {
     assert_eq!(mode("bin/plain") & 0o777, 0o755, "plain perms survive");
 }
 
+#[cfg(unix)]
+#[test]
+fn extract_layer_does_not_chmod_symlinks() {
+    // std::fs::set_permissions follows symlinks on Unix. The setid-stripping
+    // guard must exclude symlinks — otherwise a symlink with setid bits in
+    // its header would chase the link and strip perms from the target
+    // (potentially a file outside the rootfs). Build a tar with a symlink
+    // whose header claims setuid+setgid and verify the link's target file
+    // is untouched.
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+
+    let layer = {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        {
+            let mut archive = tar::Builder::new(&mut encoder);
+
+            // Target: a regular file, mode 0o755, no setid bits.
+            let mut target_header = tar::Header::new_gnu();
+            target_header.set_path("bin/real").unwrap();
+            target_header.set_size(4);
+            target_header.set_mode(0o755);
+            target_header.set_entry_type(tar::EntryType::Regular);
+            target_header.set_cksum();
+            archive.append(&target_header, &b"data"[..]).unwrap();
+
+            // Symlink: header claims setuid+setgid. If the guard breaks,
+            // chmod would follow `link` to `real` and strip its perms.
+            let mut link_header = tar::Header::new_gnu();
+            link_header.set_size(0);
+            link_header.set_mode(0o6755);
+            link_header.set_entry_type(tar::EntryType::Symlink);
+            link_header.set_cksum();
+            archive
+                .append_link(&mut link_header, "bin/link", "real")
+                .unwrap();
+
+            archive.finish().unwrap();
+        }
+        encoder.finish().unwrap()
+    };
+
+    let mut total_size = 0u64;
+    extract_layer_with_limits(&layer, dir.path(), 0, 1, &mut total_size).unwrap();
+
+    let link_meta = std::fs::symlink_metadata(dir.path().join("bin/link")).unwrap();
+    assert!(
+        link_meta.file_type().is_symlink(),
+        "entry must remain a symlink"
+    );
+    let link_target = std::fs::read_link(dir.path().join("bin/link")).unwrap();
+    assert_eq!(link_target.to_str(), Some("real"));
+
+    // The target regular file must be unchanged. If the symlink guard
+    // broke, set_permissions on `link` would have followed to `real` and
+    // stripped the setid bits from a file whose header had no setid bits
+    // set in the first place — a silent corruption path.
+    let target_mode = std::fs::metadata(dir.path().join("bin/real"))
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o7777;
+    assert_eq!(target_mode & 0o777, 0o755, "target perms unchanged");
+    assert_eq!(target_mode & 0o6000, 0, "target has no setid bits");
+}
+
 #[test]
 fn extract_layer_preserves_directory_structure() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/iii-worker/tests/oci_worker_integration.rs
+++ b/crates/iii-worker/tests/oci_worker_integration.rs
@@ -113,6 +113,42 @@ fn extract_layer_valid_multiple_files() {
     assert_eq!(config_content, "key=value");
 }
 
+#[cfg(unix)]
+#[test]
+fn extract_layer_strips_setuid_and_setgid_bits() {
+    // Host extraction runs as a regular user, so setuid binaries in the
+    // layer end up owned by that user on disk. PassthroughFs surfaces host
+    // ownership verbatim to the guest, so a setuid binary inside the VM
+    // *drops* privileges from PID-1 root to the host user's UID on exec,
+    // which is exactly what broke `mount --bind` during worker startup.
+    // Strip the setid bits at extraction time so the guest inherits the
+    // PID-1 euid.
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    let layer = make_layer_targz(&[
+        ("bin/mount", b"fake mount binary", 0o4755), // setuid
+        ("bin/wall", b"fake wall binary", 0o2755),   // setgid
+        ("bin/odd", b"suid+sgid", 0o6755),           // setuid + setgid
+        ("bin/plain", b"plain binary", 0o0755),      // control: no setid
+    ]);
+
+    let mut total_size = 0u64;
+    extract_layer_with_limits(&layer, dir.path(), 0, 1, &mut total_size).unwrap();
+
+    let mode = |p: &str| -> u32 {
+        std::fs::metadata(dir.path().join(p))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o7777
+    };
+
+    assert_eq!(mode("bin/mount") & 0o6000, 0, "setuid bit must be stripped");
+    assert_eq!(mode("bin/wall") & 0o6000, 0, "setgid bit must be stripped");
+    assert_eq!(mode("bin/odd") & 0o6000, 0, "setuid+setgid must be stripped");
+    assert_eq!(mode("bin/plain") & 0o777, 0o755, "plain perms survive");
+}
+
 #[test]
 fn extract_layer_preserves_directory_structure() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- Strip setuid/setgid bits from every regular/continuous file during OCI layer extraction. In a single-tenant microVM with no UID translation, setuid binaries carry the host extracting user's UID + setuid bit, and guest kernel semantics *drop* the caller from euid=0 to that non-zero UID on exec — breaking `mount --bind` with "must be superuser".
- Skip the strip for symlinks explicitly (`set_permissions` follows symlinks, which could chase a link out of the rootfs).
- Log a `tracing::warn!` on chmod failure instead of silently dropping the error, so a filesystem pathology can't silently re-introduce the original bug.

## Test plan

- [x] `extract_layer_strips_setuid_and_setgid_bits` — asserts setuid (0o4755), setgid (0o2755), and combined (0o6755) regular files lose their setid bits on extraction; a plain 0o755 file keeps its perms.
- [x] `extract_layer_does_not_chmod_symlinks` — builds a tar with a symlink whose header claims `0o6755` and asserts the link's target regular file is untouched, locking in the `Regular | Continuous` guard.
- [x] `cargo check -p iii-worker --tests` clean.
- [x] `cargo test -p iii-worker --test oci_worker_integration` — both new cases pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Layer extraction now strips setuid/setgid bits from regular files while preserving other permission bits; symlinks remain unchanged. Failures to clear these bits are logged as warnings instead of failing extraction.

* **Tests**
  * Added Unix-only integration tests that verify setuid/setgid bit removal on files and ensure symlinks are preserved and not subjected to permission changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->