### PR TITLE
ci(release): fix release-iii checkout tag/SHA refspec collision

### DIFF
--- a/.github/workflows/release-iii.yml
+++ b/.github/workflows/release-iii.yml
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ steps.generate_token.outputs.token }}
-          fetch-tags: true
+          fetch-depth: 0
 
       - name: Compute previous stable tag
         id: prev


### PR DESCRIPTION
## Summary
- The `create-iii-release` job of `.github/workflows/release-iii.yml` fails on tag-triggered runs with `fatal: Cannot fetch both <sha> and refs/tags/iii/v... to refs/tags/iii/v...` — a known [`actions/checkout` bug](https://github.com/actions/checkout/issues/1781) triggered by combining `fetch-tags: true` with a tag push.
- Switch that single checkout to `fetch-depth: 0`, which fetches the full history (tags included) without producing the conflicting refspec. The follow-up `git tag --list` step still has every tag it needs.

Observed failing run: https://github.com/iii-hq/iii/actions/runs/24693202014

## Test plan
- [ ] Next tag-triggered `Release iii` workflow run reaches and completes the `Create iii GitHub Release` job (no `exit code 128` from `actions/checkout@v4`).
- [ ] `Compute previous stable tag` step still resolves the previous stable `iii/v*` tag correctly (visible in the step's `::notice::` log line).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD release workflow configuration to improve git repository retrieval during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->