### PR TITLE
test(sdk): cover ApiResponse Content-Type header in Python and Rust

### DIFF
--- a/sdk/packages/python/iii/tests/test_api_triggers.py
+++ b/sdk/packages/python/iii/tests/test_api_triggers.py
@@ -195,6 +195,42 @@ async def test_custom_status_code(engine_http_url, iii_client: III):
 
 
 @pytest.mark.asyncio
+async def test_content_type_on_api_response_return(engine_http_url, iii_client: III):
+    """Returning an ApiResponse dict with headers should set the response Content-Type."""
+    xml_body = '<?xml version="1.0" encoding="UTF-8"?><note><to>user</to><body>hello</body></note>'
+
+    def handler(_input_data):
+        return {
+            "status_code": 200,
+            "headers": {"Content-Type": "text/xml"},
+            "body": xml_body,
+        }
+
+    fn_ref = iii_client.register_function({"id": "test.api.xml.return.py"}, handler)
+    trigger = iii_client.register_trigger(
+        {
+            "type": "http",
+            "function_id": "test.api.xml.return.py",
+            "config": {
+                "api_path": "test/py/xml-return",
+                "http_method": "POST",
+            },
+        }
+    )
+
+    time.sleep(0.3)
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{engine_http_url}/test/py/xml-return") as resp:
+            assert resp.status == 200
+            assert resp.headers.get("content-type") == "text/xml"
+            assert await resp.text() == xml_body
+
+    fn_ref.unregister()
+    trigger.unregister()
+
+
+@pytest.mark.asyncio
 async def test_download_pdf_streaming(engine_http_url, iii_client: III):
     """Stream a PDF file as a download response."""
     if not TEST_FILE.exists():

--- a/sdk/packages/rust/iii/tests/api_triggers.rs
+++ b/sdk/packages/rust/iii/tests/api_triggers.rs
@@ -236,6 +236,55 @@ async fn custom_status_code() {
 }
 
 #[tokio::test]
+async fn content_type_on_api_response_return() {
+    let iii = common::shared_iii();
+
+    let xml_body =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>user</to><body>hello</body></note>";
+
+    iii.register_function((
+        RegisterFunctionMessage::with_id("test::api::xml::return::rs".to_string()),
+        move |_input: Value| async move {
+            Ok(json!({
+                "status_code": 200,
+                "headers": { "Content-Type": "text/xml" },
+                "body": xml_body,
+            }))
+        },
+    ));
+
+    let _trigger = iii
+        .register_trigger(RegisterTriggerInput {
+            trigger_type: "http".to_string(),
+            function_id: "test::api::xml::return::rs".to_string(),
+            config: json!({
+                "api_path": "test/rs/xml-return",
+                "http_method": "POST",
+            }),
+            metadata: None,
+        })
+        .expect("register trigger");
+
+    common::settle().await;
+    sleep(Duration::from_millis(500)).await;
+
+    let resp = common::http_client()
+        .post(format!("{}/test/rs/xml-return", common::engine_http_url()))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 200);
+    assert_eq!(
+        resp.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok()),
+        Some("text/xml"),
+    );
+    assert_eq!(resp.text().await.expect("body"), xml_body);
+}
+
+#[tokio::test]
 async fn download_pdf_streaming() {
     let pdf_path = test_pdf_path();
 


### PR DESCRIPTION
## Summary

Mirrors the Node-SDK integration test added alongside the engine fix in #1526 to the Python and Rust SDKs: a handler that returns a structured `ApiResponse` with a custom `Content-Type` and a string body should deliver that exact Content-Type and body to the client, rather than having the response forced to `application/json`.

Depends on the engine fix in #1526 to pass — once that lands on `main` these tests go green.

## Changes

- `sdk/packages/python/iii/tests/test_api_triggers.py` — `test_content_type_on_api_response_return`
- `sdk/packages/rust/iii/tests/api_triggers.rs` — `content_type_on_api_response_return`

Both tests use the same neutral XML body + `Content-Type: text/xml` shape as the Node test for parity across SDKs.

## Test plan

- [ ] After #1526 merges, CI runs `SDK Python` and `SDK Rust Tests` green on this branch.
- [ ] Local: ran `cargo fmt --check` + `cargo check -p iii-sdk --tests` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests (Python and Rust) verifying HTTP trigger responses correctly propagate custom Content-Type headers and return exact XML response bodies and status codes.
  * Tests register temporary endpoints, send real HTTP POST requests, assert status, headers and body, then clean up the registered handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->