### PR TITLE
ci: split build-engine into parallel jobs

### DIFF
--- a/.github/workflows/WORKFLOWS.md
+++ b/.github/workflows/WORKFLOWS.md
@@ -47,12 +47,17 @@ Runs the full test suite across the monorepo. Cancels in-progress runs for PRs.
 
 | Job | Depends On | What it does |
 |-----|-----------|--------------|
-| `build-engine` | — | Fmt check, tests, release build. Uploads `iii-binary` artifact |
+| `changes` | — | Detects changed paths (engine/crates/Cargo) for scoping downstream jobs |
+| `engine-build` | — | Builds debug `iii` with all features, uploads `iii-binary` artifact (critical path) |
+| `engine-test` | — | Tests `iii-worker`, `iii-filesystem`, `iii-network`, `iii-init`, and `iii --all-features` |
+| `engine-coverage` | `changes` | `cargo llvm-cov` on `iii --all-features`. PRs: only when engine paths change. Push/dispatch: always |
+| `engine-benches` | — | `cargo bench --benches --no-run` to verify benches compile |
+| `engine-fmt` | — | `cargo fmt --all -- --check` |
 | `engine-build-matrix` | — | Cross-platform build validation (macOS, Windows, Linux, musl) |
-| `sdk-node-ci` | `build-engine` | Type check, build, start engine, run SDK tests |
-| `sdk-python-ci` | `build-engine` | Lint (ruff), type check (mypy), start engine, run pytest. Matrix: Python 3.10/3.11/3.12 |
-| `sdk-rust-ci` | `build-engine` | Fmt, clippy, start engine, run cargo tests |
-| `console-ci` | `build-engine` | Lint + build frontend (Node 22), build console Rust binary |
+| `sdk-node-ci` | `engine-build` | Type check, build, start engine, run SDK tests |
+| `sdk-python-ci` | `engine-build` | Lint (ruff), type check (mypy), start engine, run pytest. Matrix: Python 3.10/3.11/3.12 |
+| `sdk-rust-ci` | `engine-build` | Fmt, clippy, start engine, run cargo tests |
+| `console-ci` | — | Lint + build frontend (Node 22), build console Rust binary |
 
 All SDK tests download the engine binary artifact and start a live engine instance before running.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,65 +29,184 @@ env:
 
 jobs:
   # ──────────────────────────────────────────────────────────────
-  # Engine (test + build + upload artifact for downstream jobs)
+  # Change detection (used to scope expensive jobs like coverage)
   # ──────────────────────────────────────────────────────────────
 
-  build-engine:
-    name: Build Engine
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      engine: ${{ steps.filter.outputs.engine }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            engine:
+              - 'engine/**'
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/ci.yml'
+
+  # ──────────────────────────────────────────────────────────────
+  # Engine Build — critical path, produces iii binary for downstream
+  # ──────────────────────────────────────────────────────────────
+
+  engine-build:
+    name: Engine Build (artifact)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy, llvm-tools-preview
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: engine-build
 
-      - uses: taiki-e/install-action@cargo-llvm-cov
-
-      - name: Install system dependencies for iii-worker
+      - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libcap-ng-dev
 
-      - name: Build and test iii-worker
-        run: |
-          cargo build -p iii-worker
-          cargo test -p iii-worker
-          cargo test -p iii-filesystem
-          cargo test -p iii-network
-          cargo test -p iii-init
-
-      - name: Install iii-worker for integration tests
-        run: |
-          mkdir -p ~/.local/bin
-          cp target/debug/iii-worker ~/.local/bin/iii-worker
-          chmod +x ~/.local/bin/iii-worker
-
-      - name: Build and run coverage
-        run: |
-          eval "$(cargo llvm-cov show-env --export-prefix)"
-          cargo build -p iii --all-features
-          cargo test -p iii --all-features
-          cargo llvm-cov report \
-            --ignore-filename-regex \
-            "engine/src/main\.rs|(cron|pubsub|queue|state|stream)/adapters/(redis_adapter|bridge)\.rs|queue/adapters/rabbitmq/|^sdk/"
-
-      - name: Check benchmarks compile
-        run: cargo bench --benches --no-run
-
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-
-      # - name: Run clippy
-      #   run: cargo clippy -p iii -p function-macros -p iii-sdk --all-targets --all-features -- -D warnings
+      - name: Build iii (debug, all-features)
+        run: cargo build -p iii --all-features
 
       - uses: actions/upload-artifact@v4
         with:
           name: iii-binary
           path: target/debug/iii
           retention-days: 1
+
+  # ──────────────────────────────────────────────────────────────
+  # Engine Tests — parallel; does not gate downstream jobs.
+  # ──────────────────────────────────────────────────────────────
+
+  engine-test:
+    name: Engine Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: engine-test
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcap-ng-dev
+
+      - name: Build and install iii-worker (needed by iii integration tests)
+        run: |
+          cargo build -p iii-worker
+          mkdir -p ~/.local/bin
+          cp target/debug/iii-worker ~/.local/bin/iii-worker
+          chmod +x ~/.local/bin/iii-worker
+
+      - name: Run crate tests
+        run: |
+          cargo test -p iii-worker
+          cargo test -p iii-filesystem
+          cargo test -p iii-network
+          cargo test -p iii-init
+
+      - name: Run engine tests
+        run: cargo test -p iii --all-features
+
+  # ──────────────────────────────────────────────────────────────
+  # Engine Coverage — scoped: runs on push/dispatch, and on PRs
+  # only when engine/crates/Cargo paths change. Parallel, does not
+  # gate downstream.
+  # ──────────────────────────────────────────────────────────────
+
+  engine-coverage:
+    name: Engine Coverage
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.engine == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: engine-coverage
+
+      - uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcap-ng-dev
+
+      - name: Build and install iii-worker (needed by iii integration tests)
+        run: |
+          cargo build -p iii-worker
+          mkdir -p ~/.local/bin
+          cp target/debug/iii-worker ~/.local/bin/iii-worker
+          chmod +x ~/.local/bin/iii-worker
+
+      - name: Run coverage
+        run: |
+          eval "$(cargo llvm-cov show-env --export-prefix)"
+          cargo test -p iii --all-features
+          cargo llvm-cov report \
+            --ignore-filename-regex \
+            "engine/src/main\.rs|(cron|pubsub|queue|state|stream)/adapters/(redis_adapter|bridge)\.rs|queue/adapters/rabbitmq/|^sdk/"
+
+  # ──────────────────────────────────────────────────────────────
+  # Engine Benches — compile-only check, parallel, does not gate.
+  # ──────────────────────────────────────────────────────────────
+
+  engine-benches:
+    name: Engine Benches Compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: engine-benches
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcap-ng-dev
+
+      - name: Check benches compile
+        run: cargo bench --benches --no-run
+
+  # ──────────────────────────────────────────────────────────────
+  # Engine Formatting — fast, parallel
+  # ──────────────────────────────────────────────────────────────
+
+  engine-fmt:
+    name: Engine Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      # - name: Run clippy
+      #   run: cargo clippy -p iii -p function-macros -p iii-sdk --all-targets --all-features -- -D warnings
 
   # ──────────────────────────────────────────────────────────────
   # Engine RabbitMQ Integration Tests
@@ -373,7 +492,7 @@ jobs:
 
   sdk-node-ci:
     name: SDK Node Tests
-    needs: build-engine
+    needs: engine-build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -437,7 +556,7 @@ jobs:
 
   sdk-node-browser-ci:
     name: SDK Browser Tests
-    needs: build-engine
+    needs: engine-build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -491,7 +610,7 @@ jobs:
 
   sdk-python-ci:
     name: SDK Python (${{ matrix.python-version }})
-    needs: build-engine
+    needs: engine-build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -551,7 +670,7 @@ jobs:
 
   sdk-rust-ci:
     name: SDK Rust Tests
-    needs: build-engine
+    needs: engine-build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

The current \`build-engine\` job is ~18 min of serial work that gates every downstream SDK/Motia job. It compiles the workspace three times on the same runner (debug build+test, coverage-instrumented build+test, bench profile), with one shared Rust cache that the three profiles thrash.

This PR splits it into five parallel jobs and repoints downstream \`needs:\` at the minimal artifact-producing job.

| Before | After |
|---|---|
| \`build-engine\` serial: build/test iii-worker (2m36s) → coverage (5m51s) → benches compile (9m9s) → fmt → upload artifact | Five parallel jobs; downstream waits only on \`engine-build\` (~\`cargo build -p iii --all-features\`) |
| Critical path to downstream: ~18 min | Critical path to downstream: ~3–4 min |

### New jobs

- **\`engine-build\`** — builds \`target/debug/iii\` and uploads the \`iii-binary\` artifact. The only job downstream SDK/Motia jobs now wait on.
- **\`engine-test\`** — runs all crate tests (\`iii-worker\`, \`iii-filesystem\`, \`iii-network\`, \`iii-init\`) plus \`cargo test -p iii --all-features\` with \`iii-worker\` on PATH for integration tests.
- **\`engine-coverage\`** — \`cargo llvm-cov\` on \`iii --all-features\`. On PRs, gated via \`dorny/paths-filter@v3\` to run only when \`engine/**\`, \`crates/**\`, \`Cargo.toml\`, \`Cargo.lock\`, or \`.github/workflows/ci.yml\` change. On push/dispatch it always runs.
- **\`engine-benches\`** — \`cargo bench --benches --no-run\`. Previously a ~9 min blocking step; now non-gating.
- **\`engine-fmt\`** — \`cargo fmt --all -- --check\`.
- **\`changes\`** — tiny helper job that runs \`dorny/paths-filter@v3\` and exposes outputs consumed by \`engine-coverage\`.

Each job uses a distinct \`shared-key\` for \`Swatinem/rust-cache@v2\` so the dev, test, coverage, and bench profiles stop thrashing a single cache.

Downstream jobs (\`sdk-node-ci\`, \`sdk-node-browser-ci\`, \`sdk-python-ci\`, \`sdk-rust-ci\`, \`motia-js-ci\`, \`motia-py-ci\`) now \`needs: engine-build\` instead of \`needs: build-engine\`.

### Notes

- **First-run cost**: each new job seeds its own cache, so the first CI run here will be slow. Subsequent runs amortize.
- **New action**: \`dorny/paths-filter@v3\` isn't currently used in this repo. If policy requires it, I can drop the \`changes\` job and just run \`engine-coverage\` unconditionally (still non-blocking).
- **Not changed**: larger runners and sccache/mold — deferred per request; easy follow-ups if the parallelism win isn't enough.

## Test plan

- [ ] CI green on this PR
- [ ] Verify \`engine-build\` finishes in ~3–5 min and downstream jobs start promptly (no longer wait ~18 min)
- [ ] Verify \`engine-test\`, \`engine-benches\`, \`engine-fmt\` all run in parallel
- [ ] Verify \`engine-coverage\` runs on this PR (it touches \`ci.yml\`, so the paths filter triggers)
- [ ] Verify downstream SDK/Motia jobs still pass using the \`iii-binary\` artifact
- [ ] Manually confirm on a doc-only PR that \`engine-coverage\` is correctly skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructured the CI pipeline into focused engine stages for build, tests, coverage, benchmarks, and format checks.
  * Added path-based change detection to run engine-specific jobs only when relevant.
  * Updated downstream CI dependencies to point to the new engine build stage; console CI no longer depends on the engine build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->