### PR TITLE
feat(sandbox): add sandbox::fs::* triggers, upload/download CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2611,11 +2611,15 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "iii-shell-proto",
  "iii-supervisor",
  "libc",
  "nix 0.31.2",
+ "regex",
  "tempfile",
  "thiserror 2.0.18",
+ "uuid",
+ "walkdir",
 ]
 
 [[package]]
@@ -2678,6 +2682,7 @@ dependencies = [
 name = "iii-shell-proto"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/iii-init/Cargo.toml
+++ b/crates/iii-init/Cargo.toml
@@ -26,6 +26,17 @@ anyhow = "1"
 # Shell-channel stdout/stderr/stdin frames carry bytes as base64 inside
 # JSON. `0.22` matches the engine's version so cargo resolves one copy.
 base64 = "0.22"
+# Used by fs_handler::ops::grep / sed for native regex matching. Pure
+# Rust, cross-compiles cleanly to linux-musl alongside the rest of
+# this binary.
+regex = "1"
+# Used by fs_handler::ops::grep / chmod --recursive for tree walking.
+walkdir = "2"
+# Used by fs_handler streaming-write/sed temp-file naming.
+uuid = { version = "1", features = ["v4"] }
+# Shell-protocol message types and frame codec — fs_handler decodes
+# FsRequest variants and encodes FsResponse / FsChunk / FsEnd / FsError.
+iii-shell-proto = { path = "../iii-shell-proto" }
 
 [dev-dependencies]
 # Used by root_pivot's unit tests to build a fake rootfs under a

--- a/crates/iii-init/src/fs_handler.rs
+++ b/crates/iii-init/src/fs_handler.rs
@@ -1,0 +1,78 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at support@motia.dev
+// See LICENSE and PATENTS files for details.
+
+//! Filesystem-operations dispatcher for the in-VM supervisor.
+//!
+//! Runs native Rust handlers against the guest rootfs — no child
+//! processes, no shell-outs. Called from `shell_dispatcher.rs` when a
+//! `ShellMessage::FsRequest` frame arrives on a fresh session.
+//!
+//! Write and read streams are driven by follow-up `FsChunk` / `FsEnd`
+//! frames on the same correlation id; the dispatcher hands us the
+//! per-session inbound channel so we can pull them synchronously via
+//! `std::sync::mpsc::Receiver`.
+//!
+//! **Sync-only invariant.** This module contains no `tokio`, no `async
+//! fn`, no `AsyncRead`/`AsyncWrite`. All I/O uses `std::fs` and
+//! `std::io`. This matches the broader `iii-init` invariant and keeps
+//! the binary cross-compilable to linux-musl without a tokio runtime.
+
+pub mod ops;
+pub mod streaming;
+
+#[cfg(test)]
+mod tests;
+
+use iii_shell_proto::FsResult;
+
+/// One-shot ops reply with `Ok(FsResult)` or `Err(FsError)`.
+pub type FsCallResult = Result<FsResult, FsError>;
+
+/// Error payload returned by each handler. `code` is the S21x wire
+/// string, matching `SandboxError::code().as_str()` on the worker
+/// side so the trigger response serializes identically.
+#[derive(Debug, Clone)]
+pub struct FsError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl FsError {
+    pub fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    /// Translate a `std::io::Error` to the best-fitting S21x code.
+    /// Mirrors `SandboxError::from_io` on the worker side.
+    pub fn from_io(path: &str, err: std::io::Error) -> Self {
+        match err.kind() {
+            std::io::ErrorKind::NotFound => {
+                Self::new("S211", format!("path not found: {path}"))
+            }
+            std::io::ErrorKind::AlreadyExists => {
+                Self::new("S213", format!("path already exists: {path}"))
+            }
+            std::io::ErrorKind::PermissionDenied => {
+                Self::new("S215", format!("{path}: {err}"))
+            }
+            _ => Self::new("S216", format!("{path}: {err}")),
+        }
+    }
+}
+
+/// Parse an octal mode string like `"0755"` into a raw `u32` permission
+/// bit set. Returns `Err(FsError { code: "S210", .. })` if the string
+/// is not valid octal.
+pub fn parse_mode(mode: &str) -> Result<u32, FsError> {
+    // Strip leading "0" prefix (e.g. "0755" -> "755"), but keep "0" as "0".
+    let stripped = mode.trim_start_matches('0');
+    let s = if stripped.is_empty() { "0" } else { stripped };
+    u32::from_str_radix(s, 8)
+        .map_err(|_| FsError::new("S210", format!("invalid octal mode: {mode}")))
+}

--- a/crates/iii-init/src/fs_handler.rs
+++ b/crates/iii-init/src/fs_handler.rs
@@ -52,15 +52,11 @@ impl FsError {
     /// Mirrors `SandboxError::from_io` on the worker side.
     pub fn from_io(path: &str, err: std::io::Error) -> Self {
         match err.kind() {
-            std::io::ErrorKind::NotFound => {
-                Self::new("S211", format!("path not found: {path}"))
-            }
+            std::io::ErrorKind::NotFound => Self::new("S211", format!("path not found: {path}")),
             std::io::ErrorKind::AlreadyExists => {
                 Self::new("S213", format!("path already exists: {path}"))
             }
-            std::io::ErrorKind::PermissionDenied => {
-                Self::new("S215", format!("{path}: {err}"))
-            }
+            std::io::ErrorKind::PermissionDenied => Self::new("S215", format!("{path}: {err}")),
             _ => Self::new("S216", format!("{path}: {err}")),
         }
     }

--- a/crates/iii-init/src/fs_handler/ops.rs
+++ b/crates/iii-init/src/fs_handler/ops.rs
@@ -26,11 +26,7 @@ use super::{FsCallResult, FsError, parse_mode};
 /// Build an `FsEntry` from a path and its already-fetched metadata.
 /// Uses `symlink_metadata` semantics — callers must pass metadata
 /// obtained without following the symlink so `is_symlink` is accurate.
-pub(super) fn entry_from_metadata(
-    name: String,
-    _path: &Path,
-    md: &std::fs::Metadata,
-) -> FsEntry {
+pub(super) fn entry_from_metadata(name: String, _path: &Path, md: &std::fs::Metadata) -> FsEntry {
     let mode_bits = md.mode() & 0o7777;
     let mtime = md.mtime();
     FsEntry {
@@ -320,10 +316,7 @@ pub fn mkdir(path: String, mode: String, parents: bool) -> FsCallResult {
         if parents {
             return Ok(FsResult::Mkdir { created: false });
         }
-        return Err(FsError::new(
-            "S213",
-            format!("path already exists: {path}"),
-        ));
+        return Err(FsError::new("S213", format!("path already exists: {path}")));
     }
 
     let result = if parents {
@@ -364,13 +357,9 @@ pub fn rm(path: String, recursive: bool) -> FsCallResult {
         } else {
             // Check emptiness first so we return S214 with a clean
             // message rather than the generic ENOTEMPTY io error.
-            let mut rd =
-                std::fs::read_dir(p).map_err(|e| FsError::from_io(&path, e))?;
+            let mut rd = std::fs::read_dir(p).map_err(|e| FsError::from_io(&path, e))?;
             if rd.next().is_some() {
-                return Err(FsError::new(
-                    "S214",
-                    format!("directory not empty: {path}"),
-                ));
+                return Err(FsError::new("S214", format!("directory not empty: {path}")));
             }
             std::fs::remove_dir(p).map_err(|e| FsError::from_io(&path, e))?;
         }
@@ -412,8 +401,7 @@ pub fn chmod(
         std::fs::set_permissions(target, perms)
             .map_err(|e| FsError::from_io(&target.to_string_lossy(), e))?;
         if uid.is_some() || gid.is_some() {
-            chown(target, uid, gid)
-                .map_err(|e| FsError::from_io(&target.to_string_lossy(), e))?;
+            chown(target, uid, gid).map_err(|e| FsError::from_io(&target.to_string_lossy(), e))?;
         }
         Ok(())
     };
@@ -453,10 +441,7 @@ pub fn mv(src: String, dst: String, overwrite: bool) -> FsCallResult {
         return Err(FsError::new("S211", format!("src not found: {src}")));
     }
     if dst_p.exists() && !overwrite {
-        return Err(FsError::new(
-            "S213",
-            format!("dst already exists: {dst}"),
-        ));
+        return Err(FsError::new("S213", format!("dst already exists: {dst}")));
     }
 
     match std::fs::rename(src_p, dst_p) {
@@ -464,8 +449,7 @@ pub fn mv(src: String, dst: String, overwrite: bool) -> FsCallResult {
         Err(e) if e.raw_os_error() == Some(libc::EXDEV) => {
             // Cross-fs: copy to temp sibling of dst, then rename.
             let tmp = temp_sibling(dst_p);
-            std::fs::copy(src_p, &tmp)
-                .map_err(|e| FsError::from_io(&dst, e))?;
+            std::fs::copy(src_p, &tmp).map_err(|e| FsError::from_io(&dst, e))?;
             if let Err(e) = std::fs::rename(&tmp, dst_p) {
                 let _ = std::fs::remove_file(&tmp);
                 return Err(FsError::from_io(&dst, e));
@@ -517,9 +501,7 @@ pub fn grep(
     let mut truncated = false;
 
     let should_scan = |rel: &str| -> bool {
-        if !include_glob.is_empty()
-            && !include_glob.iter().any(|g| glob_matches_path(g, rel))
-        {
+        if !include_glob.is_empty() && !include_glob.iter().any(|g| glob_matches_path(g, rel)) {
             return false;
         }
         if exclude_glob.iter().any(|g| glob_matches_path(g, rel)) {
@@ -645,9 +627,7 @@ fn collect_files_to_sed(
     };
 
     let passes = |rel: &str| -> bool {
-        if !include_glob.is_empty()
-            && !include_glob.iter().any(|g| glob_matches_path(g, rel))
-        {
+        if !include_glob.is_empty() && !include_glob.iter().any(|g| glob_matches_path(g, rel)) {
             return false;
         }
         if exclude_glob.iter().any(|g| glob_matches_path(g, rel)) {
@@ -801,12 +781,8 @@ pub fn sed(
                      pass a file path or set recursive=true",
                 ));
             }
-            let collected = collect_files_to_sed(
-                root_path,
-                recursive,
-                &include_glob,
-                &exclude_glob,
-            );
+            let collected =
+                collect_files_to_sed(root_path, recursive, &include_glob, &exclude_glob);
             collected
                 .into_iter()
                 .map(|p| p.to_string_lossy().into_owned())
@@ -882,13 +858,7 @@ pub fn sed(
                     };
                     (produced, count_here)
                 }
-                None => literal_replace_line(
-                    line,
-                    &pattern,
-                    case_fold,
-                    &replacement,
-                    first_only,
-                ),
+                None => literal_replace_line(line, &pattern, case_fold, &replacement, first_only),
             };
             replacements += n;
             output.push_str(&new_line);

--- a/crates/iii-init/src/fs_handler/ops.rs
+++ b/crates/iii-init/src/fs_handler/ops.rs
@@ -1,0 +1,937 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at support@motia.dev
+// See LICENSE and PATENTS files for details.
+
+//! One-shot filesystem operation handlers.
+//!
+//! Each function maps to an `FsOp` variant except `WriteStart` /
+//! `ReadStart`, which are handled by the `streaming` sibling module.
+//! All handlers are **sync** (`fn`, not `async fn`) and use only
+//! `std::fs` / `std::io` — no tokio anywhere in this file.
+
+use std::io::{BufRead, Read};
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::path::Path;
+
+use iii_shell_proto::{FsEntry, FsMatch, FsResult, FsSedFileResult};
+
+use super::{FsCallResult, FsError, parse_mode};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Build an `FsEntry` from a path and its already-fetched metadata.
+/// Uses `symlink_metadata` semantics — callers must pass metadata
+/// obtained without following the symlink so `is_symlink` is accurate.
+pub(super) fn entry_from_metadata(
+    name: String,
+    _path: &Path,
+    md: &std::fs::Metadata,
+) -> FsEntry {
+    let mode_bits = md.mode() & 0o7777;
+    let mtime = md.mtime();
+    FsEntry {
+        name,
+        is_dir: md.is_dir(),
+        size: md.len(),
+        mode: format!("{mode_bits:04o}"),
+        mtime,
+        is_symlink: md.file_type().is_symlink(),
+    }
+}
+
+/// Build a sibling path `<path>.iii-tmp-<uuid>` for atomic write
+/// patterns. The random suffix keeps concurrent writers from colliding
+/// on the same temp name.
+pub(super) fn temp_sibling(target: &Path) -> std::path::PathBuf {
+    let mut t = target.as_os_str().to_os_string();
+    t.push(".iii-tmp-");
+    t.push(uuid::Uuid::new_v4().to_string());
+    t.into()
+}
+
+/// Match a glob `pattern` against a relative path with gitignore-style
+/// semantics:
+///
+/// - If `pattern` contains `/`, match against the full relative path.
+///   E.g. `src/*.py` matches `src/main.py` but not `data/foo.py`.
+/// - If `pattern` has no `/`, match against the **basename** of
+///   `relpath`. E.g. `*.py` matches `src/main.py`, `data/foo.py`, and
+///   any `.py` file at any depth.
+///
+/// A leading `**/` is handled by [`glob_match`]: the pattern `**/*.py`
+/// matches at any depth, including the root.
+pub(super) fn glob_matches_path(pattern: &str, relpath: &str) -> bool {
+    if pattern.contains('/') {
+        glob_match(pattern, relpath)
+    } else {
+        let base = relpath.rsplit('/').next().unwrap_or(relpath);
+        glob_match(pattern, base)
+    }
+}
+
+/// Match a filename against a simple glob. Supports `*` (zero or more
+/// of any char **except** `/`) and `?` (single char except `/`).
+/// Designed for `*.rs` / `target/*` patterns against the base filename
+/// or the relative path under the grep root.
+///
+/// A leading `**/` is treated as "any depth": `**/*.py` matches both
+/// `main.py` (depth 0) and `src/main.py` (depth 1+). The bare pattern
+/// `**` matches everything.
+pub(super) fn glob_match(pattern: &str, path: &str) -> bool {
+    if pattern == "**" {
+        return true;
+    }
+    if let Some(rest) = pattern.strip_prefix("**/") {
+        // `**/foo` matches at any depth. Try the basename first
+        // (covers depth 0, e.g. `**/*.py` against `main.py`), then
+        // fall back to the full path (covers nested cases).
+        let base = path.rsplit('/').next().unwrap_or(path);
+        if glob_match_simple(rest, base) {
+            return true;
+        }
+        return glob_match_simple(rest, path);
+    }
+    glob_match_simple(pattern, path)
+}
+
+fn glob_match_simple(pattern: &str, path: &str) -> bool {
+    let p = pattern.as_bytes();
+    let t = path.as_bytes();
+    let mut pi = 0usize;
+    let mut ti = 0usize;
+    let mut star_pi: Option<usize> = None;
+    let mut star_ti = 0usize;
+    while ti < t.len() {
+        let pc = p.get(pi).copied();
+        let tc = t[ti];
+        match pc {
+            Some(b'*') => {
+                star_pi = Some(pi);
+                star_ti = ti;
+                pi += 1;
+            }
+            Some(b'?') if tc != b'/' => {
+                pi += 1;
+                ti += 1;
+            }
+            Some(c) if c == tc => {
+                pi += 1;
+                ti += 1;
+            }
+            _ => {
+                if let Some(sp) = star_pi {
+                    if t[star_ti] == b'/' {
+                        return false;
+                    }
+                    pi = sp + 1;
+                    star_ti += 1;
+                    ti = star_ti;
+                } else {
+                    return false;
+                }
+            }
+        }
+    }
+    while pi < p.len() && p[pi] == b'*' {
+        pi += 1;
+    }
+    pi == p.len()
+}
+
+/// Peek up to 8 KiB and check for null bytes — the classic
+/// binary-file heuristic. Returns `true` if the file looks binary and
+/// should be skipped by grep.
+pub(super) fn looks_binary(path: &Path) -> bool {
+    let Ok(mut f) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mut buf = [0u8; 8192];
+    let n = f.read(&mut buf).unwrap_or(0);
+    buf[..n].contains(&0)
+}
+
+/// Expand a regex-mode replacement template. Delegates to
+/// `regex::Captures::expand` which handles `$1`, `$name`, etc.
+fn expand_regex_replacement(caps: &regex::Captures, template: &str) -> String {
+    let mut out = String::new();
+    caps.expand(template, &mut out);
+    out
+}
+
+/// Literal per-line replace. Returns `(new_line, replacement_count)`.
+///
+/// When `case_insensitive` is true we delegate to the regex engine with
+/// `(?i)` and an escaped pattern. Hand-rolling case-fold over UTF-8 is
+/// unsound: `to_lowercase()` is not byte-length preserving (e.g.
+/// `'İ'` U+0130 → `"i\u{0307}"`, 2→3 bytes), so a parallel
+/// haystack/line index walk panics or mismatches on the first
+/// length-changing codepoint. The case-sensitive path stays a hand-
+/// rolled byte search — no regex compile cost on the common path.
+fn literal_replace_line(
+    line: &str,
+    needle: &str,
+    case_insensitive: bool,
+    replacement: &str,
+    first_only: bool,
+) -> (String, u64) {
+    if line.is_empty() || needle.is_empty() {
+        return (line.to_string(), 0);
+    }
+    if case_insensitive {
+        // `(?i)` + literal-escaped needle gives correct Unicode case
+        // folding without re-implementing it. `$` in `replacement`
+        // would otherwise be expanded as a backref; escape it.
+        let escaped_needle = regex::escape(needle);
+        let escaped_replacement = replacement.replace('$', "$$");
+        let pattern = format!("(?i){escaped_needle}");
+        let re = match regex::Regex::new(&pattern) {
+            Ok(r) => r,
+            // An invalid pattern shouldn't be reachable (escape() always
+            // produces a valid regex); fall back to no-op so we never
+            // panic on otherwise-good input.
+            Err(_) => return (line.to_string(), 0),
+        };
+        let mut count = 0u64;
+        let out = if first_only {
+            re.replacen(line, 1, |_caps: &regex::Captures| {
+                count += 1;
+                escaped_replacement.clone()
+            })
+            .into_owned()
+        } else {
+            re.replace_all(line, |_caps: &regex::Captures| {
+                count += 1;
+                escaped_replacement.clone()
+            })
+            .into_owned()
+        };
+        return (out, count);
+    }
+
+    // Case-sensitive byte search. Same-byte-length needle and haystack
+    // (both `line`), so the byte walk is sound.
+    let mut out = String::with_capacity(line.len());
+    let mut n = 0u64;
+    let mut i = 0usize;
+    let bytes = line.as_bytes();
+    let needle_bytes = needle.as_bytes();
+    while i < line.len() {
+        if i + needle_bytes.len() <= bytes.len()
+            && &bytes[i..i + needle_bytes.len()] == needle_bytes
+        {
+            out.push_str(replacement);
+            i += needle_bytes.len();
+            n += 1;
+            if first_only {
+                out.push_str(&line[i..]);
+                return (out, n);
+            }
+        } else {
+            // Advance by one char boundary.
+            let next = line[i..]
+                .char_indices()
+                .nth(1)
+                .map(|(b, _)| i + b)
+                .unwrap_or(line.len());
+            out.push_str(&line[i..next]);
+            i = next;
+        }
+    }
+    (out, n)
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Public handlers
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// List the immediate children of a directory.
+///
+/// Errors:
+/// - `S211` — path does not exist.
+/// - `S212` — path exists but is not a directory.
+/// - `S216` — I/O error reading the directory.
+pub fn ls(path: String) -> FsCallResult {
+    let p = Path::new(&path);
+    let md = match p.symlink_metadata() {
+        Ok(m) => m,
+        Err(e) => return Err(FsError::from_io(&path, e)),
+    };
+    if !md.is_dir() {
+        return Err(FsError::new("S212", format!("not a directory: {path}")));
+    }
+    let rd = match std::fs::read_dir(p) {
+        Ok(r) => r,
+        Err(e) => return Err(FsError::from_io(&path, e)),
+    };
+    let mut entries = Vec::new();
+    for entry in rd {
+        let ent = match entry {
+            Ok(e) => e,
+            Err(_) => continue, // raced — skip
+        };
+        let name = ent.file_name().to_string_lossy().into_owned();
+        let md = match ent.path().symlink_metadata() {
+            Ok(m) => m,
+            Err(_) => continue, // raced — skip
+        };
+        entries.push(entry_from_metadata(name, &ent.path(), &md));
+    }
+    Ok(FsResult::Ls { entries })
+}
+
+/// Stat a single path. Reports the path itself (not its symlink target).
+///
+/// Errors:
+/// - `S211` — path does not exist.
+/// - `S216` — I/O error.
+pub fn stat(path: String) -> FsCallResult {
+    let p = Path::new(&path);
+    let md = match p.symlink_metadata() {
+        Ok(m) => m,
+        Err(e) => return Err(FsError::from_io(&path, e)),
+    };
+    let name = p
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.clone());
+    Ok(FsResult::Stat(entry_from_metadata(name, p, &md)))
+}
+
+/// Create a directory.
+///
+/// - `parents=true` → `mkdir -p` semantics; existing path is OK.
+/// - `parents=false` → fail with `S213` if path already exists;
+///   fail with `S211` if the parent does not exist.
+///
+/// Errors:
+/// - `S210` — `mode` is not valid octal.
+/// - `S211` — parent dir missing (`parents=false`).
+/// - `S213` — path already exists (`parents=false`).
+/// - `S215` / `S216` — permission / I/O error.
+pub fn mkdir(path: String, mode: String, parents: bool) -> FsCallResult {
+    let bits = parse_mode(&mode)?;
+    let p = Path::new(&path);
+
+    if p.exists() {
+        if parents {
+            return Ok(FsResult::Mkdir { created: false });
+        }
+        return Err(FsError::new(
+            "S213",
+            format!("path already exists: {path}"),
+        ));
+    }
+
+    let result = if parents {
+        std::fs::create_dir_all(p)
+    } else {
+        std::fs::create_dir(p)
+    };
+    result.map_err(|e| FsError::from_io(&path, e))?;
+
+    let perms = std::fs::Permissions::from_mode(bits);
+    std::fs::set_permissions(p, perms).map_err(|e| FsError::from_io(&path, e))?;
+
+    Ok(FsResult::Mkdir { created: true })
+}
+
+/// Remove a file or directory.
+///
+/// - For a directory: `recursive=false` requires it to be empty
+///   (returns `S214` otherwise); `recursive=true` removes the entire
+///   tree.
+/// - For a file or symlink: always uses `remove_file` (one operation,
+///   no recursion flag needed).
+///
+/// Errors:
+/// - `S211` — path does not exist.
+/// - `S214` — directory not empty and `recursive=false`.
+/// - `S215` / `S216` — permission / I/O error.
+pub fn rm(path: String, recursive: bool) -> FsCallResult {
+    let p = Path::new(&path);
+    let md = match p.symlink_metadata() {
+        Ok(m) => m,
+        Err(e) => return Err(FsError::from_io(&path, e)),
+    };
+
+    if md.is_dir() && !md.file_type().is_symlink() {
+        if recursive {
+            std::fs::remove_dir_all(p).map_err(|e| FsError::from_io(&path, e))?;
+        } else {
+            // Check emptiness first so we return S214 with a clean
+            // message rather than the generic ENOTEMPTY io error.
+            let mut rd =
+                std::fs::read_dir(p).map_err(|e| FsError::from_io(&path, e))?;
+            if rd.next().is_some() {
+                return Err(FsError::new(
+                    "S214",
+                    format!("directory not empty: {path}"),
+                ));
+            }
+            std::fs::remove_dir(p).map_err(|e| FsError::from_io(&path, e))?;
+        }
+    } else {
+        // Regular file, symlink (including to a dir), or special file.
+        std::fs::remove_file(p).map_err(|e| FsError::from_io(&path, e))?;
+    }
+    Ok(FsResult::Rm { removed: true })
+}
+
+/// Change mode (and optionally ownership) of a path.
+///
+/// - `recursive=true` → walks the entire tree via `walkdir`; the root
+///   entry itself counts in the returned `updated` tally.
+/// - `uid` / `gid` of `None` means "do not change that field".
+///
+/// Errors:
+/// - `S210` — `mode` is not valid octal.
+/// - `S211` — path does not exist.
+/// - `S215` / `S216` — permission / I/O error.
+pub fn chmod(
+    path: String,
+    mode: String,
+    uid: Option<u32>,
+    gid: Option<u32>,
+    recursive: bool,
+) -> FsCallResult {
+    use std::os::unix::fs::chown;
+
+    let bits = parse_mode(&mode)?;
+    let p = Path::new(&path);
+
+    if !p.exists() {
+        return Err(FsError::new("S211", format!("path not found: {path}")));
+    }
+
+    let apply = |target: &Path| -> Result<(), FsError> {
+        let perms = std::fs::Permissions::from_mode(bits);
+        std::fs::set_permissions(target, perms)
+            .map_err(|e| FsError::from_io(&target.to_string_lossy(), e))?;
+        if uid.is_some() || gid.is_some() {
+            chown(target, uid, gid)
+                .map_err(|e| FsError::from_io(&target.to_string_lossy(), e))?;
+        }
+        Ok(())
+    };
+
+    let mut updated: u64 = 0;
+    if recursive {
+        for entry in walkdir::WalkDir::new(p)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            apply(entry.path())?;
+            updated += 1;
+        }
+    } else {
+        apply(p)?;
+        updated = 1;
+    }
+    Ok(FsResult::Chmod { updated })
+}
+
+/// Rename / move a path.
+///
+/// - `overwrite=false` → fail with `S213` if `dst` already exists.
+/// - `overwrite=true` → atomically replace `dst` on same-fs moves;
+///   copy+unlink on cross-fs moves.
+///
+/// Errors:
+/// - `S211` — `src` does not exist.
+/// - `S213` — `dst` exists and `overwrite=false`.
+/// - `S215` / `S216` — permission / I/O error.
+pub fn mv(src: String, dst: String, overwrite: bool) -> FsCallResult {
+    let src_p = Path::new(&src);
+    let dst_p = Path::new(&dst);
+
+    if !src_p.exists() {
+        return Err(FsError::new("S211", format!("src not found: {src}")));
+    }
+    if dst_p.exists() && !overwrite {
+        return Err(FsError::new(
+            "S213",
+            format!("dst already exists: {dst}"),
+        ));
+    }
+
+    match std::fs::rename(src_p, dst_p) {
+        Ok(()) => Ok(FsResult::Mv { moved: true }),
+        Err(e) if e.raw_os_error() == Some(libc::EXDEV) => {
+            // Cross-fs: copy to temp sibling of dst, then rename.
+            let tmp = temp_sibling(dst_p);
+            std::fs::copy(src_p, &tmp)
+                .map_err(|e| FsError::from_io(&dst, e))?;
+            if let Err(e) = std::fs::rename(&tmp, dst_p) {
+                let _ = std::fs::remove_file(&tmp);
+                return Err(FsError::from_io(&dst, e));
+            }
+            std::fs::remove_file(src_p).map_err(|e| FsError::from_io(&src, e))?;
+            Ok(FsResult::Mv { moved: true })
+        }
+        Err(e) => Err(FsError::from_io(&dst, e)),
+    }
+}
+
+/// Search files for lines matching `pattern` (a Rust regex).
+///
+/// - `recursive=true` walks the tree; `false` requires `path` to be a
+///   regular file.
+/// - `include_glob` / `exclude_glob` filter by filename suffix.
+/// - Stops after `max_matches` hits (sets `truncated=true`).
+/// - Lines longer than `max_line_bytes` are truncated with `…`.
+/// - Binary files (NUL in first 8 KiB) are silently skipped.
+///
+/// Errors:
+/// - `S211` — path does not exist.
+/// - `S217` — `pattern` is not a valid regex.
+pub fn grep(
+    path: String,
+    pattern: String,
+    recursive: bool,
+    ignore_case: bool,
+    include_glob: Vec<String>,
+    exclude_glob: Vec<String>,
+    max_matches: u64,
+    max_line_bytes: u64,
+) -> FsCallResult {
+    let root = Path::new(&path);
+    let md = match root.symlink_metadata() {
+        Ok(m) => m,
+        Err(e) => return Err(FsError::from_io(&path, e)),
+    };
+
+    let re = regex::RegexBuilder::new(&pattern)
+        .case_insensitive(ignore_case)
+        .build()
+        .map_err(|e| FsError::new("S217", format!("bad regex: {e}")))?;
+
+    let max_matches_usize = max_matches as usize;
+    let max_line_usize = max_line_bytes as usize;
+
+    let mut out: Vec<FsMatch> = Vec::new();
+    let mut truncated = false;
+
+    let should_scan = |rel: &str| -> bool {
+        if !include_glob.is_empty()
+            && !include_glob.iter().any(|g| glob_matches_path(g, rel))
+        {
+            return false;
+        }
+        if exclude_glob.iter().any(|g| glob_matches_path(g, rel)) {
+            return false;
+        }
+        true
+    };
+
+    // Returns Ok(true) when this scan filled `out` to `max_matches_usize`
+    // and the caller should stop walking. Closure mutably borrows `out`
+    // only — `truncated` is decided by the caller from the return value
+    // so the post-call `if truncated` read doesn't conflict with the
+    // closure's lingering capture.
+    let mut scan = |file_path: &Path| -> Result<bool, FsError> {
+        if looks_binary(file_path) {
+            return Ok(false);
+        }
+        let f = std::fs::File::open(file_path)
+            .map_err(|e| FsError::from_io(&file_path.to_string_lossy(), e))?;
+        let reader = std::io::BufReader::new(f);
+        for (idx, line_res) in reader.lines().enumerate() {
+            let Ok(mut line) = line_res else {
+                continue; // non-UTF-8 line — skip
+            };
+            if re.is_match(&line) {
+                if max_line_usize > 0 && line.len() > max_line_usize {
+                    // String::truncate panics on a non-char-boundary index.
+                    // Floor max_line_usize to the nearest boundary so a
+                    // multi-byte UTF-8 codepoint straddling the cut doesn't
+                    // crash the per-op thread (terminal frame would never
+                    // ship and the host trigger would hang to outer timeout).
+                    let cut = (0..=max_line_usize)
+                        .rev()
+                        .find(|&i| line.is_char_boundary(i))
+                        .unwrap_or(0);
+                    line.truncate(cut);
+                    line.push('…');
+                }
+                out.push(FsMatch {
+                    path: file_path.to_string_lossy().into_owned(),
+                    line: (idx + 1) as u64,
+                    content: line,
+                });
+                if max_matches_usize > 0 && out.len() >= max_matches_usize {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
+    };
+
+    if md.is_dir() {
+        if !recursive {
+            return Err(FsError::new(
+                "S210",
+                "recursive=false on a directory is unsupported; \
+                 pass a file path or set recursive=true",
+            ));
+        }
+        for entry in walkdir::WalkDir::new(root)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().is_file())
+        {
+            let rel = entry
+                .path()
+                .strip_prefix(root)
+                .unwrap_or(entry.path())
+                .to_string_lossy()
+                .into_owned();
+            if !should_scan(&rel) {
+                continue;
+            }
+            if scan(entry.path())? {
+                truncated = true;
+                break;
+            }
+        }
+    } else {
+        // Single-file grep — include/exclude globs still apply to the
+        // filename so the caller can pre-filter a list.
+        let rel = root
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        if should_scan(&rel) && scan(root)? {
+            truncated = true;
+        }
+    }
+
+    Ok(FsResult::Grep {
+        matches: out,
+        truncated,
+    })
+}
+
+/// Walk `root` and collect every regular-file path that survives
+/// `include_glob` / `exclude_glob` filtering. Mirrors the grep walker:
+/// `walkdir::WalkDir` with `follow_links(false)` and gitignore-style
+/// glob matching against the path **relative to `root`**.
+///
+/// `root` may be a regular file (returns a single-element list after
+/// glob-filtering by basename), a directory (walks it), or a symlink
+/// (resolved via `std::fs::metadata`: link-to-file → single-element,
+/// link-to-dir → walk the link as if it were the directory using
+/// `follow_links(true)` for that one entry-point so `walkdir` will
+/// descend into the target).
+///
+/// Caller is expected to have already validated that `root` exists; a
+/// broken symlink here yields an empty result rather than an error
+/// (it would have been caught upstream by the metadata probe).
+fn collect_files_to_sed(
+    root: &Path,
+    recursive: bool,
+    include_glob: &[String],
+    exclude_glob: &[String],
+) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    let lmd = match root.symlink_metadata() {
+        Ok(m) => m,
+        Err(_) => return out,
+    };
+
+    let passes = |rel: &str| -> bool {
+        if !include_glob.is_empty()
+            && !include_glob.iter().any(|g| glob_matches_path(g, rel))
+        {
+            return false;
+        }
+        if exclude_glob.iter().any(|g| glob_matches_path(g, rel)) {
+            return false;
+        }
+        true
+    };
+
+    // Resolve "what is `root` really?" — for a symlink we have to follow
+    // it to know whether the caller meant "rewrite this one file" or
+    // "walk this directory." `is_symlink()` alone can't tell.
+    //
+    // - regular file (or symlink → file)  → single-file branch
+    // - directory (or symlink → dir)      → walker branch
+    // - broken symlink / metadata error   → empty (upstream already
+    //   validated existence; treat as nothing-to-do)
+    let target_is_dir = if lmd.file_type().is_symlink() {
+        match std::fs::metadata(root) {
+            Ok(m) => m.is_dir(),
+            Err(_) => return out,
+        }
+    } else {
+        lmd.is_dir()
+    };
+
+    if !target_is_dir {
+        let rel = root
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        if passes(&rel) {
+            out.push(root.to_path_buf());
+        }
+        return out;
+    }
+
+    // Walker branch. `follow_links` only matters for the *root* entry
+    // — we still don't want to follow links discovered mid-walk
+    // because they could point outside the tree (mirrors grep's
+    // policy). When `root` itself is a symlink-to-dir we'd need
+    // `follow_links(true)` so walkdir descends into it; resolve to the
+    // canonical target instead, which keeps the inner-walk policy
+    // (no-follow) intact.
+    let resolved_root: std::path::PathBuf = if lmd.file_type().is_symlink() {
+        match std::fs::canonicalize(root) {
+            Ok(p) => p,
+            Err(_) => return out,
+        }
+    } else {
+        root.to_path_buf()
+    };
+
+    let walker = walkdir::WalkDir::new(&resolved_root).follow_links(false);
+    let walker = if recursive {
+        walker
+    } else {
+        walker.max_depth(1)
+    };
+    for entry in walker
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+    {
+        let rel = entry
+            .path()
+            .strip_prefix(&resolved_root)
+            .unwrap_or(entry.path())
+            .to_string_lossy()
+            .into_owned();
+        if passes(&rel) {
+            out.push(entry.path().to_path_buf());
+        }
+    }
+    out
+}
+
+/// Apply a find-and-replace, atomically, to either an explicit list of
+/// files (`files`) or every file under `path` that matches the glob
+/// filters.
+///
+/// Caller must supply **exactly one** of `files` (non-empty) or `path`
+/// (a directory, a single file, or a symlink to either) — both/neither
+/// returns `S210`. The path-form mirrors grep's walker: `walkdir` with
+/// `follow_links=false`, gitignore-style glob filtering relative to
+/// `path`. Symlink-to-dir is resolved via `canonicalize` so the walker
+/// descends into the target.
+///
+/// `recursive=false` on a directory `path` is rejected with `S210`,
+/// matching grep. Use `files: [...]` or `recursive=true` (with a
+/// tighter glob) instead.
+///
+/// - `regex=true` → treat `pattern` as a Rust regex with `$N` / `$name`
+///   capture references in `replacement`.
+/// - `regex=false` → literal string match.
+/// - `first_only=true` → replace only the first match per line.
+/// - Per-file failures are isolated; the handler continues to the next
+///   file and reports `success=false` in that entry's result.
+/// - Writes are atomic: content goes to a temp sibling and is renamed
+///   over the original only on success.
+///
+/// Returns `Err` for: bad regex (S217), empty literal pattern (S210),
+/// missing `path` form root (S211), invalid input form (S210), or
+/// `recursive=false` on a directory (S210). Per-file I/O errors
+/// surface in `FsSedFileResult.success`.
+pub fn sed(
+    files: Vec<String>,
+    path: Option<String>,
+    recursive: bool,
+    include_glob: Vec<String>,
+    exclude_glob: Vec<String>,
+    pattern: String,
+    replacement: String,
+    regex_mode: bool,
+    first_only: bool,
+    ignore_case: bool,
+) -> FsCallResult {
+    // Discriminate between the two input forms. We treat an empty
+    // `files` vec as "not the files form" so old guests that send only
+    // `files` still parse, and new callers can use `path`. Exactly one
+    // form must be present.
+    let files = match (files.is_empty(), path.as_ref()) {
+        (false, None) => files,
+        (true, Some(root)) => {
+            // Path-form: walk and filter.
+            let root_path = Path::new(root);
+            // Surface a missing-root error up front so the caller can
+            // distinguish it from the "no files matched" case below.
+            // We use the symlink-following metadata here so a broken
+            // symlink (which only `metadata` notices) also surfaces
+            // S211 — same as grep's behaviour on a missing root.
+            let _ = root_path
+                .symlink_metadata()
+                .map_err(|e| FsError::from_io(root, e))?;
+            // Resolve target type so we can mirror grep's
+            // `recursive=false` rejection on directories. Symlinks
+            // here are followed because the caller's intent is "what
+            // does this path point at?", not "what is this link".
+            let target_is_dir = match std::fs::metadata(root_path) {
+                Ok(m) => m.is_dir(),
+                Err(e) => return Err(FsError::from_io(root, e)),
+            };
+            if target_is_dir && !recursive {
+                // Mirror grep's policy verbatim. Sed used to silently
+                // walk depth-1 here; that diverged from grep without
+                // good reason. Realign: callers asking for a depth-1
+                // sweep can pass `files: [...]` after enumerating, or
+                // pass `recursive: true` with a tighter `include_glob`.
+                return Err(FsError::new(
+                    "S210",
+                    "recursive=false on a directory is unsupported; \
+                     pass a file path or set recursive=true",
+                ));
+            }
+            let collected = collect_files_to_sed(
+                root_path,
+                recursive,
+                &include_glob,
+                &exclude_glob,
+            );
+            collected
+                .into_iter()
+                .map(|p| p.to_string_lossy().into_owned())
+                .collect()
+        }
+        (false, Some(_)) => {
+            return Err(FsError::new(
+                "S210",
+                "sed: provide exactly one of `files` or `path`, not both",
+            ));
+        }
+        (true, None) => {
+            return Err(FsError::new(
+                "S210",
+                "sed: must provide exactly one of `files` or `path`",
+            ));
+        }
+    };
+
+    // Compile the matcher once; a bad pattern aborts the whole call.
+    let matcher: Option<regex::Regex> = if regex_mode {
+        Some(
+            regex::RegexBuilder::new(&pattern)
+                .case_insensitive(ignore_case)
+                .build()
+                .map_err(|e| FsError::new("S217", format!("bad regex: {e}")))?,
+        )
+    } else if pattern.is_empty() {
+        return Err(FsError::new("S210", "pattern is empty"));
+    } else {
+        None
+    };
+
+    let case_fold = ignore_case && !regex_mode;
+
+    let mut results: Vec<FsSedFileResult> = Vec::with_capacity(files.len());
+    let mut total: u64 = 0;
+
+    for file in files {
+        let p = Path::new(&file);
+        let original = match std::fs::read_to_string(p) {
+            Ok(s) => s,
+            Err(e) => {
+                results.push(FsSedFileResult {
+                    path: file.clone(),
+                    replacements: 0,
+                    success: false,
+                    error: Some(format!("{e}")),
+                });
+                continue;
+            }
+        };
+
+        let mut replacements: u64 = 0;
+        let mut output = String::with_capacity(original.len());
+
+        for line in original.split_inclusive('\n') {
+            let (new_line, n) = match &matcher {
+                Some(re) => {
+                    let mut count_here = 0u64;
+                    let produced = if first_only {
+                        re.replacen(line, 1, |caps: &regex::Captures| {
+                            count_here += 1;
+                            expand_regex_replacement(caps, &replacement)
+                        })
+                        .into_owned()
+                    } else {
+                        re.replace_all(line, |caps: &regex::Captures| {
+                            count_here += 1;
+                            expand_regex_replacement(caps, &replacement)
+                        })
+                        .into_owned()
+                    };
+                    (produced, count_here)
+                }
+                None => literal_replace_line(
+                    line,
+                    &pattern,
+                    case_fold,
+                    &replacement,
+                    first_only,
+                ),
+            };
+            replacements += n;
+            output.push_str(&new_line);
+        }
+
+        // Atomic write-to-temp + rename. On any failure we report
+        // per-file failure and leave the original intact.
+        let tmp = temp_sibling(p);
+        let write_result: Result<(), std::io::Error> = (|| {
+            let original_md = std::fs::metadata(p)?;
+            std::fs::write(&tmp, output.as_bytes())?;
+            std::fs::set_permissions(
+                &tmp,
+                std::fs::Permissions::from_mode(original_md.permissions().mode()),
+            )?;
+            std::fs::rename(&tmp, p)?;
+            Ok(())
+        })();
+
+        match write_result {
+            Ok(()) => {
+                total += replacements;
+                results.push(FsSedFileResult {
+                    path: file,
+                    replacements,
+                    success: true,
+                    error: None,
+                });
+            }
+            Err(e) => {
+                let _ = std::fs::remove_file(&tmp);
+                results.push(FsSedFileResult {
+                    path: file,
+                    replacements: 0,
+                    success: false,
+                    error: Some(format!("{e}")),
+                });
+            }
+        }
+    }
+
+    Ok(FsResult::Sed {
+        results,
+        total_replacements: total,
+    })
+}

--- a/crates/iii-init/src/fs_handler/streaming.rs
+++ b/crates/iii-init/src/fs_handler/streaming.rs
@@ -1,0 +1,320 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at support@motia.dev
+// See LICENSE and PATENTS files for details.
+
+//! Streaming handlers for `WriteStart` (upload) and `ReadStart` (download).
+//!
+//! Both handlers are **sync** — they use `std::sync::mpsc` channels,
+//! `std::fs`, `std::io::Write` / `std::io::Read`. No tokio anywhere.
+//!
+//! The `handle_write_start` function receives a `Receiver<ShellMessage>`
+//! that the dispatcher populates by forwarding `FsChunk` / `FsEnd`
+//! frames for the same correlation id. Once it observes `FsEnd` it
+//! fsyncs + renames the temp file atomically.
+//!
+//! The `handle_read_start` function opens the file, sends `FsMeta` then
+//! streams 64 KiB chunks as `FsChunk` frames, and closes with `FsEnd`,
+//! all through the shared outbound `Writer` (a `SyncSender<Vec<u8>>`
+//! that feeds the wire writer thread).
+
+use std::io::{Read, Write};
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::path::Path;
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
+use std::time::Duration;
+
+use base64::Engine;
+use iii_shell_proto::{FsReadMeta, FsResult, ShellMessage};
+
+use super::ops::temp_sibling;
+use super::{FsCallResult, FsError, parse_mode};
+use crate::shell_dispatcher::Writer;
+
+/// Size of each chunk sent during `ReadStart` streaming.
+const READ_CHUNK_SIZE: usize = 64 * 1024;
+
+/// Maximum idle time between `FsChunk` / `FsEnd` frames during a
+/// `WriteStart` session. The dispatcher's `fs_writes` registry
+/// holds the per-corr_id sender for the lifetime of the session,
+/// so a blocking `recv()` would wait forever if the host trigger
+/// handler stalls (caller-side data channel hard-terminated, the
+/// worker's `ChannelReader::next_binary()` never resolves, etc.).
+/// On expiry we treat the session as aborted: unlink the temp
+/// file, return `S218`. The worker's outer 30s SDK timeout still
+/// fires, but the supervisor releases its temp first so callers
+/// don't accumulate `.iii-tmp-*` leaks across aborted uploads.
+/// 30s is well above realistic per-chunk inter-arrival latency
+/// for a healthy 64 KiB-frame channel — a real upload sees a
+/// chunk every few milliseconds.
+const WRITE_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Upload  (host → guest)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Handle a `WriteStart` upload session.
+///
+/// Pulls `FsChunk` / `FsEnd` frames from `inbound` (populated by the
+/// dispatcher routing loop), writes chunks to a temp sibling, fsyncs,
+/// sets `mode`, then atomically renames to `path`.
+///
+/// On early channel close (sender dropped before `FsEnd`) the temp file
+/// is unlinked and `S218` is returned.
+///
+/// Errors:
+/// - `S210` — bad octal `mode` or bad base64 in a chunk.
+/// - `S211` — parent dir missing and `parents=false`.
+/// - `S218` — channel closed before `FsEnd`.
+/// - `S216` — I/O error writing or renaming.
+pub fn handle_write_start(
+    path: String,
+    mode: String,
+    parents: bool,
+    inbound: Receiver<ShellMessage>,
+) -> FsCallResult {
+    handle_write_start_with_timeout(path, mode, parents, inbound, WRITE_IDLE_TIMEOUT)
+}
+
+/// Internal entry point exposed to tests so they can drive the
+/// timeout path without waiting `WRITE_IDLE_TIMEOUT`. Production
+/// always calls `handle_write_start` (which passes the const).
+pub(crate) fn handle_write_start_with_timeout(
+    path: String,
+    mode: String,
+    parents: bool,
+    inbound: Receiver<ShellMessage>,
+    idle_timeout: Duration,
+) -> FsCallResult {
+    let bits = parse_mode(&mode)?;
+    let target = std::path::PathBuf::from(&path);
+
+    // Resolve / create parent.
+    if let Some(parent) = target.parent() {
+        if !parent.as_os_str().is_empty() {
+            if parents {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| FsError::from_io(&path, e))?;
+            } else if !parent.exists() {
+                return Err(FsError::new(
+                    "S211",
+                    format!("parent not found: {}", parent.display()),
+                ));
+            }
+        }
+    }
+
+    let tmp = temp_sibling(&target);
+    let mut f = match std::fs::File::create(&tmp) {
+        Ok(f) => f,
+        Err(e) => return Err(FsError::from_io(&path, e)),
+    };
+
+    let mut written: u64 = 0;
+    let mut ended_cleanly = false;
+    let mut timed_out = false;
+
+    // Drain the inbound channel until FsEnd, the sender drops, or
+    // the per-recv idle timeout fires. recv_timeout is the only way
+    // the supervisor side can notice a stalled upload — there's no
+    // host-disconnect signal that flows down to this thread otherwise
+    // (the dispatcher's per-corr_id sender lives in fs_writes for
+    // the session lifetime).
+    loop {
+        let msg = match inbound.recv_timeout(idle_timeout) {
+            Ok(m) => m,
+            Err(RecvTimeoutError::Timeout) => {
+                timed_out = true;
+                break;
+            }
+            Err(RecvTimeoutError::Disconnected) => break, // sender dropped
+        };
+        match msg {
+            ShellMessage::FsChunk { data_b64 } => {
+                let bytes = match base64::engine::general_purpose::STANDARD
+                    .decode(&data_b64)
+                {
+                    Ok(b) => b,
+                    Err(e) => {
+                        let _ = std::fs::remove_file(&tmp);
+                        return Err(FsError::new(
+                            "S210",
+                            format!("bad base64 in chunk: {e}"),
+                        ));
+                    }
+                };
+                if let Err(e) = f.write_all(&bytes) {
+                    let _ = std::fs::remove_file(&tmp);
+                    return Err(FsError::from_io(&path, e));
+                }
+                written += bytes.len() as u64;
+            }
+            ShellMessage::FsEnd => {
+                ended_cleanly = true;
+                break;
+            }
+            other => {
+                let _ = std::fs::remove_file(&tmp);
+                return Err(FsError::new(
+                    "S210",
+                    format!("unexpected frame in write stream: {other:?}"),
+                ));
+            }
+        }
+    }
+
+    if !ended_cleanly {
+        let _ = std::fs::remove_file(&tmp);
+        let why = if timed_out {
+            format!(
+                "no chunks for {}s — caller channel stalled or aborted",
+                WRITE_IDLE_TIMEOUT.as_secs()
+            )
+        } else {
+            "channel closed before FsEnd".to_string()
+        };
+        return Err(FsError::new("S218", why));
+    }
+
+    // fsync, set mode, rename atomically.
+    if let Err(e) = f.flush() {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(FsError::from_io(&path, e));
+    }
+    if let Err(e) = f.sync_all() {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(FsError::from_io(&path, e));
+    }
+    drop(f);
+
+    if let Err(e) =
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(bits))
+    {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(FsError::from_io(&path, e));
+    }
+    if let Err(e) = std::fs::rename(&tmp, &target) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(FsError::from_io(&path, e));
+    }
+
+    Ok(FsResult::Write {
+        bytes_written: written,
+        path,
+    })
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Download  (guest → host)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Handle a `ReadStart` download session.
+///
+/// Opens `path`, emits `FsMeta` then N `FsChunk` frames (64 KiB each),
+/// and closes with a terminal `FsEnd` — all via the shared `writer`.
+///
+/// If any I/O error occurs **after** `FsMeta` has been sent, the
+/// function emits an `FsError` frame with `FLAG_TERMINAL` through
+/// `writer` (the caller sees it as a terminal error frame on the wire).
+///
+/// Errors returned from this function indicate pre-`FsMeta` failures
+/// (e.g. path not found, is a directory), so the caller can emit the
+/// `FsError` frame itself without risk of sending two terminal frames.
+///
+/// Errors:
+/// - `S211` — path does not exist.
+/// - `S212` — path is a directory.
+/// - `S216` — I/O error opening the file.
+pub fn handle_read_start(
+    path: String,
+    writer: &Writer,
+    corr_id: u32,
+) -> Result<(), FsError> {
+    use iii_shell_proto::flags::FLAG_TERMINAL;
+
+    let p = Path::new(&path);
+    // `metadata()` follows symlinks so the size/mode/mtime we ship in
+    // FsMeta describe the same bytes File::open will stream below. Using
+    // `symlink_metadata()` here would report the link itself (size ≈
+    // path length, mode 0o777) while the stream body comes from the
+    // target — caller's "expected vs received" check trips on every
+    // symlink download, and a symlink-to-dir would emit FsMeta then
+    // fail with EISDIR after the meta was already accepted.
+    let md = match std::fs::metadata(p) {
+        Ok(m) => m,
+        Err(e) => return Err(FsError::from_io(&path, e)),
+    };
+    if md.is_dir() {
+        return Err(FsError::new("S212", format!("is a directory: {path}")));
+    }
+
+    let mode_bits = md.mode() & 0o7777;
+    let meta = FsReadMeta {
+        size: md.len(),
+        mode: format!("{mode_bits:04o}"),
+        mtime: md.mtime(),
+    };
+    // Send FsMeta — after this any error must go as a wire FsError frame.
+    crate::shell_dispatcher::send_frame(writer, corr_id, 0, &ShellMessage::FsMeta(meta));
+
+    let mut file = match std::fs::File::open(p) {
+        Ok(f) => f,
+        Err(e) => {
+            let fe = FsError::from_io(&path, e);
+            crate::shell_dispatcher::send_frame(
+                writer,
+                corr_id,
+                FLAG_TERMINAL,
+                &ShellMessage::FsError {
+                    code: fe.code.to_string(),
+                    message: fe.message.clone(),
+                },
+            );
+            return Ok(()); // FsMeta already sent; caller must NOT send another frame
+        }
+    };
+
+    let mut buf = vec![0u8; READ_CHUNK_SIZE];
+    loop {
+        let n = match file.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => {
+                let fe = FsError::from_io(&path, e);
+                crate::shell_dispatcher::send_frame(
+                    writer,
+                    corr_id,
+                    FLAG_TERMINAL,
+                    &ShellMessage::FsError {
+                        code: fe.code.to_string(),
+                        message: fe.message,
+                    },
+                );
+                return Ok(());
+            }
+        };
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&buf[..n]);
+        crate::shell_dispatcher::send_frame(
+            writer,
+            corr_id,
+            0,
+            &ShellMessage::FsChunk { data_b64: encoded },
+        );
+    }
+
+    // Terminal FsEnd.
+    crate::shell_dispatcher::send_frame(writer, corr_id, FLAG_TERMINAL, &ShellMessage::FsEnd);
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests helper re-export for tests.rs
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Encode bytes as base64 (STANDARD alphabet). Exposed for tests.
+#[cfg(test)]
+pub fn b64_encode(data: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(data)
+}

--- a/crates/iii-init/src/fs_handler/streaming.rs
+++ b/crates/iii-init/src/fs_handler/streaming.rs
@@ -94,8 +94,7 @@ pub(crate) fn handle_write_start_with_timeout(
     if let Some(parent) = target.parent() {
         if !parent.as_os_str().is_empty() {
             if parents {
-                std::fs::create_dir_all(parent)
-                    .map_err(|e| FsError::from_io(&path, e))?;
+                std::fs::create_dir_all(parent).map_err(|e| FsError::from_io(&path, e))?;
             } else if !parent.exists() {
                 return Err(FsError::new(
                     "S211",
@@ -132,16 +131,11 @@ pub(crate) fn handle_write_start_with_timeout(
         };
         match msg {
             ShellMessage::FsChunk { data_b64 } => {
-                let bytes = match base64::engine::general_purpose::STANDARD
-                    .decode(&data_b64)
-                {
+                let bytes = match base64::engine::general_purpose::STANDARD.decode(&data_b64) {
                     Ok(b) => b,
                     Err(e) => {
                         let _ = std::fs::remove_file(&tmp);
-                        return Err(FsError::new(
-                            "S210",
-                            format!("bad base64 in chunk: {e}"),
-                        ));
+                        return Err(FsError::new("S210", format!("bad base64 in chunk: {e}")));
                     }
                 };
                 if let Err(e) = f.write_all(&bytes) {
@@ -188,9 +182,7 @@ pub(crate) fn handle_write_start_with_timeout(
     }
     drop(f);
 
-    if let Err(e) =
-        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(bits))
-    {
+    if let Err(e) = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(bits)) {
         let _ = std::fs::remove_file(&tmp);
         return Err(FsError::from_io(&path, e));
     }
@@ -226,11 +218,7 @@ pub(crate) fn handle_write_start_with_timeout(
 /// - `S211` — path does not exist.
 /// - `S212` — path is a directory.
 /// - `S216` — I/O error opening the file.
-pub fn handle_read_start(
-    path: String,
-    writer: &Writer,
-    corr_id: u32,
-) -> Result<(), FsError> {
+pub fn handle_read_start(path: String, writer: &Writer, corr_id: u32) -> Result<(), FsError> {
     use iii_shell_proto::flags::FLAG_TERMINAL;
 
     let p = Path::new(&path);

--- a/crates/iii-init/src/fs_handler/tests.rs
+++ b/crates/iii-init/src/fs_handler/tests.rs
@@ -136,8 +136,7 @@ fn mkdir_parents_true_creates_ancestors() {
 #[test]
 fn mkdir_existing_without_parents_returns_s213() {
     let dir = tmpdir();
-    let err =
-        ops::mkdir(dir.path().to_string_lossy().into(), "0755".into(), false).unwrap_err();
+    let err = ops::mkdir(dir.path().to_string_lossy().into(), "0755".into(), false).unwrap_err();
     assert_eq!(err.code, "S213");
 }
 
@@ -227,8 +226,14 @@ fn chmod_recursive_counts_every_entry() {
     // root + a/ + a/b/ + a/c = 4 entries
     std::fs::create_dir_all(dir.path().join("a/b")).unwrap();
     std::fs::write(dir.path().join("a/c"), b"x").unwrap();
-    let res =
-        ops::chmod(dir.path().to_string_lossy().into(), "0755".into(), None, None, true).unwrap();
+    let res = ops::chmod(
+        dir.path().to_string_lossy().into(),
+        "0755".into(),
+        None,
+        None,
+        true,
+    )
+    .unwrap();
     let FsResult::Chmod { updated } = res else {
         panic!("expected Chmod result");
     };
@@ -238,14 +243,7 @@ fn chmod_recursive_counts_every_entry() {
 
 #[test]
 fn chmod_missing_returns_s211() {
-    let err = ops::chmod(
-        "/nonexistent/xyz".into(),
-        "0755".into(),
-        None,
-        None,
-        false,
-    )
-    .unwrap_err();
+    let err = ops::chmod("/nonexistent/xyz".into(), "0755".into(), None, None, false).unwrap_err();
     assert_eq!(err.code, "S211");
 }
 
@@ -259,7 +257,12 @@ fn mv_same_fs_rename() {
     let src = dir.path().join("a");
     let dst = dir.path().join("b");
     std::fs::write(&src, b"hello").unwrap();
-    ops::mv(src.to_string_lossy().into(), dst.to_string_lossy().into(), false).unwrap();
+    ops::mv(
+        src.to_string_lossy().into(),
+        dst.to_string_lossy().into(),
+        false,
+    )
+    .unwrap();
     assert!(!src.exists());
     assert_eq!(std::fs::read(&dst).unwrap(), b"hello");
 }
@@ -271,8 +274,12 @@ fn mv_overwrite_false_on_existing_dst_returns_s213() {
     let dst = dir.path().join("b");
     std::fs::write(&src, b"A").unwrap();
     std::fs::write(&dst, b"B").unwrap();
-    let err =
-        ops::mv(src.to_string_lossy().into(), dst.to_string_lossy().into(), false).unwrap_err();
+    let err = ops::mv(
+        src.to_string_lossy().into(),
+        dst.to_string_lossy().into(),
+        false,
+    )
+    .unwrap_err();
     assert_eq!(err.code, "S213");
     assert!(src.exists(), "source should survive failed mv");
     assert_eq!(std::fs::read(&dst).unwrap(), b"B", "dst unchanged");
@@ -285,7 +292,12 @@ fn mv_overwrite_true_replaces_dst() {
     let dst = dir.path().join("b");
     std::fs::write(&src, b"A").unwrap();
     std::fs::write(&dst, b"B").unwrap();
-    ops::mv(src.to_string_lossy().into(), dst.to_string_lossy().into(), true).unwrap();
+    ops::mv(
+        src.to_string_lossy().into(),
+        dst.to_string_lossy().into(),
+        true,
+    )
+    .unwrap();
     assert!(!src.exists());
     assert_eq!(std::fs::read(&dst).unwrap(), b"A");
 }
@@ -320,14 +332,14 @@ fn write_stream_happy_path_atomic() {
         tx.send(ShellMessage::FsEnd).unwrap();
     });
 
-    let res = streaming::handle_write_start(
-        target.to_string_lossy().into(),
-        "0600".into(),
-        false,
-        rx,
-    )
-    .unwrap();
-    let FsResult::Write { bytes_written, path } = res else {
+    let res =
+        streaming::handle_write_start(target.to_string_lossy().into(), "0600".into(), false, rx)
+            .unwrap();
+    let FsResult::Write {
+        bytes_written,
+        path,
+    } = res
+    else {
         panic!("expected Write result");
     };
     assert_eq!(bytes_written, payload.len() as u64);
@@ -351,13 +363,9 @@ fn write_stream_early_channel_close_unlinks_temp() {
         // Drop tx without sending FsEnd — simulates caller abort.
     });
 
-    let err = streaming::handle_write_start(
-        target.to_string_lossy().into(),
-        "0644".into(),
-        false,
-        rx,
-    )
-    .unwrap_err();
+    let err =
+        streaming::handle_write_start(target.to_string_lossy().into(), "0644".into(), false, rx)
+            .unwrap_err();
     assert_eq!(err.code, "S218");
     assert!(!target.exists(), "target must not exist");
 
@@ -455,13 +463,9 @@ fn write_stream_parents_false_missing_parent_returns_s211() {
     let dir = tmpdir();
     let target = dir.path().join("missing/x.bin");
     let (_tx, rx) = std::sync::mpsc::sync_channel::<ShellMessage>(4);
-    let err = streaming::handle_write_start(
-        target.to_string_lossy().into(),
-        "0644".into(),
-        false,
-        rx,
-    )
-    .unwrap_err();
+    let err =
+        streaming::handle_write_start(target.to_string_lossy().into(), "0644".into(), false, rx)
+            .unwrap_err();
     assert_eq!(err.code, "S211");
 }
 
@@ -481,9 +485,7 @@ fn mock_writer() -> (
 }
 
 /// Decode the ShellMessages from a mock writer receiver.
-fn collect_messages(
-    rx: std::sync::mpsc::Receiver<Vec<u8>>,
-) -> Vec<ShellMessage> {
+fn collect_messages(rx: std::sync::mpsc::Receiver<Vec<u8>>) -> Vec<ShellMessage> {
     let mut msgs = Vec::new();
     while let Ok(frame_bytes) = rx.try_recv() {
         // frame_bytes is a complete wire frame (4-byte len + corr_id + flags + JSON).
@@ -848,7 +850,11 @@ fn sed_global_literal_replaces_all_occurrences() {
         false,
     )
     .unwrap();
-    let FsResult::Sed { results, total_replacements } = res else {
+    let FsResult::Sed {
+        results,
+        total_replacements,
+    } = res
+    else {
         panic!();
     };
     assert_eq!(total_replacements, 4);
@@ -927,7 +933,11 @@ fn sed_per_file_failure_does_not_abort_remaining() {
         false,
     )
     .unwrap();
-    let FsResult::Sed { results, total_replacements } = res else {
+    let FsResult::Sed {
+        results,
+        total_replacements,
+    } = res
+    else {
         panic!();
     };
     assert_eq!(total_replacements, 1);

--- a/crates/iii-init/src/fs_handler/tests.rs
+++ b/crates/iii-init/src/fs_handler/tests.rs
@@ -1,0 +1,1278 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at support@motia.dev
+// See LICENSE and PATENTS files for details.
+
+//! Unit tests for `fs_handler` ops and streaming handlers.
+//!
+//! Each test creates an isolated tmpdir via `tempfile::tempdir()`,
+//! exercises a handler, and asserts the returned `FsResult` or
+//! `FsError`. No shared state between tests.
+//!
+//! All tests are `#[test]` (synchronous). No tokio.
+
+use super::ops;
+use super::streaming;
+use iii_shell_proto::{FsResult, ShellMessage};
+use std::io::Write;
+
+fn tmpdir() -> tempfile::TempDir {
+    tempfile::tempdir().expect("tempdir")
+}
+
+fn write_file(dir: &std::path::Path, rel: &str, body: &str) {
+    let p = dir.join(rel);
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(p, body).unwrap();
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// ls
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn ls_returns_entries_for_dir() {
+    let dir = tmpdir();
+    std::fs::write(dir.path().join("a.txt"), b"hello").unwrap();
+    std::fs::create_dir(dir.path().join("sub")).unwrap();
+
+    let res = ops::ls(dir.path().to_string_lossy().into()).unwrap();
+    let FsResult::Ls { mut entries } = res else {
+        panic!("expected Ls result");
+    };
+    entries.sort_by(|x, y| x.name.cmp(&y.name));
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].name, "a.txt");
+    assert!(!entries[0].is_dir);
+    assert_eq!(entries[0].size, 5);
+    assert_eq!(entries[1].name, "sub");
+    assert!(entries[1].is_dir);
+}
+
+#[test]
+fn ls_on_missing_returns_s211() {
+    let err = ops::ls("/nonexistent/path/xyz".into()).unwrap_err();
+    assert_eq!(err.code, "S211");
+}
+
+#[test]
+fn ls_on_file_returns_s212() {
+    let dir = tmpdir();
+    let f = dir.path().join("a.txt");
+    std::fs::write(&f, b"hi").unwrap();
+    let err = ops::ls(f.to_string_lossy().into()).unwrap_err();
+    assert_eq!(err.code, "S212");
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// stat
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn stat_returns_file_metadata() {
+    let dir = tmpdir();
+    let f = dir.path().join("a.txt");
+    let mut fh = std::fs::File::create(&f).unwrap();
+    fh.write_all(b"hello").unwrap();
+    drop(fh);
+
+    let res = ops::stat(f.to_string_lossy().into()).unwrap();
+    let FsResult::Stat(entry) = res else {
+        panic!("expected Stat result");
+    };
+    assert_eq!(entry.name, "a.txt");
+    assert_eq!(entry.size, 5);
+    assert!(!entry.is_dir);
+    assert!(!entry.is_symlink);
+}
+
+#[test]
+fn stat_on_symlink_reports_is_symlink() {
+    let dir = tmpdir();
+    let target = dir.path().join("target");
+    let link = dir.path().join("link");
+    std::fs::write(&target, b"x").unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let res = ops::stat(link.to_string_lossy().into()).unwrap();
+    let FsResult::Stat(entry) = res else {
+        panic!("expected Stat result");
+    };
+    assert!(entry.is_symlink, "symlink flag not set");
+}
+
+#[test]
+fn stat_missing_returns_s211() {
+    let err = ops::stat("/no/such/path".into()).unwrap_err();
+    assert_eq!(err.code, "S211");
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// mkdir
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn mkdir_creates_with_mode() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tmpdir();
+    let p = dir.path().join("new");
+    ops::mkdir(p.to_string_lossy().into(), "0750".into(), false).unwrap();
+    let md = std::fs::metadata(&p).unwrap();
+    assert!(md.is_dir());
+    assert_eq!(md.permissions().mode() & 0o777, 0o750);
+}
+
+#[test]
+fn mkdir_parents_true_creates_ancestors() {
+    let dir = tmpdir();
+    let p = dir.path().join("a/b/c");
+    ops::mkdir(p.to_string_lossy().into(), "0755".into(), true).unwrap();
+    assert!(p.is_dir());
+}
+
+#[test]
+fn mkdir_existing_without_parents_returns_s213() {
+    let dir = tmpdir();
+    let err =
+        ops::mkdir(dir.path().to_string_lossy().into(), "0755".into(), false).unwrap_err();
+    assert_eq!(err.code, "S213");
+}
+
+#[test]
+fn mkdir_existing_with_parents_is_ok() {
+    let dir = tmpdir();
+    ops::mkdir(dir.path().to_string_lossy().into(), "0755".into(), true).unwrap();
+}
+
+#[test]
+fn mkdir_bad_mode_returns_s210() {
+    let dir = tmpdir();
+    let err = ops::mkdir(
+        dir.path().join("new").to_string_lossy().into(),
+        "not-octal".into(),
+        false,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, "S210");
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// rm
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn rm_file() {
+    let dir = tmpdir();
+    let f = dir.path().join("x");
+    std::fs::write(&f, b"y").unwrap();
+    ops::rm(f.to_string_lossy().into(), false).unwrap();
+    assert!(!f.exists());
+}
+
+#[test]
+fn rm_empty_dir_without_recursive() {
+    let dir = tmpdir();
+    let sub = dir.path().join("empty");
+    std::fs::create_dir(&sub).unwrap();
+    ops::rm(sub.to_string_lossy().into(), false).unwrap();
+    assert!(!sub.exists());
+}
+
+#[test]
+fn rm_non_empty_dir_without_recursive_returns_s214() {
+    let dir = tmpdir();
+    let sub = dir.path().join("full");
+    std::fs::create_dir(&sub).unwrap();
+    std::fs::write(sub.join("x"), b"y").unwrap();
+    let err = ops::rm(sub.to_string_lossy().into(), false).unwrap_err();
+    assert_eq!(err.code, "S214");
+    assert!(sub.exists(), "path should survive failed rm");
+}
+
+#[test]
+fn rm_recursive_removes_tree() {
+    let dir = tmpdir();
+    let sub = dir.path().join("full");
+    std::fs::create_dir_all(sub.join("a/b")).unwrap();
+    std::fs::write(sub.join("a/b/c"), b"x").unwrap();
+    ops::rm(sub.to_string_lossy().into(), true).unwrap();
+    assert!(!sub.exists());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// chmod
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn chmod_updates_mode() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tmpdir();
+    let f = dir.path().join("x");
+    std::fs::write(&f, b"y").unwrap();
+    let res = ops::chmod(f.to_string_lossy().into(), "0600".into(), None, None, false).unwrap();
+    let FsResult::Chmod { updated } = res else {
+        panic!("expected Chmod result");
+    };
+    assert_eq!(updated, 1);
+    let md = std::fs::metadata(&f).unwrap();
+    assert_eq!(md.permissions().mode() & 0o777, 0o600);
+}
+
+#[test]
+fn chmod_recursive_counts_every_entry() {
+    let dir = tmpdir();
+    // root + a/ + a/b/ + a/c = 4 entries
+    std::fs::create_dir_all(dir.path().join("a/b")).unwrap();
+    std::fs::write(dir.path().join("a/c"), b"x").unwrap();
+    let res =
+        ops::chmod(dir.path().to_string_lossy().into(), "0755".into(), None, None, true).unwrap();
+    let FsResult::Chmod { updated } = res else {
+        panic!("expected Chmod result");
+    };
+    // root dir + a + a/b + a/c = 4
+    assert_eq!(updated, 4);
+}
+
+#[test]
+fn chmod_missing_returns_s211() {
+    let err = ops::chmod(
+        "/nonexistent/xyz".into(),
+        "0755".into(),
+        None,
+        None,
+        false,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, "S211");
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// mv
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn mv_same_fs_rename() {
+    let dir = tmpdir();
+    let src = dir.path().join("a");
+    let dst = dir.path().join("b");
+    std::fs::write(&src, b"hello").unwrap();
+    ops::mv(src.to_string_lossy().into(), dst.to_string_lossy().into(), false).unwrap();
+    assert!(!src.exists());
+    assert_eq!(std::fs::read(&dst).unwrap(), b"hello");
+}
+
+#[test]
+fn mv_overwrite_false_on_existing_dst_returns_s213() {
+    let dir = tmpdir();
+    let src = dir.path().join("a");
+    let dst = dir.path().join("b");
+    std::fs::write(&src, b"A").unwrap();
+    std::fs::write(&dst, b"B").unwrap();
+    let err =
+        ops::mv(src.to_string_lossy().into(), dst.to_string_lossy().into(), false).unwrap_err();
+    assert_eq!(err.code, "S213");
+    assert!(src.exists(), "source should survive failed mv");
+    assert_eq!(std::fs::read(&dst).unwrap(), b"B", "dst unchanged");
+}
+
+#[test]
+fn mv_overwrite_true_replaces_dst() {
+    let dir = tmpdir();
+    let src = dir.path().join("a");
+    let dst = dir.path().join("b");
+    std::fs::write(&src, b"A").unwrap();
+    std::fs::write(&dst, b"B").unwrap();
+    ops::mv(src.to_string_lossy().into(), dst.to_string_lossy().into(), true).unwrap();
+    assert!(!src.exists());
+    assert_eq!(std::fs::read(&dst).unwrap(), b"A");
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// write streaming
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn b64_encode(data: &[u8]) -> String {
+    streaming::b64_encode(data)
+}
+
+#[test]
+fn write_stream_happy_path_atomic() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tmpdir();
+    let target = dir.path().join("out.bin");
+    let (tx, rx) = std::sync::mpsc::sync_channel::<ShellMessage>(8);
+    let payload: Vec<u8> = (0u8..=200).collect();
+
+    // Producer: push two chunks then FsEnd.
+    let payload_clone = payload.clone();
+    std::thread::spawn(move || {
+        tx.send(ShellMessage::FsChunk {
+            data_b64: b64_encode(&payload_clone[..100]),
+        })
+        .unwrap();
+        tx.send(ShellMessage::FsChunk {
+            data_b64: b64_encode(&payload_clone[100..]),
+        })
+        .unwrap();
+        tx.send(ShellMessage::FsEnd).unwrap();
+    });
+
+    let res = streaming::handle_write_start(
+        target.to_string_lossy().into(),
+        "0600".into(),
+        false,
+        rx,
+    )
+    .unwrap();
+    let FsResult::Write { bytes_written, path } = res else {
+        panic!("expected Write result");
+    };
+    assert_eq!(bytes_written, payload.len() as u64);
+    assert_eq!(path, target.to_string_lossy());
+    assert_eq!(std::fs::read(&target).unwrap(), payload);
+    let md = std::fs::metadata(&target).unwrap();
+    assert_eq!(md.permissions().mode() & 0o777, 0o600);
+}
+
+#[test]
+fn write_stream_early_channel_close_unlinks_temp() {
+    let dir = tmpdir();
+    let target = dir.path().join("out.bin");
+    let (tx, rx) = std::sync::mpsc::sync_channel::<ShellMessage>(4);
+
+    std::thread::spawn(move || {
+        tx.send(ShellMessage::FsChunk {
+            data_b64: b64_encode(b"partial"),
+        })
+        .unwrap();
+        // Drop tx without sending FsEnd — simulates caller abort.
+    });
+
+    let err = streaming::handle_write_start(
+        target.to_string_lossy().into(),
+        "0644".into(),
+        false,
+        rx,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, "S218");
+    assert!(!target.exists(), "target must not exist");
+
+    // No temp leaks.
+    let leaks: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().contains(".iii-tmp-"))
+        .collect();
+    assert!(leaks.is_empty(), "temp file leaked: {leaks:?}");
+}
+
+/// REGRESSION: when the host trigger handler stalls (e.g. the
+/// caller-side data channel was hard-terminated and the worker's
+/// `ChannelReader::next_binary()` hangs), no `FsChunk` or `FsEnd`
+/// ever arrives. The dispatcher's per-corr_id sender stays alive
+/// in `fs_writes` for the session lifetime, so a blocking `recv()`
+/// would wait forever — the temp file would leak and the host's
+/// SDK trigger eventually times out with no S-code.
+///
+/// fs-example.mjs's adversarial section repro:
+///   abortCh.writer.stream.write(Buffer.from('partial bytes'))
+///   abortCh.writer.stream.destroy(new Error('simulated caller abort'))
+///   await iii.trigger('sandbox::fs::write', { content: ref, ... })
+///     => Invocation timeout after 30000ms + temp file left behind
+///
+/// Fix: `handle_write_start` now uses `recv_timeout(idle_timeout)`.
+/// On `Timeout` it unlinks the temp and returns S218. The test
+/// drives `handle_write_start_with_timeout` with a 100 ms idle
+/// timeout and a sender that's held open but silent — so the recv
+/// side blocks purely on the timeout (NOT the Disconnected branch
+/// that the previous test covers).
+#[test]
+fn write_stream_idle_timeout_unlinks_temp_and_returns_s218() {
+    use std::time::Duration;
+
+    let dir = tmpdir();
+    let target = dir.path().join("out.bin");
+    let (tx, rx) = std::sync::mpsc::sync_channel::<ShellMessage>(4);
+
+    let started = std::time::Instant::now();
+    let err = streaming::handle_write_start_with_timeout(
+        target.to_string_lossy().into(),
+        "0644".into(),
+        false,
+        rx,
+        Duration::from_millis(100),
+    )
+    .unwrap_err();
+    let elapsed = started.elapsed();
+
+    // Hold tx alive past the recv path so the failure is *Timeout*,
+    // not *Disconnected* — that's the new code path under test.
+    drop(tx);
+
+    assert_eq!(err.code, "S218", "expected S218, got {err:?}");
+    assert!(
+        err.message.contains("stalled") || err.message.contains("aborted"),
+        "expected timeout-shaped message naming the stall, got {:?}",
+        err.message,
+    );
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "handler blocked {elapsed:?} — should have timed out near 100ms",
+    );
+    assert!(!target.exists(), "target must not exist");
+
+    let leaks: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().contains(".iii-tmp-"))
+        .collect();
+    assert!(leaks.is_empty(), "temp leaked on idle timeout: {leaks:?}");
+}
+
+#[test]
+fn write_stream_parents_true_creates_ancestors() {
+    let dir = tmpdir();
+    let target = dir.path().join("a/b/c.bin");
+    let (tx, rx) = std::sync::mpsc::sync_channel::<ShellMessage>(4);
+    std::thread::spawn(move || {
+        tx.send(ShellMessage::FsChunk {
+            data_b64: b64_encode(b"hi"),
+        })
+        .unwrap();
+        tx.send(ShellMessage::FsEnd).unwrap();
+    });
+    streaming::handle_write_start(target.to_string_lossy().into(), "0644".into(), true, rx)
+        .unwrap();
+    assert_eq!(std::fs::read(&target).unwrap(), b"hi");
+}
+
+#[test]
+fn write_stream_parents_false_missing_parent_returns_s211() {
+    let dir = tmpdir();
+    let target = dir.path().join("missing/x.bin");
+    let (_tx, rx) = std::sync::mpsc::sync_channel::<ShellMessage>(4);
+    let err = streaming::handle_write_start(
+        target.to_string_lossy().into(),
+        "0644".into(),
+        false,
+        rx,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, "S211");
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// read streaming
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Create a mock Writer that collects encoded frames into a channel.
+/// Returns (writer_tx, frame_rx) where the caller can receive Vec<u8>
+/// frames and decode them.
+fn mock_writer() -> (
+    crate::shell_dispatcher::Writer,
+    std::sync::mpsc::Receiver<Vec<u8>>,
+) {
+    let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(256);
+    (tx, rx)
+}
+
+/// Decode the ShellMessages from a mock writer receiver.
+fn collect_messages(
+    rx: std::sync::mpsc::Receiver<Vec<u8>>,
+) -> Vec<ShellMessage> {
+    let mut msgs = Vec::new();
+    while let Ok(frame_bytes) = rx.try_recv() {
+        // frame_bytes is a complete wire frame (4-byte len + corr_id + flags + JSON).
+        // Decode it.
+        if frame_bytes.len() < 9 {
+            continue;
+        }
+        let body = &frame_bytes[4..]; // skip frame_len u32
+        if let Ok((_, _, msg)) = iii_shell_proto::decode_frame_body(body) {
+            msgs.push(msg);
+        }
+    }
+    msgs
+}
+
+#[test]
+fn read_stream_delivers_meta_then_chunks_then_end() {
+    let dir = tmpdir();
+    let f = dir.path().join("x.bin");
+    let payload: Vec<u8> = (0u8..=255).cycle().take(150_000).collect();
+    std::fs::write(&f, &payload).unwrap();
+
+    let (writer, frame_rx) = mock_writer();
+
+    // Run read handler in this thread (it's sync).
+    streaming::handle_read_start(f.to_string_lossy().into(), &writer, 42).unwrap();
+    // Drop writer so frame_rx drains.
+    drop(writer);
+
+    let msgs = collect_messages(frame_rx);
+
+    // First message must be FsMeta.
+    let first = msgs.first().expect("no messages received");
+    let ShellMessage::FsMeta(meta) = first else {
+        panic!("expected FsMeta first, got {first:?}");
+    };
+    assert_eq!(meta.size, payload.len() as u64);
+
+    // Collect all chunk data and find FsEnd.
+    let mut collected: Vec<u8> = Vec::new();
+    let mut saw_end = false;
+    for msg in &msgs[1..] {
+        match msg {
+            ShellMessage::FsChunk { data_b64 } => {
+                use base64::Engine;
+                let b = base64::engine::general_purpose::STANDARD
+                    .decode(data_b64)
+                    .unwrap();
+                collected.extend_from_slice(&b);
+            }
+            ShellMessage::FsEnd => {
+                saw_end = true;
+                break;
+            }
+            other => panic!("unexpected frame: {other:?}"),
+        }
+    }
+    assert!(saw_end, "FsEnd never received");
+    assert_eq!(collected, payload);
+}
+
+#[test]
+fn read_stream_missing_file_returns_s211() {
+    let (writer, _rx) = mock_writer();
+    let err = streaming::handle_read_start("/no/such/file".into(), &writer, 1).unwrap_err();
+    assert_eq!(err.code, "S211");
+}
+
+#[test]
+fn read_stream_on_directory_returns_s212() {
+    let dir = tmpdir();
+    let (writer, _rx) = mock_writer();
+    let err =
+        streaming::handle_read_start(dir.path().to_string_lossy().into(), &writer, 2).unwrap_err();
+    assert_eq!(err.code, "S212");
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// grep
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn grep_finds_literal_matches() {
+    let dir = tmpdir();
+    write_file(dir.path(), "a.rs", "fn foo() {}\n// TODO(a): fix\n");
+    write_file(dir.path(), "b.rs", "// TODO(b): write\n");
+
+    let res = ops::grep(
+        dir.path().to_string_lossy().into(),
+        r"TODO\(.+\)".into(),
+        true,
+        false,
+        vec![],
+        vec![],
+        1000,
+        4096,
+    )
+    .unwrap();
+    let FsResult::Grep { matches, truncated } = res else {
+        panic!("expected Grep result");
+    };
+    assert!(!truncated);
+    assert_eq!(matches.len(), 2);
+    for m in &matches {
+        assert!(m.content.contains("TODO("));
+        assert!(m.line >= 1);
+    }
+}
+
+#[test]
+fn grep_respects_include_glob() {
+    let dir = tmpdir();
+    write_file(dir.path(), "a.rs", "hit\n");
+    write_file(dir.path(), "a.txt", "hit\n");
+    let res = ops::grep(
+        dir.path().to_string_lossy().into(),
+        "hit".into(),
+        true,
+        false,
+        vec!["*.rs".into()],
+        vec![],
+        1000,
+        4096,
+    )
+    .unwrap();
+    let FsResult::Grep { matches, .. } = res else {
+        panic!();
+    };
+    assert_eq!(matches.len(), 1);
+    assert!(matches[0].path.ends_with(".rs"));
+}
+
+#[test]
+fn grep_truncates_at_max_matches() {
+    let dir = tmpdir();
+    let body = "x\n".repeat(50);
+    write_file(dir.path(), "a.txt", &body);
+    let res = ops::grep(
+        dir.path().to_string_lossy().into(),
+        "x".into(),
+        true,
+        false,
+        vec![],
+        vec![],
+        10,
+        4096,
+    )
+    .unwrap();
+    let FsResult::Grep { matches, truncated } = res else {
+        panic!();
+    };
+    assert_eq!(matches.len(), 10);
+    assert!(truncated);
+}
+
+#[test]
+fn grep_ignore_case_flag_matches() {
+    let dir = tmpdir();
+    write_file(dir.path(), "a.txt", "HELLO world\n");
+    let res = ops::grep(
+        dir.path().to_string_lossy().into(),
+        "hello".into(),
+        true,
+        true,
+        vec![],
+        vec![],
+        1000,
+        4096,
+    )
+    .unwrap();
+    let FsResult::Grep { matches, .. } = res else {
+        panic!();
+    };
+    assert_eq!(matches.len(), 1);
+}
+
+#[test]
+fn grep_bad_regex_returns_s217() {
+    let dir = tmpdir();
+    let err = ops::grep(
+        dir.path().to_string_lossy().into(),
+        "(".into(), // unbalanced
+        true,
+        false,
+        vec![],
+        vec![],
+        1000,
+        4096,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, "S217");
+}
+
+#[test]
+fn grep_skips_binary_files() {
+    let dir = tmpdir();
+    // NUL in first 8 KiB marks the file as binary; it must be skipped.
+    let mut bin = vec![0u8; 16];
+    bin.extend_from_slice(b"needle");
+    std::fs::write(dir.path().join("b.bin"), &bin).unwrap();
+    write_file(dir.path(), "t.txt", "needle\n");
+    let res = ops::grep(
+        dir.path().to_string_lossy().into(),
+        "needle".into(),
+        true,
+        false,
+        vec![],
+        vec![],
+        1000,
+        4096,
+    )
+    .unwrap();
+    let FsResult::Grep { matches, .. } = res else {
+        panic!();
+    };
+    assert_eq!(matches.len(), 1);
+    assert!(matches[0].path.ends_with(".txt"));
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// grep — gitignore-style glob semantics (Task 1.3)
+//
+// `*.py` (no `/`) must match against the basename, so `src/main.py` and
+// `data/foo.py` both qualify. `src/*.py` (has `/`) must match against
+// the full relative path, so it picks `src/main.py` only. `**/*.py`
+// keeps its prior any-depth behavior.
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Helper: run grep with the given include/exclude globs, return the
+/// list of matched file basenames (sorted) so assertions are stable
+/// across walkdir traversal order.
+fn grep_basenames(
+    root: &std::path::Path,
+    pattern: &str,
+    include_glob: Vec<String>,
+    exclude_glob: Vec<String>,
+) -> Vec<String> {
+    let res = ops::grep(
+        root.to_string_lossy().into(),
+        pattern.into(),
+        true,
+        false,
+        include_glob,
+        exclude_glob,
+        1000,
+        4096,
+    )
+    .unwrap();
+    let FsResult::Grep { matches, .. } = res else {
+        panic!("expected Grep result");
+    };
+    let mut names: Vec<String> = matches
+        .into_iter()
+        .map(|m| {
+            std::path::Path::new(&m.path)
+                .file_name()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or(m.path)
+        })
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn setup_py_tree() -> tempfile::TempDir {
+    let dir = tmpdir();
+    write_file(dir.path(), "src/main.py", "hit\n");
+    write_file(dir.path(), "src/main.rs", "hit\n");
+    write_file(dir.path(), "data/foo.py", "hit\n");
+    write_file(dir.path(), "top.py", "hit\n");
+    dir
+}
+
+#[test]
+fn grep_include_glob_basename_matches_at_any_depth() {
+    // `*.py` has no slash → match basename → all .py files at any depth.
+    let dir = setup_py_tree();
+    let names = grep_basenames(dir.path(), "hit", vec!["*.py".into()], vec![]);
+    assert_eq!(names, vec!["foo.py", "main.py", "top.py"]);
+}
+
+#[test]
+fn grep_include_glob_basename_excludes_non_matching_extensions() {
+    // `*.py` must not match `main.rs`.
+    let dir = setup_py_tree();
+    let names = grep_basenames(dir.path(), "hit", vec!["*.py".into()], vec![]);
+    assert!(!names.iter().any(|n| n == "main.rs"));
+}
+
+#[test]
+fn grep_include_glob_with_slash_anchors_to_relative_path() {
+    // `src/*.py` has a slash → match against relpath → only `src/main.py`.
+    let dir = setup_py_tree();
+    let names = grep_basenames(dir.path(), "hit", vec!["src/*.py".into()], vec![]);
+    assert_eq!(names, vec!["main.py"]);
+}
+
+#[test]
+fn grep_include_glob_double_star_matches_at_any_depth_regression() {
+    // `**/*.py` already worked before this fix. Lock that in.
+    let dir = setup_py_tree();
+    let names = grep_basenames(dir.path(), "hit", vec!["**/*.py".into()], vec![]);
+    assert_eq!(names, vec!["foo.py", "main.py", "top.py"]);
+}
+
+#[test]
+fn grep_exclude_glob_basename_excludes_at_any_depth() {
+    // `exclude_glob: ['*.py']` excludes every .py file regardless of depth.
+    let dir = setup_py_tree();
+    let names = grep_basenames(dir.path(), "hit", vec![], vec!["*.py".into()]);
+    assert_eq!(names, vec!["main.rs"]);
+}
+
+#[test]
+fn grep_exclude_glob_with_slash_anchors_to_relative_path() {
+    // `exclude_glob: ['src/*.py']` excludes only `src/main.py`, not
+    // `data/foo.py` or `top.py`.
+    let dir = setup_py_tree();
+    let names = grep_basenames(dir.path(), "hit", vec![], vec!["src/*.py".into()]);
+    assert_eq!(names, vec!["foo.py", "main.rs", "top.py"]);
+}
+
+#[test]
+fn grep_glob_matches_path_helper_semantics() {
+    // Direct unit-test of the discriminator. Catches regressions in the
+    // basename-vs-relpath decision without standing up a tmpdir.
+    use super::ops::glob_matches_path;
+    // No-slash patterns → basename match.
+    assert!(glob_matches_path("*.py", "src/main.py"));
+    assert!(glob_matches_path("*.py", "data/foo.py"));
+    assert!(glob_matches_path("*.py", "main.py"));
+    assert!(!glob_matches_path("*.py", "src/main.rs"));
+    // Slash-bearing patterns → relpath match.
+    assert!(glob_matches_path("src/*.py", "src/main.py"));
+    assert!(!glob_matches_path("src/*.py", "data/foo.py"));
+    assert!(!glob_matches_path("src/*.py", "src/sub/deep.py"));
+    // `**/` prefix → any-depth match.
+    assert!(glob_matches_path("**/*.py", "src/main.py"));
+    assert!(glob_matches_path("**/*.py", "main.py"));
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// sed
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn sed_global_literal_replaces_all_occurrences() {
+    let dir = tmpdir();
+    let f = dir.path().join("x.txt");
+    std::fs::write(&f, "foo foo bar foo\nfoo end\n").unwrap();
+    let res = ops::sed(
+        vec![f.to_string_lossy().into()],
+        None,
+        true,
+        Vec::new(),
+        Vec::new(),
+        "foo".into(),
+        "BAR".into(),
+        false, // regex=false (literal)
+        false, // first_only
+        false,
+    )
+    .unwrap();
+    let FsResult::Sed { results, total_replacements } = res else {
+        panic!();
+    };
+    assert_eq!(total_replacements, 4);
+    assert_eq!(results[0].replacements, 4);
+    assert!(results[0].success);
+    assert_eq!(
+        std::fs::read_to_string(&f).unwrap(),
+        "BAR BAR bar BAR\nBAR end\n"
+    );
+}
+
+#[test]
+fn sed_first_only_replaces_one_per_line() {
+    let dir = tmpdir();
+    let f = dir.path().join("x.txt");
+    std::fs::write(&f, "a a a\nb b\n").unwrap();
+    ops::sed(
+        vec![f.to_string_lossy().into()],
+        None,
+        true,
+        Vec::new(),
+        Vec::new(),
+        "a".into(),
+        "Z".into(),
+        false,
+        true,
+        false,
+    )
+    .unwrap();
+    assert_eq!(std::fs::read_to_string(&f).unwrap(), "Z a a\nb b\n");
+}
+
+#[test]
+fn sed_regex_mode_supports_captures() {
+    let dir = tmpdir();
+    let f = dir.path().join("x.txt");
+    std::fs::write(&f, "name: alice, name: bob\n").unwrap();
+    ops::sed(
+        vec![f.to_string_lossy().into()],
+        None,
+        true,
+        Vec::new(),
+        Vec::new(),
+        r"name: (\w+)".into(),
+        "user=$1".into(),
+        true,
+        false,
+        false,
+    )
+    .unwrap();
+    assert_eq!(
+        std::fs::read_to_string(&f).unwrap(),
+        "user=alice, user=bob\n"
+    );
+}
+
+#[test]
+fn sed_per_file_failure_does_not_abort_remaining() {
+    let dir = tmpdir();
+    let good = dir.path().join("good.txt");
+    std::fs::write(&good, "x\n").unwrap();
+    let missing = dir.path().join("missing.txt");
+    let res = ops::sed(
+        vec![
+            missing.to_string_lossy().into(),
+            good.to_string_lossy().into(),
+        ],
+        None,
+        true,
+        Vec::new(),
+        Vec::new(),
+        "x".into(),
+        "Y".into(),
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+    let FsResult::Sed { results, total_replacements } = res else {
+        panic!();
+    };
+    assert_eq!(total_replacements, 1);
+    assert_eq!(results.len(), 2);
+    assert!(!results[0].success);
+    assert!(results[1].success);
+    assert_eq!(results[1].replacements, 1);
+    assert_eq!(std::fs::read_to_string(&good).unwrap(), "Y\n");
+}
+
+#[test]
+fn sed_bad_regex_returns_s217() {
+    let dir = tmpdir();
+    let err = ops::sed(
+        vec![dir.path().join("any.txt").to_string_lossy().into()],
+        None,
+        true,
+        Vec::new(),
+        Vec::new(),
+        "(".into(),
+        "".into(),
+        true,
+        false,
+        false,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, "S217");
+}
+
+#[test]
+fn sed_atomic_on_write_failure_preserves_original() {
+    // Simulate "write failed" by pointing the target into a read-only dir.
+    let dir = tmpdir();
+    let sub = dir.path().join("ro");
+    std::fs::create_dir(&sub).unwrap();
+    let f = sub.join("x.txt");
+    std::fs::write(&f, "orig\n").unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+    let res = ops::sed(
+        vec![f.to_string_lossy().into()],
+        None,
+        true,
+        Vec::new(),
+        Vec::new(),
+        "orig".into(),
+        "new".into(),
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+    let FsResult::Sed { results, .. } = res else {
+        panic!();
+    };
+    assert!(!results[0].success, "expected per-file failure");
+
+    // Restore permissions so tempdir cleanup works.
+    std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+    // Original content preserved.
+    assert_eq!(std::fs::read_to_string(&f).unwrap(), "orig\n");
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// sed (path-form: walk a directory tree, mirroring grep)
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn sed_path_recursive_walks_tree_and_rewrites_matching_files() {
+    // Layout: tmp/a.py, tmp/b.py, tmp/c.rs.
+    // Sed with path=tmp, recursive=true, include_glob=["*.py"] →
+    // both .py files rewritten, .rs file untouched.
+    let dir = tmpdir();
+    write_file(dir.path(), "a.py", "value = old\n");
+    write_file(dir.path(), "b.py", "x = old\nold\n");
+    write_file(dir.path(), "c.rs", "let s = old;\n");
+
+    let res = ops::sed(
+        Vec::new(),
+        Some(dir.path().to_string_lossy().into()),
+        true,
+        vec!["*.py".into()],
+        Vec::new(),
+        "old".into(),
+        "NEW".into(),
+        false, // literal
+        false,
+        false,
+    )
+    .unwrap();
+
+    let FsResult::Sed {
+        results,
+        total_replacements,
+    } = res
+    else {
+        panic!("expected Sed result");
+    };
+    assert!(
+        total_replacements > 0,
+        "expected at least one replacement, got total={total_replacements}"
+    );
+    // Only .py files reported; .rs filtered out.
+    assert_eq!(
+        results.len(),
+        2,
+        "expected 2 matched files (.py), got {} ({results:?})",
+        results.len()
+    );
+    for r in &results {
+        assert!(r.success, "expected per-file success: {r:?}");
+        assert!(r.path.ends_with(".py"));
+    }
+
+    // Concrete content checks.
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("a.py")).unwrap(),
+        "value = NEW\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("b.py")).unwrap(),
+        "x = NEW\nNEW\n"
+    );
+    // .rs file must remain untouched.
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("c.rs")).unwrap(),
+        "let s = old;\n"
+    );
+}
+
+#[test]
+fn sed_path_with_exclude_glob_skips_matching_files() {
+    // include + exclude both apply: include selects .py, exclude
+    // strips files under "skip/" → only top-level a.py rewritten.
+    let dir = tmpdir();
+    write_file(dir.path(), "a.py", "v = old\n");
+    write_file(dir.path(), "skip/b.py", "v = old\n");
+
+    let res = ops::sed(
+        Vec::new(),
+        Some(dir.path().to_string_lossy().into()),
+        true,
+        vec!["*.py".into()],
+        vec!["skip/*".into()],
+        "old".into(),
+        "NEW".into(),
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+    let FsResult::Sed { results, .. } = res else {
+        panic!();
+    };
+    assert_eq!(
+        results.len(),
+        1,
+        "expected exclude_glob to filter skip/b.py, got {results:?}"
+    );
+    assert!(results[0].path.ends_with("a.py"));
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("skip/b.py")).unwrap(),
+        "v = old\n",
+        "skip/b.py should be untouched"
+    );
+}
+
+#[test]
+fn sed_files_form_still_works_regression() {
+    // Belt-and-suspenders: the legacy `files: [...]` call path still
+    // works after adding the new fields.
+    let dir = tmpdir();
+    let f = dir.path().join("x.txt");
+    std::fs::write(&f, "abc abc\n").unwrap();
+    let res = ops::sed(
+        vec![f.to_string_lossy().into()],
+        None,
+        true,
+        Vec::new(),
+        Vec::new(),
+        "abc".into(),
+        "Z".into(),
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+    let FsResult::Sed {
+        results,
+        total_replacements,
+    } = res
+    else {
+        panic!();
+    };
+    assert_eq!(total_replacements, 2);
+    assert_eq!(results.len(), 1);
+    assert!(results[0].success);
+    assert_eq!(std::fs::read_to_string(&f).unwrap(), "Z Z\n");
+}
+
+#[test]
+fn sed_path_form_on_single_file_rewrites_just_that_file() {
+    // path that points at a single regular file is equivalent to
+    // files=[path]. include_glob still applies to the basename.
+    let dir = tmpdir();
+    let f = dir.path().join("only.py");
+    std::fs::write(&f, "old\n").unwrap();
+
+    let res = ops::sed(
+        Vec::new(),
+        Some(f.to_string_lossy().into()),
+        true,
+        Vec::new(),
+        Vec::new(),
+        "old".into(),
+        "NEW".into(),
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+    let FsResult::Sed {
+        results,
+        total_replacements,
+    } = res
+    else {
+        panic!();
+    };
+    assert_eq!(total_replacements, 1);
+    assert_eq!(results.len(), 1);
+    assert!(results[0].success);
+    assert_eq!(std::fs::read_to_string(&f).unwrap(), "NEW\n");
+}
+
+#[test]
+fn sed_path_form_symlink_to_dir_walks_target() {
+    // Regression: when `path` is a symlink to a directory we must
+    // resolve the link and walk it, not treat it as a single file.
+    // Previously `is_file() || is_symlink()` short-circuited into
+    // single-file rewrite, which then tried to read a directory.
+    let dir = tmpdir();
+    let real_dir = dir.path().join("real_dir");
+    std::fs::create_dir(&real_dir).unwrap();
+    write_file(&real_dir, "a.py", "x = old\n");
+    write_file(&real_dir, "b.py", "y = old\n");
+    let link = dir.path().join("link");
+    std::os::unix::fs::symlink(&real_dir, &link).unwrap();
+
+    let res = ops::sed(
+        Vec::new(),
+        Some(link.to_string_lossy().into()),
+        true,
+        vec!["*.py".into()],
+        Vec::new(),
+        "old".into(),
+        "NEW".into(),
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+    let FsResult::Sed {
+        results,
+        total_replacements,
+    } = res
+    else {
+        panic!("expected Sed result");
+    };
+    assert_eq!(
+        results.len(),
+        2,
+        "expected to walk into the symlink target and rewrite both \
+         .py files; got {results:?}"
+    );
+    for r in &results {
+        assert!(r.success, "per-file failure: {r:?}");
+    }
+    assert_eq!(total_replacements, 2);
+    assert_eq!(
+        std::fs::read_to_string(real_dir.join("a.py")).unwrap(),
+        "x = NEW\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(real_dir.join("b.py")).unwrap(),
+        "y = NEW\n"
+    );
+}
+
+#[test]
+fn sed_path_form_recursive_false_on_dir_returns_s210() {
+    // Mirrors grep: `recursive=false` on a directory `path` is rejected
+    // with S210. Sed used to silently walk depth-1 here, which diverged
+    // from grep without good reason.
+    let dir = tmpdir();
+    write_file(dir.path(), "a.py", "old\n");
+    let err = ops::sed(
+        Vec::new(),
+        Some(dir.path().to_string_lossy().into()),
+        false, // recursive=false on a directory
+        Vec::new(),
+        Vec::new(),
+        "old".into(),
+        "NEW".into(),
+        false,
+        false,
+        false,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, "S210");
+    // File must remain untouched — the rejection is up-front.
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("a.py")).unwrap(),
+        "old\n"
+    );
+}
+
+#[test]
+fn sed_path_form_recursive_false_on_single_file_is_ok() {
+    // Single-file `path` form: `recursive=false` is allowed because the
+    // rejection is keyed on `target_is_dir`. Belt-and-suspenders so a
+    // future refactor doesn't accidentally over-reject.
+    let dir = tmpdir();
+    let f = dir.path().join("only.py");
+    std::fs::write(&f, "old\n").unwrap();
+    let res = ops::sed(
+        Vec::new(),
+        Some(f.to_string_lossy().into()),
+        false,
+        Vec::new(),
+        Vec::new(),
+        "old".into(),
+        "NEW".into(),
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+    let FsResult::Sed {
+        total_replacements, ..
+    } = res
+    else {
+        panic!();
+    };
+    assert_eq!(total_replacements, 1);
+    assert_eq!(std::fs::read_to_string(&f).unwrap(), "NEW\n");
+}

--- a/crates/iii-init/src/lib.rs
+++ b/crates/iii-init/src/lib.rs
@@ -26,6 +26,11 @@ pub mod child_exits;
 pub mod shell_dispatcher;
 #[cfg(target_os = "linux")]
 pub mod supervisor;
+// Filesystem operation handlers. Linux-only because the module calls
+// std::os::unix::fs APIs and references shell_dispatcher internals.
+// Keeping it behind cfg(linux) also keeps macOS unit test builds clean.
+#[cfg(target_os = "linux")]
+pub mod fs_handler;
 
 #[cfg(target_os = "linux")]
 pub use error::InitError;

--- a/crates/iii-init/src/network.rs
+++ b/crates/iii-init/src/network.rs
@@ -5,6 +5,13 @@ use crate::error::InitError;
 /// Write `/etc/resolv.conf` with the nameserver IP.
 ///
 /// Priority: `III_INIT_DNS` env var > `/proc/net/route` gateway detection > `10.0.2.2` fallback.
+///
+/// Note: the `10.0.2.2` fallback is a QEMU-user-mode-style guess kept for
+/// backward-compat. libkrun's smoltcp stack actually allocates gateways out
+/// of `100.96.0.0/30` (so `100.96.0.1` is the typical real value), per
+/// `iii_network::SmoltcpNetwork::gateway_ipv4()`. `III_INIT_DNS` is set by
+/// the host (`vm_boot.rs`) and is authoritative; the fallback only fires
+/// when the env var is missing AND `/proc/net/route` has no default route.
 pub fn write_resolv_conf() -> Result<(), InitError> {
     let nameserver = std::env::var("III_INIT_DNS")
         .unwrap_or_else(|_| detect_gateway().unwrap_or_else(|| "10.0.2.2".to_string()));
@@ -43,6 +50,9 @@ pub fn configure_network() -> Result<(), InitError> {
         Ok(v) => v,
         Err(_) => return Ok(()),
     };
+    // See `write_resolv_conf` doc-comment for why `10.0.2.2` is a stale
+    // QEMU-style fallback (real libkrun gateway is in `100.96.0.0/30`).
+    // III_INIT_GW set by `vm_boot.rs` is authoritative.
     let gw_str = std::env::var("III_INIT_GW")
         .unwrap_or_else(|_| detect_gateway().unwrap_or_else(|| "10.0.2.2".to_string()));
     let cidr: u8 = std::env::var("III_INIT_CIDR")

--- a/crates/iii-init/src/shell_dispatcher.rs
+++ b/crates/iii-init/src/shell_dispatcher.rs
@@ -317,17 +317,20 @@ fn handle_frame(
         }
         // ── Filesystem ops ────────────────────────────────────────────────
         ShellMessage::FsRequest(op) => {
-            use iii_shell_proto::flags::FLAG_TERMINAL;
             use iii_shell_proto::FsOp;
+            use iii_shell_proto::flags::FLAG_TERMINAL;
 
             match op {
                 // ── WriteStart: streaming upload ─────────────────────────
-                FsOp::WriteStart { path, mode, parents } => {
+                FsOp::WriteStart {
+                    path,
+                    mode,
+                    parents,
+                } => {
                     // Create a sync channel for this write session and
                     // register the sender so FsChunk/FsEnd frames can
                     // be forwarded to the write thread.
-                    let (chunk_tx, chunk_rx) =
-                        std::sync::mpsc::sync_channel::<ShellMessage>(64);
+                    let (chunk_tx, chunk_rx) = std::sync::mpsc::sync_channel::<ShellMessage>(64);
                     fs_writes
                         .lock()
                         .expect("fs_writes mutex poisoned")
@@ -338,10 +341,9 @@ fn handle_frame(
                     thread::Builder::new()
                         .name(format!("iii-fs-write-{corr_id}"))
                         .spawn(move || {
-                            let result =
-                                crate::fs_handler::streaming::handle_write_start(
-                                    path, mode, parents, chunk_rx,
-                                );
+                            let result = crate::fs_handler::streaming::handle_write_start(
+                                path, mode, parents, chunk_rx,
+                            );
                             // Always remove the registry entry when done.
                             fs_writes
                                 .lock()
@@ -378,10 +380,9 @@ fn handle_frame(
                     thread::Builder::new()
                         .name(format!("iii-fs-read-{corr_id}"))
                         .spawn(move || {
-                            let result =
-                                crate::fs_handler::streaming::handle_read_start(
-                                    path, &writer, corr_id,
-                                );
+                            let result = crate::fs_handler::streaming::handle_read_start(
+                                path, &writer, corr_id,
+                            );
                             // handle_read_start only returns Err for
                             // pre-FsMeta failures; emit the terminal
                             // FsError here.
@@ -481,9 +482,11 @@ fn dispatch_one_shot(op: iii_shell_proto::FsOp) -> crate::fs_handler::FsCallResu
     match op {
         FsOp::Ls { path } => crate::fs_handler::ops::ls(path),
         FsOp::Stat { path } => crate::fs_handler::ops::stat(path),
-        FsOp::Mkdir { path, mode, parents } => {
-            crate::fs_handler::ops::mkdir(path, mode, parents)
-        }
+        FsOp::Mkdir {
+            path,
+            mode,
+            parents,
+        } => crate::fs_handler::ops::mkdir(path, mode, parents),
         FsOp::Rm { path, recursive } => crate::fs_handler::ops::rm(path, recursive),
         FsOp::Chmod {
             path,
@@ -492,7 +495,11 @@ fn dispatch_one_shot(op: iii_shell_proto::FsOp) -> crate::fs_handler::FsCallResu
             gid,
             recursive,
         } => crate::fs_handler::ops::chmod(path, mode, uid, gid, recursive),
-        FsOp::Mv { src, dst, overwrite } => crate::fs_handler::ops::mv(src, dst, overwrite),
+        FsOp::Mv {
+            src,
+            dst,
+            overwrite,
+        } => crate::fs_handler::ops::mv(src, dst, overwrite),
         FsOp::Grep {
             path,
             pattern,
@@ -536,12 +543,10 @@ fn dispatch_one_shot(op: iii_shell_proto::FsOp) -> crate::fs_handler::FsCallResu
             ignore_case,
         ),
         // Streaming ops are dispatched before this function is called.
-        FsOp::WriteStart { .. } | FsOp::ReadStart { .. } => {
-            Err(crate::fs_handler::FsError::new(
-                "S219",
-                "streaming ops must not reach dispatch_one_shot",
-            ))
-        }
+        FsOp::WriteStart { .. } | FsOp::ReadStart { .. } => Err(crate::fs_handler::FsError::new(
+            "S219",
+            "streaming ops must not reach dispatch_one_shot",
+        )),
     }
 }
 

--- a/crates/iii-init/src/shell_dispatcher.rs
+++ b/crates/iii-init/src/shell_dispatcher.rs
@@ -67,6 +67,15 @@ struct SessionHandle {
 
 type SessionRegistry = Arc<Mutex<HashMap<u32, SessionHandle>>>;
 
+/// Registry for in-flight `WriteStart` streaming sessions.
+///
+/// Key: `corr_id`. Value: a sender that the dispatcher uses to forward
+/// `FsChunk` / `FsEnd` frames to the write handler thread. The write
+/// thread removes its own entry from the registry when it finishes
+/// (success or error) so subsequent frames for that id fall through to
+/// the catch-all `_ => {}` arm silently.
+type FsWriteRegistry = Arc<Mutex<HashMap<u32, std::sync::mpsc::SyncSender<ShellMessage>>>>;
+
 /// Writer handle shared by every thread that emits frames. A single
 /// dedicated writer thread drains this channel onto the virtio-console
 /// port, so no caller ever blocks across a virtio write. If the guest
@@ -74,7 +83,7 @@ type SessionRegistry = Arc<Mutex<HashMap<u32, SessionHandle>>>;
 /// channel saturates at [`WRITER_CHANNEL_CAPACITY`] and further
 /// `try_send`s drop frames with a log line — session threads keep
 /// running instead of freezing under a shared mutex.
-type Writer = SyncSender<Vec<u8>>;
+pub(crate) type Writer = SyncSender<Vec<u8>>;
 
 /// Bound on queued frames between session threads and the writer
 /// thread. Roughly 1024 × 8 KiB worst case ≈ 8 MiB in flight. Large
@@ -101,12 +110,15 @@ pub fn run(port_path: &Path) -> anyhow::Result<()> {
     let reader_file = writer_file.try_clone()?;
     let writer = spawn_writer_thread(writer_file);
     let sessions: SessionRegistry = Arc::new(Mutex::new(HashMap::new()));
+    // Registry for in-flight WriteStart sessions. Keyed by corr_id;
+    // value is a sender that forwards FsChunk/FsEnd to the write thread.
+    let fs_writes: FsWriteRegistry = Arc::new(Mutex::new(HashMap::new()));
 
     let mut reader = BufReader::new(reader_file);
     loop {
         match sp::read_frame_blocking(&mut reader) {
             Ok(Some((corr_id, _flags, msg))) => {
-                handle_frame(corr_id, msg, &sessions, &writer);
+                handle_frame(corr_id, msg, &sessions, &writer, &fs_writes);
             }
             Ok(None) => break,
             Err(e) => {
@@ -150,7 +162,13 @@ fn spawn_writer_thread(mut file: File) -> Writer {
     tx
 }
 
-fn handle_frame(corr_id: u32, msg: ShellMessage, sessions: &SessionRegistry, writer: &Writer) {
+fn handle_frame(
+    corr_id: u32,
+    msg: ShellMessage,
+    sessions: &SessionRegistry,
+    writer: &Writer,
+    fs_writes: &FsWriteRegistry,
+) {
     match msg {
         ShellMessage::Request {
             cmd,
@@ -252,6 +270,26 @@ fn handle_frame(corr_id: u32, msg: ShellMessage, sessions: &SessionRegistry, wri
                     libc::kill(-(pid as libc::pid_t), signal as libc::c_int);
                 }
             }
+
+            // SIGKILL on a corr_id is also the relay's "host
+            // disconnected, abandon any in-flight session" signal
+            // (see shell_relay.rs::client_session cleanup, which
+            // fans out Signal{9} for every owned corr_id when the
+            // host disconnects). For exec sessions the libc::kill
+            // above terminates the child; for in-flight FS write
+            // sessions we drop the chunk_tx so handle_write_start's
+            // recv() returns Disconnected, unlinks the temp file,
+            // and returns S218 promptly. Without this, the temp
+            // leaks for up to WRITE_IDLE_TIMEOUT (30s) before
+            // streaming.rs's safety valve fires — too late for any
+            // caller-side test that asserts cleanup at trigger
+            // timeout.
+            if signal == libc::SIGKILL {
+                let _ = fs_writes
+                    .lock()
+                    .expect("fs_writes mutex poisoned")
+                    .remove(&corr_id);
+            }
         }
         ShellMessage::Resize { rows, cols } => {
             let master = {
@@ -277,11 +315,233 @@ fn handle_frame(corr_id: u32, msg: ShellMessage, sessions: &SessionRegistry, wri
                 }
             }
         }
+        // ── Filesystem ops ────────────────────────────────────────────────
+        ShellMessage::FsRequest(op) => {
+            use iii_shell_proto::flags::FLAG_TERMINAL;
+            use iii_shell_proto::FsOp;
+
+            match op {
+                // ── WriteStart: streaming upload ─────────────────────────
+                FsOp::WriteStart { path, mode, parents } => {
+                    // Create a sync channel for this write session and
+                    // register the sender so FsChunk/FsEnd frames can
+                    // be forwarded to the write thread.
+                    let (chunk_tx, chunk_rx) =
+                        std::sync::mpsc::sync_channel::<ShellMessage>(64);
+                    fs_writes
+                        .lock()
+                        .expect("fs_writes mutex poisoned")
+                        .insert(corr_id, chunk_tx);
+
+                    let writer = writer.clone();
+                    let fs_writes = fs_writes.clone();
+                    thread::Builder::new()
+                        .name(format!("iii-fs-write-{corr_id}"))
+                        .spawn(move || {
+                            let result =
+                                crate::fs_handler::streaming::handle_write_start(
+                                    path, mode, parents, chunk_rx,
+                                );
+                            // Always remove the registry entry when done.
+                            fs_writes
+                                .lock()
+                                .expect("fs_writes mutex poisoned")
+                                .remove(&corr_id);
+                            match result {
+                                Ok(fs_result) => {
+                                    send_frame(
+                                        &writer,
+                                        corr_id,
+                                        FLAG_TERMINAL,
+                                        &ShellMessage::FsResponse(fs_result),
+                                    );
+                                }
+                                Err(e) => {
+                                    send_frame(
+                                        &writer,
+                                        corr_id,
+                                        FLAG_TERMINAL,
+                                        &ShellMessage::FsError {
+                                            code: e.code.to_string(),
+                                            message: e.message,
+                                        },
+                                    );
+                                }
+                            }
+                        })
+                        .ok();
+                }
+
+                // ── ReadStart: streaming download ─────────────────────────
+                FsOp::ReadStart { path } => {
+                    let writer = writer.clone();
+                    thread::Builder::new()
+                        .name(format!("iii-fs-read-{corr_id}"))
+                        .spawn(move || {
+                            let result =
+                                crate::fs_handler::streaming::handle_read_start(
+                                    path, &writer, corr_id,
+                                );
+                            // handle_read_start only returns Err for
+                            // pre-FsMeta failures; emit the terminal
+                            // FsError here.
+                            if let Err(e) = result {
+                                send_frame(
+                                    &writer,
+                                    corr_id,
+                                    FLAG_TERMINAL,
+                                    &ShellMessage::FsError {
+                                        code: e.code.to_string(),
+                                        message: e.message,
+                                    },
+                                );
+                            }
+                        })
+                        .ok();
+                }
+
+                // ── One-shot ops ──────────────────────────────────────────
+                one_shot => {
+                    let writer = writer.clone();
+                    thread::Builder::new()
+                        .name(format!("iii-fs-op-{corr_id}"))
+                        .spawn(move || {
+                            let result = dispatch_one_shot(one_shot);
+                            match result {
+                                Ok(fs_result) => {
+                                    send_frame(
+                                        &writer,
+                                        corr_id,
+                                        FLAG_TERMINAL,
+                                        &ShellMessage::FsResponse(fs_result),
+                                    );
+                                }
+                                Err(e) => {
+                                    send_frame(
+                                        &writer,
+                                        corr_id,
+                                        FLAG_TERMINAL,
+                                        &ShellMessage::FsError {
+                                            code: e.code.to_string(),
+                                            message: e.message,
+                                        },
+                                    );
+                                }
+                            }
+                        })
+                        .ok();
+                }
+            }
+        }
+
+        // ── FsChunk / FsEnd: forward to active write session ──────────────
+        ShellMessage::FsChunk { .. } | ShellMessage::FsEnd => {
+            let sender = fs_writes
+                .lock()
+                .expect("fs_writes mutex poisoned")
+                .get(&corr_id)
+                .cloned();
+            if let Some(tx) = sender {
+                // try_send mirrors the existing pattern for Stdin: if
+                // the write thread is saturated we drop the frame and
+                // log, rather than blocking the dispatcher loop.
+                if let Err(e) = tx.try_send(msg) {
+                    use std::sync::mpsc::TrySendError;
+                    match e {
+                        TrySendError::Full(_) => {
+                            eprintln!(
+                                "iii-init: fs write channel full, \
+                                 dropping chunk for corr_id={corr_id}"
+                            );
+                        }
+                        TrySendError::Disconnected(_) => {
+                            // Write thread already exited — ignore.
+                        }
+                    }
+                }
+            }
+            // If no entry exists the write session already finished or
+            // was never started — silently drop.
+        }
+
         // Host-only variants received from the host are ignored; only
-        // Request/Stdin/Signal/Resize make sense as inbound. Anything
-        // else is a peer protocol error — dropping is less noisy
-        // than responding with Error and keeps the channel alive.
+        // Request/Stdin/Signal/Resize/FsRequest/FsChunk/FsEnd make sense
+        // as inbound. Anything else is a peer protocol error — dropping
+        // is less noisy than responding with Error and keeps the channel
+        // alive.
         _ => {}
+    }
+}
+
+/// Dispatch a one-shot `FsOp` variant to the corresponding handler.
+/// `WriteStart` and `ReadStart` are handled by the streaming path and
+/// must never reach this function.
+fn dispatch_one_shot(op: iii_shell_proto::FsOp) -> crate::fs_handler::FsCallResult {
+    use iii_shell_proto::FsOp;
+    match op {
+        FsOp::Ls { path } => crate::fs_handler::ops::ls(path),
+        FsOp::Stat { path } => crate::fs_handler::ops::stat(path),
+        FsOp::Mkdir { path, mode, parents } => {
+            crate::fs_handler::ops::mkdir(path, mode, parents)
+        }
+        FsOp::Rm { path, recursive } => crate::fs_handler::ops::rm(path, recursive),
+        FsOp::Chmod {
+            path,
+            mode,
+            uid,
+            gid,
+            recursive,
+        } => crate::fs_handler::ops::chmod(path, mode, uid, gid, recursive),
+        FsOp::Mv { src, dst, overwrite } => crate::fs_handler::ops::mv(src, dst, overwrite),
+        FsOp::Grep {
+            path,
+            pattern,
+            recursive,
+            ignore_case,
+            include_glob,
+            exclude_glob,
+            max_matches,
+            max_line_bytes,
+        } => crate::fs_handler::ops::grep(
+            path,
+            pattern,
+            recursive,
+            ignore_case,
+            include_glob,
+            exclude_glob,
+            max_matches,
+            max_line_bytes,
+        ),
+        FsOp::Sed {
+            files,
+            path,
+            recursive,
+            include_glob,
+            exclude_glob,
+            pattern,
+            replacement,
+            regex,
+            first_only,
+            ignore_case,
+        } => crate::fs_handler::ops::sed(
+            files,
+            path,
+            recursive,
+            include_glob,
+            exclude_glob,
+            pattern,
+            replacement,
+            regex,
+            first_only,
+            ignore_case,
+        ),
+        // Streaming ops are dispatched before this function is called.
+        FsOp::WriteStart { .. } | FsOp::ReadStart { .. } => {
+            Err(crate::fs_handler::FsError::new(
+                "S219",
+                "streaming ops must not reach dispatch_one_shot",
+            ))
+        }
     }
 }
 
@@ -697,7 +957,7 @@ fn stream_fd<R: Read>(writer: Writer, corr_id: u32, mut src: R, kind: OutputKind
     }
 }
 
-fn send_frame(writer: &Writer, corr_id: u32, flags: u8, msg: &ShellMessage) {
+pub(crate) fn send_frame(writer: &Writer, corr_id: u32, flags: u8, msg: &ShellMessage) {
     let frame = match sp::encode_frame(corr_id, flags, msg) {
         Ok(f) => f,
         Err(e) => {
@@ -831,9 +1091,10 @@ mod tests {
             };
             let writer = spawn_writer_thread(guest_file);
             let sessions: SessionRegistry = Arc::new(Mutex::new(HashMap::new()));
+            let fs_writes: FsWriteRegistry = Arc::new(Mutex::new(HashMap::new()));
             let mut reader = BufReader::new(guest_clone);
             while let Ok(Some((corr_id, _f, msg))) = sp::read_frame_blocking(&mut reader) {
-                handle_frame(corr_id, msg, &sessions, &writer);
+                handle_frame(corr_id, msg, &sessions, &writer, &fs_writes);
             }
         });
 
@@ -923,9 +1184,10 @@ mod tests {
             };
             let writer = spawn_writer_thread(guest_file);
             let sessions: SessionRegistry = Arc::new(Mutex::new(HashMap::new()));
+            let fs_writes: FsWriteRegistry = Arc::new(Mutex::new(HashMap::new()));
             let mut reader = BufReader::new(guest_clone);
             while let Ok(Some((corr_id, _f, msg))) = sp::read_frame_blocking(&mut reader) {
-                handle_frame(corr_id, msg, &sessions, &writer);
+                handle_frame(corr_id, msg, &sessions, &writer, &fs_writes);
             }
         });
 
@@ -1010,9 +1272,10 @@ mod tests {
             };
             let writer = spawn_writer_thread(guest_file);
             let sessions: SessionRegistry = Arc::new(Mutex::new(HashMap::new()));
+            let fs_writes: FsWriteRegistry = Arc::new(Mutex::new(HashMap::new()));
             let mut reader = BufReader::new(guest_clone);
             while let Ok(Some((corr_id, _f, msg))) = sp::read_frame_blocking(&mut reader) {
-                handle_frame(corr_id, msg, &sessions, &writer);
+                handle_frame(corr_id, msg, &sessions, &writer, &fs_writes);
             }
         });
 
@@ -1193,9 +1456,10 @@ mod tests {
                 };
                 let w = spawn_writer_thread(f);
                 let sessions: SessionRegistry = Arc::new(Mutex::new(HashMap::new()));
+                let fs_writes: FsWriteRegistry = Arc::new(Mutex::new(HashMap::new()));
                 let mut r = BufReader::new(g_clone);
                 while let Ok(Some((id, _f, msg))) = sp::read_frame_blocking(&mut r) {
-                    handle_frame(id, msg, &sessions, &w);
+                    handle_frame(id, msg, &sessions, &w, &fs_writes);
                 }
             });
             (h, 0u8)
@@ -1212,9 +1476,10 @@ mod tests {
             };
             let w = spawn_writer_thread(f);
             let sessions: SessionRegistry = Arc::new(Mutex::new(HashMap::new()));
+            let fs_writes: FsWriteRegistry = Arc::new(Mutex::new(HashMap::new()));
             let mut r = BufReader::new(g_clone);
             while let Ok(Some((id, _f, msg))) = sp::read_frame_blocking(&mut r) {
-                handle_frame(id, msg, &sessions, &w);
+                handle_frame(id, msg, &sessions, &w, &fs_writes);
             }
         });
 

--- a/crates/iii-shell-client/src/lib.rs
+++ b/crates/iii-shell-client/src/lib.rs
@@ -648,11 +648,8 @@ impl Session {
         // a typed S218 error well before any outer SDK trigger timeout.
         let mut buf = vec![0u8; 64 * 1024];
         loop {
-            let n = match tokio::time::timeout(
-                FS_WRITE_READ_IDLE_TIMEOUT,
-                reader.read(&mut buf),
-            )
-            .await
+            let n = match tokio::time::timeout(FS_WRITE_READ_IDLE_TIMEOUT, reader.read(&mut buf))
+                .await
             {
                 Ok(Ok(n)) => n,
                 Ok(Err(e)) => {
@@ -683,9 +680,8 @@ impl Session {
         }
 
         // Terminate the upload sequence.
-        let end_frame =
-            encode_frame(self.corr_id, FLAG_TERMINAL, &ShellMessage::FsEnd)
-                .map_err(|e| VmClientError::Encode(e.to_string()))?;
+        let end_frame = encode_frame(self.corr_id, FLAG_TERMINAL, &ShellMessage::FsEnd)
+            .map_err(|e| VmClientError::Encode(e.to_string()))?;
         write_frame_bounded(&mut self.stream, &end_frame).await?;
 
         // Read the single reply frame.

--- a/crates/iii-shell-client/src/lib.rs
+++ b/crates/iii-shell-client/src/lib.rs
@@ -43,6 +43,8 @@
 //!   return on the happy path" invariant that tripped shell_client.rs.
 
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use base64::Engine;
@@ -76,6 +78,31 @@ const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
 /// against a dead relay whose write side has filled and will never
 /// drain.
 const WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Per-read idle timeout for `Session::fs_write_stream`. If the
+/// caller-supplied `AsyncRead` (typically a `ChannelReader`-backed
+/// adapter feeding from an iii data channel) doesn't deliver any
+/// bytes for this long, we abort the upload with `S218`. Without
+/// this, a hard-terminated channel writer (caller-side
+/// `ws.terminate()` with no close frame) leaves the worker's
+/// `next_binary().await` hanging indefinitely — the trigger never
+/// returns, the supervisor's temp file leaks until its 30s
+/// recv_timeout safety valve fires, and the SDK's outer trigger
+/// timeout lands first as an opaque "Invocation timeout".
+///
+/// 5s is well above realistic per-chunk inter-arrival latency on
+/// a healthy 64 KiB-frame channel (chunks typically arrive in
+/// milliseconds) and tight enough that the host-side trigger
+/// returns `S218` before any reasonable caller-side test timeout
+/// fires. Aborting the host trigger triggers a shell.sock
+/// disconnect, which in turn fires the relay's SIGKILL fan-out;
+/// the dispatcher's `Signal` handler then drops the corr_id from
+/// `fs_writes`, the supervisor unlinks the temp, all within
+/// hundreds of ms. The supervisor's 30s `recv_timeout` is the
+/// defense-in-depth safety valve for paths where SIGKILL doesn't
+/// reach the dispatcher (relay died, frame dropped under
+/// saturation).
+const FS_WRITE_READ_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Specification for a single `ShellMessage::Request` frame.
 ///
@@ -229,6 +256,12 @@ pub enum VmClientError {
     /// Base64 decode failed on a Stdout/Stderr frame's data_b64 field.
     #[error("base64 decode: {0}")]
     Base64(String),
+
+    /// The guest fs handler returned a typed S21x error. `code` is the
+    /// Sx-series code (e.g. `"S211"`); `message` is the human-readable
+    /// detail from the guest.
+    #[error("fs error {code}: {message}")]
+    FsError { code: String, message: String },
 }
 
 /// Resolve the shell-channel socket path for a worker under
@@ -527,6 +560,330 @@ impl Session {
                 other => {
                     tracing::warn!("unexpected guest-originated variant: {other:?}");
                 }
+            }
+        }
+    }
+
+    /// Execute a one-shot filesystem operation (anything except
+    /// `WriteStart` and `ReadStart`) and return the typed result.
+    ///
+    /// Calling `fs_call` with `WriteStart` or `ReadStart` returns an
+    /// `FsError { code: "S210" }` immediately — use `fs_write_stream`
+    /// or `fs_read_stream` for streaming ops.
+    pub async fn fs_call(
+        mut self,
+        op: iii_shell_proto::FsOp,
+    ) -> Result<iii_shell_proto::FsResult, VmClientError> {
+        // Streaming ops must go through the dedicated helpers.
+        if matches!(
+            op,
+            iii_shell_proto::FsOp::WriteStart { .. } | iii_shell_proto::FsOp::ReadStart { .. }
+        ) {
+            return Err(VmClientError::FsError {
+                code: "S210".into(),
+                message: "use fs_write_stream / fs_read_stream for streaming ops".into(),
+            });
+        }
+
+        let frame =
+            encode_frame(self.corr_id, 0, &ShellMessage::FsRequest(op)).map_err(|e| match e {
+                iii_shell_proto::ShellCodecError::InvalidFrameLength(n) => {
+                    VmClientError::RequestTooLarge { size: n }
+                }
+                other => VmClientError::Encode(other.to_string()),
+            })?;
+        write_frame_bounded(&mut self.stream, &frame).await?;
+
+        match read_frame_async(&mut self.stream).await? {
+            None => Err(VmClientError::SessionTerminated),
+            Some((_, _, ShellMessage::FsResponse(result))) => Ok(result),
+            Some((_, _, ShellMessage::FsError { code, message })) => {
+                Err(VmClientError::FsError { code, message })
+            }
+            Some((_, _, ShellMessage::Error { message })) => {
+                Err(VmClientError::DispatcherError(message))
+            }
+            Some((_, _, other)) => Err(VmClientError::ProtocolViolation(format!(
+                "unexpected fs reply: {other:?}"
+            ))),
+        }
+    }
+
+    /// Upload bytes from `reader` to `path` inside the guest.
+    ///
+    /// Sends `FsRequest(WriteStart)` → N `FsChunk` frames → terminal
+    /// `FsEnd`, then reads the `FsResponse(Write)` reply.
+    ///
+    /// `mode` is the octal permission string (e.g. `"0644"`).
+    /// `parents` creates parent directories if missing.
+    pub async fn fs_write_stream<R>(
+        mut self,
+        path: String,
+        mode: String,
+        parents: bool,
+        mut reader: R,
+    ) -> Result<iii_shell_proto::FsResult, VmClientError>
+    where
+        R: tokio::io::AsyncRead + Unpin,
+    {
+        // Send WriteStart.
+        let start_frame = encode_frame(
+            self.corr_id,
+            0,
+            &ShellMessage::FsRequest(iii_shell_proto::FsOp::WriteStart {
+                path,
+                mode,
+                parents,
+            }),
+        )
+        .map_err(|e| VmClientError::Encode(e.to_string()))?;
+        write_frame_bounded(&mut self.stream, &start_frame).await?;
+
+        // Stream chunks (64 KiB buffer). Each `reader.read` is bounded
+        // by `FS_WRITE_READ_IDLE_TIMEOUT` so a stalled / hard-terminated
+        // caller-side data channel can't pin the trigger handler. On
+        // timeout we abort with S218; the dropped Session disconnects
+        // shell.sock, the relay's SIGKILL fan-out cascades into the
+        // supervisor, the temp file gets unlinked, and the caller sees
+        // a typed S218 error well before any outer SDK trigger timeout.
+        let mut buf = vec![0u8; 64 * 1024];
+        loop {
+            let n = match tokio::time::timeout(
+                FS_WRITE_READ_IDLE_TIMEOUT,
+                reader.read(&mut buf),
+            )
+            .await
+            {
+                Ok(Ok(n)) => n,
+                Ok(Err(e)) => {
+                    return Err(VmClientError::Io(format!("read from caller: {e}")));
+                }
+                Err(_elapsed) => {
+                    return Err(VmClientError::FsError {
+                        code: "S218".into(),
+                        message: format!(
+                            "no chunks from caller for {}s — channel stalled or aborted",
+                            FS_WRITE_READ_IDLE_TIMEOUT.as_secs(),
+                        ),
+                    });
+                }
+            };
+            if n == 0 {
+                break;
+            }
+            let chunk_frame = encode_frame(
+                self.corr_id,
+                0,
+                &ShellMessage::FsChunk {
+                    data_b64: B64.encode(&buf[..n]),
+                },
+            )
+            .map_err(|e| VmClientError::Encode(e.to_string()))?;
+            write_frame_bounded(&mut self.stream, &chunk_frame).await?;
+        }
+
+        // Terminate the upload sequence.
+        let end_frame =
+            encode_frame(self.corr_id, FLAG_TERMINAL, &ShellMessage::FsEnd)
+                .map_err(|e| VmClientError::Encode(e.to_string()))?;
+        write_frame_bounded(&mut self.stream, &end_frame).await?;
+
+        // Read the single reply frame.
+        match read_frame_async(&mut self.stream).await? {
+            None => Err(VmClientError::SessionTerminated),
+            Some((_, _, ShellMessage::FsResponse(result))) => Ok(result),
+            Some((_, _, ShellMessage::FsError { code, message })) => {
+                Err(VmClientError::FsError { code, message })
+            }
+            Some((_, _, other)) => Err(VmClientError::ProtocolViolation(format!(
+                "unexpected fs write reply: {other:?}"
+            ))),
+        }
+    }
+
+    /// Begin a streaming download of `path` from the guest.
+    ///
+    /// Sends `FsRequest(ReadStart)`, reads the `FsMeta` reply, then
+    /// returns `(meta, FsStreamReader)`. The caller reads bytes from
+    /// `FsStreamReader` which implements `tokio::io::AsyncRead`.
+    pub async fn fs_read_stream(
+        mut self,
+        path: String,
+    ) -> Result<(iii_shell_proto::FsReadMeta, FsStreamReader), VmClientError> {
+        let frame = encode_frame(
+            self.corr_id,
+            0,
+            &ShellMessage::FsRequest(iii_shell_proto::FsOp::ReadStart { path }),
+        )
+        .map_err(|e| VmClientError::Encode(e.to_string()))?;
+        write_frame_bounded(&mut self.stream, &frame).await?;
+
+        // The first reply must be FsMeta.
+        match read_frame_async(&mut self.stream).await? {
+            None => Err(VmClientError::SessionTerminated),
+            Some((_, _, ShellMessage::FsMeta(meta))) => {
+                let reader = FsStreamReader::new(self.stream);
+                Ok((meta, reader))
+            }
+            Some((_, _, ShellMessage::FsError { code, message })) => {
+                Err(VmClientError::FsError { code, message })
+            }
+            Some((_, _, other)) => Err(VmClientError::ProtocolViolation(format!(
+                "expected FsMeta, got {other:?}"
+            ))),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FsStreamReader
+// ---------------------------------------------------------------------------
+
+/// An `AsyncRead` adapter that reads `FsChunk`/`FsEnd` frames from the
+/// session stream and exposes them as a contiguous byte stream.
+///
+/// Constructed by `Session::fs_read_stream` after the `FsMeta` frame has
+/// been consumed. Reading to EOF corresponds to receiving `FsEnd` from
+/// the guest.
+///
+/// # Implementation note
+/// A dedicated background task owns the underlying `UnixStream` and
+/// runs `read_frame_async` in a loop, pushing each decoded `FsChunk` /
+/// `FsEnd` / `FsError` into an internal mpsc. `poll_read` consumes the
+/// mpsc.
+///
+/// This shape is required for correctness, not just performance: the
+/// frame-read future stores partial state across syscalls (4-byte length
+/// prefix, then body bytes). Dropping the future between polls — which
+/// happens if you `Box::pin(read_frame_async(...))` per poll —
+/// **discards already-consumed bytes** the moment the inner read
+/// suspends, corrupting framing on every multi-syscall frame. Tiny
+/// frames that fit in one read worked by accident; ~16 KiB+ frames
+/// broke deterministically with truncation to 0 bytes downstream.
+pub struct FsStreamReader {
+    /// Decoded chunks coming off the background task. `None` value
+    /// signals clean end-of-stream (FsEnd), `Err` signals a wire error
+    /// the caller should surface up the read chain.
+    rx: tokio::sync::mpsc::Receiver<Result<Vec<u8>, std::io::Error>>,
+    /// Bytes decoded from a previous chunk that didn't fit in the
+    /// caller's `ReadBuf` in one shot.
+    leftover: Vec<u8>,
+    /// Set to `true` after the background task signals end-of-stream;
+    /// subsequent reads return `Poll::Ready(Ok(()))` with zero bytes.
+    finished: bool,
+}
+
+impl FsStreamReader {
+    fn new(mut stream: UnixStream) -> Self {
+        // Bound the channel so a slow caller backpressures the wire
+        // reader instead of buffering unbounded chunks. 8 chunks ≈
+        // 8 × 64 KiB = 512 KiB ceiling — enough to hide single-stall
+        // jitter, small enough to surface a stuck caller.
+        let (tx, rx) = tokio::sync::mpsc::channel(8);
+        tokio::spawn(async move {
+            loop {
+                let frame = match read_frame_async(&mut stream).await {
+                    Ok(Some(f)) => f,
+                    Ok(None) => {
+                        // Clean EOF without FsEnd — terminate the stream.
+                        break;
+                    }
+                    Err(e) => {
+                        let _ = tx
+                            .send(Err(std::io::Error::new(
+                                std::io::ErrorKind::Other,
+                                e.to_string(),
+                            )))
+                            .await;
+                        break;
+                    }
+                };
+                match frame {
+                    (_, _, ShellMessage::FsEnd) => break,
+                    (_, _, ShellMessage::FsChunk { data_b64 }) => {
+                        let bytes = match B64.decode(data_b64.as_bytes()) {
+                            Ok(b) => b,
+                            Err(e) => {
+                                let _ = tx
+                                    .send(Err(std::io::Error::new(
+                                        std::io::ErrorKind::InvalidData,
+                                        format!("base64 decode in FsChunk: {e}"),
+                                    )))
+                                    .await;
+                                break;
+                            }
+                        };
+                        if tx.send(Ok(bytes)).await.is_err() {
+                            // Caller dropped the reader.
+                            break;
+                        }
+                    }
+                    (_, _, ShellMessage::FsError { code, message }) => {
+                        let _ = tx
+                            .send(Err(std::io::Error::new(
+                                std::io::ErrorKind::Other,
+                                format!("fs error {code}: {message}"),
+                            )))
+                            .await;
+                        break;
+                    }
+                    (_, _, other) => {
+                        let _ = tx
+                            .send(Err(std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                format!("unexpected fs frame: {other:?}"),
+                            )))
+                            .await;
+                        break;
+                    }
+                }
+            }
+            // Dropping `tx` here closes `rx` — `poll_read` sees
+            // `Poll::Ready(None)` and reports clean EOF.
+        });
+        Self {
+            rx,
+            leftover: Vec::new(),
+            finished: false,
+        }
+    }
+}
+
+impl tokio::io::AsyncRead for FsStreamReader {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+
+        // Already at EOS — signal clean EOF.
+        if this.finished {
+            return Poll::Ready(Ok(()));
+        }
+
+        // Flush leftover bytes from a previous oversized chunk first.
+        if !this.leftover.is_empty() {
+            let n = this.leftover.len().min(buf.remaining());
+            buf.put_slice(&this.leftover[..n]);
+            this.leftover.drain(..n);
+            return Poll::Ready(Ok(()));
+        }
+
+        match this.rx.poll_recv(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(None) => {
+                this.finished = true;
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Err(e)),
+            Poll::Ready(Some(Ok(bytes))) => {
+                let n = bytes.len().min(buf.remaining());
+                buf.put_slice(&bytes[..n]);
+                if n < bytes.len() {
+                    this.leftover.extend_from_slice(&bytes[n..]);
+                }
+                Poll::Ready(Ok(()))
             }
         }
     }

--- a/crates/iii-shell-client/tests/fake_fs_relay.rs
+++ b/crates/iii-shell-client/tests/fake_fs_relay.rs
@@ -1,0 +1,592 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at support@motia.dev
+// See LICENSE and PATENTS files for details.
+
+//! Fake-relay integration tests for the filesystem helpers in iii-shell-client.
+//!
+//! Mirrors the shape of `fake_relay.rs`. Each test binds a Unix socket,
+//! spawns a relay task that drives a canned frame sequence, and asserts
+//! the client-side return value.
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+use base64::Engine;
+use iii_shell_client::{FsStreamReader, Session, VmClientError};
+use iii_shell_proto::{
+    FsEntry, FsOp, FsReadMeta, FsResult, ShellMessage, encode_frame,
+    flags::FLAG_TERMINAL,
+    FRAME_HEADER_SIZE, MAX_FRAME_SIZE, decode_frame_body,
+};
+use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::task::JoinHandle;
+
+const B64: base64::engine::GeneralPurpose = base64::engine::general_purpose::STANDARD;
+
+// ---------------------------------------------------------------------------
+// Shared relay helpers
+// ---------------------------------------------------------------------------
+
+/// Bind a UnixListener on `<tempdir>/shell.sock` chmoded to 0o600.
+fn bind_socket() -> (TempDir, PathBuf, UnixListener) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sock = dir.path().join("shell.sock");
+    let listener = UnixListener::bind(&sock).expect("bind");
+    let mut perms = std::fs::metadata(&sock).expect("meta").permissions();
+    perms.set_mode(0o600);
+    std::fs::set_permissions(&sock, perms).expect("chmod");
+    (dir, sock, listener)
+}
+
+/// Read one length-prefixed frame from a `UnixStream`.
+async fn read_one_frame(
+    stream: &mut UnixStream,
+) -> std::io::Result<Option<(u32, u8, ShellMessage)>> {
+    let mut len_buf = [0u8; 4];
+    let mut read = 0;
+    while read < 4 {
+        let n = stream.read(&mut len_buf[read..]).await?;
+        if n == 0 {
+            if read == 0 {
+                return Ok(None);
+            }
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "partial length prefix",
+            ));
+        }
+        read += n;
+    }
+    let frame_len = u32::from_be_bytes(len_buf) as usize;
+    if !(FRAME_HEADER_SIZE..=MAX_FRAME_SIZE).contains(&frame_len) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("frame_len {frame_len} out of range"),
+        ));
+    }
+    let mut body = vec![0u8; frame_len];
+    stream.read_exact(&mut body).await?;
+    let parsed = decode_frame_body(&body)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+    Ok(Some(parsed))
+}
+
+/// Write a length-prefixed frame to a `UnixStream`.
+async fn write_framed(
+    stream: &mut UnixStream,
+    corr_id: u32,
+    flags: u8,
+    msg: &ShellMessage,
+) -> std::io::Result<()> {
+    let frame = encode_frame(corr_id, flags, msg)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+    stream.write_all(&frame).await
+}
+
+/// Write the 4-byte `id_offset` handshake.
+async fn write_handshake(stream: &mut UnixStream, id_offset: u32) -> std::io::Result<()> {
+    stream.write_all(&id_offset.to_be_bytes()).await
+}
+
+/// Spawn a relay task that accepts one connection.
+fn spawn_relay<F, Fut>(listener: UnixListener, body: F) -> JoinHandle<()>
+where
+    F: FnOnce(UnixStream) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = ()> + Send,
+{
+    tokio::spawn(async move {
+        let (stream, _addr) = listener.accept().await.expect("accept");
+        body(stream).await;
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Relay receives `FsRequest(Ls)`, replies with `FsResponse(Ls{entries})`.
+/// `Session::fs_call` must return the matching `FsResult::Ls`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fs_call_ls_happy_path() {
+    let (_dir, sock, listener) = bind_socket();
+
+    let relay = spawn_relay(listener, |mut s| async move {
+        write_handshake(&mut s, 0).await.expect("handshake");
+
+        let (corr, _flags, msg) = read_one_frame(&mut s)
+            .await
+            .expect("read frame")
+            .expect("frame present");
+        assert_eq!(corr, 1, "corr_id should be id_offset(0)+1");
+        assert!(
+            matches!(msg, ShellMessage::FsRequest(FsOp::Ls { .. })),
+            "expected FsRequest(Ls), got {msg:?}"
+        );
+
+        let entry = FsEntry {
+            name: "foo.txt".into(),
+            is_dir: false,
+            size: 42,
+            mode: "0644".into(),
+            mtime: 1_700_000_000,
+            is_symlink: false,
+        };
+        write_framed(
+            &mut s,
+            1,
+            FLAG_TERMINAL,
+            &ShellMessage::FsResponse(FsResult::Ls {
+                entries: vec![entry.clone()],
+            }),
+        )
+        .await
+        .expect("write response");
+    });
+
+    let session = Session::connect(&sock).await.expect("connect");
+    let result = session
+        .fs_call(FsOp::Ls {
+            path: "/workspace".into(),
+        })
+        .await
+        .expect("fs_call succeeded");
+
+    match result {
+        FsResult::Ls { entries } => {
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].name, "foo.txt");
+            assert_eq!(entries[0].size, 42);
+        }
+        other => panic!("expected FsResult::Ls, got {other:?}"),
+    }
+
+    relay.await.expect("relay join");
+}
+
+/// Relay replies with `FsError { code, message }`.
+/// `Session::fs_call` must return `Err(VmClientError::FsError { code, message })`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fs_call_surfaces_fs_error_code_and_message() {
+    let (_dir, sock, listener) = bind_socket();
+
+    let relay = spawn_relay(listener, |mut s| async move {
+        write_handshake(&mut s, 0).await.expect("handshake");
+
+        // Consume the request frame.
+        let _ = read_one_frame(&mut s).await.expect("read request");
+
+        write_framed(
+            &mut s,
+            1,
+            FLAG_TERMINAL,
+            &ShellMessage::FsError {
+                code: "S211".into(),
+                message: "no such file or directory".into(),
+            },
+        )
+        .await
+        .expect("write error");
+    });
+
+    let session = Session::connect(&sock).await.expect("connect");
+    let err = session
+        .fs_call(FsOp::Ls {
+            path: "/nonexistent".into(),
+        })
+        .await
+        .expect_err("expected Err from fs_call");
+
+    match err {
+        VmClientError::FsError { code, message } => {
+            assert_eq!(code, "S211");
+            assert_eq!(message, "no such file or directory");
+        }
+        other => panic!("expected VmClientError::FsError, got {other:?}"),
+    }
+
+    relay.await.expect("relay join");
+}
+
+/// Relay reads `FsRequest(WriteStart)`, then loops reading `FsChunk`/`FsEnd`,
+/// counts total bytes received, replies with `FsResponse(Write { bytes_written, path })`.
+/// Host calls `fs_write_stream` with a 200-byte payload via `Cursor`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fs_write_stream_sends_chunks_and_end() {
+    let (_dir, sock, listener) = bind_socket();
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<u64>();
+
+    let relay = spawn_relay(listener, |mut s| async move {
+        write_handshake(&mut s, 0).await.expect("handshake");
+
+        // First frame must be FsRequest(WriteStart).
+        let (corr, _flags, msg) = read_one_frame(&mut s)
+            .await
+            .expect("read write-start")
+            .expect("frame present");
+        assert_eq!(corr, 1);
+        assert!(
+            matches!(msg, ShellMessage::FsRequest(FsOp::WriteStart { .. })),
+            "expected WriteStart, got {msg:?}"
+        );
+
+        // Read FsChunk / FsEnd frames until FsEnd.
+        let mut total_bytes: u64 = 0;
+        loop {
+            let (_c, _f, frame) = read_one_frame(&mut s)
+                .await
+                .expect("read chunk/end")
+                .expect("frame present");
+            match frame {
+                ShellMessage::FsChunk { data_b64 } => {
+                    let bytes = B64.decode(data_b64.as_bytes()).expect("b64");
+                    total_bytes += bytes.len() as u64;
+                }
+                ShellMessage::FsEnd => break,
+                other => panic!("unexpected frame: {other:?}"),
+            }
+        }
+
+        tx.send(total_bytes).expect("send total");
+
+        write_framed(
+            &mut s,
+            1,
+            FLAG_TERMINAL,
+            &ShellMessage::FsResponse(FsResult::Write {
+                bytes_written: total_bytes,
+                path: "/workspace/out.bin".into(),
+            }),
+        )
+        .await
+        .expect("write response");
+    });
+
+    let payload = vec![0xABu8; 200];
+    let reader = std::io::Cursor::new(payload.clone());
+
+    let session = Session::connect(&sock).await.expect("connect");
+    let result = session
+        .fs_write_stream(
+            "/workspace/out.bin".into(),
+            "0644".into(),
+            false,
+            reader,
+        )
+        .await
+        .expect("fs_write_stream succeeded");
+
+    match result {
+        FsResult::Write {
+            bytes_written,
+            path,
+        } => {
+            assert_eq!(bytes_written, 200, "bytes_written must match payload length");
+            assert_eq!(path, "/workspace/out.bin");
+        }
+        other => panic!("expected FsResult::Write, got {other:?}"),
+    }
+
+    let relay_total = rx.await.expect("relay total");
+    assert_eq!(relay_total, 200, "relay counted {relay_total} bytes, expected 200");
+
+    relay.await.expect("relay join");
+}
+
+/// Relay sends `FsMeta` first, then chunks the 200-byte payload across
+/// multiple `FsChunk` frames, then `FsEnd` with FLAG_TERMINAL.
+/// Host calls `fs_read_stream`, reads the returned reader to end,
+/// asserts bytes match.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fs_read_stream_yields_meta_then_bytes() {
+    let (_dir, sock, listener) = bind_socket();
+
+    let payload = vec![0xCDu8; 200];
+    let payload_clone = payload.clone();
+
+    let relay = spawn_relay(listener, move |mut s| async move {
+        write_handshake(&mut s, 0).await.expect("handshake");
+
+        // Consume the ReadStart request.
+        let (corr, _flags, msg) = read_one_frame(&mut s)
+            .await
+            .expect("read read-start")
+            .expect("frame present");
+        assert_eq!(corr, 1);
+        assert!(
+            matches!(msg, ShellMessage::FsRequest(FsOp::ReadStart { .. })),
+            "expected ReadStart, got {msg:?}"
+        );
+
+        // Send metadata first.
+        write_framed(
+            &mut s,
+            1,
+            0,
+            &ShellMessage::FsMeta(FsReadMeta {
+                size: payload_clone.len() as u64,
+                mode: "0644".into(),
+                mtime: 1_700_000_000,
+            }),
+        )
+        .await
+        .expect("write meta");
+
+        // Send payload in two chunks of 100 bytes each.
+        write_framed(
+            &mut s,
+            1,
+            0,
+            &ShellMessage::FsChunk {
+                data_b64: B64.encode(&payload_clone[..100]),
+            },
+        )
+        .await
+        .expect("write chunk 1");
+
+        write_framed(
+            &mut s,
+            1,
+            0,
+            &ShellMessage::FsChunk {
+                data_b64: B64.encode(&payload_clone[100..]),
+            },
+        )
+        .await
+        .expect("write chunk 2");
+
+        write_framed(&mut s, 1, FLAG_TERMINAL, &ShellMessage::FsEnd)
+            .await
+            .expect("write end");
+    });
+
+    let session = Session::connect(&sock).await.expect("connect");
+    let (meta, mut reader) = session
+        .fs_read_stream("/workspace/data.bin".into())
+        .await
+        .expect("fs_read_stream succeeded");
+
+    assert_eq!(meta.size, 200);
+    assert_eq!(meta.mode, "0644");
+
+    let mut received = Vec::new();
+    tokio::io::AsyncReadExt::read_to_end(&mut reader, &mut received)
+        .await
+        .expect("read to end");
+
+    assert_eq!(received, payload, "received bytes must match sent payload");
+
+    relay.await.expect("relay join");
+}
+
+/// Regression test for the FsStreamReader truncation bug.
+///
+/// Symptom: when a single `FsChunk` frame's body doesn't arrive in one
+/// kernel read syscall, `FsStreamReader::poll_read` used to allocate a
+/// fresh `Box::pin(read_frame_async(...))` per poll. The inner future
+/// stores partial state across syscalls (4-byte length prefix + body
+/// progress); dropping it on `Poll::Pending` discards bytes already
+/// consumed from the kernel into the future's local buffer. The next
+/// poll then re-parses mid-body garbage as a fresh frame length, hits
+/// a protocol violation or EOF, and the caller sees 0 bytes.
+///
+/// Reproduction: write a single FsChunk with a body large enough that
+/// the kernel tx buffer can't deliver it atomically, splitting the
+/// `write_all` calls with `tokio::time::sleep` so the receiver's
+/// `read_frame_async` is guaranteed to suspend mid-frame at least once.
+/// Under the buggy impl the host receives 0 bytes; under the fixed
+/// impl (one task owns the stream and drives `read_frame_async` to
+/// completion in a stable loop) the host receives the full payload.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fs_read_stream_handles_partial_frame_reads() {
+    use std::time::Duration;
+
+    let (_dir, sock, listener) = bind_socket();
+
+    // 256 KiB payload of pseudo-random bytes — well over the 64 KiB
+    // tokio default kernel socket buffer on most platforms, so the
+    // receiver MUST issue multiple read syscalls to drain one frame.
+    let payload: Vec<u8> = (0..256u32 * 1024).map(|i| (i & 0xff) as u8).collect();
+    let payload_clone = payload.clone();
+
+    let relay = spawn_relay(listener, move |mut s| async move {
+        use tokio::io::AsyncWriteExt;
+
+        write_handshake(&mut s, 0).await.expect("handshake");
+
+        // Consume the ReadStart request.
+        let (corr, _flags, msg) = read_one_frame(&mut s)
+            .await
+            .expect("read read-start")
+            .expect("frame present");
+        assert_eq!(corr, 1);
+        assert!(matches!(
+            msg,
+            ShellMessage::FsRequest(FsOp::ReadStart { .. })
+        ));
+
+        // Send FsMeta cleanly (small frame, single syscall — fine).
+        write_framed(
+            &mut s,
+            1,
+            0,
+            &ShellMessage::FsMeta(FsReadMeta {
+                size: payload_clone.len() as u64,
+                mode: "0644".into(),
+                mtime: 1_700_000_000,
+            }),
+        )
+        .await
+        .expect("write meta");
+
+        // Build the single FsChunk frame containing the entire 256 KiB
+        // payload (base64-encoded, ~342 KiB total wire size).
+        let chunk_msg = ShellMessage::FsChunk {
+            data_b64: B64.encode(&payload_clone),
+        };
+        let frame_bytes = encode_frame(1, 0, &chunk_msg).expect("encode chunk");
+
+        // Hand-deliver the frame in 4 KiB pieces with a tiny sleep
+        // between writes. This guarantees the receiving end's first
+        // `read` returns less than the full frame, forcing
+        // `read_frame_async` to suspend partway through.
+        const PIECE: usize = 4 * 1024;
+        let mut offset = 0;
+        while offset < frame_bytes.len() {
+            let end = (offset + PIECE).min(frame_bytes.len());
+            s.write_all(&frame_bytes[offset..end])
+                .await
+                .expect("piece write");
+            s.flush().await.expect("flush");
+            // Yield + tiny sleep so the receiver actually polls before
+            // we ship the next piece. Without this the kernel may
+            // coalesce small writes and hide the bug.
+            tokio::time::sleep(Duration::from_millis(2)).await;
+            offset = end;
+        }
+
+        write_framed(&mut s, 1, FLAG_TERMINAL, &ShellMessage::FsEnd)
+            .await
+            .expect("write end");
+    });
+
+    let session = Session::connect(&sock).await.expect("connect");
+    let (meta, mut reader) = session
+        .fs_read_stream("/workspace/big.bin".into())
+        .await
+        .expect("fs_read_stream succeeded");
+
+    assert_eq!(meta.size, payload.len() as u64);
+
+    let mut received = Vec::new();
+    tokio::io::AsyncReadExt::read_to_end(&mut reader, &mut received)
+        .await
+        .expect("read to end");
+
+    assert_eq!(
+        received.len(),
+        payload.len(),
+        "expected {} bytes, got {} — partial-frame regression",
+        payload.len(),
+        received.len()
+    );
+    assert_eq!(received, payload, "byte-by-byte mismatch");
+
+    relay.await.expect("relay join");
+}
+
+/// REGRESSION: `Session::fs_write_stream` must not hang forever
+/// when the caller-supplied `AsyncRead` stalls indefinitely
+/// (mirrors a hard-terminated channel WS where `next_binary()`
+/// never resolves). Without the per-read idle timeout, the trigger
+/// handler sits in `reader.read().await` forever, the SDK's outer
+/// timeout fires as an opaque "Invocation timeout", and the
+/// supervisor's temp file leaks for up to 30s before its
+/// safety-valve recv_timeout fires.
+///
+/// Fix (in iii-shell-client/src/lib.rs): each `reader.read(&mut buf)`
+/// is bounded by `FS_WRITE_READ_IDLE_TIMEOUT` (5s). On idle timeout
+/// the call returns `Err(VmClientError::FsError { code: "S218" })`.
+///
+/// This test injects a `StalledReader` whose `poll_read` returns
+/// `Pending` forever and asserts the call returns S218 in well under
+/// the SDK's outer 30s default.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fs_write_stream_aborts_on_stalled_reader() {
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use tokio::io::{AsyncRead, ReadBuf};
+
+    /// AsyncRead that never makes progress — models a
+    /// hard-terminated data-channel reader where the SDK's
+    /// `next_binary()` neither errors nor returns Some/None.
+    struct StalledReader;
+    impl AsyncRead for StalledReader {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Pending
+        }
+    }
+
+    let (_dir, sock, listener) = bind_socket();
+
+    let relay = spawn_relay(listener, |mut s| async move {
+        write_handshake(&mut s, 0).await.expect("handshake");
+        // Expect WriteStart only — host should give up on its idle
+        // timeout and drop the Session before sending FsChunk/FsEnd.
+        let (_, _, msg) = read_one_frame(&mut s)
+            .await
+            .expect("read")
+            .expect("frame");
+        assert!(matches!(
+            msg,
+            ShellMessage::FsRequest(FsOp::WriteStart { .. })
+        ));
+        // Hold the relay open; the host will drop us first.
+        let _ = tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+    });
+
+    let session = Session::connect(&sock).await.expect("connect");
+    let started = std::time::Instant::now();
+    let err = session
+        .fs_write_stream(
+            "/workspace/should-fail.bin".into(),
+            "0644".into(),
+            false,
+            StalledReader,
+        )
+        .await
+        .expect_err("expected Err from stalled reader");
+    let elapsed = started.elapsed();
+
+    match err {
+        VmClientError::FsError {
+            ref code,
+            ref message,
+        } => {
+            assert_eq!(code, "S218", "expected S218, got {err:?}");
+            assert!(
+                message.contains("stalled") || message.contains("aborted"),
+                "expected idle-timeout-shaped message, got {message:?}",
+            );
+        }
+        other => panic!("expected FsError(S218), got {other:?}"),
+    }
+    // 5s timeout + scheduling slack. Anything well under 10s
+    // proves the host gives up before any reasonable outer
+    // SDK timeout fires.
+    assert!(
+        elapsed < std::time::Duration::from_secs(10),
+        "fs_write_stream blocked for {elapsed:?} — should give up near 5s",
+    );
+
+    // Don't await the relay — it's intentionally still sleeping.
+    relay.abort();
+}

--- a/crates/iii-shell-client/tests/fake_fs_relay.rs
+++ b/crates/iii-shell-client/tests/fake_fs_relay.rs
@@ -16,9 +16,8 @@ use std::path::PathBuf;
 use base64::Engine;
 use iii_shell_client::{FsStreamReader, Session, VmClientError};
 use iii_shell_proto::{
-    FsEntry, FsOp, FsReadMeta, FsResult, ShellMessage, encode_frame,
-    flags::FLAG_TERMINAL,
-    FRAME_HEADER_SIZE, MAX_FRAME_SIZE, decode_frame_body,
+    FRAME_HEADER_SIZE, FsEntry, FsOp, FsReadMeta, FsResult, MAX_FRAME_SIZE, ShellMessage,
+    decode_frame_body, encode_frame, flags::FLAG_TERMINAL,
 };
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -271,12 +270,7 @@ async fn fs_write_stream_sends_chunks_and_end() {
 
     let session = Session::connect(&sock).await.expect("connect");
     let result = session
-        .fs_write_stream(
-            "/workspace/out.bin".into(),
-            "0644".into(),
-            false,
-            reader,
-        )
+        .fs_write_stream("/workspace/out.bin".into(), "0644".into(), false, reader)
         .await
         .expect("fs_write_stream succeeded");
 
@@ -285,14 +279,20 @@ async fn fs_write_stream_sends_chunks_and_end() {
             bytes_written,
             path,
         } => {
-            assert_eq!(bytes_written, 200, "bytes_written must match payload length");
+            assert_eq!(
+                bytes_written, 200,
+                "bytes_written must match payload length"
+            );
             assert_eq!(path, "/workspace/out.bin");
         }
         other => panic!("expected FsResult::Write, got {other:?}"),
     }
 
     let relay_total = rx.await.expect("relay total");
-    assert_eq!(relay_total, 200, "relay counted {relay_total} bytes, expected 200");
+    assert_eq!(
+        relay_total, 200,
+        "relay counted {relay_total} bytes, expected 200"
+    );
 
     relay.await.expect("relay join");
 }
@@ -541,10 +541,7 @@ async fn fs_write_stream_aborts_on_stalled_reader() {
         write_handshake(&mut s, 0).await.expect("handshake");
         // Expect WriteStart only — host should give up on its idle
         // timeout and drop the Session before sending FsChunk/FsEnd.
-        let (_, _, msg) = read_one_frame(&mut s)
-            .await
-            .expect("read")
-            .expect("frame");
+        let (_, _, msg) = read_one_frame(&mut s).await.expect("read").expect("frame");
         assert!(matches!(
             msg,
             ShellMessage::FsRequest(FsOp::WriteStart { .. })

--- a/crates/iii-shell-proto/Cargo.toml
+++ b/crates/iii-shell-proto/Cargo.toml
@@ -14,3 +14,6 @@ path = "src/lib.rs"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+
+[dev-dependencies]
+base64 = "0.22"

--- a/crates/iii-shell-proto/src/lib.rs
+++ b/crates/iii-shell-proto/src/lib.rs
@@ -204,15 +204,28 @@ fn default_recursive_true() -> bool {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub enum FsResult {
-    Ls { entries: Vec<FsEntry> },
+    Ls {
+        entries: Vec<FsEntry>,
+    },
     Stat(FsEntry),
-    Mkdir { created: bool },
+    Mkdir {
+        created: bool,
+    },
     /// Terminal response of a `WriteStart` sequence. Always carries
     /// the final byte count fsync'd to the target path.
-    Write { bytes_written: u64, path: String },
-    Rm { removed: bool },
-    Chmod { updated: u64 },
-    Mv { moved: bool },
+    Write {
+        bytes_written: u64,
+        path: String,
+    },
+    Rm {
+        removed: bool,
+    },
+    Chmod {
+        updated: u64,
+    },
+    Mv {
+        moved: bool,
+    },
     Grep {
         matches: Vec<FsMatch>,
         truncated: bool,
@@ -354,10 +367,7 @@ pub enum ShellMessage {
     FsResponse(FsResult),
     /// Guest → host: terminal error frame carrying an S21x code.
     /// Always sent with `FLAG_TERMINAL`.
-    FsError {
-        code: String,
-        message: String,
-    },
+    FsError { code: String, message: String },
 }
 
 /// Encoding/decoding errors for the shell-channel frame codec.
@@ -829,8 +839,7 @@ mod tests {
     fn fs_chunk_carries_raw_bytes() {
         use base64::Engine;
         let msg = ShellMessage::FsChunk {
-            data_b64: base64::engine::general_purpose::STANDARD
-                .encode([0xDE, 0xAD, 0xBE, 0xEF]),
+            data_b64: base64::engine::general_purpose::STANDARD.encode([0xDE, 0xAD, 0xBE, 0xEF]),
         };
         let frame = encode_frame(7, 0, &msg).unwrap();
         let (_, _, decoded) = decode_frame(&frame).unwrap();
@@ -917,7 +926,11 @@ mod tests {
 
     #[test]
     fn fs_match_serializes_as_path_not_file() {
-        let m = FsMatch { path: "/x".into(), line: 1, content: "hi".into() };
+        let m = FsMatch {
+            path: "/x".into(),
+            line: 1,
+            content: "hi".into(),
+        };
         let v: serde_json::Value = serde_json::to_value(&m).unwrap();
         assert!(v.get("path").is_some(), "expected `path` key, got: {v}");
         assert!(v.get("file").is_none(), "expected no `file` key, got: {v}");

--- a/crates/iii-shell-proto/src/lib.rs
+++ b/crates/iii-shell-proto/src/lib.rs
@@ -62,6 +62,176 @@ pub mod flags {
     pub const FLAG_TERMINAL: u8 = 0x01;
 }
 
+/// Single directory entry returned by `FsOp::Ls` / `FsOp::Stat`.
+/// `mode` is the octal permission string (e.g. `"0644"`); `mtime` is
+/// Unix seconds. `is_symlink` reflects the entry itself — FS handlers
+/// never follow symlinks unless the op doc-comment says otherwise.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FsEntry {
+    pub name: String,
+    pub is_dir: bool,
+    pub size: u64,
+    pub mode: String,
+    pub mtime: i64,
+    pub is_symlink: bool,
+}
+
+/// Single grep hit. `line` is 1-based. `content` is already truncated
+/// to `max_line_bytes` (with a trailing `…`) if the original line was
+/// longer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FsMatch {
+    #[serde(alias = "file")]
+    pub path: String,
+    pub line: u64,
+    pub content: String,
+}
+
+/// One `sed` file-level outcome. `success=false` carries the human
+/// failure message in `error`; otherwise `error` is absent.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FsSedFileResult {
+    #[serde(alias = "file")]
+    pub path: String,
+    pub replacements: u64,
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub error: Option<String>,
+}
+
+/// Body of an `FsRequest` frame. Tagged on `op` so a new op can be
+/// added without a protocol rev (old peers reply with
+/// `FsError { code: "S219" }` because `deny_unknown_fields` rejects
+/// unknown tags).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "op", rename_all = "snake_case", deny_unknown_fields)]
+pub enum FsOp {
+    Ls {
+        path: String,
+    },
+    Stat {
+        path: String,
+    },
+    Mkdir {
+        path: String,
+        mode: String,
+        parents: bool,
+    },
+    /// Upload: start of a chunked write. Followed by N `FsChunk`
+    /// frames and a terminal `FsEnd`.
+    WriteStart {
+        path: String,
+        mode: String,
+        parents: bool,
+    },
+    /// Download: start of a chunked read. Supervisor responds with
+    /// `FsMeta` then streams N `FsChunk` frames and a terminal
+    /// `FsEnd`.
+    ReadStart {
+        path: String,
+    },
+    Rm {
+        path: String,
+        recursive: bool,
+    },
+    Chmod {
+        path: String,
+        mode: String,
+        #[serde(default)]
+        uid: Option<u32>,
+        #[serde(default)]
+        gid: Option<u32>,
+        recursive: bool,
+    },
+    Mv {
+        src: String,
+        dst: String,
+        overwrite: bool,
+    },
+    Grep {
+        path: String,
+        pattern: String,
+        recursive: bool,
+        ignore_case: bool,
+        include_glob: Vec<String>,
+        exclude_glob: Vec<String>,
+        max_matches: u64,
+        max_line_bytes: u64,
+    },
+    /// Apply a find-and-replace.
+    ///
+    /// Caller must provide **exactly one** of:
+    /// - `files` — explicit list of paths to rewrite (legacy form;
+    ///   non-empty vec).
+    /// - `path` + optional `recursive` / `include_glob` / `exclude_glob`
+    ///   — walk a tree like grep does and rewrite every matching file.
+    ///   `path` may be a directory, a regular file, or a symlink to
+    ///   either (symlink-to-dir is resolved before walking).
+    ///   `recursive=false` on a directory is rejected with `S210`,
+    ///   matching grep — pass `files: [...]` instead, or use
+    ///   `recursive=true` with a tighter `include_glob`.
+    ///
+    /// Both forms produce per-file atomic temp+rename writes. The handler
+    /// returns `FsError { code: "S210" }` if both or neither form is
+    /// supplied (validated in the worker before the wire call). Old
+    /// guests that only know the legacy form keep working because the
+    /// new fields are `#[serde(default)]`.
+    Sed {
+        #[serde(default)]
+        files: Vec<String>,
+        #[serde(default)]
+        path: Option<String>,
+        #[serde(default = "default_recursive_true")]
+        recursive: bool,
+        #[serde(default)]
+        include_glob: Vec<String>,
+        #[serde(default)]
+        exclude_glob: Vec<String>,
+        pattern: String,
+        replacement: String,
+        regex: bool,
+        first_only: bool,
+        ignore_case: bool,
+    },
+}
+
+fn default_recursive_true() -> bool {
+    true
+}
+
+/// Body of an `FsResponse` frame. One variant per op. Errors do not
+/// come back as `FsResult`; they come back as `FsError`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum FsResult {
+    Ls { entries: Vec<FsEntry> },
+    Stat(FsEntry),
+    Mkdir { created: bool },
+    /// Terminal response of a `WriteStart` sequence. Always carries
+    /// the final byte count fsync'd to the target path.
+    Write { bytes_written: u64, path: String },
+    Rm { removed: bool },
+    Chmod { updated: u64 },
+    Mv { moved: bool },
+    Grep {
+        matches: Vec<FsMatch>,
+        truncated: bool,
+    },
+    Sed {
+        results: Vec<FsSedFileResult>,
+        total_replacements: u64,
+    },
+}
+
+/// Metadata frame sent by the supervisor at the start of a
+/// `ReadStart` sequence (one per session, before any `FsChunk`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FsReadMeta {
+    pub size: u64,
+    pub mode: String,
+    pub mtime: i64,
+}
+
 /// One shell-channel message. Wire JSON uses an internal `t` tag so
 /// extra variants can be added without breaking existing decoders (a
 /// peer that sees an unknown tag gets a serde error and the relay
@@ -151,6 +321,41 @@ pub enum ShellMessage {
     Error {
         /// Human-readable failure description. The host surfaces this
         /// to the user and translates to a nonzero exit code.
+        message: String,
+    },
+    /// Host → guest: run a filesystem operation under this
+    /// correlation id. For one-shot ops (ls, stat, mkdir, rm, chmod,
+    /// mv, grep, sed) the guest replies with `FsResponse` (terminal)
+    /// or `FsError` (terminal). For `WriteStart`, the host sends N
+    /// `FsChunk` frames followed by `FsEnd`, and the guest replies
+    /// with `FsResponse { Write { .. } }` (terminal). For
+    /// `ReadStart`, the guest replies with `FsMeta`, N `FsChunk`
+    /// frames, and a terminal `FsEnd`.
+    FsRequest(FsOp),
+    /// Guest → host: metadata for a download. Sent exactly once at
+    /// the start of a `ReadStart` session, before any `FsChunk`.
+    FsMeta(FsReadMeta),
+    /// Host ↔ guest: raw bytes of a streamed upload (host → guest)
+    /// or download (guest → host). `data_b64` is base64-encoded for
+    /// JSON transport; producers should chunk at 64 KiB to match III
+    /// data-channel framing and stay safely under MAX_FRAME_SIZE.
+    FsChunk {
+        /// Base64-encoded bytes.
+        data_b64: String,
+    },
+    /// Host ↔ guest: terminal frame of a chunked upload/download
+    /// sequence. Always sent with `FLAG_TERMINAL`. For `WriteStart`
+    /// this flows host → guest and triggers the supervisor's
+    /// fsync+rename. For `ReadStart` this flows guest → host and
+    /// closes the session.
+    FsEnd,
+    /// Guest → host: terminal response carrying the op result.
+    /// Always sent with `FLAG_TERMINAL`.
+    FsResponse(FsResult),
+    /// Guest → host: terminal error frame carrying an S21x code.
+    /// Always sent with `FLAG_TERMINAL`.
+    FsError {
+        code: String,
         message: String,
     },
 }
@@ -598,5 +803,211 @@ mod tests {
     fn flag_terminal_bit_is_stable() {
         // Wire-visible constant: changing this silently breaks existing peers.
         assert_eq!(flags::FLAG_TERMINAL, 0x01);
+    }
+
+    /// Helper that mirrors `encode_frame` for tests: takes the full wire
+    /// frame (including the 4-byte `frame_len` prefix) and returns
+    /// `(corr_id, flags, ShellMessage)`.
+    fn decode_frame(frame: &[u8]) -> Result<(u32, u8, ShellMessage), ShellCodecError> {
+        // frame[0..4] is the frame_len prefix; body starts at byte 4.
+        decode_frame_body(&frame[4..])
+    }
+
+    #[test]
+    fn fs_request_roundtrips() {
+        let msg = ShellMessage::FsRequest(FsOp::Ls {
+            path: "/workspace".into(),
+        });
+        let frame = encode_frame(7, 0, &msg).unwrap();
+        let (corr_id, flag, decoded) = decode_frame(&frame).unwrap();
+        assert_eq!(corr_id, 7);
+        assert_eq!(flag, 0);
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn fs_chunk_carries_raw_bytes() {
+        use base64::Engine;
+        let msg = ShellMessage::FsChunk {
+            data_b64: base64::engine::general_purpose::STANDARD
+                .encode([0xDE, 0xAD, 0xBE, 0xEF]),
+        };
+        let frame = encode_frame(7, 0, &msg).unwrap();
+        let (_, _, decoded) = decode_frame(&frame).unwrap();
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn fs_end_is_terminal_flagged() {
+        let msg = ShellMessage::FsEnd;
+        let frame = encode_frame(7, flags::FLAG_TERMINAL, &msg).unwrap();
+        let (_, flag, decoded) = decode_frame(&frame).unwrap();
+        assert_eq!(flag & flags::FLAG_TERMINAL, flags::FLAG_TERMINAL);
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn fs_response_carries_result() {
+        let msg = ShellMessage::FsResponse(FsResult::Ls {
+            entries: vec![FsEntry {
+                name: "foo.py".into(),
+                is_dir: false,
+                size: 1234,
+                mode: "0644".into(),
+                mtime: 1_714_000_000,
+                is_symlink: false,
+            }],
+        });
+        let frame = encode_frame(7, flags::FLAG_TERMINAL, &msg).unwrap();
+        let (_, _, decoded) = decode_frame(&frame).unwrap();
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn fs_error_carries_code_and_message() {
+        let msg = ShellMessage::FsError {
+            code: "S211".into(),
+            message: "path not found".into(),
+        };
+        let frame = encode_frame(7, flags::FLAG_TERMINAL, &msg).unwrap();
+        let (_, _, decoded) = decode_frame(&frame).unwrap();
+        assert_eq!(decoded, msg);
+    }
+
+    /// Forward-compat: an FsRequest carrying an unknown `op` tag (e.g.
+    /// from a newer host hitting an older supervisor) must decode-fail
+    /// rather than silently land in some default variant. The supervisor
+    /// translates the decode error into an `FsError { code: "S219" }`
+    /// frame on the wire so the host gets a typed signal.
+    #[test]
+    fn unknown_fs_op_is_rejected_by_decoder() {
+        let payload = br#"{"t":"fs_request","op":"teleport","path":"/x"}"#;
+        let total_len = FRAME_HEADER_SIZE + payload.len();
+        let mut frame = Vec::with_capacity(4 + total_len);
+        frame.extend_from_slice(&(total_len as u32).to_be_bytes());
+        frame.extend_from_slice(&7u32.to_be_bytes()); // corr_id
+        frame.push(0); // flags
+        frame.extend_from_slice(payload);
+
+        let err = decode_frame(&frame).unwrap_err();
+        assert!(
+            matches!(err, ShellCodecError::Deserialize(_)),
+            "expected Deserialize error, got: {err:?}"
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // FsMatch / FsSedFileResult: canonical serde key is `path`, with
+    // `#[serde(alias = "file")]` so older wire payloads still decode.
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn fs_match_deserializes_legacy_file_alias() {
+        let json = r#"{"file":"/x","line":1,"content":"hi"}"#;
+        let m: FsMatch = serde_json::from_str(json).expect("decode legacy");
+        assert_eq!(m.path, "/x");
+    }
+
+    #[test]
+    fn fs_match_deserializes_canonical_path() {
+        let json = r#"{"path":"/x","line":1,"content":"hi"}"#;
+        let m: FsMatch = serde_json::from_str(json).expect("decode canonical");
+        assert_eq!(m.path, "/x");
+    }
+
+    #[test]
+    fn fs_match_serializes_as_path_not_file() {
+        let m = FsMatch { path: "/x".into(), line: 1, content: "hi".into() };
+        let v: serde_json::Value = serde_json::to_value(&m).unwrap();
+        assert!(v.get("path").is_some(), "expected `path` key, got: {v}");
+        assert!(v.get("file").is_none(), "expected no `file` key, got: {v}");
+    }
+
+    #[test]
+    fn fs_sed_file_result_deserializes_legacy_file_alias() {
+        let json = r#"{"file":"/x","replacements":2,"success":true}"#;
+        let r: FsSedFileResult = serde_json::from_str(json).expect("decode legacy");
+        assert_eq!(r.path, "/x");
+        assert_eq!(r.replacements, 2);
+        assert!(r.success);
+    }
+
+    #[test]
+    fn fs_sed_file_result_deserializes_canonical_path() {
+        let json = r#"{"path":"/x","replacements":2,"success":true}"#;
+        let r: FsSedFileResult = serde_json::from_str(json).expect("decode canonical");
+        assert_eq!(r.path, "/x");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // FsOp::Sed dual-form serde: legacy `files:[…]` payloads must keep
+    // decoding, and the new `path` + `recursive` + `*_glob` form must
+    // round-trip with `#[serde(default)]` on every new field.
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn fs_op_sed_legacy_files_only_payload_decodes() {
+        // Wire payload an old guest would send: only `files`, no
+        // `path`/`recursive`/`*_glob`.
+        let json = r#"{
+            "op":"sed",
+            "files":["/x/a.py","/x/b.py"],
+            "pattern":"hello",
+            "replacement":"world",
+            "regex":false,
+            "first_only":false,
+            "ignore_case":false
+        }"#;
+        let op: FsOp = serde_json::from_str(json).expect("decode legacy sed");
+        match op {
+            FsOp::Sed {
+                files,
+                path,
+                recursive,
+                include_glob,
+                exclude_glob,
+                ..
+            } => {
+                assert_eq!(files, vec!["/x/a.py".to_string(), "/x/b.py".to_string()]);
+                assert!(path.is_none(), "path should default to None");
+                // recursive defaults to true via default_recursive_true.
+                assert!(recursive, "recursive should default to true");
+                assert!(include_glob.is_empty());
+                assert!(exclude_glob.is_empty());
+            }
+            other => panic!("expected Sed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fs_op_sed_path_form_with_globs_roundtrips() {
+        let original = FsOp::Sed {
+            files: Vec::new(),
+            path: Some("/workspace".into()),
+            recursive: true,
+            include_glob: vec!["*.py".into()],
+            exclude_glob: vec!["target/*".into()],
+            pattern: "foo".into(),
+            replacement: "bar".into(),
+            regex: false,
+            first_only: false,
+            ignore_case: false,
+        };
+        let encoded = serde_json::to_string(&original).expect("encode");
+        let decoded: FsOp = serde_json::from_str(&encoded).expect("decode");
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn fs_sed_file_result_serializes_as_path_not_file() {
+        let r = FsSedFileResult {
+            path: "/x".into(),
+            replacements: 2,
+            success: true,
+            error: None,
+        };
+        let v: serde_json::Value = serde_json::to_value(&r).unwrap();
+        assert!(v.get("path").is_some(), "expected `path` key, got: {v}");
+        assert!(v.get("file").is_none(), "expected no `file` key, got: {v}");
     }
 }

--- a/crates/iii-worker/Cargo.toml
+++ b/crates/iii-worker/Cargo.toml
@@ -27,6 +27,7 @@ iii-network = { path = "../iii-network" }
 # TODO: switch to crates.io pin before shipping; path dep for co-development
 iii-sdk = { path = "../../sdk/packages/rust/iii" }
 iii-shell-client = { path = "../iii-shell-client" }
+iii-shell-proto = { path = "../iii-shell-proto" }
 iii-supervisor = { path = "../iii-supervisor" }
 msb_krun = { version = "0.1.9", features = ["net", "blk"] }
 oci-client = "0.16"

--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -403,4 +403,66 @@ pub enum SandboxCmd {
         #[arg(long, default_value_t = DEFAULT_PORT)]
         port: u16,
     },
+
+    /// Copy a local file into a running sandbox.
+    ///
+    /// Streams bytes through an iii data channel — no JSON-envelope size cap.
+    /// Reads `LOCAL_PATH` from disk (or stdin when `LOCAL_PATH` is `-`) and
+    /// writes atomically (temp file + fsync + rename) to `REMOTE_PATH` inside
+    /// the sandbox.
+    ///
+    /// Examples:
+    ///   iii sandbox upload <SB> ./script.js /workspace/script.js
+    ///   tar -cf - ./srcdir | iii sandbox upload <SB> - /workspace/src.tar
+    Upload {
+        /// Sandbox id from `iii sandbox create` / `iii sandbox list`.
+        #[arg(value_name = "SANDBOX_ID")]
+        id: String,
+
+        /// Source path on the host. Use `-` to read from stdin.
+        #[arg(value_name = "LOCAL_PATH")]
+        local_path: String,
+
+        /// Destination path inside the sandbox.
+        #[arg(value_name = "REMOTE_PATH")]
+        remote_path: String,
+
+        /// File mode (octal) applied to the destination after the rename.
+        #[arg(long, default_value = "0644", value_name = "MODE")]
+        mode: String,
+
+        /// Create parent directories of `REMOTE_PATH` if they're missing.
+        #[arg(long)]
+        parents: bool,
+
+        /// Engine WebSocket port.
+        #[arg(long, default_value_t = DEFAULT_PORT)]
+        port: u16,
+    },
+
+    /// Copy a file out of a running sandbox to a local path.
+    ///
+    /// Streams bytes through an iii data channel. Writes to `LOCAL_PATH` on
+    /// disk (or stdout when `LOCAL_PATH` is `-`).
+    ///
+    /// Examples:
+    ///   iii sandbox download <SB> /workspace/output.json ./output.json
+    ///   iii sandbox download <SB> /workspace/build.tar - | tar -tf -
+    Download {
+        /// Sandbox id from `iii sandbox create` / `iii sandbox list`.
+        #[arg(value_name = "SANDBOX_ID")]
+        id: String,
+
+        /// Source path inside the sandbox.
+        #[arg(value_name = "REMOTE_PATH")]
+        remote_path: String,
+
+        /// Destination path on the host. Use `-` to write to stdout.
+        #[arg(value_name = "LOCAL_PATH")]
+        local_path: String,
+
+        /// Engine WebSocket port.
+        #[arg(long, default_value_t = DEFAULT_PORT)]
+        port: u16,
+    },
 }

--- a/crates/iii-worker/src/cli/sandbox.rs
+++ b/crates/iii-worker/src/cli/sandbox.rs
@@ -61,13 +61,21 @@ async fn preflight_pull_if_preset(image: &str) {
     let _ = rootfs_cache::ensure_rootfs(oci_ref, &hints, || {}).await;
 }
 
-/// Extract a human-readable message from a `handler error: {...}` envelope.
+/// Extract a human-readable, S-code-tagged message from a
+/// `handler error: {...}` envelope.
+///
 /// The worker emits a flat payload shape
-/// `{"type":"SandboxNotFound","code":"S002","message":"..."}` (see
-/// `SandboxError::to_payload`), but we also tolerate a legacy nested
-/// `{"error":{"message":"..."}}` wrapper for symmetry with the SDK parser in
-/// `sdk/packages/rust/iii/src/sandbox.rs`. For anything else, fall back to
-/// the raw error display.
+/// `{"type":"...","code":"S211","message":"..."}` (see
+/// `SandboxError::to_payload`); we also tolerate a legacy nested
+/// `{"error":{"code":"...","message":"..."}}` wrapper for symmetry with
+/// the SDK parser in `sdk/packages/rust/iii/src/sandbox.rs`.
+///
+/// The returned string is `"[<code>] <message>"` whenever the payload
+/// carries both, e.g. `"[S211] path not found: /tmp/no/such/file"`.
+/// Callers and shell scripts can grep for the S-code directly. When the
+/// payload only has a message (or the body isn't JSON at all), the
+/// formatted string falls back to bare message / raw error display so we
+/// never strip information.
 fn handler_error_message(err: &IIIError) -> String {
     let raw = err.to_string();
     let stripped = raw.strip_prefix("handler error: ").unwrap_or(&raw);
@@ -78,10 +86,15 @@ fn handler_error_message(err: &IIIError) -> String {
         return raw;
     };
     let node = parsed.get("error").unwrap_or(&parsed);
-    node.get("message")
+    let message = node
+        .get("message")
         .and_then(|m| m.as_str())
-        .map(|s| s.to_string())
-        .unwrap_or(raw)
+        .unwrap_or(&raw)
+        .to_string();
+    match node.get("code").and_then(|c| c.as_str()) {
+        Some(code) => format!("[{code}] {message}"),
+        None => message,
+    }
 }
 
 /// `iii sandbox run <image> [--cpus N] [--memory MB] -- <cmd> [args...]`
@@ -421,6 +434,251 @@ pub async fn handle_stop(id: String, port: u16) -> i32 {
     code
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// upload / download
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Hard ceiling on the per-trigger timeout for upload/download. The
+/// trigger itself returns once the supervisor has fsync+rename'd
+/// (upload) or once the metadata frame is back (download), so this
+/// bounds the *handshake*, not the byte stream. The stream lives on
+/// the data channel after the trigger returns.
+const FS_TRIGGER_TIMEOUT_MS: u64 = 60_000;
+
+/// Build the engine WebSocket base URL from the port the CLI talked
+/// to. `ChannelReader` / `ChannelWriter` need this to dial the
+/// channel WebSocket; `iii.address()` is not exposed publicly so we
+/// mirror what `connect()` constructed.
+fn engine_ws_base(port: u16) -> String {
+    format!("ws://127.0.0.1:{port}")
+}
+
+/// `iii sandbox upload <SB> <LOCAL_PATH | -> <REMOTE_PATH> [--mode 0644] [--parents]`
+pub async fn handle_upload(
+    id: String,
+    local_path: String,
+    remote_path: String,
+    mode: String,
+    parents: bool,
+    port: u16,
+) -> i32 {
+    use tokio::io::AsyncReadExt;
+
+    let iii = connect(port);
+
+    // Caller creates the channel; worker reads from the reader half.
+    let channel = match iii.create_channel(None).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: create_channel: {e}");
+            iii.shutdown();
+            return 1;
+        }
+    };
+    let reader_ref = channel.reader_ref.clone();
+    let writer = channel.writer;
+
+    // Feed bytes from the local source into the channel on a separate
+    // task. The trigger call below races the feed: as soon as the
+    // supervisor sees `FsEnd` (which the channel surfaces when we
+    // close it), the trigger response comes back.
+    //
+    // 64 KiB matches `ChannelWriter`'s internal frame size; using the
+    // same chunk avoids re-chunking inside the writer.
+    const BUF: usize = 64 * 1024;
+    let local_path_for_feed = local_path.clone();
+    let feed = tokio::spawn(async move {
+        let mut buf = vec![0u8; BUF];
+        let result: Result<u64, std::io::Error> = if local_path_for_feed == "-" {
+            let mut stdin = tokio::io::stdin();
+            let mut total: u64 = 0;
+            loop {
+                let n = stdin.read(&mut buf).await?;
+                if n == 0 {
+                    break;
+                }
+                if writer.write(&buf[..n]).await.is_err() {
+                    break; // channel closed; writer.close() below is a no-op
+                }
+                total += n as u64;
+            }
+            Ok(total)
+        } else {
+            let mut f = tokio::fs::File::open(&local_path_for_feed).await?;
+            let mut total: u64 = 0;
+            loop {
+                let n = f.read(&mut buf).await?;
+                if n == 0 {
+                    break;
+                }
+                if writer.write(&buf[..n]).await.is_err() {
+                    break;
+                }
+                total += n as u64;
+            }
+            Ok(total)
+        };
+        let _ = writer.close().await;
+        result
+    });
+
+    let trigger_result = iii
+        .trigger(TriggerRequest {
+            function_id: "sandbox::fs::write".into(),
+            payload: json!({
+                "sandbox_id": id,
+                "path": remote_path,
+                "mode": mode,
+                "parents": parents,
+                "content": reader_ref,
+            }),
+            action: None,
+            timeout_ms: Some(FS_TRIGGER_TIMEOUT_MS),
+        })
+        .await;
+
+    // Always join the feed so we don't leak the task or miss a local
+    // read error. If the trigger itself succeeded but the feed errored
+    // (e.g. `--` source disappeared mid-stream), surface that — the
+    // remote file may be truncated even though the supervisor reported
+    // success on the bytes it received.
+    let feed_outcome = feed.await;
+
+    let code = match (trigger_result, feed_outcome) {
+        (Ok(resp), Ok(Ok(local_bytes))) => {
+            let bytes_written = resp
+                .get("bytes_written")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            if bytes_written != local_bytes {
+                eprintln!(
+                    "warning: local read {local_bytes} bytes but remote wrote \
+                     {bytes_written} bytes — likely a partial transfer"
+                );
+            }
+            println!("uploaded {bytes_written} bytes to {id}:{remote_path}");
+            0
+        }
+        (Ok(_), Ok(Err(e))) => {
+            eprintln!("error: reading {local_path}: {e}");
+            1
+        }
+        (Ok(_), Err(e)) => {
+            eprintln!("error: feed task panicked: {e}");
+            1
+        }
+        (Err(e), _) => {
+            eprintln!("error: {}", handler_error_message(&e));
+            1
+        }
+    };
+
+    iii.shutdown();
+    code
+}
+
+/// `iii sandbox download <SB> <REMOTE_PATH> <LOCAL_PATH | ->`
+pub async fn handle_download(
+    id: String,
+    remote_path: String,
+    local_path: String,
+    port: u16,
+) -> i32 {
+    use iii_sdk::{ChannelReader, StreamChannelRef};
+    use tokio::io::AsyncWriteExt;
+
+    let iii = connect(port);
+
+    let resp: Value = match iii
+        .trigger(TriggerRequest {
+            function_id: "sandbox::fs::read".into(),
+            payload: json!({
+                "sandbox_id": id,
+                "path": remote_path,
+            }),
+            action: None,
+            timeout_ms: Some(FS_TRIGGER_TIMEOUT_MS),
+        })
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("error: {}", handler_error_message(&e));
+            iii.shutdown();
+            return 1;
+        }
+    };
+
+    // Pull the channel ref out of the response. The supervisor sets
+    // `content: <StreamChannelRef>`; size/mode/mtime are also returned
+    // but we only surface them on stderr so stdout stays clean for
+    // pipe use (`download <id> <remote> -`).
+    let content = match resp.get("content").cloned() {
+        Some(v) => v,
+        None => {
+            eprintln!("error: read response missing `content` channel ref");
+            iii.shutdown();
+            return 1;
+        }
+    };
+    let channel_ref: StreamChannelRef = match serde_json::from_value(content) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: malformed channel ref in read response: {e}");
+            iii.shutdown();
+            return 1;
+        }
+    };
+    let size = resp.get("size").and_then(|v| v.as_u64()).unwrap_or(0);
+
+    let reader = ChannelReader::new(&engine_ws_base(port), &channel_ref);
+
+    // Pull all chunks. read_all() collects into Vec<u8> — fine for
+    // the typical "fetch a config / artifact / log" use case. For
+    // very large downloads, swap in a chunk loop later (the SDK
+    // exposes next_binary() for that).
+    let bytes = match reader.read_all().await {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("error: channel read: {e}");
+            iii.shutdown();
+            return 1;
+        }
+    };
+
+    let written = if local_path == "-" {
+        let mut out = tokio::io::stdout();
+        if let Err(e) = out.write_all(&bytes).await {
+            eprintln!("error: write to stdout: {e}");
+            iii.shutdown();
+            return 1;
+        }
+        let _ = out.flush().await;
+        bytes.len() as u64
+    } else {
+        match tokio::fs::write(&local_path, &bytes).await {
+            Ok(()) => bytes.len() as u64,
+            Err(e) => {
+                eprintln!("error: write {local_path}: {e}");
+                iii.shutdown();
+                return 1;
+            }
+        }
+    };
+
+    if size != 0 && size != written {
+        eprintln!(
+            "warning: response declared size={size} but received {written} bytes \
+             — channel may have closed early"
+        );
+    }
+    if local_path != "-" {
+        println!("downloaded {written} bytes to {local_path}");
+    }
+    iii.shutdown();
+    0
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -431,7 +689,10 @@ mod tests {
         let e = IIIError::Handler(
             r#"{"type":"SandboxNotFound","code":"S002","message":"sandbox abc not found"}"#.into(),
         );
-        assert_eq!(handler_error_message(&e), "sandbox abc not found");
+        assert_eq!(
+            handler_error_message(&e),
+            "[S002] sandbox abc not found"
+        );
     }
 
     #[test]
@@ -439,7 +700,45 @@ mod tests {
         let e = IIIError::Handler(
             r#"{"error":{"code":"S002","message":"sandbox abc not found"}}"#.into(),
         );
-        assert_eq!(handler_error_message(&e), "sandbox abc not found");
+        assert_eq!(
+            handler_error_message(&e),
+            "[S002] sandbox abc not found"
+        );
+    }
+
+    /// When the JSON payload only has a `message` and no `code` (legacy
+    /// shape, or non-Sandbox handler), fall back to the bare message —
+    /// no `[None]`-style placeholder, no thrown information.
+    #[test]
+    fn omits_code_prefix_when_only_message_present() {
+        let e = IIIError::Handler(r#"{"message":"some other error"}"#.into());
+        assert_eq!(handler_error_message(&e), "some other error");
+    }
+
+    /// FS-trigger response: the supervisor's verbatim message survives
+    /// (no doubled "fs path not found:" prefix), and the S-code lands
+    /// in stderr where shell scripts can grep for it.
+    #[test]
+    fn fs_trigger_payload_carries_s_code_without_doubled_prefix() {
+        let e = IIIError::Handler(
+            r#"{"type":"filesystem","code":"S211","message":"path not found: /tmp/no/such/file","retryable":false}"#
+                .into(),
+        );
+        let formatted = handler_error_message(&e);
+        assert!(formatted.contains("S211"), "S-code missing: {formatted}");
+        assert!(
+            formatted.contains("path not found: /tmp/no/such/file"),
+            "supervisor message missing: {formatted}"
+        );
+        // No doubled "fs path not found: path not found:" anywhere.
+        assert!(
+            !formatted.contains("path not found: path not found"),
+            "doubled prefix leaked: {formatted}"
+        );
+        assert_eq!(
+            formatted,
+            "[S211] path not found: /tmp/no/such/file"
+        );
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/sandbox.rs
+++ b/crates/iii-worker/src/cli/sandbox.rs
@@ -689,10 +689,7 @@ mod tests {
         let e = IIIError::Handler(
             r#"{"type":"SandboxNotFound","code":"S002","message":"sandbox abc not found"}"#.into(),
         );
-        assert_eq!(
-            handler_error_message(&e),
-            "[S002] sandbox abc not found"
-        );
+        assert_eq!(handler_error_message(&e), "[S002] sandbox abc not found");
     }
 
     #[test]
@@ -700,10 +697,7 @@ mod tests {
         let e = IIIError::Handler(
             r#"{"error":{"code":"S002","message":"sandbox abc not found"}}"#.into(),
         );
-        assert_eq!(
-            handler_error_message(&e),
-            "[S002] sandbox abc not found"
-        );
+        assert_eq!(handler_error_message(&e), "[S002] sandbox abc not found");
     }
 
     /// When the JSON payload only has a `message` and no `code` (legacy
@@ -735,10 +729,7 @@ mod tests {
             !formatted.contains("path not found: path not found"),
             "doubled prefix leaked: {formatted}"
         );
-        assert_eq!(
-            formatted,
-            "[S211] path not found: /tmp/no/such/file"
-        );
+        assert_eq!(formatted, "[S211] path not found: /tmp/no/such/file");
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/shell_relay.rs
+++ b/crates/iii-worker/src/cli/shell_relay.rs
@@ -474,10 +474,28 @@ fn claim_slot(slots: &Slots) -> Option<usize> {
 /// `claim_slot` won't hand the slot out until the deadline passes,
 /// giving the guest time to clean up any sessions the departing
 /// client owned.
-fn release_slot(slots: &Slots, idx: usize) {
+///
+/// `had_owned`: did the client own any guest sessions when it
+/// disconnected? Cooldown is only needed when SIGKILL fan-out
+/// happened — active exec corr_ids must drain on the guest before
+/// slot reuse, otherwise a new client claiming the same slot would
+/// reuse the same id_offset range and collide with still-alive
+/// sessions. For clean disconnects with empty `owned_ids` (every
+/// FS trigger after its terminal frame, every cleanly-exited
+/// exec), the slot returns directly to `Free` — no SIGKILL was
+/// sent so there's nothing to drain. Without this distinction,
+/// a tight burst of 16+ fast sequential triggers exhausts all
+/// `MAX_CLIENTS=16` slot cooldowns simultaneously and the listener
+/// rejects further connects with `early eof on handshake`, which
+/// surfaces as `S216` on the host side.
+fn release_slot(slots: &Slots, idx: usize, had_owned: bool) {
     let mut guard = slots.lock().expect("slots mutex poisoned");
     if idx < guard.len() {
-        guard[idx] = SlotState::Cooldown(Instant::now() + SLOT_COOLDOWN);
+        guard[idx] = if had_owned {
+            SlotState::Cooldown(Instant::now() + SLOT_COOLDOWN)
+        } else {
+            SlotState::Free
+        };
     }
 }
 
@@ -498,7 +516,9 @@ async fn client_session(
     // Handshake: 4-byte id_offset (BE) so the client knows its range.
     if let Err(e) = client_write.write_all(&id_offset.to_be_bytes()).await {
         tracing::debug!("shell_relay: handshake write failed: {e}");
-        release_slot(&slots, slot_idx);
+        // Handshake failed before any work — no owned sessions, no
+        // SIGKILL fan-out, no cooldown needed. Free immediately.
+        release_slot(&slots, slot_idx, false);
         return;
     }
 
@@ -693,7 +713,12 @@ async fn client_session(
         map.remove(id);
     }
     drop(map);
-    release_slot(&slots, slot_idx);
+    // Cooldown only when SIGKILL fan-out actually happened. For the
+    // common case (every FS trigger after its terminal frame, every
+    // cleanly-exited exec) `ids` is empty and the slot returns
+    // straight to Free — keeps tight burst patterns from exhausting
+    // the slot pool.
+    release_slot(&slots, slot_idx, !ids.is_empty());
 }
 
 /// Read one full frame (length prefix + body). `Ok(None)` on EOF at
@@ -974,6 +999,59 @@ mod tests {
             .expect("frame");
         let reply_corr = u32::from_be_bytes([reply[4], reply[5], reply[6], reply[7]]);
         assert_eq!(reply_corr, valid_id, "valid frame must still route");
+    }
+
+    /// REGRESSION: a tight burst of clean (no owned-id) disconnects
+    /// must NOT exhaust the slot pool.
+    ///
+    /// Prior bug: every disconnect put the slot into a 250 ms
+    /// `Cooldown` window unconditionally. With `MAX_CLIENTS=16`, a
+    /// burst of 17+ fast sequential connections (tens of ms each)
+    /// finished before slot 0 cooled, so the 17th claim_slot found
+    /// every slot still cooling and the listener refused with
+    /// `early eof on handshake` → host saw S216
+    /// (`relay rejected connection (uid mismatch?)`). Real-world
+    /// repro: `fs-example.mjs` running ~14 happy-path triggers then
+    /// a few adversarial-section setup triggers in <250 ms.
+    ///
+    /// Fix: only enter Cooldown when SIGKILL fan-out actually
+    /// happened (owned_ids non-empty at session end). Clean
+    /// disconnects — every FS trigger that received its terminal
+    /// frame, every cleanly-exited exec — drop straight to Free,
+    /// so back-to-back trigger bursts don't burn slot capacity.
+    ///
+    /// This test fires 32 sequential connect/handshake/disconnect
+    /// cycles — twice MAX_CLIENTS — and asserts every one received
+    /// its 4-byte handshake. Under the old behavior the 17th would
+    /// time out on read; under the fix all 32 succeed.
+    #[tokio::test]
+    async fn burst_of_clean_disconnects_does_not_exhaust_slots() {
+        let (sock, _vm_guest_sim, _tmp) = boot().await;
+
+        // 2 × MAX_CLIENTS sequential connect → read handshake → drop.
+        // Each cycle's UnixStream goes out of scope at end-of-iteration
+        // so the relay sees a clean EOF on read_frame, exits the
+        // session, and (with the fix) returns the slot to Free.
+        for i in 0..(MAX_CLIENTS as usize * 2) {
+            let mut s = tokio::net::UnixStream::connect(&sock)
+                .await
+                .unwrap_or_else(|e| panic!("connect on iteration {i} failed: {e}"));
+            let mut buf = [0u8; 4];
+            tokio::time::timeout(Duration::from_millis(500), s.read_exact(&mut buf))
+                .await
+                .unwrap_or_else(|_| panic!("iteration {i}: handshake read timed out"))
+                .unwrap_or_else(|e| panic!("iteration {i}: handshake failed: {e}"));
+            // Drop here — the UnixStream's Drop closes both halves,
+            // the relay's reader_fut sees EOF, client_session exits
+            // with empty owned_ids, slot returns to Free.
+            drop(s);
+            // Tiny yield so the relay's per-session cleanup actually
+            // schedules before we open the next connection. Without
+            // this the test stays correct but exercises a different
+            // race (claim_slot vs release_slot ordering on the same
+            // tokio task) — keeping it deterministic helps.
+            tokio::task::yield_now().await;
+        }
     }
 
     #[tokio::test]

--- a/crates/iii-worker/src/cli/vm_boot.rs
+++ b/crates/iii-worker/src/cli/vm_boot.rs
@@ -684,8 +684,7 @@ fn boot_vm(args: &VmBootArgs) -> Result<std::convert::Infallible, String> {
         let mut network =
             iii_network::SmoltcpNetwork::new(iii_network::NetworkConfig::default(), args.slot);
         network.start(tokio_rt.handle().clone());
-        builder =
-            builder.net(|net| net.mac(network.guest_mac()).custom(network.take_backend()));
+        builder = builder.net(|net| net.mac(network.guest_mac()).custom(network.take_backend()));
         (
             network.gateway_ipv4().to_string(),
             network.guest_ipv4().to_string(),

--- a/crates/iii-worker/src/cli/vm_boot.rs
+++ b/crates/iii-worker/src/cli/vm_boot.rs
@@ -123,6 +123,19 @@ pub struct VmBootArgs {
     /// error rather than silently hanging on a missing socket.
     #[arg(long)]
     pub shell_sock: Option<String>,
+
+    /// Enable network egress for the guest. When false, the smoltcp
+    /// userspace TCP/IP stack is not initialized and no virtio-net
+    /// device is attached, so the VM has no network interface — useful
+    /// for fully-isolated build steps. When true, the host runs an
+    /// `iii_network::SmoltcpNetwork` instance and proxies guest TCP
+    /// connections to the host (gateway IP rewrites to 127.0.0.1, see
+    /// `iii-network/src/proxy.rs`); guest-side `iii-init` reads
+    /// `III_INIT_IP` / `III_INIT_GW` / `III_INIT_CIDR` and configures
+    /// `eth0`. The host-side adapter (`sandbox::create`) passes
+    /// `--network` only when the request's `network` field is true.
+    #[arg(long, default_value = "false")]
+    pub network: bool,
 }
 
 /// One `--mount host:guest` CLI arg, expanded into the virtiofs attach plan.
@@ -664,15 +677,23 @@ fn boot_vm(args: &VmBootArgs) -> Result<std::convert::Infallible, String> {
         .build()
         .map_err(|e| format!("tokio runtime failed: {}", e))?;
 
-    let mut network =
-        iii_network::SmoltcpNetwork::new(iii_network::NetworkConfig::default(), args.slot);
-    network.start(tokio_rt.handle().clone());
-
-    builder = builder.net(|net| net.mac(network.guest_mac()).custom(network.take_backend()));
-
-    let dns_nameserver = network.gateway_ipv4().to_string();
-    let guest_ip = network.guest_ipv4().to_string();
-    let gateway_ip = network.gateway_ipv4().to_string();
+    // Network plumbing is gated on `--network`. When disabled, no virtio-net
+    // device is attached and the III_INIT_* env vars are left unset, so
+    // iii-init's `configure_network()` short-circuits (network.rs:42-44).
+    let (dns_nameserver, guest_ip, gateway_ip) = if args.network {
+        let mut network =
+            iii_network::SmoltcpNetwork::new(iii_network::NetworkConfig::default(), args.slot);
+        network.start(tokio_rt.handle().clone());
+        builder =
+            builder.net(|net| net.mac(network.guest_mac()).custom(network.take_backend()));
+        (
+            network.gateway_ipv4().to_string(),
+            network.guest_ipv4().to_string(),
+            network.gateway_ipv4().to_string(),
+        )
+    } else {
+        (String::new(), String::new(), String::new())
+    };
 
     let rewrite_localhost = |s: &str| -> String { rewrite_localhost(s, &gateway_ip) };
     let worker_cmd = rewrite_localhost(&worker_cmd);
@@ -738,10 +759,14 @@ fn boot_vm(args: &VmBootArgs) -> Result<std::convert::Infallible, String> {
             e = e.rlimit("RLIMIT_NOFILE", nofile_limit, nofile_limit);
         }
         e = e.env("III_WORKER_CMD", &worker_cmd);
-        e = e.env("III_INIT_DNS", &dns_nameserver);
-        e = e.env("III_INIT_IP", &guest_ip);
-        e = e.env("III_INIT_GW", &gateway_ip);
-        e = e.env("III_INIT_CIDR", "30");
+        // III_INIT_* are only meaningful when the smoltcp stack is wired up.
+        // Leaving them unset makes iii-init's configure_network() a no-op.
+        if args.network {
+            e = e.env("III_INIT_DNS", &dns_nameserver);
+            e = e.env("III_INIT_IP", &guest_ip);
+            e = e.env("III_INIT_GW", &gateway_ip);
+            e = e.env("III_INIT_CIDR", "30");
+        }
         e = e.env("III_WORKER_MEM_BYTES", &worker_heap_bytes.to_string());
         if control_port_env {
             e = e.env(

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -170,6 +170,32 @@ async fn main() -> anyhow::Result<()> {
             iii_worker::cli::app::SandboxCmd::Stop { id, port } => {
                 iii_worker::cli::sandbox::handle_stop(id, port).await
             }
+            iii_worker::cli::app::SandboxCmd::Upload {
+                id,
+                local_path,
+                remote_path,
+                mode,
+                parents,
+                port,
+            } => {
+                iii_worker::cli::sandbox::handle_upload(
+                    id,
+                    local_path,
+                    remote_path,
+                    mode,
+                    parents,
+                    port,
+                )
+                .await
+            }
+            iii_worker::cli::app::SandboxCmd::Download {
+                id,
+                remote_path,
+                local_path,
+                port,
+            } => {
+                iii_worker::cli::sandbox::handle_download(id, remote_path, local_path, port).await
+            }
         },
         Commands::SandboxDaemon(args) => iii_worker::cli::sandbox_daemon::run(args).await,
         Commands::VmBoot(args) => {

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -193,9 +193,7 @@ async fn main() -> anyhow::Result<()> {
                 remote_path,
                 local_path,
                 port,
-            } => {
-                iii_worker::cli::sandbox::handle_download(id, remote_path, local_path, port).await
-            }
+            } => iii_worker::cli::sandbox::handle_download(id, remote_path, local_path, port).await,
         },
         Commands::SandboxDaemon(args) => iii_worker::cli::sandbox_daemon::run(args).await,
         Commands::VmBoot(args) => {

--- a/crates/iii-worker/src/sandbox_daemon/adapters.rs
+++ b/crates/iii-worker/src/sandbox_daemon/adapters.rs
@@ -341,6 +341,88 @@ fn read_stderr_tail(log_path: &std::path::Path) -> String {
     }
 }
 
+/// Detect dispatcher errors that represent in-VM `execve()` failures
+/// (POSIX ENOENT/ENOTDIR/EACCES) and convert them into a synthetic
+/// `ExecResponse` carrying the canonical POSIX shell exit code (127 for
+/// "not found", 126 for "permission denied"). Returns `None` for any
+/// other dispatcher error so the caller preserves `BootFailed` (S300)
+/// semantics.
+///
+/// **Why substring matching:** the in-VM dispatcher (iii-init's
+/// `shell_dispatcher.rs:193`) builds its `Error { message }` frame as
+/// `format!("spawn: {e}")` where `e` is a `std::io::Error` from
+/// `Command::spawn()`. By the time the host receives this through
+/// `VmClientError::DispatcherError(String)`, the structured `ErrorKind`
+/// has been flattened to its `Display` representation. The strings we
+/// match here are stable POSIX `strerror(3)` messages plus libstd's
+/// `(os error N)` suffix, which are stable across every Linux target
+/// the sandbox runs on. Promoting this to a structured wire type
+/// (e.g. carrying `errno: i32` end-to-end through the proto) would be
+/// the right next step if these strings ever drift; today the brittle
+/// substring check is the smallest correct change.
+///
+/// `cmd` is folded into the synthetic stderr the way `/bin/sh` does
+/// (`exec: <cmd>: not found`) so users see what failed without
+/// scrolling through `code: S300` chrome that no longer applies.
+fn classify_dispatcher_spawn_error(
+    msg: &str,
+    cmd: &str,
+    duration_ms: u64,
+) -> Option<ExecResponse> {
+    // `os error N` is the canonical libstd suffix on Unix; we anchor on
+    // it to avoid catching unrelated dispatcher errors that happen to
+    // mention "permission" in some other context.
+    let is_enoent =
+        msg.contains("No such file or directory") || msg.contains("(os error 2)");
+    let is_enotdir = msg.contains("Not a directory") || msg.contains("(os error 20)");
+    let is_eacces =
+        msg.contains("Permission denied") || msg.contains("(os error 13)");
+
+    if is_enoent || is_enotdir {
+        return Some(ExecResponse {
+            stdout: String::new(),
+            stderr: format!("exec: {cmd}: not found\n"),
+            exit_code: Some(127),
+            timed_out: false,
+            duration_ms,
+            success: false,
+        });
+    }
+    if is_eacces {
+        return Some(ExecResponse {
+            stdout: String::new(),
+            stderr: format!("exec: {cmd}: permission denied\n"),
+            exit_code: Some(126),
+            timed_out: false,
+            duration_ms,
+            success: false,
+        });
+    }
+    None
+}
+
+/// Translate the wire-level `stdin: Option<String>` into the byte-level
+/// payload `iii-shell-client::Session::run` expects.
+///
+/// `Some(vec![])` -> open stdin, write 0 bytes, send EOF (lib.rs:448).
+/// `None` -> don't touch stdin; child stays blocked on read.
+///
+/// Both `Some("")` and missing-stdin must map to `Some(vec![])` so an
+/// exec that reads from stdin (e.g. `for line in sys.stdin:`) gets EOF
+/// instead of timing out.
+fn decode_stdin(stdin: Option<&str>) -> Result<Option<Vec<u8>>, SandboxError> {
+    match stdin {
+        Some(s) if s.is_empty() => Ok(Some(Vec::new())),
+        Some(s) => {
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(s.as_bytes())
+                .map_err(|e| SandboxError::InvalidRequest(format!("stdin base64 decode: {e}")))?;
+            Ok(Some(bytes))
+        }
+        None => Ok(Some(Vec::new())),
+    }
+}
+
 /// Uses `tokio::task::spawn_blocking` + an inner `current_thread`
 /// runtime so the `!Send` `&mut dyn OutputSink` reference never crosses
 /// the outer multi-thread runtime's Send boundary.
@@ -355,17 +437,7 @@ impl ShellRunner for ShellProtoRunner {
         let cwd = req.workdir.clone();
         let timeout_ms = req.timeout_ms.unwrap_or(DEFAULT_EXEC_TIMEOUT_MS);
 
-        let stdin: Option<Vec<u8>> = match &req.stdin {
-            Some(s) if !s.is_empty() => {
-                let bytes = base64::engine::general_purpose::STANDARD
-                    .decode(s.as_bytes())
-                    .map_err(|e| {
-                        SandboxError::InvalidRequest(format!("stdin base64 decode: {e}"))
-                    })?;
-                Some(bytes)
-            }
-            _ => None,
-        };
+        let stdin: Option<Vec<u8>> = decode_stdin(req.stdin.as_deref())?;
 
         let join: Result<ExecResponse, SandboxError> = tokio::task::spawn_blocking(move || {
             let rt = tokio::runtime::Builder::new_current_thread()
@@ -384,6 +456,12 @@ impl ShellRunner for ShellProtoRunner {
                     "exec_phase: shell_connect"
                 );
 
+                // Keep a copy of `cmd` for the spawn-failure error path
+                // (`classify_dispatcher_spawn_error`) so the synthetic
+                // stderr can name the binary the user tried to exec.
+                // `RequestSpec` consumes the original, so without this
+                // we'd have nothing to render after the move.
+                let cmd_for_err = cmd.clone();
                 let spec = RequestSpec {
                     cmd,
                     args,
@@ -423,6 +501,25 @@ impl ShellRunner for ShellProtoRunner {
                 let outcome = match outer {
                     Ok(Ok(o)) => o,
                     Ok(Err(e)) => {
+                        // In-VM `execve()` failures (binary missing, not
+                        // executable, intermediate path component is a
+                        // file) arrive as `DispatcherError`. POSIX shells
+                        // surface these as exit 127 / 126; do the same so
+                        // callers don't see S300 BootFailed for what is
+                        // really a per-exec spawn failure on a healthy
+                        // VM. See `classify_dispatcher_spawn_error` for
+                        // the substring rationale. All other dispatcher
+                        // errors fall through to the original
+                        // BootFailed mapping.
+                        if let iii_shell_client::VmClientError::DispatcherError(msg) = &e {
+                            if let Some(resp) = classify_dispatcher_spawn_error(
+                                msg,
+                                &cmd_for_err,
+                                started.elapsed().as_millis() as u64,
+                            ) {
+                                return Ok(resp);
+                            }
+                        }
                         return Err(SandboxError::BootFailed(format!("shell run: {e}")));
                     }
                     Err(_) => {
@@ -494,5 +591,145 @@ impl VmStopper for SignalStopper {
             "stop_phase: SIGTERM+grace+SIGKILL"
         );
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `Some(vec![])` is the iii-shell-client trigger for "open stdin,
+    // write 0 bytes, send EOF" (lib.rs:448-468). `None` skips stdin
+    // entirely and leaves the child blocked on read. So the wire-level
+    // `Some("")` and missing-stdin must both decode to `Some(vec![])`,
+    // not `None`.
+    #[test]
+    fn decode_stdin_empty_string_is_eof_not_none() {
+        let got = decode_stdin(Some("")).unwrap();
+        assert_eq!(
+            got,
+            Some(Vec::<u8>::new()),
+            "stdin: \"\" must produce Some(empty) so the child sees EOF"
+        );
+    }
+
+    #[test]
+    fn decode_stdin_missing_is_eof_not_none() {
+        let got = decode_stdin(None).unwrap();
+        assert_eq!(
+            got,
+            Some(Vec::<u8>::new()),
+            "missing stdin must produce Some(empty) so the child sees EOF"
+        );
+    }
+
+    #[test]
+    fn decode_stdin_non_empty_decodes_base64() {
+        // base64("hi\n") = "aGkK"
+        let got = decode_stdin(Some("aGkK")).unwrap();
+        assert_eq!(got, Some(b"hi\n".to_vec()));
+    }
+
+    #[test]
+    fn decode_stdin_invalid_base64_is_invalid_request() {
+        let err = decode_stdin(Some("!!!not-base64!!!")).unwrap_err();
+        assert_eq!(err.code().as_str(), "S001");
+    }
+
+    // The dispatcher surfaces ENOENT (execve of a missing binary) as
+    // `format!("spawn: {e}")` where `e` is a `std::io::Error`. Display
+    // for that is `"No such file or directory (os error 2)"`. POSIX
+    // shells exit 127 for "command not found"; sandbox::exec must
+    // mirror that instead of returning S300 BootFailed (which is
+    // reserved for genuine VM-boot failures).
+    #[test]
+    fn classify_spawn_enoent_returns_exit_127() {
+        let resp = classify_dispatcher_spawn_error(
+            "spawn: No such file or directory (os error 2)",
+            "/no/such/binary",
+            42,
+        )
+        .expect("ENOENT must classify as a synthetic ExecResponse, not None");
+        assert_eq!(resp.exit_code, Some(127));
+        assert!(!resp.success);
+        assert!(!resp.timed_out);
+        assert!(resp.stdout.is_empty());
+        assert!(
+            resp.stderr.contains("/no/such/binary") && resp.stderr.contains("not found"),
+            "stderr should look like POSIX shell 'not found' message, got {:?}",
+            resp.stderr
+        );
+        assert_eq!(resp.duration_ms, 42);
+    }
+
+    // Adversarial probe B15 from test.mjs uses a non-ASCII path; the
+    // classifier must not be sensitive to the cmd's contents — only to
+    // the dispatcher's message.
+    #[test]
+    fn classify_spawn_enoent_handles_non_ascii_cmd() {
+        let resp = classify_dispatcher_spawn_error(
+            "spawn: No such file or directory (os error 2)",
+            "/💥/no/such",
+            0,
+        )
+        .expect("ENOENT must classify regardless of cmd encoding");
+        assert_eq!(resp.exit_code, Some(127));
+        assert!(resp.stderr.contains("/💥/no/such"));
+    }
+
+    // ENOTDIR (an intermediate path component is a regular file) is
+    // also a "command not found" failure mode; same exit code.
+    #[test]
+    fn classify_spawn_enotdir_returns_exit_127() {
+        let resp = classify_dispatcher_spawn_error(
+            "spawn: Not a directory (os error 20)",
+            "/etc/hosts/x",
+            0,
+        )
+        .expect("ENOTDIR must classify as 127 like POSIX shells");
+        assert_eq!(resp.exit_code, Some(127));
+        assert!(resp.stderr.contains("not found"));
+    }
+
+    // EACCES (binary exists but isn't executable) maps to 126, the
+    // POSIX shell exit code for "found but not executable".
+    #[test]
+    fn classify_spawn_eacces_returns_exit_126() {
+        let resp = classify_dispatcher_spawn_error(
+            "spawn: Permission denied (os error 13)",
+            "/tmp/not-exec",
+            0,
+        )
+        .expect("EACCES must classify as 126");
+        assert_eq!(resp.exit_code, Some(126));
+        assert!(
+            resp.stderr.contains("permission denied"),
+            "stderr should mention permission denied, got {:?}",
+            resp.stderr
+        );
+    }
+
+    // Non-spawn dispatcher errors (e.g. PTY allocation failure) must
+    // fall through so the caller still sees S300. Reserving S300 for
+    // genuine VM-level failures depends on this — over-classifying
+    // here would silently swallow real boot/dispatcher bugs as exit
+    // 127.
+    #[test]
+    fn classify_unknown_dispatcher_error_returns_none() {
+        // Realistic non-spawn dispatcher message: PTY/openpty failure.
+        let resp = classify_dispatcher_spawn_error(
+            "openpty: Resource temporarily unavailable (os error 11)",
+            "/bin/sh",
+            0,
+        );
+        assert!(
+            resp.is_none(),
+            "non-ENOENT/ENOTDIR/EACCES must fall through to BootFailed, got {resp:?}"
+        );
+    }
+
+    #[test]
+    fn classify_empty_message_returns_none() {
+        assert!(classify_dispatcher_spawn_error("", "/bin/true", 0).is_none());
     }
 }

--- a/crates/iii-worker/src/sandbox_daemon/adapters.rs
+++ b/crates/iii-worker/src/sandbox_daemon/adapters.rs
@@ -364,19 +364,13 @@ fn read_stderr_tail(log_path: &std::path::Path) -> String {
 /// `cmd` is folded into the synthetic stderr the way `/bin/sh` does
 /// (`exec: <cmd>: not found`) so users see what failed without
 /// scrolling through `code: S300` chrome that no longer applies.
-fn classify_dispatcher_spawn_error(
-    msg: &str,
-    cmd: &str,
-    duration_ms: u64,
-) -> Option<ExecResponse> {
+fn classify_dispatcher_spawn_error(msg: &str, cmd: &str, duration_ms: u64) -> Option<ExecResponse> {
     // `os error N` is the canonical libstd suffix on Unix; we anchor on
     // it to avoid catching unrelated dispatcher errors that happen to
     // mention "permission" in some other context.
-    let is_enoent =
-        msg.contains("No such file or directory") || msg.contains("(os error 2)");
+    let is_enoent = msg.contains("No such file or directory") || msg.contains("(os error 2)");
     let is_enotdir = msg.contains("Not a directory") || msg.contains("(os error 20)");
-    let is_eacces =
-        msg.contains("Permission denied") || msg.contains("(os error 13)");
+    let is_eacces = msg.contains("Permission denied") || msg.contains("(os error 13)");
 
     if is_enoent || is_enotdir {
         return Some(ExecResponse {

--- a/crates/iii-worker/src/sandbox_daemon/errors.rs
+++ b/crates/iii-worker/src/sandbox_daemon/errors.rs
@@ -18,6 +18,16 @@ pub enum SandboxErrorCode {
     S101,
     S102,
     S200,
+    S210,
+    S211,
+    S212,
+    S213,
+    S214,
+    S215,
+    S216,
+    S217,
+    S218,
+    S219,
     S300,
     S400,
 }
@@ -33,6 +43,16 @@ impl SandboxErrorCode {
             Self::S101 => "S101",
             Self::S102 => "S102",
             Self::S200 => "S200",
+            Self::S210 => "S210",
+            Self::S211 => "S211",
+            Self::S212 => "S212",
+            Self::S213 => "S213",
+            Self::S214 => "S214",
+            Self::S215 => "S215",
+            Self::S216 => "S216",
+            Self::S217 => "S217",
+            Self::S218 => "S218",
+            Self::S219 => "S219",
             Self::S300 => "S300",
             Self::S400 => "S400",
         }
@@ -43,14 +63,23 @@ impl SandboxErrorCode {
             Self::S001 | Self::S002 | Self::S003 | Self::S004 => "validation",
             Self::S100 | Self::S400 => "config",
             Self::S101 => "internal",
-            Self::S102 => "transient",
+            Self::S102 | Self::S218 => "transient",
             Self::S200 => "execution",
+            Self::S210
+            | Self::S211
+            | Self::S212
+            | Self::S213
+            | Self::S214
+            | Self::S215
+            | Self::S216
+            | Self::S217
+            | Self::S219 => "filesystem",
             Self::S300 => "platform",
         }
     }
 
     pub fn retryable(&self) -> bool {
-        matches!(self, Self::S102)
+        matches!(self, Self::S102 | Self::S218)
     }
 }
 
@@ -84,11 +113,55 @@ pub enum SandboxError {
     #[error("exec timed out after {timeout_ms} ms")]
     ExecTimedOut { timeout_ms: u64 },
 
+    /// S300 means the VM itself failed to boot (or its shell socket
+    /// became unreachable mid-session). Per-exec spawn failures
+    /// (`execve` ENOENT/ENOTDIR/EACCES on a healthy VM) must NOT use
+    /// this variant — they surface as a normal `ExecResponse` with
+    /// `exit_code: 127` (or `126`) per POSIX shell semantics. See
+    /// `adapters.rs::classify_dispatcher_spawn_error`.
     #[error("VM boot failed: {0}")]
     BootFailed(String),
 
     #[error("resource limit exceeded: {0}")]
     ResourceLimit(String),
+
+    // FS variants below carry the supervisor's verbatim message in their
+    // inner `String` (or `path`) field — `IiiShellFsRunner::map_vm_error`
+    // is the canonical constructor and never reformats. Display passes
+    // the message through unchanged so it can't double-prefix the
+    // supervisor's own framing. The S-code carries the typed category
+    // on the wire (`to_payload`'s `code` + `type` fields).
+    #[error("{0}")]
+    FsInvalidRequest(String),
+
+    #[error("{path}")]
+    FsNotFound { path: String },
+
+    #[error("{path}")]
+    FsWrongType { path: String },
+
+    #[error("{path}")]
+    FsAlreadyExists { path: String },
+
+    #[error("{path}")]
+    FsNotEmpty { path: String },
+
+    #[error("{0}")]
+    FsPermission(String),
+
+    #[error("{0}")]
+    FsIo(String),
+
+    #[error("{0}")]
+    FsRegex(String),
+
+    #[error("{0}")]
+    FsChannelAborted(String),
+
+    #[error(
+        "fs operation unsupported by this sandbox supervisor; upgrade iii-worker to enable fs::* triggers (see S219 docs)"
+    )]
+    FsUnsupported,
 }
 
 impl SandboxError {
@@ -107,6 +180,16 @@ impl SandboxError {
             Self::RootfsMissing { .. } => SandboxErrorCode::S101,
             Self::AutoInstallFailed { .. } => SandboxErrorCode::S102,
             Self::ExecTimedOut { .. } => SandboxErrorCode::S200,
+            Self::FsInvalidRequest(_) => SandboxErrorCode::S210,
+            Self::FsNotFound { .. } => SandboxErrorCode::S211,
+            Self::FsWrongType { .. } => SandboxErrorCode::S212,
+            Self::FsAlreadyExists { .. } => SandboxErrorCode::S213,
+            Self::FsNotEmpty { .. } => SandboxErrorCode::S214,
+            Self::FsPermission(_) => SandboxErrorCode::S215,
+            Self::FsIo(_) => SandboxErrorCode::S216,
+            Self::FsRegex(_) => SandboxErrorCode::S217,
+            Self::FsChannelAborted(_) => SandboxErrorCode::S218,
+            Self::FsUnsupported => SandboxErrorCode::S219,
             Self::BootFailed(_) => SandboxErrorCode::S300,
             Self::ResourceLimit(_) => SandboxErrorCode::S400,
         }
@@ -138,6 +221,40 @@ impl SandboxError {
 
     pub fn exec_timed_out(timeout_ms: u64) -> Self {
         Self::ExecTimedOut { timeout_ms }
+    }
+
+    /// Construct an `FsNotFound` error for `path`.
+    pub fn fs_not_found(path: impl Into<String>) -> Self {
+        Self::FsNotFound { path: path.into() }
+    }
+
+    /// Construct an `FsWrongType` error for `path`.
+    pub fn fs_wrong_type(path: impl Into<String>) -> Self {
+        Self::FsWrongType { path: path.into() }
+    }
+
+    /// Construct an `FsAlreadyExists` error for `path`.
+    pub fn fs_already_exists(path: impl Into<String>) -> Self {
+        Self::FsAlreadyExists { path: path.into() }
+    }
+
+    /// Construct an `FsNotEmpty` error for `path`.
+    pub fn fs_not_empty(path: impl Into<String>) -> Self {
+        Self::FsNotEmpty { path: path.into() }
+    }
+
+    /// Classify a `std::io::Error` into the closest S21x variant. Callers
+    /// use this when bubbling `std::fs` / `tokio::fs` errors out of a
+    /// supervisor handler so the wire-level S-code is stable.
+    pub fn from_io(path: &str, err: std::io::Error) -> Self {
+        match err.kind() {
+            std::io::ErrorKind::NotFound => Self::fs_not_found(path),
+            std::io::ErrorKind::AlreadyExists => Self::fs_already_exists(path),
+            std::io::ErrorKind::PermissionDenied => {
+                Self::FsPermission(format!("{path}: {err}"))
+            }
+            _ => Self::FsIo(format!("{path}: {err}")),
+        }
     }
 }
 
@@ -182,6 +299,57 @@ mod tests {
         let payload = err.to_payload();
         assert_eq!(payload["code"], "S400");
         assert_eq!(payload["type"], "config");
+    }
+
+    #[test]
+    fn fs_codes_serialize_with_filesystem_type() {
+        let err = SandboxError::FsNotFound {
+            path: "/missing".into(),
+        };
+        let payload = err.to_payload();
+        assert_eq!(payload["code"], "S211");
+        assert_eq!(payload["type"], "filesystem");
+        assert_eq!(payload["retryable"], false);
+    }
+
+    #[test]
+    fn fs_channel_aborted_is_retryable() {
+        let err = SandboxError::FsChannelAborted("closed early".into());
+        let payload = err.to_payload();
+        assert_eq!(payload["code"], "S218");
+        assert_eq!(payload["retryable"], true);
+    }
+
+    #[test]
+    fn fs_unsupported_surfaces_version_hint() {
+        let err = SandboxError::FsUnsupported;
+        let payload = err.to_payload();
+        assert_eq!(payload["code"], "S219");
+        assert!(
+            payload["message"]
+                .as_str()
+                .unwrap()
+                .contains("supervisor")
+        );
+    }
+
+    #[test]
+    fn fs_contract_mapping() {
+        let cases: &[(SandboxError, &str)] = &[
+            (SandboxError::FsInvalidRequest("bad mode".into()), "S210"),
+            (SandboxError::FsNotFound { path: "x".into() }, "S211"),
+            (SandboxError::FsWrongType { path: "x".into() }, "S212"),
+            (SandboxError::FsAlreadyExists { path: "x".into() }, "S213"),
+            (SandboxError::FsNotEmpty { path: "x".into() }, "S214"),
+            (SandboxError::FsPermission("x".into()), "S215"),
+            (SandboxError::FsIo("x".into()), "S216"),
+            (SandboxError::FsRegex("x".into()), "S217"),
+            (SandboxError::FsChannelAborted("x".into()), "S218"),
+            (SandboxError::FsUnsupported, "S219"),
+        ];
+        for (err, expected) in cases {
+            assert_eq!(err.code().as_str(), *expected, "case: {err:?}");
+        }
     }
 
     /// Wire ABI pin. SDKs receive the flat `to_payload()` shape via

--- a/crates/iii-worker/src/sandbox_daemon/errors.rs
+++ b/crates/iii-worker/src/sandbox_daemon/errors.rs
@@ -250,9 +250,7 @@ impl SandboxError {
         match err.kind() {
             std::io::ErrorKind::NotFound => Self::fs_not_found(path),
             std::io::ErrorKind::AlreadyExists => Self::fs_already_exists(path),
-            std::io::ErrorKind::PermissionDenied => {
-                Self::FsPermission(format!("{path}: {err}"))
-            }
+            std::io::ErrorKind::PermissionDenied => Self::FsPermission(format!("{path}: {err}")),
             _ => Self::FsIo(format!("{path}: {err}")),
         }
     }
@@ -325,12 +323,7 @@ mod tests {
         let err = SandboxError::FsUnsupported;
         let payload = err.to_payload();
         assert_eq!(payload["code"], "S219");
-        assert!(
-            payload["message"]
-                .as_str()
-                .unwrap()
-                .contains("supervisor")
-        );
+        assert!(payload["message"].as_str().unwrap().contains("supervisor"));
     }
 
     #[test]

--- a/crates/iii-worker/src/sandbox_daemon/fs/adapter.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/adapter.rs
@@ -46,11 +46,7 @@ pub fn map_vm_error(e: VmClientError) -> SandboxError {
 #[async_trait::async_trait]
 pub trait FsRunner: Send + Sync + 'static {
     /// Run a one-shot filesystem op (anything except WriteStart/ReadStart).
-    async fn fs_call(
-        &self,
-        shell_sock: PathBuf,
-        op: FsOp,
-    ) -> Result<FsResult, SandboxError>;
+    async fn fs_call(&self, shell_sock: PathBuf, op: FsOp) -> Result<FsResult, SandboxError>;
 
     /// Upload bytes from `reader` to `path` inside the guest.
     async fn fs_write_stream(
@@ -78,14 +74,8 @@ pub struct IiiShellFsRunner;
 
 #[async_trait::async_trait]
 impl FsRunner for IiiShellFsRunner {
-    async fn fs_call(
-        &self,
-        shell_sock: PathBuf,
-        op: FsOp,
-    ) -> Result<FsResult, SandboxError> {
-        let session = Session::connect(&shell_sock)
-            .await
-            .map_err(map_vm_error)?;
+    async fn fs_call(&self, shell_sock: PathBuf, op: FsOp) -> Result<FsResult, SandboxError> {
+        let session = Session::connect(&shell_sock).await.map_err(map_vm_error)?;
         session.fs_call(op).await.map_err(map_vm_error)
     }
 
@@ -97,9 +87,7 @@ impl FsRunner for IiiShellFsRunner {
         parents: bool,
         reader: Box<dyn tokio::io::AsyncRead + Unpin + Send>,
     ) -> Result<FsResult, SandboxError> {
-        let session = Session::connect(&shell_sock)
-            .await
-            .map_err(map_vm_error)?;
+        let session = Session::connect(&shell_sock).await.map_err(map_vm_error)?;
         session
             .fs_write_stream(path, mode, parents, reader)
             .await
@@ -111,9 +99,7 @@ impl FsRunner for IiiShellFsRunner {
         shell_sock: PathBuf,
         path: String,
     ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
-        let session = Session::connect(&shell_sock)
-            .await
-            .map_err(map_vm_error)?;
+        let session = Session::connect(&shell_sock).await.map_err(map_vm_error)?;
         let (meta, stream_reader) = session.fs_read_stream(path).await.map_err(map_vm_error)?;
         Ok((meta, Box::new(stream_reader)))
     }
@@ -267,12 +253,14 @@ mod tests {
                 VmClientError::WorkerMissing("/tmp/missing.sock: ENOENT".into())
             }),
             ("Permission", || VmClientError::Permission("EACCES".into())),
-            ("RelayDown", || VmClientError::RelayDown("relay panic".into())),
+            ("RelayDown", || {
+                VmClientError::RelayDown("relay panic".into())
+            }),
             ("AuthRejected", || {
                 VmClientError::AuthRejected("uid mismatch".into())
             }),
-            ("HandshakeTruncated", || {
-                VmClientError::HandshakeTruncated { got: 2 }
+            ("HandshakeTruncated", || VmClientError::HandshakeTruncated {
+                got: 2,
             }),
             ("WriteBlocked", || VmClientError::WriteBlocked),
             ("ProtocolViolation", || {
@@ -291,9 +279,9 @@ mod tests {
                         "missing prefix for {label}: {s}"
                     );
                 }
-                other => panic!(
-                    "non-FsError VmClientError must map to FsIo, got {other:?} for {label}"
-                ),
+                other => {
+                    panic!("non-FsError VmClientError must map to FsIo, got {other:?} for {label}")
+                }
             }
             assert_eq!(
                 mapped.to_payload()["code"],

--- a/crates/iii-worker/src/sandbox_daemon/fs/adapter.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/adapter.rs
@@ -1,0 +1,305 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+//! `FsRunner` trait + `IiiShellFsRunner` implementation.
+//!
+//! The trait is the seam used by unit tests: a `FakeRunner` implements it
+//! without touching any real sockets. `IiiShellFsRunner` opens a fresh
+//! `iii_shell_client::Session` per call and forwards to the supervisor.
+
+use std::path::PathBuf;
+
+use iii_shell_client::{Session, VmClientError};
+use iii_shell_proto::{FsOp, FsReadMeta, FsResult};
+
+use crate::sandbox_daemon::errors::SandboxError;
+
+// ---------------------------------------------------------------------------
+// Error mapping helpers
+// ---------------------------------------------------------------------------
+
+/// Map a `VmClientError` to the closest `SandboxError` variant, applying
+/// the S210–S219 code table when the error is a typed `FsError`.
+pub fn map_vm_error(e: VmClientError) -> SandboxError {
+    match e {
+        VmClientError::FsError { code, message } => match code.as_str() {
+            "S210" => SandboxError::FsInvalidRequest(message),
+            "S211" => SandboxError::fs_not_found(message),
+            "S212" => SandboxError::fs_wrong_type(message),
+            "S213" => SandboxError::fs_already_exists(message),
+            "S214" => SandboxError::fs_not_empty(message),
+            "S215" => SandboxError::FsPermission(message),
+            "S216" => SandboxError::FsIo(message),
+            "S217" => SandboxError::FsRegex(message),
+            "S218" => SandboxError::FsChannelAborted(message),
+            "S219" => SandboxError::FsUnsupported,
+            other => SandboxError::FsIo(format!("fs error {other}: {message}")),
+        },
+        other => SandboxError::FsIo(format!("shell client error: {other}")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FsRunner trait
+// ---------------------------------------------------------------------------
+
+#[async_trait::async_trait]
+pub trait FsRunner: Send + Sync + 'static {
+    /// Run a one-shot filesystem op (anything except WriteStart/ReadStart).
+    async fn fs_call(
+        &self,
+        shell_sock: PathBuf,
+        op: FsOp,
+    ) -> Result<FsResult, SandboxError>;
+
+    /// Upload bytes from `reader` to `path` inside the guest.
+    async fn fs_write_stream(
+        &self,
+        shell_sock: PathBuf,
+        path: String,
+        mode: String,
+        parents: bool,
+        reader: Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+    ) -> Result<FsResult, SandboxError>;
+
+    /// Begin a streaming download; returns `(meta, AsyncRead)`.
+    async fn fs_read_stream(
+        &self,
+        shell_sock: PathBuf,
+        path: String,
+    ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError>;
+}
+
+// ---------------------------------------------------------------------------
+// Production implementation
+// ---------------------------------------------------------------------------
+
+pub struct IiiShellFsRunner;
+
+#[async_trait::async_trait]
+impl FsRunner for IiiShellFsRunner {
+    async fn fs_call(
+        &self,
+        shell_sock: PathBuf,
+        op: FsOp,
+    ) -> Result<FsResult, SandboxError> {
+        let session = Session::connect(&shell_sock)
+            .await
+            .map_err(map_vm_error)?;
+        session.fs_call(op).await.map_err(map_vm_error)
+    }
+
+    async fn fs_write_stream(
+        &self,
+        shell_sock: PathBuf,
+        path: String,
+        mode: String,
+        parents: bool,
+        reader: Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+    ) -> Result<FsResult, SandboxError> {
+        let session = Session::connect(&shell_sock)
+            .await
+            .map_err(map_vm_error)?;
+        session
+            .fs_write_stream(path, mode, parents, reader)
+            .await
+            .map_err(map_vm_error)
+    }
+
+    async fn fs_read_stream(
+        &self,
+        shell_sock: PathBuf,
+        path: String,
+    ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+        let session = Session::connect(&shell_sock)
+            .await
+            .map_err(map_vm_error)?;
+        let (meta, stream_reader) = session.fs_read_stream(path).await.map_err(map_vm_error)?;
+        Ok((meta, Box::new(stream_reader)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Wire-ABI guard for the S210-S219 mapping.
+    //!
+    //! `IiiShellFsRunner` is the only place a wire S-code from the guest
+    //! supervisor is translated back into a typed `SandboxError` variant.
+    //! Every `sandbox::fs::*` trigger response — and therefore every SDK
+    //! caller — depends on this mapping being exact. A silent rename
+    //! here (e.g. someone refactors `FsNotFound { path }` to
+    //! `FsNotFoundAt { path }`) would change the wire `code`/`type` that
+    //! the SDK error JSON carries, breaking `if (err.code === 'S211')`
+    //! branches in caller code with no compile error.
+    //!
+    //! These tests pin the round trip:
+    //!     guest emits FsError { code, message }
+    //!     -> map_vm_error
+    //!     -> SandboxError::<variant>
+    //!     -> err.to_payload() carries the same { code, type }
+    //! for every code in the band, plus the catch-all paths.
+    //!
+    //! When this table changes, the SDK's documented error contract is
+    //! changing too — that's the signal the test exists to surface.
+
+    use super::*;
+
+    fn fs_err(code: &'static str) -> VmClientError {
+        VmClientError::FsError {
+            code: code.into(),
+            message: format!("simulated {code} from supervisor"),
+        }
+    }
+
+    /// Each wire code maps to a specific SandboxError variant whose
+    /// `to_payload()` round-trips back to the same `{ code, type }` pair.
+    /// Adding a new S21x code? Add a row. Renaming a variant? This test
+    /// will not compile until you update the row, which is the point.
+    #[test]
+    fn s21x_mapping_is_complete_and_round_trips() {
+        let cases: &[(&str, &str, fn(&SandboxError) -> bool)] = &[
+            ("S210", "filesystem", |e| {
+                matches!(e, SandboxError::FsInvalidRequest(_))
+            }),
+            ("S211", "filesystem", |e| {
+                matches!(e, SandboxError::FsNotFound { .. })
+            }),
+            ("S212", "filesystem", |e| {
+                matches!(e, SandboxError::FsWrongType { .. })
+            }),
+            ("S213", "filesystem", |e| {
+                matches!(e, SandboxError::FsAlreadyExists { .. })
+            }),
+            ("S214", "filesystem", |e| {
+                matches!(e, SandboxError::FsNotEmpty { .. })
+            }),
+            ("S215", "filesystem", |e| {
+                matches!(e, SandboxError::FsPermission(_))
+            }),
+            ("S216", "filesystem", |e| matches!(e, SandboxError::FsIo(_))),
+            ("S217", "filesystem", |e| {
+                matches!(e, SandboxError::FsRegex(_))
+            }),
+            ("S218", "transient", |e| {
+                matches!(e, SandboxError::FsChannelAborted(_))
+            }),
+            ("S219", "filesystem", |e| {
+                matches!(e, SandboxError::FsUnsupported)
+            }),
+        ];
+
+        for (code, expected_type, variant_check) in cases {
+            let mapped = map_vm_error(fs_err(code));
+            assert!(
+                variant_check(&mapped),
+                "code {code} mapped to wrong variant: {mapped:?}",
+            );
+            let payload = mapped.to_payload();
+            assert_eq!(
+                payload["code"], *code,
+                "code {code}: payload.code mismatch ({:?})",
+                payload["code"]
+            );
+            assert_eq!(
+                payload["type"], *expected_type,
+                "code {code}: payload.type mismatch ({:?})",
+                payload["type"]
+            );
+        }
+    }
+
+    /// `S218` is the only retryable code in the band — caller-side
+    /// channel aborts can succeed on retry once the caller wires a
+    /// fresh channel. Pin the retryable bit so a refactor of
+    /// `SandboxErrorCode::retryable` doesn't silently shift it.
+    #[test]
+    fn s218_is_the_only_retryable_fs_code() {
+        for code in &[
+            "S210", "S211", "S212", "S213", "S214", "S215", "S216", "S217", "S219",
+        ] {
+            let payload = map_vm_error(fs_err(code)).to_payload();
+            assert_eq!(
+                payload["retryable"], false,
+                "{code} should not be retryable"
+            );
+        }
+        let payload = map_vm_error(fs_err("S218")).to_payload();
+        assert_eq!(payload["retryable"], true, "S218 must be retryable");
+    }
+
+    /// Unknown S-codes (anything outside S210-S219) MUST surface as
+    /// FsIo with the original code preserved in the message — never
+    /// silently coerced to a typed variant. SDK callers branching on
+    /// `code` will see `S216` (their generic IO bucket) plus the
+    /// original wire string in the message for forensics.
+    #[test]
+    fn unknown_fs_code_falls_back_to_fs_io_with_code_in_message() {
+        let mapped = map_vm_error(VmClientError::FsError {
+            code: "S299".into(),
+            message: "future unknown thing".into(),
+        });
+        match &mapped {
+            SandboxError::FsIo(s) => {
+                assert!(s.contains("S299"), "code preserved in message: {s}");
+                assert!(s.contains("future unknown thing"), "msg preserved: {s}");
+            }
+            other => panic!("expected FsIo, got {other:?}"),
+        }
+        // And the wire payload uses S216 (FsIo's code) as the generic bucket.
+        assert_eq!(mapped.to_payload()["code"], "S216");
+    }
+
+    /// Every non-`FsError` `VmClientError` variant — connection failures,
+    /// protocol violations, write timeouts, EOF — funnels into FsIo with
+    /// the `"shell client error: "` prefix. The prefix is what callers
+    /// see in the message field of the trigger response, so it's part
+    /// of the public surface; pin it.
+    ///
+    /// `VmClientError` is not `Clone`, so each iteration builds a fresh
+    /// value via the constructor closure.
+    #[test]
+    fn non_fs_vm_errors_become_shell_client_fs_io() {
+        // Each entry: (label, constructor). Label is for the panic
+        // message; constructor builds a fresh `VmClientError` value.
+        let cases: &[(&str, fn() -> VmClientError)] = &[
+            ("SessionTerminated", || VmClientError::SessionTerminated),
+            ("WorkerMissing", || {
+                VmClientError::WorkerMissing("/tmp/missing.sock: ENOENT".into())
+            }),
+            ("Permission", || VmClientError::Permission("EACCES".into())),
+            ("RelayDown", || VmClientError::RelayDown("relay panic".into())),
+            ("AuthRejected", || {
+                VmClientError::AuthRejected("uid mismatch".into())
+            }),
+            ("HandshakeTruncated", || {
+                VmClientError::HandshakeTruncated { got: 2 }
+            }),
+            ("WriteBlocked", || VmClientError::WriteBlocked),
+            ("ProtocolViolation", || {
+                VmClientError::ProtocolViolation("bad frame".into())
+            }),
+            ("DispatcherError", || {
+                VmClientError::DispatcherError("guest spawn failed".into())
+            }),
+        ];
+        for (label, build) in cases {
+            let mapped = map_vm_error(build());
+            match &mapped {
+                SandboxError::FsIo(s) => {
+                    assert!(
+                        s.starts_with("shell client error: "),
+                        "missing prefix for {label}: {s}"
+                    );
+                }
+                other => panic!(
+                    "non-FsError VmClientError must map to FsIo, got {other:?} for {label}"
+                ),
+            }
+            assert_eq!(
+                mapped.to_payload()["code"],
+                "S216",
+                "{label} should land on the FsIo S216 bucket"
+            );
+        }
+    }
+}

--- a/crates/iii-worker/src/sandbox_daemon/fs/chmod.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/chmod.rs
@@ -1,0 +1,221 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use iii_sdk::{IIIError, RegisterFunctionMessage};
+use iii_shell_proto::{FsOp, FsResult};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+
+#[derive(Debug, Deserialize)]
+pub struct ChmodRequest {
+    pub sandbox_id: String,
+    pub path: String,
+    pub mode: String,
+    #[serde(default)]
+    pub uid: Option<u32>,
+    #[serde(default)]
+    pub gid: Option<u32>,
+    #[serde(default)]
+    pub recursive: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChmodResponse {
+    pub updated: u64,
+}
+
+pub async fn handle_chmod<R: FsRunner + ?Sized>(
+    req: ChmodRequest,
+    registry: &SandboxRegistry,
+    runner: &R,
+) -> Result<ChmodResponse, SandboxError> {
+    let id = Uuid::parse_str(&req.sandbox_id).map_err(|_| {
+        SandboxError::InvalidRequest(format!(
+            "sandbox_id is not a valid UUID: {}",
+            req.sandbox_id
+        ))
+    })?;
+    let state = registry.get(id).await?;
+    if state.stopped {
+        return Err(SandboxError::AlreadyStopped(id.to_string()));
+    }
+    registry.bump_last_exec(id).await;
+
+    let result = runner
+        .fs_call(
+            state.shell_sock,
+            FsOp::Chmod {
+                path: req.path,
+                mode: req.mode,
+                uid: req.uid,
+                gid: req.gid,
+                recursive: req.recursive,
+            },
+        )
+        .await?;
+
+    match result {
+        FsResult::Chmod { updated } => Ok(ChmodResponse { updated }),
+        other => Err(SandboxError::FsIo(format!(
+            "expected Chmod result, got {other:?}"
+        ))),
+    }
+}
+
+pub(super) fn register(
+    iii: &iii_sdk::III,
+    registry: Arc<SandboxRegistry>,
+    runner: Arc<dyn FsRunner>,
+) {
+    let handler = move |payload: Value| {
+        let registry = registry.clone();
+        let runner = runner.clone();
+        Box::pin(async move {
+            let req: ChmodRequest = serde_json::from_value(payload)
+                .map_err(|e| IIIError::Handler(format!("bad request: {e}")))?;
+            match handle_chmod(req, &registry, &*runner).await {
+                Ok(resp) => serde_json::to_value(resp)
+                    .map_err(|e| IIIError::Handler(format!("serialize: {e}"))),
+                Err(e) => Err(IIIError::Handler(
+                    serde_json::to_string(&e.to_payload()).unwrap_or_else(|_| e.to_string()),
+                )),
+            }
+        }) as Pin<Box<dyn Future<Output = Result<Value, IIIError>> + Send>>
+    };
+    let _ = iii.register_function_with(
+        RegisterFunctionMessage {
+            id: "sandbox::fs::chmod".to_string(),
+            description: Some("Change file permissions inside a sandbox".to_string()),
+            request_format: None,
+            response_format: None,
+            metadata: None,
+            invocation: None,
+        },
+        handler,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox_daemon::{fs::adapter::FsRunner, registry::SandboxState};
+    use iii_shell_proto::{FsOp, FsReadMeta, FsResult};
+    use std::path::PathBuf;
+    use std::time::Instant;
+
+    struct FakeRunner;
+
+    #[async_trait::async_trait]
+    impl FsRunner for FakeRunner {
+        async fn fs_call(
+            &self,
+            _shell_sock: PathBuf,
+            _op: FsOp,
+        ) -> Result<FsResult, SandboxError> {
+            Ok(FsResult::Chmod { updated: 3 })
+        }
+        async fn fs_write_stream(
+            &self,
+            _shell_sock: PathBuf,
+            _path: String,
+            _mode: String,
+            _parents: bool,
+            _reader: Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+        ) -> Result<FsResult, SandboxError> {
+            unimplemented!()
+        }
+        async fn fs_read_stream(
+            &self,
+            _shell_sock: PathBuf,
+            _path: String,
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+            unimplemented!()
+        }
+    }
+
+    fn make_state(id: Uuid) -> SandboxState {
+        SandboxState {
+            id,
+            name: None,
+            image: "python".into(),
+            rootfs: PathBuf::from("/tmp/r"),
+            workdir: PathBuf::from("/tmp/w"),
+            shell_sock: PathBuf::from("/tmp/s"),
+            vm_pid: Some(1),
+            created_at: Instant::now(),
+            last_exec_at: Instant::now(),
+            exec_in_progress: false,
+            idle_timeout_secs: 300,
+            stopped: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn happy_path_returns_updated() {
+        let reg = SandboxRegistry::new();
+        let id = Uuid::new_v4();
+        reg.insert(make_state(id)).await;
+        let resp = handle_chmod(
+            ChmodRequest {
+                sandbox_id: id.to_string(),
+                path: "/workspace".into(),
+                mode: "0755".into(),
+                uid: None,
+                gid: None,
+                recursive: false,
+            },
+            &reg,
+            &FakeRunner,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.updated, 3);
+    }
+
+    #[tokio::test]
+    async fn bad_uuid_returns_s001() {
+        let reg = SandboxRegistry::new();
+        let err = handle_chmod(
+            ChmodRequest {
+                sandbox_id: "bad".into(),
+                path: "/".into(),
+                mode: "0755".into(),
+                uid: None,
+                gid: None,
+                recursive: false,
+            },
+            &reg,
+            &FakeRunner,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code().as_str(), "S001");
+    }
+
+    #[tokio::test]
+    async fn missing_sandbox_returns_s002() {
+        let reg = SandboxRegistry::new();
+        let err = handle_chmod(
+            ChmodRequest {
+                sandbox_id: Uuid::new_v4().to_string(),
+                path: "/".into(),
+                mode: "0755".into(),
+                uid: None,
+                gid: None,
+                recursive: false,
+            },
+            &reg,
+            &FakeRunner,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code().as_str(), "S002");
+    }
+}

--- a/crates/iii-worker/src/sandbox_daemon/fs/chmod.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/chmod.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+use crate::sandbox_daemon::{
+    errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry,
+};
 
 #[derive(Debug, Deserialize)]
 pub struct ChmodRequest {
@@ -114,11 +116,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl FsRunner for FakeRunner {
-        async fn fs_call(
-            &self,
-            _shell_sock: PathBuf,
-            _op: FsOp,
-        ) -> Result<FsResult, SandboxError> {
+        async fn fs_call(&self, _shell_sock: PathBuf, _op: FsOp) -> Result<FsResult, SandboxError> {
             Ok(FsResult::Chmod { updated: 3 })
         }
         async fn fs_write_stream(
@@ -135,7 +133,8 @@ mod tests {
             &self,
             _shell_sock: PathBuf,
             _path: String,
-        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError>
+        {
             unimplemented!()
         }
     }

--- a/crates/iii-worker/src/sandbox_daemon/fs/grep.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/grep.rs
@@ -1,0 +1,237 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use iii_sdk::{IIIError, RegisterFunctionMessage};
+use iii_shell_proto::{FsMatch, FsOp, FsResult};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+
+#[derive(Debug, Deserialize)]
+pub struct GrepRequest {
+    pub sandbox_id: String,
+    pub path: String,
+    pub pattern: String,
+    #[serde(default = "default_recursive")]
+    pub recursive: bool,
+    #[serde(default)]
+    pub ignore_case: bool,
+    #[serde(default)]
+    pub include_glob: Vec<String>,
+    #[serde(default)]
+    pub exclude_glob: Vec<String>,
+    #[serde(default = "default_max_matches")]
+    pub max_matches: u64,
+    #[serde(default = "default_max_line_bytes")]
+    pub max_line_bytes: u64,
+}
+
+fn default_recursive() -> bool { true }
+fn default_max_matches() -> u64 { 10_000 }
+fn default_max_line_bytes() -> u64 { 4096 }
+
+#[derive(Debug, Serialize)]
+pub struct GrepResponse {
+    pub matches: Vec<FsMatch>,
+    pub truncated: bool,
+}
+
+pub async fn handle_grep<R: FsRunner + ?Sized>(
+    req: GrepRequest,
+    registry: &SandboxRegistry,
+    runner: &R,
+) -> Result<GrepResponse, SandboxError> {
+    let id = Uuid::parse_str(&req.sandbox_id).map_err(|_| {
+        SandboxError::InvalidRequest(format!(
+            "sandbox_id is not a valid UUID: {}",
+            req.sandbox_id
+        ))
+    })?;
+    let state = registry.get(id).await?;
+    if state.stopped {
+        return Err(SandboxError::AlreadyStopped(id.to_string()));
+    }
+    registry.bump_last_exec(id).await;
+
+    let result = runner
+        .fs_call(
+            state.shell_sock,
+            FsOp::Grep {
+                path: req.path,
+                pattern: req.pattern,
+                recursive: req.recursive,
+                ignore_case: req.ignore_case,
+                include_glob: req.include_glob,
+                exclude_glob: req.exclude_glob,
+                max_matches: req.max_matches,
+                max_line_bytes: req.max_line_bytes,
+            },
+        )
+        .await?;
+
+    match result {
+        FsResult::Grep { matches, truncated } => Ok(GrepResponse { matches, truncated }),
+        other => Err(SandboxError::FsIo(format!(
+            "expected Grep result, got {other:?}"
+        ))),
+    }
+}
+
+pub(super) fn register(
+    iii: &iii_sdk::III,
+    registry: Arc<SandboxRegistry>,
+    runner: Arc<dyn FsRunner>,
+) {
+    let handler = move |payload: Value| {
+        let registry = registry.clone();
+        let runner = runner.clone();
+        Box::pin(async move {
+            let req: GrepRequest = serde_json::from_value(payload)
+                .map_err(|e| IIIError::Handler(format!("bad request: {e}")))?;
+            match handle_grep(req, &registry, &*runner).await {
+                Ok(resp) => serde_json::to_value(resp)
+                    .map_err(|e| IIIError::Handler(format!("serialize: {e}"))),
+                Err(e) => Err(IIIError::Handler(
+                    serde_json::to_string(&e.to_payload()).unwrap_or_else(|_| e.to_string()),
+                )),
+            }
+        }) as Pin<Box<dyn Future<Output = Result<Value, IIIError>> + Send>>
+    };
+    let _ = iii.register_function_with(
+        RegisterFunctionMessage {
+            id: "sandbox::fs::grep".to_string(),
+            description: Some("Search for a pattern in files inside a sandbox".to_string()),
+            request_format: None,
+            response_format: None,
+            metadata: None,
+            invocation: None,
+        },
+        handler,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox_daemon::{fs::adapter::FsRunner, registry::SandboxState};
+    use iii_shell_proto::{FsMatch, FsOp, FsReadMeta, FsResult};
+    use std::path::PathBuf;
+    use std::time::Instant;
+
+    struct FakeRunner {
+        matches: Vec<FsMatch>,
+    }
+
+    #[async_trait::async_trait]
+    impl FsRunner for FakeRunner {
+        async fn fs_call(
+            &self,
+            _shell_sock: PathBuf,
+            _op: FsOp,
+        ) -> Result<FsResult, SandboxError> {
+            Ok(FsResult::Grep { matches: self.matches.clone(), truncated: false })
+        }
+        async fn fs_write_stream(
+            &self,
+            _shell_sock: PathBuf,
+            _path: String,
+            _mode: String,
+            _parents: bool,
+            _reader: Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+        ) -> Result<FsResult, SandboxError> {
+            unimplemented!()
+        }
+        async fn fs_read_stream(
+            &self,
+            _shell_sock: PathBuf,
+            _path: String,
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+            unimplemented!()
+        }
+    }
+
+    fn make_state(id: Uuid) -> SandboxState {
+        SandboxState {
+            id,
+            name: None,
+            image: "python".into(),
+            rootfs: PathBuf::from("/tmp/r"),
+            workdir: PathBuf::from("/tmp/w"),
+            shell_sock: PathBuf::from("/tmp/s"),
+            vm_pid: Some(1),
+            created_at: Instant::now(),
+            last_exec_at: Instant::now(),
+            exec_in_progress: false,
+            idle_timeout_secs: 300,
+            stopped: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn happy_path_returns_matches() {
+        let reg = SandboxRegistry::new();
+        let id = Uuid::new_v4();
+        reg.insert(make_state(id)).await;
+        let runner = FakeRunner {
+            matches: vec![FsMatch { path: "a.py".into(), line: 1, content: "hello".into() }],
+        };
+        let req = GrepRequest {
+            sandbox_id: id.to_string(),
+            path: "/workspace".into(),
+            pattern: "hello".into(),
+            recursive: true,
+            ignore_case: false,
+            include_glob: vec![],
+            exclude_glob: vec![],
+            max_matches: 10_000,
+            max_line_bytes: 4096,
+        };
+        let resp = handle_grep(req, &reg, &runner).await.unwrap();
+        assert_eq!(resp.matches.len(), 1);
+        assert!(!resp.truncated);
+    }
+
+    #[tokio::test]
+    async fn bad_uuid_returns_s001() {
+        let reg = SandboxRegistry::new();
+        let runner = FakeRunner { matches: vec![] };
+        let req = GrepRequest {
+            sandbox_id: "bad".into(),
+            path: "/".into(),
+            pattern: "x".into(),
+            recursive: true,
+            ignore_case: false,
+            include_glob: vec![],
+            exclude_glob: vec![],
+            max_matches: 100,
+            max_line_bytes: 4096,
+        };
+        let err = handle_grep(req, &reg, &runner).await.unwrap_err();
+        assert_eq!(err.code().as_str(), "S001");
+    }
+
+    #[tokio::test]
+    async fn missing_sandbox_returns_s002() {
+        let reg = SandboxRegistry::new();
+        let runner = FakeRunner { matches: vec![] };
+        let req = GrepRequest {
+            sandbox_id: Uuid::new_v4().to_string(),
+            path: "/".into(),
+            pattern: "x".into(),
+            recursive: true,
+            ignore_case: false,
+            include_glob: vec![],
+            exclude_glob: vec![],
+            max_matches: 100,
+            max_line_bytes: 4096,
+        };
+        let err = handle_grep(req, &reg, &runner).await.unwrap_err();
+        assert_eq!(err.code().as_str(), "S002");
+    }
+}

--- a/crates/iii-worker/src/sandbox_daemon/fs/grep.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/grep.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+use crate::sandbox_daemon::{
+    errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry,
+};
 
 #[derive(Debug, Deserialize)]
 pub struct GrepRequest {
@@ -32,9 +34,15 @@ pub struct GrepRequest {
     pub max_line_bytes: u64,
 }
 
-fn default_recursive() -> bool { true }
-fn default_max_matches() -> u64 { 10_000 }
-fn default_max_line_bytes() -> u64 { 4096 }
+fn default_recursive() -> bool {
+    true
+}
+fn default_max_matches() -> u64 {
+    10_000
+}
+fn default_max_line_bytes() -> u64 {
+    4096
+}
 
 #[derive(Debug, Serialize)]
 pub struct GrepResponse {
@@ -130,12 +138,11 @@ mod tests {
 
     #[async_trait::async_trait]
     impl FsRunner for FakeRunner {
-        async fn fs_call(
-            &self,
-            _shell_sock: PathBuf,
-            _op: FsOp,
-        ) -> Result<FsResult, SandboxError> {
-            Ok(FsResult::Grep { matches: self.matches.clone(), truncated: false })
+        async fn fs_call(&self, _shell_sock: PathBuf, _op: FsOp) -> Result<FsResult, SandboxError> {
+            Ok(FsResult::Grep {
+                matches: self.matches.clone(),
+                truncated: false,
+            })
         }
         async fn fs_write_stream(
             &self,
@@ -151,7 +158,8 @@ mod tests {
             &self,
             _shell_sock: PathBuf,
             _path: String,
-        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError>
+        {
             unimplemented!()
         }
     }
@@ -179,7 +187,11 @@ mod tests {
         let id = Uuid::new_v4();
         reg.insert(make_state(id)).await;
         let runner = FakeRunner {
-            matches: vec![FsMatch { path: "a.py".into(), line: 1, content: "hello".into() }],
+            matches: vec![FsMatch {
+                path: "a.py".into(),
+                line: 1,
+                content: "hello".into(),
+            }],
         };
         let req = GrepRequest {
             sandbox_id: id.to_string(),

--- a/crates/iii-worker/src/sandbox_daemon/fs/ls.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/ls.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+use crate::sandbox_daemon::{
+    errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry,
+};
 
 #[derive(Debug, Deserialize)]
 pub struct LsRequest {
@@ -100,11 +102,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl FsRunner for FakeRunner {
-        async fn fs_call(
-            &self,
-            _shell_sock: PathBuf,
-            _op: FsOp,
-        ) -> Result<FsResult, SandboxError> {
+        async fn fs_call(&self, _shell_sock: PathBuf, _op: FsOp) -> Result<FsResult, SandboxError> {
             Ok(FsResult::Ls {
                 entries: self.entries.clone(),
             })
@@ -123,7 +121,8 @@ mod tests {
             &self,
             _shell_sock: PathBuf,
             _path: String,
-        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError>
+        {
             unimplemented!()
         }
     }

--- a/crates/iii-worker/src/sandbox_daemon/fs/ls.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/ls.rs
@@ -1,0 +1,195 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use iii_sdk::{IIIError, RegisterFunctionMessage};
+use iii_shell_proto::{FsEntry, FsOp, FsResult};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+
+#[derive(Debug, Deserialize)]
+pub struct LsRequest {
+    pub sandbox_id: String,
+    pub path: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LsResponse {
+    pub entries: Vec<FsEntry>,
+}
+
+pub async fn handle_ls<R: FsRunner + ?Sized>(
+    req: LsRequest,
+    registry: &SandboxRegistry,
+    runner: &R,
+) -> Result<LsResponse, SandboxError> {
+    let id = Uuid::parse_str(&req.sandbox_id).map_err(|_| {
+        SandboxError::InvalidRequest(format!(
+            "sandbox_id is not a valid UUID: {}",
+            req.sandbox_id
+        ))
+    })?;
+    let state = registry.get(id).await?;
+    if state.stopped {
+        return Err(SandboxError::AlreadyStopped(id.to_string()));
+    }
+    registry.bump_last_exec(id).await;
+
+    let result = runner
+        .fs_call(state.shell_sock, FsOp::Ls { path: req.path })
+        .await?;
+
+    match result {
+        FsResult::Ls { entries } => Ok(LsResponse { entries }),
+        other => Err(SandboxError::FsIo(format!(
+            "expected Ls result, got {other:?}"
+        ))),
+    }
+}
+
+pub(super) fn register(
+    iii: &iii_sdk::III,
+    registry: Arc<SandboxRegistry>,
+    runner: Arc<dyn FsRunner>,
+) {
+    let handler = move |payload: Value| {
+        let registry = registry.clone();
+        let runner = runner.clone();
+        Box::pin(async move {
+            let req: LsRequest = serde_json::from_value(payload)
+                .map_err(|e| IIIError::Handler(format!("bad request: {e}")))?;
+            match handle_ls(req, &registry, &*runner).await {
+                Ok(resp) => serde_json::to_value(resp)
+                    .map_err(|e| IIIError::Handler(format!("serialize: {e}"))),
+                Err(e) => Err(IIIError::Handler(
+                    serde_json::to_string(&e.to_payload()).unwrap_or_else(|_| e.to_string()),
+                )),
+            }
+        }) as Pin<Box<dyn Future<Output = Result<Value, IIIError>> + Send>>
+    };
+    let _ = iii.register_function_with(
+        RegisterFunctionMessage {
+            id: "sandbox::fs::ls".to_string(),
+            description: Some("List directory contents inside a sandbox".to_string()),
+            request_format: None,
+            response_format: None,
+            metadata: None,
+            invocation: None,
+        },
+        handler,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox_daemon::{fs::adapter::FsRunner, registry::SandboxState};
+    use iii_shell_proto::{FsEntry, FsReadMeta, FsResult};
+    use std::path::PathBuf;
+    use std::time::Instant;
+
+    struct FakeRunner {
+        entries: Vec<FsEntry>,
+    }
+
+    #[async_trait::async_trait]
+    impl FsRunner for FakeRunner {
+        async fn fs_call(
+            &self,
+            _shell_sock: PathBuf,
+            _op: FsOp,
+        ) -> Result<FsResult, SandboxError> {
+            Ok(FsResult::Ls {
+                entries: self.entries.clone(),
+            })
+        }
+        async fn fs_write_stream(
+            &self,
+            _shell_sock: PathBuf,
+            _path: String,
+            _mode: String,
+            _parents: bool,
+            _reader: Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+        ) -> Result<FsResult, SandboxError> {
+            unimplemented!()
+        }
+        async fn fs_read_stream(
+            &self,
+            _shell_sock: PathBuf,
+            _path: String,
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+            unimplemented!()
+        }
+    }
+
+    fn make_state(id: Uuid) -> SandboxState {
+        SandboxState {
+            id,
+            name: None,
+            image: "python".into(),
+            rootfs: PathBuf::from("/tmp/r"),
+            workdir: PathBuf::from("/tmp/w"),
+            shell_sock: PathBuf::from("/tmp/s"),
+            vm_pid: Some(1),
+            created_at: Instant::now(),
+            last_exec_at: Instant::now(),
+            exec_in_progress: false,
+            idle_timeout_secs: 300,
+            stopped: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn happy_path_returns_entries() {
+        let reg = SandboxRegistry::new();
+        let id = Uuid::new_v4();
+        reg.insert(make_state(id)).await;
+        let runner = FakeRunner {
+            entries: vec![FsEntry {
+                name: "hello.txt".into(),
+                is_dir: false,
+                size: 5,
+                mode: "0644".into(),
+                mtime: 0,
+                is_symlink: false,
+            }],
+        };
+        let req = LsRequest {
+            sandbox_id: id.to_string(),
+            path: "/workspace".into(),
+        };
+        let resp = handle_ls(req, &reg, &runner).await.unwrap();
+        assert_eq!(resp.entries.len(), 1);
+        assert_eq!(resp.entries[0].name, "hello.txt");
+    }
+
+    #[tokio::test]
+    async fn bad_uuid_returns_s001() {
+        let reg = SandboxRegistry::new();
+        let runner = FakeRunner { entries: vec![] };
+        let req = LsRequest {
+            sandbox_id: "not-a-uuid".into(),
+            path: "/".into(),
+        };
+        let err = handle_ls(req, &reg, &runner).await.unwrap_err();
+        assert_eq!(err.code().as_str(), "S001");
+    }
+
+    #[tokio::test]
+    async fn missing_sandbox_returns_s002() {
+        let reg = SandboxRegistry::new();
+        let runner = FakeRunner { entries: vec![] };
+        let req = LsRequest {
+            sandbox_id: Uuid::new_v4().to_string(),
+            path: "/".into(),
+        };
+        let err = handle_ls(req, &reg, &runner).await.unwrap_err();
+        assert_eq!(err.code().as_str(), "S002");
+    }
+}

--- a/crates/iii-worker/src/sandbox_daemon/fs/mkdir.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/mkdir.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+use crate::sandbox_daemon::{
+    errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry,
+};
 
 #[derive(Debug, Deserialize)]
 pub struct MkdirRequest {
@@ -113,11 +115,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl FsRunner for FakeRunner {
-        async fn fs_call(
-            &self,
-            _shell_sock: PathBuf,
-            _op: FsOp,
-        ) -> Result<FsResult, SandboxError> {
+        async fn fs_call(&self, _shell_sock: PathBuf, _op: FsOp) -> Result<FsResult, SandboxError> {
             Ok(FsResult::Mkdir { created: true })
         }
         async fn fs_write_stream(
@@ -134,7 +132,8 @@ mod tests {
             &self,
             _shell_sock: PathBuf,
             _path: String,
-        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError>
+        {
             unimplemented!()
         }
     }

--- a/crates/iii-worker/src/sandbox_daemon/fs/mkdir.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/mkdir.rs
@@ -1,0 +1,209 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use iii_sdk::{IIIError, RegisterFunctionMessage};
+use iii_shell_proto::{FsOp, FsResult};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+
+#[derive(Debug, Deserialize)]
+pub struct MkdirRequest {
+    pub sandbox_id: String,
+    pub path: String,
+    #[serde(default = "default_mode")]
+    pub mode: String,
+    #[serde(default)]
+    pub parents: bool,
+}
+
+fn default_mode() -> String {
+    "0755".to_string()
+}
+
+#[derive(Debug, Serialize)]
+pub struct MkdirResponse {
+    pub created: bool,
+}
+
+pub async fn handle_mkdir<R: FsRunner + ?Sized>(
+    req: MkdirRequest,
+    registry: &SandboxRegistry,
+    runner: &R,
+) -> Result<MkdirResponse, SandboxError> {
+    let id = Uuid::parse_str(&req.sandbox_id).map_err(|_| {
+        SandboxError::InvalidRequest(format!(
+            "sandbox_id is not a valid UUID: {}",
+            req.sandbox_id
+        ))
+    })?;
+    let state = registry.get(id).await?;
+    if state.stopped {
+        return Err(SandboxError::AlreadyStopped(id.to_string()));
+    }
+    registry.bump_last_exec(id).await;
+
+    let result = runner
+        .fs_call(
+            state.shell_sock,
+            FsOp::Mkdir {
+                path: req.path,
+                mode: req.mode,
+                parents: req.parents,
+            },
+        )
+        .await?;
+
+    match result {
+        FsResult::Mkdir { created } => Ok(MkdirResponse { created }),
+        other => Err(SandboxError::FsIo(format!(
+            "expected Mkdir result, got {other:?}"
+        ))),
+    }
+}
+
+pub(super) fn register(
+    iii: &iii_sdk::III,
+    registry: Arc<SandboxRegistry>,
+    runner: Arc<dyn FsRunner>,
+) {
+    let handler = move |payload: Value| {
+        let registry = registry.clone();
+        let runner = runner.clone();
+        Box::pin(async move {
+            let req: MkdirRequest = serde_json::from_value(payload)
+                .map_err(|e| IIIError::Handler(format!("bad request: {e}")))?;
+            match handle_mkdir(req, &registry, &*runner).await {
+                Ok(resp) => serde_json::to_value(resp)
+                    .map_err(|e| IIIError::Handler(format!("serialize: {e}"))),
+                Err(e) => Err(IIIError::Handler(
+                    serde_json::to_string(&e.to_payload()).unwrap_or_else(|_| e.to_string()),
+                )),
+            }
+        }) as Pin<Box<dyn Future<Output = Result<Value, IIIError>> + Send>>
+    };
+    let _ = iii.register_function_with(
+        RegisterFunctionMessage {
+            id: "sandbox::fs::mkdir".to_string(),
+            description: Some("Create a directory inside a sandbox".to_string()),
+            request_format: None,
+            response_format: None,
+            metadata: None,
+            invocation: None,
+        },
+        handler,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox_daemon::{fs::adapter::FsRunner, registry::SandboxState};
+    use iii_shell_proto::{FsOp, FsReadMeta, FsResult};
+    use std::path::PathBuf;
+    use std::time::Instant;
+
+    struct FakeRunner;
+
+    #[async_trait::async_trait]
+    impl FsRunner for FakeRunner {
+        async fn fs_call(
+            &self,
+            _shell_sock: PathBuf,
+            _op: FsOp,
+        ) -> Result<FsResult, SandboxError> {
+            Ok(FsResult::Mkdir { created: true })
+        }
+        async fn fs_write_stream(
+            &self,
+            _shell_sock: PathBuf,
+            _path: String,
+            _mode: String,
+            _parents: bool,
+            _reader: Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+        ) -> Result<FsResult, SandboxError> {
+            unimplemented!()
+        }
+        async fn fs_read_stream(
+            &self,
+            _shell_sock: PathBuf,
+            _path: String,
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+            unimplemented!()
+        }
+    }
+
+    fn make_state(id: Uuid) -> SandboxState {
+        SandboxState {
+            id,
+            name: None,
+            image: "python".into(),
+            rootfs: PathBuf::from("/tmp/r"),
+            workdir: PathBuf::from("/tmp/w"),
+            shell_sock: PathBuf::from("/tmp/s"),
+            vm_pid: Some(1),
+            created_at: Instant::now(),
+            last_exec_at: Instant::now(),
+            exec_in_progress: false,
+            idle_timeout_secs: 300,
+            stopped: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn happy_path_returns_created() {
+        let reg = SandboxRegistry::new();
+        let id = Uuid::new_v4();
+        reg.insert(make_state(id)).await;
+        let req = MkdirRequest {
+            sandbox_id: id.to_string(),
+            path: "/workspace/newdir".into(),
+            mode: "0755".into(),
+            parents: false,
+        };
+        let resp = handle_mkdir(req, &reg, &FakeRunner).await.unwrap();
+        assert!(resp.created);
+    }
+
+    #[tokio::test]
+    async fn bad_uuid_returns_s001() {
+        let reg = SandboxRegistry::new();
+        let err = handle_mkdir(
+            MkdirRequest {
+                sandbox_id: "not-a-uuid".into(),
+                path: "/".into(),
+                mode: "0755".into(),
+                parents: false,
+            },
+            &reg,
+            &FakeRunner,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code().as_str(), "S001");
+    }
+
+    #[tokio::test]
+    async fn missing_sandbox_returns_s002() {
+        let reg = SandboxRegistry::new();
+        let err = handle_mkdir(
+            MkdirRequest {
+                sandbox_id: Uuid::new_v4().to_string(),
+                path: "/".into(),
+                mode: "0755".into(),
+                parents: false,
+            },
+            &reg,
+            &FakeRunner,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code().as_str(), "S002");
+    }
+}

--- a/crates/iii-worker/src/sandbox_daemon/fs/mod.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/mod.rs
@@ -27,11 +27,7 @@ use std::sync::Arc;
 use crate::sandbox_daemon::registry::SandboxRegistry;
 
 /// Register all ten `sandbox::fs::*` triggers with the III engine.
-pub fn register_all(
-    iii: &iii_sdk::III,
-    registry: Arc<SandboxRegistry>,
-    runner: Arc<dyn FsRunner>,
-) {
+pub fn register_all(iii: &iii_sdk::III, registry: Arc<SandboxRegistry>, runner: Arc<dyn FsRunner>) {
     ls::register(iii, registry.clone(), runner.clone());
     stat::register(iii, registry.clone(), runner.clone());
     mkdir::register(iii, registry.clone(), runner.clone());

--- a/crates/iii-worker/src/sandbox_daemon/fs/mod.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/mod.rs
@@ -1,0 +1,45 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+//! `sandbox::fs::*` worker triggers — ten operations exposed as III functions.
+//!
+//! Each operation is implemented in its own sub-module following the same
+//! pattern as `sandbox_daemon::exec`: typed request/response structs, a
+//! pure `handle_*` function testable with a `FakeRunner`, and a
+//! `register(iii, registry, runner)` function wired up by `register_all`.
+
+pub mod adapter;
+pub mod chmod;
+pub mod grep;
+pub mod ls;
+pub mod mkdir;
+pub mod mv;
+pub mod read;
+pub mod rm;
+pub mod sed;
+pub mod stat;
+pub mod write;
+
+pub use adapter::{FsRunner, IiiShellFsRunner};
+
+use std::sync::Arc;
+
+use crate::sandbox_daemon::registry::SandboxRegistry;
+
+/// Register all ten `sandbox::fs::*` triggers with the III engine.
+pub fn register_all(
+    iii: &iii_sdk::III,
+    registry: Arc<SandboxRegistry>,
+    runner: Arc<dyn FsRunner>,
+) {
+    ls::register(iii, registry.clone(), runner.clone());
+    stat::register(iii, registry.clone(), runner.clone());
+    mkdir::register(iii, registry.clone(), runner.clone());
+    rm::register(iii, registry.clone(), runner.clone());
+    chmod::register(iii, registry.clone(), runner.clone());
+    mv::register(iii, registry.clone(), runner.clone());
+    grep::register(iii, registry.clone(), runner.clone());
+    sed::register(iii, registry.clone(), runner.clone());
+    write::register(iii, registry.clone(), runner.clone());
+    read::register(iii, registry.clone(), runner.clone());
+}

--- a/crates/iii-worker/src/sandbox_daemon/fs/mv.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/mv.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+use crate::sandbox_daemon::{
+    errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry,
+};
 
 #[derive(Debug, Deserialize)]
 pub struct MvRequest {
@@ -47,7 +49,11 @@ pub async fn handle_mv<R: FsRunner + ?Sized>(
     let result = runner
         .fs_call(
             state.shell_sock,
-            FsOp::Mv { src: req.src, dst: req.dst, overwrite: req.overwrite },
+            FsOp::Mv {
+                src: req.src,
+                dst: req.dst,
+                overwrite: req.overwrite,
+            },
         )
         .await?;
 
@@ -104,11 +110,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl FsRunner for FakeRunner {
-        async fn fs_call(
-            &self,
-            _shell_sock: PathBuf,
-            _op: FsOp,
-        ) -> Result<FsResult, SandboxError> {
+        async fn fs_call(&self, _shell_sock: PathBuf, _op: FsOp) -> Result<FsResult, SandboxError> {
             Ok(FsResult::Mv { moved: true })
         }
         async fn fs_write_stream(
@@ -125,7 +127,8 @@ mod tests {
             &self,
             _shell_sock: PathBuf,
             _path: String,
-        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError>
+        {
             unimplemented!()
         }
     }
@@ -171,7 +174,12 @@ mod tests {
     async fn bad_uuid_returns_s001() {
         let reg = SandboxRegistry::new();
         let err = handle_mv(
-            MvRequest { sandbox_id: "bad".into(), src: "/a".into(), dst: "/b".into(), overwrite: false },
+            MvRequest {
+                sandbox_id: "bad".into(),
+                src: "/a".into(),
+                dst: "/b".into(),
+                overwrite: false,
+            },
             &reg,
             &FakeRunner,
         )

--- a/crates/iii-worker/src/sandbox_daemon/fs/mv.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/mv.rs
@@ -1,0 +1,200 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use iii_sdk::{IIIError, RegisterFunctionMessage};
+use iii_shell_proto::{FsOp, FsResult};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+
+#[derive(Debug, Deserialize)]
+pub struct MvRequest {
+    pub sandbox_id: String,
+    pub src: String,
+    pub dst: String,
+    #[serde(default)]
+    pub overwrite: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MvResponse {
+    pub moved: bool,
+}
+
+pub async fn handle_mv<R: FsRunner + ?Sized>(
+    req: MvRequest,
+    registry: &SandboxRegistry,
+    runner: &R,
+) -> Result<MvResponse, SandboxError> {
+    let id = Uuid::parse_str(&req.sandbox_id).map_err(|_| {
+        SandboxError::InvalidRequest(format!(
+            "sandbox_id is not a valid UUID: {}",
+            req.sandbox_id
+        ))
+    })?;
+    let state = registry.get(id).await?;
+    if state.stopped {
+        return Err(SandboxError::AlreadyStopped(id.to_string()));
+    }
+    registry.bump_last_exec(id).await;
+
+    let result = runner
+        .fs_call(
+            state.shell_sock,
+            FsOp::Mv { src: req.src, dst: req.dst, overwrite: req.overwrite },
+        )
+        .await?;
+
+    match result {
+        FsResult::Mv { moved } => Ok(MvResponse { moved }),
+        other => Err(SandboxError::FsIo(format!(
+            "expected Mv result, got {other:?}"
+        ))),
+    }
+}
+
+pub(super) fn register(
+    iii: &iii_sdk::III,
+    registry: Arc<SandboxRegistry>,
+    runner: Arc<dyn FsRunner>,
+) {
+    let handler = move |payload: Value| {
+        let registry = registry.clone();
+        let runner = runner.clone();
+        Box::pin(async move {
+            let req: MvRequest = serde_json::from_value(payload)
+                .map_err(|e| IIIError::Handler(format!("bad request: {e}")))?;
+            match handle_mv(req, &registry, &*runner).await {
+                Ok(resp) => serde_json::to_value(resp)
+                    .map_err(|e| IIIError::Handler(format!("serialize: {e}"))),
+                Err(e) => Err(IIIError::Handler(
+                    serde_json::to_string(&e.to_payload()).unwrap_or_else(|_| e.to_string()),
+                )),
+            }
+        }) as Pin<Box<dyn Future<Output = Result<Value, IIIError>> + Send>>
+    };
+    let _ = iii.register_function_with(
+        RegisterFunctionMessage {
+            id: "sandbox::fs::mv".to_string(),
+            description: Some("Move or rename a path inside a sandbox".to_string()),
+            request_format: None,
+            response_format: None,
+            metadata: None,
+            invocation: None,
+        },
+        handler,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox_daemon::{fs::adapter::FsRunner, registry::SandboxState};
+    use iii_shell_proto::{FsOp, FsReadMeta, FsResult};
+    use std::path::PathBuf;
+    use std::time::Instant;
+
+    struct FakeRunner;
+
+    #[async_trait::async_trait]
+    impl FsRunner for FakeRunner {
+        async fn fs_call(
+            &self,
+            _shell_sock: PathBuf,
+            _op: FsOp,
+        ) -> Result<FsResult, SandboxError> {
+            Ok(FsResult::Mv { moved: true })
+        }
+        async fn fs_write_stream(
+            &self,
+            _shell_sock: PathBuf,
+            _path: String,
+            _mode: String,
+            _parents: bool,
+            _reader: Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+        ) -> Result<FsResult, SandboxError> {
+            unimplemented!()
+        }
+        async fn fs_read_stream(
+            &self,
+            _shell_sock: PathBuf,
+            _path: String,
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+            unimplemented!()
+        }
+    }
+
+    fn make_state(id: Uuid) -> SandboxState {
+        SandboxState {
+            id,
+            name: None,
+            image: "python".into(),
+            rootfs: PathBuf::from("/tmp/r"),
+            workdir: PathBuf::from("/tmp/w"),
+            shell_sock: PathBuf::from("/tmp/s"),
+            vm_pid: Some(1),
+            created_at: Instant::now(),
+            last_exec_at: Instant::now(),
+            exec_in_progress: false,
+            idle_timeout_secs: 300,
+            stopped: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn happy_path_returns_moved() {
+        let reg = SandboxRegistry::new();
+        let id = Uuid::new_v4();
+        reg.insert(make_state(id)).await;
+        let resp = handle_mv(
+            MvRequest {
+                sandbox_id: id.to_string(),
+                src: "/workspace/a".into(),
+                dst: "/workspace/b".into(),
+                overwrite: false,
+            },
+            &reg,
+            &FakeRunner,
+        )
+        .await
+        .unwrap();
+        assert!(resp.moved);
+    }
+
+    #[tokio::test]
+    async fn bad_uuid_returns_s001() {
+        let reg = SandboxRegistry::new();
+        let err = handle_mv(
+            MvRequest { sandbox_id: "bad".into(), src: "/a".into(), dst: "/b".into(), overwrite: false },
+            &reg,
+            &FakeRunner,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code().as_str(), "S001");
+    }
+
+    #[tokio::test]
+    async fn missing_sandbox_returns_s002() {
+        let reg = SandboxRegistry::new();
+        let err = handle_mv(
+            MvRequest {
+                sandbox_id: Uuid::new_v4().to_string(),
+                src: "/a".into(),
+                dst: "/b".into(),
+                overwrite: false,
+            },
+            &reg,
+            &FakeRunner,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code().as_str(), "S002");
+    }
+}

--- a/crates/iii-worker/src/sandbox_daemon/fs/read.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/read.rs
@@ -15,14 +15,16 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, RegisterFunctionMessage};
 use iii_sdk::channels::StreamChannelRef;
+use iii_sdk::{IIIError, RegisterFunctionMessage};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::io::AsyncReadExt;
 use uuid::Uuid;
 
-use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+use crate::sandbox_daemon::{
+    errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry,
+};
 
 #[derive(Debug, Deserialize)]
 pub struct ReadRequest {
@@ -58,7 +60,10 @@ pub async fn handle_read<R: FsRunner + ?Sized>(
     registry.bump_last_exec(id).await;
 
     let path = req.path;
-    let (meta, mut reader): (iii_shell_proto::FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>) = runner
+    let (meta, mut reader): (
+        iii_shell_proto::FsReadMeta,
+        Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+    ) = runner
         .fs_read_stream(state.shell_sock, path.clone())
         .await?;
 

--- a/crates/iii-worker/src/sandbox_daemon/fs/read.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/read.rs
@@ -1,0 +1,187 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+//! sandbox::fs::read — streaming file download trigger.
+//!
+//! 1. Calls `runner.fs_read_stream()` to get `(meta, Box<dyn AsyncRead>)`.
+//! 2. Calls `iii.create_channel()` to allocate a fresh engine channel.
+//! 3. Returns the channel's `reader_ref` (as `StreamChannelRef`) to the
+//!    caller in the response JSON, plus the file metadata.
+//! 4. Spawns a background task that pumps bytes from the `AsyncRead` into
+//!    `channel.writer`. On read error the task sends a JSON error message
+//!    on the channel before closing.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use iii_sdk::{IIIError, RegisterFunctionMessage};
+use iii_sdk::channels::StreamChannelRef;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::io::AsyncReadExt;
+use uuid::Uuid;
+
+use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+
+#[derive(Debug, Deserialize)]
+pub struct ReadRequest {
+    pub sandbox_id: String,
+    pub path: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReadResponse {
+    /// The caller reads file content from this channel ref.
+    pub content: StreamChannelRef,
+    pub size: u64,
+    pub mode: String,
+    pub mtime: i64,
+}
+
+pub async fn handle_read<R: FsRunner + ?Sized>(
+    req: ReadRequest,
+    registry: &SandboxRegistry,
+    runner: &R,
+    iii: &iii_sdk::III,
+) -> Result<ReadResponse, SandboxError> {
+    let id = Uuid::parse_str(&req.sandbox_id).map_err(|_| {
+        SandboxError::InvalidRequest(format!(
+            "sandbox_id is not a valid UUID: {}",
+            req.sandbox_id
+        ))
+    })?;
+    let state = registry.get(id).await?;
+    if state.stopped {
+        return Err(SandboxError::AlreadyStopped(id.to_string()));
+    }
+    registry.bump_last_exec(id).await;
+
+    let path = req.path;
+    let (meta, mut reader): (iii_shell_proto::FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>) = runner
+        .fs_read_stream(state.shell_sock, path.clone())
+        .await?;
+
+    let channel = iii
+        .create_channel(Some(64))
+        .await
+        .map_err(|e| SandboxError::FsIo(format!("create_channel: {e}")))?;
+
+    let reader_ref = channel.reader_ref.clone();
+    let writer = channel.writer;
+
+    // Pump bytes from the supervisor into the channel on a background task.
+    tokio::spawn(async move {
+        let mut buf = vec![0u8; 64 * 1024];
+        loop {
+            match reader.read(&mut buf).await {
+                Ok(0) => {
+                    // Clean EOF — close the channel.
+                    let _ = writer.close().await;
+                    break;
+                }
+                Ok(n) => {
+                    if let Err(e) = writer.write(&buf[..n]).await {
+                        let _ = writer
+                            .send_message(
+                                &serde_json::json!({
+                                    "error": format!("write to channel failed: {e}")
+                                })
+                                .to_string(),
+                            )
+                            .await;
+                        let _ = writer.close().await;
+                        break;
+                    }
+                }
+                Err(e) => {
+                    let _ = writer
+                        .send_message(
+                            &serde_json::json!({
+                                "error": format!("read from supervisor failed: {e}")
+                            })
+                            .to_string(),
+                        )
+                        .await;
+                    let _ = writer.close().await;
+                    break;
+                }
+            }
+        }
+    });
+
+    Ok(ReadResponse {
+        content: reader_ref,
+        size: meta.size,
+        mode: meta.mode,
+        mtime: meta.mtime,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+pub(super) fn register(
+    iii: &iii_sdk::III,
+    registry: Arc<SandboxRegistry>,
+    runner: Arc<dyn FsRunner>,
+) {
+    let iii_clone = iii.clone();
+    let handler = move |payload: Value| {
+        let registry = registry.clone();
+        let runner = runner.clone();
+        let iii = iii_clone.clone();
+        Box::pin(async move {
+            let req: ReadRequest = serde_json::from_value(payload)
+                .map_err(|e| IIIError::Handler(format!("bad request: {e}")))?;
+            match handle_read(req, &registry, &*runner, &iii).await {
+                Ok(resp) => serde_json::to_value(resp)
+                    .map_err(|e| IIIError::Handler(format!("serialize: {e}"))),
+                Err(e) => Err(IIIError::Handler(
+                    serde_json::to_string(&e.to_payload()).unwrap_or_else(|_| e.to_string()),
+                )),
+            }
+        }) as Pin<Box<dyn Future<Output = Result<Value, IIIError>> + Send>>
+    };
+    let _ = iii.register_function_with(
+        RegisterFunctionMessage {
+            id: "sandbox::fs::read".to_string(),
+            description: Some("Stream-download a file from a sandbox".to_string()),
+            request_format: None,
+            response_format: None,
+            metadata: None,
+            invocation: None,
+        },
+        handler,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+//
+// Unit tests for `handle_read` require a real `iii_sdk::III` that connects
+// to a live engine (for `create_channel`). Without an engine, the call
+// fails at channel allocation. End-to-end coverage is deferred to Phase 6
+// (external_known_sandbox_fs.rs). The S001/S002 guard tests below pass a
+// dummy `&iii_sdk::III` value from `register_worker` so they don't need
+// a live engine — they assert early-exit before the channel call.
+//
+// NOTE: S001/S002 tests are omitted here because constructing even a
+// disconnected `III` handle requires starting the background runtime thread
+// and a valid engine URL. The guard logic (UUID parse and registry lookup)
+// is identical to every other fs trigger and is covered by those test suites.
+// The background-task lifecycle (pump loop) is covered by Phase 6 e2e tests.
+//
+// #[ignore] marker is placed below as documentation that the full test is
+// intentionally skipped at unit-test time.
+
+#[cfg(test)]
+mod tests {
+    /// Full `handle_read` unit test skipped: requires a live engine for
+    /// `iii.create_channel()`. Covered by Phase 6 e2e tests instead.
+    #[tokio::test]
+    #[ignore]
+    async fn handle_read_e2e_deferred_to_phase6() {}
+}

--- a/crates/iii-worker/src/sandbox_daemon/fs/rm.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/rm.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+use crate::sandbox_daemon::{
+    errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry,
+};
 
 #[derive(Debug, Deserialize)]
 pub struct RmRequest {
@@ -46,7 +48,10 @@ pub async fn handle_rm<R: FsRunner + ?Sized>(
     let result = runner
         .fs_call(
             state.shell_sock,
-            FsOp::Rm { path: req.path, recursive: req.recursive },
+            FsOp::Rm {
+                path: req.path,
+                recursive: req.recursive,
+            },
         )
         .await?;
 
@@ -103,11 +108,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl FsRunner for FakeRunner {
-        async fn fs_call(
-            &self,
-            _shell_sock: PathBuf,
-            _op: FsOp,
-        ) -> Result<FsResult, SandboxError> {
+        async fn fs_call(&self, _shell_sock: PathBuf, _op: FsOp) -> Result<FsResult, SandboxError> {
             Ok(FsResult::Rm { removed: true })
         }
         async fn fs_write_stream(
@@ -124,7 +125,8 @@ mod tests {
             &self,
             _shell_sock: PathBuf,
             _path: String,
-        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError>
+        {
             unimplemented!()
         }
     }
@@ -152,7 +154,11 @@ mod tests {
         let id = Uuid::new_v4();
         reg.insert(make_state(id)).await;
         let resp = handle_rm(
-            RmRequest { sandbox_id: id.to_string(), path: "/workspace/file.txt".into(), recursive: false },
+            RmRequest {
+                sandbox_id: id.to_string(),
+                path: "/workspace/file.txt".into(),
+                recursive: false,
+            },
             &reg,
             &FakeRunner,
         )
@@ -165,7 +171,11 @@ mod tests {
     async fn bad_uuid_returns_s001() {
         let reg = SandboxRegistry::new();
         let err = handle_rm(
-            RmRequest { sandbox_id: "bad".into(), path: "/".into(), recursive: false },
+            RmRequest {
+                sandbox_id: "bad".into(),
+                path: "/".into(),
+                recursive: false,
+            },
             &reg,
             &FakeRunner,
         )
@@ -178,7 +188,11 @@ mod tests {
     async fn missing_sandbox_returns_s002() {
         let reg = SandboxRegistry::new();
         let err = handle_rm(
-            RmRequest { sandbox_id: Uuid::new_v4().to_string(), path: "/".into(), recursive: false },
+            RmRequest {
+                sandbox_id: Uuid::new_v4().to_string(),
+                path: "/".into(),
+                recursive: false,
+            },
             &reg,
             &FakeRunner,
         )

--- a/crates/iii-worker/src/sandbox_daemon/fs/rm.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/rm.rs
@@ -1,0 +1,189 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use iii_sdk::{IIIError, RegisterFunctionMessage};
+use iii_shell_proto::{FsOp, FsResult};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+
+#[derive(Debug, Deserialize)]
+pub struct RmRequest {
+    pub sandbox_id: String,
+    pub path: String,
+    #[serde(default)]
+    pub recursive: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RmResponse {
+    pub removed: bool,
+}
+
+pub async fn handle_rm<R: FsRunner + ?Sized>(
+    req: RmRequest,
+    registry: &SandboxRegistry,
+    runner: &R,
+) -> Result<RmResponse, SandboxError> {
+    let id = Uuid::parse_str(&req.sandbox_id).map_err(|_| {
+        SandboxError::InvalidRequest(format!(
+            "sandbox_id is not a valid UUID: {}",
+            req.sandbox_id
+        ))
+    })?;
+    let state = registry.get(id).await?;
+    if state.stopped {
+        return Err(SandboxError::AlreadyStopped(id.to_string()));
+    }
+    registry.bump_last_exec(id).await;
+
+    let result = runner
+        .fs_call(
+            state.shell_sock,
+            FsOp::Rm { path: req.path, recursive: req.recursive },
+        )
+        .await?;
+
+    match result {
+        FsResult::Rm { removed } => Ok(RmResponse { removed }),
+        other => Err(SandboxError::FsIo(format!(
+            "expected Rm result, got {other:?}"
+        ))),
+    }
+}
+
+pub(super) fn register(
+    iii: &iii_sdk::III,
+    registry: Arc<SandboxRegistry>,
+    runner: Arc<dyn FsRunner>,
+) {
+    let handler = move |payload: Value| {
+        let registry = registry.clone();
+        let runner = runner.clone();
+        Box::pin(async move {
+            let req: RmRequest = serde_json::from_value(payload)
+                .map_err(|e| IIIError::Handler(format!("bad request: {e}")))?;
+            match handle_rm(req, &registry, &*runner).await {
+                Ok(resp) => serde_json::to_value(resp)
+                    .map_err(|e| IIIError::Handler(format!("serialize: {e}"))),
+                Err(e) => Err(IIIError::Handler(
+                    serde_json::to_string(&e.to_payload()).unwrap_or_else(|_| e.to_string()),
+                )),
+            }
+        }) as Pin<Box<dyn Future<Output = Result<Value, IIIError>> + Send>>
+    };
+    let _ = iii.register_function_with(
+        RegisterFunctionMessage {
+            id: "sandbox::fs::rm".to_string(),
+            description: Some("Remove a file or directory inside a sandbox".to_string()),
+            request_format: None,
+            response_format: None,
+            metadata: None,
+            invocation: None,
+        },
+        handler,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox_daemon::{fs::adapter::FsRunner, registry::SandboxState};
+    use iii_shell_proto::{FsOp, FsReadMeta, FsResult};
+    use std::path::PathBuf;
+    use std::time::Instant;
+
+    struct FakeRunner;
+
+    #[async_trait::async_trait]
+    impl FsRunner for FakeRunner {
+        async fn fs_call(
+            &self,
+            _shell_sock: PathBuf,
+            _op: FsOp,
+        ) -> Result<FsResult, SandboxError> {
+            Ok(FsResult::Rm { removed: true })
+        }
+        async fn fs_write_stream(
+            &self,
+            _shell_sock: PathBuf,
+            _path: String,
+            _mode: String,
+            _parents: bool,
+            _reader: Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+        ) -> Result<FsResult, SandboxError> {
+            unimplemented!()
+        }
+        async fn fs_read_stream(
+            &self,
+            _shell_sock: PathBuf,
+            _path: String,
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+            unimplemented!()
+        }
+    }
+
+    fn make_state(id: Uuid) -> SandboxState {
+        SandboxState {
+            id,
+            name: None,
+            image: "python".into(),
+            rootfs: PathBuf::from("/tmp/r"),
+            workdir: PathBuf::from("/tmp/w"),
+            shell_sock: PathBuf::from("/tmp/s"),
+            vm_pid: Some(1),
+            created_at: Instant::now(),
+            last_exec_at: Instant::now(),
+            exec_in_progress: false,
+            idle_timeout_secs: 300,
+            stopped: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn happy_path_returns_removed() {
+        let reg = SandboxRegistry::new();
+        let id = Uuid::new_v4();
+        reg.insert(make_state(id)).await;
+        let resp = handle_rm(
+            RmRequest { sandbox_id: id.to_string(), path: "/workspace/file.txt".into(), recursive: false },
+            &reg,
+            &FakeRunner,
+        )
+        .await
+        .unwrap();
+        assert!(resp.removed);
+    }
+
+    #[tokio::test]
+    async fn bad_uuid_returns_s001() {
+        let reg = SandboxRegistry::new();
+        let err = handle_rm(
+            RmRequest { sandbox_id: "bad".into(), path: "/".into(), recursive: false },
+            &reg,
+            &FakeRunner,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code().as_str(), "S001");
+    }
+
+    #[tokio::test]
+    async fn missing_sandbox_returns_s002() {
+        let reg = SandboxRegistry::new();
+        let err = handle_rm(
+            RmRequest { sandbox_id: Uuid::new_v4().to_string(), path: "/".into(), recursive: false },
+            &reg,
+            &FakeRunner,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code().as_str(), "S002");
+    }
+}

--- a/crates/iii-worker/src/sandbox_daemon/fs/sed.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/sed.rs
@@ -1,0 +1,294 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use iii_sdk::{IIIError, RegisterFunctionMessage};
+use iii_shell_proto::{FsOp, FsResult, FsSedFileResult};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+
+/// Find-and-replace request, accepting either an explicit `files` list
+/// or a `path` walked like grep does. Exactly one of those two must be
+/// provided — `handle_sed` returns S210 otherwise.
+#[derive(Debug, Deserialize)]
+pub struct SedRequest {
+    pub sandbox_id: String,
+    /// Legacy form: explicit list of paths to rewrite.
+    #[serde(default)]
+    pub files: Vec<String>,
+    /// New form: walk `path` like grep does. May be a directory or a
+    /// single file. Mutually exclusive with `files`.
+    #[serde(default)]
+    pub path: Option<String>,
+    /// Whether to descend into subdirectories. Only meaningful with
+    /// `path`. Defaults to `true` so the path-form behaves like grep.
+    #[serde(default = "default_true")]
+    pub recursive: bool,
+    /// Gitignore-style include filter applied to paths relative to
+    /// `path`. Only meaningful with `path`.
+    #[serde(default)]
+    pub include_glob: Vec<String>,
+    /// Gitignore-style exclude filter applied to paths relative to
+    /// `path`. Only meaningful with `path`.
+    #[serde(default)]
+    pub exclude_glob: Vec<String>,
+    pub pattern: String,
+    pub replacement: String,
+    #[serde(default = "default_true")]
+    pub regex: bool,
+    #[serde(default)]
+    pub first_only: bool,
+    #[serde(default)]
+    pub ignore_case: bool,
+}
+
+fn default_true() -> bool { true }
+
+#[derive(Debug, Serialize)]
+pub struct SedResponse {
+    pub results: Vec<FsSedFileResult>,
+    pub total_replacements: u64,
+}
+
+pub async fn handle_sed<R: FsRunner + ?Sized>(
+    req: SedRequest,
+    registry: &SandboxRegistry,
+    runner: &R,
+) -> Result<SedResponse, SandboxError> {
+    let id = Uuid::parse_str(&req.sandbox_id).map_err(|_| {
+        SandboxError::InvalidRequest(format!(
+            "sandbox_id is not a valid UUID: {}",
+            req.sandbox_id
+        ))
+    })?;
+
+    // Mutually-exclusive form check before we touch the registry. We
+    // treat empty `files` as "not the legacy form" so old guests that
+    // always sent `files: [..]` keep working, and new callers can pass
+    // `path` instead. Both/neither -> S210.
+    match (req.files.is_empty(), req.path.as_ref()) {
+        (false, None) | (true, Some(_)) => {}
+        (false, Some(_)) => {
+            return Err(SandboxError::FsInvalidRequest(
+                "sed: provide exactly one of files or path, not both".into(),
+            ));
+        }
+        (true, None) => {
+            return Err(SandboxError::FsInvalidRequest(
+                "sed: must provide exactly one of files or path".into(),
+            ));
+        }
+    }
+
+    let state = registry.get(id).await?;
+    if state.stopped {
+        return Err(SandboxError::AlreadyStopped(id.to_string()));
+    }
+    registry.bump_last_exec(id).await;
+
+    let result = runner
+        .fs_call(
+            state.shell_sock,
+            FsOp::Sed {
+                files: req.files,
+                path: req.path,
+                recursive: req.recursive,
+                include_glob: req.include_glob,
+                exclude_glob: req.exclude_glob,
+                pattern: req.pattern,
+                replacement: req.replacement,
+                regex: req.regex,
+                first_only: req.first_only,
+                ignore_case: req.ignore_case,
+            },
+        )
+        .await?;
+
+    match result {
+        FsResult::Sed { results, total_replacements } => Ok(SedResponse { results, total_replacements }),
+        other => Err(SandboxError::FsIo(format!(
+            "expected Sed result, got {other:?}"
+        ))),
+    }
+}
+
+pub(super) fn register(
+    iii: &iii_sdk::III,
+    registry: Arc<SandboxRegistry>,
+    runner: Arc<dyn FsRunner>,
+) {
+    let handler = move |payload: Value| {
+        let registry = registry.clone();
+        let runner = runner.clone();
+        Box::pin(async move {
+            let req: SedRequest = serde_json::from_value(payload)
+                .map_err(|e| IIIError::Handler(format!("bad request: {e}")))?;
+            match handle_sed(req, &registry, &*runner).await {
+                Ok(resp) => serde_json::to_value(resp)
+                    .map_err(|e| IIIError::Handler(format!("serialize: {e}"))),
+                Err(e) => Err(IIIError::Handler(
+                    serde_json::to_string(&e.to_payload()).unwrap_or_else(|_| e.to_string()),
+                )),
+            }
+        }) as Pin<Box<dyn Future<Output = Result<Value, IIIError>> + Send>>
+    };
+    let _ = iii.register_function_with(
+        RegisterFunctionMessage {
+            id: "sandbox::fs::sed".to_string(),
+            description: Some("Search-and-replace in files inside a sandbox".to_string()),
+            request_format: None,
+            response_format: None,
+            metadata: None,
+            invocation: None,
+        },
+        handler,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox_daemon::{fs::adapter::FsRunner, registry::SandboxState};
+    use iii_shell_proto::{FsOp, FsReadMeta, FsResult, FsSedFileResult};
+    use std::path::PathBuf;
+    use std::time::Instant;
+
+    struct FakeRunner;
+
+    #[async_trait::async_trait]
+    impl FsRunner for FakeRunner {
+        async fn fs_call(
+            &self,
+            _shell_sock: PathBuf,
+            _op: FsOp,
+        ) -> Result<FsResult, SandboxError> {
+            Ok(FsResult::Sed {
+                results: vec![FsSedFileResult {
+                    path: "a.py".into(),
+                    replacements: 2,
+                    success: true,
+                    error: None,
+                }],
+                total_replacements: 2,
+            })
+        }
+        async fn fs_write_stream(
+            &self,
+            _shell_sock: PathBuf,
+            _path: String,
+            _mode: String,
+            _parents: bool,
+            _reader: Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+        ) -> Result<FsResult, SandboxError> {
+            unimplemented!()
+        }
+        async fn fs_read_stream(
+            &self,
+            _shell_sock: PathBuf,
+            _path: String,
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+            unimplemented!()
+        }
+    }
+
+    fn make_state(id: Uuid) -> SandboxState {
+        SandboxState {
+            id,
+            name: None,
+            image: "python".into(),
+            rootfs: PathBuf::from("/tmp/r"),
+            workdir: PathBuf::from("/tmp/w"),
+            shell_sock: PathBuf::from("/tmp/s"),
+            vm_pid: Some(1),
+            created_at: Instant::now(),
+            last_exec_at: Instant::now(),
+            exec_in_progress: false,
+            idle_timeout_secs: 300,
+            stopped: false,
+        }
+    }
+
+    fn req_files(sandbox_id: String, files: Vec<String>) -> SedRequest {
+        SedRequest {
+            sandbox_id,
+            files,
+            path: None,
+            recursive: true,
+            include_glob: Vec::new(),
+            exclude_glob: Vec::new(),
+            pattern: "hello".into(),
+            replacement: "world".into(),
+            regex: true,
+            first_only: false,
+            ignore_case: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn happy_path_returns_results() {
+        let reg = SandboxRegistry::new();
+        let id = Uuid::new_v4();
+        reg.insert(make_state(id)).await;
+        let req = req_files(id.to_string(), vec!["/workspace/a.py".into()]);
+        let resp = handle_sed(req, &reg, &FakeRunner).await.unwrap();
+        assert_eq!(resp.total_replacements, 2);
+        assert_eq!(resp.results.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn bad_uuid_returns_s001() {
+        let reg = SandboxRegistry::new();
+        // Note: bad-uuid returns S001 *before* the form check. Use a
+        // valid form to confirm we're testing the UUID path.
+        let err = handle_sed(
+            req_files("bad".into(), vec!["/workspace/a.py".into()]),
+            &reg,
+            &FakeRunner,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code().as_str(), "S001");
+    }
+
+    #[tokio::test]
+    async fn missing_sandbox_returns_s002() {
+        let reg = SandboxRegistry::new();
+        let err = handle_sed(
+            req_files(Uuid::new_v4().to_string(), vec!["/workspace/a.py".into()]),
+            &reg,
+            &FakeRunner,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code().as_str(), "S002");
+    }
+
+    #[tokio::test]
+    async fn sed_request_with_both_files_and_path_returns_s210() {
+        // Form-check happens after UUID parse but before registry hit,
+        // so a valid UUID with no matching sandbox is fine here.
+        let reg = SandboxRegistry::new();
+        let mut req = req_files(
+            Uuid::new_v4().to_string(),
+            vec!["/workspace/a.py".into()],
+        );
+        req.path = Some("/workspace".into());
+        let err = handle_sed(req, &reg, &FakeRunner).await.unwrap_err();
+        assert_eq!(err.code().as_str(), "S210");
+    }
+
+    #[tokio::test]
+    async fn sed_request_with_neither_returns_s210() {
+        let reg = SandboxRegistry::new();
+        let req = req_files(Uuid::new_v4().to_string(), Vec::new());
+        // path is already None via req_files default; files is empty.
+        let err = handle_sed(req, &reg, &FakeRunner).await.unwrap_err();
+        assert_eq!(err.code().as_str(), "S210");
+    }
+}

--- a/crates/iii-worker/src/sandbox_daemon/fs/sed.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/sed.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+use crate::sandbox_daemon::{
+    errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry,
+};
 
 /// Find-and-replace request, accepting either an explicit `files` list
 /// or a `path` walked like grep does. Exactly one of those two must be
@@ -48,7 +50,9 @@ pub struct SedRequest {
     pub ignore_case: bool,
 }
 
-fn default_true() -> bool { true }
+fn default_true() -> bool {
+    true
+}
 
 #[derive(Debug, Serialize)]
 pub struct SedResponse {
@@ -111,7 +115,13 @@ pub async fn handle_sed<R: FsRunner + ?Sized>(
         .await?;
 
     match result {
-        FsResult::Sed { results, total_replacements } => Ok(SedResponse { results, total_replacements }),
+        FsResult::Sed {
+            results,
+            total_replacements,
+        } => Ok(SedResponse {
+            results,
+            total_replacements,
+        }),
         other => Err(SandboxError::FsIo(format!(
             "expected Sed result, got {other:?}"
         ))),
@@ -163,11 +173,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl FsRunner for FakeRunner {
-        async fn fs_call(
-            &self,
-            _shell_sock: PathBuf,
-            _op: FsOp,
-        ) -> Result<FsResult, SandboxError> {
+        async fn fs_call(&self, _shell_sock: PathBuf, _op: FsOp) -> Result<FsResult, SandboxError> {
             Ok(FsResult::Sed {
                 results: vec![FsSedFileResult {
                     path: "a.py".into(),
@@ -192,7 +198,8 @@ mod tests {
             &self,
             _shell_sock: PathBuf,
             _path: String,
-        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError>
+        {
             unimplemented!()
         }
     }
@@ -274,10 +281,7 @@ mod tests {
         // Form-check happens after UUID parse but before registry hit,
         // so a valid UUID with no matching sandbox is fine here.
         let reg = SandboxRegistry::new();
-        let mut req = req_files(
-            Uuid::new_v4().to_string(),
-            vec!["/workspace/a.py".into()],
-        );
+        let mut req = req_files(Uuid::new_v4().to_string(), vec!["/workspace/a.py".into()]);
         req.path = Some("/workspace".into());
         let err = handle_sed(req, &reg, &FakeRunner).await.unwrap_err();
         assert_eq!(err.code().as_str(), "S210");

--- a/crates/iii-worker/src/sandbox_daemon/fs/stat.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/stat.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+use crate::sandbox_daemon::{
+    errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry,
+};
 
 #[derive(Debug, Deserialize)]
 pub struct StatRequest {
@@ -120,11 +122,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl FsRunner for FakeRunner {
-        async fn fs_call(
-            &self,
-            _shell_sock: PathBuf,
-            _op: FsOp,
-        ) -> Result<FsResult, SandboxError> {
+        async fn fs_call(&self, _shell_sock: PathBuf, _op: FsOp) -> Result<FsResult, SandboxError> {
             Ok(FsResult::Stat(self.entry.clone()))
         }
         async fn fs_write_stream(
@@ -141,7 +139,8 @@ mod tests {
             &self,
             _shell_sock: PathBuf,
             _path: String,
-        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError>
+        {
             unimplemented!()
         }
     }
@@ -179,7 +178,9 @@ mod tests {
         let reg = SandboxRegistry::new();
         let id = Uuid::new_v4();
         reg.insert(make_state(id)).await;
-        let runner = FakeRunner { entry: fake_entry() };
+        let runner = FakeRunner {
+            entry: fake_entry(),
+        };
         let req = StatRequest {
             sandbox_id: id.to_string(),
             path: "/workspace/foo.txt".into(),
@@ -192,9 +193,14 @@ mod tests {
     #[tokio::test]
     async fn bad_uuid_returns_s001() {
         let reg = SandboxRegistry::new();
-        let runner = FakeRunner { entry: fake_entry() };
+        let runner = FakeRunner {
+            entry: fake_entry(),
+        };
         let err = handle_stat(
-            StatRequest { sandbox_id: "not-a-uuid".into(), path: "/".into() },
+            StatRequest {
+                sandbox_id: "not-a-uuid".into(),
+                path: "/".into(),
+            },
             &reg,
             &runner,
         )
@@ -206,9 +212,14 @@ mod tests {
     #[tokio::test]
     async fn missing_sandbox_returns_s002() {
         let reg = SandboxRegistry::new();
-        let runner = FakeRunner { entry: fake_entry() };
+        let runner = FakeRunner {
+            entry: fake_entry(),
+        };
         let err = handle_stat(
-            StatRequest { sandbox_id: Uuid::new_v4().to_string(), path: "/".into() },
+            StatRequest {
+                sandbox_id: Uuid::new_v4().to_string(),
+                path: "/".into(),
+            },
             &reg,
             &runner,
         )

--- a/crates/iii-worker/src/sandbox_daemon/fs/stat.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/stat.rs
@@ -1,0 +1,219 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use iii_sdk::{IIIError, RegisterFunctionMessage};
+use iii_shell_proto::{FsEntry, FsOp, FsResult};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+
+#[derive(Debug, Deserialize)]
+pub struct StatRequest {
+    pub sandbox_id: String,
+    pub path: String,
+}
+
+/// Mirrors `FsEntry`. Note: the shell protocol does not carry uid/gid;
+/// those fields are absent at this trigger level.
+#[derive(Debug, Serialize)]
+pub struct StatResponse {
+    pub name: String,
+    pub is_dir: bool,
+    pub size: u64,
+    pub mode: String,
+    pub mtime: i64,
+    pub is_symlink: bool,
+}
+
+impl From<FsEntry> for StatResponse {
+    fn from(e: FsEntry) -> Self {
+        StatResponse {
+            name: e.name,
+            is_dir: e.is_dir,
+            size: e.size,
+            mode: e.mode,
+            mtime: e.mtime,
+            is_symlink: e.is_symlink,
+        }
+    }
+}
+
+pub async fn handle_stat<R: FsRunner + ?Sized>(
+    req: StatRequest,
+    registry: &SandboxRegistry,
+    runner: &R,
+) -> Result<StatResponse, SandboxError> {
+    let id = Uuid::parse_str(&req.sandbox_id).map_err(|_| {
+        SandboxError::InvalidRequest(format!(
+            "sandbox_id is not a valid UUID: {}",
+            req.sandbox_id
+        ))
+    })?;
+    let state = registry.get(id).await?;
+    if state.stopped {
+        return Err(SandboxError::AlreadyStopped(id.to_string()));
+    }
+    registry.bump_last_exec(id).await;
+
+    let result = runner
+        .fs_call(state.shell_sock, FsOp::Stat { path: req.path })
+        .await?;
+
+    match result {
+        FsResult::Stat(entry) => Ok(StatResponse::from(entry)),
+        other => Err(SandboxError::FsIo(format!(
+            "expected Stat result, got {other:?}"
+        ))),
+    }
+}
+
+pub(super) fn register(
+    iii: &iii_sdk::III,
+    registry: Arc<SandboxRegistry>,
+    runner: Arc<dyn FsRunner>,
+) {
+    let handler = move |payload: Value| {
+        let registry = registry.clone();
+        let runner = runner.clone();
+        Box::pin(async move {
+            let req: StatRequest = serde_json::from_value(payload)
+                .map_err(|e| IIIError::Handler(format!("bad request: {e}")))?;
+            match handle_stat(req, &registry, &*runner).await {
+                Ok(resp) => serde_json::to_value(resp)
+                    .map_err(|e| IIIError::Handler(format!("serialize: {e}"))),
+                Err(e) => Err(IIIError::Handler(
+                    serde_json::to_string(&e.to_payload()).unwrap_or_else(|_| e.to_string()),
+                )),
+            }
+        }) as Pin<Box<dyn Future<Output = Result<Value, IIIError>> + Send>>
+    };
+    let _ = iii.register_function_with(
+        RegisterFunctionMessage {
+            id: "sandbox::fs::stat".to_string(),
+            description: Some("Stat a path inside a sandbox".to_string()),
+            request_format: None,
+            response_format: None,
+            metadata: None,
+            invocation: None,
+        },
+        handler,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox_daemon::{fs::adapter::FsRunner, registry::SandboxState};
+    use iii_shell_proto::{FsEntry, FsReadMeta, FsResult};
+    use std::path::PathBuf;
+    use std::time::Instant;
+
+    struct FakeRunner {
+        entry: FsEntry,
+    }
+
+    #[async_trait::async_trait]
+    impl FsRunner for FakeRunner {
+        async fn fs_call(
+            &self,
+            _shell_sock: PathBuf,
+            _op: FsOp,
+        ) -> Result<FsResult, SandboxError> {
+            Ok(FsResult::Stat(self.entry.clone()))
+        }
+        async fn fs_write_stream(
+            &self,
+            _shell_sock: PathBuf,
+            _path: String,
+            _mode: String,
+            _parents: bool,
+            _reader: Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+        ) -> Result<FsResult, SandboxError> {
+            unimplemented!()
+        }
+        async fn fs_read_stream(
+            &self,
+            _shell_sock: PathBuf,
+            _path: String,
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+            unimplemented!()
+        }
+    }
+
+    fn make_state(id: Uuid) -> SandboxState {
+        SandboxState {
+            id,
+            name: None,
+            image: "python".into(),
+            rootfs: PathBuf::from("/tmp/r"),
+            workdir: PathBuf::from("/tmp/w"),
+            shell_sock: PathBuf::from("/tmp/s"),
+            vm_pid: Some(1),
+            created_at: Instant::now(),
+            last_exec_at: Instant::now(),
+            exec_in_progress: false,
+            idle_timeout_secs: 300,
+            stopped: false,
+        }
+    }
+
+    fn fake_entry() -> FsEntry {
+        FsEntry {
+            name: "foo.txt".into(),
+            is_dir: false,
+            size: 42,
+            mode: "0644".into(),
+            mtime: 100,
+            is_symlink: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn happy_path_returns_stat() {
+        let reg = SandboxRegistry::new();
+        let id = Uuid::new_v4();
+        reg.insert(make_state(id)).await;
+        let runner = FakeRunner { entry: fake_entry() };
+        let req = StatRequest {
+            sandbox_id: id.to_string(),
+            path: "/workspace/foo.txt".into(),
+        };
+        let resp = handle_stat(req, &reg, &runner).await.unwrap();
+        assert_eq!(resp.name, "foo.txt");
+        assert_eq!(resp.size, 42);
+    }
+
+    #[tokio::test]
+    async fn bad_uuid_returns_s001() {
+        let reg = SandboxRegistry::new();
+        let runner = FakeRunner { entry: fake_entry() };
+        let err = handle_stat(
+            StatRequest { sandbox_id: "not-a-uuid".into(), path: "/".into() },
+            &reg,
+            &runner,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code().as_str(), "S001");
+    }
+
+    #[tokio::test]
+    async fn missing_sandbox_returns_s002() {
+        let reg = SandboxRegistry::new();
+        let runner = FakeRunner { entry: fake_entry() };
+        let err = handle_stat(
+            StatRequest { sandbox_id: Uuid::new_v4().to_string(), path: "/".into() },
+            &reg,
+            &runner,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code().as_str(), "S002");
+    }
+}

--- a/crates/iii-worker/src/sandbox_daemon/fs/write.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/write.rs
@@ -1,0 +1,376 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+//! sandbox::fs::write — streaming file upload trigger.
+//!
+//! The caller creates a channel and passes its `reader_ref` (a
+//! `StreamChannelRef`) in the request JSON. This handler constructs a
+//! `ChannelReader` from that ref, adapts it to `tokio::io::AsyncRead`
+//! via `ChannelReaderAdapter`, then streams bytes into the supervisor
+//! through `FsRunner::fs_write_stream`.
+
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use iii_sdk::{IIIError, RegisterFunctionMessage};
+use iii_sdk::channels::{ChannelReader, StreamChannelRef};
+use iii_shell_proto::FsResult;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+
+// ---------------------------------------------------------------------------
+// AsyncRead adapter for ChannelReader
+// ---------------------------------------------------------------------------
+
+/// Wraps a `ChannelReader` and implements `tokio::io::AsyncRead` by driving
+/// `next_binary()` on each poll. Because `ChannelReader::next_binary` is
+/// async and `poll_read` is synchronous, we store a pending future when the
+/// current chunk isn't ready yet. Leftover bytes from a chunk larger than
+/// the read buffer are kept in `pending_buf`.
+///
+/// # Limitations
+/// This adapter holds a `tokio::runtime::Handle` internally and spawns the
+/// async `next_binary()` call as a task, then polls the JoinHandle. This
+/// keeps the `AsyncRead` impl `Unpin` without unsafe and avoids storing a
+/// `Pin<Box<dyn Future>>` inline (which would require `unsafe Unpin`).
+pub struct ChannelReaderAdapter {
+    reader: Arc<ChannelReader>,
+    pending_buf: Vec<u8>,
+    pending_task: Option<tokio::task::JoinHandle<Result<Option<Vec<u8>>, iii_sdk::IIIError>>>,
+    eof: bool,
+}
+
+impl ChannelReaderAdapter {
+    pub fn new(reader: ChannelReader) -> Self {
+        Self {
+            reader: Arc::new(reader),
+            pending_buf: Vec::new(),
+            pending_task: None,
+            eof: false,
+        }
+    }
+}
+
+impl tokio::io::AsyncRead for ChannelReaderAdapter {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+
+        if this.eof && this.pending_buf.is_empty() {
+            return Poll::Ready(Ok(()));
+        }
+
+        // Drain any leftover bytes from a previous oversized chunk.
+        if !this.pending_buf.is_empty() {
+            let n = this.pending_buf.len().min(buf.remaining());
+            buf.put_slice(&this.pending_buf[..n]);
+            this.pending_buf.drain(..n);
+            return Poll::Ready(Ok(()));
+        }
+
+        // Spawn a task if we don't have one in flight.
+        if this.pending_task.is_none() {
+            let reader = this.reader.clone();
+            this.pending_task = Some(tokio::spawn(async move { reader.next_binary().await }));
+        }
+
+        // Poll the in-flight task.
+        let task = this.pending_task.as_mut().unwrap();
+        match Pin::new(task).poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(join_result) => {
+                this.pending_task = None;
+                let chunk_result = join_result.map_err(|e| {
+                    io::Error::new(io::ErrorKind::BrokenPipe, format!("channel task: {e}"))
+                })?;
+                match chunk_result {
+                    Ok(None) => {
+                        this.eof = true;
+                        Poll::Ready(Ok(()))
+                    }
+                    Ok(Some(data)) => {
+                        let n = data.len().min(buf.remaining());
+                        buf.put_slice(&data[..n]);
+                        if n < data.len() {
+                            this.pending_buf.extend_from_slice(&data[n..]);
+                        }
+                        Poll::Ready(Ok(()))
+                    }
+                    Err(e) => Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        format!("channel read error: {e}"),
+                    ))),
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Request / response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct WriteRequest {
+    pub sandbox_id: String,
+    pub path: String,
+    #[serde(default = "default_mode")]
+    pub mode: String,
+    #[serde(default)]
+    pub parents: bool,
+    pub content: StreamChannelRef,
+}
+
+fn default_mode() -> String {
+    "0644".to_string()
+}
+
+#[derive(Debug, Serialize)]
+pub struct WriteResponse {
+    pub bytes_written: u64,
+    pub path: String,
+}
+
+// ---------------------------------------------------------------------------
+// Handler — testable inner function
+// ---------------------------------------------------------------------------
+
+/// Inner handler that accepts a pre-constructed `AsyncRead`. Unit tests call
+/// this directly with a `Cursor<Vec<u8>>`, bypassing the channel layer.
+pub(crate) async fn handle_write_with_reader<R: FsRunner + ?Sized>(
+    sandbox_id: String,
+    path: String,
+    mode: String,
+    parents: bool,
+    reader: Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+    registry: &SandboxRegistry,
+    runner: &R,
+) -> Result<WriteResponse, SandboxError> {
+    let id = Uuid::parse_str(&sandbox_id).map_err(|_| {
+        SandboxError::InvalidRequest(format!(
+            "sandbox_id is not a valid UUID: {sandbox_id}"
+        ))
+    })?;
+    let state = registry.get(id).await?;
+    if state.stopped {
+        return Err(SandboxError::AlreadyStopped(id.to_string()));
+    }
+    registry.bump_last_exec(id).await;
+
+    let result = runner
+        .fs_write_stream(state.shell_sock, path.clone(), mode, parents, reader)
+        .await?;
+
+    match result {
+        FsResult::Write { bytes_written, path: p } => Ok(WriteResponse {
+            bytes_written,
+            path: p,
+        }),
+        other => Err(SandboxError::FsIo(format!(
+            "expected Write result, got {other:?}"
+        ))),
+    }
+}
+
+/// Public trigger handler. Constructs a `ChannelReader` from the caller's
+/// `StreamChannelRef` and delegates to `handle_write_with_reader`.
+pub async fn handle_write<R: FsRunner + ?Sized>(
+    req: WriteRequest,
+    registry: &SandboxRegistry,
+    runner: &R,
+    engine_address: &str,
+) -> Result<WriteResponse, SandboxError> {
+    let ch_reader = ChannelReader::new(engine_address, &req.content);
+    let adapter = ChannelReaderAdapter::new(ch_reader);
+    handle_write_with_reader(
+        req.sandbox_id,
+        req.path,
+        req.mode,
+        req.parents,
+        Box::new(adapter),
+        registry,
+        runner,
+    )
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+pub(super) fn register(
+    iii: &iii_sdk::III,
+    registry: Arc<SandboxRegistry>,
+    runner: Arc<dyn FsRunner>,
+) {
+    let engine_address = iii.address().to_string();
+    let handler = move |payload: Value| {
+        let registry = registry.clone();
+        let runner = runner.clone();
+        let engine_address = engine_address.clone();
+        Box::pin(async move {
+            let req: WriteRequest = serde_json::from_value(payload)
+                .map_err(|e| IIIError::Handler(format!("bad request: {e}")))?;
+            match handle_write(req, &registry, &*runner, &engine_address).await {
+                Ok(resp) => serde_json::to_value(resp)
+                    .map_err(|e| IIIError::Handler(format!("serialize: {e}"))),
+                Err(e) => Err(IIIError::Handler(
+                    serde_json::to_string(&e.to_payload()).unwrap_or_else(|_| e.to_string()),
+                )),
+            }
+        }) as Pin<Box<dyn Future<Output = Result<Value, IIIError>> + Send>>
+    };
+    let _ = iii.register_function_with(
+        RegisterFunctionMessage {
+            id: "sandbox::fs::write".to_string(),
+            description: Some("Stream-upload a file into a sandbox".to_string()),
+            request_format: None,
+            response_format: None,
+            metadata: None,
+            invocation: None,
+        },
+        handler,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox_daemon::{fs::adapter::FsRunner, registry::SandboxState};
+    use iii_shell_proto::{FsOp, FsReadMeta, FsResult};
+    use std::io::Cursor;
+    use std::path::PathBuf;
+    use std::time::Instant;
+    use tokio::sync::Mutex;
+
+    struct FakeRunner {
+        captured: Arc<Mutex<Vec<u8>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl FsRunner for FakeRunner {
+        async fn fs_call(
+            &self,
+            _shell_sock: PathBuf,
+            _op: FsOp,
+        ) -> Result<FsResult, SandboxError> {
+            unimplemented!()
+        }
+
+        async fn fs_write_stream(
+            &self,
+            _shell_sock: PathBuf,
+            path: String,
+            _mode: String,
+            _parents: bool,
+            mut reader: Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+        ) -> Result<FsResult, SandboxError> {
+            use tokio::io::AsyncReadExt;
+            let mut buf = Vec::new();
+            reader.read_to_end(&mut buf).await.unwrap();
+            let bytes = buf.len() as u64;
+            *self.captured.lock().await = buf;
+            Ok(FsResult::Write { bytes_written: bytes, path })
+        }
+
+        async fn fs_read_stream(
+            &self,
+            _shell_sock: PathBuf,
+            _path: String,
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+            unimplemented!()
+        }
+    }
+
+    fn make_state(id: Uuid) -> SandboxState {
+        SandboxState {
+            id,
+            name: None,
+            image: "python".into(),
+            rootfs: PathBuf::from("/tmp/r"),
+            workdir: PathBuf::from("/tmp/w"),
+            shell_sock: PathBuf::from("/tmp/s"),
+            vm_pid: Some(1),
+            created_at: Instant::now(),
+            last_exec_at: Instant::now(),
+            exec_in_progress: false,
+            idle_timeout_secs: 300,
+            stopped: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn write_with_reader_captures_bytes() {
+        let reg = SandboxRegistry::new();
+        let id = Uuid::new_v4();
+        reg.insert(make_state(id)).await;
+        let data = b"hello, sandbox!";
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let runner = FakeRunner { captured: captured.clone() };
+        let cursor = Box::new(Cursor::new(data.to_vec()));
+        let resp = handle_write_with_reader(
+            id.to_string(),
+            "/workspace/test.txt".into(),
+            "0644".into(),
+            false,
+            cursor,
+            &reg,
+            &runner,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.bytes_written, data.len() as u64);
+        assert_eq!(*captured.lock().await, data);
+    }
+
+    #[tokio::test]
+    async fn bad_uuid_returns_s001() {
+        let reg = SandboxRegistry::new();
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let runner = FakeRunner { captured };
+        let err = handle_write_with_reader(
+            "not-a-uuid".into(),
+            "/".into(),
+            "0644".into(),
+            false,
+            Box::new(Cursor::new(vec![])),
+            &reg,
+            &runner,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code().as_str(), "S001");
+    }
+
+    #[tokio::test]
+    async fn missing_sandbox_returns_s002() {
+        let reg = SandboxRegistry::new();
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let runner = FakeRunner { captured };
+        let err = handle_write_with_reader(
+            Uuid::new_v4().to_string(),
+            "/".into(),
+            "0644".into(),
+            false,
+            Box::new(Cursor::new(vec![])),
+            &reg,
+            &runner,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code().as_str(), "S002");
+    }
+}

--- a/crates/iii-worker/src/sandbox_daemon/fs/write.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/write.rs
@@ -15,14 +15,16 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use iii_sdk::{IIIError, RegisterFunctionMessage};
 use iii_sdk::channels::{ChannelReader, StreamChannelRef};
+use iii_sdk::{IIIError, RegisterFunctionMessage};
 use iii_shell_proto::FsResult;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::sandbox_daemon::{errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry};
+use crate::sandbox_daemon::{
+    errors::SandboxError, fs::adapter::FsRunner, registry::SandboxRegistry,
+};
 
 // ---------------------------------------------------------------------------
 // AsyncRead adapter for ChannelReader
@@ -156,9 +158,7 @@ pub(crate) async fn handle_write_with_reader<R: FsRunner + ?Sized>(
     runner: &R,
 ) -> Result<WriteResponse, SandboxError> {
     let id = Uuid::parse_str(&sandbox_id).map_err(|_| {
-        SandboxError::InvalidRequest(format!(
-            "sandbox_id is not a valid UUID: {sandbox_id}"
-        ))
+        SandboxError::InvalidRequest(format!("sandbox_id is not a valid UUID: {sandbox_id}"))
     })?;
     let state = registry.get(id).await?;
     if state.stopped {
@@ -171,7 +171,10 @@ pub(crate) async fn handle_write_with_reader<R: FsRunner + ?Sized>(
         .await?;
 
     match result {
-        FsResult::Write { bytes_written, path: p } => Ok(WriteResponse {
+        FsResult::Write {
+            bytes_written,
+            path: p,
+        } => Ok(WriteResponse {
             bytes_written,
             path: p,
         }),
@@ -262,11 +265,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl FsRunner for FakeRunner {
-        async fn fs_call(
-            &self,
-            _shell_sock: PathBuf,
-            _op: FsOp,
-        ) -> Result<FsResult, SandboxError> {
+        async fn fs_call(&self, _shell_sock: PathBuf, _op: FsOp) -> Result<FsResult, SandboxError> {
             unimplemented!()
         }
 
@@ -283,14 +282,18 @@ mod tests {
             reader.read_to_end(&mut buf).await.unwrap();
             let bytes = buf.len() as u64;
             *self.captured.lock().await = buf;
-            Ok(FsResult::Write { bytes_written: bytes, path })
+            Ok(FsResult::Write {
+                bytes_written: bytes,
+                path,
+            })
         }
 
         async fn fs_read_stream(
             &self,
             _shell_sock: PathBuf,
             _path: String,
-        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError> {
+        ) -> Result<(FsReadMeta, Box<dyn tokio::io::AsyncRead + Unpin + Send>), SandboxError>
+        {
             unimplemented!()
         }
     }
@@ -319,7 +322,9 @@ mod tests {
         reg.insert(make_state(id)).await;
         let data = b"hello, sandbox!";
         let captured = Arc::new(Mutex::new(Vec::new()));
-        let runner = FakeRunner { captured: captured.clone() };
+        let runner = FakeRunner {
+            captured: captured.clone(),
+        };
         let cursor = Box::new(Cursor::new(data.to_vec()));
         let resp = handle_write_with_reader(
             id.to_string(),

--- a/crates/iii-worker/src/sandbox_daemon/mod.rs
+++ b/crates/iii-worker/src/sandbox_daemon/mod.rs
@@ -9,6 +9,7 @@ pub mod create;
 pub mod errors;
 pub mod events;
 pub mod exec;
+pub mod fs;
 pub mod list;
 pub mod overlay;
 pub mod reaper;
@@ -52,6 +53,11 @@ pub async fn run(config: SandboxConfig, engine_url: &str) -> anyhow::Result<()> 
     register_sandbox_exec(&iii, sandbox_registry.clone(), runner.clone());
     register_sandbox_stop(&iii, sandbox_registry.clone(), stopper.clone());
     register_sandbox_list(&iii, sandbox_registry.clone());
+
+    {
+        let fs_runner: std::sync::Arc<dyn fs::FsRunner> = std::sync::Arc::new(fs::IiiShellFsRunner);
+        fs::register_all(&iii, sandbox_registry.clone(), fs_runner);
+    }
 
     {
         let registry = (*sandbox_registry).clone();

--- a/crates/iii-worker/src/sandbox_daemon/registry.rs
+++ b/crates/iii-worker/src/sandbox_daemon/registry.rs
@@ -94,6 +94,16 @@ impl SandboxRegistry {
     pub async fn count(&self) -> usize {
         self.inner.lock().await.len()
     }
+
+    /// Update `last_exec_at` to now. Called by fs::* trigger handlers (which
+    /// don't use the exec-serialization guard) to keep the idle reaper from
+    /// evicting a sandbox that is actively performing file operations.
+    pub async fn bump_last_exec(&self, id: Uuid) {
+        let mut map = self.inner.lock().await;
+        if let Some(state) = map.get_mut(&id) {
+            state.last_exec_at = Instant::now();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/docs/api-reference/sandbox.mdx
+++ b/docs/api-reference/sandbox.mdx
@@ -27,7 +27,101 @@ how worker processes run inside isolated microVMs, see
 [Developing Sandbox Workers](/how-to/developing-sandbox-workers).
 </Note>
 
+<Warning>
+**Host requirements.** Sandboxes run as libkrun microVMs and need
+hardware virtualization on the host: macOS on **Apple Silicon**, or
+Linux with **KVM** enabled (`/dev/kvm` readable by the engine
+process). Intel Macs, Linux without KVM, and Windows hosts cannot
+boot sandboxes — `sandbox::create` returns `S300` with a stderr tail
+from the failed VM process. See [`S300`](#s-codes) in the error
+table for the full diagnostic flow.
+</Warning>
+
+## API surface at a glance
+
+The daemon registers fourteen triggers — four lifecycle ops plus ten
+filesystem ops. Every call goes through `iii.trigger()`; nothing is
+exposed over plain HTTP.
+
+The "Recommended `timeoutMs`" column is what to pass to
+`iii.trigger()`'s envelope timeout from the caller side — the daemon
+itself enforces a separate per-exec deadline (`payload.timeout_ms` on
+`sandbox::exec`) which defaults to 30s. Pad the envelope by ~5s over
+the daemon deadline so the daemon's own `timed_out` signal lands
+before the trigger client gives up.
+
+| Trigger | Category | Recommended `timeoutMs` | Purpose |
+|---|---|---|---|
+| [`sandbox::create`](#trigger-create) | lifecycle | `300_000` (cold pull can take 5-30s) | Boot a microVM and return a `sandbox_id` |
+| [`sandbox::exec`](#trigger-exec) | lifecycle | `35_000` (daemon default + 5s margin) | Run a command inside a live sandbox |
+| [`sandbox::list`](#trigger-list) | lifecycle | omit | Enumerate active sandboxes |
+| [`sandbox::stop`](#trigger-stop) | lifecycle | omit | Tear down a sandbox and reclaim resources |
+| [`sandbox::fs::ls`](#trigger-fs-ls) | filesystem | omit | List directory entries |
+| [`sandbox::fs::stat`](#trigger-fs-stat) | filesystem | omit | Inspect a single path |
+| [`sandbox::fs::mkdir`](#trigger-fs-mkdir) | filesystem | omit | Create a directory |
+| [`sandbox::fs::write`](#trigger-fs-write) | filesystem | omit (channel-paced) | Stream a file in (no envelope cap) |
+| [`sandbox::fs::read`](#trigger-fs-read) | filesystem | omit (channel-paced) | Stream a file out |
+| [`sandbox::fs::rm`](#trigger-fs-rm) | filesystem | omit | Remove a file or directory |
+| [`sandbox::fs::chmod`](#trigger-fs-chmod) | filesystem | omit | Change mode / owner |
+| [`sandbox::fs::mv`](#trigger-fs-mv) | filesystem | omit | Move or rename atomically |
+| [`sandbox::fs::grep`](#trigger-fs-grep) | filesystem | scale with tree size | Recursive regex search |
+| [`sandbox::fs::sed`](#trigger-fs-sed) | filesystem | scale with file count | Find-and-replace across files |
+
+The CLI (`iii sandbox …`) wraps a strict subset: `run`, `create`,
+`exec`, `list`, `stop`, `upload`, `download`. Anything not on that
+list is reachable only through `iii.trigger()` from your worker code.
+
+**Also on this page:**
+[Engine setup](#engine-setup) ·
+[Allowed images](#allowed-images) ·
+[Custom images](#custom-images) ·
+[Environment variables](#environment-variables) ·
+[Error handling](#error-handling) ·
+[S-codes](#s-codes) ·
+[CLI reference](#cli-reference) ·
+[Testing](#testing) ·
+[Troubleshooting](#troubleshooting)
+
 ## Quickstart
+
+The Node and Python examples below assume you already have an `iii`
+worker handle in scope. If this is your first call from outside an
+existing worker, here's the minimal setup:
+
+<CodeGroup>
+
+```typescript Node
+import { registerWorker } from 'iii-sdk'
+
+const iii = registerWorker('ws://127.0.0.1:49134')
+// `iii` is now usable for every `iii.trigger(...)` call below.
+```
+
+```python Python
+# pip install iii-sdk
+from iii import register_worker
+
+iii = register_worker("ws://127.0.0.1:49134")
+# Reuse `iii` for every `iii.trigger(...)` call below. The streaming
+# channel examples (fs::write, fs::read) rebind it as `iii_client`
+# purely to disambiguate from the SDK module name.
+```
+
+```rust Rust
+use iii_sdk::{register_worker, InitOptions};
+
+let iii = register_worker("ws://127.0.0.1:49134", InitOptions::default());
+// Reuse `iii` for every `iii.trigger(...)` call below.
+```
+
+</CodeGroup>
+
+The default engine WebSocket port is `49134` and the engine binds to
+`0.0.0.0:49134` by default. Override the port with the `--port` flag
+on every CLI command. If your engine runs on a remote host (Docker
+host, K8s service, remote dev VM), substitute that host's address in
+the `registerWorker("ws://<host>:<port>")` URL. See
+[Engine setup](#engine-setup) for the full URL convention.
 
 ### One-shot: boot, run one command, stop
 
@@ -239,6 +333,8 @@ handler invocation in an OpenTelemetry span. Route them through the
 standard observability worker — see
 [iii-observability](/workers/iii-observability).
 
+<a id="trigger-create" />
+
 ## SDK: creating a sandbox
 
 Call `sandbox::create` via `iii.trigger()` to boot a sandbox and get a `sandbox_id` handle.
@@ -316,6 +412,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 |---|---|---|
 | `sandbox_id` | `string` | UUID handle — pass to `sandbox::exec`, `sandbox::stop`, and `iii sandbox stop`. |
 | `image` | `string` | Echo of the resolved image name — the catalog preset or `custom_images` key that was booted. |
+
+<a id="trigger-exec" />
 
 ## SDK: running commands
 
@@ -495,6 +593,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 </CodeGroup>
 
+<a id="trigger-list" />
+
 ### `sandbox::list`
 
 Returns active sandboxes.
@@ -541,6 +641,413 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | `age_secs` | `number` | Seconds since create. |
 | `exec_in_progress` | `boolean` | `true` while an exec is in flight. |
 | `stopped` | `boolean` | `true` for sandboxes awaiting reap. |
+
+<a id="trigger-stop" />
+
+### `sandbox::stop`
+
+Tear down a running sandbox. The handler kills the VM process,
+unmounts and removes the overlay, drops the registry entry, and
+returns. The trigger is **not** idempotent across the registry
+boundary: once a stop succeeds, the registry entry is gone, so a
+second `sandbox::stop` against the same UUID returns `S002` (not
+found). It *is* tolerant of the rare race where the reaper marks the
+sandbox stopped between your calls — that path returns `{ stopped:
+true }` without re-killing anything.
+
+<CodeGroup>
+
+```typescript Node
+const result = await iii.trigger({
+  function_id: 'sandbox::stop',
+  payload: {
+    sandbox_id,
+    wait: true,             // optional, default false
+  },
+})
+// → { sandbox_id: '...', stopped: true }
+```
+
+```python Python
+result = await iii.trigger({
+    "function_id": "sandbox::stop",
+    "payload": {"sandbox_id": sandbox_id, "wait": True},
+})
+```
+
+```rust Rust
+use iii_sdk::{TriggerRequest};
+use serde_json::json;
+
+let _ = iii.trigger(TriggerRequest {
+    function_id: "sandbox::stop".into(),
+    payload: json!({ "sandbox_id": sandbox_id, "wait": true }),
+    action: None,
+    timeout_ms: None,
+}).await?;
+```
+
+</CodeGroup>
+
+#### `sandbox::stop` payload fields
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `sandbox_id` | `string` | — | **Required.** UUID handle from `sandbox::create`. |
+| `wait` | `boolean` | `false` | When `true`, the trigger waits for the reaper to finish releasing kernel/disk resources. When `false`, the call returns once the kill signal has been delivered — the resources may still be reclaiming in the background. |
+
+#### `sandbox::stop` response fields
+
+| Field | Type | Description |
+|---|---|---|
+| `sandbox_id` | `string` | Echo of the stopped sandbox's UUID. |
+| `stopped` | `boolean` | Always `true` on success. |
+
+Errors: `S001` on a malformed `sandbox_id`; `S002` on a UUID the
+daemon doesn't know about (which is what you'll get if you call stop
+twice on the same sandbox — the second call sees an empty registry
+slot).
+
+<a id="sdk-filesystem-operations" />
+
+## SDK: filesystem operations
+
+Ten `sandbox::fs::*` triggers give first-class file access to a live sandbox without going through `sandbox::exec`. Binary-safe, atomic where it matters (write, mv, sed all use temp + fsync + rename), and deterministic regex semantics (Rust `regex` flavor — RE2-ish, no backrefs/lookarounds) independent of the image's coreutils.
+
+| Trigger | Purpose |
+|---|---|
+| `sandbox::fs::ls` | List directory entries (non-recursive) |
+| `sandbox::fs::stat` | Get file/dir metadata |
+| `sandbox::fs::mkdir` | Create directory (with optional `parents`) |
+| `sandbox::fs::write` | Upload a file via streaming channel (no size cap) |
+| `sandbox::fs::read` | Download a file via streaming channel |
+| `sandbox::fs::rm` | Remove file or directory |
+| `sandbox::fs::chmod` | Change permissions / ownership |
+| `sandbox::fs::mv` | Move or rename |
+| `sandbox::fs::grep` | Search text recursively |
+| `sandbox::fs::sed` | Find-and-replace across files |
+
+All requests carry `sandbox_id` (the UUID returned by `sandbox::create`). Paths are absolute inside the VM's rootfs. Symlinks are operated on as symlinks, never followed.
+
+`fs::write` and `fs::read` stream bytes through III data channels — they don't share `sandbox::exec`'s 4 MiB JSON envelope cap, so multi-megabyte files round-trip cleanly. The other eight ops are one-shot JSON. None of them take the per-sandbox exec mutex, so a long `fs::grep` won't block a concurrent `sandbox::exec`.
+
+<a id="trigger-fs-ls" />
+
+### `sandbox::fs::ls`
+
+```typescript
+const { entries } = await iii.trigger({
+  function_id: 'sandbox::fs::ls',
+  payload: { sandbox_id, path: '/workspace' },
+})
+// entries: [{ name, is_dir, size, mode, mtime, is_symlink }, ...]
+```
+
+Non-recursive. Returns `S211` if the path is missing, `S212` if it's a regular file.
+
+<a id="trigger-fs-stat" />
+
+### `sandbox::fs::stat`
+
+```typescript
+const entry = await iii.trigger({
+  function_id: 'sandbox::fs::stat',
+  payload: { sandbox_id, path: '/workspace/foo.py' },
+})
+// entry: { name, is_dir, size, mode, mtime, is_symlink }
+```
+
+Returns `S211` if the path is missing.
+
+<a id="trigger-fs-mkdir" />
+
+### `sandbox::fs::mkdir`
+
+```typescript
+await iii.trigger({
+  function_id: 'sandbox::fs::mkdir',
+  payload: {
+    sandbox_id,
+    path: '/workspace/new/nested',
+    mode: '0755',           // optional, default '0755'
+    parents: true,          // optional, default false → mkdir -p semantics
+  },
+})
+// → { created: true }
+```
+
+`parents: false` + missing ancestor → `S211`. Existing path + `parents: false` → `S213`. `parents: true` on an existing directory is a no-op.
+
+<a id="trigger-fs-write" />
+
+### `sandbox::fs::write` (streaming upload)
+
+Caller opens a data channel, writes bytes into the writer half, and passes the reader half's ref to the trigger. The worker pumps from the channel into the guest's atomic temp+rename write.
+
+<CodeGroup>
+
+```typescript Node
+const channel = await iii.createChannel()
+channel.writer.stream.write(Buffer.from('hello\n'))
+channel.writer.stream.end()
+
+const { bytes_written, path } = await iii.trigger({
+  function_id: 'sandbox::fs::write',
+  payload: {
+    sandbox_id,
+    path: '/workspace/hello.txt',
+    mode: '0644',           // optional, default '0644'
+    parents: false,         // optional, default false
+    content: channel.readerRef,
+  },
+})
+// → { bytes_written: 6, path: '/workspace/hello.txt' }
+```
+
+```python Python
+channel = iii_client.create_channel()
+await channel.writer.write(b"hello\n")
+await channel.writer.close_async()
+
+result = await iii_client.trigger({
+    "function_id": "sandbox::fs::write",
+    "payload": {
+        "sandbox_id": sandbox_id,
+        "path": "/workspace/hello.txt",
+        "mode": "0644",
+        "content": channel.reader_ref.model_dump(),
+    },
+})
+```
+
+```rust Rust
+use iii_sdk::{ChannelWriter, register_worker, InitOptions, TriggerRequest};
+use serde_json::json;
+
+let iii = register_worker("ws://127.0.0.1:49134", InitOptions::default());
+let channel = iii.create_channel(None).await?;
+channel.writer.write(b"hello\n").await?;
+channel.writer.close().await?;
+
+let resp = iii.trigger(TriggerRequest {
+    function_id: "sandbox::fs::write".into(),
+    payload: json!({
+        "sandbox_id": sandbox_id,
+        "path": "/workspace/hello.txt",
+        "mode": "0644",
+        "content": channel.reader_ref,
+    }),
+    action: None,
+    timeout_ms: None,
+}).await?;
+```
+
+</CodeGroup>
+
+Atomic on disk: the supervisor writes to `<path>.iii-tmp-<uuid>`, fsyncs, then renames onto the target. If the channel closes before the writer signals end-of-stream (caller crashed mid-upload), the temp file is unlinked and the trigger returns `S218`. The original target — if it existed — is untouched.
+
+<a id="trigger-fs-read" />
+
+### `sandbox::fs::read` (streaming download)
+
+Trigger returns metadata synchronously plus a `StreamChannelRef` the caller pulls bytes from. The worker spawns a background task that pumps file bytes into the channel as the caller reads.
+
+<CodeGroup>
+
+```typescript Node
+import { ChannelReader } from 'iii-sdk'
+
+const resp = await iii.trigger({
+  function_id: 'sandbox::fs::read',
+  payload: { sandbox_id, path: '/workspace/hello.txt' },
+})
+// resp = { content: StreamChannelRef, size, mode, mtime }
+
+const reader = new ChannelReader(ENGINE_URL, resp.content)
+const chunks: Buffer[] = []
+for await (const chunk of reader.stream) chunks.push(chunk)
+const bytes = Buffer.concat(chunks)
+```
+
+```python Python
+result = await iii_client.trigger({
+    "function_id": "sandbox::fs::read",
+    "payload": {"sandbox_id": sandbox_id, "path": "/workspace/hello.txt"},
+})
+reader = ChannelReader(ENGINE_URL, StreamChannelRef(**result["content"]))
+data = await reader.read_all()
+```
+
+```rust Rust
+use iii_sdk::{ChannelReader, TriggerRequest};
+use serde_json::{json, Value};
+
+let resp: Value = iii.trigger(TriggerRequest {
+    function_id: "sandbox::fs::read".into(),
+    payload: json!({ "sandbox_id": sandbox_id, "path": "/workspace/hello.txt" }),
+    action: None,
+    timeout_ms: None,
+}).await?;
+// resp = { "content": StreamChannelRef, "size", "mode", "mtime" }
+
+let channel_ref = serde_json::from_value(resp["content"].clone())?;
+let reader = ChannelReader::new("ws://127.0.0.1:49134", &channel_ref);
+let bytes = reader.read_all().await?;
+```
+
+</CodeGroup>
+
+`S211` if the path is missing, `S212` if it's a directory. The supervisor holds the file descriptor open for the full stream so mid-read size changes don't affect the bytes you receive. If the read fails after metadata was emitted (e.g. `EIO`), the worker side-bands `{ "error": "S216", "message": "..." }` via the channel's text-message channel and closes the stream early.
+
+<a id="trigger-fs-rm" />
+
+### `sandbox::fs::rm`
+
+```typescript
+await iii.trigger({
+  function_id: 'sandbox::fs::rm',
+  payload: {
+    sandbox_id,
+    path: '/workspace/junk',
+    recursive: false,       // default false
+  },
+})
+// → { removed: true }
+```
+
+Non-recursive on a non-empty directory → `S214`, with the path preserved on disk. Symlinks are unlinked, never their targets.
+
+<a id="trigger-fs-chmod" />
+
+### `sandbox::fs::chmod`
+
+```typescript
+const { updated } = await iii.trigger({
+  function_id: 'sandbox::fs::chmod',
+  payload: {
+    sandbox_id,
+    path: '/workspace/foo.sh',
+    mode: '0755',
+    uid: null,              // optional u32
+    gid: null,              // optional u32
+    recursive: false,
+  },
+})
+// updated: number of entries successfully chmod'd (root included)
+```
+
+`uid` / `gid` are optional — pass either or both to chown alongside the mode change. `recursive: true` walks the tree (root entry counted). `updated` counts entries the call applied to, not entries whose mode actually differed.
+
+<a id="trigger-fs-mv" />
+
+### `sandbox::fs::mv`
+
+```typescript
+await iii.trigger({
+  function_id: 'sandbox::fs::mv',
+  payload: {
+    sandbox_id,
+    src: '/workspace/a',
+    dst: '/workspace/b',
+    overwrite: false,       // default false
+  },
+})
+// → { moved: true }
+```
+
+Same-filesystem moves are atomic via `rename(2)`. Cross-filesystem moves (e.g. across a virtio-fs mountpoint) fall back to copy-to-temp-at-dst, fsync, rename, unlink-src — `src` survives any partial failure. `overwrite: false` + existing `dst` → `S213`.
+
+<a id="trigger-fs-grep" />
+
+### `sandbox::fs::grep`
+
+```typescript
+const { matches, truncated } = await iii.trigger({
+  function_id: 'sandbox::fs::grep',
+  payload: {
+    sandbox_id,
+    path: '/workspace',
+    pattern: 'TODO\\(.+\\):',
+    recursive: true,
+    ignore_case: false,
+    include_glob: ['*.rs', '*.py'],
+    exclude_glob: ['target/*'],
+    max_matches: 1000,        // default 10000
+    max_line_bytes: 4096,     // default 4096
+  },
+})
+// matches: [{ path, line, content }, ...]   (legacy callers may also see `file` — it's an alias for `path`)
+```
+
+Rust `regex` syntax. Lines longer than `max_line_bytes` are truncated with `…`. Binary files (null-byte scan in the first 8 KiB) are skipped silently — same default as `ripgrep`. `truncated: true` means `max_matches` was reached and the walk stopped early. `line` is 1-based.
+
+`include_glob` / `exclude_glob` accept `*` (any chars except `/`) and `?` (any single char except `/`). For richer globbing, pre-filter via `sandbox::exec find ...` and pass single files.
+
+Bad regex → `S217`.
+
+<a id="trigger-fs-sed" />
+
+### `sandbox::fs::sed`
+
+`fs::sed` accepts **exactly one** of two forms — explicit `files`, or
+`path` + walk filters (mirrors `fs::grep`'s walk semantics so you can
+copy a grep query into a sed call). Sending both, or neither, returns
+`S210` before any file is touched.
+
+**Form 1 — explicit list (`files`):**
+
+```typescript
+const { results, total_replacements } = await iii.trigger({
+  function_id: 'sandbox::fs::sed',
+  payload: {
+    sandbox_id,
+    files: ['/workspace/a.txt', '/workspace/b.txt'],
+    pattern: 'foo',
+    replacement: 'bar',
+    regex: true,            // default true — false → literal substring match
+    first_only: false,      // true → at most one replace per line
+    ignore_case: false,
+  },
+})
+// results: [{ path, replacements, success, error? }, ...]   (alias `file` accepted for back-compat)
+```
+
+**Form 2 — walk a tree (`path`):**
+
+```typescript
+const { results, total_replacements } = await iii.trigger({
+  function_id: 'sandbox::fs::sed',
+  payload: {
+    sandbox_id,
+    path: '/workspace',
+    recursive: true,                     // default true; false on a directory → S210
+    include_glob: ['*.rs', '*.py'],      // gitignore-style; relative to `path`
+    exclude_glob: ['target/*'],
+    pattern: 'foo',
+    replacement: 'bar',
+    regex: true,
+    first_only: false,
+    ignore_case: false,
+  },
+})
+```
+
+Line-oriented: regex matches are tested per line, never across
+newlines. Use `$1`, `$2`, etc. in `replacement` for capture-group
+references. Each file is rewritten via temp+rename — a per-file error
+sets `success: false` on that entry without aborting the rest. The
+trigger always returns 2xx; check the per-file `success` flag and the
+top-level `total_replacements` counter.
+
+Bad regex → `S217` (top-level error; nothing rewritten). Mutually
+exclusive form check (`files` + `path`, or neither) → `S210`.
+
+For full POSIX sed (hold space, multi-line patterns, chained
+commands), use `sandbox::exec` with the image's own `sed` binary.
+
+### Concurrency and lifecycle
+
+Each `sandbox::fs::*` call opens a fresh `shell.sock` connection; the supervisor serves them on independent threads. There is no per-sandbox FS serialization — parallel `fs::write` and `fs::read` on the same file race at the filesystem level (same as two concurrent `sandbox::exec`s would). FS ops do **not** take the `exec_in_progress` mutex, so a long `fs::grep` does not block `sandbox::exec`. They do bump `last_exec_at` so the idle reaper leaves the sandbox alone while files are being moved around.
 
 ## Environment variables
 
@@ -681,8 +1188,14 @@ The daemon ships with two catalog presets:
 
 | Image | OCI reference | Use case |
 |---|---|---|
-| `python` | `iiidev/python:latest` | CPython 3 + standard library |
-| `node` | `iiidev/node:latest` | Node.js LTS |
+| `python` | `docker.io/iiidev/python:latest` | CPython 3 + standard library |
+| `node` | `docker.io/iiidev/node:latest` | Node.js LTS |
+
+The catalog stores fully-qualified refs (registry / namespace / repo /
+tag) so they hash to the same rootfs-cache slug as managed-worker
+boots of the same image. A custom-images entry that uses the
+shorthand `iiidev/python:latest` would pull the same bytes into a
+second cache slug under `~/.iii/cache/` — always pin the registry.
 
 Your engine's `image_allowlist` in `config.yaml` controls which images
 are actually bootable at runtime. The allowlist is fail-closed — an
@@ -751,17 +1264,25 @@ engine-level schema.
 ## Error handling
 
 Every sandbox failure throws an error whose message begins with
-`handler error:` followed by a JSON envelope. The `type` field is
-the error category — one of `validation`, `config`, `internal`,
-`transient`, `execution`, or `platform` — matching the category
-column in the [S-codes table](#s-codes) below:
+`handler error:` followed by a JSON envelope. The envelope is flat
+and always carries five fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | `string` | Category: `validation`, `config`, `internal`, `transient`, `execution`, `filesystem`, or `platform`. |
+| `code` | `string` | Stable S-code (e.g. `S100`, `S211`). The wire ABI — the [S-codes table](#s-codes) is the canonical reference. |
+| `message` | `string` | Human-readable explanation. Often includes the offending path, image, or timeout value. |
+| `docs_url` | `string` | Permalink to the per-code troubleshooting page: `https://docs.iii.dev/errors/sandbox/<code>`. |
+| `retryable` | `boolean` | `true` only for transient codes (`S102`, `S218`). All other codes are caller-fixable, not retryable. |
 
 ```
-handler error: {"type":"validation","code":"S002","message":"sandbox not found: <id>"}
-handler error: {"type":"execution","code":"S200","message":"exec timed out after 500ms"}
+handler error: {"type":"validation","code":"S002","message":"sandbox not found: <id>","docs_url":"https://docs.iii.dev/errors/sandbox/S002","retryable":false}
+handler error: {"type":"execution","code":"S200","message":"exec timed out after 500 ms","docs_url":"https://docs.iii.dev/errors/sandbox/S200","retryable":false}
+handler error: {"type":"transient","code":"S102","message":"auto-install failed for image 'python': network down","docs_url":"https://docs.iii.dev/errors/sandbox/S102","retryable":true}
 ```
 
-Parse the envelope if you need the S-code for targeted recovery:
+Parse the envelope if you need the S-code or the `retryable` flag for
+targeted recovery:
 
 <CodeGroup>
 
@@ -852,10 +1373,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### S-codes
 
-Both the S-code and the message are canonical: the daemon in
-[`errors.rs`](https://github.com/iii-hq/iii/blob/main/crates/iii-worker/src/sandbox_daemon/errors.rs)
-emits each code from a semantically matching variant. Parse `code` from the
-`handler error: {...}` envelope to distinguish cases.
+Both the S-code and the message are canonical: the daemon emits each
+code from a semantically matching error variant, and the
+`{type, code, message, docs_url, retryable}` payload is the stable
+SDK contract. Parse `code` from the `handler error: {...}` envelope
+for targeted recovery, and follow `docs_url` for the per-code
+troubleshooting page.
 
 | Code | Type | Retryable | Meaning | Typical fix |
 |---|---|---|---|---|
@@ -867,6 +1390,16 @@ emits each code from a semantically matching variant. Parse `code` from the
 | S101 | internal | false | Rootfs not on disk | Run `iii worker add iiidev/<image>` |
 | S102 | transient | **true** | Pull/unpack failed | Retry with backoff |
 | S200 | execution | false | `timeout_ms` exceeded | Raise the budget or split the work |
+| S210 | filesystem | false | Invalid `fs::*` request (bad path, malformed mode, empty pattern) | Fix the caller |
+| S211 | filesystem | false | Path not found | Check the path; create it first if needed |
+| S212 | filesystem | false | Wrong file type (e.g. `ls` on a file, `read` on a directory) | Match op to entry type |
+| S213 | filesystem | false | Path already exists (`mkdir` / `mv` without `overwrite`) | Pass `parents: true` / `overwrite: true`, or remove first |
+| S214 | filesystem | false | Directory not empty (`rm` without `recursive`) | Pass `recursive: true` |
+| S215 | filesystem | false | Permission denied inside the VM | Adjust mode/uid/gid via `fs::chmod` |
+| S216 | filesystem | false | I/O error (`EIO`, disk full, quota) | Inspect message; check VM disk health |
+| S217 | filesystem | false | Regex won't compile (`fs::grep` / `fs::sed`) | Fix the pattern (Rust regex flavor) |
+| S218 | filesystem | **true** | Channel closed before `FsEnd` (caller aborted upload mid-stream) | Retry with a fresh channel |
+| S219 | filesystem | false | FS ops not supported by this supervisor | Upgrade `iii-worker` (and restart it) |
 | S300 | platform | false | libkrun refused to boot | Check host reqs (macOS Apple Silicon / Linux KVM) |
 | S400 | config | false | cpus/memory over per-image cap | Lower request or raise cap |
 
@@ -971,6 +1504,125 @@ iii sandbox stop <sandbox-id> [--port P]
 
 Graceful stop by UUID. The id comes from `iii sandbox create`, `iii sandbox list`, or the
 `sandbox_id` field returned by `sandbox::create`.
+
+### `iii sandbox upload`
+
+```bash
+iii sandbox upload <sandbox-id> <local-path|-> <remote-path> [--mode 0644] [--parents] [--port P]
+```
+
+Stream a local file into a running sandbox via an iii data channel — no JSON-envelope size cap. Atomic on disk: the supervisor writes to a temp sibling, fsyncs, and renames onto `remote-path`. The original target (if any) is preserved on caller abort and surfaces as `S218` (retryable).
+
+Pass `-` as the local path to read from stdin, which makes the command pipe-friendly:
+
+```bash
+# Push a local file
+iii sandbox upload "$SB" ./script.js /workspace/script.js
+
+# Stream a tar archive directly into the sandbox without an intermediate file
+tar -cf - ./srcdir | iii sandbox upload "$SB" - /workspace/src.tar
+
+# Auto-create parent directories and tighten permissions
+iii sandbox upload "$SB" ./key.pem /etc/keys/app.pem --mode 0600 --parents
+```
+
+Two of the eight non-streaming `sandbox::fs::*` ops have shell equivalents that work fine through `sandbox::exec` (see [SDK: filesystem operations](#sdk-filesystem-operations)) — `upload` and `download` exist as dedicated commands because host↔guest byte movement does *not* have a clean shell equivalent.
+
+### `iii sandbox download`
+
+```bash
+iii sandbox download <sandbox-id> <remote-path> <local-path|-> [--port P]
+```
+
+Stream a sandbox file out to disk (or stdout). Pass `-` as the local path to write to stdout for piping:
+
+```bash
+# Save to disk
+iii sandbox download "$SB" /workspace/output.json ./output.json
+
+# Pipe straight into another tool — no intermediate file
+iii sandbox download "$SB" /workspace/build.tar - | tar -tf -
+
+# Inspect a JSON artifact with jq
+iii sandbox download "$SB" /workspace/result.json - | jq '.summary'
+```
+
+Errors map to the S21x band: missing path → `S211`, directory instead of file → `S212`, permission denied → `S215`, mid-stream I/O failure → `S216`. See [S-codes](#s-codes).
+
+### Smoke testing upload / download
+
+End-to-end verification you can paste into a terminal. Boots a sandbox, exercises both directions, verifies bytes round-trip, and tears down.
+
+**Upload round-trip** — push a known file, then `cat` it from inside the VM and `diff` against the original:
+
+```bash
+SB=$(iii sandbox create node)
+
+# 1. Upload from a local file
+echo "hello from upload smoke" > /tmp/payload.txt
+iii sandbox upload "$SB" /tmp/payload.txt /tmp/upload.txt
+
+# 2. Read it back via exec and diff against the source
+iii sandbox exec "$SB" -- cat /tmp/upload.txt | diff -q - /tmp/payload.txt \
+  && echo "OK: bytes match"
+
+# 3. Stdin variant — pipe directly without a temp file
+echo "from stdin" | iii sandbox upload "$SB" - /tmp/upload-stdin.txt
+iii sandbox exec "$SB" -- cat /tmp/upload-stdin.txt
+
+# 4. mode + parents into a deep path
+echo "secret" | iii sandbox upload "$SB" - /a/b/c/secret.bin --mode 0600 --parents
+iii sandbox exec "$SB" -- stat -c '%a' /a/b/c/secret.bin   # expects: 600
+
+iii sandbox stop "$SB"
+```
+
+**Download round-trip** — seed a file in the VM, download, byte-compare:
+
+```bash
+SB=$(iii sandbox create node)
+
+# 1. Seed a known file inside the sandbox
+iii sandbox exec "$SB" -- sh -c 'printf "round-trip me\n" > /tmp/source.txt'
+
+# 2. Download to a local path and diff
+iii sandbox download "$SB" /tmp/source.txt /tmp/got.txt
+iii sandbox exec "$SB" -- cat /tmp/source.txt | diff -q - /tmp/got.txt \
+  && echo "OK: bytes match"
+
+# 3. Stdout variant — pipe straight to jq, sha256sum, etc.
+iii sandbox exec "$SB" -- sh -c 'echo {"ok":true} > /tmp/out.json'
+iii sandbox download "$SB" /tmp/out.json - | jq .ok   # → true
+
+# 4. Error path — missing file surfaces S211 on stderr, nonzero exit
+iii sandbox download "$SB" /tmp/no-such-file - ; echo "rc=$?"
+
+iii sandbox stop "$SB"
+```
+
+The 16 KiB binary round-trip is the strict check — generate the same buffer host-side and in-VM, then `cmp -s`:
+
+```bash
+SB=$(iii sandbox create node)
+
+iii sandbox exec "$SB" -- node -e '
+  const fs = require("node:fs"); const buf = Buffer.alloc(16 * 1024);
+  for (let i = 0; i < buf.length; i++) buf[i] = i & 0xff;
+  fs.writeFileSync("/tmp/random.bin", buf);
+'
+node -e '
+  const fs = require("node:fs"); const buf = Buffer.alloc(16 * 1024);
+  for (let i = 0; i < buf.length; i++) buf[i] = i & 0xff;
+  fs.writeFileSync("/tmp/expected.bin", buf);
+'
+
+iii sandbox download "$SB" /tmp/random.bin /tmp/got.bin
+cmp -s /tmp/expected.bin /tmp/got.bin && echo "OK: 16 KiB binary match"
+
+iii sandbox stop "$SB"
+```
+
+This catches off-by-one truncation, base64 decode bugs in the channel layer, and partial chunk loss. If you see a sha256 mismatch instead, run with `RUST_LOG=trace,iii_worker::cli::shell_relay=trace` to inspect the per-chunk relay flow.
 
 ## Testing
 

--- a/engine/src/workers/external.rs
+++ b/engine/src/workers/external.rs
@@ -256,7 +256,18 @@ impl Worker for ExternalWorker {
         if let Some(ref path) = config_path {
             cmd.arg("--config").arg(path);
         }
-        cmd.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+        // Pipe stdio instead of inheriting the engine's TTY fds. External
+        // workers (notably iii-sandbox) load libkrun, which raws the host
+        // terminal when attaching the guest serial console — termios is per
+        // tty, so any tcsetattr by the child mutates the engine's terminal
+        // and scrambles tracing output until the VM exits. Piping isolates
+        // libkrun's tcsetattr to non-tty fds (calls become no-ops with
+        // ENOTTY) and forwarders below copy bytes line-atomic to the
+        // engine's stdout/stderr. stdin is /dev/null because workers don't
+        // read host stdin during normal operation.
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
 
         // Detach process group on Unix for clean termination
         #[cfg(unix)]
@@ -272,7 +283,7 @@ impl Worker for ExternalWorker {
             });
         }
 
-        let child = cmd.spawn().map_err(|e| {
+        let mut child = cmd.spawn().map_err(|e| {
             anyhow::anyhow!(
                 "Failed to spawn external worker '{}' ({}): {}",
                 self.name,
@@ -280,6 +291,18 @@ impl Worker for ExternalWorker {
                 e
             )
         })?;
+
+        // Forward child stdout/stderr to engine stdout/stderr line-atomically.
+        // BufReader::read_until('\n') hands us complete lines (or trailing EOF
+        // bytes). Each forwarded line is one Stdout::write_all / Stderr::write_all
+        // call, which holds the global StdoutLock/StderrLock for the duration —
+        // so worker lines never interleave mid-line with engine tracing output.
+        if let Some(stdout) = child.stdout.take() {
+            tokio::spawn(forward_pipe(stdout, false));
+        }
+        if let Some(stderr) = child.stderr.take() {
+            tokio::spawn(forward_pipe(stderr, true));
+        }
 
         tracing::info!(
             "Spawned external worker '{}' (pid: {:?})",
@@ -345,6 +368,42 @@ async fn kill_child(child: &Arc<Mutex<Option<Child>>>) {
                 let _ = proc.kill().await;
             }
             let _ = proc.wait().await;
+        }
+    }
+}
+
+/// Copy a child process pipe to the engine's stdout/stderr line-atomically.
+///
+/// `read_until(b'\n', ...)` returns each complete line (with the trailing
+/// newline) plus any unterminated tail at EOF. We then issue one
+/// `write_all` call to the engine's stdout/stderr lock, which holds the
+/// process-global `StdoutLock`/`StderrLock` for the full write — so a
+/// worker log line never lands in the middle of an engine tracing event
+/// and the terminal sees coherent line boundaries.
+///
+/// The task ends when the child closes its end of the pipe (Ok(0)) or
+/// on any read error.
+async fn forward_pipe<R>(reader: R, to_stderr: bool)
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    use std::io::Write;
+    use tokio::io::AsyncBufReadExt;
+
+    let mut buf = tokio::io::BufReader::new(reader);
+    let mut line: Vec<u8> = Vec::with_capacity(512);
+    loop {
+        line.clear();
+        match buf.read_until(b'\n', &mut line).await {
+            Ok(0) => return,
+            Ok(_) => {
+                if to_stderr {
+                    let _ = std::io::stderr().lock().write_all(&line);
+                } else {
+                    let _ = std::io::stdout().lock().write_all(&line);
+                }
+            }
+            Err(_) => return,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Ten new `sandbox::fs::*` triggers (`ls`, `stat`, `mkdir`, `write`, `read`, `rm`, `chmod`, `mv`, `grep`, `sed`) for ephemeral microVM filesystem access
- `iii sandbox upload` / `iii sandbox download` CLI commands streaming through iii data channels (with `-` for stdin/stdout). The other eight ops have clean coreutil equivalents reachable via `iii sandbox exec`.
- New S210–S219 typed error band on `SandboxError`. S218 is the only retryable code; the wire-ABI mapping is pinned by table-driven tests on `map_vm_error` so silent renames can't shift the SDK error JSON contract.
- Wire protocol additions in `iii-shell-proto`: `FsRequest`, `FsMeta`, `FsChunk`, `FsEnd`, `FsResponse`, `FsError`. `FsOp` uses `#[serde(deny_unknown_fields)]`; `FsMatch.path` / `FsSedFileResult.path` canonicalized with `#[serde(alias = "file")]` for legacy decoders.
- Atomic writes (temp + fsync + rename) for `write`, `mv`, and `sed`. `write`/`read` stream through iii data channels (no JSON-envelope size cap, inherits backpressure).
- Engine TTY isolation: external workers (notably `iii-sandbox`) load libkrun, which `tcsetattr`s the host TTY when attaching the guest serial console. Pipe stdio via dedicated forwarders fixes the engine-tracing scrambling regression.
- Reliability fixes: `sandbox::exec` `stdin: ""` now sends a real EOF; in-VM execve `ENOENT`/`ENOTDIR`/`EACCES` returns shell-style 127/126 exit codes; `--network` bool gates the smoltcp stack end-to-end; shell-relay `release_slot` no longer burns 250ms cooldown on clean disconnects (fixes S216 under burst).

## Test plan

- [x] `cargo test -p iii-shell-proto` — 35 passed
- [x] `cargo test -p iii-shell-client` — 24 passed
- [x] `cargo test -p iii-worker --lib` — 557 passed, 1 ignored, 0 failed
- [x] `cargo test -p iii-worker` — 812 passed, 4 ignored
- [x] `cargo check -p iii-init --target aarch64-unknown-linux-musl` — clean
- [x] `cargo test -p iii-init --target aarch64-unknown-linux-musl --no-run` — builds clean (cfg-gated to linux; no execution on darwin host)
- [x] `tmp/try-vm-exec/agent.mjs` — 23/23 narrative steps green
- [x] `tmp/try-vm-exec/meta-agent.mjs` — 6/6 markers green (outer creates a sibling sandbox via the engine WS protocol from inside its own VM)
- [ ] CI matrix on the PR

Spec: `docs/superpowers/specs/2026-04-24-sandbox-fs-ops-design.md`
Plan: `docs/superpowers/plans/2026-04-27-sandbox-api-dx-fixes-plan.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ten sandbox filesystem operations: ls, stat, mkdir, rm, chmod, mv, grep, sed, read, and write with streaming upload/download support.
  * Added `iii sandbox upload` and `download` CLI commands for file transfers to/from sandboxes.
  * Added `--network` flag to control guest networking initialization.

* **Documentation**
  * Updated API reference with filesystem trigger documentation, error codes, and CLI examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->