### PR TITLE
fix(worker): tighten lockfile validation and surface distinct sync er…

### DIFF
--- a/crates/iii-worker/src/cli/lockfile.rs
+++ b/crates/iii-worker/src/cli/lockfile.rs
@@ -135,13 +135,22 @@ impl Default for WorkerLockfile {
     }
 }
 
-/// Returns `true` if `s` matches the `"sha256:v1:<64-hex>"` manifest-hash
-/// shape. Used by lockfile validation and drift detection.
+/// Returns `true` if `s` matches the `"sha256:v1:<64-lowercase-hex>"`
+/// manifest-hash shape. Used by lockfile validation and drift detection.
+///
+/// Comparison against `compute_manifest_hash` output is byte-exact, and
+/// `hex::encode` always emits lowercase — so an uppercase-hex hash
+/// would silently never match and trigger false-positive drift on every
+/// sync. We reject uppercase here so the validator catches that
+/// hand-edit immediately.
 pub fn is_valid_manifest_hash(s: &str) -> bool {
     let Some(rest) = s.strip_prefix(MANIFEST_HASH_PREFIX) else {
         return false;
     };
-    rest.len() == 64 && rest.chars().all(|c| c.is_ascii_hexdigit())
+    rest.len() == 64
+        && rest
+            .chars()
+            .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
 }
 
 impl WorkerLockfile {
@@ -233,7 +242,22 @@ impl WorkerLockfile {
         {
             return Err(format!(
                 "{LOCKFILE_NAME} manifest_hash must match \
-                 `{MANIFEST_HASH_PREFIX}<64-hex>`; got `{hash}`"
+                 `{MANIFEST_HASH_PREFIX}<64-lowercase-hex>`; got `{hash}`"
+            ));
+        }
+
+        // `manifest_hash` and `declared_dependencies` must be paired:
+        // `(None, None)` is a legacy lock (drift detection skipped),
+        // `(Some, None)` is hash-only attribution, and `(Some, Some)` is
+        // the full Lane-A shape. `(None, Some)` is the dangerous combo
+        // — it means the deps are recorded but drift detection is
+        // disabled, so stripping the hash from a Lane-A lock would
+        // silently bypass `--frozen`.
+        if self.declared_dependencies.is_some() && self.manifest_hash.is_none() {
+            return Err(format!(
+                "{LOCKFILE_NAME}: declared_dependencies is set without manifest_hash; \
+                 the lock is internally inconsistent (stripping `manifest_hash` would \
+                 silently bypass drift detection)"
             ));
         }
 
@@ -242,9 +266,31 @@ impl WorkerLockfile {
                 super::registry::validate_worker_name(name).map_err(|e| {
                     format!("{LOCKFILE_NAME} declared dependency `{name}` is invalid: {e}")
                 })?;
-                if range.trim().is_empty() {
+                let trimmed = range.trim();
+                if trimmed.is_empty() {
                     return Err(format!(
                         "{LOCKFILE_NAME} declared dependency `{name}` has empty range"
+                    ));
+                }
+                semver::VersionReq::parse(trimmed).map_err(|e| {
+                    format!(
+                        "{LOCKFILE_NAME} declared dependency `{name}` has invalid \
+                         semver range `{range}`: {e}"
+                    )
+                })?;
+            }
+
+            // Cross-check: when both fields are present they must be
+            // mutually consistent. Compute the canonical hash from
+            // `declared_dependencies` and reject any mismatch — silent
+            // mismatches let drift detection produce empty,
+            // unactionable error reports.
+            if let Some(stored_hash) = &self.manifest_hash {
+                let computed = super::sync::compute_manifest_hash(declared);
+                if &computed != stored_hash {
+                    return Err(format!(
+                        "{LOCKFILE_NAME}: manifest_hash does not match \
+                         declared_dependencies; the lock is internally inconsistent"
                     ));
                 }
             }
@@ -843,7 +889,12 @@ workers:
             ("alpha".to_string(), "^1.0".to_string()),
             ("beta".to_string(), "~2.0".to_string()),
         ]);
+        // Validation requires manifest_hash and declared_dependencies
+        // to be paired and consistent. Compute the hash from the
+        // declared deps so the roundtrip stays valid.
+        let manifest_hash = Some(super::super::sync::compute_manifest_hash(&declared));
         let lock = WorkerLockfile {
+            manifest_hash,
             declared_dependencies: Some(declared.clone()),
             ..Default::default()
         };
@@ -854,12 +905,15 @@ workers:
 
     #[test]
     fn declared_dependencies_rejects_empty_range() {
-        let yaml = r#"version: 1
-declared_dependencies:
-  alpha: ""
-workers: {}
-"#;
-        let err = WorkerLockfile::from_yaml(yaml).unwrap_err();
+        // Pair the empty range with a manifest_hash so the (None,Some)
+        // pairing check doesn't fire first — we want to assert the
+        // empty-range check specifically.
+        let yaml = format!(
+            "version: 1\nmanifest_hash: \"{prefix}{hex}\"\ndeclared_dependencies:\n  alpha: \"\"\nworkers: {{}}\n",
+            prefix = MANIFEST_HASH_PREFIX,
+            hex = "0".repeat(64),
+        );
+        let err = WorkerLockfile::from_yaml(&yaml).unwrap_err();
         assert!(err.contains("alpha"), "got: {err}");
         assert!(err.contains("empty range"), "got: {err}");
     }

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -199,16 +199,38 @@ pub async fn handle_worker_sync(frozen: bool) -> i32 {
         // Drift check: only active for locks that carry a manifest_hash
         // (i.e. written by Lane A or later). Legacy locks fall through
         // to verify unchanged so we don't regress existing CI pipelines.
+        //
+        // Each `iii.worker.yaml` state surfaces a distinct error so the
+        // user sees what's actually wrong: a *missing* manifest reads
+        // as `ManifestMissing`, a *malformed* one as `CorruptManifest`,
+        // and a hash mismatch with no structural drift as
+        // `LockInconsistent`. Only an actual content change reaches the
+        // `Drift` variant — the one with actionable add/remove/change
+        // attribution.
         if let Some(stored_hash) = &lockfile.manifest_hash {
-            let manifest_deps = load_cwd_manifest_dependencies().unwrap_or_default();
-            let current_hash = super::sync::compute_manifest_hash(&manifest_deps);
-            if current_hash != *stored_hash {
-                let lock_deps = lockfile.declared_dependencies.clone().unwrap_or_default();
-                let report =
-                    super::sync::detect_drift(&manifest_deps, &lock_deps).unwrap_or_default();
-                let err = super::sync::SyncError::Drift { report };
-                // stdout is reserved for worker names; all diagnostic output
-                // — including the drift error — goes to stderr.
+            let err: Option<super::sync::SyncError> = match load_cwd_manifest_state() {
+                ManifestState::Missing => Some(super::sync::SyncError::ManifestMissing {
+                    lock_deps: lockfile.declared_dependencies.clone().unwrap_or_default(),
+                }),
+                ManifestState::Malformed(reason) => {
+                    Some(super::sync::SyncError::CorruptManifest { reason })
+                }
+                ManifestState::Loaded(manifest_deps) => {
+                    let current_hash = super::sync::compute_manifest_hash(&manifest_deps);
+                    if current_hash != *stored_hash {
+                        let lock_deps = lockfile.declared_dependencies.clone().unwrap_or_default();
+                        match super::sync::detect_drift(&manifest_deps, &lock_deps) {
+                            Some(report) => Some(super::sync::SyncError::Drift { report }),
+                            None => Some(super::sync::SyncError::LockInconsistent),
+                        }
+                    } else {
+                        None
+                    }
+                }
+            };
+            if let Some(err) = err {
+                // stdout is reserved for worker names; all diagnostic
+                // output goes to stderr.
                 eprint!("{}", err.render());
                 return 1;
             }
@@ -499,19 +521,40 @@ fn read_lockfile_or_default(
     }
 }
 
+/// Distinguishes the three states of `iii.worker.yaml` that drift
+/// detection cares about. Collapsing `Missing` and `Malformed` into the
+/// same fallback (as `load_cwd_manifest_dependencies` does for the
+/// `iii worker add` write path) is fine for *populating* a fresh hash,
+/// but it produces misleading "drift" output when those states arise
+/// during `--frozen`. The `--frozen` path uses this enum directly so
+/// each state surfaces with its own error variant.
+pub(crate) enum ManifestState {
+    Missing,
+    Malformed(String),
+    Loaded(std::collections::BTreeMap<String, String>),
+}
+
+pub(crate) fn load_cwd_manifest_state() -> ManifestState {
+    let manifest_path = std::path::Path::new("iii.worker.yaml");
+    if !manifest_path.exists() {
+        return ManifestState::Missing;
+    }
+    match super::project::load_manifest_dependencies(manifest_path) {
+        Ok(deps) => ManifestState::Loaded(deps),
+        Err(e) => ManifestState::Malformed(e),
+    }
+}
+
 /// Read the cwd `iii.worker.yaml` `dependencies:` block. Returns `None`
 /// when the file is absent, empty, or has a null dependencies field.
 /// Errors are downgraded to `None` with a stderr warning — missing or
 /// malformed root manifests should not block a resolve that otherwise
 /// succeeded; drift detection just doesn't light up for that project.
 fn load_cwd_manifest_dependencies() -> Option<std::collections::BTreeMap<String, String>> {
-    let manifest_path = std::path::Path::new("iii.worker.yaml");
-    if !manifest_path.exists() {
-        return None;
-    }
-    match super::project::load_manifest_dependencies(manifest_path) {
-        Ok(deps) => Some(deps),
-        Err(e) => {
+    match load_cwd_manifest_state() {
+        ManifestState::Loaded(deps) => Some(deps),
+        ManifestState::Missing => None,
+        ManifestState::Malformed(e) => {
             eprintln!(
                 "  {} ignoring iii.worker.yaml for manifest_hash: {e}",
                 "warning:".yellow()
@@ -3809,6 +3852,87 @@ dependencies:
             // Falls through to verify, which passes because config.yaml
             // is absent and verify is asymmetric w.r.t. extras.
             assert_eq!(rc, 0);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_worker_sync_frozen_fails_when_manifest_missing() {
+        // Lock has manifest_hash + declared_dependencies but
+        // iii.worker.yaml doesn't exist. The user must see a distinct
+        // error — NOT a misleading "drift" report — and rc must be 1.
+        in_temp_dir_async(|dir| async move {
+            use super::super::lockfile::WorkerLockfile;
+            use super::super::sync::compute_manifest_hash;
+            use std::collections::BTreeMap;
+
+            let declared = BTreeMap::from([("alpha".to_string(), "^1.0.0".to_string())]);
+            let lock = WorkerLockfile {
+                manifest_hash: Some(compute_manifest_hash(&declared)),
+                declared_dependencies: Some(declared),
+                ..Default::default()
+            };
+            lock.write_to(&dir.join("iii.lock")).unwrap();
+            // No iii.worker.yaml — that's the scenario.
+
+            let rc = handle_worker_sync(true).await;
+            assert_eq!(rc, 1);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_worker_sync_frozen_fails_when_manifest_malformed() {
+        // Lock is fine; iii.worker.yaml has bad YAML. The user must see
+        // a CorruptManifest error (with the parser reason) — not drift.
+        in_temp_dir_async(|dir| async move {
+            use super::super::lockfile::WorkerLockfile;
+            use super::super::sync::compute_manifest_hash;
+            use std::collections::BTreeMap;
+
+            let declared = BTreeMap::from([("alpha".to_string(), "^1.0.0".to_string())]);
+            let lock = WorkerLockfile {
+                manifest_hash: Some(compute_manifest_hash(&declared)),
+                declared_dependencies: Some(declared),
+                ..Default::default()
+            };
+            lock.write_to(&dir.join("iii.lock")).unwrap();
+            std::fs::write(
+                dir.join("iii.worker.yaml"),
+                "name: x\ndependencies: this-is-not-a-mapping\n",
+            )
+            .unwrap();
+
+            let rc = handle_worker_sync(true).await;
+            assert_eq!(rc, 1);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_worker_sync_frozen_rejects_inconsistent_lock_at_read() {
+        // A lock with manifest_hash that does NOT match its
+        // declared_dependencies must be rejected at read time so the
+        // empty-drift-report path is unreachable end-to-end.
+        in_temp_dir_async(|dir| async move {
+            use super::super::lockfile::MANIFEST_HASH_PREFIX;
+
+            let bogus_hash = format!("{MANIFEST_HASH_PREFIX}{}", "f".repeat(64));
+            std::fs::write(
+                dir.join("iii.lock"),
+                format!(
+                    "version: 1\nmanifest_hash: \"{bogus_hash}\"\ndeclared_dependencies:\n  alpha: \"^1.0.0\"\nworkers: {{}}\n",
+                ),
+            )
+            .unwrap();
+            std::fs::write(
+                dir.join("iii.worker.yaml"),
+                "name: x\ndependencies:\n  alpha: \"^1.0.0\"\n",
+            )
+            .unwrap();
+
+            let rc = handle_worker_sync(true).await;
+            assert_eq!(rc, 1);
         })
         .await;
     }

--- a/crates/iii-worker/src/cli/sync.rs
+++ b/crates/iii-worker/src/cli/sync.rs
@@ -107,6 +107,21 @@ pub enum SyncError {
     Drift { report: DriftReport },
     /// Lockfile on disk but malformed or unreadable.
     CorruptLock { path: String, reason: String },
+    /// `iii.worker.yaml` does not exist but the lock recorded a
+    /// manifest_hash. Distinct from drift: the manifest isn't *changed*,
+    /// it's *gone* — the user needs to restore the file or remove the
+    /// lock, not run `--refresh`.
+    ManifestMissing { lock_deps: BTreeMap<String, String> },
+    /// `iii.worker.yaml` exists but failed to parse. The reason carries
+    /// the parser's message so the user can fix the YAML directly.
+    CorruptManifest { reason: String },
+    /// The lock's `manifest_hash` does not match
+    /// `compute_manifest_hash(&declared_dependencies)` AND
+    /// declared_dependencies equals the manifest deps. The lock is
+    /// internally inconsistent (likely tampered or partially edited);
+    /// drift attribution would be empty so we surface the corruption
+    /// directly instead.
+    LockInconsistent,
     // CacheMiss and NetworkRequired variants land in Slice A.3 (install-
     // from-lock) and Lane B (CAS). Not included here to avoid dead code.
 }
@@ -127,8 +142,32 @@ impl SyncError {
                      docs: https://iii.dev/docs/sync#corrupt-lock\n"
                 )
             }
+            Self::ManifestMissing { lock_deps } => render_manifest_missing(lock_deps),
+            Self::CorruptManifest { reason } => {
+                format!(
+                    "error: iii.worker.yaml failed to parse: {reason}\n\
+                     fix: correct the YAML in iii.worker.yaml and re-run\n\
+                     docs: https://iii.dev/docs/sync#corrupt-manifest\n"
+                )
+            }
+            Self::LockInconsistent => String::from(
+                "error: iii.lock is internally inconsistent: \
+                 manifest_hash does not match declared_dependencies\n\
+                 fix: restore iii.lock from git, or regenerate with `iii worker add`\n\
+                 docs: https://iii.dev/docs/sync#corrupt-lock\n",
+            ),
         }
     }
+}
+
+fn render_manifest_missing(lock_deps: &BTreeMap<String, String>) -> String {
+    let mut out = String::from("error: iii.worker.yaml is missing but iii.lock expects it\n");
+    for (name, range) in lock_deps {
+        out.push_str(&format!("  - {name} \"{range}\" (in lock)\n"));
+    }
+    out.push_str("fix: restore iii.worker.yaml from git, or remove iii.lock\n");
+    out.push_str("docs: https://iii.dev/docs/sync#missing-manifest\n");
+    out
 }
 
 fn render_drift(report: &DriftReport) -> String {
@@ -370,5 +409,43 @@ fix: restore the file from git or run `iii worker sync --refresh`
 docs: https://iii.dev/docs/sync#corrupt-lock
 ";
         assert_eq!(err.render(), expected);
+    }
+
+    #[test]
+    fn render_manifest_missing_golden() {
+        let err = SyncError::ManifestMissing {
+            lock_deps: deps(&[("alpha", "^1.0.0"), ("beta", "^2.0.0")]),
+        };
+        let expected = "\
+error: iii.worker.yaml is missing but iii.lock expects it
+  - alpha \"^1.0.0\" (in lock)
+  - beta \"^2.0.0\" (in lock)
+fix: restore iii.worker.yaml from git, or remove iii.lock
+docs: https://iii.dev/docs/sync#missing-manifest
+";
+        assert_eq!(err.render(), expected);
+    }
+
+    #[test]
+    fn render_corrupt_manifest_golden() {
+        let err = SyncError::CorruptManifest {
+            reason: "`dependencies` must be a mapping".into(),
+        };
+        let expected = "\
+error: iii.worker.yaml failed to parse: `dependencies` must be a mapping
+fix: correct the YAML in iii.worker.yaml and re-run
+docs: https://iii.dev/docs/sync#corrupt-manifest
+";
+        assert_eq!(err.render(), expected);
+    }
+
+    #[test]
+    fn render_lock_inconsistent_golden() {
+        let expected = "\
+error: iii.lock is internally inconsistent: manifest_hash does not match declared_dependencies
+fix: restore iii.lock from git, or regenerate with `iii worker add`
+docs: https://iii.dev/docs/sync#corrupt-lock
+";
+        assert_eq!(SyncError::LockInconsistent.render(), expected);
     }
 }

--- a/crates/iii-worker/tests/sync_drift_adversarial.rs
+++ b/crates/iii-worker/tests/sync_drift_adversarial.rs
@@ -1,0 +1,378 @@
+// Adversarial tests for the drift-detection / atomic-write behavior
+// from PR #1543. Each test pins a real-world failure mode the
+// implementation must guard against.
+
+use iii_worker::cli::lockfile::{
+    LockedSource, LockedWorker, LockedWorkerType, MANIFEST_HASH_PREFIX, WorkerLockfile,
+    is_valid_manifest_hash,
+};
+use iii_worker::cli::sync::{SyncError, compute_manifest_hash, detect_drift};
+use std::collections::BTreeMap;
+
+fn deps(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect()
+}
+
+fn image_worker(image: &str) -> LockedWorker {
+    LockedWorker {
+        version: "1.0.0".to_string(),
+        worker_type: LockedWorkerType::Image,
+        dependencies: BTreeMap::new(),
+        source: LockedSource::Image {
+            image: image.to_string(),
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Hash determinism / canonicalization (acceptable behavior pinned)
+// ---------------------------------------------------------------------------
+
+/// Two ranges that are *semver-equivalent* but differ in whitespace must
+/// produce different hashes. The lockfile records the literal text; a
+/// future "normalize before hashing" change would need to re-evaluate
+/// drift semantics.
+#[test]
+fn whitespace_in_range_changes_hash() {
+    let tight = deps(&[("alpha", "^1.0")]);
+    let loose = deps(&[("alpha", "^ 1.0")]);
+    assert_ne!(compute_manifest_hash(&tight), compute_manifest_hash(&loose));
+}
+
+/// Worker names are restricted to `[a-zA-Z0-9._-]` (registry::validate_worker_name),
+/// so they cannot contain `=` or `\n`. Even a malicious caller can't
+/// produce a hash collision via embedded delimiters in ranges.
+#[test]
+fn ranges_with_embedded_eq_dont_collide() {
+    let a = deps(&[("alpha", "=1.0.0"), ("beta", "=2.0.0")]);
+    let b = deps(&[("alpha", "=1.0.0=2.0.0"), ("beta", "")]);
+    assert_ne!(compute_manifest_hash(&a), compute_manifest_hash(&b));
+}
+
+// ---------------------------------------------------------------------------
+// 2. Drift detection (correct behavior expected)
+// ---------------------------------------------------------------------------
+
+/// detect_drift on identical maps returns None.
+#[test]
+fn drift_none_when_equal_with_special_chars() {
+    let d = deps(&[("alpha", ">=1.0.0, <2.0.0"), ("beta", "*")]);
+    assert_eq!(detect_drift(&d, &d), None);
+}
+
+/// **Bug fix**: when handle_worker_sync detects a hash mismatch but
+/// declared_dependencies happens to equal the manifest deps, the user
+/// must see a `LockInconsistent` error (not a 3-line empty drift
+/// report). The render output must explain the lock is corrupt and
+/// point at the right remediation.
+#[test]
+fn lock_inconsistent_error_renders_specifically() {
+    let err = SyncError::LockInconsistent;
+    let rendered = err.render();
+    assert!(rendered.starts_with("error: iii.lock"), "got: {rendered}");
+    assert!(rendered.contains("internally inconsistent"));
+    assert!(
+        rendered.contains("fix:"),
+        "must include a remediation line: {rendered}"
+    );
+    assert!(rendered.contains("docs:"));
+    // Crucially: the rendered output must NOT look like an empty drift
+    // report (the bug we're fixing).
+    assert!(
+        !rendered.contains("drift vs iii.lock"),
+        "must not be confused with drift: {rendered}"
+    );
+}
+
+/// **Bug fix**: when iii.worker.yaml is MISSING but the lock has
+/// manifest_hash, the user must see a distinct `ManifestMissing` error
+/// — not "drift vs iii.lock". The error must name the deps the lock
+/// expects so the user knows what's at stake.
+#[test]
+fn manifest_missing_error_renders_specifically() {
+    let lock_deps = deps(&[("alpha", "^1.0.0"), ("beta", "^2.0.0")]);
+    let err = SyncError::ManifestMissing { lock_deps };
+    let rendered = err.render();
+    assert!(rendered.contains("iii.worker.yaml"), "got: {rendered}");
+    assert!(rendered.contains("missing"), "got: {rendered}");
+    assert!(rendered.contains("alpha"));
+    assert!(rendered.contains("beta"));
+    assert!(rendered.contains("fix:"));
+    // It is NOT a drift report — the headline must not be "drift vs".
+    assert!(
+        !rendered.contains("drift vs iii.lock"),
+        "manifest_missing must not be reported as drift: {rendered}"
+    );
+}
+
+/// **Bug fix**: when iii.worker.yaml exists but is malformed, the user
+/// must see a `CorruptManifest` error pointing at the YAML (with the
+/// parser's reason), not a misleading "drift" report saying everything
+/// was removed.
+#[test]
+fn corrupt_manifest_error_renders_specifically() {
+    let err = SyncError::CorruptManifest {
+        reason: "`dependencies` must be a mapping".into(),
+    };
+    let rendered = err.render();
+    assert!(rendered.contains("iii.worker.yaml"));
+    assert!(rendered.contains("`dependencies` must be a mapping"));
+    assert!(rendered.contains("fix:"));
+    assert!(
+        !rendered.contains("drift vs iii.lock"),
+        "malformed YAML must not be reported as drift: {rendered}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Atomic write (acceptable behavior pinned)
+// ---------------------------------------------------------------------------
+
+/// `write_to` REPLACES a symlinked iii.lock with a regular file. Pin
+/// the behavior so a future change is intentional.
+#[cfg(unix)]
+#[test]
+fn write_to_replaces_symlink_with_regular_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let real = dir.path().join("real.lock");
+    let link = dir.path().join("iii.lock");
+
+    std::fs::write(&real, "version: 1\nworkers: {}\n").unwrap();
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+
+    let lock = WorkerLockfile::default();
+    lock.write_to(&link).unwrap();
+
+    let meta = std::fs::symlink_metadata(&link).unwrap();
+    assert!(!meta.file_type().is_symlink(), "symlink was preserved!");
+    let real_content = std::fs::read_to_string(&real).unwrap();
+    assert_eq!(real_content, "version: 1\nworkers: {}\n");
+}
+
+/// Concurrent writers: last-writer-wins, no torn output, no leaked
+/// temp files. PR explicitly says concurrent-writer protection is out
+/// of scope; pin the documented behavior.
+#[test]
+fn concurrent_writers_dont_tear_but_last_writer_wins() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("iii.lock");
+
+    let lock_a = {
+        let mut l = WorkerLockfile::default();
+        l.workers
+            .insert("alpha".to_string(), image_worker("ghcr.io/x/a@sha256:aaa"));
+        l
+    };
+    let lock_b = {
+        let mut l = WorkerLockfile::default();
+        l.workers
+            .insert("beta".to_string(), image_worker("ghcr.io/x/b@sha256:bbb"));
+        l
+    };
+
+    let p1 = path.clone();
+    let p2 = path.clone();
+    let h1 = std::thread::spawn(move || {
+        for _ in 0..10 {
+            lock_a.write_to(&p1).unwrap();
+        }
+    });
+    let h2 = std::thread::spawn(move || {
+        for _ in 0..10 {
+            lock_b.write_to(&p2).unwrap();
+        }
+    });
+    h1.join().unwrap();
+    h2.join().unwrap();
+
+    let parsed = WorkerLockfile::read_from(&path).unwrap();
+    let names: Vec<&str> = parsed.workers.keys().map(|s| s.as_str()).collect();
+    assert!(
+        names == vec!["alpha"] || names == vec!["beta"],
+        "got: {names:?}"
+    );
+
+    let stragglers: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n != "iii.lock")
+        .collect();
+    assert!(
+        stragglers.is_empty(),
+        "found leftover temps: {stragglers:?}"
+    );
+}
+
+/// Atomic-rename contract: a concurrent reader never sees a partial
+/// write. Stress test with 1000 reads against a continuously-rewriting
+/// writer thread.
+#[test]
+fn concurrent_reader_never_sees_partial_write() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("iii.lock");
+
+    let mut seeded = WorkerLockfile::default();
+    seeded
+        .workers
+        .insert("seed".to_string(), image_worker("ghcr.io/x/s@sha256:ccc"));
+    seeded.write_to(&path).unwrap();
+
+    let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let stop_w = stop.clone();
+    let p_w = path.clone();
+
+    let writer = std::thread::spawn(move || {
+        let mut a = WorkerLockfile::default();
+        a.workers
+            .insert("alpha".to_string(), image_worker("ghcr.io/x/a@sha256:aaa"));
+        let mut b = WorkerLockfile::default();
+        b.workers
+            .insert("beta".to_string(), image_worker("ghcr.io/x/b@sha256:bbb"));
+        while !stop_w.load(std::sync::atomic::Ordering::Relaxed) {
+            a.write_to(&p_w).unwrap();
+            b.write_to(&p_w).unwrap();
+        }
+    });
+
+    let mut parse_errors = 0usize;
+    for _ in 0..1000 {
+        match WorkerLockfile::read_from(&path) {
+            Ok(_) => {}
+            Err(e) => {
+                parse_errors += 1;
+                eprintln!("torn read: {e}");
+            }
+        }
+    }
+
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    writer.join().unwrap();
+
+    assert_eq!(parse_errors, 0, "atomic-rename contract violated");
+}
+
+// ---------------------------------------------------------------------------
+// 4. Lockfile validation (correct behavior expected — bugs fixed)
+// ---------------------------------------------------------------------------
+
+/// **Bug fix**: ranges in `declared_dependencies` must parse as semver.
+/// The manifest parser enforces this; the lockfile parser must too, so
+/// hand-edited locks can't smuggle garbage past validation.
+#[test]
+fn lockfile_rejects_garbage_declared_dependency_range() {
+    // Hash + declared_dependencies must be paired (see fix below); the
+    // hash here doesn't need to match because the semver check fires
+    // first.
+    let yaml = format!(
+        "version: 1\nmanifest_hash: \"{prefix}{hex}\"\ndeclared_dependencies:\n  alpha: \"this-is-not-semver-at-all\"\nworkers: {{}}\n",
+        prefix = MANIFEST_HASH_PREFIX,
+        hex = "0".repeat(64),
+    );
+    let err = WorkerLockfile::from_yaml(&yaml).unwrap_err();
+    assert!(err.contains("alpha"), "got: {err}");
+    assert!(
+        err.to_lowercase().contains("semver"),
+        "error must name the bad range: {err}"
+    );
+}
+
+/// **Bug fix**: a lock with `declared_dependencies` but no
+/// `manifest_hash` is internally inconsistent — drift detection would
+/// silently skip. Reject the combination at validation time so
+/// stripping `manifest_hash:` from the lock doesn't bypass drift.
+#[test]
+fn lockfile_rejects_declared_deps_without_manifest_hash() {
+    let yaml = "version: 1\ndeclared_dependencies:\n  alpha: \"^1.0.0\"\nworkers: {}\n";
+    let err = WorkerLockfile::from_yaml(yaml).unwrap_err();
+    assert!(
+        err.contains("manifest_hash"),
+        "error must explain the missing hash: {err}"
+    );
+}
+
+/// **Bug fix**: when both `manifest_hash` and `declared_dependencies`
+/// are present, the hash must equal `compute_manifest_hash(&declared)`.
+/// A hand-edited lock that breaks this invariant must be rejected.
+#[test]
+fn lockfile_rejects_hash_mismatch_against_declared() {
+    // Hash of {alpha: ^1.0.0}, but declared is {alpha: ^9.9.9} — the
+    // lock would silently pass drift checks until the manifest moves.
+    let real_hash = compute_manifest_hash(&deps(&[("alpha", "^1.0.0")]));
+    let yaml = format!(
+        "version: 1\nmanifest_hash: \"{real_hash}\"\ndeclared_dependencies:\n  alpha: \"^9.9.9\"\nworkers: {{}}\n",
+    );
+    let err = WorkerLockfile::from_yaml(&yaml).unwrap_err();
+    assert!(
+        err.contains("manifest_hash") || err.to_lowercase().contains("inconsistent"),
+        "error must explain the inconsistency: {err}"
+    );
+}
+
+/// Sanity: a consistent lock (hash matches declared_dependencies) is
+/// accepted.
+#[test]
+fn lockfile_accepts_consistent_hash_and_declared() {
+    let declared = deps(&[("alpha", "^1.0.0")]);
+    let hash = compute_manifest_hash(&declared);
+    let yaml = format!(
+        "version: 1\nmanifest_hash: \"{hash}\"\ndeclared_dependencies:\n  alpha: \"^1.0.0\"\nworkers: {{}}\n",
+    );
+    let parsed = WorkerLockfile::from_yaml(&yaml).expect("consistent lock must validate");
+    assert_eq!(parsed.manifest_hash.unwrap(), hash);
+}
+
+// ---------------------------------------------------------------------------
+// 5. is_valid_manifest_hash
+// ---------------------------------------------------------------------------
+
+/// **Bug fix**: `compute_manifest_hash` always emits lowercase hex. A
+/// lock with uppercase-hex `manifest_hash` would always trigger
+/// false-positive drift on every sync. Reject at validation.
+#[test]
+fn is_valid_manifest_hash_rejects_uppercase() {
+    let upper = format!("{MANIFEST_HASH_PREFIX}{}", "ABCDEF0123456789".repeat(4));
+    assert!(
+        !is_valid_manifest_hash(&upper),
+        "uppercase hex must be rejected for byte-exact comparison"
+    );
+}
+
+/// Lowercase hex remains accepted (sanity).
+#[test]
+fn is_valid_manifest_hash_accepts_lowercase() {
+    let lower = format!("{MANIFEST_HASH_PREFIX}{}", "abcdef0123456789".repeat(4));
+    assert!(is_valid_manifest_hash(&lower));
+}
+
+/// `compute_manifest_hash` of a single-entry dep is the SHA-256 of the
+/// 12-byte string `"alpha=^1.0\n"` with the `sha256:v1:` prefix.
+#[test]
+fn compute_manifest_hash_byte_stable_pin() {
+    let h = compute_manifest_hash(&deps(&[("alpha", "^1.0")]));
+    let expected_hex = {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(b"alpha=^1.0\n");
+        hex::encode(hasher.finalize())
+    };
+    assert_eq!(h, format!("{MANIFEST_HASH_PREFIX}{expected_hex}"));
+}
+
+/// Prefix is case-sensitive: `Sha256:v1:` (capital S) is rejected.
+#[test]
+fn is_valid_manifest_hash_prefix_is_case_sensitive() {
+    let bad = format!("Sha256:v1:{}", "0".repeat(64));
+    assert!(!is_valid_manifest_hash(&bad));
+}
+
+/// Unicode lookalikes for hex digits are rejected.
+#[test]
+fn manifest_hash_rejects_unicode_lookalike_hex() {
+    let unicode_zero = "\u{0966}";
+    let crafted = format!("{MANIFEST_HASH_PREFIX}{}", unicode_zero.repeat(64));
+    assert!(!is_valid_manifest_hash(&crafted));
+}


### PR DESCRIPTION
…rors

Closes five edge cases in `iii worker sync --frozen` that produced misleading or actionable-but-wrong output:

1. Hash-mismatch + matching declared_dependencies rendered an empty "drift" report with no diff items. The lockfile validator now cross-checks `manifest_hash == compute_manifest_hash(&declared)` when both fields are present, rejecting tampered/corrupt locks at read time. The unreachable `unwrap_or_default()` call site is replaced with an explicit `LockInconsistent` SyncError variant.

2. Missing iii.worker.yaml triggered a misleading "drift vs iii.lock" error with `removed` lines. `handle_worker_sync` now distinguishes manifest states via a `ManifestState` enum (Missing / Malformed / Loaded) and surfaces a `ManifestMissing` SyncError that names the deps the lock expects and points at the right remediation.

3. Malformed iii.worker.yaml emitted a buried `warning:` followed by a misleading drift report. The malformed state now produces a `CorruptManifest` SyncError carrying the parser's reason string.

4. Drift detection could be silently bypassed by stripping the `manifest_hash:` line from a Lane-A lock. Validation now rejects `(declared_dependencies: Some, manifest_hash: None)` so the bypass is impossible.

5. `declared_dependencies` ranges weren't semver-validated and the manifest_hash hex check accepted uppercase. Both gaps closed: ranges now go through `semver::VersionReq::parse`, and `is_valid_manifest_hash` rejects uppercase hex (which would otherwise produce false-positive drift on every sync because `hex::encode` always emits lowercase).

Tests: 9 new failing-then-passing tests in
`crates/iii-worker/tests/sync_drift_adversarial.rs`, 3 new render goldens in `cli::sync`, 3 new integration tests covering the new SyncError paths in `cli::managed::handle_worker_sync`. Two existing lockfile roundtrip tests updated to maintain consistent (hash, deps) pairs under the new validation rules.

## What

<!-- Brief description of the change -->

## Why

<!-- Motivation or context -->

## Notes

<!-- Anything reviewers should know (breaking changes, migration steps, etc.) -->

---

<!-- This box must be checked in order to submit a PR -->

- [ ] I am licensing the entirety of this PR under Apache 2 and have all necessary rights to the code I am contributing.
