### PR TITLE
docs: stop highlighting sidebar Install link

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -308,74 +308,23 @@ button {
   box-shadow: none !important;
 }
 
-nav a[href="/install"],
-nav a[href="/docs/install"],
-nav a[href$="/install"],
-nav a[href="install"],
-header a[href="/install"],
-header a[href="/docs/install"],
-header a[href$="/install"],
-header a[href="install"],
-a[href="install"],
-a[href="/docs/install"] {
-  background: var(--iii-ink) !important;
-  border: 1px solid var(--iii-ink) !important;
-  color: var(--iii-bg) !important;
-  box-shadow: none !important;
-}
-
-nav a[href="/install"]:hover,
-nav a[href="/docs/install"]:hover,
-nav a[href$="/install"]:hover,
-nav a[href="install"]:hover,
-header a[href="/install"]:hover,
-header a[href="/docs/install"]:hover,
-header a[href$="/install"]:hover,
-header a[href="install"]:hover,
-a[href="install"]:hover,
-a[href="/docs/install"]:hover {
-  background: var(--iii-bg) !important;
-  color: var(--iii-ink) !important;
-}
-
-a[target="_blank"][href="/docs/install"],
-a[target="_blank"][href="/install"],
-a[target="_blank"][href="install"] {
-  background: transparent !important;
-  border: 1px solid var(--iii-ink) !important;
-  color: var(--iii-bg) !important;
-  padding: 0.375rem 1rem !important;
-}
-
-a[target="_blank"][href="/docs/install"] > span.absolute,
-a[target="_blank"][href="/install"] > span.absolute,
-a[target="_blank"][href="install"] > span.absolute {
+a > span.bg-primary-dark {
   background: var(--iii-ink) !important;
   border-radius: 0 !important;
 }
 
-a[target="_blank"][href="/docs/install"] span,
-a[target="_blank"][href="/docs/install"] svg,
-a[target="_blank"][href="/install"] span,
-a[target="_blank"][href="/install"] svg,
-a[target="_blank"][href="install"] span,
-a[target="_blank"][href="install"] svg {
-  color: var(--iii-bg) !important;
-}
-
-a[target="_blank"][href="/docs/install"]:hover > span.absolute,
-a[target="_blank"][href="/install"]:hover > span.absolute,
-a[target="_blank"][href="install"]:hover > span.absolute {
+a:hover > span.bg-primary-dark {
   background: var(--iii-bg) !important;
   opacity: 1 !important;
 }
 
-a[target="_blank"][href="/docs/install"]:hover span,
-a[target="_blank"][href="/docs/install"]:hover svg,
-a[target="_blank"][href="/install"]:hover span,
-a[target="_blank"][href="/install"]:hover svg,
-a[target="_blank"][href="install"]:hover span,
-a[target="_blank"][href="install"]:hover svg {
+a:has(> span.bg-primary-dark) span.text-white,
+a:has(> span.bg-primary-dark) svg {
+  color: var(--iii-bg) !important;
+}
+
+a:has(> span.bg-primary-dark):hover span.text-white,
+a:has(> span.bg-primary-dark):hover svg {
   color: var(--iii-ink) !important;
 }
 


### PR DESCRIPTION
## Summary
- Scope the navbar primary CTA styling to Mintlify's actual primary button shape (the `<a>` containing `<span class="bg-primary-dark">`) instead of every link with `href$="/install"`.
- Sidebar `Install` entries no longer pick up the dark CTA background, so the active state renders correctly.

## Test plan
- Visual check on the Mintlify PR preview that the sidebar `Install` entry no longer renders with a black background, while the top navbar Install CTA still renders ink-on-cream per the schematic design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined link styling for improved visual consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->