### PR TITLE
Replay locked workers without resolver drift

### DIFF
--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -134,8 +134,8 @@ pub enum Commands {
     /// List all workers and their status
     List,
 
-    /// Read iii.lock and report pinned workers.
-    /// Pass --frozen in CI to fail if config.yaml and iii.lock disagree.
+    /// Install registry-managed workers exactly from iii.lock.
+    /// Pass --frozen in CI to verify without mutating local files.
     Sync {
         /// Verify the lockfile without mutating local files.
         #[arg(long)]
@@ -143,7 +143,11 @@ pub enum Commands {
     },
 
     /// Verify config.yaml is represented in iii.lock without mutating files
-    Verify,
+    Verify {
+        /// Also check dependency declarations against locked versions.
+        #[arg(long)]
+        strict: bool,
+    },
 
     /// Show detailed status of one worker (config, sandbox, process, logs).
     /// By default refreshes live in place until the worker reaches a terminal

--- a/crates/iii-worker/src/cli/binary_download.rs
+++ b/crates/iii-worker/src/cli/binary_download.rs
@@ -166,7 +166,16 @@ pub fn validate_locked_artifact_url(url: &str) -> Result<(), String> {
 }
 
 fn is_trusted_registry_host(host: &str) -> bool {
-    matches!(host, "workers.iii.dev" | "api.workers.iii.dev") || host.ends_with(".workers.iii.dev")
+    if matches!(host, "workers.iii.dev" | "api.workers.iii.dev") {
+        return true;
+    }
+    // Suffix match must be anchored on a non-empty label so hosts like
+    // `.workers.iii.dev` or `..workers.iii.dev` (empty leading labels) are
+    // not silently treated as trusted subdomains.
+    let Some(prefix) = host.strip_suffix(".workers.iii.dev") else {
+        return false;
+    };
+    !prefix.is_empty() && prefix.split('.').all(|label| !label.is_empty())
 }
 
 fn is_loopback_host(host: &str) -> bool {
@@ -412,6 +421,26 @@ mod tests {
     fn validate_locked_artifact_url_rejects_untrusted_host() {
         let err = validate_locked_artifact_url("https://example.com/worker.tar.gz").unwrap_err();
         assert!(err.contains("not trusted"));
+    }
+
+    #[test]
+    fn validate_locked_artifact_url_rejects_leading_dot_subdomain() {
+        // `.workers.iii.dev` literally ends with `.workers.iii.dev`, so a
+        // naive suffix check accepts it. Empty DNS labels are not valid
+        // hostnames and must not be treated as trusted registry hosts.
+        for url in [
+            "https://.workers.iii.dev/worker.tar.gz",
+            "https://..workers.iii.dev/worker.tar.gz",
+            "https://.api.workers.iii.dev/worker.tar.gz",
+        ] {
+            let err = validate_locked_artifact_url(url)
+                .err()
+                .unwrap_or_else(|| panic!("expected {url} to be rejected"));
+            assert!(
+                err.contains("not trusted"),
+                "expected `not trusted` for {url}, got: {err}",
+            );
+        }
     }
 
     /// Helper: create a tar.gz archive in memory containing one file.

--- a/crates/iii-worker/src/cli/binary_download.rs
+++ b/crates/iii-worker/src/cli/binary_download.rs
@@ -10,11 +10,23 @@ use super::registry::validate_worker_name;
 use sha2::{Digest, Sha256};
 use std::io::Read as _;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{
+    LazyLock,
+    atomic::{AtomicU64, Ordering},
+};
 
 /// Maximum allowed download size: 512 MB.
 const MAX_DOWNLOAD_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_REDIRECTS: usize = 10;
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+static NO_REDIRECT_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(120))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("Failed to create no-redirect HTTP client")
+});
 
 /// Returns the directory where binary workers are installed: `~/.iii/workers/`.
 pub fn binary_workers_dir() -> PathBuf {
@@ -212,26 +224,14 @@ async fn download_archive_bytes(
     url: &str,
     validate_final_url: Option<&dyn Fn(&str) -> Result<(), String>>,
 ) -> Result<Vec<u8>, String> {
-    let client = &super::registry::HTTP_CLIENT;
-
-    let resp = client
-        .get(url)
-        .send()
-        .await
-        .map_err(|e| format!("Failed to download binary: {}", e))?;
-
-    // The shared HTTP_CLIENT follows up to 10 redirects by default, so a
-    // trusted artifact URL could redirect to an untrusted host and bypass the
-    // pre-send allowlist check. Re-validate the final URL before reading the
-    // body when a validator is provided.
-    if let Some(validator) = validate_final_url {
-        let final_url = resp.url().as_str();
-        if final_url != url {
-            validator(final_url).map_err(|e| {
-                format!("artifact download for `{url}` was redirected to an untrusted URL: {e}")
-            })?;
-        }
-    }
+    let resp = match validate_final_url {
+        Some(validator) => download_archive_bytes_with_validated_redirects(url, validator).await?,
+        None => super::registry::HTTP_CLIENT
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to download binary: {}", e))?,
+    };
 
     if !resp.status().is_success() {
         return Err(format!(
@@ -263,6 +263,57 @@ async fn download_archive_bytes(
     }
 
     Ok(binary_data.to_vec())
+}
+
+async fn download_archive_bytes_with_validated_redirects(
+    url: &str,
+    validator: &dyn Fn(&str) -> Result<(), String>,
+) -> Result<reqwest::Response, String> {
+    let mut current_url =
+        reqwest::Url::parse(url).map_err(|e| format!("invalid artifact URL `{url}`: {e}"))?;
+
+    for redirects_followed in 0..=MAX_REDIRECTS {
+        let resp = NO_REDIRECT_HTTP_CLIENT
+            .get(current_url.clone())
+            .send()
+            .await
+            .map_err(|e| format!("Failed to download binary: {}", e))?;
+
+        if !resp.status().is_redirection() {
+            return Ok(resp);
+        }
+
+        if redirects_followed == MAX_REDIRECTS {
+            return Err(format!(
+                "Binary download exceeded {MAX_REDIRECTS} redirects"
+            ));
+        }
+
+        let location = resp
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .ok_or_else(|| {
+                format!(
+                    "Binary download redirect from `{}` did not include a Location header",
+                    current_url
+                )
+            })?
+            .to_str()
+            .map_err(|e| format!("Binary download redirect has invalid Location header: {e}"))?;
+        let next_url = current_url.join(location).map_err(|e| {
+            format!(
+                "Binary download redirect from `{}` has invalid Location `{}`: {}",
+                current_url, location, e
+            )
+        })?;
+
+        validator(next_url.as_str()).map_err(|e| {
+            format!("artifact download for `{url}` was redirected to an untrusted URL: {e}")
+        })?;
+        current_url = next_url;
+    }
+
+    unreachable!("redirect loop always returns or errors");
 }
 
 pub async fn download_locked_binary_archive(
@@ -499,21 +550,36 @@ mod tests {
     /// to whatever request comes in. Returns the bound base URL and a join
     /// handle that the caller should `abort()` when done.
     async fn spawn_oneshot_http(response_bytes: Vec<u8>) -> (String, tokio::task::JoinHandle<()>) {
+        let (base_url, handle, _) = spawn_counting_http(response_bytes).await;
+        (base_url, handle)
+    }
+
+    async fn spawn_counting_http(
+        response_bytes: Vec<u8>,
+    ) -> (
+        String,
+        tokio::task::JoinHandle<()>,
+        std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    ) {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
+        let hit_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let server_hit_count = hit_count.clone();
         let handle = tokio::spawn(async move {
             while let Ok((mut stream, _)) = listener.accept().await {
                 let response = response_bytes.clone();
+                let server_hit_count = server_hit_count.clone();
                 tokio::spawn(async move {
+                    server_hit_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                     let mut buf = [0u8; 4096];
                     let _ = stream.read(&mut buf).await;
                     let _ = stream.write_all(&response).await;
                 });
             }
         });
-        (format!("http://{addr}"), handle)
+        (format!("http://{addr}"), handle, hit_count)
     }
 
     #[tokio::test]
@@ -530,7 +596,7 @@ mod tests {
             bytes.extend_from_slice(&final_body);
             bytes
         };
-        let (final_base, final_server) = spawn_oneshot_http(final_response).await;
+        let (final_base, final_server, final_hits) = spawn_counting_http(final_response).await;
 
         // Redirect server: returns 302 -> final_base/final, so the final URL
         // observed after `send()` differs from the input URL and the validator
@@ -553,6 +619,11 @@ mod tests {
             err.contains("redirected to an untrusted URL"),
             "expected wrapped redirect rejection, got: {err}",
         );
+        assert_eq!(
+            final_hits.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "validated redirects must be rejected before requesting the target",
+        );
 
         // 2. No-redirect path with validator: validator NOT called when the
         //    final URL matches the request URL, so the download succeeds.
@@ -561,6 +632,7 @@ mod tests {
             .await
             .expect("direct download with unchanged URL must skip validator");
         assert_eq!(body, final_body);
+        assert_eq!(final_hits.load(std::sync::atomic::Ordering::SeqCst), 1);
 
         // 3. Redirect path without validator: legacy behavior preserved —
         //    redirects are still followed.

--- a/crates/iii-worker/src/cli/binary_download.rs
+++ b/crates/iii-worker/src/cli/binary_download.rs
@@ -10,9 +10,11 @@ use super::registry::validate_worker_name;
 use sha2::{Digest, Sha256};
 use std::io::Read as _;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Maximum allowed download size: 512 MB.
 const MAX_DOWNLOAD_BYTES: u64 = 512 * 1024 * 1024;
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Returns the directory where binary workers are installed: `~/.iii/workers/`.
 pub fn binary_workers_dir() -> PathBuf {
@@ -130,23 +132,78 @@ pub fn verify_sha256(data: &[u8], checksum_content: &str) -> Result<(), String> 
     }
 }
 
-/// Downloads a binary worker from the URL provided by the API, verifies its
-/// SHA256 checksum, and installs it to `~/.iii/workers/{worker_name}`.
-///
-/// Returns the path to the installed binary on success.
-pub async fn download_and_install_binary(
-    worker_name: &str,
-    binary_info: &super::registry::BinaryInfo,
-) -> Result<PathBuf, String> {
-    validate_worker_name(worker_name)?;
+pub fn validate_locked_artifact_url(url: &str) -> Result<(), String> {
+    let parsed =
+        reqwest::Url::parse(url).map_err(|e| format!("invalid artifact URL `{url}`: {e}"))?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| format!("artifact URL `{url}` has no host"))?;
 
-    tracing::debug!("Downloading from {}", binary_info.url);
+    #[cfg(debug_assertions)]
+    if matches!(parsed.scheme(), "http" | "https") && is_loopback_host(host) {
+        return Ok(());
+    }
 
+    if parsed.scheme() != "https" {
+        return Err(format!(
+            "artifact URL `{url}` is not trusted: locked worker artifacts must use HTTPS registry URLs"
+        ));
+    }
+
+    if is_private_or_loopback_host(host) {
+        return Err(format!(
+            "artifact URL `{url}` is not trusted: private and loopback hosts are not allowed in iii.lock"
+        ));
+    }
+
+    if !is_trusted_registry_host(host) {
+        return Err(format!(
+            "artifact URL `{url}` is not trusted: expected a iii registry artifact host"
+        ));
+    }
+
+    Ok(())
+}
+
+fn is_trusted_registry_host(host: &str) -> bool {
+    matches!(host, "workers.iii.dev" | "api.workers.iii.dev") || host.ends_with(".workers.iii.dev")
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    host == "localhost"
+        || host
+            .parse::<std::net::IpAddr>()
+            .map(|ip| ip.is_loopback())
+            .unwrap_or(false)
+}
+
+fn is_private_or_loopback_host(host: &str) -> bool {
+    let Ok(ip) = host.parse::<std::net::IpAddr>() else {
+        return false;
+    };
+    match ip {
+        std::net::IpAddr::V4(ip) => {
+            ip.is_loopback()
+                || ip.is_private()
+                || ip.is_link_local()
+                || ip.is_broadcast()
+                || ip.is_documentation()
+                || ip.octets()[0] == 0
+        }
+        std::net::IpAddr::V6(ip) => {
+            ip.is_loopback()
+                || ip.is_unspecified()
+                || ip.segments()[0] & 0xfe00 == 0xfc00
+                || ip.segments()[0] & 0xffc0 == 0xfe80
+        }
+    }
+}
+
+async fn download_archive_bytes(url: &str) -> Result<Vec<u8>, String> {
     let client = &super::registry::HTTP_CLIENT;
 
-    // Download binary.
     let resp = client
-        .get(&binary_info.url)
+        .get(url)
         .send()
         .await
         .map_err(|e| format!("Failed to download binary: {}", e))?;
@@ -180,6 +237,61 @@ pub async fn download_and_install_binary(
         ));
     }
 
+    Ok(binary_data.to_vec())
+}
+
+pub async fn download_locked_binary_archive(
+    worker_name: &str,
+    target: &str,
+    binary_info: &super::registry::BinaryInfo,
+) -> Result<Vec<u8>, String> {
+    validate_worker_name(worker_name)?;
+    validate_locked_artifact_url(&binary_info.url).map_err(|e| {
+        format!(
+            "worker `{worker_name}` target `{target}` cannot be replayed from iii.lock: {e}. \
+             Fix: restore the committed iii.lock, use a registry-managed artifact URL, or run \
+             `iii worker update {worker_name}` only if changing pins is intentional"
+        )
+    })?;
+    let binary_data = download_archive_bytes(&binary_info.url).await?;
+    verify_sha256(&binary_data, &binary_info.sha256)?;
+    Ok(binary_data)
+}
+
+pub fn unique_worker_temp_path(worker_name: &str, suffix: &str) -> PathBuf {
+    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    binary_workers_dir().join(format!(".{worker_name}.{pid}.{nanos}.{counter}.{suffix}"))
+}
+
+pub fn set_executable_permission(path: &std::path::Path) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+            .map_err(|e| format!("Failed to set executable permission: {}", e))?;
+    }
+    Ok(())
+}
+
+/// Downloads a binary worker from the URL provided by the API, verifies its
+/// SHA256 checksum, and installs it to `~/.iii/workers/{worker_name}`.
+///
+/// Returns the path to the installed binary on success.
+pub async fn download_and_install_binary(
+    worker_name: &str,
+    binary_info: &super::registry::BinaryInfo,
+) -> Result<PathBuf, String> {
+    validate_worker_name(worker_name)?;
+
+    tracing::debug!("Downloading from {}", binary_info.url);
+
+    let binary_data = download_archive_bytes(&binary_info.url).await?;
+
     // Verify checksum (always — the API provides sha256 for every binary).
     verify_sha256(&binary_data, &binary_info.sha256)?;
 
@@ -192,18 +304,13 @@ pub async fn download_and_install_binary(
         .map_err(|e| format!("Failed to create install directory: {}", e))?;
 
     let install_path = install_dir.join(worker_name);
-    let tmp_path = install_dir.join(format!("{}.tmp", worker_name));
+    let tmp_path = unique_worker_temp_path(worker_name, "tmp");
 
     std::fs::write(&tmp_path, &extracted)
         .map_err(|e| format!("Failed to write binary to temp file: {}", e))?;
 
     let finalize = || -> Result<PathBuf, String> {
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o755))
-                .map_err(|e| format!("Failed to set executable permission: {}", e))?;
-        }
+        set_executable_permission(&tmp_path)?;
 
         std::fs::rename(&tmp_path, &install_path)
             .map_err(|e| format!("Failed to move binary into place: {}", e))?;
@@ -294,6 +401,17 @@ mod tests {
         let result = verify_sha256(data, "");
         assert!(result.is_err(), "expected error for empty checksum");
         assert!(result.unwrap_err().contains("empty"));
+    }
+
+    #[test]
+    fn validate_locked_artifact_url_accepts_registry_host() {
+        validate_locked_artifact_url("https://workers.iii.dev/worker.tar.gz").unwrap();
+    }
+
+    #[test]
+    fn validate_locked_artifact_url_rejects_untrusted_host() {
+        let err = validate_locked_artifact_url("https://example.com/worker.tar.gz").unwrap_err();
+        assert!(err.contains("not trusted"));
     }
 
     /// Helper: create a tar.gz archive in memory containing one file.

--- a/crates/iii-worker/src/cli/binary_download.rs
+++ b/crates/iii-worker/src/cli/binary_download.rs
@@ -208,7 +208,10 @@ fn is_private_or_loopback_host(host: &str) -> bool {
     }
 }
 
-async fn download_archive_bytes(url: &str) -> Result<Vec<u8>, String> {
+async fn download_archive_bytes(
+    url: &str,
+    validate_final_url: Option<&dyn Fn(&str) -> Result<(), String>>,
+) -> Result<Vec<u8>, String> {
     let client = &super::registry::HTTP_CLIENT;
 
     let resp = client
@@ -216,6 +219,19 @@ async fn download_archive_bytes(url: &str) -> Result<Vec<u8>, String> {
         .send()
         .await
         .map_err(|e| format!("Failed to download binary: {}", e))?;
+
+    // The shared HTTP_CLIENT follows up to 10 redirects by default, so a
+    // trusted artifact URL could redirect to an untrusted host and bypass the
+    // pre-send allowlist check. Re-validate the final URL before reading the
+    // body when a validator is provided.
+    if let Some(validator) = validate_final_url {
+        let final_url = resp.url().as_str();
+        if final_url != url {
+            validator(final_url).map_err(|e| {
+                format!("artifact download for `{url}` was redirected to an untrusted URL: {e}")
+            })?;
+        }
+    }
 
     if !resp.status().is_success() {
         return Err(format!(
@@ -262,7 +278,8 @@ pub async fn download_locked_binary_archive(
              `iii worker update {worker_name}` only if changing pins is intentional"
         )
     })?;
-    let binary_data = download_archive_bytes(&binary_info.url).await?;
+    let binary_data =
+        download_archive_bytes(&binary_info.url, Some(&validate_locked_artifact_url)).await?;
     verify_sha256(&binary_data, &binary_info.sha256)?;
     Ok(binary_data)
 }
@@ -299,7 +316,7 @@ pub async fn download_and_install_binary(
 
     tracing::debug!("Downloading from {}", binary_info.url);
 
-    let binary_data = download_archive_bytes(&binary_info.url).await?;
+    let binary_data = download_archive_bytes(&binary_info.url, None).await?;
 
     // Verify checksum (always — the API provides sha256 for every binary).
     verify_sha256(&binary_data, &binary_info.sha256)?;
@@ -476,6 +493,84 @@ mod tests {
         let result = extract_binary_from_targz("my-worker", &archive);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("not found in archive"));
+    }
+
+    /// Spawn a one-shot HTTP server on loopback that returns `response_bytes`
+    /// to whatever request comes in. Returns the bound base URL and a join
+    /// handle that the caller should `abort()` when done.
+    async fn spawn_oneshot_http(response_bytes: Vec<u8>) -> (String, tokio::task::JoinHandle<()>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                let response = response_bytes.clone();
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 4096];
+                    let _ = stream.read(&mut buf).await;
+                    let _ = stream.write_all(&response).await;
+                });
+            }
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    #[tokio::test]
+    async fn download_archive_bytes_revalidates_redirect_target() {
+        // Final server: returns a 200 with a body. A direct fetch here yields
+        // `final_url == url`, so the validator must NOT be called.
+        let final_body = b"final-payload".to_vec();
+        let final_response = {
+            let mut bytes = format!(
+                "HTTP/1.1 200 OK\r\ncontent-length: {}\r\ncontent-type: application/octet-stream\r\nconnection: close\r\n\r\n",
+                final_body.len()
+            )
+            .into_bytes();
+            bytes.extend_from_slice(&final_body);
+            bytes
+        };
+        let (final_base, final_server) = spawn_oneshot_http(final_response).await;
+
+        // Redirect server: returns 302 -> final_base/final, so the final URL
+        // observed after `send()` differs from the input URL and the validator
+        // MUST be called.
+        let redirect_target = format!("{final_base}/final");
+        let redirect_response = format!(
+            "HTTP/1.1 302 Found\r\nlocation: {redirect_target}\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+        )
+        .into_bytes();
+        let (redirect_base, redirect_server) = spawn_oneshot_http(redirect_response).await;
+
+        let always_reject = |url: &str| -> Result<(), String> { Err(format!("untrusted: {url}")) };
+
+        // 1. Redirect path: validator IS called and its error is wrapped.
+        let err = download_archive_bytes(&format!("{redirect_base}/start"), Some(&always_reject))
+            .await
+            .err()
+            .expect("redirected download must be rejected by validator");
+        assert!(
+            err.contains("redirected to an untrusted URL"),
+            "expected wrapped redirect rejection, got: {err}",
+        );
+
+        // 2. No-redirect path with validator: validator NOT called when the
+        //    final URL matches the request URL, so the download succeeds.
+        let direct = format!("{final_base}/final");
+        let body = download_archive_bytes(&direct, Some(&always_reject))
+            .await
+            .expect("direct download with unchanged URL must skip validator");
+        assert_eq!(body, final_body);
+
+        // 3. Redirect path without validator: legacy behavior preserved —
+        //    redirects are still followed.
+        let body = download_archive_bytes(&format!("{redirect_base}/start"), None)
+            .await
+            .expect("download without validator must follow redirects");
+        assert_eq!(body, final_body);
+
+        redirect_server.abort();
+        final_server.abort();
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -34,6 +34,8 @@ use super::registry::{
     fetch_resolved_worker_graph, fetch_worker_info, parse_worker_input,
 };
 use super::worker_manager::state::WorkerDef;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 
 pub use super::local_worker::{handle_local_add, is_local_path, start_local_worker};
 
@@ -221,6 +223,123 @@ pub async fn handle_managed_add_many(worker_names: &[String], wait: bool) -> i32
     if fail_count == 0 { 0 } else { 1 }
 }
 
+#[derive(Default)]
+struct SyncSummary {
+    installed: usize,
+    already_current: usize,
+    repaired: usize,
+    skipped: usize,
+    failed: usize,
+}
+
+enum PreparedLockedWorker {
+    Binary {
+        name: String,
+        version: String,
+        bytes: Vec<u8>,
+        existed_before: bool,
+    },
+    Image {
+        name: String,
+        version: String,
+    },
+}
+
+struct ProjectOperationLock {
+    path: PathBuf,
+}
+
+impl ProjectOperationLock {
+    fn acquire() -> Result<Self, String> {
+        let path = PathBuf::from(".iii-worker.lock");
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(mut file) => {
+                use std::io::Write as _;
+                let _ = writeln!(file, "pid={}", std::process::id());
+                Ok(Self { path })
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Err(format!(
+                "another iii worker operation is active (lock: {}). Wait for it to finish, \
+                 or remove the lock if the process crashed.",
+                path.display()
+            )),
+            Err(e) => Err(format!(
+                "failed to acquire iii worker operation lock {}: {e}",
+                path.display()
+            )),
+        }
+    }
+}
+
+impl Drop for ProjectOperationLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+struct WorkerActivationLock {
+    path: PathBuf,
+}
+
+impl WorkerActivationLock {
+    fn acquire(name: &str) -> Result<Self, String> {
+        super::registry::validate_worker_name(name)?;
+        let dir = binary_download::binary_workers_dir();
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("failed to create worker install directory: {e}"))?;
+        let path = dir.join(format!(".{name}.lock"));
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(mut file) => {
+                use std::io::Write as _;
+                let _ = writeln!(file, "pid={}", std::process::id());
+                Ok(Self { path })
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Err(format!(
+                "worker `{name}` is being installed by another process (lock: {}). Wait and rerun \
+                 `iii worker sync`.",
+                path.display()
+            )),
+            Err(e) => Err(format!(
+                "failed to acquire activation lock for worker `{name}`: {e}"
+            )),
+        }
+    }
+}
+
+impl Drop for WorkerActivationLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+struct ActiveWorkerRestore {
+    install_path: PathBuf,
+    backup_path: Option<PathBuf>,
+}
+
+impl ActiveWorkerRestore {
+    fn rollback(self) {
+        let _ = std::fs::remove_file(&self.install_path);
+        if let Some(backup_path) = self.backup_path {
+            let _ = std::fs::rename(backup_path, self.install_path);
+        }
+    }
+
+    fn commit(self) {
+        if let Some(backup_path) = self.backup_path {
+            let _ = std::fs::remove_file(backup_path);
+        }
+    }
+}
+
 pub async fn handle_worker_sync(frozen: bool) -> i32 {
     if frozen {
         let lock_path = super::lockfile::lockfile_path();
@@ -272,7 +391,7 @@ pub async fn handle_worker_sync(frozen: bool) -> i32 {
             }
         }
 
-        return handle_worker_verify().await;
+        return handle_worker_verify(false).await;
     }
 
     let lock_path = super::lockfile::lockfile_path();
@@ -284,17 +403,293 @@ pub async fn handle_worker_sync(frozen: bool) -> i32 {
         }
     };
 
-    eprintln!(
-        "  {} {} worker(s) pinned in {}",
-        "✓".green(),
-        lockfile.workers.len(),
-        "iii.lock".dimmed(),
-    );
-    eprintln!("  Run `iii worker verify` in CI to check config.yaml against the lockfile.");
-    0
+    let config_names = match super::config_file::list_worker_names_result() {
+        Ok(names) => names,
+        Err(e) => {
+            eprintln!("{} {}", "error:".red(), e);
+            return 1;
+        }
+    };
+    let names = lockfile_relevant_config_worker_names(&lockfile, &config_names);
+    if let Err(e) =
+        lockfile.verify_config_workers_for_target(&names, binary_download::current_target())
+    {
+        eprintln!("{} {}", "error:".red(), e);
+        return 1;
+    }
+    let skipped_unmanaged = skipped_unmanaged_config_workers(&lockfile, &config_names);
+
+    let _operation_lock = match ProjectOperationLock::acquire() {
+        Ok(lock) => lock,
+        Err(e) => {
+            eprintln!("{} {}", "error:".red(), e);
+            return 1;
+        }
+    };
+
+    match replay_lockfile(&lockfile).await {
+        Ok(mut summary) => {
+            summary.skipped += skipped_unmanaged.len();
+            eprintln!(
+                "  {} Synced registry-managed workers from {}",
+                "✓".green(),
+                "iii.lock".dimmed()
+            );
+            eprintln!(
+                "    installed: {}, already current: {}, repaired: {}, skipped: {}, failed: {}",
+                summary.installed,
+                summary.already_current,
+                summary.repaired,
+                summary.skipped,
+                summary.failed
+            );
+            if summary.skipped > 0 {
+                eprintln!(
+                    "    {} skipped entries are outside the v1 iii.lock replay contract.",
+                    "note:".yellow()
+                );
+                for (name, reason) in skipped_unmanaged {
+                    eprintln!("      - {}: {}", name, reason);
+                }
+            }
+            0
+        }
+        Err(e) => {
+            eprintln!("{} {}", "error:".red(), e);
+            1
+        }
+    }
 }
 
-pub async fn handle_worker_verify() -> i32 {
+fn skipped_unmanaged_config_workers(
+    lockfile: &super::lockfile::WorkerLockfile,
+    names: &[String],
+) -> Vec<(String, &'static str)> {
+    names
+        .iter()
+        .filter(|name| !lockfile.workers.contains_key(name.as_str()))
+        .filter_map(|name| {
+            if get_builtin_default(name).is_some() {
+                return Some((name.clone(), "built-in worker"));
+            }
+            match super::config_file::resolve_worker_type(name) {
+                ResolvedWorkerType::Local { .. } => Some((name.clone(), "local-path worker")),
+                ResolvedWorkerType::Oci { .. } => Some((name.clone(), "direct OCI worker")),
+                ResolvedWorkerType::Binary { .. } | ResolvedWorkerType::Config => None,
+            }
+        })
+        .collect()
+}
+
+async fn replay_lockfile(
+    lockfile: &super::lockfile::WorkerLockfile,
+) -> Result<SyncSummary, String> {
+    let mut prepared = Vec::with_capacity(lockfile.workers.len());
+    let mut summary = SyncSummary::default();
+
+    for (name, worker) in &lockfile.workers {
+        match prepare_locked_worker(name, worker).await {
+            Ok(Some(worker)) => prepared.push(worker),
+            Ok(None) => summary.skipped += 1,
+            Err(e) => return Err(e),
+        }
+    }
+
+    activate_locked_workers(prepared, &mut summary)?;
+    Ok(summary)
+}
+
+async fn prepare_locked_worker(
+    name: &str,
+    worker: &super::lockfile::LockedWorker,
+) -> Result<Option<PreparedLockedWorker>, String> {
+    let source = match &worker.source {
+        Some(source) => source,
+        None => return Ok(None),
+    };
+    match source {
+        super::lockfile::LockedSource::Binary { artifacts } => {
+            let target = binary_download::current_target();
+            if binary_download::archive_extension(target) != "tar.gz" {
+                return Err(format!(
+                    "worker `{name}` has artifact target `{target}`, but `iii worker sync` currently supports tar.gz binary artifacts only. \
+                     Fix: use `iii worker verify --strict` in CI for this target until zip replay support lands."
+                ));
+            }
+            let artifact = artifacts.get(target).ok_or_else(|| {
+                let available = artifacts.keys().cloned().collect::<Vec<_>>().join(", ");
+                format!(
+                    "iii.lock is missing binary artifact for worker `{name}` target `{target}` (available: {available}). \
+                     Fix: run `iii worker update {name}` on a registry version that publishes this target, or restore a lockfile with this artifact."
+                )
+            })?;
+            let archive = binary_download::download_locked_binary_archive(
+                name,
+                target,
+                &super::registry::BinaryInfo {
+                    url: artifact.url.clone(),
+                    sha256: artifact.sha256.clone(),
+                },
+            )
+            .await?;
+            let bytes = binary_download::extract_binary_from_targz(name, &archive)?;
+            let existed_before = binary_download::binary_worker_path(name).exists();
+            Ok(Some(PreparedLockedWorker::Binary {
+                name: name.to_string(),
+                version: worker.version.clone(),
+                bytes,
+                existed_before,
+            }))
+        }
+        super::lockfile::LockedSource::Image { image } => {
+            if !image.contains("@sha256:") {
+                return Err(format!(
+                    "worker `{name}` image source is not digest-pinned. Fix: run `iii worker update {name}` to refresh iii.lock from the registry."
+                ));
+            }
+            let adapter = super::worker_manager::create_adapter("libkrun");
+            adapter.pull(image).await.map_err(|e| {
+                format!(
+                    "failed to pull locked image for worker `{name}` from `{image}`: {e}. \
+                     Fix: check registry access or run `iii worker update {name}` only if changing pins is intentional."
+                )
+            })?;
+            Ok(Some(PreparedLockedWorker::Image {
+                name: name.to_string(),
+                version: worker.version.clone(),
+            }))
+        }
+    }
+}
+
+fn activate_locked_workers(
+    prepared: Vec<PreparedLockedWorker>,
+    summary: &mut SyncSummary,
+) -> Result<(), String> {
+    let mut restores = Vec::new();
+
+    for worker in prepared {
+        match activate_locked_worker(worker) {
+            Ok(Some(restore)) => {
+                if restore.backup_path.is_some() {
+                    summary.repaired += 1;
+                } else {
+                    summary.installed += 1;
+                }
+                restores.push(restore);
+            }
+            Ok(None) => summary.already_current += 1,
+            Err(e) => {
+                for restore in restores.into_iter().rev() {
+                    restore.rollback();
+                }
+                return Err(e);
+            }
+        }
+    }
+
+    for restore in restores {
+        restore.commit();
+    }
+    Ok(())
+}
+
+fn activate_locked_worker(
+    worker: PreparedLockedWorker,
+) -> Result<Option<ActiveWorkerRestore>, String> {
+    match worker {
+        PreparedLockedWorker::Binary {
+            name,
+            version,
+            bytes,
+            existed_before,
+        } => {
+            let _lock = WorkerActivationLock::acquire(&name)?;
+            activate_locked_binary(&name, &version, &bytes, existed_before)
+        }
+        PreparedLockedWorker::Image { name, version } => {
+            eprintln!(
+                "    {} image worker {} v{} is pinned by digest; no binary artifact to install",
+                "✓".green(),
+                name.bold(),
+                version
+            );
+            Ok(None)
+        }
+    }
+}
+
+fn activate_locked_binary(
+    name: &str,
+    version: &str,
+    bytes: &[u8],
+    existed_before: bool,
+) -> Result<Option<ActiveWorkerRestore>, String> {
+    let install_dir = binary_download::binary_workers_dir();
+    std::fs::create_dir_all(&install_dir)
+        .map_err(|e| format!("failed to create worker install directory: {e}"))?;
+    let install_path = binary_download::binary_worker_path(name);
+
+    if install_path.exists()
+        && let Ok(existing) = std::fs::read(&install_path)
+        && existing == bytes
+    {
+        eprintln!(
+            "    {} {} v{} already current",
+            "✓".green(),
+            name.bold(),
+            version
+        );
+        return Ok(None);
+    }
+
+    let tmp_path = binary_download::unique_worker_temp_path(name, "sync.tmp");
+    std::fs::write(&tmp_path, bytes)
+        .map_err(|e| format!("failed to write temporary binary for `{name}`: {e}"))?;
+    if let Err(e) = binary_download::set_executable_permission(&tmp_path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+
+    let backup_path = if install_path.exists() {
+        let backup_path = binary_download::unique_worker_temp_path(name, "sync.bak");
+        if let Err(e) = std::fs::rename(&install_path, &backup_path) {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(format!("failed to backup active binary for `{name}`: {e}"));
+        }
+        Some(backup_path)
+    } else {
+        None
+    };
+
+    if let Err(e) = std::fs::rename(&tmp_path, &install_path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        if let Some(backup_path) = &backup_path {
+            let _ = std::fs::rename(backup_path, &install_path);
+        }
+        return Err(format!("failed to activate binary for `{name}`: {e}"));
+    }
+
+    let action = if existed_before {
+        "repaired"
+    } else {
+        "installed"
+    };
+    eprintln!(
+        "    {} {} {} to v{}",
+        "✓".green(),
+        name.bold(),
+        action,
+        version
+    );
+
+    Ok(Some(ActiveWorkerRestore {
+        install_path,
+        backup_path,
+    }))
+}
+
+pub async fn handle_worker_verify(strict: bool) -> i32 {
     let lock_path = super::lockfile::lockfile_path();
     let lockfile = match super::lockfile::WorkerLockfile::read_from(lock_path) {
         Ok(lockfile) => lockfile,
@@ -303,6 +698,11 @@ pub async fn handle_worker_verify() -> i32 {
             return 1;
         }
     };
+
+    if strict && let Err(e) = verify_lockfile_strict(&lockfile) {
+        eprintln!("{} {}", "error:".red(), e);
+        return 1;
+    }
 
     let names = match super::config_file::list_worker_names_result() {
         Ok(names) => names,
@@ -315,12 +715,85 @@ pub async fn handle_worker_verify() -> i32 {
     match lockfile.verify_config_workers_for_target(&names, binary_download::current_target()) {
         Ok(()) => {
             eprintln!("  {} config.yaml matches iii.lock", "✓".green());
+            if strict {
+                eprintln!("  {} declaration freshness checks passed", "✓".green());
+            }
             0
         }
         Err(e) => {
             eprintln!("{} {}", "error:".red(), e);
             1
         }
+    }
+}
+
+fn verify_lockfile_strict(lockfile: &super::lockfile::WorkerLockfile) -> Result<(), String> {
+    for (worker_name, worker) in &lockfile.workers {
+        for (dependency, range) in &worker.dependencies {
+            let locked_dependency = lockfile.workers.get(dependency).ok_or_else(|| {
+                format!(
+                    "iii.lock worker `{worker_name}` depends on `{dependency}` but `{dependency}` is missing from iii.lock"
+                )
+            })?;
+            version_satisfies_range(&locked_dependency.version, range).map_err(|e| {
+                format!(
+                    "iii.lock worker `{worker_name}` dependency `{dependency}` is stale: locked version {} does not satisfy range `{range}` ({e}). \
+                     Fix: run `iii worker update {worker_name}` only if changing pins is intentional.",
+                    locked_dependency.version
+                )
+            })?;
+        }
+    }
+
+    for (worker_name, worker_path) in local_worker_manifest_paths()? {
+        let manifest_path = Path::new(&worker_path).join(super::project::WORKER_MANIFEST);
+        let deps = super::project::load_manifest_dependencies(&manifest_path).map_err(|e| {
+            format!(
+                "{e}. Fix: correct `{}` and rerun `iii worker verify --strict`.",
+                manifest_path.display()
+            )
+        })?;
+        for (dependency, range) in deps {
+            let locked = lockfile.workers.get(&dependency).ok_or_else(|| {
+                format!(
+                    "local worker `{worker_name}` declares dependency `{dependency}@{range}` in {}, but `{dependency}` is missing from iii.lock. \
+                     Fix: run `iii worker add {}` to resolve and lock declared dependencies.",
+                    manifest_path.display(),
+                    worker_path
+                )
+            })?;
+            version_satisfies_range(&locked.version, &range).map_err(|e| {
+                format!(
+                    "local worker `{worker_name}` declares dependency `{dependency}@{range}`, but iii.lock pins version {} ({e}). \
+                     Fix: run `iii worker add {}` after confirming the dependency range.",
+                    locked.version, worker_path
+                )
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+fn local_worker_manifest_paths() -> Result<BTreeMap<String, String>, String> {
+    let mut paths = BTreeMap::new();
+    for name in super::config_file::list_worker_names_result()? {
+        if let ResolvedWorkerType::Local { worker_path } =
+            super::config_file::resolve_worker_type(&name)
+        {
+            paths.insert(name, worker_path);
+        }
+    }
+    Ok(paths)
+}
+
+fn version_satisfies_range(version: &str, range: &str) -> Result<(), String> {
+    let version = semver::Version::parse(version).map_err(|e| format!("invalid version: {e}"))?;
+    let range = semver::VersionReq::parse(range).map_err(|e| format!("invalid range: {e}"))?;
+    if range.matches(&version) {
+        Ok(())
+    } else {
+        Err("range mismatch".to_string())
     }
 }
 
@@ -3395,7 +3868,7 @@ workers:
             )
             .unwrap();
 
-            let rc = handle_worker_verify().await;
+            let rc = handle_worker_verify(false).await;
 
             assert_eq!(rc, 0);
         })
@@ -3414,7 +3887,7 @@ workers:
             )
             .unwrap();
 
-            let rc = handle_worker_verify().await;
+            let rc = handle_worker_verify(false).await;
 
             assert_eq!(rc, 1);
         })
@@ -3454,7 +3927,7 @@ workers:
             )
             .unwrap();
 
-            let rc = handle_worker_verify().await;
+            let rc = handle_worker_verify(false).await;
 
             assert_eq!(rc, 1);
         })
@@ -4070,6 +4543,61 @@ dependencies:
     }
 
     #[tokio::test]
+    async fn handle_worker_sync_installs_binary_from_lockfile_without_config_mutation() {
+        in_temp_dir_async(|dir| async move {
+            let _env_guard = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let home = dir.join("home");
+            std::fs::create_dir_all(&home).unwrap();
+            let _home_guard = set_env_var_for_test("HOME", &home);
+
+            let worker_name = "sync-worker";
+            let archive = binary_archive(worker_name);
+            let archive_sha = sha256_hex(&archive);
+            let (base_url, server) = spawn_static_http_server(StdHashMap::from([(
+                format!("GET /{worker_name}.tar.gz"),
+                TestResponse {
+                    status: 200,
+                    content_type: "application/gzip",
+                    body: archive,
+                },
+            )]))
+            .await;
+
+            let mut lock = cli_lockfile::WorkerLockfile::default();
+            lock.workers.insert(
+                worker_name.to_string(),
+                cli_lockfile::LockedWorker {
+                    version: "1.0.0".to_string(),
+                    worker_type: cli_lockfile::LockedWorkerType::Binary,
+                    dependencies: Default::default(),
+                    source: locked_binary_source(
+                        binary_download::current_target(),
+                        &format!("{base_url}/{worker_name}.tar.gz"),
+                        archive_sha,
+                    ),
+                },
+            );
+            lock.write_to(cli_lockfile::lockfile_path()).unwrap();
+            let config = "workers:\n  - name: sync-worker\n";
+            std::fs::write("config.yaml", config).unwrap();
+
+            let rc = handle_worker_sync(false).await;
+
+            assert_eq!(rc, 0);
+            assert!(home.join(".iii/workers").join(worker_name).exists());
+            assert_eq!(std::fs::read_to_string("config.yaml").unwrap(), config);
+            assert!(
+                !std::path::Path::new(".iii-worker.lock").exists(),
+                "project operation lock should be removed after sync"
+            );
+            server.abort();
+        })
+        .await;
+    }
+
+    #[tokio::test]
     async fn handle_worker_sync_frozen_reports_drift_on_added_dep() {
         in_temp_dir_async(|dir| async move {
             use super::super::lockfile::WorkerLockfile;
@@ -4141,6 +4669,61 @@ dependencies:
     }
 
     #[tokio::test]
+    async fn handle_worker_sync_is_idempotent_for_matching_active_binary() {
+        in_temp_dir_async(|dir| async move {
+            let _env_guard = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let home = dir.join("home");
+            std::fs::create_dir_all(&home).unwrap();
+            let _home_guard = set_env_var_for_test("HOME", &home);
+
+            let worker_name = "same-worker";
+            let archive = binary_archive(worker_name);
+            let archive_sha = sha256_hex(&archive);
+            let extracted =
+                binary_download::extract_binary_from_targz(worker_name, &archive).unwrap();
+            let (base_url, server) = spawn_static_http_server(StdHashMap::from([(
+                format!("GET /{worker_name}.tar.gz"),
+                TestResponse {
+                    status: 200,
+                    content_type: "application/gzip",
+                    body: archive,
+                },
+            )]))
+            .await;
+
+            let worker_dir = home.join(".iii/workers");
+            std::fs::create_dir_all(&worker_dir).unwrap();
+            let active_path = worker_dir.join(worker_name);
+            std::fs::write(&active_path, &extracted).unwrap();
+
+            let mut lock = cli_lockfile::WorkerLockfile::default();
+            lock.workers.insert(
+                worker_name.to_string(),
+                cli_lockfile::LockedWorker {
+                    version: "1.0.0".to_string(),
+                    worker_type: cli_lockfile::LockedWorkerType::Binary,
+                    dependencies: Default::default(),
+                    source: locked_binary_source(
+                        binary_download::current_target(),
+                        &format!("{base_url}/{worker_name}.tar.gz"),
+                        archive_sha,
+                    ),
+                },
+            );
+            lock.write_to(cli_lockfile::lockfile_path()).unwrap();
+
+            let rc = handle_worker_sync(false).await;
+
+            assert_eq!(rc, 0);
+            assert_eq!(std::fs::read(&active_path).unwrap(), extracted);
+            server.abort();
+        })
+        .await;
+    }
+
+    #[tokio::test]
     async fn handle_worker_sync_frozen_fails_when_manifest_missing() {
         // Lock has manifest_hash + declared_dependencies but
         // iii.worker.yaml doesn't exist. The user must see a distinct
@@ -4161,6 +4744,58 @@ dependencies:
 
             let rc = handle_worker_sync(true).await;
             assert_eq!(rc, 1);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_worker_sync_hash_mismatch_preserves_existing_binary() {
+        in_temp_dir_async(|dir| async move {
+            let _env_guard = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let home = dir.join("home");
+            std::fs::create_dir_all(&home).unwrap();
+            let _home_guard = set_env_var_for_test("HOME", &home);
+
+            let worker_name = "protected-worker";
+            let archive = binary_archive(worker_name);
+            let (base_url, server) = spawn_static_http_server(StdHashMap::from([(
+                format!("GET /{worker_name}.tar.gz"),
+                TestResponse {
+                    status: 200,
+                    content_type: "application/gzip",
+                    body: archive,
+                },
+            )]))
+            .await;
+
+            let worker_dir = home.join(".iii/workers");
+            std::fs::create_dir_all(&worker_dir).unwrap();
+            let active_path = worker_dir.join(worker_name);
+            std::fs::write(&active_path, b"old-good-binary").unwrap();
+
+            let mut lock = cli_lockfile::WorkerLockfile::default();
+            lock.workers.insert(
+                worker_name.to_string(),
+                cli_lockfile::LockedWorker {
+                    version: "1.0.0".to_string(),
+                    worker_type: cli_lockfile::LockedWorkerType::Binary,
+                    dependencies: Default::default(),
+                    source: locked_binary_source(
+                        binary_download::current_target(),
+                        &format!("{base_url}/{worker_name}.tar.gz"),
+                        "0".repeat(64),
+                    ),
+                },
+            );
+            lock.write_to(cli_lockfile::lockfile_path()).unwrap();
+
+            let rc = handle_worker_sync(false).await;
+
+            assert_eq!(rc, 1);
+            assert_eq!(std::fs::read(&active_path).unwrap(), b"old-good-binary");
+            server.abort();
         })
         .await;
     }
@@ -4222,9 +4857,83 @@ dependencies:
     }
 
     #[tokio::test]
+    async fn handle_worker_sync_rejects_untrusted_lockfile_url() {
+        in_temp_dir_async(|dir| async move {
+            let _env_guard = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let home = dir.join("home");
+            std::fs::create_dir_all(&home).unwrap();
+            let _home_guard = set_env_var_for_test("HOME", &home);
+
+            let worker_name = "untrusted-worker";
+            let mut lock = cli_lockfile::WorkerLockfile::default();
+            lock.workers.insert(
+                worker_name.to_string(),
+                cli_lockfile::LockedWorker {
+                    version: "1.0.0".to_string(),
+                    worker_type: cli_lockfile::LockedWorkerType::Binary,
+                    dependencies: Default::default(),
+                    source: locked_binary_source(
+                        binary_download::current_target(),
+                        "https://example.com/untrusted-worker.tar.gz",
+                        "a".repeat(64),
+                    ),
+                },
+            );
+            lock.write_to(cli_lockfile::lockfile_path()).unwrap();
+
+            let rc = handle_worker_sync(false).await;
+
+            assert_eq!(rc, 1);
+            assert!(!home.join(".iii/workers").join(worker_name).exists());
+        })
+        .await;
+    }
+
+    #[tokio::test]
     async fn handle_worker_verify_fails_when_lockfile_is_absent() {
         in_temp_dir_async(|_| async move {
-            let rc = handle_worker_verify().await;
+            let rc = handle_worker_verify(false).await;
+            assert_eq!(rc, 1);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_worker_verify_strict_rejects_dependency_range_mismatch() {
+        in_temp_dir_async(|_| async move {
+            let mut lock = cli_lockfile::WorkerLockfile::default();
+            lock.workers.insert(
+                "root-worker".to_string(),
+                cli_lockfile::LockedWorker {
+                    version: "1.0.0".to_string(),
+                    worker_type: cli_lockfile::LockedWorkerType::Binary,
+                    dependencies: [("helper".to_string(), "^2.0.0".to_string())].into(),
+                    source: locked_binary_source(
+                        binary_download::current_target(),
+                        "https://workers.iii.dev/root-worker.tar.gz",
+                        "a".repeat(64),
+                    ),
+                },
+            );
+            lock.workers.insert(
+                "helper".to_string(),
+                cli_lockfile::LockedWorker {
+                    version: "1.0.0".to_string(),
+                    worker_type: cli_lockfile::LockedWorkerType::Binary,
+                    dependencies: Default::default(),
+                    source: locked_binary_source(
+                        binary_download::current_target(),
+                        "https://workers.iii.dev/helper.tar.gz",
+                        "b".repeat(64),
+                    ),
+                },
+            );
+            lock.write_to(cli_lockfile::lockfile_path()).unwrap();
+
+            let rc = handle_worker_verify(true).await;
+
             assert_eq!(rc, 1);
         })
         .await;

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -925,15 +925,23 @@ fn lockfile_from_graph(
                 let artifacts = binaries
                     .iter()
                     .map(|(target, binary)| {
-                        (
+                        binary_download::validate_locked_artifact_url(&binary.url).map_err(
+                            |e| {
+                                format!(
+                                    "resolved binary worker '{}' target '{}' has unreplayable artifact URL: {}",
+                                    node.name, target, e
+                                )
+                            },
+                        )?;
+                        Ok((
                             target.clone(),
                             super::lockfile::LockedBinaryArtifact {
                                 url: binary.url.clone(),
                                 sha256: binary.sha256.clone(),
                             },
-                        )
+                        ))
                     })
-                    .collect();
+                    .collect::<Result<_, String>>()?;
                 (
                     super::lockfile::LockedWorkerType::Binary,
                     Some(super::lockfile::LockedSource::Binary { artifacts }),
@@ -3705,14 +3713,14 @@ mod tests {
         binaries.insert(
             "x86_64-unknown-linux-gnu".to_string(),
             cli_registry::BinaryInfo {
-                url: "https://example.com/linux.tar.gz".to_string(),
+                url: "https://workers.iii.dev/linux.tar.gz".to_string(),
                 sha256: "b".repeat(64),
             },
         );
         binaries.insert(
             "aarch64-apple-darwin".to_string(),
             cli_registry::BinaryInfo {
-                url: "https://example.com/darwin.tar.gz".to_string(),
+                url: "https://workers.iii.dev/darwin.tar.gz".to_string(),
                 sha256: "a".repeat(64),
             },
         );
@@ -3726,15 +3734,34 @@ mod tests {
                 assert_eq!(artifacts.len(), 2);
                 assert_eq!(
                     artifacts.get("aarch64-apple-darwin").unwrap().url,
-                    "https://example.com/darwin.tar.gz"
+                    "https://workers.iii.dev/darwin.tar.gz"
                 );
                 assert_eq!(
                     artifacts.get("x86_64-unknown-linux-gnu").unwrap().url,
-                    "https://example.com/linux.tar.gz"
+                    "https://workers.iii.dev/linux.tar.gz"
                 );
             }
             other => panic!("expected binary source, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn lockfile_from_graph_rejects_unreplayable_binary_artifact_url() {
+        let mut binaries = StdHashMap::new();
+        binaries.insert(
+            "aarch64-apple-darwin".to_string(),
+            cli_registry::BinaryInfo {
+                url: "https://example.com/h.tar.gz".to_string(),
+                sha256: "c".repeat(64),
+            },
+        );
+        let worker = resolved_binary_worker("hello-worker", "1.0.0", binaries);
+
+        let err = lockfile_from_graph(&graph_with(worker)).unwrap_err();
+
+        assert!(err.contains("hello-worker"));
+        assert!(err.contains("aarch64-apple-darwin"));
+        assert!(err.contains("unreplayable artifact URL"));
     }
 
     #[test]
@@ -3768,7 +3795,7 @@ mod tests {
         binaries.insert(
             "aarch64-apple-darwin".to_string(),
             cli_registry::BinaryInfo {
-                url: "https://example.com/h.tar.gz".to_string(),
+                url: "https://workers.iii.dev/h.tar.gz".to_string(),
                 sha256: "c".repeat(64),
             },
         );
@@ -3789,7 +3816,7 @@ mod tests {
         match entry.source.as_ref().unwrap() {
             cli_lockfile::LockedSource::Binary { artifacts } => {
                 let artifact = artifacts.get("aarch64-apple-darwin").unwrap();
-                assert_eq!(artifact.url, "https://example.com/h.tar.gz");
+                assert_eq!(artifact.url, "https://workers.iii.dev/h.tar.gz");
                 assert_eq!(artifact.sha256.len(), 64);
             }
             other => panic!("expected binary source, got {:?}", other),
@@ -3840,7 +3867,7 @@ mod tests {
                     dependencies: Default::default(),
                     source: locked_binary_source(
                         "aarch64-apple-darwin",
-                        "https://example.com/image-resize.tar.gz",
+                        "https://workers.iii.dev/image-resize.tar.gz",
                         "a".repeat(64),
                     ),
                 },
@@ -3909,7 +3936,7 @@ workers:
                     dependencies: Default::default(),
                     source: locked_binary_source(
                         binary_download::current_target(),
-                        "https://example.com/image-resize.tar.gz",
+                        "https://workers.iii.dev/image-resize.tar.gz",
                         "a".repeat(64),
                     ),
                 },
@@ -3975,7 +4002,7 @@ workers:
                     dependencies: Default::default(),
                     source: locked_binary_source(
                         other_target,
-                        "https://example.com/image-resize.tar.gz",
+                        "https://workers.iii.dev/image-resize.tar.gz",
                         "a".repeat(64),
                     ),
                 },
@@ -4008,7 +4035,7 @@ workers:
                 dependencies: [("helper".to_string(), "^1.0.0".to_string())].into(),
                 source: locked_binary_source(
                     "aarch64-apple-darwin",
-                    "https://example.com/root.tar.gz",
+                    "https://workers.iii.dev/root.tar.gz",
                     "a".repeat(64),
                 ),
             },
@@ -4021,7 +4048,7 @@ workers:
                 dependencies: Default::default(),
                 source: locked_binary_source(
                     "aarch64-apple-darwin",
-                    "https://example.com/helper.tar.gz",
+                    "https://workers.iii.dev/helper.tar.gz",
                     "b".repeat(64),
                 ),
             },
@@ -4061,7 +4088,7 @@ workers:
             binaries.insert(
                 target.to_string(),
                 cli_registry::BinaryInfo {
-                    url: "https://example.com/evil.tar.gz".to_string(),
+                    url: "https://workers.iii.dev/evil.tar.gz".to_string(),
                     sha256: "a".repeat(64),
                 },
             );
@@ -4282,7 +4309,7 @@ workers:
                 binaries.insert(
                     other_target.to_string(),
                     cli_registry::BinaryInfo {
-                        url: format!("https://example.com/{name}-{other_target}.tar.gz"),
+                        url: format!("https://workers.iii.dev/{name}-{other_target}.tar.gz"),
                         sha256: "f".repeat(64),
                     },
                 );

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -323,6 +323,11 @@ impl Drop for WorkerActivationLock {
 struct ActiveWorkerRestore {
     install_path: PathBuf,
     backup_path: Option<PathBuf>,
+    // Hold the per-worker activation lock until the batch commits or rolls
+    // back. Dropping it earlier would let a concurrent sync overwrite this
+    // worker's install before our rollback runs, causing rollback to delete
+    // a newer install and resurrect a stale backup.
+    _lock: WorkerActivationLock,
 }
 
 impl ActiveWorkerRestore {
@@ -604,8 +609,8 @@ fn activate_locked_worker(
             bytes,
             existed_before,
         } => {
-            let _lock = WorkerActivationLock::acquire(&name)?;
-            activate_locked_binary(&name, &version, &bytes, existed_before)
+            let lock = WorkerActivationLock::acquire(&name)?;
+            activate_locked_binary(&name, &version, &bytes, existed_before, lock)
         }
         PreparedLockedWorker::Image { name, version } => {
             eprintln!(
@@ -624,6 +629,7 @@ fn activate_locked_binary(
     version: &str,
     bytes: &[u8],
     existed_before: bool,
+    lock: WorkerActivationLock,
 ) -> Result<Option<ActiveWorkerRestore>, String> {
     let install_dir = binary_download::binary_workers_dir();
     std::fs::create_dir_all(&install_dir)
@@ -686,6 +692,7 @@ fn activate_locked_binary(
     Ok(Some(ActiveWorkerRestore {
         install_path,
         backup_path,
+        _lock: lock,
     }))
 }
 
@@ -3416,6 +3423,62 @@ mod tests {
     #[test]
     fn binary_config_yaml_omits_empty_registry_config() {
         assert_eq!(binary_config_yaml(&serde_json::json!({})), None);
+    }
+
+    #[test]
+    fn active_worker_restore_holds_activation_lock_until_commit() {
+        in_temp_dir(|dir| {
+            let _env_guard = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let home = dir.join("home");
+            std::fs::create_dir_all(&home).unwrap();
+            let _home_guard = set_env_var_for_test("HOME", &home);
+
+            let name = "lock-holder";
+            let lock = WorkerActivationLock::acquire(name).expect("first acquire");
+            let restore = activate_locked_binary(name, "1.0.0", b"binary-bytes", false, lock)
+                .expect("activate must succeed")
+                .expect("expected Some(restore) for fresh install");
+
+            // Critical: while the restore is alive (i.e., commit/rollback not
+            // yet called), a concurrent sync MUST NOT be able to overwrite this
+            // worker. If the lock were dropped early, the second acquire would
+            // succeed and a later rollback could resurrect a stale backup over
+            // the newer install.
+            let err = WorkerActivationLock::acquire(name)
+                .err()
+                .expect("second acquire must fail while restore is alive");
+            assert!(
+                err.contains("being installed by another process"),
+                "expected lock-busy message, got: {err}"
+            );
+
+            restore.commit();
+            WorkerActivationLock::acquire(name).expect("acquire after commit must succeed");
+        });
+    }
+
+    #[test]
+    fn active_worker_restore_holds_activation_lock_until_rollback() {
+        in_temp_dir(|dir| {
+            let _env_guard = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let home = dir.join("home");
+            std::fs::create_dir_all(&home).unwrap();
+            let _home_guard = set_env_var_for_test("HOME", &home);
+
+            let name = "rollback-lock-holder";
+            let lock = WorkerActivationLock::acquire(name).unwrap();
+            let restore = activate_locked_binary(name, "1.0.0", b"x", false, lock)
+                .unwrap()
+                .unwrap();
+
+            assert!(WorkerActivationLock::acquire(name).is_err());
+            restore.rollback();
+            WorkerActivationLock::acquire(name).expect("acquire after rollback must succeed");
+        });
     }
 
     #[test]

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -109,7 +109,7 @@ async fn main() -> anyhow::Result<()> {
         } => iii_worker::cli::managed::handle_managed_restart(&worker_name, !no_wait, port).await,
         Commands::List => iii_worker::cli::managed::handle_worker_list().await,
         Commands::Sync { frozen } => iii_worker::cli::managed::handle_worker_sync(frozen).await,
-        Commands::Verify => iii_worker::cli::managed::handle_worker_verify().await,
+        Commands::Verify { strict } => iii_worker::cli::managed::handle_worker_verify(strict).await,
         Commands::Status {
             worker_name,
             no_watch,

--- a/crates/iii-worker/tests/worker_integration.rs
+++ b/crates/iii-worker/tests/worker_integration.rs
@@ -35,7 +35,10 @@ fn cli_parses_all_subcommands() {
             assert!(matches!(c, Commands::Sync { .. }))
         }),
         (&["iii-worker", "verify"], |c| {
-            assert!(matches!(c, Commands::Verify))
+            assert!(matches!(c, Commands::Verify { strict: false }))
+        }),
+        (&["iii-worker", "verify", "--strict"], |c| {
+            assert!(matches!(c, Commands::Verify { strict: true }))
         }),
         (&["iii-worker", "logs", "my-worker"], |c| {
             assert!(matches!(c, Commands::Logs { .. }))
@@ -186,11 +189,11 @@ fn sync_subcommand_accepts_frozen_flag() {
 }
 
 #[test]
-fn sync_help_matches_current_read_only_behavior() {
+fn sync_help_matches_lockfile_replay_behavior() {
     let help = Cli::command().render_long_help().to_string();
 
-    assert!(help.contains("Read iii.lock and report pinned workers"));
-    assert!(!help.contains("Install workers exactly from iii.lock"));
+    assert!(help.contains("Install registry-managed workers exactly from iii.lock"));
+    assert!(help.contains("Pass --frozen in CI to verify without mutating local files"));
 }
 
 #[test]

--- a/docs/how-to/reproduce-worker-installs.mdx
+++ b/docs/how-to/reproduce-worker-installs.mdx
@@ -5,7 +5,7 @@ description: 'Use iii.lock to pin registry-managed workers and verify installs a
 
 ## Goal
 
-Use `iii.lock` to make registry-managed worker installs reproducible across local development, CI, and deployment environments.
+Use `iii.lock` to replay registry-managed worker installs across local development, CI, and deployment environments.
 
 ## Context
 
@@ -74,15 +74,23 @@ You can use `sync --frozen` for the same non-mutating check:
 iii worker sync --frozen
 ```
 
-### 4. Inspect the Pinned Set
+Use strict verification when you also want dependency declarations checked against the locked versions:
 
-Run `iii worker sync` to read `iii.lock` and print the number of pinned workers.
+```bash
+iii worker verify --strict
+```
+
+Strict mode checks dependency ranges recorded in `iii.lock` and local `iii.worker.yaml` dependency blocks. It does not update pins; use `iii worker update` when you intentionally want new resolved versions.
+
+### 4. Replay the Pinned Set
+
+Run `iii worker sync` after cloning a repo, changing machines, or restoring CI/deployment state. The command reads `iii.lock`, installs or repairs registry-managed workers for the current platform, and verifies binary artifacts by SHA-256 before activation.
 
 ```bash
 iii worker sync
 ```
 
-In the current implementation, non-frozen `sync` reads and parses the lockfile, then reports the pinned worker count. It does not install artifacts from `iii.lock` yet.
+`sync` does not contact the registry resolver, does not refresh versions, and does not rewrite `config.yaml` or `iii.lock`. It reports installed, already-current, repaired, skipped, and failed workers. Built-ins, direct OCI image references, local-path workers, and sandbox rootfs/base images are skipped because they are outside the v1 lockfile replay contract.
 
 ### 5. Update Pins Intentionally
 
@@ -102,7 +110,7 @@ iii worker update
 
 ## Result
 
-Your registry-managed workers are recorded in `iii.lock`, CI can verify that `config.yaml` and the lockfile agree, and worker updates happen through explicit `iii worker update` commands.
+Your registry-managed workers are recorded in `iii.lock`, `iii worker sync` can replay them from trusted registry artifact URLs, CI can verify that `config.yaml` and the lockfile agree, and worker updates happen through explicit `iii worker update` commands.
 
 <Info title="Lockfile reference">
   For the full lockfile schema and command summary, see [Managed Worker Lockfile](/workers/managed-worker-lockfile).

--- a/docs/workers/managed-worker-lockfile.mdx
+++ b/docs/workers/managed-worker-lockfile.mdx
@@ -3,7 +3,7 @@ title: 'Managed Worker Lockfile'
 description: 'Reference for iii.lock and the managed-worker lockfile commands.'
 ---
 
-`iii.lock` is a YAML lockfile in the project root. It records the resolved source pins for registry-managed workers so worker installs can be reproduced across environments. Binary workers can include artifacts for multiple platform targets in the same lockfile.
+`iii.lock` is a YAML lockfile in the project root. It records the resolved source pins for registry-managed workers so those workers can be replayed across environments with `iii worker sync`. Binary workers can include artifacts for multiple platform targets in the same lockfile.
 
 ## Location
 
@@ -42,7 +42,7 @@ Binary source entries are platform-neutral at the worker level. The `artifacts` 
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `url` | `string` | Yes | Download URL for this target's binary artifact. |
+| `url` | `string` | Yes | Trusted HTTPS iii registry download URL for this target's binary artifact. |
 | `sha256` | `string` | Yes | Expected SHA-256 digest for this target's binary artifact. |
 
 ### Image Source
@@ -86,9 +86,18 @@ workers:
 | --- | --- | --- |
 | `iii worker add <worker[@version]>` | Yes | Adds a registry-managed worker. When the registry returns a resolved graph, writes or merges `iii.lock` entries for the graph. |
 | `iii worker update [worker]` | Yes | Re-resolves `latest` for one locked worker, or inferred root workers when no name is provided, then rewrites `iii.lock`. |
-| `iii worker sync` | No | Reads `iii.lock` and reports the number of pinned workers. Current behavior does not install artifacts from the lockfile. |
+| `iii worker sync` | Yes, local artifacts only | Replays registry-managed workers from `iii.lock` for the current target. It installs or repairs active worker artifacts, does not contact the registry resolver, and does not rewrite `config.yaml` or `iii.lock`. |
 | `iii worker sync --frozen` | No | Delegates to `iii worker verify`. |
 | `iii worker verify` | No | Checks that every lockfile-managed worker in `config.yaml` has an entry in `iii.lock` and that locked binary workers include an artifact for the current target. Built-ins, direct OCI refs, and local-path sandbox workers are skipped. Extra lockfile entries are allowed. |
+| `iii worker verify --strict` | No | Runs the normal verification plus declaration freshness checks for locked dependency ranges and local `iii.worker.yaml` dependency blocks. |
+
+<Info title="Replay scope">
+  `iii worker sync` replays registry-managed workers recorded in `iii.lock`. Built-in workers, direct OCI refs, local-path workers, and sandbox rootfs/base images stay on their existing lifecycle flows and are reported as outside the v1 replay contract.
+</Info>
+
+<Info title="Artifact trust">
+  Binary replay accepts trusted HTTPS iii registry artifact URLs and verifies the downloaded bytes against the lockfile SHA-256 before activation. A hash proves integrity of the bytes, not that an arbitrary host is trusted, so lockfile replay rejects untrusted artifact hosts by default.
+</Info>
 
 <Info title="Legacy binary sources">
   Lockfiles that use the older single-target `target`, `url`, and `sha256` binary source fields are still read by the CLI. When the lockfile is rewritten, binary sources are serialized with the `artifacts` map.


### PR DESCRIPTION
## Summary
- make `iii worker sync` replay registry-managed workers from `iii.lock` without resolver/config/lockfile mutation
- add trusted artifact URL validation, unique temp paths, project and per-worker activation locks, staged activation, and rollback
- add `iii worker verify --strict` for dependency declaration freshness checks
- update CLI coverage and docs for lockfile replay behavior

## Tests
- `cargo fmt --all`
- `cargo test -p iii-worker --test worker_integration`
- `cargo test -p iii-worker handle_worker_sync`
- `cargo test -p iii-worker handle_worker_verify_strict`
- `cargo test -p iii-worker validate_locked_artifact_url`
- `cargo test -p iii-worker -- --test-threads=1`

## Notes
- Default parallel `cargo test -p iii-worker` previously exposed existing test isolation races around HOME/pidfile/process discovery; the targeted checks and full serial suite passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--strict` flag to `iii worker verify` for stricter dependency-range and manifest freshness checks.

* **Improvements**
  * `iii worker sync` now replays and installs registry-managed workers exactly from `iii.lock` for the current platform and reports installed/already_current/repaired/skipped/failed counts.
  * `--frozen` runs verification without mutating local files (CI mode).
  * Binary installs are idempotent, use activation locking with rollback support, verify SHA-256, and use safer download/validation rules that restrict artifact hosts. 

* **Documentation**
  * Updated docs to describe lockfile replay behavior, artifact trust model, and `verify --strict` usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->