### PR TITLE
feat(worker): detect manifest drift on `iii worker sync --frozen`

### DIFF
--- a/crates/iii-worker/src/cli/lockfile.rs
+++ b/crates/iii-worker/src/cli/lockfile.rs
@@ -137,13 +137,22 @@ impl Default for WorkerLockfile {
     }
 }
 
-/// Returns `true` if `s` matches the `"sha256:v1:<64-hex>"` manifest-hash
-/// shape. Used by lockfile validation and drift detection.
+/// Returns `true` if `s` matches the `"sha256:v1:<64-lowercase-hex>"`
+/// manifest-hash shape. Used by lockfile validation and drift detection.
+///
+/// Comparison against `compute_manifest_hash` output is byte-exact, and
+/// `hex::encode` always emits lowercase — so an uppercase-hex hash
+/// would silently never match and trigger false-positive drift on every
+/// sync. We reject uppercase here so the validator catches that
+/// hand-edit immediately.
 pub fn is_valid_manifest_hash(s: &str) -> bool {
     let Some(rest) = s.strip_prefix(MANIFEST_HASH_PREFIX) else {
         return false;
     };
-    rest.len() == 64 && rest.chars().all(|c| c.is_ascii_hexdigit())
+    rest.len() == 64
+        && rest
+            .chars()
+            .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
 }
 
 impl WorkerLockfile {
@@ -235,7 +244,22 @@ impl WorkerLockfile {
         {
             return Err(format!(
                 "{LOCKFILE_NAME} manifest_hash must match \
-                 `{MANIFEST_HASH_PREFIX}<64-hex>`; got `{hash}`"
+                 `{MANIFEST_HASH_PREFIX}<64-lowercase-hex>`; got `{hash}`"
+            ));
+        }
+
+        // `manifest_hash` and `declared_dependencies` must be paired:
+        // `(None, None)` is a legacy lock (drift detection skipped),
+        // `(Some, None)` is hash-only attribution, and `(Some, Some)` is
+        // the full Lane-A shape. `(None, Some)` is the dangerous combo
+        // — it means the deps are recorded but drift detection is
+        // disabled, so stripping the hash from a Lane-A lock would
+        // silently bypass `--frozen`.
+        if self.declared_dependencies.is_some() && self.manifest_hash.is_none() {
+            return Err(format!(
+                "{LOCKFILE_NAME}: declared_dependencies is set without manifest_hash; \
+                 the lock is internally inconsistent (stripping `manifest_hash` would \
+                 silently bypass drift detection)"
             ));
         }
 
@@ -244,9 +268,31 @@ impl WorkerLockfile {
                 super::registry::validate_worker_name(name).map_err(|e| {
                     format!("{LOCKFILE_NAME} declared dependency `{name}` is invalid: {e}")
                 })?;
-                if range.trim().is_empty() {
+                let trimmed = range.trim();
+                if trimmed.is_empty() {
                     return Err(format!(
                         "{LOCKFILE_NAME} declared dependency `{name}` has empty range"
+                    ));
+                }
+                semver::VersionReq::parse(trimmed).map_err(|e| {
+                    format!(
+                        "{LOCKFILE_NAME} declared dependency `{name}` has invalid \
+                         semver range `{range}`: {e}"
+                    )
+                })?;
+            }
+
+            // Cross-check: when both fields are present they must be
+            // mutually consistent. Compute the canonical hash from
+            // `declared_dependencies` and reject any mismatch — silent
+            // mismatches let drift detection produce empty,
+            // unactionable error reports.
+            if let Some(stored_hash) = &self.manifest_hash {
+                let computed = super::sync::compute_manifest_hash(declared);
+                if &computed != stored_hash {
+                    return Err(format!(
+                        "{LOCKFILE_NAME}: manifest_hash does not match \
+                         declared_dependencies; the lock is internally inconsistent"
                     ));
                 }
             }
@@ -925,7 +971,12 @@ workers:
             ("alpha".to_string(), "^1.0".to_string()),
             ("beta".to_string(), "~2.0".to_string()),
         ]);
+        // Validation requires manifest_hash and declared_dependencies
+        // to be paired and consistent. Compute the hash from the
+        // declared deps so the roundtrip stays valid.
+        let manifest_hash = Some(super::super::sync::compute_manifest_hash(&declared));
         let lock = WorkerLockfile {
+            manifest_hash,
             declared_dependencies: Some(declared.clone()),
             ..Default::default()
         };
@@ -936,12 +987,15 @@ workers:
 
     #[test]
     fn declared_dependencies_rejects_empty_range() {
-        let yaml = r#"version: 1
-declared_dependencies:
-  alpha: ""
-workers: {}
-"#;
-        let err = WorkerLockfile::from_yaml(yaml).unwrap_err();
+        // Pair the empty range with a manifest_hash so the (None,Some)
+        // pairing check doesn't fire first — we want to assert the
+        // empty-range check specifically.
+        let yaml = format!(
+            "version: 1\nmanifest_hash: \"{prefix}{hex}\"\ndeclared_dependencies:\n  alpha: \"\"\nworkers: {{}}\n",
+            prefix = MANIFEST_HASH_PREFIX,
+            hex = "0".repeat(64),
+        );
+        let err = WorkerLockfile::from_yaml(&yaml).unwrap_err();
         assert!(err.contains("alpha"), "got: {err}");
         assert!(err.contains("empty range"), "got: {err}");
     }

--- a/crates/iii-worker/src/cli/lockfile.rs
+++ b/crates/iii-worker/src/cli/lockfile.rs
@@ -13,9 +13,30 @@ use std::path::Path;
 const LOCKFILE_VERSION: u8 = 1;
 const LOCKFILE_NAME: &str = "iii.lock";
 
+/// Prefix for the manifest_hash header value: "sha256:v1:<64-hex>".
+/// The "v1" segment is the hash ALGORITHM version, independent of the
+/// lockfile FORMAT version. Changing the hash scheme in the future bumps
+/// this to "v2", and readers detect and recompute rather than silently
+/// accept a mismatched hash. Keeping it adjacent to the hex makes the
+/// shape greppable and the intent obvious in diffs.
+pub const MANIFEST_HASH_PREFIX: &str = "sha256:v1:";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkerLockfile {
     pub version: u8,
+    /// SHA-256 of the canonical manifest_dependencies serialization, prefixed
+    /// with [`MANIFEST_HASH_PREFIX`]. Optional for backward compat with locks
+    /// written before Lane A; absence means "drift detection unavailable for
+    /// this lock, treat all syncs as potentially drifted and re-resolve."
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manifest_hash: Option<String>,
+    /// The project's declared `iii.worker.yaml` dependencies at lock-write
+    /// time. `Some(map)` (even empty) means the lock was written by Lane A or
+    /// later and drift reports can name the exact added/removed/changed deps.
+    /// `None` means legacy lock — drift detection falls back to hash-only
+    /// compare without structured attribution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub declared_dependencies: Option<BTreeMap<String, String>>,
     pub workers: BTreeMap<String, LockedWorker>,
 }
 
@@ -109,9 +130,20 @@ impl Default for WorkerLockfile {
     fn default() -> Self {
         Self {
             version: LOCKFILE_VERSION,
+            manifest_hash: None,
+            declared_dependencies: None,
             workers: BTreeMap::new(),
         }
     }
+}
+
+/// Returns `true` if `s` matches the `"sha256:v1:<64-hex>"` manifest-hash
+/// shape. Used by lockfile validation and drift detection.
+pub fn is_valid_manifest_hash(s: &str) -> bool {
+    let Some(rest) = s.strip_prefix(MANIFEST_HASH_PREFIX) else {
+        return false;
+    };
+    rest.len() == 64 && rest.chars().all(|c| c.is_ascii_hexdigit())
 }
 
 impl WorkerLockfile {
@@ -135,9 +167,59 @@ impl WorkerLockfile {
         Self::from_yaml(&content)
     }
 
+    /// Write the lockfile atomically: serialize, write to an adjacent temp
+    /// file in the same directory, fsync, then `rename(2)` over the dest.
+    /// On POSIX rename is atomic on the same filesystem, so a concurrent
+    /// reader sees either the previous content or the new content, never
+    /// a partial mixture. On rename failure the temp file is cleaned up;
+    /// the destination is untouched.
     pub fn write_to(&self, path: &Path) -> Result<(), String> {
+        use std::io::Write;
+
         let yaml = self.to_yaml()?;
-        std::fs::write(path, yaml).map_err(|e| format!("failed to write {}: {e}", path.display()))
+        let parent = path.parent().filter(|p| !p.as_os_str().is_empty());
+        let dir = parent.unwrap_or_else(|| Path::new("."));
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| format!("invalid lockfile path: {}", path.display()))?
+            .to_string_lossy();
+
+        // PID + nanosecond timestamp + counter keeps the temp name unique
+        // across concurrent writers within this process and across forks.
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let nonce = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let tmp_name = format!(".{file_name}.tmp.{}.{nanos}.{nonce}", std::process::id());
+        let tmp_path = dir.join(&tmp_name);
+
+        let cleanup = |tmp: &Path| {
+            let _ = std::fs::remove_file(tmp);
+        };
+
+        let mut file = std::fs::File::create(&tmp_path).map_err(|e| {
+            format!(
+                "failed to create temp lockfile adjacent to {}: {e}",
+                path.display()
+            )
+        })?;
+        if let Err(e) = file.write_all(yaml.as_bytes()) {
+            cleanup(&tmp_path);
+            return Err(format!("failed to write {}: {e}", path.display()));
+        }
+        if let Err(e) = file.sync_all() {
+            cleanup(&tmp_path);
+            return Err(format!("failed to fsync {}: {e}", path.display()));
+        }
+        drop(file);
+
+        if let Err(e) = std::fs::rename(&tmp_path, path) {
+            cleanup(&tmp_path);
+            return Err(format!("failed to write {}: {e}", path.display()));
+        }
+        Ok(())
     }
 
     fn validate(&self) -> Result<(), String> {
@@ -146,6 +228,28 @@ impl WorkerLockfile {
                 "unsupported {LOCKFILE_NAME} version {} (expected {})",
                 self.version, LOCKFILE_VERSION
             ));
+        }
+
+        if let Some(hash) = &self.manifest_hash
+            && !is_valid_manifest_hash(hash)
+        {
+            return Err(format!(
+                "{LOCKFILE_NAME} manifest_hash must match \
+                 `{MANIFEST_HASH_PREFIX}<64-hex>`; got `{hash}`"
+            ));
+        }
+
+        if let Some(declared) = &self.declared_dependencies {
+            for (name, range) in declared {
+                super::registry::validate_worker_name(name).map_err(|e| {
+                    format!("{LOCKFILE_NAME} declared dependency `{name}` is invalid: {e}")
+                })?;
+                if range.trim().is_empty() {
+                    return Err(format!(
+                        "{LOCKFILE_NAME} declared dependency `{name}` has empty range"
+                    ));
+                }
+            }
         }
 
         for (name, worker) in &self.workers {
@@ -583,6 +687,75 @@ workers:
     }
 
     #[test]
+    fn write_to_does_not_leak_temp_files_on_success() {
+        // Atomicity requires writing through a temp file adjacent to the
+        // destination. That temp file must be cleaned up on success; a stale
+        // `.iii.lock.XXXXX.tmp` accumulating next to the lock every run
+        // would be a resource leak.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("iii.lock");
+        let lock = WorkerLockfile::default();
+
+        lock.write_to(&path).unwrap();
+
+        assert!(path.exists());
+        let stragglers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|name| name != "iii.lock")
+            .collect();
+        assert!(
+            stragglers.is_empty(),
+            "expected only iii.lock after successful write; found stragglers: {stragglers:?}"
+        );
+    }
+
+    #[test]
+    fn write_to_preserves_existing_file_when_serialization_fails() {
+        // If the lock fails validation during to_yaml(), the on-disk file
+        // must not be truncated. This is the atomic-rename contract: we
+        // only touch the destination after the new content is fully ready.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("iii.lock");
+
+        // Seed a valid lockfile.
+        let mut good = WorkerLockfile::default();
+        good.workers.insert(
+            "first".to_string(),
+            LockedWorker {
+                version: "1.0.0".to_string(),
+                worker_type: LockedWorkerType::Image,
+                dependencies: BTreeMap::new(),
+                source: Some(LockedSource::Image {
+                    image: "ghcr.io/iii-hq/first@sha256:abc".to_string(),
+                }),
+            },
+        );
+        good.write_to(&path).unwrap();
+        let seeded = std::fs::read_to_string(&path).unwrap();
+
+        // Craft a broken lockfile (unpinned image fails validate()).
+        let mut bad = WorkerLockfile::default();
+        bad.workers.insert(
+            "broken".to_string(),
+            LockedWorker {
+                version: "1.0.0".to_string(),
+                worker_type: LockedWorkerType::Image,
+                dependencies: BTreeMap::new(),
+                source: Some(LockedSource::Image {
+                    image: "ghcr.io/iii-hq/broken:latest".to_string(),
+                }),
+            },
+        );
+        let _ = bad.write_to(&path).unwrap_err();
+
+        // Failed write leaves seeded content intact.
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(after, seeded);
+    }
+
+    #[test]
     fn read_from_roundtrips_via_disk() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("iii.lock");
@@ -674,6 +847,156 @@ workers:
         assert!(err.contains("iii-http"));
         assert!(err.contains("engine"));
         assert!(err.contains("source"));
+    }
+
+    #[test]
+    fn manifest_hash_absent_roundtrips() {
+        // Legacy locks written before Lane A don't carry the header.
+        // Reading and writing one must leave it absent, not materialize
+        // an empty string.
+        let yaml = r#"version: 1
+workers:
+  hello:
+    version: 1.0.0
+    type: image
+    dependencies: {}
+    source:
+      kind: image
+      image: ghcr.io/iii-hq/hello@sha256:abc
+"#;
+        let parsed = WorkerLockfile::from_yaml(yaml).unwrap();
+        assert_eq!(parsed.manifest_hash, None);
+
+        let serialized = parsed.to_yaml().unwrap();
+        assert!(
+            !serialized.contains("manifest_hash"),
+            "absent hash must stay absent in output; got: {serialized}"
+        );
+    }
+
+    #[test]
+    fn manifest_hash_present_roundtrips() {
+        let hash = format!("{MANIFEST_HASH_PREFIX}{}", "a".repeat(64));
+        let mut lock = WorkerLockfile {
+            manifest_hash: Some(hash.clone()),
+            ..Default::default()
+        };
+        lock.workers.insert(
+            "hello".to_string(),
+            LockedWorker {
+                version: "1.0.0".to_string(),
+                worker_type: LockedWorkerType::Image,
+                dependencies: BTreeMap::new(),
+                source: Some(LockedSource::Image {
+                    image: "ghcr.io/iii-hq/hello@sha256:abc".to_string(),
+                }),
+            },
+        );
+        let serialized = lock.to_yaml().unwrap();
+        assert!(serialized.contains(&hash));
+        let parsed = WorkerLockfile::from_yaml(&serialized).unwrap();
+        assert_eq!(parsed.manifest_hash, Some(hash));
+    }
+
+    #[test]
+    fn declared_dependencies_absent_roundtrips() {
+        let yaml = r#"version: 1
+workers:
+  hello:
+    version: 1.0.0
+    type: image
+    dependencies: {}
+    source:
+      kind: image
+      image: ghcr.io/iii-hq/hello@sha256:abc
+"#;
+        let parsed = WorkerLockfile::from_yaml(yaml).unwrap();
+        assert_eq!(parsed.declared_dependencies, None);
+        let serialized = parsed.to_yaml().unwrap();
+        assert!(
+            !serialized.contains("declared_dependencies"),
+            "absent declared_dependencies must stay absent; got: {serialized}"
+        );
+    }
+
+    #[test]
+    fn declared_dependencies_roundtrip_with_entries() {
+        let declared = BTreeMap::from([
+            ("alpha".to_string(), "^1.0".to_string()),
+            ("beta".to_string(), "~2.0".to_string()),
+        ]);
+        let lock = WorkerLockfile {
+            declared_dependencies: Some(declared.clone()),
+            ..Default::default()
+        };
+        let serialized = lock.to_yaml().unwrap();
+        let parsed = WorkerLockfile::from_yaml(&serialized).unwrap();
+        assert_eq!(parsed.declared_dependencies, Some(declared));
+    }
+
+    #[test]
+    fn declared_dependencies_rejects_empty_range() {
+        let yaml = r#"version: 1
+declared_dependencies:
+  alpha: ""
+workers: {}
+"#;
+        let err = WorkerLockfile::from_yaml(yaml).unwrap_err();
+        assert!(err.contains("alpha"), "got: {err}");
+        assert!(err.contains("empty range"), "got: {err}");
+    }
+
+    #[test]
+    fn from_yaml_rejects_malformed_manifest_hash() {
+        let yaml = r#"version: 1
+manifest_hash: "not-even-close"
+workers: {}
+"#;
+        let err = WorkerLockfile::from_yaml(yaml).unwrap_err();
+        assert!(err.contains("manifest_hash"), "got: {err}");
+        assert!(err.contains(MANIFEST_HASH_PREFIX), "got: {err}");
+    }
+
+    #[test]
+    fn from_yaml_rejects_manifest_hash_with_wrong_algo_prefix() {
+        // Algorithm version bump guard: a lock written by future iii with a
+        // different hash algorithm must not be silently accepted by current
+        // iii. The prefix is the whole point of this check.
+        let yaml = format!(
+            "version: 1\nmanifest_hash: \"sha256:v2:{}\"\nworkers: {{}}\n",
+            "a".repeat(64)
+        );
+        let err = WorkerLockfile::from_yaml(&yaml).unwrap_err();
+        assert!(err.contains("manifest_hash"), "got: {err}");
+    }
+
+    #[test]
+    fn is_valid_manifest_hash_checks_prefix_and_hex_length() {
+        assert!(is_valid_manifest_hash(&format!(
+            "{MANIFEST_HASH_PREFIX}{}",
+            "0".repeat(64)
+        )));
+        assert!(is_valid_manifest_hash(&format!(
+            "{MANIFEST_HASH_PREFIX}{}",
+            "abcdef0123456789".repeat(4)
+        )));
+        // Missing prefix.
+        assert!(!is_valid_manifest_hash(&"0".repeat(64)));
+        // Wrong prefix.
+        assert!(!is_valid_manifest_hash(&format!(
+            "sha512:v1:{}",
+            "0".repeat(64)
+        )));
+        // Short hex.
+        assert!(!is_valid_manifest_hash(&format!(
+            "{MANIFEST_HASH_PREFIX}{}",
+            "0".repeat(63)
+        )));
+        // Non-hex.
+        assert!(!is_valid_manifest_hash(&format!(
+            "{MANIFEST_HASH_PREFIX}{}",
+            "z".repeat(64)
+        )));
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -223,6 +223,33 @@ pub async fn handle_managed_add_many(worker_names: &[String], wait: bool) -> i32
 
 pub async fn handle_worker_sync(frozen: bool) -> i32 {
     if frozen {
+        let lock_path = super::lockfile::lockfile_path();
+        let lockfile = match super::lockfile::WorkerLockfile::read_from(lock_path) {
+            Ok(lockfile) => lockfile,
+            Err(e) => {
+                eprintln!("{} {}", "error:".red(), e);
+                return 1;
+            }
+        };
+
+        // Drift check: only active for locks that carry a manifest_hash
+        // (i.e. written by Lane A or later). Legacy locks fall through
+        // to verify unchanged so we don't regress existing CI pipelines.
+        if let Some(stored_hash) = &lockfile.manifest_hash {
+            let manifest_deps = load_cwd_manifest_dependencies().unwrap_or_default();
+            let current_hash = super::sync::compute_manifest_hash(&manifest_deps);
+            if current_hash != *stored_hash {
+                let lock_deps = lockfile.declared_dependencies.clone().unwrap_or_default();
+                let report =
+                    super::sync::detect_drift(&manifest_deps, &lock_deps).unwrap_or_default();
+                let err = super::sync::SyncError::Drift { report };
+                // stdout is reserved for worker names; all diagnostic output
+                // — including the drift error — goes to stderr.
+                eprint!("{}", err.render());
+                return 1;
+            }
+        }
+
         return handle_worker_verify().await;
     }
 
@@ -542,6 +569,41 @@ fn persist_engine_worker_config_and_lock(
     Ok(())
 }
 
+/// Read the cwd `iii.worker.yaml` `dependencies:` block. Returns `None`
+/// when the file is absent, empty, or has a null dependencies field.
+/// Errors are downgraded to `None` with a stderr warning — missing or
+/// malformed root manifests should not block a resolve that otherwise
+/// succeeded; drift detection just doesn't light up for that project.
+fn load_cwd_manifest_dependencies() -> Option<std::collections::BTreeMap<String, String>> {
+    let manifest_path = std::path::Path::new("iii.worker.yaml");
+    if !manifest_path.exists() {
+        return None;
+    }
+    match super::project::load_manifest_dependencies(manifest_path) {
+        Ok(deps) => Some(deps),
+        Err(e) => {
+            eprintln!(
+                "  {} ignoring iii.worker.yaml for manifest_hash: {e}",
+                "warning:".yellow()
+            );
+            None
+        }
+    }
+}
+
+/// Populate [`super::lockfile::WorkerLockfile::manifest_hash`] and
+/// [`super::lockfile::WorkerLockfile::declared_dependencies`] from the
+/// current cwd manifest. No-ops when the manifest is absent, leaving both
+/// fields at whatever they were before (preserves previous writer's
+/// values across incremental `iii worker add` runs).
+fn populate_manifest_hash_fields(lockfile: &mut super::lockfile::WorkerLockfile) {
+    let Some(deps) = load_cwd_manifest_dependencies() else {
+        return;
+    };
+    lockfile.manifest_hash = Some(super::sync::compute_manifest_hash(&deps));
+    lockfile.declared_dependencies = Some(deps);
+}
+
 async fn handle_resolved_graph_add(graph: &ResolvedWorkerGraph, brief: bool) -> i32 {
     for node in &graph.graph {
         if let Err(e) = super::registry::validate_worker_name(&node.name) {
@@ -644,6 +706,16 @@ async fn handle_resolved_graph_add(graph: &ResolvedWorkerGraph, brief: bool) -> 
     for (name, worker) in graph_lockfile.workers {
         lockfile.workers.insert(name, worker);
     }
+
+    // Populate manifest_hash + declared_dependencies from the project's
+    // root iii.worker.yaml (if present) so `iii worker sync --frozen` can
+    // detect drift on the next run. Projects without a root manifest get
+    // `None` for both fields, which preserves legacy behavior.
+    //
+    // Slice A.1 limitation: only the cwd manifest is scanned. Multi-worker
+    // projects with manifests in subdirectories won't get aggregate
+    // drift detection until Slice A.2 adds project-wide scanning.
+    populate_manifest_hash_fields(&mut lockfile);
 
     if let Err(e) = lockfile.write_to(&lock_path) {
         eprintln!("{} {}", "error:".red(), e);
@@ -3906,6 +3978,121 @@ workers:
         in_temp_dir_async(|_| async move {
             let rc = handle_worker_sync(true).await;
             assert_eq!(rc, 1);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_worker_sync_frozen_passes_when_hash_matches() {
+        // A fresh lock written by Lane A carries manifest_hash +
+        // declared_dependencies. When the cwd manifest agrees, --frozen
+        // falls through to verify, which in turn passes because config.yaml
+        // is absent and the asymmetric verify design ignores extras.
+        in_temp_dir_async(|dir| async move {
+            use super::super::lockfile::{
+                LockedSource, LockedWorker, LockedWorkerType, WorkerLockfile,
+            };
+            use super::super::sync::compute_manifest_hash;
+            use std::collections::BTreeMap;
+
+            let manifest = r#"name: my-project
+dependencies:
+  alpha: "^1.0.0"
+"#;
+            std::fs::write(dir.join("iii.worker.yaml"), manifest).unwrap();
+
+            let declared = BTreeMap::from([("alpha".to_string(), "^1.0.0".to_string())]);
+            let mut lock = WorkerLockfile {
+                manifest_hash: Some(compute_manifest_hash(&declared)),
+                declared_dependencies: Some(declared),
+                ..Default::default()
+            };
+            lock.workers.insert(
+                "alpha".to_string(),
+                LockedWorker {
+                    version: "1.0.0".to_string(),
+                    worker_type: LockedWorkerType::Image,
+                    dependencies: BTreeMap::new(),
+                    source: Some(LockedSource::Image {
+                        image: "ghcr.io/iii-hq/alpha@sha256:aaa".to_string(),
+                    }),
+                },
+            );
+            lock.write_to(&dir.join("iii.lock")).unwrap();
+
+            let rc = handle_worker_sync(true).await;
+            assert_eq!(rc, 0);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_worker_sync_frozen_reports_drift_on_added_dep() {
+        in_temp_dir_async(|dir| async move {
+            use super::super::lockfile::WorkerLockfile;
+            use super::super::sync::compute_manifest_hash;
+            use std::collections::BTreeMap;
+
+            // Lock was written with only `alpha`, but the manifest now
+            // declares `alpha` + `beta`. --frozen must fail and name `beta`.
+            let original = BTreeMap::from([("alpha".to_string(), "^1.0.0".to_string())]);
+            let lock = WorkerLockfile {
+                manifest_hash: Some(compute_manifest_hash(&original)),
+                declared_dependencies: Some(original),
+                ..Default::default()
+            };
+            lock.write_to(&dir.join("iii.lock")).unwrap();
+
+            std::fs::write(
+                dir.join("iii.worker.yaml"),
+                "name: my-project\ndependencies:\n  alpha: \"^1.0.0\"\n  beta: \"^2.0.0\"\n",
+            )
+            .unwrap();
+
+            let rc = handle_worker_sync(true).await;
+            assert_eq!(rc, 1);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_worker_sync_frozen_skips_drift_on_legacy_lock() {
+        // Legacy lock (no manifest_hash) must NOT trigger drift detection.
+        // It falls through to the existing verify path, which fails because
+        // config.yaml listing is broken in a pristine tempdir; but the code
+        // path we're testing is that we got to verify, not that sync
+        // short-circuited with a drift error.
+        in_temp_dir_async(|dir| async move {
+            use super::super::lockfile::{
+                LockedSource, LockedWorker, LockedWorkerType, WorkerLockfile,
+            };
+            use std::collections::BTreeMap;
+
+            let mut lock = WorkerLockfile::default();
+            lock.workers.insert(
+                "alpha".to_string(),
+                LockedWorker {
+                    version: "1.0.0".to_string(),
+                    worker_type: LockedWorkerType::Image,
+                    dependencies: BTreeMap::new(),
+                    source: Some(LockedSource::Image {
+                        image: "ghcr.io/iii-hq/alpha@sha256:aaa".to_string(),
+                    }),
+                },
+            );
+            lock.write_to(&dir.join("iii.lock")).unwrap();
+            // Manifest declares a dep not in the legacy lock. With no
+            // manifest_hash stored, this MUST NOT trigger drift.
+            std::fs::write(
+                dir.join("iii.worker.yaml"),
+                "name: my-project\ndependencies:\n  beta: \"^2.0.0\"\n",
+            )
+            .unwrap();
+
+            let rc = handle_worker_sync(true).await;
+            // Falls through to verify, which passes because config.yaml
+            // is absent and verify is asymmetric w.r.t. extras.
+            assert_eq!(rc, 0);
         })
         .await;
     }

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -235,16 +235,38 @@ pub async fn handle_worker_sync(frozen: bool) -> i32 {
         // Drift check: only active for locks that carry a manifest_hash
         // (i.e. written by Lane A or later). Legacy locks fall through
         // to verify unchanged so we don't regress existing CI pipelines.
+        //
+        // Each `iii.worker.yaml` state surfaces a distinct error so the
+        // user sees what's actually wrong: a *missing* manifest reads
+        // as `ManifestMissing`, a *malformed* one as `CorruptManifest`,
+        // and a hash mismatch with no structural drift as
+        // `LockInconsistent`. Only an actual content change reaches the
+        // `Drift` variant — the one with actionable add/remove/change
+        // attribution.
         if let Some(stored_hash) = &lockfile.manifest_hash {
-            let manifest_deps = load_cwd_manifest_dependencies().unwrap_or_default();
-            let current_hash = super::sync::compute_manifest_hash(&manifest_deps);
-            if current_hash != *stored_hash {
-                let lock_deps = lockfile.declared_dependencies.clone().unwrap_or_default();
-                let report =
-                    super::sync::detect_drift(&manifest_deps, &lock_deps).unwrap_or_default();
-                let err = super::sync::SyncError::Drift { report };
-                // stdout is reserved for worker names; all diagnostic output
-                // — including the drift error — goes to stderr.
+            let err: Option<super::sync::SyncError> = match load_cwd_manifest_state() {
+                ManifestState::Missing => Some(super::sync::SyncError::ManifestMissing {
+                    lock_deps: lockfile.declared_dependencies.clone().unwrap_or_default(),
+                }),
+                ManifestState::Malformed(reason) => {
+                    Some(super::sync::SyncError::CorruptManifest { reason })
+                }
+                ManifestState::Loaded(manifest_deps) => {
+                    let current_hash = super::sync::compute_manifest_hash(&manifest_deps);
+                    if current_hash != *stored_hash {
+                        let lock_deps = lockfile.declared_dependencies.clone().unwrap_or_default();
+                        match super::sync::detect_drift(&manifest_deps, &lock_deps) {
+                            Some(report) => Some(super::sync::SyncError::Drift { report }),
+                            None => Some(super::sync::SyncError::LockInconsistent),
+                        }
+                    } else {
+                        None
+                    }
+                }
+            };
+            if let Some(err) = err {
+                // stdout is reserved for worker names; all diagnostic
+                // output goes to stderr.
                 eprint!("{}", err.render());
                 return 1;
             }
@@ -569,19 +591,40 @@ fn persist_engine_worker_config_and_lock(
     Ok(())
 }
 
+/// Distinguishes the three states of `iii.worker.yaml` that drift
+/// detection cares about. Collapsing `Missing` and `Malformed` into the
+/// same fallback (as `load_cwd_manifest_dependencies` does for the
+/// `iii worker add` write path) is fine for *populating* a fresh hash,
+/// but it produces misleading "drift" output when those states arise
+/// during `--frozen`. The `--frozen` path uses this enum directly so
+/// each state surfaces with its own error variant.
+pub(crate) enum ManifestState {
+    Missing,
+    Malformed(String),
+    Loaded(std::collections::BTreeMap<String, String>),
+}
+
+pub(crate) fn load_cwd_manifest_state() -> ManifestState {
+    let manifest_path = std::path::Path::new("iii.worker.yaml");
+    if !manifest_path.exists() {
+        return ManifestState::Missing;
+    }
+    match super::project::load_manifest_dependencies(manifest_path) {
+        Ok(deps) => ManifestState::Loaded(deps),
+        Err(e) => ManifestState::Malformed(e),
+    }
+}
+
 /// Read the cwd `iii.worker.yaml` `dependencies:` block. Returns `None`
 /// when the file is absent, empty, or has a null dependencies field.
 /// Errors are downgraded to `None` with a stderr warning — missing or
 /// malformed root manifests should not block a resolve that otherwise
 /// succeeded; drift detection just doesn't light up for that project.
 fn load_cwd_manifest_dependencies() -> Option<std::collections::BTreeMap<String, String>> {
-    let manifest_path = std::path::Path::new("iii.worker.yaml");
-    if !manifest_path.exists() {
-        return None;
-    }
-    match super::project::load_manifest_dependencies(manifest_path) {
-        Ok(deps) => Some(deps),
-        Err(e) => {
+    match load_cwd_manifest_state() {
+        ManifestState::Loaded(deps) => Some(deps),
+        ManifestState::Missing => None,
+        ManifestState::Malformed(e) => {
             eprintln!(
                 "  {} ignoring iii.worker.yaml for manifest_hash: {e}",
                 "warning:".yellow()
@@ -4093,6 +4136,87 @@ dependencies:
             // Falls through to verify, which passes because config.yaml
             // is absent and verify is asymmetric w.r.t. extras.
             assert_eq!(rc, 0);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_worker_sync_frozen_fails_when_manifest_missing() {
+        // Lock has manifest_hash + declared_dependencies but
+        // iii.worker.yaml doesn't exist. The user must see a distinct
+        // error — NOT a misleading "drift" report — and rc must be 1.
+        in_temp_dir_async(|dir| async move {
+            use super::super::lockfile::WorkerLockfile;
+            use super::super::sync::compute_manifest_hash;
+            use std::collections::BTreeMap;
+
+            let declared = BTreeMap::from([("alpha".to_string(), "^1.0.0".to_string())]);
+            let lock = WorkerLockfile {
+                manifest_hash: Some(compute_manifest_hash(&declared)),
+                declared_dependencies: Some(declared),
+                ..Default::default()
+            };
+            lock.write_to(&dir.join("iii.lock")).unwrap();
+            // No iii.worker.yaml — that's the scenario.
+
+            let rc = handle_worker_sync(true).await;
+            assert_eq!(rc, 1);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_worker_sync_frozen_fails_when_manifest_malformed() {
+        // Lock is fine; iii.worker.yaml has bad YAML. The user must see
+        // a CorruptManifest error (with the parser reason) — not drift.
+        in_temp_dir_async(|dir| async move {
+            use super::super::lockfile::WorkerLockfile;
+            use super::super::sync::compute_manifest_hash;
+            use std::collections::BTreeMap;
+
+            let declared = BTreeMap::from([("alpha".to_string(), "^1.0.0".to_string())]);
+            let lock = WorkerLockfile {
+                manifest_hash: Some(compute_manifest_hash(&declared)),
+                declared_dependencies: Some(declared),
+                ..Default::default()
+            };
+            lock.write_to(&dir.join("iii.lock")).unwrap();
+            std::fs::write(
+                dir.join("iii.worker.yaml"),
+                "name: x\ndependencies: this-is-not-a-mapping\n",
+            )
+            .unwrap();
+
+            let rc = handle_worker_sync(true).await;
+            assert_eq!(rc, 1);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_worker_sync_frozen_rejects_inconsistent_lock_at_read() {
+        // A lock with manifest_hash that does NOT match its
+        // declared_dependencies must be rejected at read time so the
+        // empty-drift-report path is unreachable end-to-end.
+        in_temp_dir_async(|dir| async move {
+            use super::super::lockfile::MANIFEST_HASH_PREFIX;
+
+            let bogus_hash = format!("{MANIFEST_HASH_PREFIX}{}", "f".repeat(64));
+            std::fs::write(
+                dir.join("iii.lock"),
+                format!(
+                    "version: 1\nmanifest_hash: \"{bogus_hash}\"\ndeclared_dependencies:\n  alpha: \"^1.0.0\"\nworkers: {{}}\n",
+                ),
+            )
+            .unwrap();
+            std::fs::write(
+                dir.join("iii.worker.yaml"),
+                "name: x\ndependencies:\n  alpha: \"^1.0.0\"\n",
+            )
+            .unwrap();
+
+            let rc = handle_worker_sync(true).await;
+            assert_eq!(rc, 1);
         })
         .await;
     }

--- a/crates/iii-worker/src/cli/mod.rs
+++ b/crates/iii-worker/src/cli/mod.rs
@@ -26,6 +26,7 @@ pub mod shell_relay;
 pub mod source_watcher;
 pub mod status;
 pub mod supervisor_ctl;
+pub mod sync;
 #[cfg(test)]
 pub(crate) mod test_support;
 pub mod vm_boot;

--- a/crates/iii-worker/src/cli/sync.rs
+++ b/crates/iii-worker/src/cli/sync.rs
@@ -107,6 +107,21 @@ pub enum SyncError {
     Drift { report: DriftReport },
     /// Lockfile on disk but malformed or unreadable.
     CorruptLock { path: String, reason: String },
+    /// `iii.worker.yaml` does not exist but the lock recorded a
+    /// manifest_hash. Distinct from drift: the manifest isn't *changed*,
+    /// it's *gone* — the user needs to restore the file or remove the
+    /// lock, not run `--refresh`.
+    ManifestMissing { lock_deps: BTreeMap<String, String> },
+    /// `iii.worker.yaml` exists but failed to parse. The reason carries
+    /// the parser's message so the user can fix the YAML directly.
+    CorruptManifest { reason: String },
+    /// The lock's `manifest_hash` does not match
+    /// `compute_manifest_hash(&declared_dependencies)` AND
+    /// declared_dependencies equals the manifest deps. The lock is
+    /// internally inconsistent (likely tampered or partially edited);
+    /// drift attribution would be empty so we surface the corruption
+    /// directly instead.
+    LockInconsistent,
     // CacheMiss and NetworkRequired variants land in Slice A.3 (install-
     // from-lock) and Lane B (CAS). Not included here to avoid dead code.
 }
@@ -127,8 +142,32 @@ impl SyncError {
                      docs: https://iii.dev/docs/sync#corrupt-lock\n"
                 )
             }
+            Self::ManifestMissing { lock_deps } => render_manifest_missing(lock_deps),
+            Self::CorruptManifest { reason } => {
+                format!(
+                    "error: iii.worker.yaml failed to parse: {reason}\n\
+                     fix: correct the YAML in iii.worker.yaml and re-run\n\
+                     docs: https://iii.dev/docs/sync#corrupt-manifest\n"
+                )
+            }
+            Self::LockInconsistent => String::from(
+                "error: iii.lock is internally inconsistent: \
+                 manifest_hash does not match declared_dependencies\n\
+                 fix: restore iii.lock from git, or regenerate with `iii worker add`\n\
+                 docs: https://iii.dev/docs/sync#corrupt-lock\n",
+            ),
         }
     }
+}
+
+fn render_manifest_missing(lock_deps: &BTreeMap<String, String>) -> String {
+    let mut out = String::from("error: iii.worker.yaml is missing but iii.lock expects it\n");
+    for (name, range) in lock_deps {
+        out.push_str(&format!("  - {name} \"{range}\" (in lock)\n"));
+    }
+    out.push_str("fix: restore iii.worker.yaml from git, or remove iii.lock\n");
+    out.push_str("docs: https://iii.dev/docs/sync#missing-manifest\n");
+    out
 }
 
 fn render_drift(report: &DriftReport) -> String {
@@ -370,5 +409,43 @@ fix: restore the file from git or run `iii worker sync --refresh`
 docs: https://iii.dev/docs/sync#corrupt-lock
 ";
         assert_eq!(err.render(), expected);
+    }
+
+    #[test]
+    fn render_manifest_missing_golden() {
+        let err = SyncError::ManifestMissing {
+            lock_deps: deps(&[("alpha", "^1.0.0"), ("beta", "^2.0.0")]),
+        };
+        let expected = "\
+error: iii.worker.yaml is missing but iii.lock expects it
+  - alpha \"^1.0.0\" (in lock)
+  - beta \"^2.0.0\" (in lock)
+fix: restore iii.worker.yaml from git, or remove iii.lock
+docs: https://iii.dev/docs/sync#missing-manifest
+";
+        assert_eq!(err.render(), expected);
+    }
+
+    #[test]
+    fn render_corrupt_manifest_golden() {
+        let err = SyncError::CorruptManifest {
+            reason: "`dependencies` must be a mapping".into(),
+        };
+        let expected = "\
+error: iii.worker.yaml failed to parse: `dependencies` must be a mapping
+fix: correct the YAML in iii.worker.yaml and re-run
+docs: https://iii.dev/docs/sync#corrupt-manifest
+";
+        assert_eq!(err.render(), expected);
+    }
+
+    #[test]
+    fn render_lock_inconsistent_golden() {
+        let expected = "\
+error: iii.lock is internally inconsistent: manifest_hash does not match declared_dependencies
+fix: restore iii.lock from git, or regenerate with `iii worker add`
+docs: https://iii.dev/docs/sync#corrupt-lock
+";
+        assert_eq!(SyncError::LockInconsistent.render(), expected);
     }
 }

--- a/crates/iii-worker/src/cli/sync.rs
+++ b/crates/iii-worker/src/cli/sync.rs
@@ -1,0 +1,374 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at support@motia.dev
+// See LICENSE and PATENTS files for details.
+
+//! `iii worker sync` — lock-as-truth install path and drift detection.
+//!
+//! Slice A.1 (this file): the primitives — manifest hashing, drift
+//! detection, and the `SyncError` rendering contract for user-facing
+//! errors. The `handle_worker_sync` callsite in `managed.rs` wires the
+//! `--frozen` path to these primitives. Install-from-lock and CAS land
+//! in later slices.
+
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+
+use super::lockfile::MANIFEST_HASH_PREFIX;
+
+/// Compute the canonical hash of a declared-dependency set.
+///
+/// The input is the parser output from `worker_manifest_deps::parse_dependencies`
+/// — a sorted `BTreeMap<String, String>` of `name → semver-range`. Serialization
+/// is explicit and whitespace-stable: one line per entry, `"{name}={range}\n"`.
+/// YAML quoting, comments, and key ordering in the source file are normalized
+/// away by the parser before they reach this function, so a `yamlfmt` round-trip
+/// produces the same hash.
+///
+/// Output is prefixed with `MANIFEST_HASH_PREFIX` (`"sha256:v1:"`). The `v1`
+/// segment is the ALGORITHM version — if we ever change what bytes we hash or
+/// how we serialize them, bump to `v2:` so existing locks are recognized as
+/// stale and re-hashed rather than silently mismatching.
+pub fn compute_manifest_hash(deps: &BTreeMap<String, String>) -> String {
+    let mut hasher = Sha256::new();
+    for (name, range) in deps {
+        hasher.update(name.as_bytes());
+        hasher.update(b"=");
+        hasher.update(range.as_bytes());
+        hasher.update(b"\n");
+    }
+    let digest = hasher.finalize();
+    format!("{MANIFEST_HASH_PREFIX}{}", hex::encode(digest))
+}
+
+/// What changed between the manifest's declared deps and the locked
+/// transitive graph's root declared deps. `changed` holds the name plus
+/// `(old_range, new_range)`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DriftReport {
+    pub added: Vec<(String, String)>,
+    pub removed: Vec<(String, String)>,
+    pub changed: Vec<(String, String, String)>,
+}
+
+impl DriftReport {
+    pub fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.removed.is_empty() && self.changed.is_empty()
+    }
+}
+
+/// Compare the current manifest-declared deps against the deps recorded
+/// in the lockfile. Returns `None` when they agree. Returns `Some(report)`
+/// naming every added, removed, and range-changed entry, sorted by name
+/// within each bucket so diffs are stable in CI output.
+pub fn detect_drift(
+    manifest_deps: &BTreeMap<String, String>,
+    lock_deps: &BTreeMap<String, String>,
+) -> Option<DriftReport> {
+    let mut report = DriftReport::default();
+
+    for (name, range) in manifest_deps {
+        match lock_deps.get(name) {
+            None => report.added.push((name.clone(), range.clone())),
+            Some(locked) if locked != range => {
+                report
+                    .changed
+                    .push((name.clone(), locked.clone(), range.clone()));
+            }
+            Some(_) => {}
+        }
+    }
+    for (name, range) in lock_deps {
+        if !manifest_deps.contains_key(name) {
+            report.removed.push((name.clone(), range.clone()));
+        }
+    }
+
+    // Inputs are BTreeMaps so iteration is already sorted; the Vec order
+    // inherits that. Explicit here so reorderings above stay safe.
+    report.added.sort();
+    report.removed.sort();
+    report.changed.sort();
+
+    if report.is_empty() {
+        None
+    } else {
+        Some(report)
+    }
+}
+
+/// User-facing errors emitted by the sync command. Each variant carries
+/// enough context to render the `error: / fix: / docs:` three-line format
+/// committed to in the plan (D8).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SyncError {
+    /// The manifest and lockfile disagree. Rendered as a structured diff.
+    Drift { report: DriftReport },
+    /// Lockfile on disk but malformed or unreadable.
+    CorruptLock { path: String, reason: String },
+    // CacheMiss and NetworkRequired variants land in Slice A.3 (install-
+    // from-lock) and Lane B (CAS). Not included here to avoid dead code.
+}
+
+impl SyncError {
+    /// Three-line rendering: `error:`, per-item diff, `fix:`, `docs:`.
+    /// Stable byte-for-byte output so downstream snapshot tests can pin
+    /// exact bytes. Colors are intentionally omitted here — the callsite
+    /// in `managed.rs` wraps with `colored` when writing to a TTY, but
+    /// golden tests compare the raw template.
+    pub fn render(&self) -> String {
+        match self {
+            Self::Drift { report } => render_drift(report),
+            Self::CorruptLock { path, reason } => {
+                format!(
+                    "error: iii.lock at {path} is unreadable: {reason}\n\
+                     fix: restore the file from git or run `iii worker sync --refresh`\n\
+                     docs: https://iii.dev/docs/sync#corrupt-lock\n"
+                )
+            }
+        }
+    }
+}
+
+fn render_drift(report: &DriftReport) -> String {
+    let mut out = String::from("error: iii.worker.yaml drift vs iii.lock\n");
+    for (name, range) in &report.added {
+        out.push_str(&format!("  + {name} \"{range}\" (not in lock)\n"));
+    }
+    for (name, range) in &report.removed {
+        out.push_str(&format!(
+            "  - {name} \"{range}\" (in lock, not in manifest)\n"
+        ));
+    }
+    for (name, old, new) in &report.changed {
+        out.push_str(&format!("  ~ {name} \"{old}\" → \"{new}\"\n"));
+    }
+    out.push_str("fix: run `iii worker sync --refresh && git add iii.lock`\n");
+    out.push_str("docs: https://iii.dev/docs/sync#drift\n");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn deps(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn compute_manifest_hash_is_deterministic() {
+        let a = deps(&[("alpha", "^1.0"), ("beta", "~2.0")]);
+        let b = deps(&[("alpha", "^1.0"), ("beta", "~2.0")]);
+        assert_eq!(compute_manifest_hash(&a), compute_manifest_hash(&b));
+    }
+
+    #[test]
+    fn compute_manifest_hash_is_key_order_independent() {
+        // BTreeMap sorts on insert, so this is really checking that iteration
+        // order in the hasher matches the sort order. Documented here so a
+        // future switch to HashMap doesn't silently break.
+        let mut forward = BTreeMap::new();
+        forward.insert("alpha".to_string(), "^1.0".to_string());
+        forward.insert("beta".to_string(), "~2.0".to_string());
+
+        let mut reverse = BTreeMap::new();
+        reverse.insert("beta".to_string(), "~2.0".to_string());
+        reverse.insert("alpha".to_string(), "^1.0".to_string());
+
+        assert_eq!(
+            compute_manifest_hash(&forward),
+            compute_manifest_hash(&reverse)
+        );
+    }
+
+    #[test]
+    fn compute_manifest_hash_distinguishes_range_changes() {
+        let a = deps(&[("alpha", "^1.0")]);
+        let b = deps(&[("alpha", "^1.1")]);
+        assert_ne!(compute_manifest_hash(&a), compute_manifest_hash(&b));
+    }
+
+    #[test]
+    fn compute_manifest_hash_distinguishes_dep_set_changes() {
+        let a = deps(&[("alpha", "^1.0")]);
+        let b = deps(&[("alpha", "^1.0"), ("beta", "^2.0")]);
+        assert_ne!(compute_manifest_hash(&a), compute_manifest_hash(&b));
+    }
+
+    #[test]
+    fn compute_manifest_hash_empty_is_stable() {
+        // An empty deps map still produces a deterministic well-formed hash.
+        // This is the hash embedded into locks created by projects with no
+        // declared dependencies — it must be distinguishable from "no hash
+        // was ever computed" (None in the lockfile field).
+        let h = compute_manifest_hash(&BTreeMap::new());
+        assert!(h.starts_with(MANIFEST_HASH_PREFIX));
+        // SHA-256 of the empty string.
+        let expected_hex = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        assert_eq!(h, format!("{MANIFEST_HASH_PREFIX}{expected_hex}"));
+    }
+
+    #[test]
+    fn compute_manifest_hash_has_algorithm_version_prefix() {
+        // The "v1:" segment is load-bearing — it lets future iii detect
+        // hash-algo bumps. If someone drops it, this test fails.
+        let h = compute_manifest_hash(&deps(&[("alpha", "^1.0")]));
+        assert!(h.starts_with("sha256:v1:"), "got: {h}");
+    }
+
+    #[test]
+    fn detect_drift_none_on_exact_match() {
+        let d = deps(&[("alpha", "^1.0"), ("beta", "~2.0")]);
+        assert_eq!(detect_drift(&d, &d), None);
+    }
+
+    #[test]
+    fn detect_drift_none_on_both_empty() {
+        assert_eq!(detect_drift(&BTreeMap::new(), &BTreeMap::new()), None);
+    }
+
+    #[test]
+    fn detect_drift_flags_added_deps() {
+        let manifest = deps(&[("alpha", "^1.0"), ("beta", "~2.0")]);
+        let lock = deps(&[("alpha", "^1.0")]);
+        let report = detect_drift(&manifest, &lock).unwrap();
+        assert_eq!(report.added, vec![("beta".to_string(), "~2.0".to_string())]);
+        assert!(report.removed.is_empty());
+        assert!(report.changed.is_empty());
+    }
+
+    #[test]
+    fn detect_drift_flags_removed_deps() {
+        let manifest = deps(&[("alpha", "^1.0")]);
+        let lock = deps(&[("alpha", "^1.0"), ("gone", "^9.0")]);
+        let report = detect_drift(&manifest, &lock).unwrap();
+        assert_eq!(
+            report.removed,
+            vec![("gone".to_string(), "^9.0".to_string())]
+        );
+    }
+
+    #[test]
+    fn detect_drift_flags_range_changes() {
+        let manifest = deps(&[("alpha", "^1.1")]);
+        let lock = deps(&[("alpha", "^1.0")]);
+        let report = detect_drift(&manifest, &lock).unwrap();
+        assert_eq!(
+            report.changed,
+            vec![("alpha".to_string(), "^1.0".to_string(), "^1.1".to_string())]
+        );
+    }
+
+    #[test]
+    fn detect_drift_buckets_mixed_changes() {
+        let manifest = deps(&[("added", "^1.0"), ("changed", "^2.1"), ("same", "^3.0")]);
+        let lock = deps(&[("changed", "^2.0"), ("removed", "^9.0"), ("same", "^3.0")]);
+        let report = detect_drift(&manifest, &lock).unwrap();
+        assert_eq!(
+            report.added,
+            vec![("added".to_string(), "^1.0".to_string())]
+        );
+        assert_eq!(
+            report.removed,
+            vec![("removed".to_string(), "^9.0".to_string())]
+        );
+        assert_eq!(
+            report.changed,
+            vec![(
+                "changed".to_string(),
+                "^2.0".to_string(),
+                "^2.1".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn render_drift_added_only_golden() {
+        let err = SyncError::Drift {
+            report: DriftReport {
+                added: vec![("helper-worker".into(), "^2.0.0".into())],
+                ..Default::default()
+            },
+        };
+        let expected = "\
+error: iii.worker.yaml drift vs iii.lock
+  + helper-worker \"^2.0.0\" (not in lock)
+fix: run `iii worker sync --refresh && git add iii.lock`
+docs: https://iii.dev/docs/sync#drift
+";
+        assert_eq!(err.render(), expected);
+    }
+
+    #[test]
+    fn render_drift_removed_only_golden() {
+        let err = SyncError::Drift {
+            report: DriftReport {
+                removed: vec![("stale-worker".into(), "^1.0.0".into())],
+                ..Default::default()
+            },
+        };
+        let expected = "\
+error: iii.worker.yaml drift vs iii.lock
+  - stale-worker \"^1.0.0\" (in lock, not in manifest)
+fix: run `iii worker sync --refresh && git add iii.lock`
+docs: https://iii.dev/docs/sync#drift
+";
+        assert_eq!(err.render(), expected);
+    }
+
+    #[test]
+    fn render_drift_range_change_golden() {
+        let err = SyncError::Drift {
+            report: DriftReport {
+                changed: vec![("http-worker".into(), "^1.0.0".into(), "^1.1.0".into())],
+                ..Default::default()
+            },
+        };
+        let expected = "\
+error: iii.worker.yaml drift vs iii.lock
+  ~ http-worker \"^1.0.0\" → \"^1.1.0\"
+fix: run `iii worker sync --refresh && git add iii.lock`
+docs: https://iii.dev/docs/sync#drift
+";
+        assert_eq!(err.render(), expected);
+    }
+
+    #[test]
+    fn render_drift_mixed_golden() {
+        // The exact shape committed to in the plan's D8 example.
+        let err = SyncError::Drift {
+            report: DriftReport {
+                added: vec![("helper-worker".into(), "^2.0.0".into())],
+                changed: vec![("http-worker".into(), "^1.0.0".into(), "^1.1.0".into())],
+                ..Default::default()
+            },
+        };
+        let expected = "\
+error: iii.worker.yaml drift vs iii.lock
+  + helper-worker \"^2.0.0\" (not in lock)
+  ~ http-worker \"^1.0.0\" → \"^1.1.0\"
+fix: run `iii worker sync --refresh && git add iii.lock`
+docs: https://iii.dev/docs/sync#drift
+";
+        assert_eq!(err.render(), expected);
+    }
+
+    #[test]
+    fn render_corrupt_lock() {
+        let err = SyncError::CorruptLock {
+            path: "iii.lock".into(),
+            reason: "unexpected character at line 3".into(),
+        };
+        let expected = "\
+error: iii.lock at iii.lock is unreadable: unexpected character at line 3
+fix: restore the file from git or run `iii worker sync --refresh`
+docs: https://iii.dev/docs/sync#corrupt-lock
+";
+        assert_eq!(err.render(), expected);
+    }
+}

--- a/crates/iii-worker/tests/sync_drift_adversarial.rs
+++ b/crates/iii-worker/tests/sync_drift_adversarial.rs
@@ -1,0 +1,378 @@
+// Adversarial tests for the drift-detection / atomic-write behavior
+// from PR #1543. Each test pins a real-world failure mode the
+// implementation must guard against.
+
+use iii_worker::cli::lockfile::{
+    LockedSource, LockedWorker, LockedWorkerType, MANIFEST_HASH_PREFIX, WorkerLockfile,
+    is_valid_manifest_hash,
+};
+use iii_worker::cli::sync::{SyncError, compute_manifest_hash, detect_drift};
+use std::collections::BTreeMap;
+
+fn deps(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect()
+}
+
+fn image_worker(image: &str) -> LockedWorker {
+    LockedWorker {
+        version: "1.0.0".to_string(),
+        worker_type: LockedWorkerType::Image,
+        dependencies: BTreeMap::new(),
+        source: Some(LockedSource::Image {
+            image: image.to_string(),
+        }),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Hash determinism / canonicalization (acceptable behavior pinned)
+// ---------------------------------------------------------------------------
+
+/// Two ranges that are *semver-equivalent* but differ in whitespace must
+/// produce different hashes. The lockfile records the literal text; a
+/// future "normalize before hashing" change would need to re-evaluate
+/// drift semantics.
+#[test]
+fn whitespace_in_range_changes_hash() {
+    let tight = deps(&[("alpha", "^1.0")]);
+    let loose = deps(&[("alpha", "^ 1.0")]);
+    assert_ne!(compute_manifest_hash(&tight), compute_manifest_hash(&loose));
+}
+
+/// Worker names are restricted to `[a-zA-Z0-9._-]` (registry::validate_worker_name),
+/// so they cannot contain `=` or `\n`. Even a malicious caller can't
+/// produce a hash collision via embedded delimiters in ranges.
+#[test]
+fn ranges_with_embedded_eq_dont_collide() {
+    let a = deps(&[("alpha", "=1.0.0"), ("beta", "=2.0.0")]);
+    let b = deps(&[("alpha", "=1.0.0=2.0.0"), ("beta", "")]);
+    assert_ne!(compute_manifest_hash(&a), compute_manifest_hash(&b));
+}
+
+// ---------------------------------------------------------------------------
+// 2. Drift detection (correct behavior expected)
+// ---------------------------------------------------------------------------
+
+/// detect_drift on identical maps returns None.
+#[test]
+fn drift_none_when_equal_with_special_chars() {
+    let d = deps(&[("alpha", ">=1.0.0, <2.0.0"), ("beta", "*")]);
+    assert_eq!(detect_drift(&d, &d), None);
+}
+
+/// **Bug fix**: when handle_worker_sync detects a hash mismatch but
+/// declared_dependencies happens to equal the manifest deps, the user
+/// must see a `LockInconsistent` error (not a 3-line empty drift
+/// report). The render output must explain the lock is corrupt and
+/// point at the right remediation.
+#[test]
+fn lock_inconsistent_error_renders_specifically() {
+    let err = SyncError::LockInconsistent;
+    let rendered = err.render();
+    assert!(rendered.starts_with("error: iii.lock"), "got: {rendered}");
+    assert!(rendered.contains("internally inconsistent"));
+    assert!(
+        rendered.contains("fix:"),
+        "must include a remediation line: {rendered}"
+    );
+    assert!(rendered.contains("docs:"));
+    // Crucially: the rendered output must NOT look like an empty drift
+    // report (the bug we're fixing).
+    assert!(
+        !rendered.contains("drift vs iii.lock"),
+        "must not be confused with drift: {rendered}"
+    );
+}
+
+/// **Bug fix**: when iii.worker.yaml is MISSING but the lock has
+/// manifest_hash, the user must see a distinct `ManifestMissing` error
+/// — not "drift vs iii.lock". The error must name the deps the lock
+/// expects so the user knows what's at stake.
+#[test]
+fn manifest_missing_error_renders_specifically() {
+    let lock_deps = deps(&[("alpha", "^1.0.0"), ("beta", "^2.0.0")]);
+    let err = SyncError::ManifestMissing { lock_deps };
+    let rendered = err.render();
+    assert!(rendered.contains("iii.worker.yaml"), "got: {rendered}");
+    assert!(rendered.contains("missing"), "got: {rendered}");
+    assert!(rendered.contains("alpha"));
+    assert!(rendered.contains("beta"));
+    assert!(rendered.contains("fix:"));
+    // It is NOT a drift report — the headline must not be "drift vs".
+    assert!(
+        !rendered.contains("drift vs iii.lock"),
+        "manifest_missing must not be reported as drift: {rendered}"
+    );
+}
+
+/// **Bug fix**: when iii.worker.yaml exists but is malformed, the user
+/// must see a `CorruptManifest` error pointing at the YAML (with the
+/// parser's reason), not a misleading "drift" report saying everything
+/// was removed.
+#[test]
+fn corrupt_manifest_error_renders_specifically() {
+    let err = SyncError::CorruptManifest {
+        reason: "`dependencies` must be a mapping".into(),
+    };
+    let rendered = err.render();
+    assert!(rendered.contains("iii.worker.yaml"));
+    assert!(rendered.contains("`dependencies` must be a mapping"));
+    assert!(rendered.contains("fix:"));
+    assert!(
+        !rendered.contains("drift vs iii.lock"),
+        "malformed YAML must not be reported as drift: {rendered}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Atomic write (acceptable behavior pinned)
+// ---------------------------------------------------------------------------
+
+/// `write_to` REPLACES a symlinked iii.lock with a regular file. Pin
+/// the behavior so a future change is intentional.
+#[cfg(unix)]
+#[test]
+fn write_to_replaces_symlink_with_regular_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let real = dir.path().join("real.lock");
+    let link = dir.path().join("iii.lock");
+
+    std::fs::write(&real, "version: 1\nworkers: {}\n").unwrap();
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+
+    let lock = WorkerLockfile::default();
+    lock.write_to(&link).unwrap();
+
+    let meta = std::fs::symlink_metadata(&link).unwrap();
+    assert!(!meta.file_type().is_symlink(), "symlink was preserved!");
+    let real_content = std::fs::read_to_string(&real).unwrap();
+    assert_eq!(real_content, "version: 1\nworkers: {}\n");
+}
+
+/// Concurrent writers: last-writer-wins, no torn output, no leaked
+/// temp files. PR explicitly says concurrent-writer protection is out
+/// of scope; pin the documented behavior.
+#[test]
+fn concurrent_writers_dont_tear_but_last_writer_wins() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("iii.lock");
+
+    let lock_a = {
+        let mut l = WorkerLockfile::default();
+        l.workers
+            .insert("alpha".to_string(), image_worker("ghcr.io/x/a@sha256:aaa"));
+        l
+    };
+    let lock_b = {
+        let mut l = WorkerLockfile::default();
+        l.workers
+            .insert("beta".to_string(), image_worker("ghcr.io/x/b@sha256:bbb"));
+        l
+    };
+
+    let p1 = path.clone();
+    let p2 = path.clone();
+    let h1 = std::thread::spawn(move || {
+        for _ in 0..10 {
+            lock_a.write_to(&p1).unwrap();
+        }
+    });
+    let h2 = std::thread::spawn(move || {
+        for _ in 0..10 {
+            lock_b.write_to(&p2).unwrap();
+        }
+    });
+    h1.join().unwrap();
+    h2.join().unwrap();
+
+    let parsed = WorkerLockfile::read_from(&path).unwrap();
+    let names: Vec<&str> = parsed.workers.keys().map(|s| s.as_str()).collect();
+    assert!(
+        names == vec!["alpha"] || names == vec!["beta"],
+        "got: {names:?}"
+    );
+
+    let stragglers: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n != "iii.lock")
+        .collect();
+    assert!(
+        stragglers.is_empty(),
+        "found leftover temps: {stragglers:?}"
+    );
+}
+
+/// Atomic-rename contract: a concurrent reader never sees a partial
+/// write. Stress test with 1000 reads against a continuously-rewriting
+/// writer thread.
+#[test]
+fn concurrent_reader_never_sees_partial_write() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("iii.lock");
+
+    let mut seeded = WorkerLockfile::default();
+    seeded
+        .workers
+        .insert("seed".to_string(), image_worker("ghcr.io/x/s@sha256:ccc"));
+    seeded.write_to(&path).unwrap();
+
+    let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let stop_w = stop.clone();
+    let p_w = path.clone();
+
+    let writer = std::thread::spawn(move || {
+        let mut a = WorkerLockfile::default();
+        a.workers
+            .insert("alpha".to_string(), image_worker("ghcr.io/x/a@sha256:aaa"));
+        let mut b = WorkerLockfile::default();
+        b.workers
+            .insert("beta".to_string(), image_worker("ghcr.io/x/b@sha256:bbb"));
+        while !stop_w.load(std::sync::atomic::Ordering::Relaxed) {
+            a.write_to(&p_w).unwrap();
+            b.write_to(&p_w).unwrap();
+        }
+    });
+
+    let mut parse_errors = 0usize;
+    for _ in 0..1000 {
+        match WorkerLockfile::read_from(&path) {
+            Ok(_) => {}
+            Err(e) => {
+                parse_errors += 1;
+                eprintln!("torn read: {e}");
+            }
+        }
+    }
+
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    writer.join().unwrap();
+
+    assert_eq!(parse_errors, 0, "atomic-rename contract violated");
+}
+
+// ---------------------------------------------------------------------------
+// 4. Lockfile validation (correct behavior expected — bugs fixed)
+// ---------------------------------------------------------------------------
+
+/// **Bug fix**: ranges in `declared_dependencies` must parse as semver.
+/// The manifest parser enforces this; the lockfile parser must too, so
+/// hand-edited locks can't smuggle garbage past validation.
+#[test]
+fn lockfile_rejects_garbage_declared_dependency_range() {
+    // Hash + declared_dependencies must be paired (see fix below); the
+    // hash here doesn't need to match because the semver check fires
+    // first.
+    let yaml = format!(
+        "version: 1\nmanifest_hash: \"{prefix}{hex}\"\ndeclared_dependencies:\n  alpha: \"this-is-not-semver-at-all\"\nworkers: {{}}\n",
+        prefix = MANIFEST_HASH_PREFIX,
+        hex = "0".repeat(64),
+    );
+    let err = WorkerLockfile::from_yaml(&yaml).unwrap_err();
+    assert!(err.contains("alpha"), "got: {err}");
+    assert!(
+        err.to_lowercase().contains("semver"),
+        "error must name the bad range: {err}"
+    );
+}
+
+/// **Bug fix**: a lock with `declared_dependencies` but no
+/// `manifest_hash` is internally inconsistent — drift detection would
+/// silently skip. Reject the combination at validation time so
+/// stripping `manifest_hash:` from the lock doesn't bypass drift.
+#[test]
+fn lockfile_rejects_declared_deps_without_manifest_hash() {
+    let yaml = "version: 1\ndeclared_dependencies:\n  alpha: \"^1.0.0\"\nworkers: {}\n";
+    let err = WorkerLockfile::from_yaml(yaml).unwrap_err();
+    assert!(
+        err.contains("manifest_hash"),
+        "error must explain the missing hash: {err}"
+    );
+}
+
+/// **Bug fix**: when both `manifest_hash` and `declared_dependencies`
+/// are present, the hash must equal `compute_manifest_hash(&declared)`.
+/// A hand-edited lock that breaks this invariant must be rejected.
+#[test]
+fn lockfile_rejects_hash_mismatch_against_declared() {
+    // Hash of {alpha: ^1.0.0}, but declared is {alpha: ^9.9.9} — the
+    // lock would silently pass drift checks until the manifest moves.
+    let real_hash = compute_manifest_hash(&deps(&[("alpha", "^1.0.0")]));
+    let yaml = format!(
+        "version: 1\nmanifest_hash: \"{real_hash}\"\ndeclared_dependencies:\n  alpha: \"^9.9.9\"\nworkers: {{}}\n",
+    );
+    let err = WorkerLockfile::from_yaml(&yaml).unwrap_err();
+    assert!(
+        err.contains("manifest_hash") || err.to_lowercase().contains("inconsistent"),
+        "error must explain the inconsistency: {err}"
+    );
+}
+
+/// Sanity: a consistent lock (hash matches declared_dependencies) is
+/// accepted.
+#[test]
+fn lockfile_accepts_consistent_hash_and_declared() {
+    let declared = deps(&[("alpha", "^1.0.0")]);
+    let hash = compute_manifest_hash(&declared);
+    let yaml = format!(
+        "version: 1\nmanifest_hash: \"{hash}\"\ndeclared_dependencies:\n  alpha: \"^1.0.0\"\nworkers: {{}}\n",
+    );
+    let parsed = WorkerLockfile::from_yaml(&yaml).expect("consistent lock must validate");
+    assert_eq!(parsed.manifest_hash.unwrap(), hash);
+}
+
+// ---------------------------------------------------------------------------
+// 5. is_valid_manifest_hash
+// ---------------------------------------------------------------------------
+
+/// **Bug fix**: `compute_manifest_hash` always emits lowercase hex. A
+/// lock with uppercase-hex `manifest_hash` would always trigger
+/// false-positive drift on every sync. Reject at validation.
+#[test]
+fn is_valid_manifest_hash_rejects_uppercase() {
+    let upper = format!("{MANIFEST_HASH_PREFIX}{}", "ABCDEF0123456789".repeat(4));
+    assert!(
+        !is_valid_manifest_hash(&upper),
+        "uppercase hex must be rejected for byte-exact comparison"
+    );
+}
+
+/// Lowercase hex remains accepted (sanity).
+#[test]
+fn is_valid_manifest_hash_accepts_lowercase() {
+    let lower = format!("{MANIFEST_HASH_PREFIX}{}", "abcdef0123456789".repeat(4));
+    assert!(is_valid_manifest_hash(&lower));
+}
+
+/// `compute_manifest_hash` of a single-entry dep is the SHA-256 of the
+/// 12-byte string `"alpha=^1.0\n"` with the `sha256:v1:` prefix.
+#[test]
+fn compute_manifest_hash_byte_stable_pin() {
+    let h = compute_manifest_hash(&deps(&[("alpha", "^1.0")]));
+    let expected_hex = {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(b"alpha=^1.0\n");
+        hex::encode(hasher.finalize())
+    };
+    assert_eq!(h, format!("{MANIFEST_HASH_PREFIX}{expected_hex}"));
+}
+
+/// Prefix is case-sensitive: `Sha256:v1:` (capital S) is rejected.
+#[test]
+fn is_valid_manifest_hash_prefix_is_case_sensitive() {
+    let bad = format!("Sha256:v1:{}", "0".repeat(64));
+    assert!(!is_valid_manifest_hash(&bad));
+}
+
+/// Unicode lookalikes for hex digits are rejected.
+#[test]
+fn manifest_hash_rejects_unicode_lookalike_hex() {
+    let unicode_zero = "\u{0966}";
+    let crafted = format!("{MANIFEST_HASH_PREFIX}{}", unicode_zero.repeat(64));
+    assert!(!is_valid_manifest_hash(&crafted));
+}


### PR DESCRIPTION
## Summary

- Teach `iii.lock` to carry an optional `manifest_hash` + `declared_dependencies` header so we can detect manifest drift on a subsequent sync.
- Wire `iii worker sync --frozen` to fail loudly when the root `iii.worker.yaml` has drifted from what the lock was written against, with a stable three-line error naming the exact added / removed / range-changed deps and the remediation command.
- Make `iii.lock` writes atomic (adjacent temp file → `fsync` → `rename(2)`) so a concurrent reader sees either the old or new bytes, never a torn mixture.

Today's CI pipelines hit the "registry returns a 502 on a branch nobody touched" narrative because every `iii worker add` unconditionally calls `/resolve`, even when the lock is fully pinned. This change doesn't yet make the lock an input to install (that's a follow-up), but it does give `--frozen` the teeth to catch drift before the pipeline spends time resolving.

The hash has an algorithm-version prefix (`sha256:v1:`) so a future bump can be detected rather than silently accepted. Legacy locks (no `manifest_hash`) continue to fall through to the existing `verify` path unchanged.

## What's in scope

- `crates/iii-worker/src/cli/lockfile.rs` — `manifest_hash` + `declared_dependencies` optional fields, `is_valid_manifest_hash` validator, atomic `write_to` via temp-file + rename, byte-stable YAML output for both present and absent hash cases.
- `crates/iii-worker/src/cli/sync.rs` (new) — `compute_manifest_hash`, `DriftReport`, `detect_drift`, `SyncError::{Drift, CorruptLock}` with byte-stable renderers pinned by six golden tests.
- `crates/iii-worker/src/cli/managed.rs` — `handle_resolved_graph_add` populates the two new fields from the cwd manifest at write time; `handle_worker_sync(frozen=true)` runs the drift check before delegating to `verify`.

## What's explicitly NOT in scope

- Install-from-lock. `iii worker sync` without `--frozen` still prints "N workers pinned" and points at `verify`.
- Project-wide manifest aggregation. Only the cwd `iii.worker.yaml` feeds the hash today; multi-worker projects with subdirectory manifests don't get aggregate drift detection yet.
- `--refresh` / `--upgrade-lock` flags.
- Concurrent-writer protection beyond atomic rename.

## Test plan

- [x] `cargo test -p iii-worker --lib` (476 passing, includes 22 new tests)
- [x] `cargo test -p iii-worker --tests` (all integration suites green)
- [x] Golden-file coverage for every drift shape (added-only, removed-only, range-changed, mixed) pins the exact bytes of the `error: / fix: / docs:` output.
- [x] Legacy-lock compatibility test: `iii.lock` without `manifest_hash` still passes `--frozen` and falls through to `verify`.
- [x] Atomic-write contract: no straggler temp files after a successful write, and a failed write (via invalid lock content hitting validation) preserves the existing file intact.

Example drift output in CI logs (matches the golden test):

```
error: iii.worker.yaml drift vs iii.lock
  + helper-worker "^2.0.0" (not in lock)
  ~ http-worker "^1.0.0" → "^1.1.0"
fix: run `iii worker sync --refresh && git add iii.lock`
docs: https://iii.dev/docs/sync#drift
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manifest-based frozen-sync: compares manifest to lock, emits actionable drift reports, and renders clear three-line remediation messages.
  * CLI add now persists manifest hash and declared dependencies into the lock when a valid manifest is present.

* **Improvements**
  * Atomic lockfile writes to prevent partial/corrupt files.
  * Stricter lock validation: enforces manifest-hash format, requires pairing of manifest hash and declared dependencies, and verifies hash matches declared deps.

* **Tests**
  * Extensive tests for hash determinism, drift detection, error rendering, validation, and atomic-write behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->