### PR TITLE
ci: move Worker Tests (VM) to public ubuntu-24.04 with KVM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,8 +388,7 @@ jobs:
 
   worker-test-vm-linux:
     name: Worker Tests (VM) - linux
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: [self-hosted, linux, kvm]
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
@@ -401,6 +400,23 @@ jobs:
           key: worker-test-vm-linux
 
       - uses: taiki-e/install-action@cargo-nextest
+
+      # Public GitHub-hosted Linux runners expose /dev/kvm as of April 2024
+      # (github.blog/changelog/2024-04-02-github-actions-hardware-accelerated-android-virtualization-now-available).
+      # The udev rule below grants the runner user direct access — required for
+      # libkrun-backed sandbox tests that boot a real microVM. Cheap no-op for
+      # any feature-gated tests that don't actually launch a guest.
+      - name: Enable KVM
+        run: |
+          if [ -e /dev/kvm ]; then
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+              | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
+            ls -l /dev/kvm
+          else
+            echo "::warning::/dev/kvm missing on this runner image; libkrun guest boot will be unavailable"
+          fi
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
## Summary

Move the `worker-test-vm-linux` job from a `workflow_dispatch`-gated self-hosted runner to a public `ubuntu-24.04` runner with `/dev/kvm` enabled. Lane now runs on every PR, no infra dependencies.

## Why

GitHub-hosted Linux runners have exposed `/dev/kvm` since [April 2024](https://github.blog/changelog/2024-04-02-github-actions-hardware-accelerated-android-virtualization-now-available/) — even on the free 2-vCPU tier. The self-hosted KVM lane was a pre-2024 workaround that's no longer needed for libkrun-backed tests.

## What changes

`.github/workflows/ci.yml` — three changes to `worker-test-vm-linux`:

1. `runs-on: [self-hosted, linux, kvm]` → `runs-on: ubuntu-24.04`
2. Drop `if: github.event_name == 'workflow_dispatch'` so the lane runs on every PR (matches the existing `worker-test-vm-macos` posture)
3. Add an "Enable KVM" step:
   ```yaml
   - name: Enable KVM
     run: |
       if [ -e /dev/kvm ]; then
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
           | sudo tee /etc/udev/rules.d/99-kvm4all.rules
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
         ls -l /dev/kvm
       else
         echo "::warning::/dev/kvm missing..."
       fi
   ```
   Cheap no-op for tests that don't actually boot a guest. Required for any future libkrun-backed test (e.g., the tier-C stubs in PR #1564).

## What's NOT in this PR

- Building a guest rootfs fixture or cross-compiled `iii-init` for the tier-C tests. Those still skip with `[skip]` messages until `III_VM_INTEGRATION_ROOTFS` is set. A separate follow-up PR can wire the rootfs build step.
- macOS lane is unchanged — Hypervisor.framework / nested virt is [explicitly unsupported](https://docs.github.com/en/actions/reference/runners/larger-runners#limitations-for-macos-larger-runners) on GitHub-hosted macOS runners. The `worker-test-vm-macos` job stays for compile-coverage only.

## Relation to #1564

Independent. This PR can land before or after #1564. The new lane runs whatever `--features integration-vm` exposes today (clap parsing tests in `vm_integration.rs`); once #1564 lands, the same lane will also compile-cover `sandbox_integration_e2e.rs` (whose `#[ignore]`'d stubs remain skipped pending a rootfs).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses
- [ ] CI: this PR's `Worker Tests (VM) - linux` job runs and passes on `ubuntu-24.04` with `/dev/kvm` available
- [ ] Verify the "Enable KVM" step prints `crw-rw-rw- ... /dev/kvm` (proves world access)
- [ ] CI: `worker-test-vm-macos` still passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to execute tests on GitHub-hosted runners, expanding testing infrastructure capabilities alongside existing self-hosted runner support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->