### PR TITLE
test(sandbox): activate tier-C smoke driver with III_WORKER_BINARY_OVERRIDE seam

### DIFF
--- a/crates/iii-worker/src/sandbox_daemon/adapters.rs
+++ b/crates/iii-worker/src/sandbox_daemon/adapters.rs
@@ -42,8 +42,17 @@ impl VmLauncher for IiiWorkerLauncher {
         // reliable than a PATH lookup: current_exe() is guaranteed to
         // resolve (unlike PATH, which can be empty in service managers)
         // and cannot disagree with the version we compiled against.
-        let bin = std::env::current_exe()
-            .map_err(|e| SandboxError::BootFailed(format!("current_exe() failed: {e}")))?;
+        //
+        // Test seam: integration tests run from a Cargo test binary
+        // whose `current_exe()` lacks `__vm-boot`. The env override
+        // lets the tier-C suite (sandbox_integration_e2e.rs) point at
+        // the real `iii-worker` binary built earlier in the same CI
+        // job. Production never sets this var.
+        let bin = match std::env::var("III_WORKER_BINARY_OVERRIDE") {
+            Ok(p) if !p.is_empty() => std::path::PathBuf::from(p),
+            _ => std::env::current_exe()
+                .map_err(|e| SandboxError::BootFailed(format!("current_exe() failed: {e}")))?,
+        };
 
         // Per-host provisioning: codesign (macOS Hypervisor entitlement)
         // and libkrunfw dylib placement. Both are idempotent but touch

--- a/crates/iii-worker/tests/sandbox_integration_e2e.rs
+++ b/crates/iii-worker/tests/sandbox_integration_e2e.rs
@@ -22,14 +22,16 @@
 //!   - Network access to docker.io for the first `iiidev/python:latest` pull
 //!     (~30 s on cold cache; subsequent runs hit `~/.iii/cache/`)
 //!
-//! The first real test driver is `sandbox_create_exec_stop_smoke`. The other
-//! two scenarios remain `[todo]` stubs pending iteration on a Linux+KVM
-//! host that can run them end-to-end.
+//! All three test bodies are real drivers:
+//!   - `sandbox_create_exec_stop_smoke` — happy-path lifecycle
+//!   - `create_with_network_disabled_yields_no_host_egress` — egress isolation
+//!   - `raii_guard_reaps_vm_on_panic_mid_scenario` — teardown contract under panic
 
 #![cfg(feature = "integration-vm")]
 
+use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use uuid::Uuid;
 
@@ -251,35 +253,234 @@ async fn sandbox_create_exec_stop_smoke() {
     // the expected steady-state for the happy path.
 }
 
-/// Verify network=false produces no host egress. Catches the
-/// localhost-rewrite class of bugs hit on 2026-04-28 in vm_boot.rs.
+/// Verify network=false produces no host egress. Catches the localhost-rewrite
+/// class of bugs hit on 2026-04-28 in vm_boot.rs (which manifested by mangling
+/// URLs into invalid forms when networking was disabled — a problem only
+/// observable end-to-end with a real guest).
+///
+/// Strategy: with network=false, libkrun attaches no virtio-net device. From
+/// inside the guest, every outbound socket connect must fail (no route, no
+/// resolver, no interface). The python preset has `python` available so we
+/// drive a small inline script that attempts a TCP connect to a public IP and
+/// asserts the call returned a non-zero exit. We deliberately probe `1.1.1.1`
+/// (Cloudflare) on port 443: it is globally reachable from any host with real
+/// networking, so a success would mean network=false is broken.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "sandbox-e2e: requires KVM + guest rootfs (integration-vm CI lane)"]
 async fn create_with_network_disabled_yields_no_host_egress() {
-    let Some(_bin) = worker_binary() else {
+    let Some(bin) = worker_binary() else {
         return;
     };
     eprintln!(
-        "[todo] sandbox_integration_e2e: create_with_network_disabled_yields_no_host_egress \
-         driver body not yet implemented. Shape: bind a TCP listener on the host, \
-         create with network=Some(false), exec `nc -w 2 <host_ip> <port>` inside the guest, \
-         assert connect failed and the host listener saw no accept(). Build out after \
-         sandbox_create_exec_stop_smoke is green in CI."
+        "sandbox_integration_e2e: using iii-worker binary at {}",
+        bin.display()
+    );
+
+    let cfg = SandboxConfig {
+        auto_install: true,
+        image_allowlist: vec!["python".into()],
+        ..Default::default()
+    };
+    let registry = SandboxRegistry::new();
+    let launcher = IiiWorkerLauncher;
+    let runner = ShellProtoRunner;
+
+    let create_resp = handle_create(
+        CreateRequest {
+            image: "python".into(),
+            cpus: Some(1),
+            memory_mb: Some(512),
+            name: None,
+            network: Some(false), // the property under test
+            idle_timeout_secs: Some(60),
+            env: vec![],
+        },
+        &cfg,
+        &registry,
+        &launcher,
+        |_| {},
+    )
+    .await
+    .expect("handle_create with network=false must still boot the VM");
+    let id = create_resp.sandbox_id;
+
+    // RAII teardown — fires whether the assertion below passes, fails, or panics.
+    let _guard = SandboxGuard::new(id.clone(), registry.clone());
+
+    // Probe outbound connectivity. With network=false there is no virtio-net
+    // device; the connect must fail. Short in-script timeout (3 s) so a
+    // misconfiguration surfaces quickly instead of stalling the test.
+    //
+    // Exit semantics:
+    //   0 = connect succeeded — network=false is BROKEN
+    //   2 = connect raised an exception (expected: socket.timeout, OSError)
+    //   any other = unexpected interpreter error
+    let probe_script = r#"
+import socket, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.settimeout(3.0)
+try:
+    s.connect(('1.1.1.1', 443))
+    print('UNEXPECTED_CONNECT_OK')
+    sys.exit(0)
+except (socket.timeout, OSError) as e:
+    print(f'CONNECT_FAILED: {type(e).__name__}: {e}')
+    sys.exit(2)
+"#;
+
+    let resp = handle_exec(
+        ExecRequest {
+            sandbox_id: id.clone(),
+            cmd: "/usr/bin/python3".into(),
+            args: vec!["-c".into(), probe_script.into()],
+            stdin: None,
+            env: vec![],
+            timeout_ms: Some(15_000),
+            workdir: None,
+        },
+        &registry,
+        &runner,
+    )
+    .await
+    .expect("handle_exec must reach the guest even with network=false");
+
+    eprintln!(
+        "probe stdout: {:?}\nprobe stderr: {:?}\nexit: {:?}",
+        resp.stdout, resp.stderr, resp.exit_code
+    );
+
+    assert_ne!(
+        resp.exit_code,
+        Some(0),
+        "guest with network=false must NOT reach 1.1.1.1; got exit=0 stdout={:?}",
+        resp.stdout
+    );
+    assert!(
+        !resp.stdout.contains("UNEXPECTED_CONNECT_OK"),
+        "guest must not have egress; stdout={:?}",
+        resp.stdout
+    );
+    assert!(
+        resp.stdout.contains("CONNECT_FAILED"),
+        "expected probe to print CONNECT_FAILED; got stdout={:?}, stderr={:?}",
+        resp.stdout, resp.stderr
     );
 }
 
-/// Tier-C teardown contract: a panic mid-scenario must not leak the VM.
-/// The test deliberately panics; outer harness asserts the VM was reaped.
+/// Tier-C teardown contract: a panic inside a `SandboxGuard`-guarded scope
+/// must reap the VM. Without this property a single test failure leaks a
+/// libkrun guest process per failed run, which compounds into CI host
+/// resource exhaustion.
+///
+/// Strategy:
+///   1. Create a real sandbox; capture the libkrun child pid.
+///   2. Inside `catch_unwind`, construct a `SandboxGuard` that owns the id
+///      and immediately panic. The guard is dropped during stack unwinding.
+///   3. After the unwind completes, verify (a) the libkrun pid is gone via
+///      `kill(pid, 0) == ESRCH`, and (b) the registry no longer knows about
+///      the sandbox. Both conditions must hold for the contract to be met.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "sandbox-e2e: requires KVM + guest rootfs (integration-vm CI lane)"]
 async fn raii_guard_reaps_vm_on_panic_mid_scenario() {
-    let Some(_bin) = worker_binary() else {
+    let Some(bin) = worker_binary() else {
         return;
     };
     eprintln!(
-        "[todo] sandbox_integration_e2e: raii_guard_reaps_vm_on_panic_mid_scenario \
-         driver body not yet implemented. Shape: spawn child process that creates a \
-         sandbox via the SandboxGuard pattern then panics; parent verifies the VM pid \
-         is gone (kill(pid, 0) returns ESRCH). Build out after the smoke is green."
+        "sandbox_integration_e2e: using iii-worker binary at {}",
+        bin.display()
     );
+
+    let cfg = SandboxConfig {
+        auto_install: true,
+        image_allowlist: vec!["python".into()],
+        ..Default::default()
+    };
+    let registry = SandboxRegistry::new();
+    let launcher = IiiWorkerLauncher;
+
+    // 1. Create the sandbox we will deliberately abandon mid-test.
+    let create_resp = handle_create(
+        CreateRequest {
+            image: "python".into(),
+            cpus: Some(1),
+            memory_mb: Some(512),
+            name: None,
+            network: Some(false),
+            idle_timeout_secs: Some(60),
+            env: vec![],
+        },
+        &cfg,
+        &registry,
+        &launcher,
+        |_| {},
+    )
+    .await
+    .expect("handle_create must succeed before testing teardown");
+    let id = create_resp.sandbox_id;
+    let id_uuid = Uuid::parse_str(&id).expect("sandbox_id must be a valid uuid");
+    let vm_pid = registry
+        .get(id_uuid)
+        .await
+        .expect("registry must contain the new sandbox")
+        .vm_pid
+        .expect("freshly-created sandbox must have a vm_pid");
+    eprintln!("created sandbox {id} with vm_pid={vm_pid}");
+
+    // 2. Trigger a panic inside a guard-protected scope. AssertUnwindSafe
+    // is required because SandboxRegistry holds a Mutex (not UnwindSafe by
+    // default); we know the cleanup path tolerates being entered during
+    // unwind because Drop catches its own errors with eprintln.
+    let registry_for_panic = registry.clone();
+    let id_for_panic = id.clone();
+    let panic_outcome = std::panic::catch_unwind(AssertUnwindSafe(move || {
+        let _guard = SandboxGuard::new(id_for_panic, registry_for_panic);
+        panic!("simulated test failure inside guarded scope");
+    }));
+    assert!(
+        panic_outcome.is_err(),
+        "the inner block was supposed to panic so we could observe cleanup"
+    );
+
+    // SandboxGuard::drop spawns a std thread and joins it, so the cleanup
+    // is synchronous by the time catch_unwind returns. Sleep briefly anyway
+    // because the kernel may need a tick to reap the child after SIGKILL.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // 3a. The libkrun child must be gone. kill(pid, 0) returns -1/ESRCH
+    // for a reaped process; returns 0 for a live process. Use a short loop
+    // because some kernels delay marking the pid free for a few ms after
+    // the SIGKILL is delivered.
+    let alive_now = pid_alive(vm_pid);
+    let mut attempts = 0;
+    let mut still_alive = alive_now;
+    while still_alive && attempts < 10 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        still_alive = pid_alive(vm_pid);
+        attempts += 1;
+    }
+    assert!(
+        !still_alive,
+        "vm_pid {vm_pid} is still alive after panic + guard drop + {} ms grace;          the SandboxGuard contract is broken",
+        500 + attempts * 100
+    );
+
+    // 3b. The registry must no longer track the sandbox.
+    assert!(
+        registry.get(id_uuid).await.is_err(),
+        "registry must have removed the sandbox after the guard's stop call"
+    );
+}
+
+/// Local copy of `adapters::pid_alive`. Kept inline so this test file does
+/// not have to add a new pub item to the adapters module just for testing.
+#[cfg(unix)]
+fn pid_alive(pid: u32) -> bool {
+    // SAFETY: kill(pid, 0) with signum 0 performs error checking only —
+    // no signal is delivered, no side effects on the target process.
+    unsafe { libc::kill(pid as i32, 0) == 0 }
+}
+
+#[cfg(not(unix))]
+fn pid_alive(_pid: u32) -> bool {
+    true
 }

--- a/crates/iii-worker/tests/sandbox_integration_e2e.rs
+++ b/crates/iii-worker/tests/sandbox_integration_e2e.rs
@@ -11,106 +11,275 @@
 //!
 //! Same gating pattern as `vm_lifecycle_integration.rs`:
 //!   - `#[ignore]` so default `cargo test` does not boot a VM
-//!   - `III_VM_INTEGRATION_ROOTFS` env gate; `[skip]` printed if missing
-//!   - Run with: `cargo test --test sandbox_integration_e2e -- --ignored`
+//!   - env gate `III_WORKER_BINARY_OVERRIDE` (must point at the iii-worker
+//!     binary built earlier in the CI job; production never sets it)
+//!   - Run with: `cargo test --features integration-vm --test sandbox_integration_e2e -- --ignored`
 //!
 //! Host requirements:
 //!   - Linux + KVM (or macOS with Hypervisor.framework entitlements)
-//!   - A built `iii-init` binary cross-compiled for the guest arch
-//!   - A rootfs with `/bin/sh`, `/bin/echo`, `/bin/cat` available
-//!   - `iii-worker` built with the `integration-vm` feature
+//!   - `iii-worker` built with `--features integration-vm` and on a path
+//!     exported via `III_WORKER_BINARY_OVERRIDE`
+//!   - Network access to docker.io for the first `iiidev/python:latest` pull
+//!     (~30 s on cold cache; subsequent runs hit `~/.iii/cache/`)
 //!
-//! Gaps tracked here are post-merge work; the test bodies are skeleton
-//! stubs that emit a `[todo]` message and exit cleanly so the test count
-//! stays honest. A Linux contributor with libkrun set up can replace
-//! each `[todo]` with the driver code without touching the gating.
+//! The first real test driver is `sandbox_create_exec_stop_smoke`. The other
+//! two scenarios remain `[todo]` stubs pending iteration on a Linux+KVM
+//! host that can run them end-to-end.
+
+#![cfg(feature = "integration-vm")]
 
 use std::path::PathBuf;
+use std::time::Instant;
 
-fn integration_rootfs() -> Option<PathBuf> {
-    match std::env::var("III_VM_INTEGRATION_ROOTFS") {
+use uuid::Uuid;
+
+use iii_worker::sandbox_daemon::adapters::{IiiWorkerLauncher, ShellProtoRunner, SignalStopper};
+use iii_worker::sandbox_daemon::config::SandboxConfig;
+use iii_worker::sandbox_daemon::create::{CreateRequest, handle_create};
+use iii_worker::sandbox_daemon::exec::{ExecRequest, handle_exec};
+use iii_worker::sandbox_daemon::list::{ListRequest, handle_list};
+use iii_worker::sandbox_daemon::registry::SandboxRegistry;
+use iii_worker::sandbox_daemon::stop::{StopRequest, handle_stop};
+
+/// Returns Some(path) when `III_WORKER_BINARY_OVERRIDE` points at an
+/// existing executable, otherwise prints a `[skip]` line and returns None.
+/// The same env var is read by `IiiWorkerLauncher::boot()` to override
+/// `current_exe()` (which in tests points at the test binary, not iii-worker).
+fn worker_binary() -> Option<PathBuf> {
+    match std::env::var("III_WORKER_BINARY_OVERRIDE") {
         Ok(s) if !s.is_empty() => {
             let path = PathBuf::from(&s);
-            if path.exists() {
+            if path.is_file() {
                 Some(path)
             } else {
-                eprintln!("[skip] sandbox_integration_e2e: III_VM_INTEGRATION_ROOTFS={s} missing");
+                eprintln!(
+                    "[skip] sandbox_integration_e2e: III_WORKER_BINARY_OVERRIDE={s} \
+                     does not point at a file"
+                );
                 None
             }
         }
         _ => {
-            eprintln!("[skip] sandbox_integration_e2e: III_VM_INTEGRATION_ROOTFS not set");
+            eprintln!(
+                "[skip] sandbox_integration_e2e: III_WORKER_BINARY_OVERRIDE not set; \
+                 build iii-worker and export the path before running with --ignored"
+            );
             None
         }
     }
 }
 
-/// Full-surface E2E: walk all 14 sandbox::* triggers in one workflow.
+/// RAII guard: tears down the sandbox on drop, even if the test panics.
+/// Without this, a panicking test leaves a libkrun guest process alive
+/// on the CI host until the runner image is recycled — eventual but not
+/// immediate, and noisy.
+struct SandboxGuard {
+    id: String,
+    registry: SandboxRegistry,
+}
+
+impl SandboxGuard {
+    fn new(id: String, registry: SandboxRegistry) -> Self {
+        Self { id, registry }
+    }
+}
+
+impl Drop for SandboxGuard {
+    fn drop(&mut self) {
+        // Synchronous drop in async tests requires building a small
+        // runtime to await the stop call. Failures are logged, not
+        // propagated, because Drop cannot return errors.
+        let id = self.id.clone();
+        let registry = self.registry.clone();
+        let stopper = SignalStopper;
+        let res = std::thread::spawn(move || {
+            let rt = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => rt,
+                Err(e) => {
+                    eprintln!("SandboxGuard: failed to build teardown runtime: {e}");
+                    return;
+                }
+            };
+            rt.block_on(async {
+                let req = StopRequest {
+                    sandbox_id: id.clone(),
+                    wait: true,
+                };
+                if let Err(e) = handle_stop(req, &registry, &stopper).await {
+                    eprintln!("SandboxGuard: teardown of {id} failed: {e}");
+                }
+            });
+        })
+        .join();
+        if let Err(panic_payload) = res {
+            eprintln!("SandboxGuard: teardown thread panicked: {panic_payload:?}");
+        }
+    }
+}
+
+/// Smoke test: drive `sandbox::create` -> `sandbox::list` -> `sandbox::exec`
+/// -> `sandbox::stop` -> `sandbox::list` end-to-end against a real microVM.
 ///
-/// 1.  sandbox::create with image=alpine, network=false
-/// 2.  sandbox::fs::mkdir /work
-/// 3.  sandbox::fs::write /work/hello.txt = "world"
-/// 4.  sandbox::fs::stat /work/hello.txt -> size=5
-/// 5.  sandbox::fs::ls /work -> ["hello.txt"]
-/// 6.  sandbox::fs::grep "wor" /work/hello.txt -> match
-/// 7.  sandbox::fs::sed s/world/earth/ /work/hello.txt
-/// 8.  sandbox::fs::read /work/hello.txt -> "earth"
-/// 9.  sandbox::fs::chmod 0600 /work/hello.txt
-/// 10. sandbox::fs::mv /work/hello.txt /work/h2.txt
-/// 11. sandbox::fs::rm /work/h2.txt
-/// 12. sandbox::exec ["sh","-c","echo done"] -> exit=0
-/// 13. sandbox::list -> 1 sandbox, state=Running
-/// 14. sandbox::stop
-/// 15. sandbox::list -> empty
-///
-/// Implementation note: this test must use a `SandboxGuard` RAII helper
-/// so that any panic mid-scenario still tears down the VM. Otherwise
-/// a single panicking test cascades into CI-host resource exhaustion.
-#[test]
-#[ignore = "sandbox-e2e: requires KVM + guest rootfs (integration-vm CI lane)"]
-fn full_surface_e2e_walks_all_14_triggers() {
-    let Some(rootfs) = integration_rootfs() else {
+/// Asserts:
+///   - create returns a uuid sandbox_id
+///   - list shows the new sandbox (image=python, not stopped, not exec_in_progress)
+///   - exec("echo", "tier-c-smoke") returns exit_code=0 and stdout contains the marker
+///   - stop returns stopped=true
+///   - list is empty after stop
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "sandbox-e2e: requires KVM + iii-worker binary (integration-vm CI lane)"]
+async fn sandbox_create_exec_stop_smoke() {
+    let Some(bin) = worker_binary() else {
         return;
     };
     eprintln!(
-        "[todo] sandbox_integration_e2e: full_surface_e2e_walks_all_14_triggers \
-         has a rootfs at {} but the driver body is not yet implemented. \
-         Build out using IiiWorkerLauncher + ShellProtoRunner + SignalStopper, \
-         install a SandboxGuard RAII helper for panic-safe teardown.",
-        rootfs.display()
+        "sandbox_integration_e2e: using iii-worker binary at {}",
+        bin.display()
     );
+
+    // auto_install=true so the test self-heals if the rootfs cache is
+    // empty. CI may pre-seed via a setup step to skip the ~30s OCI pull
+    // on each run, but the test does not require it.
+    let cfg = SandboxConfig {
+        auto_install: true,
+        image_allowlist: vec!["python".into()],
+        ..Default::default()
+    };
+    let registry = SandboxRegistry::new();
+    let launcher = IiiWorkerLauncher;
+    let runner = ShellProtoRunner;
+    let stopper = SignalStopper;
+
+    // 1. create
+    let t_create = Instant::now();
+    let create_resp = handle_create(
+        CreateRequest {
+            image: "python".into(),
+            cpus: Some(1),
+            memory_mb: Some(512),
+            name: None,
+            network: Some(false),
+            idle_timeout_secs: Some(60),
+            env: vec![],
+        },
+        &cfg,
+        &registry,
+        &launcher,
+        |e| eprintln!("create event: {e:?}"),
+    )
+    .await
+    .expect("handle_create must succeed against a real rootfs + KVM");
+    let id = create_resp.sandbox_id;
+    eprintln!(
+        "create: sandbox_id={id} in {} ms",
+        t_create.elapsed().as_millis()
+    );
+    assert!(
+        Uuid::parse_str(&id).is_ok(),
+        "sandbox_id must be a valid uuid, got {id}"
+    );
+
+    // RAII teardown — runs even if the assertions below panic.
+    let _guard = SandboxGuard::new(id.clone(), registry.clone());
+
+    // 2. list — shows the new sandbox
+    let listed = handle_list(ListRequest::default(), &registry).await;
+    assert_eq!(listed.sandboxes.len(), 1);
+    let summary = &listed.sandboxes[0];
+    assert_eq!(summary.sandbox_id, id);
+    assert_eq!(summary.image, "python");
+    assert!(!summary.stopped);
+    assert!(!summary.exec_in_progress);
+
+    // 3. exec
+    let t_exec = Instant::now();
+    let exec_resp = handle_exec(
+        ExecRequest {
+            sandbox_id: id.clone(),
+            cmd: "/bin/echo".into(),
+            args: vec!["tier-c-smoke".into()],
+            stdin: None,
+            env: vec![],
+            timeout_ms: Some(15_000),
+            workdir: None,
+        },
+        &registry,
+        &runner,
+    )
+    .await
+    .expect("handle_exec must succeed once the VM is up");
+    eprintln!("exec: {} ms", t_exec.elapsed().as_millis());
+    assert_eq!(
+        exec_resp.exit_code,
+        Some(0),
+        "echo must exit 0; stderr={:?}",
+        exec_resp.stderr
+    );
+    assert!(
+        exec_resp.stdout.contains("tier-c-smoke"),
+        "stdout must contain the echo marker, got {:?}",
+        exec_resp.stdout
+    );
+    assert!(!exec_resp.timed_out);
+
+    // 4. stop (also triggered by guard if we panic above)
+    let stop_resp = handle_stop(
+        StopRequest {
+            sandbox_id: id.clone(),
+            wait: true,
+        },
+        &registry,
+        &stopper,
+    )
+    .await
+    .expect("handle_stop must succeed");
+    assert!(stop_resp.stopped);
+
+    // 5. list — empty
+    let after = handle_list(ListRequest::default(), &registry).await;
+    assert!(
+        after.sandboxes.is_empty(),
+        "list must be empty after stop, got {:?}",
+        after.sandboxes
+    );
+
+    // Guard's drop is now a no-op (registry doesn't know about this id
+    // anymore), which the guard tolerates with a logged warning. That's
+    // the expected steady-state for the happy path.
 }
 
 /// Verify network=false produces no host egress. Catches the
 /// localhost-rewrite class of bugs hit on 2026-04-28 in vm_boot.rs.
-#[test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "sandbox-e2e: requires KVM + guest rootfs (integration-vm CI lane)"]
-fn create_with_network_disabled_yields_no_host_egress() {
-    let Some(rootfs) = integration_rootfs() else {
+async fn create_with_network_disabled_yields_no_host_egress() {
+    let Some(_bin) = worker_binary() else {
         return;
     };
     eprintln!(
         "[todo] sandbox_integration_e2e: create_with_network_disabled_yields_no_host_egress \
-         has a rootfs at {} but the driver body is not yet implemented. \
-         Shape: create network=false, exec `nc -w 2 <host_ip> <listening_port>`, \
-         assert connection refused or unreachable.",
-        rootfs.display()
+         driver body not yet implemented. Shape: bind a TCP listener on the host, \
+         create with network=Some(false), exec `nc -w 2 <host_ip> <port>` inside the guest, \
+         assert connect failed and the host listener saw no accept(). Build out after \
+         sandbox_create_exec_stop_smoke is green in CI."
     );
 }
 
 /// Tier-C teardown contract: a panic mid-scenario must not leak the VM.
 /// The test deliberately panics; outer harness asserts the VM was reaped.
-#[test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "sandbox-e2e: requires KVM + guest rootfs (integration-vm CI lane)"]
-fn raii_guard_reaps_vm_on_panic_mid_scenario() {
-    let Some(rootfs) = integration_rootfs() else {
+async fn raii_guard_reaps_vm_on_panic_mid_scenario() {
+    let Some(_bin) = worker_binary() else {
         return;
     };
     eprintln!(
         "[todo] sandbox_integration_e2e: raii_guard_reaps_vm_on_panic_mid_scenario \
-         has a rootfs at {} but the driver body is not yet implemented. \
-         Shape: SandboxGuard wraps a created sandbox; spawn a child process \
-         that runs the test logic + panics; parent verifies VM pid is gone.",
-        rootfs.display()
+         driver body not yet implemented. Shape: spawn child process that creates a \
+         sandbox via the SandboxGuard pattern then panics; parent verifies the VM pid \
+         is gone (kill(pid, 0) returns ESRCH). Build out after the smoke is green."
     );
 }


### PR DESCRIPTION
## Summary

Activates the first real tier-C scenario — `sandbox_create_exec_stop_smoke` — by adding a one-line env override seam in production and replacing one of the three `[todo]` stubs in `sandbox_integration_e2e.rs` with a working driver.

**Stacked on #1564** (the tier-A test suite). Review #1564 first; this PR adds two files on top.

## Why this needs a prod change

`IiiWorkerLauncher::boot()` calls `std::env::current_exe()` to locate the binary it forks for `__vm-boot`. In production this is `iii-worker`. In a Cargo integration test, `current_exe()` returns the test binary, which does not have `__vm-boot` as a subcommand — so any test that exercises the real launcher fails immediately on spawn.

**Fix:** add an `III_WORKER_BINARY_OVERRIDE` env override (`adapters.rs`, ~10 LOC). Production never sets it; CI exports it to the iii-worker binary built earlier in the same job.

## What's in the PR

**`crates/iii-worker/src/sandbox_daemon/adapters.rs`** (+10 / -2)
- `III_WORKER_BINARY_OVERRIDE` env override for `current_exe()`. Test-only seam.

**`crates/iii-worker/tests/sandbox_integration_e2e.rs`** (replaced)
- `sandbox_create_exec_stop_smoke` — real driver. Boots a microVM via `IiiWorkerLauncher`, lists, execs `/bin/echo tier-c-smoke`, asserts exit=0 + stdout matches, stops, asserts list-empty. `auto_install=true` so the test self-heals on cold rootfs cache.
- `SandboxGuard` — RAII teardown that synchronously stops the sandbox on Drop, even when an assertion panics. Prevents one failed run leaking a libkrun guest per panic.
- The other two `[todo]` stubs (`network-disabled-no-egress`, `raii-guard-reaps-on-panic`) intentionally remain stubs. The smoke needs to land green first; iterate from there.

## Activation (manual today, CI tomorrow)

```
cargo build -p iii-worker --features integration-vm
III_WORKER_BINARY_OVERRIDE=$(realpath ./target/debug/iii-worker) \
  cargo test --features integration-vm --test sandbox_integration_e2e -- --ignored
```

Requires Linux+KVM (or macOS+Hypervisor.framework) plus network for the OCI pull on cold cache (~30s). Test `[skip]`s cleanly when `III_WORKER_BINARY_OVERRIDE` is unset.

## What's NOT in this PR

- **CI wiring** to actually invoke the tier-C lane. Lands as a small follow-up PR after #1569 (the `ubuntu-24.04` + KVM enablement) merges, so the workflow patch only has one moving target. The follow-up adds three steps to `worker-test-vm-linux`: build iii-worker, export `III_WORKER_BINARY_OVERRIDE`, run `cargo test ... -- --ignored`.
- **Filling in the other two `[todo]` stubs.** Best done after the smoke is green in CI so the iteration loop has a real signal.

## Honest caveat

The driver was written and compile-checked on Darwin without libkrun. The test code is correct relative to the trait signatures and assertion API; whether libkrun + iiidev/python boot end-to-end on a public `ubuntu-24.04` runner is unverified. Expect 1-2 follow-up commits to chase whatever the first CI run surfaces (timing tweaks, missing apt deps, OCI pull edge cases).

## Test plan

- [x] `cargo check --tests -p iii-worker --features integration-vm` — clean
- [x] `cargo test -p iii-worker --tests` — pre-existing 938 tests still green (including 28 tier-A from #1564)
- [ ] Manual local run on a Linux+KVM box with `III_WORKER_BINARY_OVERRIDE` set
- [ ] CI: tier-C smoke runs in a follow-up PR after #1569 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)