### PR TITLE
docs: apply schematic styling to Mintlify docs

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1,0 +1,610 @@
+@import url("https://fonts.googleapis.com/css2?family=Chivo+Mono:wght@400;500;600&display=swap");
+
+:root {
+  --iii-bg: #f2f0ed;
+  --iii-panel: #e9e6e2;
+  --iii-paper-2: #ebe8e3;
+  --iii-ink: #0a0a0a;
+  --iii-ink-faint: #6b6865;
+  --iii-ink-ghost: #a3a09c;
+  --iii-rule: #d8d5d0;
+  --iii-rule-2: #e6e3df;
+  --iii-accent: #ff5a1f;
+  --iii-accent-fg: #f2f0ed;
+  --iii-alert: #c43e1c;
+  --iii-warn: #a87a00;
+}
+
+html.dark,
+[data-theme="dark"] {
+  --iii-bg: #111110;
+  --iii-panel: #1a1916;
+  --iii-paper-2: #1f1e1c;
+  --iii-ink: #f2f0ed;
+  --iii-ink-faint: #9c9893;
+  --iii-ink-ghost: #5d5a55;
+  --iii-rule: #2a2926;
+  --iii-rule-2: #1f1e1c;
+  --iii-accent: #3ea8ff;
+  --iii-accent-fg: #111110;
+}
+
+html,
+body {
+  background: var(--iii-bg) !important;
+  color: var(--iii-ink) !important;
+  font-family:
+    "Chivo Mono",
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    "Liberation Mono",
+    "Courier New",
+    monospace !important;
+  font-feature-settings: "liga" 0, "clig" 0, "calt" 0, "dlig" 0;
+  scrollbar-gutter: stable;
+}
+
+* {
+  border-radius: 0 !important;
+}
+
+::selection {
+  background: var(--iii-accent);
+  color: var(--iii-accent-fg);
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--iii-rule);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--iii-ink-ghost);
+}
+
+body,
+button,
+input,
+textarea,
+select,
+code,
+pre {
+  font-family:
+    "Chivo Mono",
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    "Liberation Mono",
+    "Courier New",
+    monospace !important;
+}
+
+a {
+  color: var(--iii-ink) !important;
+  text-decoration-color: var(--iii-rule);
+  text-underline-offset: 3px;
+}
+
+a:hover {
+  color: var(--iii-accent) !important;
+  text-decoration-color: var(--iii-accent);
+}
+
+header,
+nav,
+aside,
+main,
+article {
+  background-color: var(--iii-bg) !important;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--iii-ink) !important;
+  font-family:
+    "Chivo Mono",
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    "Liberation Mono",
+    "Courier New",
+    monospace !important;
+  letter-spacing: -0.02em;
+}
+
+p,
+li,
+td,
+dd {
+  color: var(--iii-ink-faint) !important;
+  line-height: 1.7;
+}
+
+strong,
+th {
+  color: var(--iii-ink) !important;
+  font-weight: 600;
+}
+
+hr {
+  border-color: var(--iii-rule) !important;
+}
+
+pre,
+kbd {
+  background-color: var(--iii-bg) !important;
+  color: var(--iii-ink) !important;
+  border-color: var(--iii-rule) !important;
+}
+
+pre {
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+pre code,
+pre code * {
+  background: transparent !important;
+  border: 0 !important;
+  padding: 0 !important;
+}
+
+pre code {
+  color: inherit !important;
+}
+
+.code-block {
+  background: var(--iii-bg) !important;
+  border: 1px solid var(--iii-rule) !important;
+  box-shadow: none !important;
+}
+
+.code-block [data-component-part="code-block-root"] {
+  background: transparent !important;
+  padding: 14px 16px !important;
+}
+
+.code-block [data-component-part="code-block-root"] > pre {
+  background: transparent !important;
+}
+
+.code-block [data-line],
+.code-block .line,
+.code-block [class*="line"] {
+  background: transparent !important;
+}
+
+:not(pre) > code {
+  background-color: var(--iii-bg) !important;
+  border: 1px solid var(--iii-rule-2) !important;
+  color: var(--iii-ink) !important;
+  padding: 0.08rem 0.28rem;
+}
+
+table {
+  border-collapse: collapse !important;
+  border: 1px solid var(--iii-rule) !important;
+  font-variant-numeric: tabular-nums;
+  width: 100%;
+}
+
+thead {
+  background: var(--iii-panel) !important;
+}
+
+th,
+td {
+  border-color: var(--iii-rule-2) !important;
+  padding: 0.9rem 1rem !important;
+  vertical-align: top;
+}
+
+th:first-child,
+td:first-child {
+  min-width: 11rem;
+  padding-left: 1.25rem !important;
+}
+
+#table-of-contents {
+  background: transparent !important;
+  border-left: 0 !important;
+  color: var(--iii-ink-faint) !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+  width: 16.5rem !important;
+}
+
+#table-of-contents > div:first-child {
+  color: var(--iii-ink) !important;
+  font-size: 12px !important;
+  font-weight: 600 !important;
+  gap: 0.45rem !important;
+  margin-bottom: 0.75rem !important;
+}
+
+#table-of-contents-content {
+  border-left: 1px solid var(--iii-rule) !important;
+  margin: 0 !important;
+  padding-left: 0.875rem !important;
+  position: relative;
+}
+
+#table-of-contents .toc-item {
+  margin: 0 !important;
+  position: relative;
+}
+
+#table-of-contents .toc-item:has(> a[aria-current="true"])::before,
+#table-of-contents .toc-item:has(> a[data-active="true"])::before,
+#table-of-contents .toc-item:has(> a[class*="text-primary"])::before {
+  background: var(--iii-accent);
+  content: "";
+  height: calc(100% - 0.35rem);
+  left: -0.9375rem;
+  position: absolute;
+  top: 0.175rem;
+  width: 1px;
+}
+
+#table-of-contents a {
+  background: transparent !important;
+  border-left: 0 !important;
+  color: var(--iii-ink-faint) !important;
+  display: flex !important;
+  font-size: 12px !important;
+  line-height: 1.4 !important;
+  padding: 0.28rem 0 !important;
+  text-decoration: none !important;
+  transition:
+    color 150ms ease;
+  white-space: normal !important;
+}
+
+#table-of-contents a:hover,
+#table-of-contents a[aria-current="true"],
+#table-of-contents a[data-active="true"],
+#table-of-contents a[class*="text-primary"] {
+  background: transparent !important;
+  color: var(--iii-ink) !important;
+}
+
+blockquote {
+  background: var(--iii-bg) !important;
+  border-left: 2px solid var(--iii-accent) !important;
+  color: var(--iii-ink-faint) !important;
+}
+
+input,
+textarea,
+select {
+  background: var(--iii-bg) !important;
+  border-color: var(--iii-rule) !important;
+  color: var(--iii-ink) !important;
+}
+
+button {
+  box-shadow: none !important;
+}
+
+nav a[href="https://docs.iii.dev/install"],
+nav a[href="/install"],
+nav a[href$="/install"],
+header a[href="https://docs.iii.dev/install"],
+header a[href="/install"],
+header a[href$="/install"],
+a[href="https://docs.iii.dev/install"] {
+  background: var(--iii-ink) !important;
+  border: 1px solid var(--iii-ink) !important;
+  color: var(--iii-bg) !important;
+  box-shadow: none !important;
+}
+
+nav a[href="https://docs.iii.dev/install"]:hover,
+nav a[href="/install"]:hover,
+nav a[href$="/install"]:hover,
+header a[href="https://docs.iii.dev/install"]:hover,
+header a[href="/install"]:hover,
+header a[href$="/install"]:hover,
+a[href="https://docs.iii.dev/install"]:hover {
+  background: var(--iii-bg) !important;
+  color: var(--iii-ink) !important;
+}
+
+a[target="_blank"][href="https://docs.iii.dev/install"] {
+  background: transparent !important;
+  border: 1px solid var(--iii-ink) !important;
+  color: var(--iii-bg) !important;
+  padding: 0.375rem 1rem !important;
+}
+
+a[target="_blank"][href="https://docs.iii.dev/install"] > span.absolute {
+  background: var(--iii-ink) !important;
+  border-radius: 0 !important;
+}
+
+a[target="_blank"][href="https://docs.iii.dev/install"] span,
+a[target="_blank"][href="https://docs.iii.dev/install"] svg {
+  color: var(--iii-bg) !important;
+}
+
+a[target="_blank"][href="https://docs.iii.dev/install"]:hover > span.absolute {
+  background: var(--iii-bg) !important;
+  opacity: 1 !important;
+}
+
+a[target="_blank"][href="https://docs.iii.dev/install"]:hover span,
+a[target="_blank"][href="https://docs.iii.dev/install"]:hover svg {
+  color: var(--iii-ink) !important;
+}
+
+.iii-live-count {
+  color: var(--iii-ink-faint);
+  font-size: 0.9em;
+  font-variant-numeric: tabular-nums;
+  margin-left: 0.35rem;
+}
+
+.iii-schematic-shell {
+  background: var(--iii-bg);
+  border-left: 1px solid var(--iii-rule);
+  border-right: 1px solid var(--iii-rule);
+  color: var(--iii-ink);
+  margin: 0 auto;
+  max-width: 1200px;
+  min-height: 100vh;
+}
+
+.iii-schematic-nav {
+  align-items: center;
+  background: var(--iii-bg);
+  border-bottom: 1px solid var(--iii-rule);
+  display: flex;
+  justify-content: space-between;
+  padding: 18px 36px;
+}
+
+.iii-wordmark {
+  color: var(--iii-ink);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+
+.iii-nav-meta {
+  color: var(--iii-ink-faint);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.iii-hero {
+  display: grid;
+  gap: 64px;
+  grid-template-columns: minmax(0, 1.08fr) minmax(300px, 0.92fr);
+  padding: 96px 36px 80px;
+}
+
+.iii-prompt {
+  color: var(--iii-accent);
+}
+
+.iii-eyebrow {
+  color: var(--iii-ink-faint);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  margin-bottom: 18px;
+  text-transform: uppercase;
+}
+
+.iii-hero-title {
+  color: var(--iii-ink);
+  font-size: clamp(42px, 7vw, 72px);
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  line-height: 1.02;
+  margin: 0;
+  max-width: 11ch;
+}
+
+.iii-hero-copy {
+  color: var(--iii-ink-faint);
+  font-size: 14px;
+  line-height: 1.7;
+  margin-top: 24px;
+  max-width: 62ch;
+}
+
+.iii-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 32px;
+}
+
+.iii-button {
+  align-items: center;
+  border: 1px solid var(--iii-ink);
+  display: inline-flex;
+  font-size: 13px;
+  height: 42px;
+  justify-content: center;
+  padding: 0 20px;
+  text-decoration: none !important;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    border-color 150ms ease;
+}
+
+.iii-button-primary {
+  background: var(--iii-ink);
+  color: var(--iii-bg) !important;
+}
+
+.iii-button-primary:hover {
+  background: var(--iii-bg);
+  color: var(--iii-ink) !important;
+}
+
+.iii-button-secondary {
+  background: var(--iii-bg);
+  color: var(--iii-ink) !important;
+}
+
+.iii-button-secondary:hover {
+  background: var(--iii-ink);
+  color: var(--iii-bg) !important;
+}
+
+.iii-terminal {
+  background: var(--iii-bg);
+  border: 1px solid var(--iii-rule);
+}
+
+.iii-terminal-head {
+  background: var(--iii-panel);
+  border-bottom: 1px solid var(--iii-rule);
+  color: var(--iii-ink-faint);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  padding: 10px 14px;
+  text-transform: uppercase;
+}
+
+.iii-terminal-body {
+  color: var(--iii-ink);
+  font-size: 12.5px;
+  line-height: 1.65;
+  overflow-x: auto;
+  padding: 18px 20px;
+}
+
+.iii-terminal-row {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+  white-space: nowrap;
+}
+
+.iii-terminal-row + .iii-terminal-row {
+  margin-top: 12px;
+}
+
+.iii-muted {
+  color: var(--iii-ink-faint);
+}
+
+.iii-grid {
+  border-left: 1px solid var(--iii-rule);
+  border-top: 1px solid var(--iii-rule);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 0;
+}
+
+.iii-cell {
+  background: var(--iii-bg);
+  border-bottom: 1px solid var(--iii-rule);
+  border-right: 1px solid var(--iii-rule);
+  padding: 28px;
+}
+
+.iii-cell h2,
+.iii-cell h3 {
+  color: var(--iii-ink) !important;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0 0 12px;
+}
+
+.iii-cell p {
+  color: var(--iii-ink-faint) !important;
+  font-size: 13px;
+  line-height: 1.7;
+  margin: 0;
+}
+
+.iii-section {
+  border-top: 1px solid var(--iii-rule);
+  padding: 80px 36px;
+}
+
+.iii-section-header {
+  align-items: end;
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+
+.iii-section-title {
+  color: var(--iii-ink);
+  font-size: 28px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+  margin: 0;
+}
+
+.iii-status-dot {
+  background: var(--iii-accent);
+  border-radius: 9999px !important;
+  display: inline-block;
+  height: 6px;
+  width: 6px;
+}
+
+@keyframes iii-pulse-dot {
+  0% {
+    box-shadow: 0 0 0 0 var(--iii-accent);
+  }
+  100% {
+    box-shadow: 0 0 0 8px transparent;
+  }
+}
+
+.iii-status-dot-live {
+  animation: iii-pulse-dot 1.6s ease-out infinite;
+}
+
+@media (max-width: 880px) {
+  .iii-schematic-nav,
+  .iii-hero,
+  .iii-section {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+
+  .iii-hero {
+    grid-template-columns: 1fr;
+    padding-top: 72px;
+  }
+
+  .iii-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2,10 +2,32 @@
   "$schema": "https://mintlify.com/docs.json",
   "name": "iii",
   "theme": "mint",
+  "appearance": {
+    "default": "light"
+  },
   "colors": {
-    "primary": "#8a8c00",
-    "light": "#c8ca00",
-    "dark": "#6b6d00"
+    "primary": "#ff5a1f",
+    "light": "#ff7a45",
+    "dark": "#3ea8ff"
+  },
+  "fonts": {
+    "family": "Chivo Mono",
+    "heading": {
+      "family": "Chivo Mono"
+    },
+    "body": {
+      "family": "Chivo Mono"
+    }
+  },
+  "background": {
+    "color": {
+      "light": "#f2f0ed",
+      "dark": "#111110"
+    }
+  },
+  "styling": {
+    "eyebrows": "breadcrumbs",
+    "codeblocks": "system"
   },
   "logo": {
     "light": "/images/icons/iii-black.svg",
@@ -15,14 +37,20 @@
   "navbar": {
     "links": [
       {
+        "label": "Discord",
+        "href": "https://discord.gg/motia",
+        "icon": "discord"
+      },
+      {
         "type": "github",
+        "label": "GitHub",
         "href": "https://github.com/iii-hq/iii"
       }
     ],
     "primary": {
       "type": "button",
       "label": "Install",
-      "href": "/install"
+      "href": "https://docs.iii.dev/install"
     }
   },
   "navigation": {

--- a/docs/navbar-counters.js
+++ b/docs/navbar-counters.js
@@ -1,0 +1,111 @@
+;(() => {
+  const CACHE_KEY = 'iii-navbar-counters'
+  const CACHE_TTL_MS = 1000 * 60 * 10
+  const GITHUB_REPO = 'iii-hq/iii'
+  const DISCORD_INVITE = 'motia'
+
+  function compact(value) {
+    if (!Number.isFinite(value)) return null
+    return new Intl.NumberFormat('en', {
+      notation: 'compact',
+      maximumFractionDigits: value >= 10000 ? 0 : 1,
+    }).format(value)
+  }
+
+  function readCache() {
+    try {
+      const cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null')
+      if (!cached || Date.now() - cached.updatedAt > CACHE_TTL_MS) return null
+      return cached.values
+    } catch (_) {
+      return null
+    }
+  }
+
+  function writeCache(values) {
+    try {
+      localStorage.setItem(CACHE_KEY, JSON.stringify({ updatedAt: Date.now(), values }))
+    } catch (_) {
+      // Ignore storage errors; counters are decorative.
+    }
+  }
+
+  async function fetchCounts() {
+    const cached = readCache()
+    if (cached) return cached
+
+    const [github, discord] = await Promise.allSettled([
+      fetch(`https://api.github.com/repos/${GITHUB_REPO}`, {
+        headers: { Accept: 'application/vnd.github+json' },
+      }).then((response) => (response.ok ? response.json() : null)),
+      fetch(`https://discord.com/api/v10/invites/${DISCORD_INVITE}?with_counts=true`).then((response) =>
+        response.ok ? response.json() : null,
+      ),
+    ])
+
+    const values = {
+      github: github.status === 'fulfilled' ? compact(github.value?.stargazers_count) : null,
+      discord: discord.status === 'fulfilled' ? compact(discord.value?.approximate_member_count) : null,
+    }
+
+    writeCache(values)
+    return values
+  }
+
+  function upsertCount(link, value) {
+    if (!link || !value) return
+
+    let count = link.querySelector('.iii-live-count')
+    if (!count) {
+      count = document.createElement('span')
+      count.className = 'iii-live-count'
+      count.setAttribute('aria-hidden', 'true')
+      link.appendChild(count)
+    }
+    count.textContent = value
+    link.setAttribute('aria-label', `${link.textContent.trim()} members`)
+  }
+
+  function applyCounts(values) {
+    const githubLink = document.querySelector('a[href="https://github.com/iii-hq/iii"]')
+    const discordLink = document.querySelector('a[href="https://discord.gg/motia"]')
+
+    upsertCount(githubLink, values.github)
+    upsertCount(discordLink, values.discord)
+
+    if (githubLink && values.github) {
+      githubLink.setAttribute('aria-label', `GitHub, ${values.github} stars`)
+    }
+    if (discordLink && values.discord) {
+      discordLink.setAttribute('aria-label', `Discord, ${values.discord} members`)
+    }
+  }
+
+  let pending = false
+
+  function scheduleApply(values) {
+    if (pending) return
+    pending = true
+    requestAnimationFrame(() => {
+      pending = false
+      applyCounts(values)
+    })
+  }
+
+  function init() {
+    fetchCounts()
+      .then((values) => {
+        scheduleApply(values)
+        new MutationObserver(() => scheduleApply(values)).observe(document.body, { childList: true, subtree: true })
+      })
+      .catch(() => {
+        // Keep the static navbar labels if either network request is blocked.
+      })
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true })
+  } else {
+    init()
+  }
+})()

--- a/docs/navbar-counters.js
+++ b/docs/navbar-counters.js
@@ -1,7 +1,6 @@
 ;(() => {
   const CACHE_KEY = 'iii-navbar-counters'
   const CACHE_TTL_MS = 1000 * 60 * 10
-  const GITHUB_REPO = 'iii-hq/iii'
   const DISCORD_INVITE = 'motia'
 
   function compact(value) {
@@ -34,18 +33,12 @@
     const cached = readCache()
     if (cached) return cached
 
-    const [github, discord] = await Promise.allSettled([
-      fetch(`https://api.github.com/repos/${GITHUB_REPO}`, {
-        headers: { Accept: 'application/vnd.github+json' },
-      }).then((response) => (response.ok ? response.json() : null)),
-      fetch(`https://discord.com/api/v10/invites/${DISCORD_INVITE}?with_counts=true`).then((response) =>
-        response.ok ? response.json() : null,
-      ),
-    ])
+    const discord = await fetch(`https://discord.com/api/v10/invites/${DISCORD_INVITE}?with_counts=true`).then(
+      (response) => (response.ok ? response.json() : null),
+    )
 
     const values = {
-      github: github.status === 'fulfilled' ? compact(github.value?.stargazers_count) : null,
-      discord: discord.status === 'fulfilled' ? compact(discord.value?.approximate_member_count) : null,
+      discord: compact(discord?.approximate_member_count),
     }
 
     writeCache(values)
@@ -67,15 +60,10 @@
   }
 
   function applyCounts(values) {
-    const githubLink = document.querySelector('a[href="https://github.com/iii-hq/iii"]')
     const discordLink = document.querySelector('a[href="https://discord.gg/motia"]')
 
-    upsertCount(githubLink, values.github)
     upsertCount(discordLink, values.discord)
 
-    if (githubLink && values.github) {
-      githubLink.setAttribute('aria-label', `GitHub, ${values.github} stars`)
-    }
     if (discordLink && values.discord) {
       discordLink.setAttribute('aria-label', `Discord, ${values.discord} members`)
     }


### PR DESCRIPTION
## Summary
- Apply the iii Schematic visual system to Mintlify docs via global CSS and docs.json branding.
- Restore the Discord navbar link, style the Install CTA, and add live Discord/GitHub counters with cached client-side enhancement.
- Polish docs UI surfaces including code blocks, tables, and the right-hand table of contents.

## Test plan
- Ran `pnpm exec biome check docs/navbar-counters.js`.
- Ran and visually checked the local Mintlify preview at `http://localhost:3000`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live Discord community counter displayed in the navigation bar.
  * Discord community link added to the navigation.
  * “Install” primary button now points to the external install page.

* **Style**
  * New monochrome theme with light/dark palettes and responsive adjustments.
  * Updated typography to Chivo Mono, refined spacing, headings, code, tables, and interactive elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->