### PR TITLE
Enforce PR license agreement acknowledgements

### DIFF
--- a/.github/scripts/license-agreement-check.mjs
+++ b/.github/scripts/license-agreement-check.mjs
@@ -1,0 +1,313 @@
+import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+export const AGREEMENT_TEXT =
+  'I am licensing the entirety of this PR under Apache 2 and have all necessary rights to the code I am contributing.';
+export const ACKNOWLEDGEMENT_PHRASE = AGREEMENT_TEXT;
+export const STATUS_CONTEXT = 'license-agreement';
+export const STICKY_COMMENT_MARKER = '<!-- iii-license-agreement-check -->';
+
+const TEAM_PERMISSIONS = new Set(['write', 'maintain', 'admin']);
+const BOT_LOGINS = new Set(['github-actions[bot]']);
+
+export function hasCheckedLicenseAgreement(body = '') {
+  return String(body ?? '')
+    .split(/\r?\n/)
+    .some((line) => {
+      const match = line.match(/^\s*-\s*\[[xX]\]\s*(.*)$/);
+      return match && normalizeAgreementText(match[1]) === normalizeAgreementText(AGREEMENT_TEXT);
+    });
+}
+
+export function normalizeAgreementText(value = '') {
+  return value.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+export function isTeamPermission(permission = '') {
+  return TEAM_PERMISSIONS.has(permission);
+}
+
+export function isAgreementComment(comment, prAuthor) {
+  if (!comment?.body || !comment?.user?.login) {
+    return false;
+  }
+
+  if (BOT_LOGINS.has(comment.user.login)) {
+    return false;
+  }
+
+  if (comment.user.login !== prAuthor) {
+    return false;
+  }
+
+  if (comment.body.includes(STICKY_COMMENT_MARKER)) {
+    return false;
+  }
+
+  return normalizeAgreementText(comment.body) === normalizeAgreementText(ACKNOWLEDGEMENT_PHRASE);
+}
+
+export function hasAgreementComment(comments = [], prAuthor) {
+  return comments.some((comment) => isAgreementComment(comment, prAuthor));
+}
+
+export function findStickyComment(comments = []) {
+  return comments.find(
+    (comment) =>
+      comment.body?.includes(STICKY_COMMENT_MARKER) && BOT_LOGINS.has(comment.user?.login),
+  );
+}
+
+export function evaluateAgreement({ body = '', comments = [], permission = '', prAuthor = '' }) {
+  const teamMember = isTeamPermission(permission);
+  const bodyAcknowledged = hasCheckedLicenseAgreement(body);
+  const commentAcknowledged = hasAgreementComment(comments, prAuthor);
+  const acknowledged = teamMember || bodyAcknowledged || commentAcknowledged;
+
+  return {
+    acknowledged,
+    bodyAcknowledged,
+    commentAcknowledged,
+    teamMember,
+  };
+}
+
+export function buildPendingComment(prAuthor) {
+  return [
+    STICKY_COMMENT_MARKER,
+    '## License agreement required',
+    '',
+    `@${prAuthor}, thanks for contributing. Before this PR can be merged, please acknowledge the contributor license agreement:`,
+    '',
+    `> ${AGREEMENT_TEXT}`,
+    '',
+    'You can satisfy this requirement in either of these ways:',
+    '',
+    `- Check the license agreement box in the PR description.`,
+    `- Reply to this PR with exactly: ${ACKNOWLEDGEMENT_PHRASE}`,
+  ].join('\n');
+}
+
+export function buildSatisfiedComment(prAuthor, source) {
+  const sourceLabel = source === 'comment' ? 'PR comment' : 'PR description checkbox';
+
+  return [
+    STICKY_COMMENT_MARKER,
+    '## License agreement recorded',
+    '',
+    `@${prAuthor}, the license agreement acknowledgement has been recorded from the ${sourceLabel}.`,
+    '',
+    `> ${AGREEMENT_TEXT}`,
+  ].join('\n');
+}
+
+function getRequiredEnv(name) {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+
+  return value;
+}
+
+function getRepoParts() {
+  const repository = getRequiredEnv('GITHUB_REPOSITORY');
+  const [owner, repo] = repository.split('/');
+
+  if (!owner || !repo) {
+    throw new Error(`Invalid GITHUB_REPOSITORY: ${repository}`);
+  }
+
+  return { owner, repo, repository };
+}
+
+async function githubRequest(path, options = {}) {
+  const token = getRequiredEnv('GITHUB_TOKEN');
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...options,
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+      'x-github-api-version': '2022-11-28',
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    const error = new Error(`GitHub API request failed: ${response.status} ${path} ${message}`);
+    error.status = response.status;
+    throw error;
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  return response.json();
+}
+
+async function getPermission({ owner, repo, username }) {
+  try {
+    const result = await githubRequest(
+      `/repos/${owner}/${repo}/collaborators/${encodeURIComponent(username)}/permission`,
+    );
+
+    return result.permission || 'none';
+  } catch (error) {
+    if (error.status === 404) {
+      return 'none';
+    }
+
+    throw error;
+  }
+}
+
+async function listIssueComments({ owner, repo, issueNumber }) {
+  const comments = [];
+
+  for (let page = 1; ; page += 1) {
+    const batch = await githubRequest(
+      `/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
+    );
+    comments.push(...batch);
+
+    if (batch.length < 100) {
+      return comments;
+    }
+  }
+}
+
+async function upsertStickyComment({ owner, repo, issueNumber, comments, body }) {
+  const stickyComment = findStickyComment(comments);
+
+  if (stickyComment) {
+    await githubRequest(`/repos/${owner}/${repo}/issues/comments/${stickyComment.id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ body }),
+    });
+    return;
+  }
+
+  await githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
+    method: 'POST',
+    body: JSON.stringify({ body }),
+  });
+}
+
+async function createCommitStatus({ owner, repo, sha, state, description }) {
+  const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+  const repository = getRequiredEnv('GITHUB_REPOSITORY');
+  const runId = getRequiredEnv('GITHUB_RUN_ID');
+
+  await githubRequest(`/repos/${owner}/${repo}/statuses/${sha}`, {
+    method: 'POST',
+    body: JSON.stringify({
+      context: STATUS_CONTEXT,
+      description,
+      state,
+      target_url: `${serverUrl}/${repository}/actions/runs/${runId}`,
+    }),
+  });
+}
+
+async function getPullRequestForEvent({ event, owner, repo }) {
+  if (event.pull_request) {
+    return {
+      issueNumber: event.pull_request.number,
+      pullRequest: event.pull_request,
+    };
+  }
+
+  if (!event.issue?.pull_request) {
+    return null;
+  }
+
+  return {
+    issueNumber: event.issue.number,
+    pullRequest: await githubRequest(`/repos/${owner}/${repo}/pulls/${event.issue.number}`),
+  };
+}
+
+export async function run() {
+  const event = JSON.parse(await readFile(getRequiredEnv('GITHUB_EVENT_PATH'), 'utf8'));
+  const { owner, repo } = getRepoParts();
+  const prContext = await getPullRequestForEvent({ event, owner, repo });
+
+  if (!prContext) {
+    console.log('No pull request found for this event; skipping license agreement check.');
+    return;
+  }
+
+  const { issueNumber, pullRequest } = prContext;
+  const prAuthor = pullRequest.user.login;
+  const headSha = pullRequest.head.sha;
+  const comments = await listIssueComments({ owner, repo, issueNumber });
+  const permission = await getPermission({ owner, repo, username: prAuthor });
+  const result = evaluateAgreement({
+    body: pullRequest.body || '',
+    comments,
+    permission,
+    prAuthor,
+  });
+
+  if (result.teamMember) {
+    await createCommitStatus({
+      owner,
+      repo,
+      sha: headSha,
+      state: 'success',
+      description: 'iii team member; license agreement check skipped.',
+    });
+    console.log(`Skipping license agreement prompt for ${prAuthor} with ${permission} permission.`);
+    return;
+  }
+
+  if (result.acknowledged) {
+    const source = result.commentAcknowledged ? 'comment' : 'body';
+    await upsertStickyComment({
+      owner,
+      repo,
+      issueNumber,
+      comments,
+      body: buildSatisfiedComment(prAuthor, source),
+    });
+    await createCommitStatus({
+      owner,
+      repo,
+      sha: headSha,
+      state: 'success',
+      description: 'License agreement acknowledged.',
+    });
+    console.log(`License agreement acknowledged by ${prAuthor} through ${source}.`);
+    return;
+  }
+
+  await upsertStickyComment({
+    owner,
+    repo,
+    issueNumber,
+    comments,
+    body: buildPendingComment(prAuthor),
+  });
+  await createCommitStatus({
+    owner,
+    repo,
+    sha: headSha,
+    state: 'failure',
+    description: 'License agreement acknowledgement required.',
+  });
+  console.error(
+    `::error::License agreement acknowledgement required. ${prAuthor} must check the PR description box or reply with the exact acknowledgement phrase.`,
+  );
+  process.exitCode = 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  run().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/license-agreement-check.test.mjs
+++ b/.github/scripts/license-agreement-check.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  ACKNOWLEDGEMENT_PHRASE,
+  STICKY_COMMENT_MARKER,
+  evaluateAgreement,
+  findStickyComment,
+  hasAgreementComment,
+  hasCheckedLicenseAgreement,
+  isAgreementComment,
+  isTeamPermission,
+} from './license-agreement-check.mjs';
+
+test('detects a checked Apache license agreement in the PR body', () => {
+  const body = [
+    '## What',
+    'A contribution',
+    '',
+    '- [x] I am licensing the entirety of this PR under Apache 2 and have all necessary rights to the code I am contributing.',
+  ].join('\n');
+
+  assert.equal(hasCheckedLicenseAgreement(body), true);
+});
+
+test('detects an uppercase checked Apache license agreement in the PR body', () => {
+  const body = `- [X] ${ACKNOWLEDGEMENT_PHRASE}`;
+
+  assert.equal(hasCheckedLicenseAgreement(body), true);
+});
+
+test('handles a null PR body', () => {
+  assert.equal(hasCheckedLicenseAgreement(null), false);
+});
+
+test('rejects an unchecked Apache license agreement in the PR body', () => {
+  const body =
+    '- [ ] I am licensing the entirety of this PR under Apache 2 and have all necessary rights to the code I am contributing.';
+
+  assert.equal(hasCheckedLicenseAgreement(body), false);
+});
+
+test('rejects checked tasks that do not mention licensing and Apache', () => {
+  assert.equal(hasCheckedLicenseAgreement('- [x] Tests pass locally'), false);
+});
+
+test('accepts the exact acknowledgement phrase from the PR author', () => {
+  const comment = {
+    body: ACKNOWLEDGEMENT_PHRASE,
+    user: { login: 'external-user' },
+  };
+
+  assert.equal(isAgreementComment(comment, 'external-user'), true);
+});
+
+test('rejects the acknowledgement phrase when embedded in a longer comment', () => {
+  const comment = {
+    body: `No, ${ACKNOWLEDGEMENT_PHRASE}`,
+    user: { login: 'external-user' },
+  };
+
+  assert.equal(isAgreementComment(comment, 'external-user'), false);
+});
+
+test('ignores acknowledgement comments from other users', () => {
+  const comment = {
+    body: ACKNOWLEDGEMENT_PHRASE,
+    user: { login: 'reviewer' },
+  };
+
+  assert.equal(isAgreementComment(comment, 'external-user'), false);
+});
+
+test('ignores bot-authored acknowledgement comments', () => {
+  const comment = {
+    body: ACKNOWLEDGEMENT_PHRASE,
+    user: { login: 'github-actions[bot]' },
+  };
+
+  assert.equal(isAgreementComment(comment, 'github-actions[bot]'), false);
+});
+
+test('ignores the sticky comment marker as acknowledgement', () => {
+  const comment = {
+    body: `${STICKY_COMMENT_MARKER}\n${ACKNOWLEDGEMENT_PHRASE}`,
+    user: { login: 'external-user' },
+  };
+
+  assert.equal(isAgreementComment(comment, 'external-user'), false);
+});
+
+test('finds an author acknowledgement among comments', () => {
+  const comments = [
+    { body: ACKNOWLEDGEMENT_PHRASE, user: { login: 'reviewer' } },
+    { body: ACKNOWLEDGEMENT_PHRASE, user: { login: 'external-user' } },
+  ];
+
+  assert.equal(hasAgreementComment(comments, 'external-user'), true);
+});
+
+test('finds sticky comments only when authored by the workflow bot', () => {
+  const comments = [
+    { body: STICKY_COMMENT_MARKER, user: { login: 'external-user' } },
+    { body: STICKY_COMMENT_MARKER, user: { login: 'github-actions[bot]' }, id: 123 },
+  ];
+
+  assert.deepEqual(findStickyComment(comments), comments[1]);
+});
+
+test('classifies write, maintain, and admin permissions as team members', () => {
+  assert.equal(isTeamPermission('write'), true);
+  assert.equal(isTeamPermission('maintain'), true);
+  assert.equal(isTeamPermission('admin'), true);
+});
+
+test('classifies read, triage, and none permissions as external contributors', () => {
+  assert.equal(isTeamPermission('read'), false);
+  assert.equal(isTeamPermission('triage'), false);
+  assert.equal(isTeamPermission('none'), false);
+});
+
+test('passes team members without an acknowledgement', () => {
+  const result = evaluateAgreement({
+    body: '',
+    comments: [],
+    permission: 'write',
+    prAuthor: 'team-member',
+  });
+
+  assert.deepEqual(result, {
+    acknowledged: true,
+    bodyAcknowledged: false,
+    commentAcknowledged: false,
+    teamMember: true,
+  });
+});
+
+test('passes external contributors with an acknowledgement comment', () => {
+  const result = evaluateAgreement({
+    body: '',
+    comments: [{ body: ACKNOWLEDGEMENT_PHRASE, user: { login: 'external-user' } }],
+    permission: 'read',
+    prAuthor: 'external-user',
+  });
+
+  assert.deepEqual(result, {
+    acknowledged: true,
+    bodyAcknowledged: false,
+    commentAcknowledged: true,
+    teamMember: false,
+  });
+});
+
+test('fails external contributors without body or comment acknowledgement', () => {
+  const result = evaluateAgreement({
+    body: '',
+    comments: [],
+    permission: 'none',
+    prAuthor: 'external-user',
+  });
+
+  assert.deepEqual(result, {
+    acknowledged: false,
+    bodyAcknowledged: false,
+    commentAcknowledged: false,
+    teamMember: false,
+  });
+});

--- a/.github/workflows/WORKFLOWS.md
+++ b/.github/workflows/WORKFLOWS.md
@@ -33,6 +33,7 @@ The workflows are organized into two categories:
    ci.yml ◄── push to main / PRs
    docker-engine.yml ◄── called by release-iii / manual
    license-check.yml ◄── push to main / PRs
+   checklist-checker.yml ◄── PR license agreement / comments
 ```
 
 ---
@@ -158,6 +159,14 @@ Downloads pre-built binaries from the GitHub Release (no Rust compilation) and p
 **Triggers:** push to `main`, pull requests to `main`
 
 Uses [hawkeye](https://github.com/korandoru/hawkeye) to verify license headers across source files, configured via `engine/licenserc.toml`.
+
+### `checklist-checker.yml` — License Agreement Check
+
+**Triggers:** `pull_request_target` for pull request changes, `issue_comment` for PR comments
+
+Requires external contributors to acknowledge the Apache 2.0 contributor license agreement before merge. Contributors can satisfy the gate by checking the license box in the PR description or by replying with the exact acknowledgement phrase posted by the bot. iii team members with `write`, `maintain`, or `admin` repository permission are skipped.
+
+The workflow posts a sticky PR comment and publishes the `license-agreement` commit status on the PR head SHA. Branch protection should require the `license-agreement` status context.
 
 ---
 

--- a/.github/workflows/checklist-checker.yml
+++ b/.github/workflows/checklist-checker.yml
@@ -1,37 +1,36 @@
-name: 'PR Tasks Completed Check'
+name: License Agreement Check
+
 on:
-  pull_request:
-    types: [opened, edited, synchronize, reopened]
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created, edited, deleted]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+  statuses: write
+
+concurrency:
+  group: license-agreement-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
 
 jobs:
-  task-check:
+  license-agreement:
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
     runs-on: ubuntu-latest
     steps:
-      - name: Check repo permission
-        id: perm-check
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Check license agreement
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          USER=$(jq -r '.pull_request.user.login' "$GITHUB_EVENT_PATH")
-          PERM=$(gh api "repos/${{ github.repository }}/collaborators/$USER/permission" --jq '.permission')
-          echo "level=$PERM" >> "$GITHUB_OUTPUT"
-      - name: Check all tasks are completed
-        if: steps.perm-check.outputs.level != 'admin'
-        run: |
-          BODY=$(jq -r '.pull_request.body' "$GITHUB_EVENT_PATH")
-          TOTAL=$(echo "$BODY" | grep -cE '^\s*- \[[ xX]\]' || true)
-          if [ "$TOTAL" -eq 0 ]; then
-            echo "::error::PR has no checklist items. The template checklist was removed — restore it from .github/pull_request_template.md."
-            exit 1
-          fi
-          # Match a checked box that mentions both "licens" and "Apache" so the
-          # check survives minor rewordings of the template copy.
-          if ! echo "$BODY" | grep -qiE '^\s*- \[[xX]\].*licens.*Apache'; then
-            echo "::error::Apache 2.0 license checkbox is unchecked. Edit this PR's description (click the Edit pencil at the top of the PR) and tick the box that starts with 'I am licensing...'. This confirmation is required before the PR can be merged."
-            exit 1
-          fi
-          UNCHECKED=$(echo "$BODY" | grep -cE '^\s*- \[ \]' || true)
-          if [ "$UNCHECKED" -gt 0 ]; then
-            echo "::error::PR has $UNCHECKED unchecked task(s). Edit the PR description and tick each remaining checkbox."
-            exit 1
-          fi
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/license-agreement-check.mjs


### PR DESCRIPTION
## Summary
- Replace the PR checklist workflow with a license agreement gate for external contributors.
- Allow acknowledgement through the existing PR checkbox or an exact PR-author comment reply.
- Add sticky PR comments and a `license-agreement` commit status for branch protection.

## Test plan
- `node --check .github/scripts/license-agreement-check.mjs`
- `node --test .github/scripts/license-agreement-check.test.mjs`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/checklist-checker.yml'); puts 'workflow yaml parsed'"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated license agreement acknowledgement check for pull requests. Contributors can acknowledge via PR description checkbox or comment. Team members with write access or higher bypass the check automatically.

* **Tests**
  * Added comprehensive test suite for license agreement validation.

* **Documentation**
  * Added workflow documentation describing the license agreement enforcement process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->