### PR TITLE
Surface state update failures consistently

### DIFF
--- a/docs/workers/iii-state.mdx
+++ b/docs/workers/iii-state.mdx
@@ -243,7 +243,7 @@ Each `state::update` op may add an entry to the response `errors` array. Operati
 | `merge.value.too_many_keys` | `merge` value has more than 1024 top-level keys | Split the write into smaller updates. |
 | `merge.value.proto_polluted` | A top-level key in the merge value is `__proto__`, `constructor`, or `prototype` | Use a different key name. |
 
-All errors include `op_index`, `code`, `message`, and `doc_url`.
+Each error includes `op_index`, `code`, and `message`; `doc_url` is optional.
 
 ```json
 {

--- a/docs/workers/iii-state.mdx
+++ b/docs/workers/iii-state.mdx
@@ -203,7 +203,7 @@ name: bridge
 
         Each array element is a *literal* key. `["a.b"]` writes a single key named `"a.b"`, not `a → b`.
 
-        Validation: invalid `merge` inputs are rejected with a structured error in the response's `errors` array. Reasons include path depth > 32 segments, segment > 256 bytes, value depth > 16, > 1024 top-level keys, or any segment / top-level key matching `__proto__` / `constructor` / `prototype`. Successfully applied ops still reflect in `new_value`.
+        Validation: invalid update inputs are rejected with a structured error in the response's `errors` array. Reasons include path depth > 32 segments, segment > 256 bytes, value depth > 16, > 1024 top-level keys, type mismatches, non-object targets, or any segment / top-level key matching `__proto__` / `constructor` / `prototype`. Successfully applied ops still reflect in `new_value`.
       </ResponseField>
     </Accordion>
     <Accordion title="Returns">
@@ -214,11 +214,66 @@ name: bridge
         The value after all operations were applied.
       </ResponseField>
       <ResponseField name="errors" type="UpdateOpError[]">
-        Per-op validation errors. Currently emitted only by `merge` for inputs that violate validation bounds (path depth/size, value depth, prototype-pollution sinks). Field is omitted when empty. Each entry has `op_index`, `code`, `message`, and an optional `doc_url`.
+        Per-op validation errors. Field is omitted when empty. Each entry has `op_index`, `code`, `message`, and an optional `doc_url`.
       </ResponseField>
     </Accordion>
   </AccordionGroup>
 </ResponseField>
+
+## Error codes
+
+Each `state::update` op may add an entry to the response `errors` array. Operations are best-effort: successfully applied ops still reflect in `new_value`, and failed ops are skipped.
+
+| Code | Triggered when | Fix |
+|------|----------------|-----|
+| `set.target_not_object` | `set` tried to write a field while the current value is not an object | Set the root to an object first, or use `path: ""` to replace the root. |
+| `append.target_not_object` | `append` used a field path while the current value is not an object | Set the root to an object first, or append at `path: ""`. |
+| `append.type_mismatch` | `append` targeted an incompatible existing value, such as appending to a number or appending a non-string to a string | Match the appended value to the existing field type, or initialize the field to an array, string, or null. |
+| `increment.target_not_object` | `increment` used a field path while the current value is not an object | Set the root to an object first. |
+| `increment.not_number` | `increment` targeted an existing field that is not a number | Initialize the field as a number first, for example with `set` to `0`. |
+| `decrement.target_not_object` | `decrement` used a field path while the current value is not an object | Set the root to an object first. |
+| `decrement.not_number` | `decrement` targeted an existing field that is not a number | Initialize the field as a number first, for example with `set` to `0`. |
+| `remove.target_not_object` | `remove` used a field path while the current value is not an object | Set the root to an object first. Removing a missing field from an object remains silent. |
+| `<op>.path.proto_polluted` | A path segment is `__proto__`, `constructor`, or `prototype` | Use a different field name. |
+| `<op>.path.segment_too_long` | A path segment is longer than 256 bytes | Shorten the field name or merge path segment. |
+| `merge.path.too_deep` | A nested merge path has more than 32 segments | Reduce the nested path depth. |
+| `merge.path.empty_segment` | A nested merge path array contains an empty segment | Remove the empty segment. |
+| `merge.value.not_an_object` | `merge` value is not a JSON object | Pass an object as the merge value. |
+| `merge.value.too_deep` | `merge` value has JSON nesting deeper than 16 levels | Flatten the value. |
+| `merge.value.too_many_keys` | `merge` value has more than 1024 top-level keys | Split the write into smaller updates. |
+| `merge.value.proto_polluted` | A top-level key in the merge value is `__proto__`, `constructor`, or `prototype` | Use a different key name. |
+
+All errors include `op_index`, `code`, `message`, and `doc_url`.
+
+```json
+{
+  "old_value": { "name": "Ada" },
+  "new_value": { "name": "Ada" },
+  "errors": [
+    {
+      "op_index": 0,
+      "code": "increment.not_number",
+      "message": "Expected number at path 'name', got string.",
+      "doc_url": "https://iii.dev/docs/workers/iii-state#error-codes"
+    }
+  ]
+}
+```
+
+```json
+{
+  "old_value": {},
+  "new_value": {},
+  "errors": [
+    {
+      "op_index": 0,
+      "code": "set.path.proto_polluted",
+      "message": "Path segment '__proto__' is not allowed (prototype pollution).",
+      "doc_url": "https://iii.dev/docs/workers/iii-state#error-codes"
+    }
+  ]
+}
+```
 
 <ResponseField name="state::list" type="function">
   List all values within a scope.

--- a/docs/workers/iii-stream.mdx
+++ b/docs/workers/iii-stream.mdx
@@ -304,11 +304,51 @@ config:
         The value now stored in the stream after applying the operations.
       </ResponseField>
       <ResponseField name="errors" type="UpdateOpError[]">
-        Per-op validation errors. Currently emitted only by `merge` for inputs that violate validation bounds. Field is omitted when empty.
+        Per-op validation errors. Field is omitted when empty. Each entry has `op_index`, `code`, `message`, and an optional `doc_url`.
       </ResponseField>
     </Accordion>
   </AccordionGroup>
 </ResponseField>
+
+## Error codes
+
+`stream::update` uses the same update engine as [`state::update`](/workers/iii-state#error-codes). Each op may add an entry to the response `errors` array. Operations are best-effort: successfully applied ops still reflect in `new_value`, and failed ops are skipped.
+
+| Code | Triggered when | Fix |
+|------|----------------|-----|
+| `set.target_not_object` | `set` tried to write a field while the current value is not an object | Set the root to an object first, or use `path: ""` to replace the root. |
+| `append.target_not_object` | `append` used a field path while the current value is not an object | Set the root to an object first, or append at `path: ""`. |
+| `append.type_mismatch` | `append` targeted an incompatible existing value, such as appending to a number or appending a non-string to a string | Match the appended value to the existing field type, or initialize the field to an array, string, or null. |
+| `increment.target_not_object` | `increment` used a field path while the current value is not an object | Set the root to an object first. |
+| `increment.not_number` | `increment` targeted an existing field that is not a number | Initialize the field as a number first, for example with `set` to `0`. |
+| `decrement.target_not_object` | `decrement` used a field path while the current value is not an object | Set the root to an object first. |
+| `decrement.not_number` | `decrement` targeted an existing field that is not a number | Initialize the field as a number first, for example with `set` to `0`. |
+| `remove.target_not_object` | `remove` used a field path while the current value is not an object | Set the root to an object first. Removing a missing field from an object remains silent. |
+| `<op>.path.proto_polluted` | A path segment is `__proto__`, `constructor`, or `prototype` | Use a different field name. |
+| `<op>.path.segment_too_long` | A path segment is longer than 256 bytes | Shorten the field name or merge path segment. |
+| `merge.path.too_deep` | A nested merge path has more than 32 segments | Reduce the nested path depth. |
+| `merge.path.empty_segment` | A nested merge path array contains an empty segment | Remove the empty segment. |
+| `merge.value.not_an_object` | `merge` value is not a JSON object | Pass an object as the merge value. |
+| `merge.value.too_deep` | `merge` value has JSON nesting deeper than 16 levels | Flatten the value. |
+| `merge.value.too_many_keys` | `merge` value has more than 1024 top-level keys | Split the write into smaller updates. |
+| `merge.value.proto_polluted` | A top-level key in the merge value is `__proto__`, `constructor`, or `prototype` | Use a different key name. |
+
+All errors include `op_index`, `code`, `message`, and `doc_url`.
+
+```json
+{
+  "old_value": { "count": 1 },
+  "new_value": { "count": 1 },
+  "errors": [
+    {
+      "op_index": 0,
+      "code": "append.type_mismatch",
+      "message": "Cannot append at path 'count': target is number, expected array, string, null, or missing field.",
+      "doc_url": "https://iii.dev/docs/workers/iii-state#error-codes"
+    }
+  ]
+}
+```
 
 ## Authentication
 

--- a/docs/workers/iii-stream.mdx
+++ b/docs/workers/iii-stream.mdx
@@ -333,7 +333,7 @@ config:
 | `merge.value.too_many_keys` | `merge` value has more than 1024 top-level keys | Split the write into smaller updates. |
 | `merge.value.proto_polluted` | A top-level key in the merge value is `__proto__`, `constructor`, or `prototype` | Use a different key name. |
 
-All errors include `op_index`, `code`, `message`, and `doc_url`.
+Each error includes `op_index`, `code`, and `message`; `doc_url` is optional.
 
 ```json
 {

--- a/engine/src/update_ops.rs
+++ b/engine/src/update_ops.rs
@@ -261,7 +261,22 @@ fn increment_number(value: &Value, by: i64) -> Option<Value> {
         return Some(Value::Number(Number::from(sum)));
     }
 
-    Number::from_f64(value.as_f64()? + by as f64).map(Value::Number)
+    if let Some(num) = value.as_u64() {
+        let sum = if by >= 0 {
+            num.checked_add(by as u64)?
+        } else {
+            num.checked_sub(by.unsigned_abs())?
+        };
+        return Some(Value::Number(Number::from(sum)));
+    }
+
+    if let Value::Number(number) = value
+        && number.is_f64()
+    {
+        return Number::from_f64(number.as_f64()? + by as f64).map(Value::Number);
+    }
+
+    None
 }
 
 fn decrement_number(value: &Value, by: i64) -> Option<Value> {
@@ -271,7 +286,30 @@ fn decrement_number(value: &Value, by: i64) -> Option<Value> {
         return Some(Value::Number(Number::from(diff)));
     }
 
-    Number::from_f64(value.as_f64()? - by as f64).map(Value::Number)
+    if let Some(num) = value.as_u64() {
+        let diff = if by >= 0 {
+            num.checked_sub(by as u64)?
+        } else {
+            num.checked_add(by.unsigned_abs())?
+        };
+        return Some(Value::Number(Number::from(diff)));
+    }
+
+    if let Value::Number(number) = value
+        && number.is_f64()
+    {
+        return Number::from_f64(number.as_f64()? - by as f64).map(Value::Number);
+    }
+
+    None
+}
+
+fn missing_decrement_value(by: i64) -> Value {
+    if let Some(negated) = by.checked_neg() {
+        Value::Number(Number::from(negated))
+    } else {
+        Value::Number(Number::from(by.unsigned_abs()))
+    }
 }
 
 pub(crate) fn apply_update_ops(
@@ -349,7 +387,25 @@ pub(crate) fn apply_update_ops(
                 if !validate_op_path("increment", op_index, segments, &mut errors) {
                     continue;
                 }
-                if let Value::Object(ref mut map) = current {
+                if path.0.is_empty() {
+                    if using_missing_default {
+                        current = Value::Number(Number::from(*by));
+                    } else if let Some(updated) = increment_number(&current, *by) {
+                        current = updated;
+                    } else {
+                        errors.push(err(
+                            op_index,
+                            ERR_INCREMENT_NOT_NUMBER,
+                            format!(
+                                "Expected number at path '{}', got {}.",
+                                path_label(&path.0),
+                                json_type_name(&current)
+                            ),
+                        ));
+                        continue;
+                    }
+                    using_missing_default = false;
+                } else if let Value::Object(ref mut map) = current {
                     if let Some(existing_val) = map.get_mut(&path.0) {
                         if let Some(updated) = increment_number(existing_val, *by) {
                             *existing_val = updated;
@@ -386,7 +442,25 @@ pub(crate) fn apply_update_ops(
                 if !validate_op_path("decrement", op_index, segments, &mut errors) {
                     continue;
                 }
-                if let Value::Object(ref mut map) = current {
+                if path.0.is_empty() {
+                    if using_missing_default {
+                        current = missing_decrement_value(*by);
+                    } else if let Some(updated) = decrement_number(&current, *by) {
+                        current = updated;
+                    } else {
+                        errors.push(err(
+                            op_index,
+                            ERR_DECREMENT_NOT_NUMBER,
+                            format!(
+                                "Expected number at path '{}', got {}.",
+                                path_label(&path.0),
+                                json_type_name(&current)
+                            ),
+                        ));
+                        continue;
+                    }
+                    using_missing_default = false;
+                } else if let Value::Object(ref mut map) = current {
                     if let Some(existing_val) = map.get_mut(&path.0) {
                         if let Some(updated) = decrement_number(existing_val, *by) {
                             *existing_val = updated;
@@ -403,7 +477,7 @@ pub(crate) fn apply_update_ops(
                             continue;
                         }
                     } else {
-                        map.insert(path.0.clone(), Value::Number(Number::from(-*by)));
+                        map.insert(path.0.clone(), missing_decrement_value(*by));
                     }
                     using_missing_default = false;
                 } else {
@@ -454,7 +528,10 @@ pub(crate) fn apply_update_ops(
                 if !validate_op_path("remove", op_index, segments, &mut errors) {
                     continue;
                 }
-                if let Value::Object(ref mut map) = current {
+                if path.0.is_empty() {
+                    current = Value::Null;
+                    using_missing_default = false;
+                } else if let Value::Object(ref mut map) = current {
                     map.remove(&path.0);
                     using_missing_default = false;
                 } else {
@@ -535,7 +612,7 @@ fn initial_append_value(value: &Value) -> Value {
 #[cfg(test)]
 mod tests {
     use iii_sdk::{FieldPath, UpdateOp, types::MergePath};
-    use serde_json::json;
+    use serde_json::{Number, json};
 
     use super::apply_update_ops;
 
@@ -757,14 +834,51 @@ mod tests {
     }
 
     #[test]
-    fn numeric_overflow_falls_back_to_json_float_number() {
+    fn numeric_overflow_promotes_to_exact_unsigned_integer() {
         let updated = run(
             Some(json!({ "count": i64::MAX })),
             &[UpdateOp::increment("count", 1)],
         );
 
-        assert!(updated["count"].is_number());
-        assert_eq!(updated["count"].as_f64(), Some(i64::MAX as f64 + 1.0));
+        assert_eq!(updated["count"].as_u64(), Some(i64::MAX as u64 + 1));
+    }
+
+    #[test]
+    fn numeric_ops_preserve_large_unsigned_integer_precision() {
+        let large = Number::from(i64::MAX as u64 + 10);
+        let updated = run(
+            Some(json!({ "inc": large.clone(), "dec": large })),
+            &[UpdateOp::increment("inc", 1), UpdateOp::decrement("dec", 1)],
+        );
+
+        assert_eq!(updated["inc"].as_u64(), Some(i64::MAX as u64 + 11));
+        assert_eq!(updated["dec"].as_u64(), Some(i64::MAX as u64 + 9));
+    }
+
+    #[test]
+    fn missing_decrement_by_i64_min_initializes_exact_unsigned_value() {
+        let updated = run(Some(json!({})), &[UpdateOp::decrement("count", i64::MIN)]);
+
+        assert_eq!(updated["count"].as_u64(), Some(i64::MIN.unsigned_abs()));
+    }
+
+    #[test]
+    fn empty_path_numeric_ops_target_root_value() {
+        let incremented = run(Some(json!(2)), &[UpdateOp::increment("", 3)]);
+        let decremented = run(Some(json!(5)), &[UpdateOp::decrement("", 3)]);
+
+        assert_eq!(incremented, json!(5));
+        assert_eq!(decremented, json!(2));
+    }
+
+    #[test]
+    fn empty_path_remove_clears_root_value() {
+        let updated = run(
+            Some(json!({ "": "empty-field", "keep": true })),
+            &[UpdateOp::remove("")],
+        );
+
+        assert_eq!(updated, json!(null));
     }
 
     #[test]

--- a/engine/src/update_ops.rs
+++ b/engine/src/update_ops.rs
@@ -29,8 +29,16 @@ pub(crate) const ERR_VALUE_TOO_DEEP: &str = "merge.value.too_deep";
 pub(crate) const ERR_VALUE_TOO_MANY_KEYS: &str = "merge.value.too_many_keys";
 pub(crate) const ERR_VALUE_PROTO: &str = "merge.value.proto_polluted";
 pub(crate) const ERR_VALUE_NOT_OBJECT: &str = "merge.value.not_an_object";
+pub(crate) const ERR_SET_TARGET_NOT_OBJECT: &str = "set.target_not_object";
+pub(crate) const ERR_APPEND_TARGET_NOT_OBJECT: &str = "append.target_not_object";
+pub(crate) const ERR_APPEND_TYPE_MISMATCH: &str = "append.type_mismatch";
+pub(crate) const ERR_INCREMENT_TARGET_NOT_OBJECT: &str = "increment.target_not_object";
+pub(crate) const ERR_INCREMENT_NOT_NUMBER: &str = "increment.not_number";
+pub(crate) const ERR_DECREMENT_TARGET_NOT_OBJECT: &str = "decrement.target_not_object";
+pub(crate) const ERR_DECREMENT_NOT_NUMBER: &str = "decrement.not_number";
+pub(crate) const ERR_REMOVE_TARGET_NOT_OBJECT: &str = "remove.target_not_object";
 
-const DOC_URL_BASE: &str = "https://iii.dev/docs/workers/iii-state#merge-bounds";
+const DOC_URL_BASE: &str = "https://iii.dev/docs/workers/iii-state#error-codes";
 
 fn err(op_index: usize, code: &str, message: String) -> UpdateOpError {
     UpdateOpError {
@@ -44,7 +52,7 @@ fn err(op_index: usize, code: &str, message: String) -> UpdateOpError {
 /// Normalize an `Option<MergePath>` into a borrowed slice of segments.
 /// `None`, `Single("")`, and `Segments(vec![])` all collapse to an
 /// empty slice meaning "root merge".
-fn merge_path_segments<'a>(path: &'a Option<MergePath>) -> &'a [String] {
+fn merge_path_segments(path: &Option<MergePath>) -> &[String] {
     match path {
         None => &[],
         Some(MergePath::Single(s)) => {
@@ -58,7 +66,26 @@ fn merge_path_segments<'a>(path: &'a Option<MergePath>) -> &'a [String] {
     }
 }
 
-fn validate_merge_path(
+fn field_path_segments(path: &String) -> &[String] {
+    if path.is_empty() {
+        &[]
+    } else {
+        std::slice::from_ref(path)
+    }
+}
+
+fn path_error_code(op_name: &str, reason: &str) -> String {
+    match (op_name, reason) {
+        ("merge", "too_deep") => ERR_PATH_TOO_DEEP.to_string(),
+        ("merge", "segment_too_long") => ERR_SEGMENT_TOO_LONG.to_string(),
+        ("merge", "empty_segment") => ERR_EMPTY_SEGMENT.to_string(),
+        ("merge", "proto_polluted") => ERR_PATH_PROTO.to_string(),
+        _ => format!("{op_name}.path.{reason}"),
+    }
+}
+
+fn validate_op_path(
+    op_name: &str,
     op_index: usize,
     segments: &[String],
     errors: &mut Vec<UpdateOpError>,
@@ -66,7 +93,7 @@ fn validate_merge_path(
     if segments.len() > MAX_PATH_DEPTH {
         errors.push(err(
             op_index,
-            ERR_PATH_TOO_DEEP,
+            &path_error_code(op_name, "too_deep"),
             format!(
                 "Path depth {} exceeds maximum of {}",
                 segments.len(),
@@ -79,7 +106,7 @@ fn validate_merge_path(
         if seg.is_empty() {
             errors.push(err(
                 op_index,
-                ERR_EMPTY_SEGMENT,
+                &path_error_code(op_name, "empty_segment"),
                 "Path contains an empty segment".to_string(),
             ));
             return false;
@@ -87,7 +114,7 @@ fn validate_merge_path(
         if seg.len() > MAX_SEGMENT_BYTES {
             errors.push(err(
                 op_index,
-                ERR_SEGMENT_TOO_LONG,
+                &path_error_code(op_name, "segment_too_long"),
                 format!(
                     "Path segment of {} bytes exceeds maximum of {}",
                     seg.len(),
@@ -99,13 +126,21 @@ fn validate_merge_path(
         if PROTO_POLLUTION_KEYS.contains(&seg.as_str()) {
             errors.push(err(
                 op_index,
-                ERR_PATH_PROTO,
-                format!("Path segment {:?} is a prototype-pollution sink", seg),
+                &path_error_code(op_name, "proto_polluted"),
+                format!("Path segment '{seg}' is not allowed (prototype pollution)."),
             ));
             return false;
         }
     }
     true
+}
+
+fn validate_merge_path(
+    op_index: usize,
+    segments: &[String],
+    errors: &mut Vec<UpdateOpError>,
+) -> bool {
+    validate_op_path("merge", op_index, segments, errors)
 }
 
 fn json_depth(value: &Value) -> usize {
@@ -204,6 +239,41 @@ fn walk_or_create<'a>(
     }
 }
 
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn path_label(path: &str) -> &str {
+    if path.is_empty() { "root" } else { path }
+}
+
+fn increment_number(value: &Value, by: i64) -> Option<Value> {
+    if let Some(num) = value.as_i64()
+        && let Some(sum) = num.checked_add(by)
+    {
+        return Some(Value::Number(Number::from(sum)));
+    }
+
+    Number::from_f64(value.as_f64()? + by as f64).map(Value::Number)
+}
+
+fn decrement_number(value: &Value, by: i64) -> Option<Value> {
+    if let Some(num) = value.as_i64()
+        && let Some(diff) = num.checked_sub(by)
+    {
+        return Some(Value::Number(Number::from(diff)));
+    }
+
+    Number::from_f64(value.as_f64()? - by as f64).map(Value::Number)
+}
+
 pub(crate) fn apply_update_ops(
     old_value: Option<Value>,
     ops: &[UpdateOp],
@@ -215,19 +285,26 @@ pub(crate) fn apply_update_ops(
     for (op_index, op) in ops.iter().enumerate() {
         match op {
             UpdateOp::Set { path, value } => {
-                if path.0.is_empty()
-                    && let Some(value) = value
-                {
-                    current = value.clone();
+                let segments = field_path_segments(&path.0);
+                if !validate_op_path("set", op_index, segments, &mut errors) {
+                    continue;
+                }
+                if path.0.is_empty() {
+                    current = value.clone().unwrap_or(Value::Null);
                     using_missing_default = false;
                 } else if let Value::Object(ref mut map) = current {
                     map.insert(path.0.clone(), value.clone().unwrap_or(Value::Null));
                     using_missing_default = false;
                 } else {
-                    tracing::warn!(
-                        path = %path.0,
-                        "Set operation with path requires existing value to be a JSON object"
-                    );
+                    errors.push(err(
+                        op_index,
+                        ERR_SET_TARGET_NOT_OBJECT,
+                        format!(
+                            "Cannot set at path '{}': target is {}, expected object.",
+                            path_label(&path.0),
+                            json_type_name(&current)
+                        ),
+                    ));
                 }
             }
             UpdateOp::Merge { path, value } => {
@@ -268,74 +345,128 @@ pub(crate) fn apply_update_ops(
                 }
             }
             UpdateOp::Increment { path, by } => {
+                let segments = field_path_segments(&path.0);
+                if !validate_op_path("increment", op_index, segments, &mut errors) {
+                    continue;
+                }
                 if let Value::Object(ref mut map) = current {
                     if let Some(existing_val) = map.get_mut(&path.0) {
-                        if let Some(num) = existing_val.as_i64() {
-                            *existing_val = Value::Number(Number::from(num + *by));
+                        if let Some(updated) = increment_number(existing_val, *by) {
+                            *existing_val = updated;
                         } else {
-                            *existing_val = Value::Number(Number::from(*by));
+                            errors.push(err(
+                                op_index,
+                                ERR_INCREMENT_NOT_NUMBER,
+                                format!(
+                                    "Expected number at path '{}', got {}.",
+                                    path_label(&path.0),
+                                    json_type_name(existing_val)
+                                ),
+                            ));
+                            continue;
                         }
                     } else {
                         map.insert(path.0.clone(), Value::Number(Number::from(*by)));
                     }
                     using_missing_default = false;
                 } else {
-                    tracing::warn!(
-                        path = %path.0,
-                        "Increment operation requires existing value to be a JSON object"
-                    );
+                    errors.push(err(
+                        op_index,
+                        ERR_INCREMENT_TARGET_NOT_OBJECT,
+                        format!(
+                            "Cannot increment at path '{}': target is {}, expected object.",
+                            path_label(&path.0),
+                            json_type_name(&current)
+                        ),
+                    ));
                 }
             }
             UpdateOp::Decrement { path, by } => {
+                let segments = field_path_segments(&path.0);
+                if !validate_op_path("decrement", op_index, segments, &mut errors) {
+                    continue;
+                }
                 if let Value::Object(ref mut map) = current {
                     if let Some(existing_val) = map.get_mut(&path.0) {
-                        if let Some(num) = existing_val.as_i64() {
-                            *existing_val = Value::Number(Number::from(num - *by));
+                        if let Some(updated) = decrement_number(existing_val, *by) {
+                            *existing_val = updated;
                         } else {
-                            *existing_val = Value::Number(Number::from(-*by));
+                            errors.push(err(
+                                op_index,
+                                ERR_DECREMENT_NOT_NUMBER,
+                                format!(
+                                    "Expected number at path '{}', got {}.",
+                                    path_label(&path.0),
+                                    json_type_name(existing_val)
+                                ),
+                            ));
+                            continue;
                         }
                     } else {
                         map.insert(path.0.clone(), Value::Number(Number::from(-*by)));
                     }
                     using_missing_default = false;
                 } else {
-                    tracing::warn!(
-                        path = %path.0,
-                        "Decrement operation requires existing value to be a JSON object"
-                    );
+                    errors.push(err(
+                        op_index,
+                        ERR_DECREMENT_TARGET_NOT_OBJECT,
+                        format!(
+                            "Cannot decrement at path '{}': target is {}, expected object.",
+                            path_label(&path.0),
+                            json_type_name(&current)
+                        ),
+                    ));
                 }
             }
             UpdateOp::Append { path, value } => {
+                let segments = field_path_segments(&path.0);
+                if !validate_op_path("append", op_index, segments, &mut errors) {
+                    continue;
+                }
                 if path.0.is_empty() {
                     if using_missing_default {
                         current = Value::Null;
                     }
-                    if append_to_target(&mut current, value, "root") {
+                    if append_to_target(&mut current, value, "root", op_index, &mut errors) {
                         using_missing_default = false;
                     }
                 } else if let Value::Object(ref mut map) = current {
                     if let Some(existing_val) = map.get_mut(&path.0) {
-                        append_to_target(existing_val, value, &path.0);
+                        append_to_target(existing_val, value, &path.0, op_index, &mut errors);
                     } else {
                         map.insert(path.0.clone(), initial_append_value(value));
                     }
                     using_missing_default = false;
                 } else {
-                    tracing::warn!(
-                        path = %path.0,
-                        "Append operation with path requires existing value to be a JSON object"
-                    );
+                    errors.push(err(
+                        op_index,
+                        ERR_APPEND_TARGET_NOT_OBJECT,
+                        format!(
+                            "Cannot append at path '{}': target is {}, expected object.",
+                            path_label(&path.0),
+                            json_type_name(&current)
+                        ),
+                    ));
                 }
             }
             UpdateOp::Remove { path } => {
+                let segments = field_path_segments(&path.0);
+                if !validate_op_path("remove", op_index, segments, &mut errors) {
+                    continue;
+                }
                 if let Value::Object(ref mut map) = current {
                     map.remove(&path.0);
                     using_missing_default = false;
                 } else {
-                    tracing::warn!(
-                        path = %path.0,
-                        "Remove operation requires existing value to be a JSON object"
-                    );
+                    errors.push(err(
+                        op_index,
+                        ERR_REMOVE_TARGET_NOT_OBJECT,
+                        format!(
+                            "Cannot remove at path '{}': target is {}, expected object.",
+                            path_label(&path.0),
+                            json_type_name(&current)
+                        ),
+                    ));
                 }
             }
         }
@@ -345,7 +476,13 @@ pub(crate) fn apply_update_ops(
     (current, errors)
 }
 
-fn append_to_target(target: &mut Value, value: &Value, path: &str) -> bool {
+fn append_to_target(
+    target: &mut Value,
+    value: &Value,
+    path: &str,
+    op_index: usize,
+    errors: &mut Vec<UpdateOpError>,
+) -> bool {
     match target {
         Value::Array(items) => {
             items.push(value.clone());
@@ -356,10 +493,15 @@ fn append_to_target(target: &mut Value, value: &Value, path: &str) -> bool {
                 existing.push_str(chunk);
                 true
             } else {
-                tracing::warn!(
-                    path,
-                    "Append operation on a string target requires a string value"
-                );
+                errors.push(err(
+                    op_index,
+                    ERR_APPEND_TYPE_MISMATCH,
+                    format!(
+                        "Expected string append value at path '{}', got {}.",
+                        path_label(path),
+                        json_type_name(value)
+                    ),
+                ));
                 false
             }
         }
@@ -368,10 +510,15 @@ fn append_to_target(target: &mut Value, value: &Value, path: &str) -> bool {
             true
         }
         _ => {
-            tracing::warn!(
-                path,
-                "Append operation requires target to be an array, string, null, or missing field"
-            );
+            errors.push(err(
+                op_index,
+                ERR_APPEND_TYPE_MISMATCH,
+                format!(
+                    "Cannot append at path '{}': target is {}, expected array, string, null, or missing field.",
+                    path_label(path),
+                    json_type_name(target)
+                ),
+            ));
             false
         }
     }
@@ -453,28 +600,58 @@ mod tests {
     }
 
     #[test]
-    fn skips_incompatible_string_append_value() {
+    fn set_empty_path_replaces_root_even_with_null_value() {
         let updated = run(
+            Some(json!({ "": "empty-field", "keep": true })),
+            &[UpdateOp::Set {
+                path: "".into(),
+                value: None,
+            }],
+        );
+
+        assert_eq!(updated, json!(null));
+    }
+
+    #[test]
+    fn skips_incompatible_string_append_value() {
+        let (updated, errors) = apply_update_ops(
             Some(json!({ "transcript": "hello" })),
             &[UpdateOp::append("transcript", json!({"not": "string"}))],
         );
 
         assert_eq!(updated, json!({ "transcript": "hello" }));
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, super::ERR_APPEND_TYPE_MISMATCH);
     }
 
     #[test]
     fn skips_incompatible_object_append_target() {
-        let updated = run(
+        let (updated, errors) = apply_update_ops(
             Some(json!({ "events": {} })),
             &[UpdateOp::append("events", json!("chunk"))],
         );
 
         assert_eq!(updated, json!({ "events": {} }));
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, super::ERR_APPEND_TYPE_MISMATCH);
     }
 
     #[test]
-    fn increments_existing_non_number_and_missing_fields() {
+    fn increments_existing_number_and_missing_fields() {
         let updated = run(
+            Some(json!({ "count": 2 })),
+            &[
+                UpdateOp::increment("count", 3),
+                UpdateOp::increment("missing", 3),
+            ],
+        );
+
+        assert_eq!(updated, json!({ "count": 5, "missing": 3 }));
+    }
+
+    #[test]
+    fn increment_rejects_existing_non_number() {
+        let (updated, errors) = apply_update_ops(
             Some(json!({ "count": 2, "bad": "value" })),
             &[
                 UpdateOp::increment("count", 3),
@@ -483,12 +660,28 @@ mod tests {
             ],
         );
 
-        assert_eq!(updated, json!({ "count": 5, "bad": 3, "missing": 3 }));
+        assert_eq!(updated, json!({ "count": 5, "bad": "value", "missing": 3 }));
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, super::ERR_INCREMENT_NOT_NUMBER);
+        assert_eq!(errors[0].op_index, 1);
     }
 
     #[test]
-    fn decrements_existing_non_number_and_missing_fields() {
+    fn decrements_existing_number_and_missing_fields() {
         let updated = run(
+            Some(json!({ "count": 5 })),
+            &[
+                UpdateOp::decrement("count", 3),
+                UpdateOp::decrement("missing", 3),
+            ],
+        );
+
+        assert_eq!(updated, json!({ "count": 2, "missing": -3 }));
+    }
+
+    #[test]
+    fn decrement_rejects_existing_non_number() {
+        let (updated, errors) = apply_update_ops(
             Some(json!({ "count": 5, "bad": "value" })),
             &[
                 UpdateOp::decrement("count", 3),
@@ -497,7 +690,13 @@ mod tests {
             ],
         );
 
-        assert_eq!(updated, json!({ "count": 2, "bad": -3, "missing": -3 }));
+        assert_eq!(
+            updated,
+            json!({ "count": 2, "bad": "value", "missing": -3 })
+        );
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, super::ERR_DECREMENT_NOT_NUMBER);
+        assert_eq!(errors[0].op_index, 1);
     }
 
     #[test]
@@ -511,6 +710,89 @@ mod tests {
         );
 
         assert_eq!(updated, json!({ "count": 12 }));
+    }
+
+    #[test]
+    fn numeric_ops_accept_json_float_fields() {
+        let updated = run(
+            Some(json!({ "count": 1.5 })),
+            &[
+                UpdateOp::increment("count", 2),
+                UpdateOp::decrement("count", 1),
+            ],
+        );
+
+        assert_eq!(updated, json!({ "count": 2.5 }));
+    }
+
+    #[test]
+    fn numeric_ops_reject_null_fields_instead_of_treating_them_as_missing() {
+        let (updated, errors) = apply_update_ops(
+            Some(json!({ "inc": null, "dec": null })),
+            &[UpdateOp::increment("inc", 1), UpdateOp::decrement("dec", 1)],
+        );
+
+        assert_eq!(updated, json!({ "inc": null, "dec": null }));
+        assert_eq!(errors.len(), 2);
+        assert_eq!(errors[0].op_index, 0);
+        assert_eq!(errors[0].code, super::ERR_INCREMENT_NOT_NUMBER);
+        assert_eq!(errors[1].op_index, 1);
+        assert_eq!(errors[1].code, super::ERR_DECREMENT_NOT_NUMBER);
+    }
+
+    #[test]
+    fn numeric_ops_with_zero_still_validate_existing_type() {
+        let (updated, errors) = apply_update_ops(
+            Some(json!({ "bad": "value", "count": 2 })),
+            &[
+                UpdateOp::increment("bad", 0),
+                UpdateOp::decrement("count", 0),
+            ],
+        );
+
+        assert_eq!(updated, json!({ "bad": "value", "count": 2 }));
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].op_index, 0);
+        assert_eq!(errors[0].code, super::ERR_INCREMENT_NOT_NUMBER);
+    }
+
+    #[test]
+    fn numeric_overflow_falls_back_to_json_float_number() {
+        let updated = run(
+            Some(json!({ "count": i64::MAX })),
+            &[UpdateOp::increment("count", 1)],
+        );
+
+        assert!(updated["count"].is_number());
+        assert_eq!(updated["count"].as_f64(), Some(i64::MAX as f64 + 1.0));
+    }
+
+    #[test]
+    fn failed_ops_continue_and_preserve_error_indexes() {
+        let (updated, errors) = apply_update_ops(
+            Some(json!({ "bad": "value", "events": {} })),
+            &[
+                UpdateOp::increment("bad", 1),
+                UpdateOp::Set {
+                    path: "__proto__".into(),
+                    value: Some(json!(true)),
+                },
+                UpdateOp::append("events", json!("chunk")),
+                UpdateOp::Set {
+                    path: "ok".into(),
+                    value: Some(json!(true)),
+                },
+            ],
+        );
+
+        assert_eq!(updated, json!({ "bad": "value", "events": {}, "ok": true }));
+        assert_eq!(errors.len(), 3);
+        assert_eq!(errors[0].op_index, 0);
+        assert_eq!(errors[0].code, super::ERR_INCREMENT_NOT_NUMBER);
+        assert_eq!(errors[1].op_index, 1);
+        assert_eq!(errors[1].code, "set.path.proto_polluted");
+        assert_eq!(errors[2].op_index, 2);
+        assert_eq!(errors[2].code, super::ERR_APPEND_TYPE_MISMATCH);
     }
 
     #[test]
@@ -540,6 +822,35 @@ mod tests {
         );
 
         assert_eq!(updated, json!({ "events": ["first", "second"] }));
+    }
+
+    #[test]
+    fn append_array_value_to_array_target_as_single_element() {
+        let updated = run(
+            Some(json!({ "events": [] })),
+            &[UpdateOp::append("events", json!(["nested", "array"]))],
+        );
+
+        assert_eq!(updated, json!({ "events": [["nested", "array"]] }));
+    }
+
+    #[test]
+    fn append_to_null_field_initializes_by_value_kind() {
+        let updated = run(
+            Some(json!({ "string": null, "array": null })),
+            &[
+                UpdateOp::append("string", json!("chunk")),
+                UpdateOp::append("array", json!({ "kind": "chunk" })),
+            ],
+        );
+
+        assert_eq!(
+            updated,
+            json!({
+                "string": "chunk",
+                "array": [{ "kind": "chunk" }],
+            })
+        );
     }
 
     // ----- Nested merge tests (issue #1546) -----
@@ -656,6 +967,15 @@ mod tests {
     }
 
     #[test]
+    fn root_merge_on_non_object_current_value_remains_silent_noop() {
+        let (updated, errors) =
+            apply_update_ops(Some(json!("leaf")), &[UpdateOp::merge(json!({ "a": 1 }))]);
+
+        assert_eq!(updated, json!("leaf"));
+        assert!(errors.is_empty());
+    }
+
+    #[test]
     fn single_string_path_equivalent_to_single_segment_array() {
         let from_string = run(Some(json!({})), &[merge_at("foo", json!({ "x": 1 }))]);
         let from_array = run(Some(json!({})), &[merge_at(vec!["foo"], json!({ "x": 1 }))]);
@@ -725,6 +1045,78 @@ mod tests {
             assert_eq!(errors.len(), 1, "expected proto rejection for {sink}");
             assert_eq!(errors[0].code, super::ERR_PATH_PROTO);
         }
+    }
+
+    #[test]
+    fn rejects_all_proto_pollution_sinks_for_each_non_merge_op() {
+        for sink in super::PROTO_POLLUTION_KEYS {
+            let cases = [
+                (
+                    "set",
+                    UpdateOp::Set {
+                        path: (*sink).into(),
+                        value: Some(json!(true)),
+                    },
+                    "set.path.proto_polluted",
+                ),
+                (
+                    "append",
+                    UpdateOp::append(*sink, json!("chunk")),
+                    "append.path.proto_polluted",
+                ),
+                (
+                    "increment",
+                    UpdateOp::increment(*sink, 1),
+                    "increment.path.proto_polluted",
+                ),
+                (
+                    "decrement",
+                    UpdateOp::decrement(*sink, 1),
+                    "decrement.path.proto_polluted",
+                ),
+                (
+                    "remove",
+                    UpdateOp::Remove {
+                        path: (*sink).into(),
+                    },
+                    "remove.path.proto_polluted",
+                ),
+            ];
+
+            for (op_name, op, code) in cases {
+                let (_value, errors) = apply_update_ops(Some(json!({})), &[op]);
+                assert_eq!(
+                    errors.len(),
+                    1,
+                    "expected proto rejection for {op_name} path sink {sink}"
+                );
+                assert_eq!(errors[0].code, code);
+            }
+        }
+    }
+
+    #[test]
+    fn validates_set_path_segments_with_op_specific_error_code() {
+        let (_value, errors) = apply_update_ops(
+            Some(json!({})),
+            &[UpdateOp::Set {
+                path: "__proto__".into(),
+                value: Some(json!(true)),
+            }],
+        );
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, "set.path.proto_polluted");
+    }
+
+    #[test]
+    fn validates_append_path_segments_with_op_specific_error_code() {
+        let oversized = "a".repeat(super::MAX_SEGMENT_BYTES + 1);
+        let (_value, errors) =
+            apply_update_ops(Some(json!({})), &[UpdateOp::append(oversized, json!("x"))]);
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, "append.path.segment_too_long");
     }
 
     #[test]

--- a/engine/src/workers/redis.rs
+++ b/engine/src/workers/redis.rs
@@ -24,7 +24,7 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
     local MAX_VALUE_DEPTH = 16
     local MAX_VALUE_KEYS = 1024
     local PROTO = { __proto__ = true, constructor = true, prototype = true }
-    local DOC_URL = 'https://iii.dev/docs/workers/iii-state#merge-bounds'
+    local DOC_URL = 'https://iii.dev/docs/workers/iii-state#error-codes'
 
     local key = KEYS[1]
     local field = ARGV[1]
@@ -85,6 +85,33 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
         }
     end
 
+    local function path_error_code(op_name, reason)
+        return op_name .. '.path.' .. reason
+    end
+
+    local function json_type_name(value)
+        if value == cjson.null then return 'null' end
+        local value_type = type(value)
+        if value_type == 'boolean' then return 'boolean' end
+        if value_type == 'number' then return 'number' end
+        if value_type == 'string' then return 'string' end
+        if value_type == 'table' then
+            if value[1] ~= nil then return 'array' end
+            return 'object'
+        end
+        return value_type
+    end
+
+    local function path_label(path)
+        if path == nil or path == '' then return 'root' end
+        return path
+    end
+
+    local function field_path_segments(path)
+        if path == nil or path == '' then return {} end
+        return { path }
+    end
+
     local function json_depth(value)
         if type(value) ~= 'table' then return 0 end
         local max = 0
@@ -95,30 +122,34 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
         return 1 + max
     end
 
-    local function validate_merge_path(op_index, segments)
+    local function validate_op_path(op_name, op_index, segments)
         if #segments > MAX_PATH_DEPTH then
-            push_error(op_index, 'merge.path.too_deep',
+            push_error(op_index, path_error_code(op_name, 'too_deep'),
                 'Path depth ' .. #segments .. ' exceeds maximum of ' .. MAX_PATH_DEPTH)
             return false
         end
         for _, seg in ipairs(segments) do
             if type(seg) ~= 'string' or seg == '' then
-                push_error(op_index, 'merge.path.empty_segment',
+                push_error(op_index, path_error_code(op_name, 'empty_segment'),
                     'Path contains an empty or non-string segment')
                 return false
             end
             if #seg > MAX_SEGMENT_BYTES then
-                push_error(op_index, 'merge.path.segment_too_long',
+                push_error(op_index, path_error_code(op_name, 'segment_too_long'),
                     'Path segment of ' .. #seg .. ' bytes exceeds maximum of ' .. MAX_SEGMENT_BYTES)
                 return false
             end
             if PROTO[seg] then
-                push_error(op_index, 'merge.path.proto_polluted',
-                    'Path segment "' .. seg .. '" is a prototype-pollution sink')
+                push_error(op_index, path_error_code(op_name, 'proto_polluted'),
+                    "Path segment '" .. seg .. "' is not allowed (prototype pollution).")
                 return false
             end
         end
         return true
+    end
+
+    local function validate_merge_path(op_index, segments)
+        return validate_op_path('merge', op_index, segments)
     end
 
     local function validate_merge_value(op_index, value)
@@ -195,10 +226,10 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
             end
             count = count + 1
         end
-        return count > 0 and count == max
+        return count == max
     end
 
-    local function append_to_target(target, value)
+    local function append_to_target(target, value, path, op_index)
         if target == nil or target == cjson.null then
             return true, initial_append_value(value)
         end
@@ -206,12 +237,16 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
             if type(value) == 'string' then
                 return true, target .. value
             end
+            push_error(op_index, 'append.type_mismatch',
+                "Expected string append value at path '" .. path_label(path) .. "', got " .. json_type_name(value) .. ".")
             return false, target
         end
         if is_array(target) then
             table.insert(target, value)
             return true, target
         end
+        push_error(op_index, 'append.type_mismatch',
+            "Cannot append at path '" .. path_label(path) .. "': target is " .. json_type_name(target) .. ", expected array, string, null, or missing field.")
         return false, target
     end
 
@@ -220,19 +255,21 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
         local zero_index = op_index - 1
         if op.type == 'set' then
             local path = get_path(op.path)
-            if (path == '' or path == nil) and op.value ~= nil then
+            if validate_op_path('set', zero_index, field_path_segments(path)) then
+              if (path == '' or path == nil) and op.value ~= nil then
                 current = op.value
                 using_missing_default = false
-            else
-                if type(current) ~= 'table' or current == nil then
-                    current = {}
-                end
+              elseif type(current) == 'table' and current ~= cjson.null then
                 if op.value == nil then
                     current[path] = cjson.null
                 else
                     current[path] = op.value
                 end
                 using_missing_default = false
+              else
+                push_error(zero_index, 'set.target_not_object',
+                    "Cannot set at path '" .. path_label(path) .. "': target is " .. json_type_name(current) .. ", expected object.")
+              end
             end
         elseif op.type == 'merge' then
             local segments = merge_path_segments(op.path)
@@ -261,50 +298,74 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
             end
         elseif op.type == 'increment' then
             local path = get_path(op.path)
-            if type(current) ~= 'table' or current == nil then
-                current = {}
+            if validate_op_path('increment', zero_index, field_path_segments(path)) then
+              if type(current) == 'table' and current ~= cjson.null then
+                local val = current[path]
+                if val == nil then
+                    current[path] = op.by
+                    using_missing_default = false
+                elseif type(val) == 'number' then
+                    current[path] = val + op.by
+                    using_missing_default = false
+                else
+                    push_error(zero_index, 'increment.not_number',
+                        "Expected number at path '" .. path_label(path) .. "', got " .. json_type_name(val) .. ".")
+                end
+              else
+                push_error(zero_index, 'increment.target_not_object',
+                    "Cannot increment at path '" .. path_label(path) .. "': target is " .. json_type_name(current) .. ", expected object.")
+              end
             end
-            local val = current[path]
-            if type(val) == 'number' then
-                current[path] = val + op.by
-            else
-                current[path] = op.by
-            end
-            using_missing_default = false
         elseif op.type == 'decrement' then
             local path = get_path(op.path)
-            if type(current) ~= 'table' or current == nil then
-                current = {}
+            if validate_op_path('decrement', zero_index, field_path_segments(path)) then
+              if type(current) == 'table' and current ~= cjson.null then
+                local val = current[path]
+                if val == nil then
+                    current[path] = -op.by
+                    using_missing_default = false
+                elseif type(val) == 'number' then
+                    current[path] = val - op.by
+                    using_missing_default = false
+                else
+                    push_error(zero_index, 'decrement.not_number',
+                        "Expected number at path '" .. path_label(path) .. "', got " .. json_type_name(val) .. ".")
+                end
+              else
+                push_error(zero_index, 'decrement.target_not_object',
+                    "Cannot decrement at path '" .. path_label(path) .. "': target is " .. json_type_name(current) .. ", expected object.")
+              end
             end
-            local val = current[path]
-            if type(val) == 'number' then
-                current[path] = val - op.by
-            else
-                current[path] = -op.by
-            end
-            using_missing_default = false
         elseif op.type == 'append' then
             local path = get_path(op.path)
-            if path == '' or path == nil then
-                local changed, next_value = append_to_target(using_missing_default and cjson.null or current, op.value)
+            if validate_op_path('append', zero_index, field_path_segments(path)) then
+              if path == '' or path == nil then
+                local changed, next_value = append_to_target(using_missing_default and cjson.null or current, op.value, 'root', zero_index)
                 if changed then
                     current = next_value
                     using_missing_default = false
                 end
-            else
-                if type(current) == 'table' and current ~= nil then
-                    local changed, next_value = append_to_target(current[path], op.value)
+              elseif type(current) == 'table' and current ~= cjson.null then
+                    local changed, next_value = append_to_target(current[path], op.value, path, zero_index)
                     if changed then
                         current[path] = next_value
                         using_missing_default = false
                     end
-                end
+              else
+                push_error(zero_index, 'append.target_not_object',
+                    "Cannot append at path '" .. path_label(path) .. "': target is " .. json_type_name(current) .. ", expected object.")
+              end
             end
         elseif op.type == 'remove' then
             local path = get_path(op.path)
-            if type(current) == 'table' and current ~= nil then
+            if validate_op_path('remove', zero_index, field_path_segments(path)) then
+              if type(current) == 'table' and current ~= cjson.null then
                 current[path] = nil
                 using_missing_default = false
+              else
+                push_error(zero_index, 'remove.target_not_object',
+                    "Cannot remove at path '" .. path_label(path) .. "': target is " .. json_type_name(current) .. ", expected object.")
+              end
             end
         end
     end

--- a/engine/src/workers/redis.rs
+++ b/engine/src/workers/redis.rs
@@ -299,7 +299,18 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
         elseif op.type == 'increment' then
             local path = get_path(op.path)
             if validate_op_path('increment', zero_index, field_path_segments(path)) then
-              if type(current) == 'table' and current ~= cjson.null then
+              if path == '' or path == nil then
+                if using_missing_default then
+                    current = op.by
+                    using_missing_default = false
+                elseif type(current) == 'number' then
+                    current = current + op.by
+                    using_missing_default = false
+                else
+                    push_error(zero_index, 'increment.not_number',
+                        "Expected number at path '" .. path_label(path) .. "', got " .. json_type_name(current) .. ".")
+                end
+              elseif type(current) == 'table' and current ~= cjson.null then
                 local val = current[path]
                 if val == nil then
                     current[path] = op.by
@@ -319,7 +330,18 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
         elseif op.type == 'decrement' then
             local path = get_path(op.path)
             if validate_op_path('decrement', zero_index, field_path_segments(path)) then
-              if type(current) == 'table' and current ~= cjson.null then
+              if path == '' or path == nil then
+                if using_missing_default then
+                    current = -op.by
+                    using_missing_default = false
+                elseif type(current) == 'number' then
+                    current = current - op.by
+                    using_missing_default = false
+                else
+                    push_error(zero_index, 'decrement.not_number',
+                        "Expected number at path '" .. path_label(path) .. "', got " .. json_type_name(current) .. ".")
+                end
+              elseif type(current) == 'table' and current ~= cjson.null then
                 local val = current[path]
                 if val == nil then
                     current[path] = -op.by
@@ -359,7 +381,10 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
         elseif op.type == 'remove' then
             local path = get_path(op.path)
             if validate_op_path('remove', zero_index, field_path_segments(path)) then
-              if type(current) == 'table' and current ~= cjson.null then
+              if path == '' or path == nil then
+                current = cjson.null
+                using_missing_default = false
+              elseif type(current) == 'table' and current ~= cjson.null then
                 current[path] = nil
                 using_missing_default = false
               else

--- a/engine/src/workers/state/adapters/redis_adapter.rs
+++ b/engine/src/workers/state/adapters/redis_adapter.rs
@@ -322,4 +322,108 @@ mod tests {
 
         let _ = adapter.delete(scope, key).await;
     }
+
+    #[tokio::test]
+    #[ignore] // Requires Redis running
+    async fn test_update_structured_errors_redis() {
+        let adapter = setup_test_adapter().await;
+        let scope = "test_error_scope";
+        let key = "error_item";
+
+        let _ = adapter.delete(scope, key).await;
+        adapter
+            .set(
+                scope,
+                key,
+                json!({"bad": "value", "events": {"nested": true}}),
+            )
+            .await
+            .unwrap();
+
+        let result = adapter
+            .update(
+                scope,
+                key,
+                vec![
+                    UpdateOp::increment("bad", 1),
+                    UpdateOp::Set {
+                        path: "__proto__".into(),
+                        value: Some(json!(true)),
+                    },
+                    UpdateOp::append("events", json!("chunk")),
+                    UpdateOp::Set {
+                        path: "ok".into(),
+                        value: Some(json!(true)),
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.new_value,
+            json!({"bad": "value", "events": {"nested": true}, "ok": true})
+        );
+        assert_eq!(result.errors.len(), 3);
+        assert_eq!(result.errors[0].op_index, 0);
+        assert_eq!(result.errors[0].code, "increment.not_number");
+        assert_eq!(result.errors[1].op_index, 1);
+        assert_eq!(result.errors[1].code, "set.path.proto_polluted");
+        assert_eq!(result.errors[2].op_index, 2);
+        assert_eq!(result.errors[2].code, "append.type_mismatch");
+
+        let _ = adapter.delete(scope, key).await;
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires Redis running
+    async fn test_update_root_null_and_numeric_null_errors_redis() {
+        let adapter = setup_test_adapter().await;
+        let scope = "test_null_scope";
+        let key = "null_item";
+
+        let _ = adapter.delete(scope, key).await;
+        adapter
+            .set(scope, key, json!({"": "empty-field", "keep": true}))
+            .await
+            .unwrap();
+
+        let result = adapter
+            .update(
+                scope,
+                key,
+                vec![UpdateOp::Set {
+                    path: "".into(),
+                    value: None,
+                }],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.new_value, json!(null));
+        assert!(result.errors.is_empty());
+
+        adapter
+            .set(scope, key, json!({"inc": null, "dec": null}))
+            .await
+            .unwrap();
+
+        let result = adapter
+            .update(
+                scope,
+                key,
+                vec![UpdateOp::increment("inc", 1), UpdateOp::decrement("dec", 1)],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.new_value, json!({"inc": null, "dec": null}));
+        assert_eq!(result.errors.len(), 2);
+        assert_eq!(result.errors[0].op_index, 0);
+        assert_eq!(result.errors[0].code, "increment.not_number");
+        assert_eq!(result.errors[1].op_index, 1);
+        assert_eq!(result.errors[1].code, "decrement.not_number");
+
+        let _ = adapter.delete(scope, key).await;
+    }
 }

--- a/engine/src/workers/state/adapters/redis_adapter.rs
+++ b/engine/src/workers/state/adapters/redis_adapter.rs
@@ -426,4 +426,41 @@ mod tests {
 
         let _ = adapter.delete(scope, key).await;
     }
+
+    #[tokio::test]
+    #[ignore] // Requires Redis running
+    async fn test_update_empty_path_numeric_and_remove_ops_target_root_redis() {
+        let adapter = setup_test_adapter().await;
+        let scope = "test_root_ops_scope";
+        let key = "root_ops_item";
+
+        let _ = adapter.delete(scope, key).await;
+        adapter.set(scope, key, json!(2)).await.unwrap();
+
+        let result = adapter
+            .update(scope, key, vec![UpdateOp::increment("", 3)])
+            .await
+            .unwrap();
+
+        assert_eq!(result.new_value, json!(5));
+        assert!(result.errors.is_empty());
+
+        let result = adapter
+            .update(scope, key, vec![UpdateOp::decrement("", 2)])
+            .await
+            .unwrap();
+
+        assert_eq!(result.new_value, json!(3));
+        assert!(result.errors.is_empty());
+
+        let result = adapter
+            .update(scope, key, vec![UpdateOp::remove("")])
+            .await
+            .unwrap();
+
+        assert_eq!(result.new_value, json!(null));
+        assert!(result.errors.is_empty());
+
+        let _ = adapter.delete(scope, key).await;
+    }
 }

--- a/engine/tests/state_stream_update_e2e.rs
+++ b/engine/tests/state_stream_update_e2e.rs
@@ -11,12 +11,27 @@
 use serde_json::json;
 
 use iii::builtins::kv::BuiltinKvStore;
-use iii_sdk::{UpdateOp, types::MergePath};
+use iii_sdk::{UpdateOp, UpdateOpError, types::MergePath};
 
 const SCOPE: &str = "audio::transcripts";
 
 async fn fresh_store() -> BuiltinKvStore {
     BuiltinKvStore::new(None)
+}
+
+fn set_op(path: impl Into<iii_sdk::FieldPath>, value: serde_json::Value) -> UpdateOp {
+    UpdateOp::Set {
+        path: path.into(),
+        value: Some(value),
+    }
+}
+
+fn assert_structured_error(errors: &[UpdateOpError], op_index: usize, code: &str, path_text: &str) {
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].code, code);
+    assert_eq!(errors[0].op_index, op_index);
+    assert!(errors[0].message.contains(path_text));
+    assert!(errors[0].doc_url.is_some());
 }
 
 #[tokio::test]
@@ -149,4 +164,243 @@ async fn merge_with_proto_polluted_segment_returns_structured_error() {
     assert!(r.errors[0].doc_url.is_some());
     // The op did not apply.
     assert_eq!(r.new_value, json!({}));
+}
+
+#[tokio::test]
+async fn non_merge_ops_with_proto_polluted_path_return_structured_errors() {
+    let cases: Vec<(&str, UpdateOp)> = vec![
+        ("set", set_op("__proto__", json!(1))),
+        ("append", UpdateOp::append("__proto__", json!(1))),
+        ("increment", UpdateOp::increment("__proto__", 1)),
+        ("decrement", UpdateOp::decrement("__proto__", 1)),
+        (
+            "remove",
+            UpdateOp::Remove {
+                path: "__proto__".into(),
+            },
+        ),
+    ];
+
+    for (op_name, op) in cases {
+        let store = fresh_store().await;
+        let result = store
+            .update(SCOPE.to_string(), format!("proto-{op_name}"), vec![op])
+            .await;
+
+        assert_structured_error(
+            &result.errors,
+            0,
+            &format!("{op_name}.path.proto_polluted"),
+            "__proto__",
+        );
+        assert_eq!(result.new_value, json!({}), "op {op_name} should not apply");
+    }
+}
+
+#[tokio::test]
+async fn set_on_non_object_target_returns_structured_error_and_skips() {
+    let store = fresh_store().await;
+    let key = "set-target".to_string();
+
+    store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![set_op("", json!("leaf"))],
+        )
+        .await;
+
+    let result = store
+        .update(SCOPE.to_string(), key, vec![set_op("field", json!(1))])
+        .await;
+
+    assert_structured_error(&result.errors, 0, "set.target_not_object", "field");
+    assert_eq!(result.new_value, json!("leaf"));
+}
+
+#[tokio::test]
+async fn append_type_mismatch_returns_structured_error_and_skips() {
+    let store = fresh_store().await;
+    let key = "append-type".to_string();
+
+    store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![set_op("count", json!(1))],
+        )
+        .await;
+
+    let result = store
+        .update(
+            SCOPE.to_string(),
+            key,
+            vec![UpdateOp::append("count", json!("chunk"))],
+        )
+        .await;
+
+    assert_structured_error(&result.errors, 0, "append.type_mismatch", "count");
+    assert_eq!(result.new_value, json!({ "count": 1 }));
+}
+
+#[tokio::test]
+async fn append_on_non_object_target_returns_structured_error_and_skips() {
+    let store = fresh_store().await;
+    let key = "append-target".to_string();
+
+    store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![set_op("", json!("leaf"))],
+        )
+        .await;
+
+    let result = store
+        .update(
+            SCOPE.to_string(),
+            key,
+            vec![UpdateOp::append("events", json!("chunk"))],
+        )
+        .await;
+
+    assert_structured_error(&result.errors, 0, "append.target_not_object", "events");
+    assert_eq!(result.new_value, json!("leaf"));
+}
+
+#[tokio::test]
+async fn failed_update_ops_continue_and_report_original_indexes() {
+    let store = fresh_store().await;
+    let key = "partial-errors".to_string();
+
+    store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![set_op("", json!({ "bad": "value", "events": {} }))],
+        )
+        .await;
+
+    let result = store
+        .update(
+            SCOPE.to_string(),
+            key,
+            vec![
+                UpdateOp::increment("bad", 1),
+                set_op("__proto__", json!(true)),
+                UpdateOp::append("events", json!("chunk")),
+                set_op("ok", json!(true)),
+            ],
+        )
+        .await;
+
+    assert_eq!(
+        result.new_value,
+        json!({ "bad": "value", "events": {}, "ok": true })
+    );
+    assert_eq!(result.errors.len(), 3);
+    assert_eq!(result.errors[0].op_index, 0);
+    assert_eq!(result.errors[0].code, "increment.not_number");
+    assert_eq!(result.errors[1].op_index, 1);
+    assert_eq!(result.errors[1].code, "set.path.proto_polluted");
+    assert_eq!(result.errors[2].op_index, 2);
+    assert_eq!(result.errors[2].code, "append.type_mismatch");
+}
+
+#[tokio::test]
+async fn increment_non_number_returns_structured_error_and_skips() {
+    let store = fresh_store().await;
+    let key = "increment-number".to_string();
+
+    store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![set_op("name", json!("Ada"))],
+        )
+        .await;
+
+    let result = store
+        .update(SCOPE.to_string(), key, vec![UpdateOp::increment("name", 1)])
+        .await;
+
+    assert_structured_error(&result.errors, 0, "increment.not_number", "name");
+    assert_eq!(result.new_value, json!({ "name": "Ada" }));
+}
+
+#[tokio::test]
+async fn decrement_non_number_returns_structured_error_and_skips() {
+    let store = fresh_store().await;
+    let key = "decrement-number".to_string();
+
+    store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![set_op("name", json!("Ada"))],
+        )
+        .await;
+
+    let result = store
+        .update(SCOPE.to_string(), key, vec![UpdateOp::decrement("name", 1)])
+        .await;
+
+    assert_structured_error(&result.errors, 0, "decrement.not_number", "name");
+    assert_eq!(result.new_value, json!({ "name": "Ada" }));
+}
+
+#[tokio::test]
+async fn numeric_ops_and_remove_on_non_object_target_return_structured_errors() {
+    let cases: Vec<(&str, UpdateOp)> = vec![
+        ("increment", UpdateOp::increment("count", 1)),
+        ("decrement", UpdateOp::decrement("count", 1)),
+        (
+            "remove",
+            UpdateOp::Remove {
+                path: "count".into(),
+            },
+        ),
+    ];
+
+    for (op_name, op) in cases {
+        let store = fresh_store().await;
+        let key = format!("{op_name}-target");
+
+        store
+            .update(
+                SCOPE.to_string(),
+                key.clone(),
+                vec![set_op("", json!("leaf"))],
+            )
+            .await;
+
+        let result = store.update(SCOPE.to_string(), key, vec![op]).await;
+
+        assert_structured_error(
+            &result.errors,
+            0,
+            &format!("{op_name}.target_not_object"),
+            "count",
+        );
+        assert_eq!(result.new_value, json!("leaf"));
+    }
+}
+
+#[tokio::test]
+async fn remove_missing_path_remains_idempotent_and_silent() {
+    let store = fresh_store().await;
+    let key = "remove-missing".to_string();
+
+    let result = store
+        .update(
+            SCOPE.to_string(),
+            key,
+            vec![UpdateOp::Remove {
+                path: "missing".into(),
+            }],
+        )
+        .await;
+
+    assert!(result.errors.is_empty());
+    assert_eq!(result.new_value, json!({}));
 }

--- a/sdk/packages/rust/iii/src/types.rs
+++ b/sdk/packages/rust/iii/src/types.rs
@@ -194,10 +194,7 @@ impl UpdateOp {
     }
 }
 
-/// Per-op error reported by an atomic update operation. Currently
-/// emitted only for the `merge` op when input violates the new
-/// validation bounds (depth/size/proto-pollution); the other ops
-/// retain warn-and-skip semantics for backward compatibility.
+/// Per-op error reported by an atomic update operation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct UpdateOpError {
     /// Index of the offending op within the original `ops` array.


### PR DESCRIPTION
## What

- Emit structured `UpdateOpError` entries for non-merge state/stream update failures instead of silently skipping them.
- Keep Redis-backed update semantics aligned with the Rust kv path.
- Add adversarial tests for partial-failure continuation, `op_index` preservation, target/type mismatches, proto path rejection, JSON float numeric ops, root-null set semantics, numeric null rejection, overflow fallback, append edge cases, and Redis structured errors.
- Document the unified state/stream error-code surface.

## Why

Only `merge` populated the existing `errors` envelope reliably. Other update ops could skip invalid writes without returning structured errors, and Redis-backed adapters diverged from the Rust kv path.

## Notes

- `UpdateResult.errors` already exists, so this is wire-format additive.
- Multi-op updates remain best-effort: failed ops are skipped, later valid ops continue, and errors retain original zero-based `op_index`.
- `set` with `path: ""` and `value: null` now consistently replaces the root with JSON null.
- Existing Redis Lua cannot distinguish decoded empty JSON arrays from empty objects; Redis append parity preserves the existing empty-array append expectation, while object mismatch tests use non-empty objects.
- Local `TODOS.md` is ignored by repo rules and is not included.

Verification:

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p iii update_ops` (40 tests)
- [x] `cargo test -p iii --test state_stream_update_e2e` (13 tests)
- [x] `cargo test -p iii-sdk types`
- [x] `cargo test -p iii workers::state::adapters::redis_adapter::tests::test_update_ -- --ignored` with local Redis (3 tests)
- [x] `cargo build -p iii`

Known blockers:

- `pnpm fmt:check` fails on existing nested Biome root config errors.
- `cargo clippy -p iii --lib -- -D warnings` fails on pre-existing clippy issues outside this patch.

---

- [x] I am licensing the entirety of this PR under Apache 2 and have all necessary rights to the code I am contributing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded error docs for state::update and stream::update with a new Error Codes section, clearer per-operation error entries, example JSON responses, and updated guidance for validation, type, and non-object-target failures.

* **Improvements**
  * Non-merge ops now return structured per-op errors (op_index, code, message, optional doc_url); numeric, path, append, and target-not-object errors are formalized. Batch updates are best-effort: failed ops are skipped and later ops still apply. Root-path semantics clarified.

* **Tests**
  * Added unit and e2e tests validating structured errors, op ordering/continuation, numeric/float behavior, root-path cases, and append/type/path edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->