### PR TITLE
fix(ci): deploy iii.dev as static site

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -23,8 +23,8 @@ permissions:
   id-token: write
 
 jobs:
-  build-and-deploy:
-    name: Build & deploy to S3 + CloudFront
+  deploy:
+    name: Deploy to S3 + CloudFront
     runs-on: ubuntu-latest
     environment: iii-website-prod
     timeout-minutes: 15
@@ -37,38 +37,29 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: 'website/package-lock.json'
-
-      - name: Install dependencies
-        working-directory: website
-        run: npm install --include=dev
-
-      - name: Build
-        working-directory: website
-        env:
-          VITE_MAILMODO_FORM_URL: ${{ secrets.VITE_MAILMODO_FORM_URL }}
-        run: npm run build
-
       - name: Configure AWS credentials (GitHub OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Sync hashed assets (long cache, immutable)
+      - name: Sync static assets (long cache, immutable)
         run: |
-          aws s3 sync website/dist/ "s3://${{ vars.S3_BUCKET }}/" \
+          aws s3 sync website/ "s3://${{ vars.S3_BUCKET }}/" \
             --delete \
             --cache-control "public,max-age=31536000,immutable" \
-            --exclude "*.html"
+            --exclude "*.html" \
+            --exclude "node_modules/*" \
+            --exclude "package.json" \
+            --exclude "package-lock.json" \
+            --exclude "pnpm-lock.yaml" \
+            --exclude ".gitignore" \
+            --exclude "README.md" \
+            --exclude "vercel.json"
 
       - name: Sync HTML (no cache, must revalidate)
         run: |
-          aws s3 sync website/dist/ "s3://${{ vars.S3_BUCKET }}/" \
+          aws s3 sync website/ "s3://${{ vars.S3_BUCKET }}/" \
             --delete \
             --cache-control "public,max-age=0,must-revalidate" \
             --exclude "*" \


### PR DESCRIPTION
## Summary

- Fixes the `Deploy Website` workflow, which broke on the merge of [#1560](https://github.com/iii-hq/iii/pull/1560) — see failed run [25072016933](https://github.com/iii-hq/iii/actions/runs/25072016933).
- Removes the Node setup / install / build steps (the site is plain static HTML now — `package.json`'s `build` script is just an echo, no `dist/` is produced).
- Syncs `website/` directly to S3 with the same caching semantics as before (immutable for non-HTML, `must-revalidate` for HTML), excluding dev-only files (`package.json`, `README.md`, `vercel.json`, lockfiles, `node_modules/`, `.gitignore`).

## Why two failures were hiding behind one

The first failure was `actions/setup-node@v4` complaining `Some specified paths were not resolved, unable to cache dependencies.` — `cache-dependency-path: website/package-lock.json` doesn't exist. Even if a lockfile were committed, the next step (`aws s3 sync website/dist/ ...`) would have failed because the new static site never produces a `dist/` directory. Dropping the Node steps entirely is the right shape for a site with no build.

## Test plan

- [ ] CI green on this PR (workflow's `paths` filter doesn't match for non-`main` runs, so verify by inspecting the YAML diff — there's nothing to run on the PR itself).
- [ ] After merge, confirm the `Deploy Website` run completes: setup-node step is gone, S3 sync succeeds against `website/`, CloudFront invalidation is created.
- [ ] Spot-check `iii.dev` for `index.html`, `manifesto.html`, `favicon.svg`, `robots.txt`, `og-image.png`, `fonts/` after deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Streamlined deployment workflow to focus on release operations and remove redundant build steps.
  * Updated S3 deployment configuration to improve efficiency of asset delivery to production.
  * Refined deployment job naming for enhanced clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->