### PR TITLE
fix(rbac): auto-allow SDK-infrastructure engine::* functions

### DIFF
--- a/docs/how-to/worker-rbac.mdx
+++ b/docs/how-to/worker-rbac.mdx
@@ -5,6 +5,47 @@ description: 'Configure the iii-worker-manager to enable role-based access contr
 
 This guide walks you through enabling RBAC on your iii instance using the **iii-worker-manager**. Workers connect via WebSocket to a dedicated RBAC port, separate from the internal engine bridge.
 
+## Quick start: RBAC in 2 minutes
+
+Drop these two files side-by-side, start the engine with the config, run the worker, and curl the endpoint. If you see `hello from the handler` in the worker's terminal, RBAC is working.
+
+```yaml title="iii-config.yaml"
+workers:
+  - name: iii-http
+    config: { port: 3111, host: 127.0.0.1 }
+  - name: iii-worker-manager
+    config:
+      port: 49135
+      rbac:
+        expose_functions:
+          - match("api::*")
+```
+
+```typescript title="worker.ts"
+import { Logger, registerWorker } from 'iii-sdk'
+
+const iii = registerWorker('ws://localhost:49135')
+const logger = new Logger()
+
+iii.registerFunction('api::hello', async () => {
+  logger.info('hello from the handler')
+  return { ok: true }
+})
+```
+
+```bash title="run it"
+# In one terminal: start the engine with the config above
+iii-worker start --config iii-config.yaml
+
+# In another: run the worker
+bun worker.ts
+
+# In a third: hit the function over HTTP
+curl http://127.0.0.1:3111/api/hello
+```
+
+The worker's terminal prints `hello from the handler`. That's it — the worker's `expose_functions` only lists `api::*`, but logger dispatch, worker registration, and other SDK-internal engine calls still work because infrastructure functions are auto-allowed (see [Infrastructure functions](#infrastructure-functions-auto-allowed) below).
+
 ## 1. Add RBAC Config to the Worker Manager
 
 Add an `iii-worker-manager` entry with RBAC config to your engine config file. At minimum you need a port and an `expose_functions` list inside `rbac`:
@@ -22,6 +63,39 @@ workers:
 ```
 
 This exposes all functions whose ID starts with `api::` on port 49135 with no authentication.
+
+### Infrastructure functions (auto-allowed)
+
+Your `expose_functions` list only needs to cover the **business** functions you intend to expose. A small set of **infrastructure** `engine::*` IDs that the SDK invokes on your behalf (worker connection setup, structured logging, baggage/context propagation, channel primitives) are auto-allowed regardless of `expose_functions`:
+
+| Function ID | Purpose |
+|---|---|
+| `engine::channels::create` | Data channels (streams, pubsub). |
+| `engine::workers::register` | Fired at worker connect to publish runtime metadata. |
+| `engine::log::info` / `warn` / `error` / `debug` / `trace` | Structured logger dispatch. |
+| `engine::baggage::get` / `set` / `get_all` | Cross-cutting context propagation. |
+
+These are part of iii's public contract and follow an **additive-only stability policy**: within a major version, IDs are never removed from the carve-out except for a documented security fix, which would be called out in release notes.
+
+`forbidden_functions` returned by your auth function still wins — if you genuinely want to block an infrastructure ID for a session, you can, but the worker's behavior becomes unpredictable (connection setup, logging, or context propagation may fail silently). iii logs a `tracing::warn` when this happens.
+
+### Discovery and admin functions (stay gated)
+
+Everything else under `engine::*` — discovery (`engine::functions::list`, `engine::workers::list`, `engine::triggers::list`, `engine::queue::*`), tracing (`engine::traces::*`), alerts (`engine::alerts::*`), health (`engine::health::check`), log storage (`engine::logs::*`), etc. — stays gated by `expose_functions`. A handler that calls `iii.listFunctions()` on a session that only exposes `api::*` will get:
+
+```
+IIIInvocationError: FORBIDDEN: function 'engine::functions::list' not allowed
+```
+
+If you want those discovery calls to work, add them to `expose_functions` explicitly:
+
+```yaml title="iii-config.yaml"
+rbac:
+  expose_functions:
+    - match("api::*")
+    - match("engine::functions::*")   # enable iii.listFunctions()
+    - match("engine::workers::list")
+```
 
 ## 2. Write an Auth Function
 

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -565,7 +565,12 @@ impl Engine {
         );
     }
 
-    async fn router_msg(&self, worker: &WorkerConnection, msg: &Message) -> anyhow::Result<()> {
+    #[doc(hidden)]
+    pub async fn router_msg(
+        &self,
+        worker: &WorkerConnection,
+        msg: &Message,
+    ) -> anyhow::Result<()> {
         match msg {
             Message::TriggerRegistrationResult {
                 id,
@@ -803,7 +808,10 @@ impl Engine {
                                 invocation_id: inv_id,
                                 function_id: function_id.clone(),
                                 result: None,
-                                error: Some(ErrorBody::new("FORBIDDEN", "function not allowed")),
+                                error: Some(ErrorBody::new(
+                                    "FORBIDDEN",
+                                    format!("function '{}' not allowed", function_id),
+                                )),
                                 traceparent: traceparent.clone(),
                                 baggage: baggage.clone(),
                             },

--- a/engine/src/workers/worker/rbac_config.rs
+++ b/engine/src/workers/worker/rbac_config.rs
@@ -206,7 +206,49 @@ impl<'de> Deserialize<'de> for FunctionFilter {
     }
 }
 
-const CHANNEL_CREATE_FUNCTION: &str = "engine::channels::create";
+// RBAC decision flow (post-fix):
+//
+//     InvokeFunction with session.config.rbac
+//     │
+//     ▼
+//  1. function_id in forbidden_functions?   ── yes ──► DENY
+//                       │ no
+//                       ▼
+//  2. function_id in allowed_functions?     ── yes ──► ALLOW
+//                       │ no
+//                       ▼
+//  3. function_id in INFRASTRUCTURE_FUNCTIONS? ─ yes ─► ALLOW
+//                       │ no
+//                       ▼
+//  4. any(expose_functions filter matches)? ── yes ──► ALLOW
+//                       │ no
+//                       ▼
+//                     DENY (FORBIDDEN)
+//
+// Two independent rules define "infrastructure": the RBAC carve-out (this
+// slice, specific IDs) and the middleware bypass (prefix match on
+// `engine::*`, broader — see engine/src/engine/mod.rs). They diverge on
+// purpose: the threat models differ, so do NOT unify them.
+//
+// INFRASTRUCTURE_FUNCTIONS is part of iii's public contract. Within a
+// major version, it is additive-only: IDs are never removed from the
+// carve-out except for a documented security fix, which MUST be called
+// out in release notes and landed alongside a deprecation/migration
+// note. Renames keep both old and new IDs in the slice through at least
+// one major version. Security-driven removal is the only narrow
+// exception to additive-only.
+const INFRASTRUCTURE_FUNCTIONS: &[&str] = &[
+    "engine::channels::create",
+    "engine::workers::register",
+    "engine::log::info",
+    "engine::log::warn",
+    "engine::log::error",
+    "engine::log::debug",
+    "engine::log::trace",
+    "engine::baggage::get",
+    "engine::baggage::set",
+    "engine::baggage::get_all",
+];
 
 pub fn is_function_allowed(
     function_id: &str,
@@ -216,6 +258,13 @@ pub fn is_function_allowed(
     function: Option<&Function>,
 ) -> bool {
     if forbidden_functions.iter().any(|f| f == function_id) {
+        if INFRASTRUCTURE_FUNCTIONS.contains(&function_id) {
+            tracing::warn!(
+                function_id = %function_id,
+                "auth function forbids infrastructure function '{}' — worker may behave unpredictably (connection setup, logging, or context propagation may be blocked)",
+                function_id
+            );
+        }
         return false;
     }
 
@@ -223,7 +272,7 @@ pub fn is_function_allowed(
         return true;
     }
 
-    if function_id == CHANNEL_CREATE_FUNCTION {
+    if INFRASTRUCTURE_FUNCTIONS.contains(&function_id) {
         return true;
     }
 
@@ -463,5 +512,135 @@ mod tests {
             &[],
             None
         ));
+    }
+
+    fn rbac_config_with_expose(patterns: &[&str]) -> RbacConfig {
+        RbacConfig {
+            auth_function_id: None,
+            expose_functions: patterns
+                .iter()
+                .map(|p| FunctionFilter::Match(WildcardPattern::new(p)))
+                .collect(),
+            on_trigger_registration_function_id: None,
+            on_trigger_type_registration_function_id: None,
+            on_function_registration_function_id: None,
+        }
+    }
+
+    // Locks the exact membership of the INFRASTRUCTURE_FUNCTIONS carve-out.
+    // Per the slice's stability policy (additive-only), changes to this
+    // list must add IDs, never remove them (except for documented security
+    // fixes). If this test fails because an ID was removed, verify the
+    // removal is security-justified and release-noted.
+    const ALL_INFRASTRUCTURE_IDS: &[&str] = &[
+        "engine::channels::create",
+        "engine::workers::register",
+        "engine::log::info",
+        "engine::log::warn",
+        "engine::log::error",
+        "engine::log::debug",
+        "engine::log::trace",
+        "engine::baggage::get",
+        "engine::baggage::set",
+        "engine::baggage::get_all",
+    ];
+
+    #[test]
+    fn infrastructure_functions_always_allowed() {
+        for id in ALL_INFRASTRUCTURE_IDS {
+            // Empty expose_functions
+            let config = rbac_config_with_expose(&[]);
+            assert!(
+                is_function_allowed(id, Some(config), &[], &[], None),
+                "expected {} to be allowed with empty expose_functions",
+                id
+            );
+
+            // Unrelated expose pattern
+            let config = rbac_config_with_expose(&["api::*"]);
+            assert!(
+                is_function_allowed(id, Some(config), &[], &[], None),
+                "expected {} to be allowed when only api::* exposed",
+                id
+            );
+        }
+    }
+
+    #[test]
+    fn infrastructure_functions_respect_forbidden_list() {
+        for id in ALL_INFRASTRUCTURE_IDS {
+            let config = rbac_config_with_expose(&[]);
+            let forbidden = vec![id.to_string()];
+            assert!(
+                !is_function_allowed(id, Some(config), &[], &forbidden, None),
+                "expected {} to be denied when present in forbidden_functions",
+                id
+            );
+        }
+    }
+
+    #[test]
+    fn infrastructure_functions_respect_allowed_list() {
+        for id in ALL_INFRASTRUCTURE_IDS {
+            let config = rbac_config_with_expose(&[]);
+            let allowed = vec![id.to_string()];
+            assert!(
+                is_function_allowed(id, Some(config), &allowed, &[], None),
+                "expected {} to remain allowed when also in allowed_functions",
+                id
+            );
+        }
+    }
+
+    #[test]
+    fn discovery_functions_still_gated() {
+        let discovery_ids = [
+            "engine::functions::list",
+            "engine::workers::list",
+            "engine::triggers::list",
+            "engine::trigger-types::list",
+            "engine::traces::list",
+            "engine::queue::list_topics",
+            "engine::health::check",
+            "engine::alerts::list",
+        ];
+        for id in discovery_ids {
+            let config = rbac_config_with_expose(&[]);
+            assert!(
+                !is_function_allowed(id, Some(config), &[], &[], None),
+                "expected discovery id {} to be denied with empty expose_functions",
+                id
+            );
+        }
+    }
+
+    #[test]
+    fn discovery_functions_allowed_via_expose() {
+        let config = rbac_config_with_expose(&["engine::functions::*"]);
+        assert!(is_function_allowed(
+            "engine::functions::list",
+            Some(config),
+            &[],
+            &[],
+            None
+        ));
+    }
+
+    #[test]
+    fn no_rbac_config_still_allows_everything() {
+        for id in ALL_INFRASTRUCTURE_IDS.iter().chain([
+            "engine::functions::list",
+            "engine::workers::list",
+            "api::anything",
+            "internal::private",
+        ]
+        .iter())
+        {
+            assert!(
+                is_function_allowed(id, None, &[], &[], None),
+                "expected {} to be allowed when config is None",
+                id
+            );
+        }
     }
 }

--- a/engine/tests/rbac_infrastructure_e2e.rs
+++ b/engine/tests/rbac_infrastructure_e2e.rs
@@ -1,0 +1,256 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at support@motia.dev
+// See LICENSE and PATENTS files for details.
+
+//! End-to-end tests for the `INFRASTRUCTURE_FUNCTIONS` carve-out in RBAC.
+//! Wires up a real `Engine` plus an in-process `WorkerConnection` that holds
+//! a session with a restricted `expose_functions`, and dispatches
+//! `Message::InvokeFunction` through `Engine::router_msg` — the same path a
+//! real worker would use over the WebSocket. Asserts:
+//! - infrastructure IDs are allowed even when `expose_functions` does not
+//!   cover them;
+//! - discovery IDs stay gated;
+//! - `forbidden_functions` still wins over the carve-out;
+//! - the middleware bypass for `engine::*` is preserved so infrastructure
+//!   calls do not recurse through user middleware.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::json;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use iii::{
+    engine::{Engine, EngineTrait, Handler, Outbound, RegisterFunctionRequest},
+    function::FunctionResult,
+    protocol::{ErrorBody, Message},
+    worker_connections::WorkerConnection,
+    workers::{
+        observability::metrics::ensure_default_meter,
+        worker::{
+            WorkerManagerConfig,
+            rbac_config::{FunctionFilter, RbacConfig, WildcardPattern},
+            rbac_session::Session,
+        },
+    },
+};
+
+fn register_echo_handler(engine: &Engine, function_id: &str) {
+    engine.register_function_handler(
+        RegisterFunctionRequest {
+            function_id: function_id.to_string(),
+            description: Some(format!("echo handler for {function_id}")),
+            request_format: None,
+            response_format: None,
+            metadata: None,
+        },
+        Handler::new(|input| async move { FunctionResult::Success(Some(json!({ "echo": input }))) }),
+    );
+}
+
+fn session_with(
+    engine: Arc<Engine>,
+    rbac: RbacConfig,
+    forbidden: Vec<String>,
+    middleware: Option<String>,
+) -> Session {
+    Session {
+        engine,
+        config: Arc::new(WorkerManagerConfig {
+            port: 0,
+            host: "127.0.0.1".to_string(),
+            middleware_function_id: middleware,
+            rbac: Some(rbac),
+        }),
+        ip_address: "127.0.0.1".to_string(),
+        session_id: Uuid::new_v4(),
+        allowed_functions: vec![],
+        forbidden_functions: forbidden,
+        allowed_trigger_types: None,
+        allow_function_registration: true,
+        allow_trigger_type_registration: true,
+        context: json!({}),
+        function_registration_prefix: None,
+    }
+}
+
+fn restrictive_rbac() -> RbacConfig {
+    RbacConfig {
+        auth_function_id: None,
+        expose_functions: vec![FunctionFilter::Match(WildcardPattern::new("api::*"))],
+        on_trigger_registration_function_id: None,
+        on_trigger_type_registration_function_id: None,
+        on_function_registration_function_id: None,
+    }
+}
+
+/// Helper: send an InvokeFunction and collect the single `InvocationResult`
+/// the engine emits in response. Panics if anything else is received first.
+async fn expect_result(
+    engine: &Engine,
+    worker: &WorkerConnection,
+    rx: &mut mpsc::Receiver<Outbound>,
+    function_id: &str,
+) -> (String, Option<serde_json::Value>, Option<ErrorBody>) {
+    let invocation_id = Uuid::new_v4();
+    let msg = Message::InvokeFunction {
+        invocation_id: Some(invocation_id),
+        function_id: function_id.to_string(),
+        data: json!({ "hello": "world" }),
+        traceparent: None,
+        baggage: None,
+        action: None,
+    };
+    engine
+        .router_msg(worker, &msg)
+        .await
+        .expect("router_msg must not error");
+
+    loop {
+        let outbound = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("timed out waiting for InvocationResult")
+            .expect("worker channel closed");
+        match outbound {
+            Outbound::Protocol(Message::InvocationResult {
+                function_id: got_id,
+                result,
+                error,
+                ..
+            }) => {
+                return (got_id, result, error);
+            }
+            // Other outbound messages (e.g. telemetry) can appear — skip them.
+            _ => continue,
+        }
+    }
+}
+
+#[tokio::test]
+async fn infrastructure_function_allowed_under_restricted_expose() {
+    ensure_default_meter();
+    let engine = Arc::new(Engine::new());
+    register_echo_handler(&engine, "engine::log::info");
+
+    let (tx, mut rx) = mpsc::channel::<Outbound>(16);
+    let session = session_with(engine.clone(), restrictive_rbac(), vec![], None);
+    let worker = WorkerConnection::with_session(tx, session);
+
+    let (function_id, result, error) =
+        expect_result(&engine, &worker, &mut rx, "engine::log::info").await;
+
+    assert_eq!(function_id, "engine::log::info");
+    assert!(
+        error.is_none(),
+        "expected engine::log::info to be allowed under restricted expose_functions; got error {error:?}"
+    );
+    assert!(
+        result.is_some(),
+        "expected echo handler to return a result for engine::log::info"
+    );
+}
+
+#[tokio::test]
+async fn discovery_function_denied_under_restricted_expose() {
+    ensure_default_meter();
+    let engine = Arc::new(Engine::new());
+    register_echo_handler(&engine, "engine::functions::list");
+
+    let (tx, mut rx) = mpsc::channel::<Outbound>(16);
+    let session = session_with(engine.clone(), restrictive_rbac(), vec![], None);
+    let worker = WorkerConnection::with_session(tx, session);
+
+    let (function_id, result, error) =
+        expect_result(&engine, &worker, &mut rx, "engine::functions::list").await;
+
+    assert_eq!(function_id, "engine::functions::list");
+    let err = error.expect("expected FORBIDDEN for engine::functions::list under restricted expose");
+    assert_eq!(err.code, "FORBIDDEN");
+    assert!(
+        err.message.contains("engine::functions::list"),
+        "FORBIDDEN message must name the offending function_id; got: {}",
+        err.message
+    );
+    assert!(
+        result.is_none(),
+        "no result should be returned for a FORBIDDEN invocation"
+    );
+}
+
+#[tokio::test]
+async fn forbidden_list_still_wins_over_infrastructure_carve_out() {
+    ensure_default_meter();
+    let engine = Arc::new(Engine::new());
+    register_echo_handler(&engine, "engine::log::error");
+
+    let (tx, mut rx) = mpsc::channel::<Outbound>(16);
+    let session = session_with(
+        engine.clone(),
+        restrictive_rbac(),
+        vec!["engine::log::error".to_string()],
+        None,
+    );
+    let worker = WorkerConnection::with_session(tx, session);
+
+    let (_function_id, result, error) =
+        expect_result(&engine, &worker, &mut rx, "engine::log::error").await;
+
+    let err = error.expect("forbidden_functions must still deny even infrastructure IDs");
+    assert_eq!(err.code, "FORBIDDEN");
+    assert!(err.message.contains("engine::log::error"));
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn middleware_bypass_preserved_for_infrastructure_functions() {
+    // Guards the existing prefix-based bypass at engine/src/engine/mod.rs
+    // (`!function_id.starts_with("engine::")`). With the carve-out,
+    // infrastructure calls become reachable on restricted sessions — if the
+    // bypass ever regressed, those calls would start recursing through user
+    // middleware, which is silent surprise behavior. Verify the middleware
+    // handler is NOT invoked when the target is `engine::log::info`.
+
+    ensure_default_meter();
+    let engine = Arc::new(Engine::new());
+    register_echo_handler(&engine, "engine::log::info");
+
+    let middleware_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let middleware_calls_for_handler = middleware_calls.clone();
+    engine.register_function_handler(
+        RegisterFunctionRequest {
+            function_id: "mw::guard".to_string(),
+            description: Some("middleware that counts calls".to_string()),
+            request_format: None,
+            response_format: None,
+            metadata: None,
+        },
+        Handler::new(move |_input| {
+            let counter = middleware_calls_for_handler.clone();
+            async move {
+                counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                FunctionResult::Success(Some(json!({ "allow": true })))
+            }
+        }),
+    );
+
+    let (tx, mut rx) = mpsc::channel::<Outbound>(16);
+    let session = session_with(
+        engine.clone(),
+        restrictive_rbac(),
+        vec![],
+        Some("mw::guard".to_string()),
+    );
+    let worker = WorkerConnection::with_session(tx, session);
+
+    let (_function_id, _result, error) =
+        expect_result(&engine, &worker, &mut rx, "engine::log::info").await;
+    assert!(error.is_none(), "infrastructure call must succeed");
+    assert_eq!(
+        middleware_calls.load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "middleware must NOT be invoked for engine::* infrastructure calls"
+    );
+}

--- a/sdk/packages/node/iii/src/errors.ts
+++ b/sdk/packages/node/iii/src/errors.ts
@@ -1,0 +1,52 @@
+/**
+ * Typed error surfaced when an invocation dispatched over the SDK fails — RBAC
+ * rejection (FORBIDDEN), handler-level failure, or a timeout waiting for the
+ * engine to respond. Wraps the wire `ErrorBody` shape plus the `function_id`
+ * that was targeted, so callers get a single error type across all failure
+ * modes and can disambiguate via `err.code`.
+ *
+ * Before this existed, rejection values were plain `ErrorBody`-shaped objects,
+ * which printed as `[object Object]` when stringified — leaving developers to
+ * grep through SDK source to figure out what tripped. The class name, `code`
+ * prefix in the message, and `function_id` field together make a rejection
+ * self-describing.
+ */
+export type IIIInvocationErrorInit = {
+  code: string
+  message: string
+  function_id?: string
+  stacktrace?: string
+}
+
+export class IIIInvocationError extends Error {
+  public readonly code: string
+  public readonly function_id?: string
+  public readonly stacktrace?: string
+
+  constructor(init: IIIInvocationErrorInit) {
+    super(`${init.code}: ${init.message}`)
+    this.name = 'IIIInvocationError'
+    this.code = init.code
+    this.function_id = init.function_id
+    this.stacktrace = init.stacktrace
+  }
+}
+
+/**
+ * True when `value` looks like the wire `ErrorBody` the engine sends in
+ * `InvocationResult.error`: `{ code: string, message: string, stacktrace?: string }`.
+ * Used to distinguish an engine rejection (which we wrap in
+ * {@link IIIInvocationError}) from a JS `Error` thrown elsewhere.
+ */
+export function isErrorBody(value: unknown): value is {
+  code: string
+  message: string
+  stacktrace?: string
+} {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { code?: unknown }).code === 'string' &&
+    typeof (value as { message?: unknown }).message === 'string'
+  )
+}

--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -3,6 +3,7 @@ import { createRequire } from 'node:module'
 import * as os from 'node:os'
 import { type Data, WebSocket } from 'ws'
 import { ChannelReader, ChannelWriter } from './channels'
+import { IIIInvocationError, isErrorBody } from './errors'
 import {
   DEFAULT_BRIDGE_RECONNECTION_CONFIG,
   DEFAULT_INVOCATION_TIMEOUT_MS,
@@ -455,7 +456,13 @@ class Sdk implements ISdk {
         const invocation = this.invocations.get(invocation_id)
         if (invocation) {
           this.invocations.delete(invocation_id)
-          reject(new Error(`Invocation timeout after ${effectiveTimeout}ms: ${function_id}`))
+          reject(
+            new IIIInvocationError({
+              code: 'TIMEOUT',
+              message: `invocation timed out after ${effectiveTimeout}ms`,
+              function_id,
+            }),
+          )
         }
       }, effectiveTimeout)
 
@@ -468,6 +475,7 @@ class Sdk implements ISdk {
           clearTimeout(timeout)
           reject(error)
         },
+        function_id,
         timeout,
       })
 
@@ -880,10 +888,40 @@ class Sdk implements ISdk {
       if (invocation.timeout) {
         clearTimeout(invocation.timeout)
       }
-      error ? invocation.reject(error) : invocation.resolve(result)
+      if (error) {
+        invocation.reject(this.toInvocationError(error, invocation.function_id))
+      } else {
+        invocation.resolve(result)
+      }
     }
 
     this.invocations.delete(invocation_id)
+  }
+
+  /**
+   * Wrap a wire-format `ErrorBody` in {@link IIIInvocationError} so callers get
+   * a real `Error` with a readable `.message` and a typed `.code`. Pass-through
+   * for values that are already `Error` subclasses. Everything else is wrapped
+   * under an `UNKNOWN` code so `String(err) !== '[object Object]'` holds for
+   * every rejection path.
+   */
+  private toInvocationError(error: unknown, function_id?: string): Error {
+    if (error instanceof Error) {
+      return error
+    }
+    if (isErrorBody(error)) {
+      return new IIIInvocationError({
+        code: error.code,
+        message: error.message,
+        function_id,
+        stacktrace: error.stacktrace,
+      })
+    }
+    return new IIIInvocationError({
+      code: 'UNKNOWN',
+      message: typeof error === 'string' ? error : JSON.stringify(error),
+      function_id,
+    })
   }
 
   private resolveChannelValue(value: unknown): unknown {

--- a/sdk/packages/node/iii/src/index.ts
+++ b/sdk/packages/node/iii/src/index.ts
@@ -1,5 +1,7 @@
 export { ChannelReader, ChannelWriter } from './channels'
 
+export { IIIInvocationError, type IIIInvocationErrorInit } from './errors'
+
 export { type InitOptions, registerWorker, TriggerAction } from './iii'
 
 export type {

--- a/sdk/packages/node/iii/src/types.ts
+++ b/sdk/packages/node/iii/src/types.ts
@@ -63,6 +63,12 @@ export type Invocation<TOutput = any> = {
   resolve: (data: TOutput) => void
   // biome-ignore lint/suspicious/noExplicitAny: error can be any type
   reject: (error: any) => void
+  /**
+   * Target function_id for the pending invocation, preserved so timeout and
+   * error-wrapping paths can name the function that tripped without needing
+   * to plumb it through every call site.
+   */
+  function_id?: string
 }
 
 /** Internal handler type that includes traceparent and baggage for distributed tracing */

--- a/sdk/packages/node/iii/tests/errors.test.ts
+++ b/sdk/packages/node/iii/tests/errors.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { IIIInvocationError } from '../src/index'
+import { isErrorBody } from '../src/errors'
+
+describe('IIIInvocationError', () => {
+  it('exposes code, function_id, stacktrace and a readable message', () => {
+    const err = new IIIInvocationError({
+      code: 'FORBIDDEN',
+      message: "function 'engine::functions::list' not allowed",
+      function_id: 'engine::functions::list',
+      stacktrace: 'trace here',
+    })
+
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(IIIInvocationError)
+    expect(err.name).toBe('IIIInvocationError')
+    expect(err.code).toBe('FORBIDDEN')
+    expect(err.function_id).toBe('engine::functions::list')
+    expect(err.stacktrace).toBe('trace here')
+    expect(err.message).toBe("FORBIDDEN: function 'engine::functions::list' not allowed")
+  })
+
+  it('does NOT serialize to "[object Object]" (the original bug)', () => {
+    const err = new IIIInvocationError({
+      code: 'FORBIDDEN',
+      message: "function 'engine::functions::list' not allowed",
+      function_id: 'engine::functions::list',
+    })
+
+    // The bug reporter saw `[object Object]` when printing a plain ErrorBody.
+    // Real Error subclasses stringify as `Name: message`, not `[object Object]`.
+    expect(String(err)).not.toBe('[object Object]')
+    expect(String(err)).toContain('IIIInvocationError')
+    expect(String(err)).toContain("engine::functions::list")
+  })
+
+  it('propagates stack traces as a real Error subclass', () => {
+    const err = new IIIInvocationError({ code: 'UNKNOWN', message: 'oops' })
+    expect(err.stack).toBeTruthy()
+    expect(typeof err.stack).toBe('string')
+  })
+
+  it('supports errors without function_id or stacktrace', () => {
+    const err = new IIIInvocationError({ code: 'TIMEOUT', message: 'gone' })
+    expect(err.function_id).toBeUndefined()
+    expect(err.stacktrace).toBeUndefined()
+    expect(err.message).toBe('TIMEOUT: gone')
+  })
+})
+
+describe('isErrorBody', () => {
+  it('identifies wire-format ErrorBody objects', () => {
+    expect(isErrorBody({ code: 'FORBIDDEN', message: 'nope' })).toBe(true)
+    expect(isErrorBody({ code: 'X', message: 'y', stacktrace: 'z' })).toBe(true)
+  })
+
+  it('rejects non-ErrorBody values', () => {
+    expect(isErrorBody(null)).toBe(false)
+    expect(isErrorBody(undefined)).toBe(false)
+    expect(isErrorBody('string')).toBe(false)
+    expect(isErrorBody(42)).toBe(false)
+    expect(isErrorBody({ code: 'X' })).toBe(false)
+    expect(isErrorBody({ message: 'Y' })).toBe(false)
+    expect(isErrorBody({ code: 1, message: 'Y' })).toBe(false)
+    expect(isErrorBody(new Error('plain'))).toBe(false)
+  })
+})

--- a/sdk/packages/node/iii/tests/rbac-workers.test.ts
+++ b/sdk/packages/node/iii/tests/rbac-workers.test.ts
@@ -10,7 +10,7 @@ import type {
   OnTriggerTypeRegistrationInput,
   OnTriggerTypeRegistrationResult,
 } from '../src/index'
-import { registerWorker } from '../src/index'
+import { IIIInvocationError, registerWorker } from '../src/index'
 import { iii, sleep } from './utils'
 
 const EW_URL = process.env.III_RBAC_WORKER_URL ?? 'ws://localhost:49135'
@@ -320,6 +320,66 @@ describe('RBAC Workers', () => {
       expect(functionIds).not.toContain('test::ew::valid-token-echo')
       expect(functionIds).not.toContain('test::ew::private')
       expect(functionIds).not.toContain('test::rbac-worker::auth')
+    } finally {
+      await iiiClient.shutdown()
+    }
+  })
+
+  // REGRESSION — the bug that motivated the infrastructure carve-out.
+  // A worker whose expose_functions does not cover `engine::*` used to fail
+  // on any SDK-transparent engine call (logger dispatch, worker registration
+  // metadata, etc.) with a FORBIDDEN that surfaced as `[object Object]`.
+  // This test exists so any future refactor that re-breaks the RBAC carve-out
+  // fails CI immediately.
+  it('infrastructure calls (logger, worker::register) succeed under restricted expose', async () => {
+    const iiiClient = registerWorker(EW_URL, {
+      headers: { 'x-test-token': 'valid-token' },
+      otel: { enabled: false },
+    })
+
+    try {
+      // If the carve-out ever regressed, the startup `engine::workers::register`
+      // trigger would FORBIDDEN-reject and connection setup would hang or fail.
+      // A successful invocation of the exposed handler proves the worker
+      // completed the handshake without tripping RBAC on infra IDs.
+      // biome-ignore lint/suspicious/noExplicitAny: any is fine here
+      const result = await iiiClient.trigger<any, any>({
+        function_id: 'test::ew::valid-token-echo',
+        payload: { msg: 'hello' },
+      })
+      expect(result.echoed.msg).toBe('hello')
+    } finally {
+      await iiiClient.shutdown()
+    }
+  })
+
+  it('wraps FORBIDDEN rejection in IIIInvocationError with function_id', async () => {
+    const iiiClient = registerWorker(EW_URL, {
+      headers: { 'x-test-token': 'valid-token' },
+      otel: { enabled: false },
+    })
+
+    try {
+      let caught: unknown
+      try {
+        // biome-ignore lint/suspicious/noExplicitAny: any is fine here
+        await iiiClient.trigger<any, any>({
+          function_id: 'test::ew::private',
+          payload: {},
+        })
+      } catch (err) {
+        caught = err
+      }
+
+      expect(caught).toBeInstanceOf(Error)
+      expect(caught).toBeInstanceOf(IIIInvocationError)
+      const err = caught as IIIInvocationError
+      expect(err.code).toBe('FORBIDDEN')
+      expect(err.function_id).toBe('test::ew::private')
+      expect(err.message).toContain('FORBIDDEN')
+      expect(err.message).toContain('test::ew::private')
+      // The original bug: plain ErrorBody printed as `[object Object]`.
+      expect(String(err)).not.toBe('[object Object]')
     } finally {
       await iiiClient.shutdown()
     }


### PR DESCRIPTION
## Summary

- **Engine:** Expand the always-allowed set in `is_function_allowed` from a single constant to an `INFRASTRUCTURE_FUNCTIONS` slice covering the `engine::*` IDs the SDK invokes transparently (channels, `workers::register`, `log::*`, `baggage::*`). Slice is documented as part of iii's public contract with an additive-only stability policy.
- **Engine:** FORBIDDEN errors now name the offending `function_id` in the message, turning a blank rejection into a copy-into-`expose_functions` diagnostic. `tracing::warn!` fires when `forbidden_functions` denies an infrastructure ID so silent worker breakage becomes debuggable.
- **Node SDK:** New `IIIInvocationError extends Error` with `code`, `function_id`, `stacktrace`. Wraps wire `ErrorBody` in `onInvocationResult` and unifies the invocation timeout path under the same type. Exported from `iii-sdk`. This fixes the `[object Object]` half of the bug report.
- **Docs:** `docs/how-to/worker-rbac.mdx` gains a 2-minute quick-start snippet at the top, an explicit "Infrastructure functions" subsection with the ID table + additive-only policy, and discovery-gating guidance for callers who want `iii.listFunctions()` to work.

## Motivation

A user reported `FORBIDDEN: "function not allowed"` when invoking a handler via HTTP with RBAC enabled — the handler indirectly tripped an SDK-transparent `engine::*` call their `expose_functions` didn't cover. The rejection printed as `[object Object]` unless wrapped in `try/catch`. Every comparable system (Supabase RLS, Firebase Rules, Temporal, NATS) exempts its own plumbing from user-authored policies; iii was the outlier.

## Out of scope (follow-up)

Python and Rust SDK typed-error parity (mirror `IIIInvocationError`) — the engine-side fix is the single source of truth for the carve-out, so every SDK already benefits without a protocol change. Typed-error parity on those SDKs is a DX polish that can ship independently.

## Test plan

- [x] `cargo test -p iii --lib rbac_config` — 24 passed (new: `infrastructure_functions_always_allowed`, `..._respect_forbidden_list`, `..._respect_allowed_list`, `discovery_functions_still_gated`, `discovery_functions_allowed_via_expose`, `no_rbac_config_still_allows_everything`).
- [x] `cargo test -p iii --test rbac_infrastructure_e2e` — 4 passed (infrastructure allowed under restricted expose, discovery denied, forbidden-list wins, middleware bypass preserved).
- [x] `cargo test -p iii --lib` — 1466 passed, 1 ignored (no regressions).
- [x] `bunx vitest run tests/errors.test.ts` — 6 passed (`IIIInvocationError` shape, `String(err) !== '[object Object]'`, real Error subclass).
- [ ] Manual end-to-end reproduction of the reporter's config: run engine with `expose_functions: [match("api::*")]`, call `logger.info` from a handler, confirm 200 + log entry, then call `iii.listFunctions()` and confirm the error prints as `IIIInvocationError: FORBIDDEN: function 'engine::functions::list' not allowed`.
- [ ] Reach out to the reporter with a build from this PR before closing the original issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Infrastructure engine functions are now automatically allowed in RBAC, even with restrictive exposure policies.
  * Added typed error class in SDK for invocation failures, including function ID and error code information.

* **Documentation**
  * Added RBAC quickstart guide with end-to-end examples and configuration samples.
  * Clarified infrastructure vs. discovery function behavior in RBAC policies.

* **Bug Fixes**
  * Forbidden function errors now include the specific function ID in the error message for better debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->