### PR TITLE
ci(workers): publish builtin workers to both `next` and `latest` tags

### DIFF
--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -17,7 +17,7 @@ on:
         type: string
         default: ''
       registry_tag:
-        description: 'Registry tag (latest, next, ...)'
+        description: 'Registry tag(s), comma-separated (e.g. "latest" or "next,latest")'
         required: false
         type: string
         default: latest
@@ -55,7 +55,10 @@ jobs:
           worker_dir = pathlib.Path(os.environ["WORKER_DIR"])
           expected_version = os.environ["VERSION"]
           ref_name = os.environ.get("GITHUB_REF_NAME", "")
-          reg_tag = os.environ["REGISTRY_TAG"] or "latest"
+          reg_tags_raw = os.environ["REGISTRY_TAG"] or "latest"
+          reg_tags = [t.strip() for t in reg_tags_raw.split(",") if t.strip()]
+          if not reg_tags:
+              reg_tags = ["latest"]
           repo_url = os.environ["REPO_URL"]
 
           engine_manifest = pathlib.Path("engine/Cargo.toml")
@@ -83,44 +86,57 @@ jobs:
           readme_path = worker_dir / "README.md"
           readme = readme_path.read_text() if readme_path.exists() else ""
 
-          payload = {
+          base_payload = {
               "worker_name": worker,
               "version": version,
-              "tag": reg_tag,
               "type": "engine",
               "readme": readme,
               "repo": repo_url,
               "description": meta.get("description", ""),
           }
 
-          out = pathlib.Path("payload.json")
-          out.write_text(json.dumps(payload, indent=2))
+          for tag in reg_tags:
+              payload = {**base_payload, "tag": tag}
+              pathlib.Path(f"payload-{tag}.json").write_text(json.dumps(payload, indent=2))
+
           if github_output := os.environ.get("GITHUB_OUTPUT"):
               with open(github_output, "a", encoding="utf-8") as handle:
                   handle.write(f"version={version}\n")
-          print(json.dumps({k: payload[k] for k in payload if k != "readme"}, indent=2))
+                  handle.write(f"tags={' '.join(reg_tags)}\n")
+          summary = {k: base_payload[k] for k in base_payload if k != "readme"}
+          summary["tags"] = reg_tags
+          print(json.dumps(summary, indent=2))
           PY
 
       - name: POST /publish
         env:
           API_URL: ${{ inputs.api_url }}
           API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
+          TAGS: ${{ steps.payload.outputs.tags }}
+          WORKER: ${{ inputs.worker }}
+          VERSION: ${{ steps.payload.outputs.version }}
         run: |
           if [[ -z "$API_KEY" ]]; then
             echo "::error::WORKERS_REGISTRY_API_KEY secret is not set"
             exit 1
           fi
-          http=$(curl -sS -o response.json -w '%{http_code}' \
-            -H "X-API-Key: $API_KEY" \
-            -H "Content-Type: application/json" \
-            -X POST "$API_URL/publish" \
-            --data-binary @payload.json)
-          echo "HTTP $http"
-          cat response.json
-          if [[ "$http" != "200" && "$http" != "409" ]]; then
-            echo "::error::publish failed with HTTP $http"
-            exit 1
-          fi
-          if [[ "$http" == "409" ]]; then
-            echo "::notice::${{ inputs.worker }} v${{ steps.payload.outputs.version }} already published (409) — skipping"
-          fi
+          for tag in $TAGS; do
+            echo "::group::publish ${WORKER} v${VERSION} tag=${tag}"
+            http=$(curl -sS -o response.json -w '%{http_code}' \
+              -H "X-API-Key: $API_KEY" \
+              -H "Content-Type: application/json" \
+              -X POST "$API_URL/publish" \
+              --data-binary "@payload-${tag}.json")
+            echo "HTTP $http"
+            cat response.json
+            echo
+            if [[ "$http" != "200" && "$http" != "409" ]]; then
+              echo "::error::publish failed for tag=${tag} with HTTP $http"
+              echo "::endgroup::"
+              exit 1
+            fi
+            if [[ "$http" == "409" ]]; then
+              echo "::notice::${WORKER} v${VERSION} (tag=${tag}) already published (409) — skipping"
+            fi
+            echo "::endgroup::"
+          done

--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -91,8 +91,10 @@ jobs:
               "version": version,
               "type": "engine",
               "readme": readme,
-              "repo": repo_url,
+              "repo": meta.get("repo", repo_url),
               "description": meta.get("description", ""),
+              "config": meta.get("config", {}) or {},
+              "dependencies": meta.get("dependencies", []) or [],
           }
 
           for tag in reg_tags:

--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -17,7 +17,7 @@ on:
         type: string
         default: ''
       registry_tag:
-        description: 'Registry tag(s), comma-separated (e.g. "latest" or "next,latest")'
+        description: 'Registry tag (latest, next, ...)'
         required: false
         type: string
         default: latest
@@ -55,10 +55,7 @@ jobs:
           worker_dir = pathlib.Path(os.environ["WORKER_DIR"])
           expected_version = os.environ["VERSION"]
           ref_name = os.environ.get("GITHUB_REF_NAME", "")
-          reg_tags_raw = os.environ["REGISTRY_TAG"] or "latest"
-          reg_tags = [t.strip() for t in reg_tags_raw.split(",") if t.strip()]
-          if not reg_tags:
-              reg_tags = ["latest"]
+          reg_tag = os.environ["REGISTRY_TAG"] or "latest"
           repo_url = os.environ["REPO_URL"]
 
           engine_manifest = pathlib.Path("engine/Cargo.toml")
@@ -86,9 +83,10 @@ jobs:
           readme_path = worker_dir / "README.md"
           readme = readme_path.read_text() if readme_path.exists() else ""
 
-          base_payload = {
+          payload = {
               "worker_name": worker,
               "version": version,
+              "tag": reg_tag,
               "type": "engine",
               "readme": readme,
               "repo": meta.get("repo", repo_url),
@@ -97,48 +95,34 @@ jobs:
               "dependencies": meta.get("dependencies", []) or [],
           }
 
-          for tag in reg_tags:
-              payload = {**base_payload, "tag": tag}
-              pathlib.Path(f"payload-{tag}.json").write_text(json.dumps(payload, indent=2))
-
+          out = pathlib.Path("payload.json")
+          out.write_text(json.dumps(payload, indent=2))
           if github_output := os.environ.get("GITHUB_OUTPUT"):
               with open(github_output, "a", encoding="utf-8") as handle:
                   handle.write(f"version={version}\n")
-                  handle.write(f"tags={' '.join(reg_tags)}\n")
-          summary = {k: base_payload[k] for k in base_payload if k != "readme"}
-          summary["tags"] = reg_tags
-          print(json.dumps(summary, indent=2))
+          print(json.dumps({k: payload[k] for k in payload if k != "readme"}, indent=2))
           PY
 
       - name: POST /publish
         env:
           API_URL: ${{ inputs.api_url }}
           API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
-          TAGS: ${{ steps.payload.outputs.tags }}
-          WORKER: ${{ inputs.worker }}
-          VERSION: ${{ steps.payload.outputs.version }}
         run: |
           if [[ -z "$API_KEY" ]]; then
             echo "::error::WORKERS_REGISTRY_API_KEY secret is not set"
             exit 1
           fi
-          for tag in $TAGS; do
-            echo "::group::publish ${WORKER} v${VERSION} tag=${tag}"
-            http=$(curl -sS -o response.json -w '%{http_code}' \
-              -H "X-API-Key: $API_KEY" \
-              -H "Content-Type: application/json" \
-              -X POST "$API_URL/publish" \
-              --data-binary "@payload-${tag}.json")
-            echo "HTTP $http"
-            cat response.json
-            echo
-            if [[ "$http" != "200" && "$http" != "409" ]]; then
-              echo "::error::publish failed for tag=${tag} with HTTP $http"
-              echo "::endgroup::"
-              exit 1
-            fi
-            if [[ "$http" == "409" ]]; then
-              echo "::notice::${WORKER} v${VERSION} (tag=${tag}) already published (409) — skipping"
-            fi
-            echo "::endgroup::"
-          done
+          http=$(curl -sS -o response.json -w '%{http_code}' \
+            -H "X-API-Key: $API_KEY" \
+            -H "Content-Type: application/json" \
+            -X POST "$API_URL/publish" \
+            --data-binary @payload.json)
+          echo "HTTP $http"
+          cat response.json
+          if [[ "$http" != "200" && "$http" != "409" ]]; then
+            echo "::error::publish failed with HTTP $http"
+            exit 1
+          fi
+          if [[ "$http" == "409" ]]; then
+            echo "::notice::${{ inputs.worker }} v${{ steps.payload.outputs.version }} already published (409) — skipping"
+          fi

--- a/.github/workflows/release-iii.yml
+++ b/.github/workflows/release-iii.yml
@@ -583,7 +583,7 @@ jobs:
     with:
       worker: ${{ matrix.worker }}
       worker_dir: ${{ matrix.worker_dir }}
-      registry_tag: ${{ needs.setup.outputs.is_prerelease == 'true' && 'next' || 'latest' }}
+      registry_tag: ${{ needs.setup.outputs.is_prerelease == 'true' && 'next,latest' || 'latest' }}
     secrets: inherit
 
   # ──────────────────────────────────────────────────────────────

--- a/.github/workflows/release-iii.yml
+++ b/.github/workflows/release-iii.yml
@@ -583,7 +583,7 @@ jobs:
     with:
       worker: ${{ matrix.worker }}
       worker_dir: ${{ matrix.worker_dir }}
-      registry_tag: ${{ needs.setup.outputs.is_prerelease == 'true' && 'next,latest' || 'latest' }}
+      registry_tag: ${{ needs.setup.outputs.is_prerelease == 'true' && 'next' || 'latest' }}
     secrets: inherit
 
   # ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Builtin worker pages on https://workers.iii.dev/workers/iii-* render as **v0.0.0** with **"no readme for this version"** because the registry resolves the default worker-level view from whatever is tagged `latest`, and engine workers have only ever been published under `next` (we've only cut prereleases).
- `_publish-engine-workers.yml` now accepts a comma-separated `registry_tag`, writes one `payload-<tag>.json` per tag, and loops the POST.
- `release-iii.yml` passes `next,latest` for prereleases (was `next`); stable releases stay on `latest`.

## Verification

After this lands, the next prerelease bump will publish each builtin worker under both `next` and `latest`. Then:

- [ ] Action logs show two `HTTP 200` POSTs per worker job (one per tag).
- [ ] `curl https://api.workers.iii.dev/w/iii-observability` returns the real `version` (not `"0.0.0"`) and a non-empty `readme`.
- [ ] https://workers.iii.dev/workers/iii-observability sidebar shows the real version and the README tab renders the markdown from `engine/src/workers/observability/README.md`.
- [ ] `/w/iii-observability/versions` lists both `next` and `latest` tags pointing at the same version.

Existing `0.11.4-next.5` records will be backfilled automatically on the next prerelease bump (the `(worker, version)` 409-as-success branch keeps re-runs safe; the second tag will be created on the new version).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved engine worker publishing workflow to enhance metadata handling, now including configuration and dependency information in deployment payloads with appropriate fallback mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->