### PR TITLE
test(rbac): isolate carve-out handler tests from shared registrations

### DIFF
--- a/sdk/packages/node/iii/tests/rbac-workers.test.ts
+++ b/sdk/packages/node/iii/tests/rbac-workers.test.ts
@@ -406,8 +406,12 @@ describe('RBAC Workers', () => {
     })
 
     try {
+      // Use a test-unique function_id so this test doesn't clobber shared
+      // registrations — a worker-client registration supersedes the shared
+      // one, and the implicit unregister when the worker shuts down would
+      // break every subsequent test that expects the shared function to exist.
       iiiClient.registerFunction(
-        'test::ew::valid-token-echo',
+        'test::ew::carveout-logger-handler',
         async (data: Record<string, unknown>) => {
           // If the carve-out regresses, this inner trigger returns FORBIDDEN
           // and the handler throws instead of returning { logged: true }.
@@ -426,7 +430,7 @@ describe('RBAC Workers', () => {
 
       // biome-ignore lint/suspicious/noExplicitAny: any is fine here
       const result = await iii.trigger<any, any>({
-        function_id: 'test::ew::valid-token-echo',
+        function_id: 'test::ew::carveout-logger-handler',
         payload: { msg: 'real-usage-case' },
       })
       expect(result.logged).toBe(true)

--- a/sdk/packages/python/iii/tests/test_rbac_workers.py
+++ b/sdk/packages/python/iii/tests/test_rbac_workers.py
@@ -435,11 +435,16 @@ class TestRbacWorkers:
                 })
                 return {"logged": True, "echoed": data}
 
-            iii_client.register_function("test::ew::valid-token-echo", handler)
+            # Use a test-unique function_id so this test doesn't clobber shared
+            # registrations — a worker-client registration supersedes the
+            # shared one, and the implicit unregister when the worker shuts
+            # down would break every subsequent test that expects the shared
+            # function to exist.
+            iii_client.register_function("test::ew::carveout-logger-handler", handler)
             time.sleep(0.5)
 
             result = iii_server.trigger({
-                "function_id": "test::ew::valid-token-echo",
+                "function_id": "test::ew::carveout-logger-handler",
                 "payload": {"msg": "real-usage-case"},
             })
             assert result["logged"] is True

--- a/sdk/packages/rust/iii/tests/rbac_workers.rs
+++ b/sdk/packages/rust/iii/tests/rbac_workers.rs
@@ -698,9 +698,15 @@ async fn infrastructure_logger_callable_from_user_handler_under_restricted_expos
     // Register a handler whose body calls engine::log::info. If the carve-out
     // regresses, this inner trigger returns FORBIDDEN and the outer trigger
     // propagates the error.
+    //
+    // Use a test-unique function_id (not an id from ensure_functions_registered())
+    // so this test doesn't clobber shared registrations: a worker-client
+    // registration would supersede the shared one, and dropping _handle at the
+    // end of the test would unregister the function entirely, breaking every
+    // subsequent serial test that expects `test::ew::valid-token-echo` to exist.
     let inner_client = iii_client.clone();
     let _handle = iii_client.register_function(RegisterFunction::new_async(
-        "test::ew::valid-token-echo",
+        "test::ew::carveout-logger-handler",
         move |input: Value| {
             let client = inner_client.clone();
             async move {
@@ -731,7 +737,7 @@ async fn infrastructure_logger_callable_from_user_handler_under_restricted_expos
 
     let result = common::shared_iii()
         .trigger(TriggerRequest {
-            function_id: "test::ew::valid-token-echo".to_string(),
+            function_id: "test::ew::carveout-logger-handler".to_string(),
             payload: json!({ "msg": "real-usage-case" }),
             action: None,
             timeout_ms: None,


### PR DESCRIPTION
## Summary

The "real usage" carve-out tests added in #1525 registered a handler with the same function_id (`test::ew::valid-token-echo`) that the shared test harness already registers in `ensure_functions_registered()`.

A worker-client registration supersedes the shared one in the engine's routing table, and when the worker shuts down at end-of-test the function unregisters entirely. Every subsequent serial test that expected `test::ew::valid-token-echo` to exist then fails with `function_not_found: Function test::ew::valid-token-echo not found`.

Observed on PR #1529's SDK Rust Tests job (run 24785381936):
- `should_return_auth_result_for_valid_token` FAILED
- `should_only_list_allowed_functions_for_valid_token` FAILED

Fix applied to all three SDKs: register under a test-unique function_id `test::ew::carveout-logger-handler` instead. Doesn't touch shared fixtures, drops cleanly at end of test.

## Test plan

- [x] `cargo check -p iii-sdk --tests --test rbac_workers` — compiles clean
- [x] Node SDK builds clean
- [x] Python syntax check passes
- [ ] Full Rust RBAC test suite passes end-to-end (requires engine harness, will run in CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation across Node.js, Python, and Rust SDK implementations to prevent interference between test cases during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->