### PR TITLE
ci(license-agreement): don't cancel in-flight runs

### DIFF
--- a/.github/workflows/checklist-checker.yml
+++ b/.github/workflows/checklist-checker.yml
@@ -14,7 +14,11 @@ permissions:
 
 concurrency:
   group: license-agreement-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  # Let an in-flight run finish so it can post its final commit status. With
+  # `cancel-in-progress: true` a synchronize event would cancel the prior run
+  # mid-flight, leaving a CANCELLED check on the PR rollup even for team-member
+  # PRs that the script would otherwise mark `success`.
+  cancel-in-progress: false
 
 jobs:
   license-agreement:


### PR DESCRIPTION
## Summary

- The `license-agreement` job is configured with `cancel-in-progress: true`. On every PR push the in-flight run is killed, leaving a CANCELLED check on the rollup until the next run finishes — visually indistinguishable from a failure even on team-member PRs where the script would have posted a `success` commit status if it had been allowed to complete.
- Switch to `cancel-in-progress: false` so prior runs finish and post their final status. The script is fast and idempotent, so letting an older run complete before a newer one starts does not race or produce stale results.

## Test plan

- [ ] Push a synchronize event to a PR and confirm the rollup never shows a CANCELLED `license-agreement` check.
- [ ] Confirm a team-member PR still ends with a green `license-agreement` commit status.
- [ ] Confirm a non-team-member PR without acknowledgement still ends with a red `license-agreement` commit status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to allow in-progress checks to complete and publish their final status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->