### PR TITLE
fix(state,stream): support nested shallow-merge paths in atomic update ops

### DIFF
--- a/console/packages/console-frontend/src/api/types/shared.ts
+++ b/console/packages/console-frontend/src/api/types/shared.ts
@@ -8,11 +8,24 @@ export type StreamUpdateOp =
   | { type: 'increment'; path: string; by: number }
   | { type: 'decrement'; path: string; by: number }
   | { type: 'remove'; path: string }
-  | { type: 'merge'; path: string; value: unknown }
+  // Merge accepts a single string (legacy / first-level field) or an
+  // array of literal segments (nested path). Path may be omitted to
+  // target the root value.
+  | { type: 'merge'; path?: string | string[]; value: unknown }
+
+export type StreamUpdateOpError = {
+  op_index: number
+  code: string
+  message: string
+  doc_url?: string
+}
 
 export type StreamUpdateResult = {
   old_value?: unknown
   new_value: unknown
+  // Per-op errors. Currently emitted only by `merge` for validation
+  // rejections (depth/size/proto-pollution). Field omitted when empty.
+  errors?: StreamUpdateOpError[]
 }
 
 export type MetricsSnapshot = {

--- a/docs/how-to/manage-state.mdx
+++ b/docs/how-to/manage-state.mdx
@@ -365,11 +365,102 @@ await iii.trigger({
 
 If `transcript` is missing, a string append creates a string. If `events` is missing, a non-string append creates an array with one element. Existing arrays receive one new element per append. Existing strings only accept string values.
 
-Paths are first-level field names. `user.name` means the field literally named `user.name`; it does not traverse nested objects. Use `path: ""` to append to the root value.
+Paths for `set` / `append` / `increment` / `decrement` / `remove` are first-level field names. `user.name` means the field literally named `user.name`; it does not traverse nested objects. Use `path: ""` to target the root value.
 
 <Warning>
   Atomic append rewrites and returns the full JSON value. For very large payloads or long-running high-throughput streams, store chunks as separate stream items or use channels instead of repeatedly appending to one large value.
 </Warning>
+
+### Build per-session structured state with nested merge
+
+`merge` is the one update op that accepts a nested path. Its `path` is either a single string (legacy / first-level field) or an array of literal segments. This makes it the right tool for accumulating per-session structured state — a transcript timeline keyed by session, an event log per user, the metadata sidebar of an in-flight call.
+
+The example below builds `audio::transcripts[<session-id>] = { "<timestamp>": chunk }` incrementally. Two writers can append to different timestamps in the same session without stepping on each other; sibling timestamps are preserved by every merge.
+
+<Tabs>
+<Tab title="Node / TypeScript">
+```typescript title="record-transcript-chunk.ts"
+await iii.trigger({
+  function_id: 'state::update',
+  payload: {
+    scope: 'audio::transcripts',
+    key: 'session-abc',
+    ops: [
+      // Nested path: walks into "session-abc" → "metadata", auto-
+      // creating each intermediate object. Sibling keys at any level
+      // are preserved.
+      {
+        type: 'merge',
+        path: ['session-abc', 'metadata'],
+        value: { author: 'alice' },
+      },
+      // First-level form (sugar for path: ['session-abc']).
+      {
+        type: 'merge',
+        path: 'session-abc',
+        value: { [Date.now()]: 'transcript chunk' },
+      },
+    ],
+  },
+})
+```
+</Tab>
+<Tab title="Python">
+```python title="record_transcript_chunk.py"
+import time
+
+iii.trigger({
+    "function_id": "state::update",
+    "payload": {
+        "scope": "audio::transcripts",
+        "key": "session-abc",
+        "ops": [
+            {
+                "type": "merge",
+                "path": ["session-abc", "metadata"],
+                "value": {"author": "alice"},
+            },
+            {
+                "type": "merge",
+                "path": "session-abc",
+                "value": {str(int(time.time() * 1000)): "transcript chunk"},
+            },
+        ],
+    },
+})
+```
+</Tab>
+<Tab title="Rust">
+```rust title="record_transcript_chunk.rs"
+use iii_sdk::{TriggerRequest, UpdateOp};
+use serde_json::{json, Value};
+
+iii.trigger(TriggerRequest {
+    function_id: "state::update".into(),
+    payload: json!({
+        "scope": "audio::transcripts",
+        "key": "session-abc",
+        "ops": [
+            UpdateOp::merge_at_path(
+                ["session-abc", "metadata"],
+                json!({ "author": "alice" }),
+            ),
+            UpdateOp::merge_at(
+                "session-abc",
+                json!({ format!("{}", chrono::Utc::now().timestamp_millis()): "transcript chunk" }),
+            ),
+        ],
+    }),
+    action: None,
+    timeout_ms: None,
+}).await?;
+```
+</Tab>
+</Tabs>
+
+Each segment in a `merge` path array is a *literal* key. `["a.b"]` writes a single key named `"a.b"`, not `a → b`. To deep-merge sub-objects, compose multiple ops with deeper paths.
+
+If the engine rejects a `merge` op (path > 32 segments, segment > 256 bytes, value > 16 levels deep, > 1024 top-level keys, or a `__proto__` / `constructor` / `prototype` segment or top-level key), it returns an entry in the response's `errors` array with a stable `code`, `message`, and `doc_url`. Successfully applied ops still reflect in `new_value`.
 
 ## Result
 

--- a/docs/workers/iii-state.mdx
+++ b/docs/workers/iii-state.mdx
@@ -174,18 +174,36 @@ name: bridge
         The key to update.
       </ResponseField>
       <ResponseField name="ops" type="UpdateOp[]" required>
-        Array of update operations applied in order. Each operation is a tagged object with a `type` field and a first-level `path`. Use `path: ""` to target the root value.
+        Array of update operations applied in order. Each operation is a tagged object with a `type` field and a `path`. Use `path: ""` (or omit `path`) to target the root value.
 
         | Operation | Shape | Description |
         |-----------|-------|-------------|
         | `set` | `{ "type": "set", "path": "status", "value": "active" }` | Set a field or replace the root value. |
-        | `merge` | `{ "type": "merge", "path": "", "value": { "status": "active" } }` | Shallow-merge an object at the root. |
+        | `merge` | `{ "type": "merge", "path": ["sessions", "abc"], "value": { "ts": "chunk" } }` | Shallow-merge an object at the root or at any nested path. |
         | `increment` | `{ "type": "increment", "path": "count", "by": 1 }` | Add `by` to a numeric field. |
         | `decrement` | `{ "type": "decrement", "path": "count", "by": 1 }` | Subtract `by` from a numeric field. |
         | `append` | `{ "type": "append", "path": "events", "value": { "kind": "chunk" } }` | Push one element to an array or concatenate a string value. |
         | `remove` | `{ "type": "remove", "path": "status" }` | Remove a field from the current object. |
 
-        Paths are first-level field names. For example, `user.name` updates the field named `user.name`; it does not traverse into `{ "user": { "name": ... } }`.
+        For `set`, `increment`, `decrement`, `append`, and `remove`, paths are first-level field names. For example, `user.name` updates the field named `user.name`; it does not traverse into `{ "user": { "name": ... } }`.
+
+        For `merge`, `path` accepts either a single string (legacy / first-level field) or an array of literal segments for nested merge:
+
+        ```json
+        // Root merge (existing behavior, unchanged).
+        { "type": "merge", "path": "", "value": { "status": "active" } }
+
+        // First-level merge into the field named "session-abc".
+        { "type": "merge", "path": "session-abc", "value": { "author": "alice" } }
+
+        // Nested merge: walks "sessions" → "abc", auto-creating
+        // missing or non-object intermediates as it goes.
+        { "type": "merge", "path": ["sessions", "abc"], "value": { "ts": "chunk" } }
+        ```
+
+        Each array element is a *literal* key. `["a.b"]` writes a single key named `"a.b"`, not `a → b`.
+
+        Validation: invalid `merge` inputs are rejected with a structured error in the response's `errors` array. Reasons include path depth > 32 segments, segment > 256 bytes, value depth > 16, > 1024 top-level keys, or any segment / top-level key matching `__proto__` / `constructor` / `prototype`. Successfully applied ops still reflect in `new_value`.
       </ResponseField>
     </Accordion>
     <Accordion title="Returns">
@@ -194,6 +212,9 @@ name: bridge
       </ResponseField>
       <ResponseField name="new_value" type="any">
         The value after all operations were applied.
+      </ResponseField>
+      <ResponseField name="errors" type="UpdateOpError[]">
+        Per-op validation errors. Currently emitted only by `merge` for inputs that violate validation bounds (path depth/size, value depth, prototype-pollution sinks). Field is omitted when empty. Each entry has `op_index`, `code`, `message`, and an optional `doc_url`.
       </ResponseField>
     </Accordion>
   </AccordionGroup>

--- a/docs/workers/iii-stream.mdx
+++ b/docs/workers/iii-stream.mdx
@@ -293,7 +293,7 @@ config:
         The item ID in the stream to update.
       </ResponseField>
       <ResponseField name="ops" type="UpdateOp[]" required>
-        The list of atomic operations to apply. Each operation is a tagged object with a `type` field (`set`, `merge`, `increment`, `decrement`, `append`, or `remove`) and associated fields (`path`, `value`, `by`). Paths are first-level field names; use `path: ""` to target the root value.
+        The list of atomic operations to apply. Each operation is a tagged object with a `type` field (`set`, `merge`, `increment`, `decrement`, `append`, or `remove`) and associated fields (`path`, `value`, `by`). For `set` / `increment` / `decrement` / `append` / `remove`, paths are first-level field names. For `merge`, `path` accepts either a single string (legacy / first-level field) or an array of literal segments for nested merge — see the [state worker docs](/workers/iii-state) for the full contract and validation rules. Use `path: ""` (or omit `path`) to target the root value.
       </ResponseField>
     </Accordion>
     <Accordion title="Returns">
@@ -302,6 +302,9 @@ config:
       </ResponseField>
       <ResponseField name="new_value" type="any" required>
         The value now stored in the stream after applying the operations.
+      </ResponseField>
+      <ResponseField name="errors" type="UpdateOpError[]">
+        Per-op validation errors. Currently emitted only by `merge` for inputs that violate validation bounds. Field is omitted when empty.
       </ResponseField>
     </Accordion>
   </AccordionGroup>

--- a/engine/src/builtins/kv.rs
+++ b/engine/src/builtins/kv.rs
@@ -455,7 +455,7 @@ impl BuiltinKvStore {
         let index_map = store.entry(index.clone()).or_insert_with(IndexMap::new);
 
         let old_value = index_map.get(&key).cloned();
-        let updated_value = crate::update_ops::apply_update_ops(old_value.clone(), &ops);
+        let (updated_value, errors) = crate::update_ops::apply_update_ops(old_value.clone(), &ops);
 
         // Write the updated value back to the store
         index_map.insert(key.clone(), updated_value.clone());
@@ -472,6 +472,7 @@ impl BuiltinKvStore {
         UpdateResult {
             old_value,
             new_value: updated_value,
+            errors,
         }
     }
 

--- a/engine/src/update_ops.rs
+++ b/engine/src/update_ops.rs
@@ -4,14 +4,215 @@
 // This software is patent protected. We welcome discussions - reach out at support@motia.dev
 // See LICENSE and PATENTS files for details.
 
-use iii_sdk::UpdateOp;
+use iii_sdk::{UpdateOp, UpdateOpError, types::MergePath};
 use serde_json::{Map, Number, Value};
 
-pub(crate) fn apply_update_ops(old_value: Option<Value>, ops: &[UpdateOp]) -> Value {
+// Validation bounds for merge ops. Mirrored in
+// `engine/src/workers/redis.rs` Lua so Redis-backed adapters share
+// identical semantics. Update both sides together.
+pub(crate) const MAX_PATH_DEPTH: usize = 32;
+pub(crate) const MAX_SEGMENT_BYTES: usize = 256;
+pub(crate) const MAX_VALUE_DEPTH: usize = 16;
+pub(crate) const MAX_VALUE_KEYS: usize = 1024;
+
+// Segments and merge-value top-level keys matching any of these are
+// rejected. They are JS prototype-pollution sinks reachable through
+// any consumer that does `Object.assign(obj, mergedValue)` or similar
+// unsafe spreading on the merged JSON.
+pub(crate) const PROTO_POLLUTION_KEYS: &[&str] = &["__proto__", "constructor", "prototype"];
+
+pub(crate) const ERR_PATH_TOO_DEEP: &str = "merge.path.too_deep";
+pub(crate) const ERR_SEGMENT_TOO_LONG: &str = "merge.path.segment_too_long";
+pub(crate) const ERR_EMPTY_SEGMENT: &str = "merge.path.empty_segment";
+pub(crate) const ERR_PATH_PROTO: &str = "merge.path.proto_polluted";
+pub(crate) const ERR_VALUE_TOO_DEEP: &str = "merge.value.too_deep";
+pub(crate) const ERR_VALUE_TOO_MANY_KEYS: &str = "merge.value.too_many_keys";
+pub(crate) const ERR_VALUE_PROTO: &str = "merge.value.proto_polluted";
+pub(crate) const ERR_VALUE_NOT_OBJECT: &str = "merge.value.not_an_object";
+
+const DOC_URL_BASE: &str = "https://docs.iii.dev/workers/iii-state#merge-bounds";
+
+fn err(op_index: usize, code: &str, message: String) -> UpdateOpError {
+    UpdateOpError {
+        op_index,
+        code: code.to_string(),
+        message,
+        doc_url: Some(DOC_URL_BASE.to_string()),
+    }
+}
+
+/// Normalize an `Option<MergePath>` into a borrowed slice of segments.
+/// `None`, `Single("")`, and `Segments(vec![])` all collapse to an
+/// empty slice meaning "root merge".
+fn merge_path_segments<'a>(path: &'a Option<MergePath>) -> &'a [String] {
+    match path {
+        None => &[],
+        Some(MergePath::Single(s)) => {
+            if s.is_empty() {
+                &[]
+            } else {
+                std::slice::from_ref(s)
+            }
+        }
+        Some(MergePath::Segments(v)) => v.as_slice(),
+    }
+}
+
+fn validate_merge_path(
+    op_index: usize,
+    segments: &[String],
+    errors: &mut Vec<UpdateOpError>,
+) -> bool {
+    if segments.len() > MAX_PATH_DEPTH {
+        errors.push(err(
+            op_index,
+            ERR_PATH_TOO_DEEP,
+            format!(
+                "Path depth {} exceeds maximum of {}",
+                segments.len(),
+                MAX_PATH_DEPTH
+            ),
+        ));
+        return false;
+    }
+    for seg in segments {
+        if seg.is_empty() {
+            errors.push(err(
+                op_index,
+                ERR_EMPTY_SEGMENT,
+                "Path contains an empty segment".to_string(),
+            ));
+            return false;
+        }
+        if seg.len() > MAX_SEGMENT_BYTES {
+            errors.push(err(
+                op_index,
+                ERR_SEGMENT_TOO_LONG,
+                format!(
+                    "Path segment of {} bytes exceeds maximum of {}",
+                    seg.len(),
+                    MAX_SEGMENT_BYTES
+                ),
+            ));
+            return false;
+        }
+        if PROTO_POLLUTION_KEYS.contains(&seg.as_str()) {
+            errors.push(err(
+                op_index,
+                ERR_PATH_PROTO,
+                format!("Path segment {:?} is a prototype-pollution sink", seg),
+            ));
+            return false;
+        }
+    }
+    true
+}
+
+fn json_depth(value: &Value) -> usize {
+    match value {
+        Value::Object(map) => 1 + map.values().map(json_depth).max().unwrap_or(0),
+        Value::Array(items) => 1 + items.iter().map(json_depth).max().unwrap_or(0),
+        _ => 0,
+    }
+}
+
+fn validate_merge_value(op_index: usize, value: &Value, errors: &mut Vec<UpdateOpError>) -> bool {
+    let map = match value {
+        Value::Object(map) => map,
+        _ => {
+            errors.push(err(
+                op_index,
+                ERR_VALUE_NOT_OBJECT,
+                "Merge value must be a JSON object".to_string(),
+            ));
+            return false;
+        }
+    };
+    if map.len() > MAX_VALUE_KEYS {
+        errors.push(err(
+            op_index,
+            ERR_VALUE_TOO_MANY_KEYS,
+            format!(
+                "Merge value has {} top-level keys, exceeds maximum of {}",
+                map.len(),
+                MAX_VALUE_KEYS
+            ),
+        ));
+        return false;
+    }
+    for k in map.keys() {
+        if PROTO_POLLUTION_KEYS.contains(&k.as_str()) {
+            errors.push(err(
+                op_index,
+                ERR_VALUE_PROTO,
+                format!(
+                    "Merge value top-level key {:?} is a prototype-pollution sink",
+                    k
+                ),
+            ));
+            return false;
+        }
+    }
+    let depth = json_depth(value);
+    if depth > MAX_VALUE_DEPTH {
+        errors.push(err(
+            op_index,
+            ERR_VALUE_TOO_DEEP,
+            format!(
+                "Merge value JSON nesting depth {} exceeds maximum of {}",
+                depth, MAX_VALUE_DEPTH
+            ),
+        ));
+        return false;
+    }
+    true
+}
+
+/// Walk the segment path within `current`, replacing or auto-creating
+/// non-object intermediates along the way (RFC 7396-style). Returns a
+/// mutable reference to the target object's map, ready for shallow
+/// merging. Caller must ensure `current` is itself an object before
+/// calling (root case is the only place where this matters).
+fn walk_or_create<'a>(
+    current: &'a mut Value,
+    segments: &[String],
+) -> Option<&'a mut Map<String, Value>> {
+    // Make sure the root is an object before we descend.
+    if !matches!(current, Value::Object(_)) {
+        *current = Value::Object(Map::new());
+    }
+    let mut node = current;
+    for seg in segments {
+        let map = match node {
+            Value::Object(m) => m,
+            // Should not happen — we replace non-object nodes below
+            // before recursing into them. Defensive bail-out.
+            _ => return None,
+        };
+        // Replace any non-object intermediate with a fresh object.
+        let entry = map
+            .entry(seg.clone())
+            .or_insert_with(|| Value::Object(Map::new()));
+        if !matches!(entry, Value::Object(_)) {
+            *entry = Value::Object(Map::new());
+        }
+        node = entry;
+    }
+    match node {
+        Value::Object(m) => Some(m),
+        _ => None,
+    }
+}
+
+pub(crate) fn apply_update_ops(
+    old_value: Option<Value>,
+    ops: &[UpdateOp],
+) -> (Value, Vec<UpdateOpError>) {
     let mut using_missing_default = old_value.is_none();
     let mut current = old_value.unwrap_or_else(|| Value::Object(Map::new()));
+    let mut errors: Vec<UpdateOpError> = Vec::new();
 
-    for op in ops {
+    for (op_index, op) in ops.iter().enumerate() {
         match op {
             UpdateOp::Set { path, value } => {
                 if path.0.is_empty()
@@ -30,21 +231,40 @@ pub(crate) fn apply_update_ops(old_value: Option<Value>, ops: &[UpdateOp]) -> Va
                 }
             }
             UpdateOp::Merge { path, value } => {
-                if path.is_none() || path.as_ref().is_some_and(|path| path.0.is_empty()) {
-                    if let (Value::Object(existing_map), Value::Object(new_map)) =
-                        (&mut current, value)
-                    {
+                let segments = merge_path_segments(path);
+                if !validate_merge_path(op_index, segments, &mut errors) {
+                    continue;
+                }
+                if !validate_merge_value(op_index, value, &mut errors) {
+                    continue;
+                }
+                let new_map = match value {
+                    Value::Object(m) => m,
+                    // Already rejected by validate_merge_value above.
+                    _ => continue,
+                };
+                if segments.is_empty() {
+                    // Root merge — preserve existing semantics.
+                    if let Value::Object(existing_map) = &mut current {
                         for (k, v) in new_map {
                             existing_map.insert(k.clone(), v.clone());
                         }
                         using_missing_default = false;
                     } else {
                         tracing::warn!(
-                            "Merge operation requires both existing and new values to be JSON objects"
+                            "Merge operation requires existing root to be a JSON object"
                         );
                     }
-                } else if let Some(path) = path {
-                    tracing::warn!(path = %path.0, "Only root-level merge is supported");
+                } else if let Some(target) = walk_or_create(&mut current, segments) {
+                    for (k, v) in new_map {
+                        target.insert(k.clone(), v.clone());
+                    }
+                    using_missing_default = false;
+                } else {
+                    tracing::warn!(
+                        path = ?segments,
+                        "Merge operation could not resolve target path"
+                    );
                 }
             }
             UpdateOp::Increment { path, by } => {
@@ -121,7 +341,8 @@ pub(crate) fn apply_update_ops(old_value: Option<Value>, ops: &[UpdateOp]) -> Va
         }
     }
 
-    current
+    let _ = using_missing_default;
+    (current, errors)
 }
 
 fn append_to_target(target: &mut Value, value: &Value, path: &str) -> bool {
@@ -166,14 +387,23 @@ fn initial_append_value(value: &Value) -> Value {
 
 #[cfg(test)]
 mod tests {
-    use iii_sdk::{FieldPath, UpdateOp};
+    use iii_sdk::{FieldPath, UpdateOp, types::MergePath};
     use serde_json::json;
 
     use super::apply_update_ops;
 
+    /// Asserts no errors and returns the resulting value. Most tests
+    /// don't expect errors; the ones that do call `apply_update_ops`
+    /// directly and inspect the second tuple element.
+    fn run(old_value: Option<serde_json::Value>, ops: &[UpdateOp]) -> serde_json::Value {
+        let (value, errors) = apply_update_ops(old_value, ops);
+        assert!(errors.is_empty(), "expected no errors, got: {errors:?}");
+        value
+    }
+
     #[test]
     fn appends_to_array_field_as_single_element() {
-        let updated = apply_update_ops(
+        let updated = run(
             Some(json!({ "events": [{"kind": "start"}] })),
             &[UpdateOp::append("events", json!({"kind": "chunk"}))],
         );
@@ -186,7 +416,7 @@ mod tests {
 
     #[test]
     fn concatenates_string_fields() {
-        let updated = apply_update_ops(
+        let updated = run(
             Some(json!({ "transcript": "hello" })),
             &[UpdateOp::append("transcript", json!(" world"))],
         );
@@ -196,7 +426,7 @@ mod tests {
 
     #[test]
     fn initializes_missing_fields_by_value_kind() {
-        let updated = apply_update_ops(
+        let updated = run(
             Some(json!({})),
             &[
                 UpdateOp::append("transcript", json!("hello")),
@@ -215,8 +445,8 @@ mod tests {
 
     #[test]
     fn initializes_missing_root_by_value_kind() {
-        let string_root = apply_update_ops(None, &[UpdateOp::append("", json!("hello"))]);
-        let array_root = apply_update_ops(None, &[UpdateOp::append("", json!({"kind": "chunk"}))]);
+        let string_root = run(None, &[UpdateOp::append("", json!("hello"))]);
+        let array_root = run(None, &[UpdateOp::append("", json!({"kind": "chunk"}))]);
 
         assert_eq!(string_root, json!("hello"));
         assert_eq!(array_root, json!([{"kind": "chunk"}]));
@@ -224,7 +454,7 @@ mod tests {
 
     #[test]
     fn skips_incompatible_string_append_value() {
-        let updated = apply_update_ops(
+        let updated = run(
             Some(json!({ "transcript": "hello" })),
             &[UpdateOp::append("transcript", json!({"not": "string"}))],
         );
@@ -234,7 +464,7 @@ mod tests {
 
     #[test]
     fn skips_incompatible_object_append_target() {
-        let updated = apply_update_ops(
+        let updated = run(
             Some(json!({ "events": {} })),
             &[UpdateOp::append("events", json!("chunk"))],
         );
@@ -244,7 +474,7 @@ mod tests {
 
     #[test]
     fn increments_existing_non_number_and_missing_fields() {
-        let updated = apply_update_ops(
+        let updated = run(
             Some(json!({ "count": 2, "bad": "value" })),
             &[
                 UpdateOp::increment("count", 3),
@@ -258,7 +488,7 @@ mod tests {
 
     #[test]
     fn decrements_existing_non_number_and_missing_fields() {
-        let updated = apply_update_ops(
+        let updated = run(
             Some(json!({ "count": 5, "bad": "value" })),
             &[
                 UpdateOp::decrement("count", 3),
@@ -272,7 +502,7 @@ mod tests {
 
     #[test]
     fn preserves_order_across_multiple_numeric_ops() {
-        let updated = apply_update_ops(
+        let updated = run(
             Some(json!({ "count": 10 })),
             &[
                 UpdateOp::increment("count", 5),
@@ -285,7 +515,7 @@ mod tests {
 
     #[test]
     fn dotted_paths_are_first_level_fields() {
-        let updated = apply_update_ops(
+        let updated = run(
             Some(json!({ "user.name": ["A"], "user": { "name": ["B"] } })),
             &[UpdateOp::Append {
                 path: FieldPath("user.name".to_string()),
@@ -301,7 +531,7 @@ mod tests {
 
     #[test]
     fn preserves_order_across_multiple_append_ops() {
-        let updated = apply_update_ops(
+        let updated = run(
             Some(json!({ "events": [] })),
             &[
                 UpdateOp::append("events", json!("first")),
@@ -310,5 +540,217 @@ mod tests {
         );
 
         assert_eq!(updated, json!({ "events": ["first", "second"] }));
+    }
+
+    // ----- Nested merge tests (issue #1546) -----
+
+    fn merge_at(path: impl Into<MergePath>, value: serde_json::Value) -> UpdateOp {
+        UpdateOp::merge_at(path, value)
+    }
+
+    #[test]
+    fn merges_into_existing_first_level_object_field() {
+        let updated = run(
+            Some(json!({ "session-1": { "ts1": "a" } })),
+            &[merge_at("session-1", json!({ "ts2": "b" }))],
+        );
+
+        assert_eq!(updated, json!({ "session-1": { "ts1": "a", "ts2": "b" } }));
+    }
+
+    #[test]
+    fn merges_into_missing_first_level_field_creates_object() {
+        let updated = run(
+            Some(json!({})),
+            &[merge_at("session-1", json!({ "author": "alice" }))],
+        );
+
+        assert_eq!(updated, json!({ "session-1": { "author": "alice" } }));
+    }
+
+    #[test]
+    fn merges_at_nested_path_replacing_non_object_intermediate() {
+        // Intermediate "abc" is a non-object string; merge at
+        // ["sessions", "abc"] must replace it with {} and merge in.
+        let updated = run(
+            Some(json!({ "sessions": { "abc": "garbage" } })),
+            &[merge_at(
+                vec!["sessions", "abc"],
+                json!({ "author": "alice" }),
+            )],
+        );
+
+        assert_eq!(
+            updated,
+            json!({ "sessions": { "abc": { "author": "alice" } } })
+        );
+    }
+
+    #[test]
+    fn merges_at_nested_path_creating_missing_intermediates() {
+        let updated = run(
+            Some(json!({})),
+            &[merge_at(vec!["a", "b", "c"], json!({ "x": 1 }))],
+        );
+
+        assert_eq!(updated, json!({ "a": { "b": { "c": { "x": 1 } } } }));
+    }
+
+    #[test]
+    fn merges_at_nested_target_shallowly_overwrites_keys() {
+        let updated = run(
+            Some(json!({
+                "sessions": {
+                    "abc": { "author": "old", "topic": "preserved" }
+                }
+            })),
+            &[merge_at(
+                vec!["sessions", "abc"],
+                json!({ "author": "new" }),
+            )],
+        );
+
+        // "topic" preserved; "author" replaced.
+        assert_eq!(
+            updated,
+            json!({
+                "sessions": {
+                    "abc": { "author": "new", "topic": "preserved" }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn merge_with_non_object_value_returns_error_and_no_ops() {
+        let (value, errors) = apply_update_ops(
+            Some(json!({ "a": 1 })),
+            &[merge_at("foo", json!("not-an-object"))],
+        );
+
+        assert_eq!(value, json!({ "a": 1 }));
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, super::ERR_VALUE_NOT_OBJECT);
+        assert_eq!(errors[0].op_index, 0);
+    }
+
+    #[test]
+    fn root_level_merge_unchanged_for_none_empty_string_and_empty_array() {
+        // path: None
+        let none_path = run(
+            Some(json!({ "a": 1 })),
+            &[UpdateOp::merge(json!({ "b": 2 }))],
+        );
+        // path: Single("")
+        let empty_string = run(Some(json!({ "a": 1 })), &[merge_at("", json!({ "b": 2 }))]);
+        // path: Segments(vec![])
+        let empty_array = run(
+            Some(json!({ "a": 1 })),
+            &[merge_at(Vec::<&str>::new(), json!({ "b": 2 }))],
+        );
+
+        let expected = json!({ "a": 1, "b": 2 });
+        assert_eq!(none_path, expected);
+        assert_eq!(empty_string, expected);
+        assert_eq!(empty_array, expected);
+    }
+
+    #[test]
+    fn single_string_path_equivalent_to_single_segment_array() {
+        let from_string = run(Some(json!({})), &[merge_at("foo", json!({ "x": 1 }))]);
+        let from_array = run(Some(json!({})), &[merge_at(vec!["foo"], json!({ "x": 1 }))]);
+
+        assert_eq!(from_string, from_array);
+        assert_eq!(from_string, json!({ "foo": { "x": 1 } }));
+    }
+
+    #[test]
+    fn literal_dotted_segment_treated_as_one_key() {
+        // ["a.b"] is a single literal key, not a→b traversal.
+        let updated = run(
+            Some(json!({ "a": { "b": { "preserved": true } } })),
+            &[merge_at(vec!["a.b"], json!({ "x": 1 }))],
+        );
+
+        assert_eq!(
+            updated,
+            json!({
+                "a": { "b": { "preserved": true } },
+                "a.b": { "x": 1 }
+            })
+        );
+    }
+
+    // ----- Validation rejection tests -----
+
+    #[test]
+    fn rejects_path_too_deep() {
+        let path: Vec<String> = (0..super::MAX_PATH_DEPTH + 1)
+            .map(|i| format!("k{i}"))
+            .collect();
+        let (_value, errors) =
+            apply_update_ops(Some(json!({})), &[merge_at(path, json!({ "x": 1 }))]);
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, super::ERR_PATH_TOO_DEEP);
+    }
+
+    #[test]
+    fn rejects_oversized_segment() {
+        let big = "a".repeat(super::MAX_SEGMENT_BYTES + 1);
+        let (_value, errors) =
+            apply_update_ops(Some(json!({})), &[merge_at(vec![big], json!({ "x": 1 }))]);
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, super::ERR_SEGMENT_TOO_LONG);
+    }
+
+    #[test]
+    fn rejects_empty_segment() {
+        let (_value, errors) = apply_update_ops(
+            Some(json!({})),
+            &[merge_at(vec!["a", ""], json!({ "x": 1 }))],
+        );
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, super::ERR_EMPTY_SEGMENT);
+    }
+
+    #[test]
+    fn rejects_proto_polluted_path_segment() {
+        for sink in super::PROTO_POLLUTION_KEYS {
+            let (_value, errors) =
+                apply_update_ops(Some(json!({})), &[merge_at(vec![*sink], json!({ "x": 1 }))]);
+
+            assert_eq!(errors.len(), 1, "expected proto rejection for {sink}");
+            assert_eq!(errors[0].code, super::ERR_PATH_PROTO);
+        }
+    }
+
+    #[test]
+    fn rejects_proto_polluted_value_top_level_key() {
+        let (_value, errors) = apply_update_ops(
+            Some(json!({})),
+            &[merge_at(
+                "foo",
+                json!({ "__proto__": { "polluted": true } }),
+            )],
+        );
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, super::ERR_VALUE_PROTO);
+    }
+
+    #[test]
+    fn rejects_value_too_deep() {
+        // Build nested object of depth MAX_VALUE_DEPTH + 1.
+        let mut v = json!({});
+        for _ in 0..=super::MAX_VALUE_DEPTH {
+            v = json!({ "n": v });
+        }
+        let (_value, errors) = apply_update_ops(Some(json!({})), &[merge_at("foo", v)]);
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, super::ERR_VALUE_TOO_DEEP);
     }
 }

--- a/engine/src/workers/redis.rs
+++ b/engine/src/workers/redis.rs
@@ -8,9 +8,23 @@ use std::time::Duration;
 
 pub const DEFAULT_REDIS_CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
 
+// Validation bounds mirrored from `engine/src/update_ops.rs`. If you
+// change one side, change both.
+//   MAX_PATH_DEPTH    = 32
+//   MAX_SEGMENT_BYTES = 256
+//   MAX_VALUE_DEPTH   = 16
+//   MAX_VALUE_KEYS    = 1024
+// Prototype-pollution sinks: __proto__, constructor, prototype.
 pub const JSON_UPDATE_SCRIPT: &str = r#"
     local json_decode = cjson.decode
     local json_encode = cjson.encode
+
+    local MAX_PATH_DEPTH = 32
+    local MAX_SEGMENT_BYTES = 256
+    local MAX_VALUE_DEPTH = 16
+    local MAX_VALUE_KEYS = 1024
+    local PROTO = { __proto__ = true, constructor = true, prototype = true }
+    local DOC_URL = 'https://docs.iii.dev/workers/iii-state#merge-bounds'
 
     local key = KEYS[1]
     local field = ARGV[1]
@@ -30,23 +44,133 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
     local ops = json_decode(ops_json)
     local current = json_decode(json_encode(old_value))
     local using_missing_default = old_value_str == nil
+    local errors = {}
 
+    -- get_path for legacy non-merge ops: collapses anything to a single
+    -- first-level key for backward compat.
     local function get_path(path)
-        if path == nil then
-            return nil
-        end
-        if type(path) == 'string' then
-            return path
-        end
+        if path == nil then return nil end
+        if type(path) == 'string' then return path end
         if type(path) == 'table' then
-            if path[1] then
-                return path[1]
-            end
-            if path['0'] then
-                return path['0']
-            end
+            if path[1] then return path[1] end
+            if path['0'] then return path['0'] end
         end
         return path
+    end
+
+    -- merge_path_segments: returns a Lua array of literal segments, or
+    -- empty array meaning "root merge".
+    local function merge_path_segments(path)
+        if path == nil then return {} end
+        if type(path) == 'string' then
+            if path == '' then return {} end
+            return { path }
+        end
+        if type(path) == 'table' then
+            local out = {}
+            for i, seg in ipairs(path) do
+                out[i] = seg
+            end
+            return out
+        end
+        return {}
+    end
+
+    local function push_error(op_index, code, message)
+        errors[#errors + 1] = {
+            op_index = op_index,
+            code = code,
+            message = message,
+            doc_url = DOC_URL,
+        }
+    end
+
+    local function json_depth(value)
+        if type(value) ~= 'table' then return 0 end
+        local max = 0
+        for _, v in pairs(value) do
+            local d = json_depth(v)
+            if d > max then max = d end
+        end
+        return 1 + max
+    end
+
+    local function validate_merge_path(op_index, segments)
+        if #segments > MAX_PATH_DEPTH then
+            push_error(op_index, 'merge.path.too_deep',
+                'Path depth ' .. #segments .. ' exceeds maximum of ' .. MAX_PATH_DEPTH)
+            return false
+        end
+        for _, seg in ipairs(segments) do
+            if type(seg) ~= 'string' or seg == '' then
+                push_error(op_index, 'merge.path.empty_segment',
+                    'Path contains an empty or non-string segment')
+                return false
+            end
+            if #seg > MAX_SEGMENT_BYTES then
+                push_error(op_index, 'merge.path.segment_too_long',
+                    'Path segment of ' .. #seg .. ' bytes exceeds maximum of ' .. MAX_SEGMENT_BYTES)
+                return false
+            end
+            if PROTO[seg] then
+                push_error(op_index, 'merge.path.proto_polluted',
+                    'Path segment "' .. seg .. '" is a prototype-pollution sink')
+                return false
+            end
+        end
+        return true
+    end
+
+    local function validate_merge_value(op_index, value)
+        if type(value) ~= 'table' or value == cjson.null then
+            push_error(op_index, 'merge.value.not_an_object',
+                'Merge value must be a JSON object')
+            return false
+        end
+        local key_count = 0
+        for k, _ in pairs(value) do
+            -- JSON arrays land as Lua arrays with numeric keys; reject.
+            if type(k) ~= 'string' then
+                push_error(op_index, 'merge.value.not_an_object',
+                    'Merge value must be a JSON object')
+                return false
+            end
+            if PROTO[k] then
+                push_error(op_index, 'merge.value.proto_polluted',
+                    'Merge value top-level key "' .. k .. '" is a prototype-pollution sink')
+                return false
+            end
+            key_count = key_count + 1
+            if key_count > MAX_VALUE_KEYS then
+                push_error(op_index, 'merge.value.too_many_keys',
+                    'Merge value has more than ' .. MAX_VALUE_KEYS .. ' top-level keys')
+                return false
+            end
+        end
+        if json_depth(value) > MAX_VALUE_DEPTH then
+            push_error(op_index, 'merge.value.too_deep',
+                'Merge value JSON nesting depth exceeds maximum of ' .. MAX_VALUE_DEPTH)
+            return false
+        end
+        return true
+    end
+
+    -- Walk segments inside `root`, replacing or auto-creating non-object
+    -- intermediates. Returns the target object table for shallow merge.
+    local function walk_or_create(root, segments)
+        if type(root) ~= 'table' or root == cjson.null then
+            return nil  -- caller normalises root before invoking
+        end
+        local node = root
+        for _, seg in ipairs(segments) do
+            local next_node = node[seg]
+            if type(next_node) ~= 'table' or next_node == cjson.null then
+                next_node = {}
+                node[seg] = next_node
+            end
+            node = next_node
+        end
+        return node
     end
 
     local function initial_append_value(value)
@@ -91,7 +215,9 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
         return false, target
     end
 
-    for _, op in ipairs(ops) do
+    for op_index, op in ipairs(ops) do
+        -- ipairs yields 1-based; mirror the engine's 0-based op_index.
+        local zero_index = op_index - 1
         if op.type == 'set' then
             local path = get_path(op.path)
             if (path == '' or path == nil) and op.value ~= nil then
@@ -109,12 +235,29 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
                 using_missing_default = false
             end
         elseif op.type == 'merge' then
-            local path = get_path(op.path)
-            if (path == nil or path == '') and type(current) == 'table' and type(op.value) == 'table' then
-                for k, v in pairs(op.value) do
-                    current[k] = v
+            local segments = merge_path_segments(op.path)
+            if validate_merge_path(zero_index, segments) and
+               validate_merge_value(zero_index, op.value) then
+                if #segments == 0 then
+                    -- Root merge — preserve existing semantics.
+                    if type(current) == 'table' and current ~= cjson.null then
+                        for k, v in pairs(op.value) do
+                            current[k] = v
+                        end
+                        using_missing_default = false
+                    end
+                else
+                    if type(current) ~= 'table' or current == cjson.null then
+                        current = {}
+                    end
+                    local target = walk_or_create(current, segments)
+                    if target ~= nil then
+                        for k, v in pairs(op.value) do
+                            target[k] = v
+                        end
+                        using_missing_default = false
+                    end
                 end
-                using_missing_default = false
             end
         elseif op.type == 'increment' then
             local path = get_path(op.path)
@@ -169,5 +312,14 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
     local new_value_str = json_encode(current)
     redis.call('HSET', key, field, new_value_str)
 
-    return {'true', old_value_str or '', new_value_str}
+    -- Return tuple shape:
+    --   {'true', old_value_str, new_value_str, errors_json}
+    -- errors_json is omitted (4 elements only when present) when no
+    -- errors occurred, preserving backward compatibility with adapters
+    -- that expect 3 elements.
+    if #errors == 0 then
+        return {'true', old_value_str or '', new_value_str}
+    else
+        return {'true', old_value_str or '', new_value_str, json_encode(errors)}
+    end
 "#;

--- a/engine/src/workers/state/adapters/redis_adapter.rs
+++ b/engine/src/workers/state/adapters/redis_adapter.rs
@@ -138,7 +138,7 @@ impl StateAdapter for StateRedisAdapter {
                     ));
                 }
 
-                if values.len() == 3 {
+                if values.len() == 3 || values.len() == 4 {
                     let old_value = if values[1].is_empty() {
                         None
                     } else {
@@ -150,13 +150,22 @@ impl StateAdapter for StateRedisAdapter {
                     let new_value = serde_json::from_str(&values[2])
                         .map_err(|e| anyhow::anyhow!("Failed to deserialize new value: {}", e))?;
 
+                    let errors = if values.len() == 4 && !values[3].is_empty() {
+                        serde_json::from_str(&values[3]).map_err(|e| {
+                            anyhow::anyhow!("Failed to deserialize update errors: {}", e)
+                        })?
+                    } else {
+                        Vec::new()
+                    };
+
                     Ok(UpdateResult {
                         old_value,
                         new_value,
+                        errors,
                     })
                 } else {
                     Err(anyhow::anyhow!(
-                        "Unexpected return value from update script: expected 3 values, got {}",
+                        "Unexpected return value from update script: expected 3 or 4 values, got {}",
                         values.len()
                     ))
                 }

--- a/engine/src/workers/state/state.rs
+++ b/engine/src/workers/state/state.rs
@@ -451,6 +451,7 @@ mod tests {
                 update_result: UpdateResult {
                     old_value: None,
                     new_value: serde_json::json!({"ok": true}),
+                    errors: Vec::new(),
                 },
                 list_values: Vec::new(),
                 groups: Vec::new(),

--- a/engine/src/workers/state/structs.rs
+++ b/engine/src/workers/state/structs.rs
@@ -90,6 +90,35 @@ mod tests {
     }
 
     #[test]
+    fn state_update_input_schema_merge_path_accepts_string_or_array() {
+        // Regression: changing UpdateOp::Merge.path to an untagged
+        // enum (MergePath: Single | Segments) must keep the schemars
+        // schema for ops accepting both string and array path forms.
+        // This test catches silent drift if schemars output changes.
+        let schema = schemars::schema_for!(StateUpdateInput);
+        let schema_value = serde_json::to_value(&schema).unwrap();
+        let pretty = serde_json::to_string_pretty(&schema_value).unwrap();
+
+        // The Merge variant must surface anyOf-of-(string, array of string)
+        // somewhere in the generated schema. We don't pin the exact
+        // shape (schemars output evolves) but we assert presence of
+        // both forms in the pretty-printed schema text.
+        assert!(
+            pretty.contains("\"merge\""),
+            "schema must mention the merge variant: {}",
+            pretty
+        );
+        assert!(
+            pretty.contains("array"),
+            "schema must include an array form for merge.path"
+        );
+        assert!(
+            pretty.contains("string"),
+            "schema must include a string form for merge.path"
+        );
+    }
+
+    #[test]
     fn state_event_type_serde() {
         let created = StateEventType::Created;
         let json = serde_json::to_value(&created).unwrap();

--- a/engine/src/workers/state/structs.rs
+++ b/engine/src/workers/state/structs.rs
@@ -90,35 +90,6 @@ mod tests {
     }
 
     #[test]
-    fn state_update_input_schema_merge_path_accepts_string_or_array() {
-        // Regression: changing UpdateOp::Merge.path to an untagged
-        // enum (MergePath: Single | Segments) must keep the schemars
-        // schema for ops accepting both string and array path forms.
-        // This test catches silent drift if schemars output changes.
-        let schema = schemars::schema_for!(StateUpdateInput);
-        let schema_value = serde_json::to_value(&schema).unwrap();
-        let pretty = serde_json::to_string_pretty(&schema_value).unwrap();
-
-        // The Merge variant must surface anyOf-of-(string, array of string)
-        // somewhere in the generated schema. We don't pin the exact
-        // shape (schemars output evolves) but we assert presence of
-        // both forms in the pretty-printed schema text.
-        assert!(
-            pretty.contains("\"merge\""),
-            "schema must mention the merge variant: {}",
-            pretty
-        );
-        assert!(
-            pretty.contains("array"),
-            "schema must include an array form for merge.path"
-        );
-        assert!(
-            pretty.contains("string"),
-            "schema must include a string form for merge.path"
-        );
-    }
-
-    #[test]
     fn state_event_type_serde() {
         let created = StateEventType::Created;
         let json = serde_json::to_value(&created).unwrap();

--- a/engine/src/workers/state/trigger.rs
+++ b/engine/src/workers/state/trigger.rs
@@ -144,6 +144,7 @@ mod tests {
             Ok(UpdateResult {
                 old_value: None,
                 new_value: serde_json::Value::Null,
+                errors: Vec::new(),
             })
         }
 

--- a/engine/src/workers/stream/adapters/redis_adapter.rs
+++ b/engine/src/workers/stream/adapters/redis_adapter.rs
@@ -104,7 +104,7 @@ impl StreamAdapter for RedisAdapter {
                     ));
                 }
 
-                if values.len() == 3 {
+                if values.len() == 3 || values.len() == 4 {
                     let old_value = if values[1].is_empty() {
                         None
                     } else {
@@ -116,13 +116,22 @@ impl StreamAdapter for RedisAdapter {
                     let new_value = serde_json::from_str(&values[2])
                         .map_err(|e| anyhow::anyhow!("Failed to deserialize new value: {}", e))?;
 
+                    let errors = if values.len() == 4 && !values[3].is_empty() {
+                        serde_json::from_str(&values[3]).map_err(|e| {
+                            anyhow::anyhow!("Failed to deserialize update errors: {}", e)
+                        })?
+                    } else {
+                        Vec::new()
+                    };
+
                     Ok(UpdateResult {
                         old_value,
                         new_value,
+                        errors,
                     })
                 } else {
                     Err(anyhow::anyhow!(
-                        "Unexpected return value from update script: expected 3 values, got {}",
+                        "Unexpected return value from update script: expected 3 or 4 values, got {}",
                         values.len()
                     ))
                 }

--- a/engine/src/workers/stream/socket.rs
+++ b/engine/src/workers/stream/socket.rs
@@ -326,6 +326,7 @@ mod tests {
             Ok(UpdateResult {
                 old_value: None,
                 new_value: json!({}),
+                errors: Vec::new(),
             })
         }
     }

--- a/engine/src/workers/stream/stream.rs
+++ b/engine/src/workers/stream/stream.rs
@@ -937,6 +937,7 @@ mod tests {
                 update_result: Mutex::new(Ok(UpdateResult {
                     old_value: None,
                     new_value: serde_json::json!({}),
+                    errors: Vec::new(),
                 })),
                 emitted_messages: Mutex::new(Vec::new()),
                 destroy_called: AtomicBool::new(false),

--- a/engine/tests/state_stream_update_e2e.rs
+++ b/engine/tests/state_stream_update_e2e.rs
@@ -150,4 +150,3 @@ async fn merge_with_proto_polluted_segment_returns_structured_error() {
     // The op did not apply.
     assert_eq!(r.new_value, json!({}));
 }
-

--- a/engine/tests/state_stream_update_e2e.rs
+++ b/engine/tests/state_stream_update_e2e.rs
@@ -1,0 +1,204 @@
+// Integration tests for nested merge in `state::update` (and the
+// shared `apply_update_ops` machinery used by `stream::update`).
+//
+// Closes iii-hq/iii#1546. Runs the same op sequences against the
+// in-memory `BuiltinKvStore`. A Redis-backed pass is gated on a
+// `IIITEST_REDIS_URL` env var; when set, we run the same ops against
+// the Lua `JSON_UPDATE_SCRIPT` and assert identical resulting state.
+
+use serde_json::json;
+
+use iii::builtins::kv::BuiltinKvStore;
+use iii_sdk::{UpdateOp, types::MergePath};
+
+const SCOPE: &str = "audio::transcripts";
+
+async fn fresh_store() -> BuiltinKvStore {
+    BuiltinKvStore::new(None)
+}
+
+#[tokio::test]
+async fn merge_first_level_path_accumulates_siblings_across_calls() {
+    // Issue #1546 case 1: two merges into the same first-level field
+    // accumulate timestamps without nuking siblings.
+    let store = fresh_store().await;
+    let key = "session-abc".to_string();
+
+    let r1 = store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![UpdateOp::merge_at(
+                "session-1",
+                json!({ "ts:0001": "first chunk" }),
+            )],
+        )
+        .await;
+    assert!(r1.errors.is_empty(), "first merge errors: {:?}", r1.errors);
+
+    let r2 = store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![UpdateOp::merge_at(
+                "session-1",
+                json!({ "ts:0002": "second chunk" }),
+            )],
+        )
+        .await;
+    assert!(r2.errors.is_empty(), "second merge errors: {:?}", r2.errors);
+
+    assert_eq!(
+        r2.new_value,
+        json!({
+            "session-1": {
+                "ts:0001": "first chunk",
+                "ts:0002": "second chunk",
+            }
+        })
+    );
+}
+
+#[tokio::test]
+async fn merge_at_nested_path_creates_missing_intermediates_from_empty_root() {
+    // Closes the bug class: nested merge from empty state must
+    // auto-create every intermediate object.
+    let store = fresh_store().await;
+    let segs: Vec<String> = vec!["sessions".into(), "abc".into(), "metadata".into()];
+
+    let result = store
+        .update(
+            SCOPE.to_string(),
+            "key".to_string(),
+            vec![UpdateOp::merge_at(
+                MergePath::Segments(segs),
+                json!({ "author": "alice" }),
+            )],
+        )
+        .await;
+
+    assert!(
+        result.errors.is_empty(),
+        "nested merge errors: {:?}",
+        result.errors
+    );
+    assert_eq!(
+        result.new_value,
+        json!({
+            "sessions": {
+                "abc": {
+                    "metadata": { "author": "alice" }
+                }
+            }
+        })
+    );
+}
+
+#[tokio::test]
+async fn merge_replaces_null_intermediate_along_nested_path() {
+    // Hostile-target case: an existing `null` intermediate must be
+    // replaced by `{}` and the merge proceed. Previously this would
+    // silently no-op (Codex's "non-object blocks merge forever"
+    // finding).
+    let store = fresh_store().await;
+    let key = "key".to_string();
+
+    // Seed `sessions: null` via a set op.
+    store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![UpdateOp::Set {
+                path: "sessions".into(),
+                value: Some(serde_json::Value::Null),
+            }],
+        )
+        .await;
+
+    let result = store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![UpdateOp::merge_at(
+                MergePath::Segments(vec!["sessions".into(), "abc".into()]),
+                json!({ "author": "alice" }),
+            )],
+        )
+        .await;
+
+    assert!(result.errors.is_empty());
+    assert_eq!(
+        result.new_value,
+        json!({
+            "sessions": {
+                "abc": { "author": "alice" }
+            }
+        })
+    );
+}
+
+#[tokio::test]
+async fn merge_then_remove_then_merge_recreates_field_cleanly() {
+    let store = fresh_store().await;
+    let key = "key".to_string();
+
+    let r = store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![
+                UpdateOp::merge_at("session-1", json!({ "a": 1 })),
+                UpdateOp::Remove {
+                    path: "session-1".into(),
+                },
+                UpdateOp::merge_at("session-1", json!({ "b": 2 })),
+            ],
+        )
+        .await;
+
+    assert!(r.errors.is_empty());
+    assert_eq!(r.new_value, json!({ "session-1": { "b": 2 } }));
+}
+
+#[tokio::test]
+async fn merge_with_proto_polluted_segment_returns_structured_error() {
+    let store = fresh_store().await;
+    let key = "key".to_string();
+
+    let r = store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![UpdateOp::merge_at(
+                MergePath::Segments(vec!["__proto__".into(), "polluted".into()]),
+                json!({ "x": 1 }),
+            )],
+        )
+        .await;
+
+    assert_eq!(r.errors.len(), 1);
+    assert_eq!(r.errors[0].code, "merge.path.proto_polluted");
+    assert_eq!(r.errors[0].op_index, 0);
+    assert!(r.errors[0].doc_url.is_some());
+    // The op did not apply.
+    assert_eq!(r.new_value, json!({}));
+}
+
+#[tokio::test]
+async fn root_merge_unchanged_for_legacy_callers() {
+    // Existing root-merge senders (`path: ""` or omitted) must keep
+    // working unchanged.
+    let store = fresh_store().await;
+    let key = "key".to_string();
+
+    let r = store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![UpdateOp::merge(json!({ "a": 1, "b": 2 }))],
+        )
+        .await;
+
+    assert!(r.errors.is_empty());
+    assert_eq!(r.new_value, json!({ "a": 1, "b": 2 }));
+}

--- a/engine/tests/state_stream_update_e2e.rs
+++ b/engine/tests/state_stream_update_e2e.rs
@@ -1,10 +1,12 @@
 // Integration tests for nested merge in `state::update` (and the
 // shared `apply_update_ops` machinery used by `stream::update`).
 //
-// Closes iii-hq/iii#1546. Runs the same op sequences against the
-// in-memory `BuiltinKvStore`. A Redis-backed pass is gated on a
-// `IIITEST_REDIS_URL` env var; when set, we run the same ops against
-// the Lua `JSON_UPDATE_SCRIPT` and assert identical resulting state.
+// Closes iii-hq/iii#1546. Each test here exercises behavior that
+// requires going through `BuiltinKvStore` (persistence across calls,
+// op-batch interleaving, error plumbing into `UpdateResult`). The
+// in-batch nested-merge mechanics — auto-create intermediates, replace
+// non-object intermediates, validation rejections — are covered by
+// the unit tests in `engine/src/update_ops.rs`.
 
 use serde_json::json;
 
@@ -54,41 +56,6 @@ async fn merge_first_level_path_accumulates_siblings_across_calls() {
             "session-1": {
                 "ts:0001": "first chunk",
                 "ts:0002": "second chunk",
-            }
-        })
-    );
-}
-
-#[tokio::test]
-async fn merge_at_nested_path_creates_missing_intermediates_from_empty_root() {
-    // Closes the bug class: nested merge from empty state must
-    // auto-create every intermediate object.
-    let store = fresh_store().await;
-    let segs: Vec<String> = vec!["sessions".into(), "abc".into(), "metadata".into()];
-
-    let result = store
-        .update(
-            SCOPE.to_string(),
-            "key".to_string(),
-            vec![UpdateOp::merge_at(
-                MergePath::Segments(segs),
-                json!({ "author": "alice" }),
-            )],
-        )
-        .await;
-
-    assert!(
-        result.errors.is_empty(),
-        "nested merge errors: {:?}",
-        result.errors
-    );
-    assert_eq!(
-        result.new_value,
-        json!({
-            "sessions": {
-                "abc": {
-                    "metadata": { "author": "alice" }
-                }
             }
         })
     );
@@ -184,21 +151,3 @@ async fn merge_with_proto_polluted_segment_returns_structured_error() {
     assert_eq!(r.new_value, json!({}));
 }
 
-#[tokio::test]
-async fn root_merge_unchanged_for_legacy_callers() {
-    // Existing root-merge senders (`path: ""` or omitted) must keep
-    // working unchanged.
-    let store = fresh_store().await;
-    let key = "key".to_string();
-
-    let r = store
-        .update(
-            SCOPE.to_string(),
-            key.clone(),
-            vec![UpdateOp::merge(json!({ "a": 1, "b": 2 }))],
-        )
-        .await;
-
-    assert!(r.errors.is_empty());
-    assert_eq!(r.new_value, json!({ "a": 1, "b": 2 }));
-}

--- a/sdk/packages/node/iii-browser/src/state.ts
+++ b/sdk/packages/node/iii-browser/src/state.ts
@@ -1,4 +1,4 @@
-import type { UpdateOp } from './stream'
+import type { UpdateOp, UpdateOpError } from './stream'
 
 /** Input for retrieving a state value. */
 export type StateGetInput = {
@@ -54,6 +54,11 @@ export type StateUpdateResult<TData> = {
   old_value?: TData
   /** New value after the update. */
   new_value: TData
+  /**
+   * Per-op errors. Currently emitted only by the `merge` op when
+   * input violates validation bounds. Field omitted when empty.
+   */
+  errors?: UpdateOpError[]
 }
 
 /** Result of a state delete operation. */

--- a/sdk/packages/node/iii-browser/src/stream.ts
+++ b/sdk/packages/node/iii-browser/src/stream.ts
@@ -101,6 +101,11 @@ export type StreamUpdateResult<TData> = {
   old_value?: TData
   /** New value after the update. */
   new_value: TData
+  /**
+   * Per-op errors. Currently emitted only by the `merge` op when
+   * input violates validation bounds. Field omitted when empty.
+   */
+  errors?: UpdateOpError[]
 }
 
 /** Set a field at the given path to a value. */
@@ -148,14 +153,50 @@ export type UpdateRemove = {
   path: string
 }
 
-/** Shallow-merge an object into the root value. Only root-level merge is supported. */
+/**
+ * Path target for a {@link UpdateMerge} op. Accepts:
+ *   - a single string (legacy / first-level field)
+ *   - an array of literal segments (nested path; each element is one
+ *     literal key, dots are NOT interpreted as separators)
+ *
+ * Omit `path`, pass `""`, or pass `[]` to target the root value.
+ *
+ * @example single first-level field
+ *   { type: 'merge', path: 'session-abc', value: { author: 'alice' } }
+ * @example nested path
+ *   { type: 'merge', path: ['sessions', 'abc'], value: { ts: chunk } }
+ */
+export type MergePath = string | string[]
+
+/**
+ * Shallow-merge an object into the target. The target is the root
+ * (when `path` is omitted/empty) or an arbitrary nested location
+ * specified by an array of literal segments. See {@link MergePath}.
+ *
+ * Validation: invalid paths/values (depth > 32, segment > 256 bytes,
+ * value depth > 16, > 1024 top-level keys, or any
+ * `__proto__`/`constructor`/`prototype` segment or top-level key) are
+ * rejected with a structured error in the response's `errors` array.
+ */
 export type UpdateMerge = {
   type: 'merge'
-  /** Must be an empty string. Non-empty paths are ignored. */
-  path: string
-  /** Object to merge. */
+  /** Optional path to the merge target. See {@link MergePath}. */
+  path?: MergePath
+  /** Object to merge. Must be a JSON object. */
   // biome-ignore lint/suspicious/noExplicitAny: any is fine here
   value: any
+}
+
+/** Per-op error returned by `state::update` / `stream::update`. */
+export type UpdateOpError = {
+  /** Index of the offending op within the original `ops` array. */
+  op_index: number
+  /** Stable error code, e.g. `"merge.path.too_deep"`. */
+  code: string
+  /** Human-readable description with concrete numbers when applicable. */
+  message: string
+  /** Optional documentation URL. */
+  doc_url?: string
 }
 
 /** Result of a stream delete operation. */

--- a/sdk/packages/node/iii-browser/tests/exports.test.ts
+++ b/sdk/packages/node/iii-browser/tests/exports.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { ChannelReader, ChannelWriter, registerWorker, TriggerAction } from '../src/index'
-import type { UpdateAppend, UpdateMerge, UpdateOp, UpdateOpError } from '../src/stream'
+import type { UpdateAppend, UpdateMerge, UpdateOp } from '../src/stream'
 
 describe('Package Exports', () => {
   it('should export main SDK symbols', () => {
@@ -56,21 +56,6 @@ describe('Package Exports', () => {
     expect(parsed).toEqual(op)
   })
 
-  it('should type merge with no path (root merge)', () => {
-    const op: UpdateMerge = { type: 'merge', value: { x: 1 } }
-    expect(op.path).toBeUndefined()
-  })
-
-  it('should type UpdateOpError with required fields', () => {
-    const err: UpdateOpError = {
-      op_index: 0,
-      code: 'merge.path.too_deep',
-      message: 'Path depth 33 exceeds maximum of 32',
-      doc_url: 'https://docs.iii.dev/workers/iii-state#merge-bounds',
-    }
-
-    expect(err.code).toBe('merge.path.too_deep')
-  })
 
   it('should import state module', async () => {
     const stateModule = await import('../src/state')

--- a/sdk/packages/node/iii-browser/tests/exports.test.ts
+++ b/sdk/packages/node/iii-browser/tests/exports.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { ChannelReader, ChannelWriter, registerWorker, TriggerAction } from '../src/index'
-import type { UpdateAppend, UpdateOp } from '../src/stream'
+import type { UpdateAppend, UpdateMerge, UpdateOp, UpdateOpError } from '../src/stream'
 
 describe('Package Exports', () => {
   it('should export main SDK symbols', () => {
@@ -30,6 +30,46 @@ describe('Package Exports', () => {
     const ops: UpdateOp[] = [op]
 
     expect(ops[0]).toEqual({ type: 'append', path: 'chunks', value: 'hello' })
+  })
+
+  it('should type merge with a string path (legacy/first-level form)', () => {
+    const op = {
+      type: 'merge',
+      path: 'session-abc',
+      value: { author: 'alice' },
+    } satisfies UpdateMerge
+
+    expect(op).toEqual({ type: 'merge', path: 'session-abc', value: { author: 'alice' } })
+  })
+
+  it('should type merge with an array path (nested form)', () => {
+    const op = {
+      type: 'merge',
+      path: ['sessions', 'abc'],
+      value: { ts: 'chunk' },
+    } satisfies UpdateMerge
+
+    expect(op).toEqual({ type: 'merge', path: ['sessions', 'abc'], value: { ts: 'chunk' } })
+
+    // Round-trips through JSON unchanged.
+    const parsed: UpdateMerge = JSON.parse(JSON.stringify(op))
+    expect(parsed).toEqual(op)
+  })
+
+  it('should type merge with no path (root merge)', () => {
+    const op: UpdateMerge = { type: 'merge', value: { x: 1 } }
+    expect(op.path).toBeUndefined()
+  })
+
+  it('should type UpdateOpError with required fields', () => {
+    const err: UpdateOpError = {
+      op_index: 0,
+      code: 'merge.path.too_deep',
+      message: 'Path depth 33 exceeds maximum of 32',
+      doc_url: 'https://docs.iii.dev/workers/iii-state#merge-bounds',
+    }
+
+    expect(err.code).toBe('merge.path.too_deep')
   })
 
   it('should import state module', async () => {

--- a/sdk/packages/node/iii-browser/tests/exports.test.ts
+++ b/sdk/packages/node/iii-browser/tests/exports.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { ChannelReader, ChannelWriter, registerWorker, TriggerAction } from '../src/index'
-import type { UpdateAppend, UpdateMerge, UpdateOp } from '../src/stream'
+import type { UpdateAppend, UpdateOp } from '../src/stream'
 
 describe('Package Exports', () => {
   it('should export main SDK symbols', () => {
@@ -31,31 +31,6 @@ describe('Package Exports', () => {
 
     expect(ops[0]).toEqual({ type: 'append', path: 'chunks', value: 'hello' })
   })
-
-  it('should type merge with a string path (legacy/first-level form)', () => {
-    const op = {
-      type: 'merge',
-      path: 'session-abc',
-      value: { author: 'alice' },
-    } satisfies UpdateMerge
-
-    expect(op).toEqual({ type: 'merge', path: 'session-abc', value: { author: 'alice' } })
-  })
-
-  it('should type merge with an array path (nested form)', () => {
-    const op = {
-      type: 'merge',
-      path: ['sessions', 'abc'],
-      value: { ts: 'chunk' },
-    } satisfies UpdateMerge
-
-    expect(op).toEqual({ type: 'merge', path: ['sessions', 'abc'], value: { ts: 'chunk' } })
-
-    // Round-trips through JSON unchanged.
-    const parsed: UpdateMerge = JSON.parse(JSON.stringify(op))
-    expect(parsed).toEqual(op)
-  })
-
 
   it('should import state module', async () => {
     const stateModule = await import('../src/state')

--- a/sdk/packages/node/iii/src/state.ts
+++ b/sdk/packages/node/iii/src/state.ts
@@ -1,4 +1,4 @@
-import type { UpdateOp } from './stream'
+import type { UpdateOp, UpdateOpError } from './stream'
 
 /** Input for retrieving a state value. */
 export type StateGetInput = {
@@ -54,6 +54,13 @@ export type StateUpdateResult<TData> = {
   old_value?: TData
   /** New value after the update. */
   new_value: TData
+  /**
+   * Per-op errors. Currently emitted only by the `merge` op when input
+   * violates the validation bounds. See {@link UpdateOpError} and the
+   * `UpdateMerge` JSDoc in `./stream` for the error codes. Field is
+   * omitted from the JSON wire when empty.
+   */
+  errors?: UpdateOpError[]
 }
 
 /** Result of a state delete operation. */

--- a/sdk/packages/node/iii/src/stream.ts
+++ b/sdk/packages/node/iii/src/stream.ts
@@ -101,6 +101,14 @@ export type StreamUpdateResult<TData> = {
   old_value?: TData
   /** New value after the update. */
   new_value: TData
+  /**
+   * Per-op errors. Currently emitted only by the `merge` op when input
+   * violates the validation bounds (path depth/size, value depth, or
+   * a `__proto__`/`constructor`/`prototype` segment or top-level key).
+   * Successfully applied ops are still reflected in `new_value`. The
+   * field is omitted from the JSON wire when empty.
+   */
+  errors?: UpdateOpError[]
 }
 
 /** Set a field at the given path to a value. */
@@ -148,14 +156,61 @@ export type UpdateRemove = {
   path: string
 }
 
-/** Shallow-merge an object into the root value. Only root-level merge is supported. */
+/**
+ * Path target for a {@link UpdateMerge} op. Accepts:
+ *   - a single string (legacy / first-level field)
+ *   - an array of literal segments (nested path; each element is one
+ *     literal key, dots are NOT interpreted as separators)
+ *
+ * Omit `path`, pass `""`, or pass `[]` to target the root value.
+ *
+ * @example single first-level field
+ *   { type: 'merge', path: 'session-abc', value: { author: 'alice' } }
+ * @example nested path (closes issue #1546's structured-state use case)
+ *   { type: 'merge', path: ['sessions', 'abc'], value: { ts: chunk } }
+ */
+export type MergePath = string | string[]
+
+/**
+ * Shallow-merge an object into the target. The target is the root
+ * (when `path` is omitted/empty) or an arbitrary nested location
+ * specified by an array of literal segments.
+ *
+ * Engine semantics:
+ *   - Missing or non-object intermediates along the path are
+ *     auto-replaced with `{}` so a stray `null` or scalar never
+ *     blocks future merges.
+ *   - The merge is shallow at the target — top-level keys of `value`
+ *     replace same-named keys; siblings are preserved.
+ *   - Each path segment is a literal key. `["a.b"]` writes a single
+ *     key named `"a.b"`, not `a → b`.
+ *
+ * Validation: invalid paths/values (depth > 32 segments, segment >
+ * 256 bytes, value depth > 16, > 1024 top-level keys, or any
+ * `__proto__`/`constructor`/`prototype` segment or top-level key)
+ * are rejected with a structured error in the `errors` field of the
+ * `state::update` / `stream::update` response. The merge does not
+ * apply when an error is returned for that op.
+ */
 export type UpdateMerge = {
   type: 'merge'
-  /** Must be an empty string. Non-empty paths are ignored. */
-  path: string
-  /** Object to merge. */
+  /** Optional path to the merge target. See {@link MergePath}. */
+  path?: MergePath
+  /** Object to merge. Must be a JSON object. */
   // biome-ignore lint/suspicious/noExplicitAny: any is fine here
   value: any
+}
+
+/** Per-op error returned by `state::update` / `stream::update`. */
+export type UpdateOpError = {
+  /** Index of the offending op within the original `ops` array. */
+  op_index: number
+  /** Stable error code, e.g. `"merge.path.too_deep"`. */
+  code: string
+  /** Human-readable description with concrete numbers when applicable. */
+  message: string
+  /** Optional documentation URL. */
+  doc_url?: string
 }
 
 /** Result of a stream delete operation. */

--- a/sdk/packages/node/iii/tests/stream.test.ts
+++ b/sdk/packages/node/iii/tests/stream.test.ts
@@ -5,9 +5,7 @@ import type {
   StreamSetResult,
   StreamUpdateResult,
   UpdateAppend,
-  UpdateMerge,
   UpdateOp,
-  UpdateOpError,
 } from '../src/stream'
 
 type TestData = {
@@ -256,29 +254,6 @@ describe('Stream Operations', () => {
       expect(ops[0]).toEqual({ type: 'append', path: 'chunks', value: 'hello' })
     })
 
-    it.each<[string, UpdateMerge]>([
-      ['string path (legacy / first-level)', { type: 'merge', path: 'session-abc', value: { author: 'alice' } }],
-      ['array path (nested)', { type: 'merge', path: ['sessions', 'abc'], value: { ts: 'chunk' } }],
-    ])('should round-trip merge with %s through JSON', (_, op) => {
-      const parsed: UpdateMerge = JSON.parse(JSON.stringify(op))
-      expect(parsed).toEqual(op)
-    })
-
-    it('should type a StreamUpdateResult with errors', () => {
-      const err: UpdateOpError = {
-        op_index: 0,
-        code: 'merge.path.proto_polluted',
-        message: 'Path segment "__proto__" is a prototype-pollution sink',
-      }
-      const result: StreamUpdateResult<{ x: number }> = {
-        old_value: undefined,
-        new_value: { x: 1 },
-        errors: [err],
-      }
-
-      expect(result.errors?.[0].code).toBe('merge.path.proto_polluted')
-    })
-
     it('should apply partial updates via ops array', async () => {
       // Ported from motia-js integration test: stream#update applies partial updates
       const groupId = `update-group-${Date.now()}`
@@ -364,6 +339,112 @@ describe('Stream Operations', () => {
 
       expect(result?.chunks).toEqual([{ text: 'hello' }])
       expect(result?.transcript).toBe('hello world')
+
+      await iii.trigger({
+        function_id: 'stream::delete',
+        payload: {
+          stream_name: testStreamName,
+          group_id: groupId,
+          item_id: itemId,
+        },
+      })
+    })
+
+    it('should merge into a first-level path and preserve siblings', async () => {
+      const groupId = `merge-group-${Date.now()}`
+      const itemId = `merge-item-${Date.now()}`
+
+      await iii.trigger({
+        function_id: 'stream::set',
+        payload: {
+          stream_name: testStreamName,
+          group_id: groupId,
+          item_id: itemId,
+          data: {},
+        },
+      })
+
+      const update = await iii.trigger<unknown, StreamUpdateResult<Record<string, unknown>>>({
+        function_id: 'stream::update',
+        payload: {
+          stream_name: testStreamName,
+          group_id: groupId,
+          item_id: itemId,
+          ops: [
+            { type: 'merge', path: 'session-abc', value: { author: 'alice' } },
+            { type: 'merge', path: 'session-abc', value: { ts: 'chunk' } },
+          ],
+        },
+      })
+
+      expect(update.errors ?? []).toEqual([])
+      expect(update.new_value).toEqual({
+        'session-abc': { author: 'alice', ts: 'chunk' },
+      })
+
+      const result = await iii.trigger<unknown, Record<string, unknown>>({
+        function_id: 'stream::get',
+        payload: {
+          stream_name: testStreamName,
+          group_id: groupId,
+          item_id: itemId,
+        },
+      })
+
+      expect(result).toEqual(update.new_value)
+
+      await iii.trigger({
+        function_id: 'stream::delete',
+        payload: {
+          stream_name: testStreamName,
+          group_id: groupId,
+          item_id: itemId,
+        },
+      })
+    })
+
+    it('should merge into a nested array path and persist the updated record', async () => {
+      const groupId = `nested-merge-group-${Date.now()}`
+      const itemId = `nested-merge-item-${Date.now()}`
+
+      await iii.trigger({
+        function_id: 'stream::set',
+        payload: {
+          stream_name: testStreamName,
+          group_id: groupId,
+          item_id: itemId,
+          data: { sessions: { existing: { ts: 'anchor' } } },
+        },
+      })
+
+      const update = await iii.trigger<unknown, StreamUpdateResult<Record<string, unknown>>>({
+        function_id: 'stream::update',
+        payload: {
+          stream_name: testStreamName,
+          group_id: groupId,
+          item_id: itemId,
+          ops: [{ type: 'merge', path: ['sessions', 'abc'], value: { ts: 'chunk' } }],
+        },
+      })
+
+      expect(update.errors ?? []).toEqual([])
+      expect(update.new_value).toEqual({
+        sessions: {
+          existing: { ts: 'anchor' },
+          abc: { ts: 'chunk' },
+        },
+      })
+
+      const result = await iii.trigger<unknown, Record<string, unknown>>({
+        function_id: 'stream::get',
+        payload: {
+          stream_name: testStreamName,
+          group_id: groupId,
+          item_id: itemId,
+        },
+      })
+
+      expect(result).toEqual(update.new_value)
 
       await iii.trigger({
         function_id: 'stream::delete',

--- a/sdk/packages/node/iii/tests/stream.test.ts
+++ b/sdk/packages/node/iii/tests/stream.test.ts
@@ -1,6 +1,14 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { iii, sleep } from './utils'
-import type { StreamSetInput, StreamSetResult, UpdateAppend, UpdateOp } from '../src/stream'
+import type {
+  StreamSetInput,
+  StreamSetResult,
+  StreamUpdateResult,
+  UpdateAppend,
+  UpdateMerge,
+  UpdateOp,
+  UpdateOpError,
+} from '../src/stream'
 
 type TestData = {
   name?: string
@@ -246,6 +254,45 @@ describe('Stream Operations', () => {
       const ops: UpdateOp[] = [op]
 
       expect(ops[0]).toEqual({ type: 'append', path: 'chunks', value: 'hello' })
+    })
+
+    it('should round-trip merge with string path through JSON', () => {
+      const op = {
+        type: 'merge',
+        path: 'session-abc',
+        value: { author: 'alice' },
+      } satisfies UpdateMerge
+
+      const parsed: UpdateMerge = JSON.parse(JSON.stringify(op))
+      expect(parsed).toEqual(op)
+      expect(parsed.path).toBe('session-abc')
+    })
+
+    it('should round-trip merge with array path through JSON', () => {
+      const op = {
+        type: 'merge',
+        path: ['sessions', 'abc'],
+        value: { ts: 'chunk' },
+      } satisfies UpdateMerge
+
+      const parsed: UpdateMerge = JSON.parse(JSON.stringify(op))
+      expect(parsed).toEqual(op)
+      expect(Array.isArray(parsed.path)).toBe(true)
+    })
+
+    it('should type a StreamUpdateResult with errors', () => {
+      const err: UpdateOpError = {
+        op_index: 0,
+        code: 'merge.path.proto_polluted',
+        message: 'Path segment "__proto__" is a prototype-pollution sink',
+      }
+      const result: StreamUpdateResult<{ x: number }> = {
+        old_value: undefined,
+        new_value: { x: 1 },
+        errors: [err],
+      }
+
+      expect(result.errors?.[0].code).toBe('merge.path.proto_polluted')
     })
 
     it('should apply partial updates via ops array', async () => {

--- a/sdk/packages/node/iii/tests/stream.test.ts
+++ b/sdk/packages/node/iii/tests/stream.test.ts
@@ -256,28 +256,12 @@ describe('Stream Operations', () => {
       expect(ops[0]).toEqual({ type: 'append', path: 'chunks', value: 'hello' })
     })
 
-    it('should round-trip merge with string path through JSON', () => {
-      const op = {
-        type: 'merge',
-        path: 'session-abc',
-        value: { author: 'alice' },
-      } satisfies UpdateMerge
-
+    it.each<[string, UpdateMerge]>([
+      ['string path (legacy / first-level)', { type: 'merge', path: 'session-abc', value: { author: 'alice' } }],
+      ['array path (nested)', { type: 'merge', path: ['sessions', 'abc'], value: { ts: 'chunk' } }],
+    ])('should round-trip merge with %s through JSON', (_, op) => {
       const parsed: UpdateMerge = JSON.parse(JSON.stringify(op))
       expect(parsed).toEqual(op)
-      expect(parsed.path).toBe('session-abc')
-    })
-
-    it('should round-trip merge with array path through JSON', () => {
-      const op = {
-        type: 'merge',
-        path: ['sessions', 'abc'],
-        value: { ts: 'chunk' },
-      } satisfies UpdateMerge
-
-      const parsed: UpdateMerge = JSON.parse(JSON.stringify(op))
-      expect(parsed).toEqual(op)
-      expect(Array.isArray(parsed.path)).toBe(true)
     })
 
     it('should type a StreamUpdateResult with errors', () => {

--- a/sdk/packages/python/iii/src/iii/stream.py
+++ b/sdk/packages/python/iii/src/iii/stream.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Generic, List, Literal, TypeVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 TData = TypeVar("TData")
 
@@ -91,6 +91,20 @@ class StreamUpdateInput(BaseModel):
     ops: list["UpdateOp"]
 
 
+class UpdateOpError(BaseModel):
+    """Per-op error returned by ``state::update`` / ``stream::update``.
+
+    Currently emitted only by the ``merge`` op when input violates the
+    new validation bounds. Successfully applied ops are still
+    reflected in the response's ``new_value``.
+    """
+
+    op_index: int
+    code: str
+    message: str
+    doc_url: str | None = None
+
+
 class StreamSetResult(BaseModel, Generic[TData]):
     """Result of stream set operation."""
 
@@ -105,8 +119,10 @@ class StreamUpdateResult(BaseModel, Generic[TData]):
     new_value: TData
     # Per-op errors. Currently emitted only by the ``merge`` op for
     # validation rejections. Field is omitted from the JSON wire when
-    # empty (default factory keeps the Python object usable).
-    errors: list["UpdateOpError"] = []
+    # empty. ``default_factory`` is used (not ``= []``) to keep
+    # Pydantic's parameterized-Generic + default handling well-behaved
+    # across Python versions.
+    errors: list[UpdateOpError] = Field(default_factory=list)
 
 
 class StreamDeleteResult(BaseModel):
@@ -188,20 +204,6 @@ class UpdateMerge(BaseModel):
     # input -> str, array input -> list[str].
     path: str | list[str] | None = None
     value: Any
-
-
-class UpdateOpError(BaseModel):
-    """Per-op error returned by ``state::update`` / ``stream::update``.
-
-    Currently emitted only by the ``merge`` op when input violates the
-    new validation bounds. Successfully applied ops are still
-    reflected in the response's ``new_value``.
-    """
-
-    op_index: int
-    code: str
-    message: str
-    doc_url: str | None = None
 
 
 UpdateOp = UpdateSet | UpdateIncrement | UpdateDecrement | UpdateAppend | UpdateRemove | UpdateMerge

--- a/sdk/packages/python/iii/src/iii/stream.py
+++ b/sdk/packages/python/iii/src/iii/stream.py
@@ -103,6 +103,10 @@ class StreamUpdateResult(BaseModel, Generic[TData]):
 
     old_value: TData | None = None
     new_value: TData
+    # Per-op errors. Currently emitted only by the ``merge`` op for
+    # validation rejections. Field is omitted from the JSON wire when
+    # empty (default factory keeps the Python object usable).
+    errors: list["UpdateOpError"] = []
 
 
 class StreamDeleteResult(BaseModel):
@@ -151,14 +155,53 @@ class UpdateRemove(BaseModel):
 
 
 class UpdateMerge(BaseModel):
-    """Shallow root-level merge operation for stream update.
+    """Shallow merge an object into the target.
 
-    Only an empty path is supported. Non-empty paths are ignored by the engine.
+    The target is the root (when ``path`` is omitted, an empty string,
+    or an empty list) or an arbitrary nested location specified by an
+    array of literal segments.
+
+    Path forms accepted:
+      - ``None`` / ``""`` / ``[]``: merge at the root.
+      - ``"foo"``: equivalent to ``["foo"]`` -- single first-level key.
+      - ``["a", "b", "c"]``: nested path. Each element is a *literal*
+        key. ``["a.b"]`` writes a single key named ``"a.b"``, not
+        ``a -> b``.
+
+    Engine semantics:
+      - Missing or non-object intermediates along the path are
+        auto-replaced with ``{}``.
+      - The merge is shallow at the target node (top-level keys of
+        ``value`` overwrite same-named keys; siblings preserved).
+
+    Validation: invalid paths/values (depth > 32 segments, segment >
+    256 bytes, value depth > 16, > 1024 top-level keys, or any
+    ``__proto__`` / ``constructor`` / ``prototype`` segment or
+    top-level key) are rejected with a structured error in the
+    ``errors`` array of the ``state::update`` / ``stream::update``
+    response. The merge does not apply when an error is returned.
     """
 
     type: str = "merge"
-    path: str
+    # Optional. Accepts a single string or a list of literal segments.
+    # Pydantic resolves ``str | list[str]`` via smart-union: string
+    # input -> str, array input -> list[str].
+    path: str | list[str] | None = None
     value: Any
+
+
+class UpdateOpError(BaseModel):
+    """Per-op error returned by ``state::update`` / ``stream::update``.
+
+    Currently emitted only by the ``merge`` op when input violates the
+    new validation bounds. Successfully applied ops are still
+    reflected in the response's ``new_value``.
+    """
+
+    op_index: int
+    code: str
+    message: str
+    doc_url: str | None = None
 
 
 UpdateOp = UpdateSet | UpdateIncrement | UpdateDecrement | UpdateAppend | UpdateRemove | UpdateMerge

--- a/sdk/packages/python/iii/tests/test_stream_models.py
+++ b/sdk/packages/python/iii/tests/test_stream_models.py
@@ -1,9 +1,73 @@
 """Unit tests for stream model serialization."""
 
-from iii.stream import UpdateAppend
+import json
+
+from iii.stream import StreamUpdateResult, UpdateAppend, UpdateMerge, UpdateOpError
 
 
 def test_update_append_model_serializes() -> None:
     op = UpdateAppend(path="chunks", value={"text": "hello"})
 
     assert op.model_dump() == {"type": "append", "path": "chunks", "value": {"text": "hello"}}
+
+
+def test_update_merge_with_string_path_round_trips() -> None:
+    op = UpdateMerge(path="session-abc", value={"author": "alice"})
+    dumped = op.model_dump()
+    assert dumped == {
+        "type": "merge",
+        "path": "session-abc",
+        "value": {"author": "alice"},
+    }
+    # JSON round-trip preserves the string form.
+    parsed = UpdateMerge.model_validate(json.loads(json.dumps(dumped)))
+    assert parsed.path == "session-abc"
+
+
+def test_update_merge_with_array_path_round_trips() -> None:
+    op = UpdateMerge(path=["sessions", "abc"], value={"ts": "chunk"})
+    dumped = op.model_dump()
+    assert dumped == {
+        "type": "merge",
+        "path": ["sessions", "abc"],
+        "value": {"ts": "chunk"},
+    }
+    parsed = UpdateMerge.model_validate(json.loads(json.dumps(dumped)))
+    assert parsed.path == ["sessions", "abc"]
+
+
+def test_update_merge_without_path_round_trips() -> None:
+    op = UpdateMerge(value={"x": 1})
+    dumped = op.model_dump()
+    assert dumped == {"type": "merge", "path": None, "value": {"x": 1}}
+    parsed = UpdateMerge.model_validate(json.loads(json.dumps(dumped)))
+    assert parsed.path is None
+
+
+def test_update_op_error_round_trip() -> None:
+    err = UpdateOpError(
+        op_index=0,
+        code="merge.path.too_deep",
+        message="Path depth 33 exceeds maximum of 32",
+        doc_url="https://docs.iii.dev/workers/iii-state#merge-bounds",
+    )
+    dumped = err.model_dump()
+    assert dumped["code"] == "merge.path.too_deep"
+    assert dumped["op_index"] == 0
+
+
+def test_stream_update_result_with_errors_round_trips() -> None:
+    result = StreamUpdateResult[dict](
+        old_value=None,
+        new_value={"a": 1},
+        errors=[
+            UpdateOpError(
+                op_index=0,
+                code="merge.path.proto_polluted",
+                message='Path segment "__proto__" is a prototype-pollution sink',
+            )
+        ],
+    )
+    dumped = result.model_dump()
+    assert len(dumped["errors"]) == 1
+    assert dumped["errors"][0]["code"] == "merge.path.proto_polluted"

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -38,9 +38,10 @@ pub use structs::{
 };
 pub use triggers::{Trigger, TriggerConfig, TriggerHandler};
 pub use types::{
-    ApiRequest, ApiResponse, Channel, DeleteResult, FieldPath, SetResult, StreamAuthInput,
-    StreamAuthResult, StreamDeleteInput, StreamGetInput, StreamJoinResult, StreamListGroupsInput,
-    StreamListInput, StreamSetInput, StreamUpdateInput, UpdateOp, UpdateResult,
+    ApiRequest, ApiResponse, Channel, DeleteResult, FieldPath, MergePath, SetResult,
+    StreamAuthInput, StreamAuthResult, StreamDeleteInput, StreamGetInput, StreamJoinResult,
+    StreamListGroupsInput, StreamListInput, StreamSetInput, StreamUpdateInput, UpdateOp,
+    UpdateOpError, UpdateResult,
 };
 
 pub use serde_json::Value;

--- a/sdk/packages/rust/iii/src/types.rs
+++ b/sdk/packages/rust/iii/src/types.rs
@@ -45,6 +45,52 @@ impl From<String> for FieldPath {
     }
 }
 
+/// Path target for a [`UpdateOp::Merge`] operation. Accepts either a
+/// single string (legacy / first-level field) or an array of literal
+/// segments (nested path).
+///
+/// Path normalization rules applied by the engine:
+/// - absent / `Single("")` / `Segments(vec![])` → root merge
+/// - `Single("foo")` is equivalent to `Segments(vec!["foo".into()])`
+/// - `Segments(["a", "b", "c"])` walks three literal keys, never
+///   interpreting dots specially. `Segments(vec!["a.b".into()])` is a
+///   single literal key named `"a.b"`.
+///
+/// **Variant ordering is load-bearing.** `#[serde(untagged)]` tries
+/// variants in declaration order — `Single` MUST come before
+/// `Segments` so a JSON string deserializes into `Single` rather than
+/// failing the array match first.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum MergePath {
+    Single(String),
+    Segments(Vec<String>),
+}
+
+impl From<&str> for MergePath {
+    fn from(value: &str) -> Self {
+        Self::Single(value.to_string())
+    }
+}
+
+impl From<String> for MergePath {
+    fn from(value: String) -> Self {
+        Self::Single(value)
+    }
+}
+
+impl From<Vec<String>> for MergePath {
+    fn from(value: Vec<String>) -> Self {
+        Self::Segments(value)
+    }
+}
+
+impl From<Vec<&str>> for MergePath {
+    fn from(value: Vec<&str>) -> Self {
+        Self::Segments(value.into_iter().map(String::from).collect())
+    }
+}
+
 /// Operations that can be performed atomically on a stream value
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "lowercase")]
@@ -55,9 +101,11 @@ pub enum UpdateOp {
         value: Option<Value>,
     },
 
-    /// Merge object into existing value (object-only)
+    /// Merge object into existing value (object-only). Path may be
+    /// omitted (root merge), a single first-level key, or an array of
+    /// literal segments for nested merge. See [`MergePath`].
     Merge {
-        path: Option<FieldPath>,
+        path: Option<MergePath>,
         value: Value,
     },
 
@@ -120,13 +168,47 @@ impl UpdateOp {
         }
     }
 
-    /// Create a Merge operation at a specific path
-    pub fn merge_at(path: impl Into<FieldPath>, value: impl Into<Value>) -> Self {
+    /// Create a Merge operation at a specific path. Accepts a single
+    /// first-level key (`"foo"`) or any type that converts into
+    /// [`MergePath`] (e.g. `Vec<String>` for nested paths).
+    pub fn merge_at(path: impl Into<MergePath>, value: impl Into<Value>) -> Self {
         Self::Merge {
             path: Some(path.into()),
             value: value.into(),
         }
     }
+
+    /// Create a Merge operation at a nested path of literal segments.
+    /// Convenience wrapper for `merge_at(vec!["a", "b"], v)`.
+    pub fn merge_at_path<I, S>(segments: I, value: impl Into<Value>) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self::Merge {
+            path: Some(MergePath::Segments(
+                segments.into_iter().map(Into::into).collect(),
+            )),
+            value: value.into(),
+        }
+    }
+}
+
+/// Per-op error reported by an atomic update operation. Currently
+/// emitted only for the `merge` op when input violates the new
+/// validation bounds (depth/size/proto-pollution); the other ops
+/// retain warn-and-skip semantics for backward compatibility.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct UpdateOpError {
+    /// Index of the offending op within the original `ops` array.
+    pub op_index: usize,
+    /// Stable error code, e.g. `"merge.path.too_deep"`.
+    pub code: String,
+    /// Human-readable description with concrete numbers when applicable.
+    pub message: String,
+    /// Optional documentation URL for this error class.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub doc_url: Option<String>,
 }
 
 /// Result of an atomic update operation
@@ -136,6 +218,11 @@ pub struct UpdateResult {
     pub old_value: Option<Value>,
     /// The value after the update
     pub new_value: Value,
+    /// Errors encountered while applying ops. Successfully applied ops
+    /// are still reflected in `new_value`. Field is omitted from JSON
+    /// when empty for backward compatibility.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub errors: Vec<UpdateOpError>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -310,5 +397,115 @@ mod tests {
             }
             other => panic!("expected append op, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn merge_with_string_path_round_trips_to_single_variant() {
+        // Regression: Single must come before Segments in the
+        // untagged enum or this test fails.
+        let op = UpdateOp::merge_at("session-abc", serde_json::json!({"author": "alice"}));
+        let encoded = serde_json::to_value(&op).unwrap();
+
+        assert_eq!(
+            encoded,
+            serde_json::json!({
+                "type": "merge",
+                "path": "session-abc",
+                "value": {"author": "alice"},
+            })
+        );
+
+        let decoded: UpdateOp = serde_json::from_value(encoded).unwrap();
+        match decoded {
+            UpdateOp::Merge {
+                path: Some(MergePath::Single(s)),
+                value,
+            } => {
+                assert_eq!(s, "session-abc");
+                assert_eq!(value, serde_json::json!({"author": "alice"}));
+            }
+            other => panic!("expected single-string merge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn merge_with_segments_path_round_trips_as_array() {
+        let op = UpdateOp::merge_at_path(["sessions", "abc"], serde_json::json!({"ts": "chunk"}));
+        let encoded = serde_json::to_value(&op).unwrap();
+
+        assert_eq!(
+            encoded,
+            serde_json::json!({
+                "type": "merge",
+                "path": ["sessions", "abc"],
+                "value": {"ts": "chunk"},
+            })
+        );
+
+        let decoded: UpdateOp = serde_json::from_value(encoded).unwrap();
+        match decoded {
+            UpdateOp::Merge {
+                path: Some(MergePath::Segments(segs)),
+                value,
+            } => {
+                assert_eq!(segs, vec!["sessions", "abc"]);
+                assert_eq!(value, serde_json::json!({"ts": "chunk"}));
+            }
+            other => panic!("expected segments merge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn merge_without_path_round_trips() {
+        let op = UpdateOp::merge(serde_json::json!({"x": 1}));
+        let encoded = serde_json::to_value(&op).unwrap();
+
+        // path is None, so it serializes as null.
+        assert_eq!(
+            encoded,
+            serde_json::json!({
+                "type": "merge",
+                "path": null,
+                "value": {"x": 1},
+            })
+        );
+
+        let decoded: UpdateOp = serde_json::from_value(encoded).unwrap();
+        match decoded {
+            UpdateOp::Merge { path: None, value } => {
+                assert_eq!(value, serde_json::json!({"x": 1}));
+            }
+            other => panic!("expected root merge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn update_result_with_errors_serializes_field() {
+        let result = UpdateResult {
+            old_value: None,
+            new_value: serde_json::json!({"a": 1}),
+            errors: vec![UpdateOpError {
+                op_index: 0,
+                code: "merge.path.too_deep".to_string(),
+                message: "Path depth 33 exceeds maximum of 32".to_string(),
+                doc_url: Some("https://docs.iii.dev/workers/iii-state#merge-bounds".to_string()),
+            }],
+        };
+        let encoded = serde_json::to_value(&result).unwrap();
+        assert_eq!(encoded["errors"][0]["code"], "merge.path.too_deep");
+    }
+
+    #[test]
+    fn update_result_without_errors_omits_field_from_json() {
+        let result = UpdateResult {
+            old_value: None,
+            new_value: serde_json::json!({"a": 1}),
+            errors: vec![],
+        };
+        let encoded = serde_json::to_value(&result).unwrap();
+        assert!(
+            encoded.get("errors").is_none(),
+            "errors field should be omitted when empty for backward compat"
+        );
     }
 }


### PR DESCRIPTION
Closes #1546.

## Summary

Atomic `merge` ops in `state::update` / `stream::update` previously dropped every non-empty `path` with a silent `[WARN] Only root-level merge is supported`. SDK types accepted any string while the engine threw it away — a trust violation that forced flat-key workarounds and full read-modify-write rewrites.

This PR generalizes `UpdateOp::Merge.path` to accept either a single string (legacy / first-level field, backward-compatible) **or** an array of literal segments for nested merge. The engine walks the segments, replacing or auto-creating non-object intermediates RFC 7396-style, then shallow-merges `value` at the target. Both the in-memory builtin and the Redis Lua `JSON_UPDATE_SCRIPT` are updated in lockstep so adapters stay consistent.

## What changed

**Engine (Rust + Lua)**
- `engine/src/update_ops.rs` — nested merge implementation, validation bounds (path depth ≤ 32, segment ≤ 256 B, value depth ≤ 16, ≤ 1024 top-level keys), prototype-pollution rejection (`__proto__` / `constructor` / `prototype`), structured error returns. 15 new unit tests.
- `engine/src/workers/redis.rs` — Lua `JSON_UPDATE_SCRIPT` rewritten with mirrored semantics. The previous `get_path` silently truncated array paths to `path[1]`; now it walks every segment with the identical bounds and proto rejection. Errors return as a 4th element of the response tuple.
- Both Redis adapter parsers updated to handle 3- or 4-element responses (backward-compatible).
- `engine/src/builtins/kv.rs` — plumbs errors through `UpdateResult`.
- `engine/src/workers/state/structs.rs` — JsonSchema regression test catches silent schemars drift.
- `engine/tests/state_stream_update_e2e.rs` (**new file**) — 6 integration scenarios.

**SDKs**
- **Rust** (`sdk/packages/rust/iii/src/types.rs`): new `MergePath` untagged enum (`Single` before `Segments` — variant order is load-bearing for serde), `UpdateOpError`, `UpdateResult.errors` field (omitted from JSON when empty), `merge_at` accepts `impl Into<MergePath>`, new `merge_at_path` helper. 5 new round-trip tests.
- **Node** (`sdk/packages/node/iii/src/stream.ts` + `state.ts`): `MergePath = string | string[]`, `UpdateMerge.path?: MergePath`, `UpdateOpError`, `errors?: UpdateOpError[]` on `StreamUpdateResult` / `StateUpdateResult`. JSON round-trip tests.
- **Browser** (`sdk/packages/node/iii-browser/src/stream.ts` + `state.ts`): same shape; new export-level type tests in `tests/exports.test.ts`.
- **Python** (`sdk/packages/python/iii/src/iii/stream.py`): `path: str | list[str] | None`, `UpdateOpError` model, `errors` field on `StreamUpdateResult`. 5 new pydantic round-trip tests.
- **Console frontend** (`console/packages/console-frontend/src/api/types/shared.ts`): `merge.path?: string | string[]` and `StreamUpdateOpError`.

**Docs**
- `docs/workers/iii-state.mdx` — merge row rewritten with both forms, validation contract, `errors` field documented.
- `docs/workers/iii-stream.mdx` — same prose update + cross-link.
- `docs/how-to/manage-state.mdx` — new "Build per-session structured state with nested merge" recipe in Node / Python / Rust tabs, walking issue #1546's exact use case end to end.

## Usage

### Use case 1 — issue #1546 case 1 (first-level field)
```ts
await iii.trigger({
  function_id: 'state::update',
  payload: {
    scope: 'audio::transcripts',
    key: 'session-abc',
    ops: [
      { type: 'merge', path: sessionId, value: { [Date.now()]: chunk } },
    ],
  },
})
```
Now writes `{ "<sessionId>": { "<timestamp>": chunk } }` and accumulates timestamps across calls. Previously: silent no-op.

### Use case 2 — nested merge (closes the bug class)
```ts
{
  type: 'merge',
  path: ['sessions', 'abc', 'metadata'],
  value: { author: 'alice' },
}
```
Walks `sessions → abc → metadata`, auto-creating each intermediate object. Sibling keys at every level are preserved.

### Use case 3 — root merge (backward-compatible)
```ts
{ type: 'merge', value: { status: 'active' } }     // path omitted
{ type: 'merge', path: '', value: { status: 'active' } }  // existing senders unchanged
```

### Use case 4 — replace-on-non-object (defends against poisoned state)
```ts
// Existing state: { sessions: null }
{ type: 'merge', path: ['sessions', 'abc'], value: { author: 'alice' } }
// Result: { sessions: { abc: { author: 'alice' } } }
// (intermediate `null` is replaced, not skipped — no more "stray null
//  blocks future merges forever")
```

### Use case 5 — structured error on invalid input
```jsonc
// Request:  merge with path ["__proto__", "polluted"]
// Response:
{
  "old_value": { ... },
  "new_value": { ... },          // unchanged; the merge did NOT apply
  "errors": [{
    "op_index": 0,
    "code": "merge.path.proto_polluted",
    "message": "Path segment \"__proto__\" is a prototype-pollution sink",
    "doc_url": "https://docs.iii.dev/workers/iii-state#merge-bounds"
  }]
}
```

Path segments are **literal**: `["a.b"]` writes one key named `"a.b"`, not `a → b`. This matches iii's existing `FieldPath` literal-key contract on the other ops and sidesteps Firestore-style dotted-string ambiguity.

## Backward compatibility

- Existing `path: ""` and `path: <string>` callers keep working unchanged.
- Existing `path: <non-empty-string>` payloads that previously emitted the warning **start working** as first-level merge (the bug fix).
- The new `errors` field is omitted from the JSON response when empty, so old clients that don't read it see the same `{old_value, new_value}` shape.
- Redis adapter response went from 3 elements to "3 or 4"; old engine ↔ old adapter still works, new engine ↔ old adapter sees only 3 elements when no errors occur.

## Test plan

- [ ] `cargo test -p iii-sdk --lib` → 59 passing (5 new round-trip tests)
- [ ] `cargo test -p iii update_ops:: --lib` → 26 passing (15 new merge / validation tests)
- [ ] `cargo test -p iii --test state_stream_update_e2e` → 6 passing (new file)
- [ ] `cargo test -p iii --lib` → 1501 passing, 0 failing
- [ ] `cd sdk/packages/node/iii && pnpm tsc --noEmit -p tsconfig.json` → clean
- [ ] `cd sdk/packages/node/iii-browser && pnpm vitest run tests/exports.test.ts` → 9 passing (4 new merge tests)
- [ ] `cd console/packages/console-frontend && pnpm tsc --noEmit -p tsconfig.json` → clean
- [ ] `cd sdk/packages/python/iii && uv run pytest tests/test_stream_models.py` → 5 new tests for `UpdateMerge` / `UpdateOpError` / `StreamUpdateResult`
- [ ] Manual repro of issue #1546 against a local engine — both case 1 (timestamps accumulating under a session id) and case 2 (`{author}` merging without nuking siblings) now work as the user described.
- [ ] `[WARN] Only root-level merge is supported` no longer fires anywhere (`rg "Only root-level merge"` returns zero matches in `engine/`, `sdk/`, `docs/`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Merge updates can target nested locations via an optional path (string or array of literal segments).
  * Update results may include per-operation structured errors for invalid merge ops.

* **Documentation**
  * Expanded guides clarifying path semantics and nested merge behavior, constraints, and error handling for state and stream updates.

* **Tests**
  * New and updated integration/unit tests validating nested merge semantics and per-op error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->