### PR TITLE
ci: improve PR checklist-checker error messages and loosen license regex

### DIFF
--- a/.github/workflows/checklist-checker.yml
+++ b/.github/workflows/checklist-checker.yml
@@ -21,15 +21,17 @@ jobs:
           BODY=$(jq -r '.pull_request.body' "$GITHUB_EVENT_PATH")
           TOTAL=$(echo "$BODY" | grep -cE '^\s*- \[[ xX]\]' || true)
           if [ "$TOTAL" -eq 0 ]; then
-            echo "::error::PR has no checklist items — do not remove the template checklist"
+            echo "::error::PR has no checklist items. The template checklist was removed — restore it from .github/pull_request_template.md."
             exit 1
           fi
-          if ! echo "$BODY" | grep -qE '^\s*- \[[xX]\] I am licensing the entirety of this PR under Apache 2 and have all necessary rights to the code I am contributing\.$'; then
-            echo "::error::The Apache 2 licensing checkbox must be checked"
+          # Match a checked box that mentions both "licens" and "Apache" so the
+          # check survives minor rewordings of the template copy.
+          if ! echo "$BODY" | grep -qiE '^\s*- \[[xX]\].*licens.*Apache'; then
+            echo "::error::Apache 2.0 license checkbox is unchecked. Edit this PR's description (click the Edit pencil at the top of the PR) and tick the box that starts with 'I am licensing...'. This confirmation is required before the PR can be merged."
             exit 1
           fi
           UNCHECKED=$(echo "$BODY" | grep -cE '^\s*- \[ \]' || true)
           if [ "$UNCHECKED" -gt 0 ]; then
-            echo "::error::PR has $UNCHECKED unchecked task(s)"
+            echo "::error::PR has $UNCHECKED unchecked task(s). Edit the PR description and tick each remaining checkbox."
             exit 1
           fi


### PR DESCRIPTION
<!-- iii-pr-template-marker: do not remove (required by .github/workflows/checklist-checker.yml) -->

## What

Three small DX polish items on `.github/workflows/checklist-checker.yml` so first-time contributors who hit a red check on their PR know what to do:

- "No checklist items" error now tells them where the template lives.
- License-checkbox error tells them to edit the PR description via the GitHub UI and which box to tick.
- "Unchecked tasks" error tells them how to fix it.

Also softens the license-check regex from an exact-copy match to a case-insensitive substring match on `licens.*Apache`. The previous regex silently broke any time the template copy drifted; the new one survives minor rewordings while still requiring both "licens(e/ing)" and "Apache" in the same checked checkbox line.

## Why

Contributors who see a generic "Apache 2 licensing checkbox must be checked" on red CI have no idea they need to edit the PR *description* (not add a commit, not reply with a comment). The new message tells them exactly which button to click and which box to tick. Cuts a support loop.

The regex coupling was a separate trap: any future wording change to `.github/pull_request_template.md` line 17 would silently require a lockstep update to the workflow regex. Decoupling by matching on the two stable terms ("licens" and "Apache") keeps enforcement intact across reasonable rewordings.

## Notes

No change to the PR template itself. No change to the admin bypass. No change to any enforcement policy — a checked license box is still required for non-admin PRs to pass CI.

Validated locally against 8 PR-body scenarios: current template (checked/unchecked), reworded copy, empty body, unrelated-box-only, mixed-state, uppercase `X`, indented checkbox. All produce the expected pass/fail and reach the correct error branch.

## Test plan

- [x] Local validation of grep logic against 8 scenarios
- [ ] CI runs this workflow on the PR itself — it should pass (license box below is checked)
- [ ] Sanity check: uncheck the box and push → CI fails with the new error message

---

<!-- This box must be checked in order to submit a PR -->

- [x] I am licensing the entirety of this PR under Apache 2 and have all necessary rights to the code I am contributing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request checklist validation error messages with clearer instructions
  * Enhanced licensing acknowledgement verification with more flexible pattern matching
  * Refined validation feedback to better guide contributors through the submission process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

