### PR TITLE
ci: free disk space in engine-test job to fix cache save OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Free up disk space to avoid "No space left on device" during the
+      # post-job rust-cache save step on ubuntu-latest runners.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/microsoft
+          df -h /
+
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

The Engine Tests job on [run 25014001264](https://github.com/iii-hq/iii/actions/runs/25014001264/job/73256896119) failed in the post-job `Swatinem/rust-cache@v2` save step with `No space left on device`, even though every test had passed:

```
##[error]No space left on device : '/home/runner/actions-runner/cached/2.333.1/_diag/pages/...'
Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
... Cleaning /home/runner/work/iii/iii/target ...
```

The ubuntu-latest runner has ~14GB free; the Rust `target/` directory plus the cache-save tarball pushed it over.

This adds a `Free disk space` step at the top of the `engine-test` job that removes pre-installed toolchains we don't use (CodeQL, dotnet, Android SDK, GHC, Microsoft tools), giving the runner ~30GB of additional headroom before the cache save runs.

## Test plan

- [ ] CI green on this PR (the same engine-test job runs here)
- [ ] `df -h /` output in the new step shows the freed space

## Notes

The same run also had a flake in SDK Node Tests (`HTTP Middleware > should execute multiple middleware in order`, 30s timeout). The exact same commit passed CI on the PR branch and the test passed in 306ms on the previous main run, with no engine-runtime code changes touching the middleware path. Not patched here — out of scope and would be a guess without being able to reproduce. If it recurs, capturing `/tmp/iii-engine.log` as a CI artifact on failure would be the next investigation step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow stability by implementing automatic disk space cleanup during test execution to prevent storage-related failures and ensure reliable testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->