### PR TITLE
feat(worker): declare iii.worker.yaml dependencies, chain-install on local add

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,6 +2682,7 @@ dependencies = [
  "oci-client",
  "oci-spec",
  "reqwest 0.12.28",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/iii-worker/Cargo.toml
+++ b/crates/iii-worker/Cargo.toml
@@ -34,6 +34,7 @@ colored = "3.0.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+semver = { workspace = true }
 serde_yml = "0.0.12"
 anyhow = "1.0.100"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -453,8 +453,43 @@ pub async fn handle_local_add(
         }
     }
 
-    // 6. Extract default config from iii.worker.yaml
     let manifest_path = project_path.join(WORKER_MANIFEST);
+
+    // 5b. Resolve + install declared manifest dependencies BEFORE we touch
+    //     config.yaml. A failure here leaves the local worker NOT in
+    //     config.yaml and iii.lock unchanged — retry is just retry, no
+    //     `--force` dance required. This is load-bearing: reversing this
+    //     order recreates the "already in config.yaml" rerun trap.
+    let declared_deps = match super::project::load_manifest_dependencies(&manifest_path) {
+        Ok(deps) => deps,
+        Err(e) => {
+            eprintln!(
+                "{} {} in {}\n  \
+                 Fix: correct the `dependencies:` block and rerun \
+                 `iii worker add {}`.",
+                "error:".red(),
+                e,
+                manifest_path.display(),
+                path,
+            );
+            return 1;
+        }
+    };
+    if !declared_deps.is_empty()
+        && let Err(e) = super::managed::install_manifest_dependencies(&declared_deps, brief).await
+    {
+        eprintln!(
+            "{} {}\n  \
+             Nothing was written to config.yaml or iii.lock. Rerun \
+             `iii worker add {}` after fixing the failure.",
+            "error:".red(),
+            e,
+            path,
+        );
+        return 1;
+    }
+
+    // 6. Extract default config from iii.worker.yaml
     let config_yaml = if manifest_path.exists() {
         std::fs::read_to_string(&manifest_path)
             .ok()

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -4240,12 +4240,14 @@ workers:
 
     #[tokio::test]
     async fn kill_stale_worker_no_op_when_no_pid_files() {
+        let _h = super::super::test_support::lock_home();
         // Should not panic when no PID files exist
         kill_stale_worker("__iii_test_nonexistent_99999__").await;
     }
 
     #[tokio::test]
     async fn kill_stale_worker_removes_watch_pid_file() {
+        let _h = super::super::test_support::lock_home();
         // Writes a fake `watch.pid` with a highly unlikely-to-be-alive
         // PID, then verifies `kill_stale_worker` reaps it from the
         // pid-file list introduced when the source watcher sidecar
@@ -4271,6 +4273,7 @@ workers:
 
     #[tokio::test]
     async fn reap_source_watcher_removes_pid_file() {
+        let _h = super::super::test_support::lock_home();
         // Exercises the stop-path helper used by `handle_managed_stop`
         // to tear down the watcher sidecar before stopping the VM. A
         // dead PID in watch.pid should still produce a clean remove
@@ -4296,6 +4299,7 @@ workers:
 
     #[tokio::test]
     async fn reap_source_watcher_no_op_when_no_pid_file() {
+        let _h = super::super::test_support::lock_home();
         // Idempotent on the cold path — no watch.pid, nothing to do,
         // no panic.
         reap_source_watcher("__iii_test_reap_watcher_nonexistent__").await;
@@ -4303,6 +4307,7 @@ workers:
 
     #[tokio::test]
     async fn reap_source_watcher_handles_garbage_pid_content() {
+        let _h = super::super::test_support::lock_home();
         // Parse failure must not prevent file removal.
         let home = dirs::home_dir().unwrap_or_default();
         let worker_name = "__iii_test_reap_watcher_garbage__";
@@ -4319,6 +4324,7 @@ workers:
 
     #[tokio::test]
     async fn kill_stale_worker_handles_invalid_pid_content() {
+        let _h = super::super::test_support::lock_home();
         // Use real function with a worker name that won't collide
         // The function should handle garbage content gracefully
         let home = dirs::home_dir().unwrap_or_default();
@@ -4336,6 +4342,7 @@ workers:
     #[cfg(unix)]
     #[tokio::test]
     async fn kill_stale_worker_ignores_symlinked_pidfile() {
+        let _h = super::super::test_support::lock_home();
         // A pre-planted symlink at the pidfile location must not be
         // followed: read_pid opens with O_NOFOLLOW and returns None, so
         // we skip the kill. The symlink itself is still removed so
@@ -4343,6 +4350,10 @@ workers:
         let home = dirs::home_dir().unwrap_or_default();
         let worker_name = "__iii_test_symlink_pidfile__";
         let managed_dir = home.join(".iii/managed").join(worker_name);
+        // Scrub leftover state from an aborted prior run so `symlink`
+        // below (which errors EEXIST if the path already exists) and
+        // the post-run assertions see a clean slate.
+        let _ = std::fs::remove_dir_all(&managed_dir);
         let _ = std::fs::create_dir_all(&managed_dir);
 
         // Attacker-controlled file we must NOT overwrite or target.

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -572,6 +572,106 @@ async fn handle_resolved_graph_add(graph: &ResolvedWorkerGraph, brief: bool) -> 
     0
 }
 
+/// Merge N resolved graphs into a single graph. Nodes are deduped by name.
+/// If the same name appears at different versions across graphs, returns an
+/// error naming the conflicting dep and both versions — this is the cross-dep
+/// version-conflict gate.
+pub(crate) fn merge_resolved_graphs(
+    graphs: Vec<(String, ResolvedWorkerGraph)>,
+) -> Result<ResolvedWorkerGraph, String> {
+    if graphs.is_empty() {
+        return Err("merge_resolved_graphs: no graphs provided".to_string());
+    }
+
+    let mut nodes_by_name: std::collections::BTreeMap<String, super::registry::ResolvedWorker> =
+        std::collections::BTreeMap::new();
+    let mut edges: Vec<super::registry::ResolvedEdge> = Vec::new();
+    let first_root = graphs[0].1.root.clone();
+
+    for (origin, graph) in graphs {
+        for node in graph.graph {
+            if let Some(existing) = nodes_by_name.get(&node.name) {
+                if existing.version != node.version {
+                    return Err(format!(
+                        "dependency `{name}` resolved to conflicting versions across declared deps: \
+                         `{v1}` (from earlier graph) vs `{v2}` (from `{origin}`)",
+                        name = node.name,
+                        v1 = existing.version,
+                        v2 = node.version,
+                        origin = origin,
+                    ));
+                }
+                // Same version — skip; first wins.
+            } else {
+                nodes_by_name.insert(node.name.clone(), node);
+            }
+        }
+        edges.extend(graph.edges);
+    }
+
+    Ok(ResolvedWorkerGraph {
+        root: first_root,
+        target: None,
+        graph: nodes_by_name.into_values().collect(),
+        edges,
+    })
+}
+
+/// Resolve every declared manifest dependency against the registry and install
+/// the full transitive chain into `config.yaml` + `iii.lock` using the same
+/// path that `iii worker add <name>` uses.
+///
+/// Pass-1: resolve each dep via `fetch_resolved_worker_graph` (serial — fine
+/// for ≤3 deps; parallel fan-out is a future optimization).
+/// Pass-2: merge all graphs into one synthetic graph (dedupes shared
+/// transitive deps, errors on cross-graph version conflicts).
+/// Pass-3: single call to `handle_resolved_graph_add`. Its snapshot/rollback
+/// boundary covers the whole chain — no partial-install state is possible.
+pub(crate) async fn install_manifest_dependencies(
+    deps: &std::collections::BTreeMap<String, String>,
+    brief: bool,
+) -> Result<(), String> {
+    if deps.is_empty() {
+        return Ok(());
+    }
+
+    let mut graphs = Vec::with_capacity(deps.len());
+    for (name, range) in deps {
+        let graph = match fetch_resolved_worker_graph(name, Some(range.as_str()), None).await {
+            Ok(g) => g,
+            Err(e) => {
+                // If the declared range is a prerelease, preempt the common
+                // confusion: the default registry resolver filters to stable
+                // versions, so a published prerelease looks "not found."
+                let hint = semver::VersionReq::parse(range)
+                    .ok()
+                    .filter(|req| req.comparators.iter().any(|c| !c.pre.is_empty()))
+                    .map(|_| {
+                        " (note: the registry filters prereleases by default; \
+                         configure the registry to expose prereleases if this \
+                         range is intentional)"
+                    })
+                    .unwrap_or("");
+                return Err(format!(
+                    "failed to resolve dependency `{name}@{range}`: {e}{hint}"
+                ));
+            }
+        };
+        graphs.push((name.clone(), graph));
+    }
+
+    let merged = merge_resolved_graphs(graphs)?;
+
+    let rc = handle_resolved_graph_add(&merged, brief).await;
+    if rc != 0 {
+        return Err(format!(
+            "failed to install merged dependency graph (exit {rc}); no partial \
+             state written — rerun after fixing the failure",
+        ));
+    }
+    Ok(())
+}
+
 pub async fn handle_managed_add(
     image_or_name: &str,
     brief: bool,
@@ -4365,5 +4465,126 @@ workers:
             );
         })
         .await;
+    }
+
+    // ------------------------------------------------------------------
+    // install_manifest_dependencies / merge_resolved_graphs
+    // ------------------------------------------------------------------
+
+    fn graph_with_nodes(
+        root_name: &str,
+        root_version: &str,
+        nodes: Vec<cli_registry::ResolvedWorker>,
+    ) -> cli_registry::ResolvedWorkerGraph {
+        cli_registry::ResolvedWorkerGraph {
+            root: cli_registry::ResolvedRoot {
+                name: root_name.to_string(),
+                version: root_version.to_string(),
+            },
+            target: None,
+            graph: nodes,
+            edges: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn install_manifest_dependencies_empty_is_noop() {
+        let deps: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
+        let result = super::install_manifest_dependencies(&deps, true).await;
+        assert!(result.is_ok(), "empty deps must succeed as noop");
+    }
+
+    #[tokio::test]
+    async fn install_manifest_dependencies_propagates_resolve_error() {
+        let prev = std::env::var("III_API_URL").ok();
+        unsafe { std::env::set_var("III_API_URL", "http://127.0.0.1:1") };
+        let mut deps = std::collections::BTreeMap::new();
+        deps.insert("math-worker".to_string(), "^0.1.0".to_string());
+        let result = super::install_manifest_dependencies(&deps, true).await;
+        match prev {
+            Some(v) => unsafe { std::env::set_var("III_API_URL", v) },
+            None => unsafe { std::env::remove_var("III_API_URL") },
+        }
+        assert!(
+            result.is_err(),
+            "unreachable registry must surface an error"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            !err.contains("filters prereleases"),
+            "stable range must not emit the prerelease hint; got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn install_manifest_dependencies_emits_prerelease_hint() {
+        let prev = std::env::var("III_API_URL").ok();
+        unsafe { std::env::set_var("III_API_URL", "http://127.0.0.1:1") };
+        let mut deps = std::collections::BTreeMap::new();
+        deps.insert("math-worker".to_string(), "1.0.0-beta.1".to_string());
+        let result = super::install_manifest_dependencies(&deps, true).await;
+        match prev {
+            Some(v) => unsafe { std::env::set_var("III_API_URL", v) },
+            None => unsafe { std::env::remove_var("III_API_URL") },
+        }
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("filters prereleases"),
+            "prerelease range must trigger the registry-filter hint; got: {err}"
+        );
+    }
+
+    #[test]
+    fn merge_graphs_unifies_shared_nodes_at_same_version() {
+        let a = graph_with_nodes(
+            "a",
+            "1.0.0",
+            vec![
+                resolved_binary_worker("a", "1.0.0", StdHashMap::new()),
+                resolved_binary_worker("shared", "1.2.3", StdHashMap::new()),
+            ],
+        );
+        let b = graph_with_nodes(
+            "b",
+            "1.0.0",
+            vec![
+                resolved_binary_worker("b", "1.0.0", StdHashMap::new()),
+                resolved_binary_worker("shared", "1.2.3", StdHashMap::new()),
+            ],
+        );
+        let merged =
+            super::merge_resolved_graphs(vec![("a".to_string(), a), ("b".to_string(), b)]).unwrap();
+        let names: std::collections::BTreeSet<_> =
+            merged.graph.iter().map(|n| n.name.clone()).collect();
+        assert_eq!(
+            names,
+            ["a", "b", "shared"].iter().map(|s| s.to_string()).collect()
+        );
+    }
+
+    #[test]
+    fn merge_graphs_errors_on_cross_graph_version_mismatch() {
+        let a = graph_with_nodes(
+            "a",
+            "1.0.0",
+            vec![
+                resolved_binary_worker("a", "1.0.0", StdHashMap::new()),
+                resolved_binary_worker("shared", "1.2.3", StdHashMap::new()),
+            ],
+        );
+        let b = graph_with_nodes(
+            "b",
+            "1.0.0",
+            vec![
+                resolved_binary_worker("b", "1.0.0", StdHashMap::new()),
+                resolved_binary_worker("shared", "2.0.0", StdHashMap::new()),
+            ],
+        );
+        let err = super::merge_resolved_graphs(vec![("a".to_string(), a), ("b".to_string(), b)])
+            .unwrap_err();
+        assert!(
+            err.contains("shared") && err.contains("1.2.3") && err.contains("2.0.0"),
+            "error should name the conflicting dep + both versions; got: {err}",
+        );
     }
 }

--- a/crates/iii-worker/src/cli/mod.rs
+++ b/crates/iii-worker/src/cli/mod.rs
@@ -26,3 +26,4 @@ pub mod supervisor_ctl;
 pub(crate) mod test_support;
 pub mod vm_boot;
 pub mod worker_manager;
+pub mod worker_manifest_deps;

--- a/crates/iii-worker/src/cli/project.rs
+++ b/crates/iii-worker/src/cli/project.rs
@@ -7,7 +7,7 @@
 //! Project auto-detection and manifest loading for worker dev sessions.
 
 use colored::Colorize;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 pub const WORKER_MANIFEST: &str = "iii.worker.yaml";
 
@@ -260,6 +260,24 @@ pub fn load_from_manifest(manifest_path: &std::path::Path) -> Option<ProjectInfo
         env,
         base_image,
     })
+}
+
+/// Read only the `dependencies:` block from an `iii.worker.yaml` manifest.
+/// Returns an empty map when the file is missing (authors without deps work
+/// unchanged) or the field is absent/null. Returns `Err` only when the file
+/// exists but is malformed YAML or the `dependencies:` block is invalid.
+pub fn load_manifest_dependencies(
+    manifest_path: &std::path::Path,
+) -> Result<BTreeMap<String, String>, String> {
+    if !manifest_path.exists() {
+        return Ok(BTreeMap::new());
+    }
+    let content = std::fs::read_to_string(manifest_path)
+        .map_err(|e| format!("failed to read {}: {e}", manifest_path.display()))?;
+    let doc: serde_yaml::Value = serde_yaml::from_str(&content)
+        .map_err(|e| format!("failed to parse {}: {e}", manifest_path.display()))?;
+    let self_name = doc.get("name").and_then(|v| v.as_str());
+    super::worker_manifest_deps::parse_dependencies(&doc, self_name)
 }
 
 pub fn auto_detect_project(path: &std::path::Path) -> Option<ProjectInfo> {
@@ -675,5 +693,31 @@ runtime:
             base_image: None,
         };
         assert!(project.validate().is_ok());
+    }
+
+    #[test]
+    fn load_manifest_dependencies_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("iii.worker.yaml");
+        let yaml = r#"
+name: caller
+runtime:
+  kind: bun
+  entry: src/index.ts
+dependencies:
+  math-worker: "^0.1.0"
+"#;
+        std::fs::write(&manifest_path, yaml).unwrap();
+        let deps = super::load_manifest_dependencies(&manifest_path).unwrap();
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps.get("math-worker").unwrap(), "^0.1.0");
+    }
+
+    #[test]
+    fn load_manifest_dependencies_missing_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("iii.worker.yaml");
+        let deps = super::load_manifest_dependencies(&manifest_path).unwrap();
+        assert!(deps.is_empty());
     }
 }

--- a/crates/iii-worker/src/cli/worker_manifest_deps.rs
+++ b/crates/iii-worker/src/cli/worker_manifest_deps.rs
@@ -1,0 +1,91 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at support@motia.dev
+// See LICENSE and PATENTS files for details.
+
+//! Parse and validate the optional `dependencies:` block of `iii.worker.yaml`.
+
+use std::collections::BTreeMap;
+
+/// Parse the `dependencies:` field from an already-loaded YAML document.
+/// Returns an empty map when the field is absent. Returns `Err` when the
+/// field exists but is malformed (not a mapping, empty keys, invalid
+/// semver range, worker name with disallowed characters, or self-reference
+/// when `self_name` is `Some`).
+///
+/// NOTE on prerelease ranges: this parser accepts any valid semver range,
+/// including prereleases like `1.0.0-beta.1` or `^1.2.0-rc.0`. The default
+/// iii registry resolver filters candidates to stable versions only
+/// (`../registry/api/src/services/resolver.service.ts:222`), so declaring a
+/// prerelease range will surface as a `version_not_found` error at
+/// `/resolve` time even when the prerelease is actually published. This is
+/// intentional — author declarations stay forward-compatible with any
+/// registry that chooses to expose prereleases.
+pub fn parse_dependencies(
+    doc: &serde_yaml::Value,
+    self_name: Option<&str>,
+) -> Result<BTreeMap<String, String>, String> {
+    let Some(field) = doc.get("dependencies") else {
+        return Ok(BTreeMap::new());
+    };
+
+    if field.is_null() {
+        return Ok(BTreeMap::new());
+    }
+
+    let mapping = field.as_mapping().ok_or_else(|| {
+        "`dependencies` must be a mapping of worker-name -> semver range".to_string()
+    })?;
+
+    let mut out = BTreeMap::new();
+    for (k, v) in mapping {
+        let name = k
+            .as_str()
+            .ok_or_else(|| "`dependencies` keys must be strings".to_string())?
+            .trim();
+        let range = v
+            .as_str()
+            .ok_or_else(|| format!("`dependencies.{name}` must be a string semver range"))?
+            .trim();
+
+        if name.is_empty() {
+            return Err("`dependencies` key cannot be empty".to_string());
+        }
+        if range.is_empty() {
+            return Err(format!("`dependencies.{name}` range cannot be empty"));
+        }
+        super::registry::validate_worker_name(name)
+            .map_err(|e| format!("invalid dependency key `{name}`: {e}"))?;
+        semver::VersionReq::parse(range).map_err(|e| {
+            format!("invalid semver range for dependency `{name}`: `{range}` ({e})")
+        })?;
+        if let Some(self_name) = self_name
+            && name == self_name
+        {
+            return Err(format!(
+                "dependency `{name}` refers to the worker itself; remove the self-reference"
+            ));
+        }
+        if out.insert(name.to_string(), range.to_string()).is_some() {
+            return Err(format!("duplicate dependency key `{name}`"));
+        }
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn yaml(input: &str) -> serde_yaml::Value {
+        serde_yaml::from_str(input).unwrap()
+    }
+
+    #[test]
+    fn absent_field_is_empty_map() {
+        let deps = parse_dependencies(&yaml("name: foo\n"), Some("foo")).unwrap();
+        assert!(deps.is_empty());
+    }
+}

--- a/crates/iii-worker/src/cli/worker_manifest_deps.rs
+++ b/crates/iii-worker/src/cli/worker_manifest_deps.rs
@@ -88,4 +88,57 @@ mod tests {
         let deps = parse_dependencies(&yaml("name: foo\n"), Some("foo")).unwrap();
         assert!(deps.is_empty());
     }
+
+    #[test]
+    fn parses_valid_dependencies() {
+        let doc = yaml(
+            "name: caller\ndependencies:\n  math-worker: \"^0.1.0\"\n  iii-http: \"~1.2.0\"\n",
+        );
+        let deps = parse_dependencies(&doc, Some("caller")).unwrap();
+        assert_eq!(deps.len(), 2);
+        assert_eq!(deps.get("math-worker").unwrap(), "^0.1.0");
+        assert_eq!(deps.get("iii-http").unwrap(), "~1.2.0");
+    }
+
+    #[test]
+    fn rejects_non_mapping() {
+        let doc = yaml("name: caller\ndependencies: \"nope\"\n");
+        let err = parse_dependencies(&doc, Some("caller")).unwrap_err();
+        assert!(err.contains("must be a mapping"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_empty_range() {
+        let doc = yaml("name: caller\ndependencies:\n  math-worker: \"\"\n");
+        let err = parse_dependencies(&doc, Some("caller")).unwrap_err();
+        assert!(err.contains("range cannot be empty"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_invalid_range() {
+        let doc = yaml("name: caller\ndependencies:\n  math-worker: \"not-a-range\"\n");
+        let err = parse_dependencies(&doc, Some("caller")).unwrap_err();
+        assert!(err.contains("invalid semver range"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_invalid_name() {
+        let doc = yaml("name: caller\ndependencies:\n  \"../bad\": \"^1.0.0\"\n");
+        let err = parse_dependencies(&doc, Some("caller")).unwrap_err();
+        assert!(err.contains("invalid dependency key"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_self_dependency() {
+        let doc = yaml("name: caller\ndependencies:\n  caller: \"^0.1.0\"\n");
+        let err = parse_dependencies(&doc, Some("caller")).unwrap_err();
+        assert!(err.contains("refers to the worker itself"), "got: {err}");
+    }
+
+    #[test]
+    fn null_dependencies_is_empty_map() {
+        let doc = yaml("name: caller\ndependencies: null\n");
+        let deps = parse_dependencies(&doc, Some("caller")).unwrap();
+        assert!(deps.is_empty());
+    }
 }

--- a/crates/iii-worker/src/lib.rs
+++ b/crates/iii-worker/src/lib.rs
@@ -14,5 +14,10 @@ pub mod cli;
 pub use cli::app::{AddArgs, Cli, Commands, DEFAULT_PORT, ExecArgs, WatchSourceArgs};
 pub use cli::vm_boot::VmBootArgs;
 
+// Test-time env/HOME/CWD serialization: unified with `cli::test_support::TEST_HOME_LOCK`
+// so every HOME-mutating test (`TEST_ENV_LOCK` callers) is mutually exclusive with
+// every HOME-reading test (`test_support::lock_home()` callers). Keeping two distinct
+// mutexes silently let HOME get rewritten under tests that only read it via
+// `dirs::home_dir()`, producing intermittent pidfile-path mismatches.
 #[cfg(test)]
-pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+pub(crate) use crate::cli::test_support::TEST_HOME_LOCK as TEST_ENV_LOCK;

--- a/crates/iii-worker/tests/local_add_dependencies_integration.rs
+++ b/crates/iii-worker/tests/local_add_dependencies_integration.rs
@@ -10,12 +10,23 @@
 //! is hermetic and the test asserts real disk state after the call.
 
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+/// Serializes tests in this file that mutate CWD and `III_API_URL`.
+/// Without it, one test's `set_var("III_API_URL", fixture)` leaks into
+/// another test's "unreachable" scenario and the second test sees the
+/// first fixture's URL — turning the failure path into a download-stage
+/// 404 and breaking the deps-before-append assertion.
+static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
 
 async fn in_temp_dir<F, Fut, R>(f: F) -> R
 where
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = R>,
 {
+    let _guard = TEST_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let prev = std::env::current_dir().unwrap();
     let dir = tempfile::tempdir().unwrap();
     std::env::set_current_dir(dir.path()).unwrap();

--- a/crates/iii-worker/tests/local_add_dependencies_integration.rs
+++ b/crates/iii-worker/tests/local_add_dependencies_integration.rs
@@ -1,0 +1,200 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at support@motia.dev
+// See LICENSE and PATENTS files for details.
+
+//! End-to-end coverage for `iii worker add <local-path>` with declared
+//! manifest dependencies. Uses `file://` API fixtures (the pattern already
+//! used in `tests/config_managed_integration.rs:345`) so every round-trip
+//! is hermetic and the test asserts real disk state after the call.
+
+use std::path::{Path, PathBuf};
+
+async fn in_temp_dir<F, Fut, R>(f: F) -> R
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = R>,
+{
+    let prev = std::env::current_dir().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+    let result = f().await;
+    std::env::set_current_dir(prev).unwrap();
+    result
+}
+
+fn write_worker_manifest(dir: &Path, name: &str, deps_block: &str) {
+    let manifest =
+        format!("name: {name}\nruntime:\n  kind: bun\n  entry: src/index.ts\n{deps_block}");
+    std::fs::write(dir.join("iii.worker.yaml"), manifest).unwrap();
+}
+
+/// Failure path: unreachable registry must NOT leave config.yaml or iii.lock
+/// written. This verifies the deps-before-append ordering.
+#[tokio::test]
+async fn local_add_with_unreachable_dep_leaves_no_state() {
+    in_temp_dir(|| async {
+        let worker_dir: PathBuf = std::env::current_dir().unwrap().join("my-worker");
+        std::fs::create_dir(&worker_dir).unwrap();
+        write_worker_manifest(
+            &worker_dir,
+            "my-worker",
+            "dependencies:\n  math-worker: \"^0.1.0\"\n",
+        );
+
+        let prev_api = std::env::var("III_API_URL").ok();
+        unsafe { std::env::set_var("III_API_URL", "http://127.0.0.1:1") };
+
+        let rc = iii_worker::cli::managed::handle_managed_add(
+            worker_dir.to_str().unwrap(),
+            true,
+            false,
+            false,
+            false,
+        )
+        .await;
+
+        match prev_api {
+            Some(v) => unsafe { std::env::set_var("III_API_URL", v) },
+            None => unsafe { std::env::remove_var("III_API_URL") },
+        }
+
+        assert_ne!(rc, 0, "unreachable dep must fail the whole add");
+        assert!(
+            !std::env::current_dir()
+                .unwrap()
+                .join("config.yaml")
+                .exists(),
+            "config.yaml must not exist — deps failed before append"
+        );
+        assert!(
+            !std::env::current_dir().unwrap().join("iii.lock").exists(),
+            "iii.lock must not exist — deps failed before install"
+        );
+    })
+    .await;
+}
+
+/// No-deps path: plain local worker still works when registry is unreachable.
+#[tokio::test]
+async fn local_add_without_dependencies_ignores_registry() {
+    in_temp_dir(|| async {
+        let worker_dir: PathBuf = std::env::current_dir().unwrap().join("plain-worker");
+        std::fs::create_dir(&worker_dir).unwrap();
+        write_worker_manifest(&worker_dir, "plain-worker", "");
+
+        let prev_api = std::env::var("III_API_URL").ok();
+        unsafe { std::env::set_var("III_API_URL", "http://127.0.0.1:1") };
+
+        let rc = iii_worker::cli::managed::handle_managed_add(
+            worker_dir.to_str().unwrap(),
+            true,
+            false,
+            false,
+            false,
+        )
+        .await;
+
+        match prev_api {
+            Some(v) => unsafe { std::env::set_var("III_API_URL", v) },
+            None => unsafe { std::env::remove_var("III_API_URL") },
+        }
+
+        assert_eq!(rc, 0, "no-deps local add must succeed");
+        assert!(
+            std::env::current_dir()
+                .unwrap()
+                .join("config.yaml")
+                .exists(),
+            "config.yaml must exist for the happy-path local worker"
+        );
+    })
+    .await;
+}
+
+/// Exercises the full chain wiring: fixture resolves successfully, the merged
+/// graph is installed, and we reach the binary-download stage — which fails
+/// because the fixture URL is synthetic. The assertion is that the error
+/// originates from the download path, not the resolve path, proving every
+/// step from parse -> load_manifest_dependencies -> install_manifest_dependencies
+/// -> fetch_resolved_worker_graph -> merge_resolved_graphs ->
+/// handle_resolved_graph_add -> handle_binary_add fires in order. The
+/// snapshot/rollback boundary of `handle_resolved_graph_add` then rolls
+/// config.yaml back so the failed add leaves the workspace pristine.
+#[tokio::test]
+async fn local_add_dep_resolves_and_reaches_install_stage() {
+    in_temp_dir(|| async {
+        let worker_dir: PathBuf = std::env::current_dir().unwrap().join("my-worker");
+        std::fs::create_dir(&worker_dir).unwrap();
+        write_worker_manifest(
+            &worker_dir,
+            "my-worker",
+            "dependencies:\n  math-worker: \"^0.1.0\"\n",
+        );
+
+        let sha = "a".repeat(64);
+        let fixture_json = format!(
+            r#"{{
+                "root": {{"name": "math-worker", "version": "0.1.3"}},
+                "graph": [{{
+                    "name": "math-worker",
+                    "type": "binary",
+                    "version": "0.1.3",
+                    "repo": "",
+                    "config": {{}},
+                    "binaries": {{
+                        "aarch64-apple-darwin": {{"sha256": "{sha}", "url": "https://example.com/math-0.1.3-mac.tar.gz"}},
+                        "x86_64-unknown-linux-gnu": {{"sha256": "{sha}", "url": "https://example.com/math-0.1.3-lin.tar.gz"}}
+                    }},
+                    "dependencies": {{}}
+                }}],
+                "edges": []
+            }}"#
+        );
+        let fixture = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(fixture.path(), fixture_json).unwrap();
+        let url = format!("file://{}", fixture.path().display());
+
+        let prev_api = std::env::var("III_API_URL").ok();
+        unsafe { std::env::set_var("III_API_URL", &url) };
+
+        let rc = iii_worker::cli::managed::handle_managed_add(
+            worker_dir.to_str().unwrap(),
+            true,
+            false,
+            false,
+            false,
+        )
+        .await;
+
+        match prev_api {
+            Some(v) => unsafe { std::env::set_var("III_API_URL", v) },
+            None => unsafe { std::env::remove_var("III_API_URL") },
+        }
+
+        // Non-zero because the synthetic binary URL can't actually be
+        // downloaded — that's expected. What matters is that we got
+        // through resolve -> merge -> install attempt.
+        assert_ne!(
+            rc, 0,
+            "fixture URL is synthetic; expected download-stage failure"
+        );
+
+        // Snapshot/rollback in handle_resolved_graph_add restores config.yaml,
+        // and iii.lock is only written after all downloads succeed. A pristine
+        // workspace after the failed add proves the atomic boundary held.
+        let cwd = std::env::current_dir().unwrap();
+        assert!(
+            !cwd.join("iii.lock").exists(),
+            "iii.lock must not be written when install fails mid-chain"
+        );
+        let config_contents = std::fs::read_to_string(cwd.join("config.yaml"))
+            .unwrap_or_default();
+        assert!(
+            !config_contents.contains("my-worker"),
+            "config.yaml must roll back the local worker on install failure; got:\n{config_contents}"
+        );
+    })
+    .await;
+}


### PR DESCRIPTION
## Summary
- Adds optional `dependencies:` map to `iii.worker.yaml` (worker-name → semver range), parsed and validated by a new `worker_manifest_deps` module (invalid semver, invalid worker names, self-reference, duplicates, non-mapping shapes all fail closed).
- `iii worker add <local-path>` now resolves the declared deps against the registry **before** appending the local worker to `config.yaml`, so any failure (bad range, unreachable registry, cross-graph version conflict, download blowup) leaves `config.yaml` and `iii.lock` untouched — retry is just retry, no `--force` dance.
- Deps are resolved per-name then merged into a single synthetic `ResolvedWorkerGraph` (dedupes shared transitive deps, errors on version mismatch). The existing `handle_resolved_graph_add` snapshot/rollback boundary covers the whole chain atomically.
- Prerelease asymmetry handled: parser accepts prerelease ranges (forward-compat), and the error path appends a one-line hint when a prerelease range fails resolve, preempting the common "published but `version_not_found`" confusion against the default stable-only registry filter.

## What this does NOT do
- No `iii worker publish` or registry `/publish` endpoint — that's the companion work in `../registry`. Registry-side deps continue to flow through hand-edited fixtures.
- The local worker itself is not a `LockedWorker` entry. Lockfile tracks registry downloads only.
- `/resolve` fan-out is serial. Parallel `try_join_all` is captured in `TODOS.md` for follow-up once workers commonly declare >3 deps.

## Test Plan
- [x] `cargo test -p iii-worker --lib worker_manifest_deps` — 8 tests (happy path + 7 error branches + null handling)
- [x] `cargo test -p iii-worker --lib project::tests::load_manifest_dependencies` — 2 tests (round-trip + missing-file)
- [x] `cargo test -p iii-worker --lib managed::tests::install_manifest_dependencies` — 3 tests (empty noop, stable-range error without hint, prerelease-range error with hint)
- [x] `cargo test -p iii-worker --lib managed::tests::merge_graphs` — 2 tests (shared-node dedup, cross-graph version conflict)
- [x] `cargo test -p iii-worker --test local_add_dependencies_integration` — 3 end-to-end tests (unreachable registry leaves no state, no-deps unchanged, `file://` fixture exercises full chain + rollback)
- [ ] Reviewer: confirm the deps-before-append ordering is preserved (regression risk if the block ever moves past `append_worker_with_path`).
- [ ] Reviewer: confirm the prerelease-hint detection via `req.comparators.iter().any(|c| !c.pre.is_empty())` matches your mental model of prerelease ranges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for declaring and installing manifest dependencies before applying worker config
* **Improvements**
  * More robust dependency resolution with prerelease-aware hints and deduplication/conflict detection
  * Stronger manifest dependency validation (names, ranges, duplicates, self-references)
* **Bug Fixes**
  * Prevents partial writes to config/lock files when dependency installation fails
* **Tests**
  * New integration and unit tests covering dependency flows and error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->