### PR TITLE
docs: fix stale links

### DIFF
--- a/crates/iii-worker/src/sandbox_daemon/errors.rs
+++ b/crates/iii-worker/src/sandbox_daemon/errors.rs
@@ -6,7 +6,7 @@
 use serde_json::json;
 use thiserror::Error;
 
-const DOCS_BASE: &str = "https://docs.iii.dev/errors/sandbox/";
+const DOCS_BASE: &str = "https://iii.dev/docs/errors/sandbox/";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SandboxErrorCode {

--- a/docs/0-10-0/api-reference/sdk-python.mdx
+++ b/docs/0-10-0/api-reference/sdk-python.mdx
@@ -693,7 +693,7 @@ Telemetry metadata to be reported to the engine.
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
 | `amplitude_api_key` | `str \| None` | No | Amplitude API key for product analytics. |
-| `framework` | `str \| None` | No | Framework name (e.g. ``motia``) if applicable. |
+| `framework` | `str \| None` | No | Framework name if applicable. |
 | `language` | `str \| None` | No | Programming language of the worker (e.g. ``python``). |
 | `project_name` | `str \| None` | No | Name of the project this worker belongs to. |
 

--- a/docs/0-10-0/how-to/configure-engine.mdx
+++ b/docs/0-10-0/how-to/configure-engine.mdx
@@ -652,7 +652,7 @@ Enables HTTP-invoked functions (outbound HTTP calls from the engine). Required f
 
 **Class:** `modules::shell::ExecModule`
 
-Spawns external processes (SDK workers) and watches for file changes. Useful for setups where workers need to run alongside the engine on the same host, or from frameworks like Motia.
+Spawns external processes (SDK workers) and watches for file changes. Useful for setups where workers need to run alongside the engine on the same host.
 
 <ResponseField name="config.watch" type="string[]">
   Directories to watch for file changes. Changes trigger process restart.
@@ -667,18 +667,19 @@ Spawns external processes (SDK workers) and watches for file changes. Useful for
 - class: modules::shell::ExecModule
   config:
     watch:
-      - ./steps
+      - ./workers
     exec:
-      - motia-py
+      - python
+      - ./workers/main.py
 
 # Example: run Node.js SDK worker
 - class: modules::shell::ExecModule
   config:
     watch:
-      - ./steps
+      - ./workers
     exec:
-      - npx
-      - motia-node
+      - node
+      - ./workers/main.js
 ```
 
 </Accordion>

--- a/docs/api-reference/sandbox.mdx
+++ b/docs/api-reference/sandbox.mdx
@@ -1272,13 +1272,13 @@ and always carries five fields:
 | `type` | `string` | Category: `validation`, `config`, `internal`, `transient`, `execution`, `filesystem`, or `platform`. |
 | `code` | `string` | Stable S-code (e.g. `S100`, `S211`). The wire ABI — the [S-codes table](#s-codes) is the canonical reference. |
 | `message` | `string` | Human-readable explanation. Often includes the offending path, image, or timeout value. |
-| `docs_url` | `string` | Permalink to the per-code troubleshooting page: `https://docs.iii.dev/errors/sandbox/<code>`. |
+| `docs_url` | `string` | Permalink to the per-code troubleshooting page: `https://iii.dev/docs/errors/sandbox/<code>`. |
 | `retryable` | `boolean` | `true` only for transient codes (`S102`, `S218`). All other codes are caller-fixable, not retryable. |
 
 ```
-handler error: {"type":"validation","code":"S002","message":"sandbox not found: <id>","docs_url":"https://docs.iii.dev/errors/sandbox/S002","retryable":false}
-handler error: {"type":"execution","code":"S200","message":"exec timed out after 500 ms","docs_url":"https://docs.iii.dev/errors/sandbox/S200","retryable":false}
-handler error: {"type":"transient","code":"S102","message":"auto-install failed for image 'python': network down","docs_url":"https://docs.iii.dev/errors/sandbox/S102","retryable":true}
+handler error: {"type":"validation","code":"S002","message":"sandbox not found: <id>","docs_url":"https://iii.dev/docs/errors/sandbox/S002","retryable":false}
+handler error: {"type":"execution","code":"S200","message":"exec timed out after 500 ms","docs_url":"https://iii.dev/docs/errors/sandbox/S200","retryable":false}
+handler error: {"type":"transient","code":"S102","message":"auto-install failed for image 'python': network down","docs_url":"https://iii.dev/docs/errors/sandbox/S102","retryable":true}
 ```
 
 Parse the envelope if you need the S-code or the `retryable` flag for

--- a/docs/architecture/external-workers.mdx
+++ b/docs/architecture/external-workers.mdx
@@ -163,5 +163,5 @@ workers = result.get("workers", [])
 ```
 
 <Info title="See also">
-  For details on building and deploying Workers in production, see the [Quickstart tutorial](/quickstart) or the [SDK Reference](/api-reference/iii-sdk).
+  For details on building and deploying Workers in production, see the [Quickstart tutorial](/quickstart) or the [SDK Reference](/api-reference/sdk-node).
 </Info>

--- a/docs/architecture/queues.mdx
+++ b/docs/architecture/queues.mdx
@@ -52,7 +52,7 @@ This separation solves three problems:
 2. **Reliability** — transient failures (network blips, service restarts) are retried automatically instead of being lost.
 3. **Load control** — concurrency limits prevent consumers from overwhelming downstream systems.
 
-## When to Use Named Queues
+## When to Use Queues
 
 | Scenario | Use a queue? | Why |
 |----------|-------------|-----|
@@ -65,7 +65,7 @@ This separation solves three problems:
 | The work is non-critical and losing it is acceptable | **Maybe** | [TriggerAction.Void()](/how-to/trigger-actions#2-void-fire-and-forget) is simpler if you don't need retries |
 
 <Info title="How-to guide">
-  For step-by-step instructions on setting up queues, see [Use Named Queues](/how-to/use-named-queues).
+  For queue modes, configuration, retries, and adapter guidance, see the [Queue worker reference](/workers/iii-queue).
 </Info>
 
 ## RabbitMQ Resource Topology
@@ -196,7 +196,7 @@ The conceptual model is identical across all adapters. Only the transport differ
 ## Related
 
 <CardGroup cols={3}>
-  <Card title="Use Named Queues" href="/how-to/use-named-queues" icon="list-check">
+  <Card title="Use Queues" href="/workers/iii-queue" icon="list-check">
     Configure named queues with retries, concurrency, and FIFO ordering
   </Card>
   <Card title="Dead Letter Queues" href="/how-to/dead-letter-queues" icon="skull">

--- a/docs/architecture/queues.mdx
+++ b/docs/architecture/queues.mdx
@@ -52,7 +52,7 @@ This separation solves three problems:
 2. **Reliability** — transient failures (network blips, service restarts) are retried automatically instead of being lost.
 3. **Load control** — concurrency limits prevent consumers from overwhelming downstream systems.
 
-## When to Use Queues
+## When to Use Named Queues
 
 | Scenario | Use a queue? | Why |
 |----------|-------------|-----|
@@ -65,7 +65,7 @@ This separation solves three problems:
 | The work is non-critical and losing it is acceptable | **Maybe** | [TriggerAction.Void()](/how-to/trigger-actions#2-void-fire-and-forget) is simpler if you don't need retries |
 
 <Info title="How-to guide">
-  For step-by-step instructions on setting up queues, see [Use Queues](/how-to/use-queues).
+  For step-by-step instructions on setting up queues, see [Use Named Queues](/how-to/use-named-queues).
 </Info>
 
 ## RabbitMQ Resource Topology
@@ -108,7 +108,7 @@ Because each of the three lifecycle stages is a separate routing destination, an
 | Dead-letter | `iii.__fn_queue::<name>::dlq` | `iii.__fn_queue::<name>::dlq.queue` |
 
 <Info title="Full resource map">
-  For the complete naming convention and examples, see the [Queue module reference — Queue naming in RabbitMQ](/modules/module-queue#queue-naming-in-rabbitmq).
+  For the complete naming convention and examples, see the [Queue worker reference — Queue naming in RabbitMQ](/workers/iii-queue#queue-naming-in-rabbitmq).
 </Info>
 
 ## The Delayed Retry Problem
@@ -190,19 +190,19 @@ The builtin adapter implements the same three-stage lifecycle entirely in-proces
 The conceptual model is identical across all adapters. Only the transport differs. This means you can develop locally with the builtin adapter and deploy to production with RabbitMQ, and the retry and DLQ behavior stays the same.
 
 <Info title="Choosing an adapter">
-  For a feature comparison of all queue adapters and scenario-based recommendations, see the [adapter comparison](/modules/module-queue#adapter-comparison).
+  For a feature comparison of all queue adapters and scenario-based recommendations, see the [adapter comparison](/workers/iii-queue#adapter-comparison).
 </Info>
 
 ## Related
 
 <CardGroup cols={3}>
-  <Card title="Use Queues" href="/how-to/use-queues" icon="list-check">
+  <Card title="Use Named Queues" href="/how-to/use-named-queues" icon="list-check">
     Configure named queues with retries, concurrency, and FIFO ordering
   </Card>
   <Card title="Dead Letter Queues" href="/how-to/dead-letter-queues" icon="skull">
     Inspect and redrive failed queue messages
   </Card>
-  <Card title="Queue Worker Reference" href="/modules/module-queue" icon="gear">
+  <Card title="Queue Worker Reference" href="/workers/iii-queue" icon="gear">
     Full configuration reference for queues and adapters
   </Card>
 </CardGroup>

--- a/docs/architecture/trigger-types.mdx
+++ b/docs/architecture/trigger-types.mdx
@@ -95,7 +95,7 @@ graph LR
 
 Executes functions in response to HTTP requests.
 
-**Provided by**: [HTTP Worker](/modules/module-http)
+**Provided by**: [HTTP Worker](/workers/iii-http)
 
 **Configuration:**
 
@@ -152,7 +152,7 @@ json!({
 // Handler receives: { path_params: { userId: '123', postId: '456' } }
 ```
 
-<Card title="HTTP Worker" href="/modules/module-http" icon="globe">
+<Card title="HTTP Worker" href="/workers/iii-http" icon="globe">
   Learn more about the API trigger
 </Card>
 
@@ -527,7 +527,7 @@ Each SSE frame follows the standard format: `id`, `event`, and `data` fields sep
 
 Executes functions when events are published to subscribed topics.
 
-**Provided by**: [Queue Worker](/modules/module-queue)
+**Provided by**: [Queue Worker](/workers/iii-queue)
 
 **Configuration:**
 
@@ -575,7 +575,7 @@ json!({
 
 **Multiple Topics**: Register separate triggers for each topic.
 
-<Card title="Queue Worker" href="/modules/module-queue" icon="bolt">
+<Card title="Queue Worker" href="/workers/iii-queue" icon="bolt">
   Learn more about the Queue trigger
 </Card>
 
@@ -585,7 +585,7 @@ json!({
 
 Executes functions on a time-based schedule using cron expressions.
 
-**Provided by**: [Cron Worker](/modules/module-cron)
+**Provided by**: [Cron Worker](/workers/iii-cron)
 
 **Configuration:**
 
@@ -633,7 +633,7 @@ json!({
 
 **Cron Expression**: Standard 5-field format (minute hour day month weekday)
 
-<Card title="Cron Worker" href="/modules/module-cron" icon="clock">
+<Card title="Cron Worker" href="/workers/iii-cron" icon="clock">
   Learn more about the Cron trigger
 </Card>
 
@@ -643,7 +643,7 @@ json!({
 
 Executes functions when log entries match specified criteria.
 
-**Provided by**: [Observability Worker](/modules/module-observability)
+**Provided by**: [Observability Worker](/workers/iii-observability)
 
 **Configuration:**
 
@@ -689,7 +689,7 @@ json!({
 
 **Log Levels**: `info`, `warn`, `error`, `debug` (omit to receive all levels)
 
-<Card title="Observability Worker" href="/modules/module-observability" icon="file-text">
+<Card title="Observability Worker" href="/workers/iii-observability" icon="file-text">
   Learn more about the Log trigger
 </Card>
 
@@ -699,7 +699,7 @@ json!({
 
 Executes functions when clients connect to or disconnect from streams.
 
-**Provided by**: [Stream Worker](/modules/module-stream)
+**Provided by**: [Stream Worker](/workers/iii-stream)
 
 **Configuration:**
 
@@ -723,7 +723,7 @@ Executes functions when clients connect to or disconnect from streams.
 
 **Conditions**: Optional. Add `condition_function_id` to config for stream:join/stream:leave. See [Trigger Conditions](#trigger-conditions).
 
-<Card title="Stream Worker" href="/modules/module-stream" icon="chart-line">
+<Card title="Stream Worker" href="/workers/iii-stream" icon="chart-line">
   Learn more about Stream triggers
 </Card>
 
@@ -1513,6 +1513,6 @@ impl CoreWorker for CustomWorker {
 
 ## Next Steps
 
-<Card title="Modules" href="/modules" icon="cubes">
+<Card title="Modules" href="/workers" icon="cubes">
   Explore modules that provide trigger types
 </Card>

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -311,9 +311,12 @@ button {
 nav a[href="/install"],
 nav a[href="/docs/install"],
 nav a[href$="/install"],
+nav a[href="install"],
 header a[href="/install"],
 header a[href="/docs/install"],
 header a[href$="/install"],
+header a[href="install"],
+a[href="install"],
 a[href="/docs/install"] {
   background: var(--iii-ink) !important;
   border: 1px solid var(--iii-ink) !important;
@@ -324,16 +327,20 @@ a[href="/docs/install"] {
 nav a[href="/install"]:hover,
 nav a[href="/docs/install"]:hover,
 nav a[href$="/install"]:hover,
+nav a[href="install"]:hover,
 header a[href="/install"]:hover,
 header a[href="/docs/install"]:hover,
 header a[href$="/install"]:hover,
+header a[href="install"]:hover,
+a[href="install"]:hover,
 a[href="/docs/install"]:hover {
   background: var(--iii-bg) !important;
   color: var(--iii-ink) !important;
 }
 
 a[target="_blank"][href="/docs/install"],
-a[target="_blank"][href="/install"] {
+a[target="_blank"][href="/install"],
+a[target="_blank"][href="install"] {
   background: transparent !important;
   border: 1px solid var(--iii-ink) !important;
   color: var(--iii-bg) !important;
@@ -341,7 +348,8 @@ a[target="_blank"][href="/install"] {
 }
 
 a[target="_blank"][href="/docs/install"] > span.absolute,
-a[target="_blank"][href="/install"] > span.absolute {
+a[target="_blank"][href="/install"] > span.absolute,
+a[target="_blank"][href="install"] > span.absolute {
   background: var(--iii-ink) !important;
   border-radius: 0 !important;
 }
@@ -349,12 +357,15 @@ a[target="_blank"][href="/install"] > span.absolute {
 a[target="_blank"][href="/docs/install"] span,
 a[target="_blank"][href="/docs/install"] svg,
 a[target="_blank"][href="/install"] span,
-a[target="_blank"][href="/install"] svg {
+a[target="_blank"][href="/install"] svg,
+a[target="_blank"][href="install"] span,
+a[target="_blank"][href="install"] svg {
   color: var(--iii-bg) !important;
 }
 
 a[target="_blank"][href="/docs/install"]:hover > span.absolute,
-a[target="_blank"][href="/install"]:hover > span.absolute {
+a[target="_blank"][href="/install"]:hover > span.absolute,
+a[target="_blank"][href="install"]:hover > span.absolute {
   background: var(--iii-bg) !important;
   opacity: 1 !important;
 }
@@ -362,7 +373,9 @@ a[target="_blank"][href="/install"]:hover > span.absolute {
 a[target="_blank"][href="/docs/install"]:hover span,
 a[target="_blank"][href="/docs/install"]:hover svg,
 a[target="_blank"][href="/install"]:hover span,
-a[target="_blank"][href="/install"]:hover svg {
+a[target="_blank"][href="/install"]:hover svg,
+a[target="_blank"][href="install"]:hover span,
+a[target="_blank"][href="install"]:hover svg {
   color: var(--iii-ink) !important;
 }
 

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -308,54 +308,61 @@ button {
   box-shadow: none !important;
 }
 
-nav a[href="https://docs.iii.dev/install"],
 nav a[href="/install"],
+nav a[href="/docs/install"],
 nav a[href$="/install"],
-header a[href="https://docs.iii.dev/install"],
 header a[href="/install"],
+header a[href="/docs/install"],
 header a[href$="/install"],
-a[href="https://docs.iii.dev/install"] {
+a[href="/docs/install"] {
   background: var(--iii-ink) !important;
   border: 1px solid var(--iii-ink) !important;
   color: var(--iii-bg) !important;
   box-shadow: none !important;
 }
 
-nav a[href="https://docs.iii.dev/install"]:hover,
 nav a[href="/install"]:hover,
+nav a[href="/docs/install"]:hover,
 nav a[href$="/install"]:hover,
-header a[href="https://docs.iii.dev/install"]:hover,
 header a[href="/install"]:hover,
+header a[href="/docs/install"]:hover,
 header a[href$="/install"]:hover,
-a[href="https://docs.iii.dev/install"]:hover {
+a[href="/docs/install"]:hover {
   background: var(--iii-bg) !important;
   color: var(--iii-ink) !important;
 }
 
-a[target="_blank"][href="https://docs.iii.dev/install"] {
+a[target="_blank"][href="/docs/install"],
+a[target="_blank"][href="/install"] {
   background: transparent !important;
   border: 1px solid var(--iii-ink) !important;
   color: var(--iii-bg) !important;
   padding: 0.375rem 1rem !important;
 }
 
-a[target="_blank"][href="https://docs.iii.dev/install"] > span.absolute {
+a[target="_blank"][href="/docs/install"] > span.absolute,
+a[target="_blank"][href="/install"] > span.absolute {
   background: var(--iii-ink) !important;
   border-radius: 0 !important;
 }
 
-a[target="_blank"][href="https://docs.iii.dev/install"] span,
-a[target="_blank"][href="https://docs.iii.dev/install"] svg {
+a[target="_blank"][href="/docs/install"] span,
+a[target="_blank"][href="/docs/install"] svg,
+a[target="_blank"][href="/install"] span,
+a[target="_blank"][href="/install"] svg {
   color: var(--iii-bg) !important;
 }
 
-a[target="_blank"][href="https://docs.iii.dev/install"]:hover > span.absolute {
+a[target="_blank"][href="/docs/install"]:hover > span.absolute,
+a[target="_blank"][href="/install"]:hover > span.absolute {
   background: var(--iii-bg) !important;
   opacity: 1 !important;
 }
 
-a[target="_blank"][href="https://docs.iii.dev/install"]:hover span,
-a[target="_blank"][href="https://docs.iii.dev/install"]:hover svg {
+a[target="_blank"][href="/docs/install"]:hover span,
+a[target="_blank"][href="/docs/install"]:hover svg,
+a[target="_blank"][href="/install"]:hover span,
+a[target="_blank"][href="/install"]:hover svg {
   color: var(--iii-ink) !important;
 }
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -50,7 +50,7 @@
     "primary": {
       "type": "button",
       "label": "Install",
-      "href": "install"
+      "href": "/install"
     }
   },
   "navigation": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -50,7 +50,7 @@
     "primary": {
       "type": "button",
       "label": "Install",
-      "href": "/docs/install"
+      "href": "install"
     }
   },
   "navigation": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -50,7 +50,7 @@
     "primary": {
       "type": "button",
       "label": "Install",
-      "href": "https://docs.iii.dev/install"
+      "href": "/docs/install"
     }
   },
   "navigation": {

--- a/docs/how-to/expose-http-endpoint.mdx
+++ b/docs/how-to/expose-http-endpoint.mdx
@@ -152,5 +152,5 @@ curl -X POST http://127.0.0.1:3111/users \
 Your Function is now accessible as `POST /users` on port 3111. The `http` trigger handles request parsing and response serialization automatically.
 
 <Info title="Request and Response types">
-  HTTP-triggered Functions receive an `ApiRequest` and should return an `ApiResponse`. See the [SDK Reference](/api-reference/iii-sdk) for type details.
+  HTTP-triggered Functions receive an `ApiRequest` and should return an `ApiResponse`. See the [SDK Reference](/api-reference/sdk-node) for type details.
 </Info>

--- a/docs/how-to/observability-and-logs.mdx
+++ b/docs/how-to/observability-and-logs.mdx
@@ -274,7 +274,7 @@ graph LR
 ```
 
 <Info>
-  The `endpoint` field can also be set via the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable. See the [Observability worker reference](/workers/worker-observability) for the full list of configuration fields and environment variable overrides.
+  The `endpoint` field can also be set via the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable. See the [Observability worker reference](/workers/iii-observability) for the full list of configuration fields and environment variable overrides.
 </Info>
 
 ## Using iii Console
@@ -347,7 +347,7 @@ Your iii application is now fully observable:
   <Card title="OpenTelemetry Integration" href="/advanced/telemetry" icon="signal">
     Custom spans, metrics, and telemetry utilities
   </Card>
-  <Card title="Observability Worker" href="/workers/worker-observability" icon="gear">
+  <Card title="Observability Worker" href="/workers/iii-observability" icon="gear">
     Full configuration reference for traces, logs, metrics, alerts, and sampling
   </Card>
   <Card title="Observability Example" href="/examples/observability" icon="code">

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -61,7 +61,7 @@ npx skillkit add iii-hq/iii/skills
   <Card title="Quickstart" href="/quickstart" icon="terminal">
     Follow the Quickstart and explore a live iii application.
   </Card>
-  <Card title="Concepts" href="/primitives-and-concepts" icon="table-layout">
+  <Card title="Concepts" href="/primitives-and-concepts/functions-triggers-workers" icon="table-layout">
     Understand Functions and Triggers from a conceptual point of view.
   </Card>
 </CardGroup>

--- a/engine/src/update_ops.rs
+++ b/engine/src/update_ops.rs
@@ -30,7 +30,7 @@ pub(crate) const ERR_VALUE_TOO_MANY_KEYS: &str = "merge.value.too_many_keys";
 pub(crate) const ERR_VALUE_PROTO: &str = "merge.value.proto_polluted";
 pub(crate) const ERR_VALUE_NOT_OBJECT: &str = "merge.value.not_an_object";
 
-const DOC_URL_BASE: &str = "https://docs.iii.dev/workers/iii-state#merge-bounds";
+const DOC_URL_BASE: &str = "https://iii.dev/docs/workers/iii-state#merge-bounds";
 
 fn err(op_index: usize, code: &str, message: String) -> UpdateOpError {
     UpdateOpError {

--- a/engine/src/workers/redis.rs
+++ b/engine/src/workers/redis.rs
@@ -24,7 +24,7 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
     local MAX_VALUE_DEPTH = 16
     local MAX_VALUE_KEYS = 1024
     local PROTO = { __proto__ = true, constructor = true, prototype = true }
-    local DOC_URL = 'https://docs.iii.dev/workers/iii-state#merge-bounds'
+    local DOC_URL = 'https://iii.dev/docs/workers/iii-state#merge-bounds'
 
     local key = KEYS[1]
     local field = ARGV[1]

--- a/sdk/packages/python/iii/tests/test_stream_models.py
+++ b/sdk/packages/python/iii/tests/test_stream_models.py
@@ -49,7 +49,7 @@ def test_update_op_error_round_trip() -> None:
         op_index=0,
         code="merge.path.too_deep",
         message="Path depth 33 exceeds maximum of 32",
-        doc_url="https://docs.iii.dev/workers/iii-state#merge-bounds",
+        doc_url="https://iii.dev/docs/workers/iii-state#merge-bounds",
     )
     dumped = err.model_dump()
     assert dumped["code"] == "merge.path.too_deep"

--- a/sdk/packages/rust/iii/src/types.rs
+++ b/sdk/packages/rust/iii/src/types.rs
@@ -488,7 +488,7 @@ mod tests {
                 op_index: 0,
                 code: "merge.path.too_deep".to_string(),
                 message: "Path depth 33 exceeds maximum of 32".to_string(),
-                doc_url: Some("https://docs.iii.dev/workers/iii-state#merge-bounds".to_string()),
+                doc_url: Some("https://iii.dev/docs/workers/iii-state#merge-bounds".to_string()),
             }],
         };
         let encoded = serde_json::to_value(&result).unwrap();

--- a/skills/references/agentic-backend.js
+++ b/skills/references/agentic-backend.js
@@ -11,7 +11,7 @@
  *   - Functions & Triggers: https://iii.dev/docs/how-to/use-functions-and-triggers
  *   - State management:    https://iii.dev/docs/how-to/manage-state
  *   - State reactions:     https://iii.dev/docs/how-to/react-to-state-changes
- *   - Queues:              https://iii.dev/docs/how-to/use-queues
+ *   - Queues:              https://iii.dev/docs/how-to/use-named-queues
  *   - Conditions:          https://iii.dev/docs/how-to/use-trigger-conditions
  */
 

--- a/skills/references/agentic-backend.js
+++ b/skills/references/agentic-backend.js
@@ -11,7 +11,7 @@
  *   - Functions & Triggers: https://iii.dev/docs/how-to/use-functions-and-triggers
  *   - State management:    https://iii.dev/docs/how-to/manage-state
  *   - State reactions:     https://iii.dev/docs/how-to/react-to-state-changes
- *   - Queues:              https://iii.dev/docs/how-to/use-named-queues
+ *   - Queues:              https://iii.dev/docs/workers/iii-queue
  *   - Conditions:          https://iii.dev/docs/how-to/use-trigger-conditions
  */
 

--- a/skills/references/event-driven-cqrs.js
+++ b/skills/references/event-driven-cqrs.js
@@ -8,7 +8,7 @@
  * fan-out — both to projections and downstream notification consumers.
  *
  * How-to references:
- *   - Queues:           https://iii.dev/docs/how-to/use-queues
+ *   - Queues:           https://iii.dev/docs/how-to/use-named-queues
  *   - State management: https://iii.dev/docs/how-to/manage-state
  *   - State reactions:  https://iii.dev/docs/how-to/react-to-state-changes
  *   - HTTP endpoints:   https://iii.dev/docs/how-to/expose-http-endpoint

--- a/skills/references/event-driven-cqrs.js
+++ b/skills/references/event-driven-cqrs.js
@@ -8,7 +8,7 @@
  * fan-out — both to projections and downstream notification consumers.
  *
  * How-to references:
- *   - Queues:           https://iii.dev/docs/how-to/use-named-queues
+ *   - Queues:           https://iii.dev/docs/workers/iii-queue
  *   - State management: https://iii.dev/docs/how-to/manage-state
  *   - State reactions:  https://iii.dev/docs/how-to/react-to-state-changes
  *   - HTTP endpoints:   https://iii.dev/docs/how-to/expose-http-endpoint

--- a/skills/references/http-invoked-functions.js
+++ b/skills/references/http-invoked-functions.js
@@ -10,7 +10,7 @@
  *   - Engine config:         https://iii.dev/docs/how-to/configure-engine
  *   - State management:      https://iii.dev/docs/how-to/manage-state
  *   - Cron:                  https://iii.dev/docs/how-to/schedule-cron-task
- *   - Queues:                https://iii.dev/docs/how-to/use-named-queues
+ *   - Queues:                https://iii.dev/docs/workers/iii-queue
  *
  * Prerequisites:
  *   - HttpFunctionsModule enabled in iii engine config

--- a/skills/references/http-invoked-functions.js
+++ b/skills/references/http-invoked-functions.js
@@ -10,7 +10,7 @@
  *   - Engine config:         https://iii.dev/docs/how-to/configure-engine
  *   - State management:      https://iii.dev/docs/how-to/manage-state
  *   - Cron:                  https://iii.dev/docs/how-to/schedule-cron-task
- *   - Queues:                https://iii.dev/docs/how-to/use-queues
+ *   - Queues:                https://iii.dev/docs/how-to/use-named-queues
  *
  * Prerequisites:
  *   - HttpFunctionsModule enabled in iii engine config

--- a/skills/references/http-invoked-functions.py
+++ b/skills/references/http-invoked-functions.py
@@ -10,7 +10,7 @@ How-to references:
   - Engine config:         https://iii.dev/docs/how-to/configure-engine
   - State management:      https://iii.dev/docs/how-to/manage-state
   - Cron:                  https://iii.dev/docs/how-to/schedule-cron-task
-  - Queues:                https://iii.dev/docs/how-to/use-queues
+  - Queues:                https://iii.dev/docs/how-to/use-named-queues
 
 Prerequisites:
   - HttpFunctionsModule enabled in iii engine config

--- a/skills/references/http-invoked-functions.py
+++ b/skills/references/http-invoked-functions.py
@@ -10,7 +10,7 @@ How-to references:
   - Engine config:         https://iii.dev/docs/how-to/configure-engine
   - State management:      https://iii.dev/docs/how-to/manage-state
   - Cron:                  https://iii.dev/docs/how-to/schedule-cron-task
-  - Queues:                https://iii.dev/docs/how-to/use-named-queues
+  - Queues:                https://iii.dev/docs/workers/iii-queue
 
 Prerequisites:
   - HttpFunctionsModule enabled in iii engine config

--- a/skills/references/low-code-automation.js
+++ b/skills/references/low-code-automation.js
@@ -10,7 +10,7 @@
  * How-to references:
  *   - Functions & Triggers: https://iii.dev/docs/how-to/use-functions-and-triggers
  *   - HTTP endpoints:       https://iii.dev/docs/how-to/expose-http-endpoint
- *   - Queues:               https://iii.dev/docs/how-to/use-queues
+ *   - Queues:               https://iii.dev/docs/how-to/use-named-queues
  *   - PubSub:               https://iii.dev/docs/how-to/use-functions-and-triggers
  *   - Cron:                 https://iii.dev/docs/how-to/schedule-cron-task
  */

--- a/skills/references/low-code-automation.js
+++ b/skills/references/low-code-automation.js
@@ -10,7 +10,7 @@
  * How-to references:
  *   - Functions & Triggers: https://iii.dev/docs/how-to/use-functions-and-triggers
  *   - HTTP endpoints:       https://iii.dev/docs/how-to/expose-http-endpoint
- *   - Queues:               https://iii.dev/docs/how-to/use-named-queues
+ *   - Queues:               https://iii.dev/docs/workers/iii-queue
  *   - PubSub:               https://iii.dev/docs/how-to/use-functions-and-triggers
  *   - Cron:                 https://iii.dev/docs/how-to/schedule-cron-task
  */

--- a/skills/references/queue-processing.js
+++ b/skills/references/queue-processing.js
@@ -19,7 +19,7 @@
  *       concurrency: 1
  *
  * How-to references:
- *   - Queues: https://iii.dev/docs/how-to/use-named-queues
+ *   - Queues: https://iii.dev/docs/workers/iii-queue
  */
 
 import { registerWorker, Logger, TriggerAction } from 'iii-sdk'

--- a/skills/references/queue-processing.js
+++ b/skills/references/queue-processing.js
@@ -19,7 +19,7 @@
  *       concurrency: 1
  *
  * How-to references:
- *   - Queues: https://iii.dev/docs/how-to/use-queues
+ *   - Queues: https://iii.dev/docs/how-to/use-named-queues
  */
 
 import { registerWorker, Logger, TriggerAction } from 'iii-sdk'

--- a/skills/references/queue-processing.py
+++ b/skills/references/queue-processing.py
@@ -17,7 +17,7 @@ Retry / backoff is configured in iii-config.yaml under queue_configs:
       backoff_ms: 500
 
 How-to references:
-  - Queues: https://iii.dev/docs/how-to/use-named-queues
+  - Queues: https://iii.dev/docs/workers/iii-queue
 """
 
 import asyncio

--- a/skills/references/queue-processing.py
+++ b/skills/references/queue-processing.py
@@ -17,7 +17,7 @@ Retry / backoff is configured in iii-config.yaml under queue_configs:
       backoff_ms: 500
 
 How-to references:
-  - Queues: https://iii.dev/docs/how-to/use-queues
+  - Queues: https://iii.dev/docs/how-to/use-named-queues
 """
 
 import asyncio

--- a/skills/references/workflow-orchestration.js
+++ b/skills/references/workflow-orchestration.js
@@ -7,7 +7,7 @@
  * Each step is its own function chained via named queues.
  *
  * How-to references:
- *   - Queues & retries: https://iii.dev/docs/how-to/use-named-queues
+ *   - Queues & retries: https://iii.dev/docs/workers/iii-queue
  *   - DLQ handling:     https://iii.dev/docs/how-to/dead-letter-queues
  *   - Cron scheduling:  https://iii.dev/docs/how-to/schedule-cron-task
  *   - State management: https://iii.dev/docs/how-to/manage-state

--- a/skills/references/workflow-orchestration.js
+++ b/skills/references/workflow-orchestration.js
@@ -7,7 +7,7 @@
  * Each step is its own function chained via named queues.
  *
  * How-to references:
- *   - Queues & retries: https://iii.dev/docs/how-to/use-queues
+ *   - Queues & retries: https://iii.dev/docs/how-to/use-named-queues
  *   - DLQ handling:     https://iii.dev/docs/how-to/dead-letter-queues
  *   - Cron scheduling:  https://iii.dev/docs/how-to/schedule-cron-task
  *   - State management: https://iii.dev/docs/how-to/manage-state


### PR DESCRIPTION
This pull request updates documentation and code references to use the new canonical domain and path structure for docs (`iii.dev` and `/docs/...`), and standardizes internal and external links throughout the codebase and documentation. It also updates navigation, UI, and example links to reflect these changes, ensuring consistency and reducing confusion for users.

The most important changes include:

**Domain and Docs URL Migration:**
- Changed all references from `https://docs.iii.dev/` to `https://iii.dev/docs/` for error documentation URLs in both backend code (`errors.rs`, `update_ops.rs`, Redis scripts) and user-facing error messages. [[1]](diffhunk://#diff-4b202c9c9740eb6c2a7832948035779d402ad0d685f0791dcf68dbecc68d7addL9-R9) [[2]](diffhunk://#diff-9c2de9d42cfbe8dc552b0734f5778b87a47fe9ec7bf6e8090ec1c7476f2dce39L33-R33) [[3]](diffhunk://#diff-ebd482c65716c8bea207a045e8458e83cc0d69a0c0a08520bbe8e697e746f7e3L27-R27) [[4]](diffhunk://#diff-2e95bca81d24982486a13464167c8cd5f35f20f985e63e1083bbd01fccddd4a8L52-R52) [[5]](diffhunk://#diff-64f547a41ec7474e74e0dbbaf8e64244069e0f2ec153c59c6b8d913a6d27d59aL491-R491) [[6]](diffhunk://#diff-dc16f9edc24974d9911a539f9695c93fbbdf0f1be0a537873985a991b4b616a7L1275-R1281)

**Docs Navigation and Structure Updates:**
- Updated internal documentation links to reflect new paths, such as `/api-reference/sdk-node` instead of `/api-reference/iii-sdk`, and reorganized links to worker/module references under `/workers/iii-*`. [[1]](diffhunk://#diff-e68caf9ea0b0ba41f00ba1c961db30c2ee45a71767262c1e79d50423cffd3becL166-R166) [[2]](diffhunk://#diff-18ffc55cfddcfe66e5dc7b396740d4719fb750d0a56cd28ef406d55f0d9a9df6L155-R155) [[3]](diffhunk://#diff-91aa1e0e855681bcc62187f52aeba99d81b73537832af82ead33c760b258b8b0L277-R277) [[4]](diffhunk://#diff-91aa1e0e855681bcc62187f52aeba99d81b73537832af82ead33c760b258b8b0L350-R350) [[5]](diffhunk://#diff-c41f0759a674bfe6afb3ba6cc99c30c6fb0456a0c960c869bf93f65504a0949aL98-R98) [[6]](diffhunk://#diff-c41f0759a674bfe6afb3ba6cc99c30c6fb0456a0c960c869bf93f65504a0949aL155-R155) [[7]](diffhunk://#diff-c41f0759a674bfe6afb3ba6cc99c30c6fb0456a0c960c869bf93f65504a0949aL530-R530) [[8]](diffhunk://#diff-c41f0759a674bfe6afb3ba6cc99c30c6fb0456a0c960c869bf93f65504a0949aL578-R578) [[9]](diffhunk://#diff-c41f0759a674bfe6afb3ba6cc99c30c6fb0456a0c960c869bf93f65504a0949aL588-R588) [[10]](diffhunk://#diff-c41f0759a674bfe6afb3ba6cc99c30c6fb0456a0c960c869bf93f65504a0949aL636-R636) [[11]](diffhunk://#diff-c41f0759a674bfe6afb3ba6cc99c30c6fb0456a0c960c869bf93f65504a0949aL646-R646) [[12]](diffhunk://#diff-c41f0759a674bfe6afb3ba6cc99c30c6fb0456a0c960c869bf93f65504a0949aL692-R692) [[13]](diffhunk://#diff-c41f0759a674bfe6afb3ba6cc99c30c6fb0456a0c960c869bf93f65504a0949aL702-R702) [[14]](diffhunk://#diff-c41f0759a674bfe6afb3ba6cc99c30c6fb0456a0c960c869bf93f65504a0949aL726-R726) [[15]](diffhunk://#diff-c41f0759a674bfe6afb3ba6cc99c30c6fb0456a0c960c869bf93f65504a0949aL1516-R1516) [[16]](diffhunk://#diff-59b8332273b260cd04fff574b95efda75d20173dba2933a1f48ecf51e3d427a3L64-R64)

**UI and Navigation Button Fixes:**
- Updated navigation and button selectors in `docs.json` and `custom.css` to use the new `/docs/install` path, ensuring UI elements and styles work as intended with the new URLs. [[1]](diffhunk://#diff-873ce17c654718debe2fe308a2f2279bde8663686423c51f97fab2dd0722b8d9L53-R53) [[2]](diffhunk://#diff-d4b0be054c73b4ea560725dd514f279410ebc71dbf2022331c57e31df9a98b03L311-R365)

**How-to and Concept Documentation:**
- Updated links in how-to guides and concept documentation to point to the new locations, such as the concepts page and quickstart/tutorials, improving the onboarding flow.

**Queue and Worker Documentation Improvements:**
- Renamed and clarified references to "Named Queues" and updated links to queue and worker documentation for greater accuracy and discoverability. [[1]](diffhunk://#diff-6d0d8da7a79085627c2bd0244b3fc1d514bd370e548694b46e874bcf60d2b4e2L55-R55) [[2]](diffhunk://#diff-6d0d8da7a79085627c2bd0244b3fc1d514bd370e548694b46e874bcf60d2b4e2L68-R68) [[3]](diffhunk://#diff-6d0d8da7a79085627c2bd0244b3fc1d514bd370e548694b46e874bcf60d2b4e2L111-R111) [[4]](diffhunk://#diff-6d0d8da7a79085627c2bd0244b3fc1d514bd370e548694b46e874bcf60d2b4e2L193-R205)

These changes ensure all documentation and code references are consistent with the new canonical domain and structure, improving the developer experience and reducing the risk of broken or outdated links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Install CTA now routes to the internal /install path and styling covers relative install link patterns.

* **Documentation**
  * Multiple doc links updated to more specific pages (workers, queue guide, SDK Node) and to the new docs host/path (iii.dev) for error/troubleshooting links.
  * Navigation cards and headings adjusted for consistency.

* **Tests**
  * Test fixtures updated to expect the new documentation URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->