### PR TITLE
fix(engine): restore explicit version in engine/Cargo.toml

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iii"
-version.workspace = true
+version = "0.11.4-next.4"
 edition = "2024"
 license = "Elastic-2.0"
 


### PR DESCRIPTION
## Summary
- The Create Tag workflow has been failing with `error: unexpected character '.' while parsing major version number` (run [25056873806](https://github.com/iii-hq/iii/actions/runs/25056873806)).
- Root cause: PR #1545 changed `engine/Cargo.toml` from `version = "0.11.4-next.4"` to `version.workspace = true`. The workflow's `read_cargo_version()` helper reads the current release version from `engine/Cargo.toml` via `grep '^version = '`, which no longer matches — so `current` came back empty and `bump_version` produced `..1-next.1`, which `cargo update` rejected.
- This PR reverts only that single line. The workspace root `Cargo.toml` still carries the same version string, so engine effectively keeps the same value either way.

## Test plan
- [ ] Run the Create Tag workflow (dry run) on this branch and confirm it produces a sensible next version (e.g. `0.11.4-next.5`) instead of `..1-next.1`.
- [ ] `cargo check -p iii` passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version update to 0.11.4-next.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->