### PR TITLE
fix(vm-boot): skip localhost rewrite when networking is disabled

### DIFF
--- a/crates/iii-worker/src/cli/vm_boot.rs
+++ b/crates/iii-worker/src/cli/vm_boot.rs
@@ -268,6 +268,22 @@ pub fn rewrite_localhost(s: &str, gateway_ip: &str) -> String {
         .replace("://127.0.0.1:", &format!("://{}:", gateway_ip))
 }
 
+/// Conditionally rewrite localhost/loopback URLs.
+///
+/// `None` means networking is disabled — no virtio-net device is attached,
+/// so there is no gateway and `localhost`/`127.0.0.1` resolve correctly via
+/// the guest's loopback. The rewrite is skipped to avoid mangling URLs into
+/// `://:PORT`.
+///
+/// `Some(gw)` mirrors the original behaviour: replace `://localhost:` and
+/// `://127.0.0.1:` with `://gw:`.
+pub fn maybe_rewrite_localhost(s: &str, gateway_ip: Option<&str>) -> String {
+    match gateway_ip {
+        Some(gw) => rewrite_localhost(s, gw),
+        None => s.to_string(),
+    }
+}
+
 /// Identity of a bound control socket: path plus (dev, ino) of the
 /// filesystem entry that `UnixListener::bind` produced. Captured at
 /// bind time and consulted by the VM-exit cleanup hook so we only
@@ -680,21 +696,31 @@ fn boot_vm(args: &VmBootArgs) -> Result<std::convert::Infallible, String> {
     // Network plumbing is gated on `--network`. When disabled, no virtio-net
     // device is attached and the III_INIT_* env vars are left unset, so
     // iii-init's `configure_network()` short-circuits (network.rs:42-44).
-    let (dns_nameserver, guest_ip, gateway_ip) = if args.network {
-        let mut network =
-            iii_network::SmoltcpNetwork::new(iii_network::NetworkConfig::default(), args.slot);
-        network.start(tokio_rt.handle().clone());
-        builder = builder.net(|net| net.mac(network.guest_mac()).custom(network.take_backend()));
-        (
-            network.gateway_ipv4().to_string(),
-            network.guest_ipv4().to_string(),
-            network.gateway_ipv4().to_string(),
-        )
-    } else {
-        (String::new(), String::new(), String::new())
-    };
+    //
+    // The triple is `Option<String>` so absence is explicit at the type level:
+    // empty-string sentinels would silently turn `://localhost:` into `://:`
+    // when the rewrite below ran with networking off (see `rewrite_localhost`).
+    let (dns_nameserver, guest_ip, gateway_ip): (Option<String>, Option<String>, Option<String>) =
+        if args.network {
+            let mut network =
+                iii_network::SmoltcpNetwork::new(iii_network::NetworkConfig::default(), args.slot);
+            network.start(tokio_rt.handle().clone());
+            builder =
+                builder.net(|net| net.mac(network.guest_mac()).custom(network.take_backend()));
+            (
+                Some(network.gateway_ipv4().to_string()),
+                Some(network.guest_ipv4().to_string()),
+                Some(network.gateway_ipv4().to_string()),
+            )
+        } else {
+            (None, None, None)
+        };
 
-    let rewrite_localhost = |s: &str| -> String { rewrite_localhost(s, &gateway_ip) };
+    // Skip the rewrite entirely when networking is off — no gateway exists,
+    // and `localhost`/`127.0.0.1` resolve via the guest's loopback interface
+    // unchanged.
+    let rewrite_localhost =
+        |s: &str| -> String { maybe_rewrite_localhost(s, gateway_ip.as_deref()) };
     let worker_cmd = rewrite_localhost(&worker_cmd);
 
     let worker_heap_mib = (args.ram as u64 * 3 / 4).max(128);
@@ -760,10 +786,14 @@ fn boot_vm(args: &VmBootArgs) -> Result<std::convert::Infallible, String> {
         e = e.env("III_WORKER_CMD", &worker_cmd);
         // III_INIT_* are only meaningful when the smoltcp stack is wired up.
         // Leaving them unset makes iii-init's configure_network() a no-op.
-        if args.network {
-            e = e.env("III_INIT_DNS", &dns_nameserver);
-            e = e.env("III_INIT_IP", &guest_ip);
-            e = e.env("III_INIT_GW", &gateway_ip);
+        if let (Some(dns), Some(ip), Some(gw)) = (
+            dns_nameserver.as_deref(),
+            guest_ip.as_deref(),
+            gateway_ip.as_deref(),
+        ) {
+            e = e.env("III_INIT_DNS", dns);
+            e = e.env("III_INIT_IP", ip);
+            e = e.env("III_INIT_GW", gw);
             e = e.env("III_INIT_CIDR", "30");
         }
         e = e.env("III_WORKER_MEM_BYTES", &worker_heap_bytes.to_string());

--- a/crates/iii-worker/tests/vm_args_integration.rs
+++ b/crates/iii-worker/tests/vm_args_integration.rs
@@ -321,6 +321,37 @@ fn rewrite_localhost_no_port_unchanged() {
     );
 }
 
+// Regression: with networking disabled, `gateway_ip` is `None` and the
+// rewrite must be a no-op. Empty-string sentinels previously turned
+// `://localhost:9000` into `://:9000` (vm_boot.rs:683-698 pre-fix).
+#[test]
+fn maybe_rewrite_localhost_skips_when_networking_disabled() {
+    use iii_worker::cli::vm_boot::maybe_rewrite_localhost;
+
+    assert_eq!(
+        maybe_rewrite_localhost("http://localhost:9000/api", None),
+        "http://localhost:9000/api"
+    );
+    assert_eq!(
+        maybe_rewrite_localhost("ws://127.0.0.1:8080/ws", None),
+        "ws://127.0.0.1:8080/ws"
+    );
+}
+
+#[test]
+fn maybe_rewrite_localhost_rewrites_when_gateway_present() {
+    use iii_worker::cli::vm_boot::maybe_rewrite_localhost;
+
+    assert_eq!(
+        maybe_rewrite_localhost("http://localhost:3000/api", Some("192.168.1.1")),
+        "http://192.168.1.1:3000/api"
+    );
+    assert_eq!(
+        maybe_rewrite_localhost("ws://127.0.0.1:8080/ws", Some("10.0.0.1")),
+        "ws://10.0.0.1:8080/ws"
+    );
+}
+
 #[test]
 fn build_container_spec_managed_with_resources() {
     let mut env = HashMap::new();


### PR DESCRIPTION
## Summary

Fixes the URL-mangling regression where `vm_boot.rs` rewrote `://localhost:9000` into `://:9000` when launched with `--network` off, because the network triple defaulted to empty strings and `rewrite_localhost` ran unconditionally. Diagnosed 2026-04-28 (gbrain obs 2931–2936) with a clean repro; the fix had been sitting uncommitted in the working tree.

## What changes

`crates/iii-worker/src/cli/vm_boot.rs` (+48 / -18)
- New `pub fn maybe_rewrite_localhost(s, gateway_ip: Option<&str>)` wrapper. `None` returns the input unchanged; `Some(gw)` delegates to the existing `rewrite_localhost(s, gw)`.
- The network triple in `boot_vm` becomes `(Option<String>, Option<String>, Option<String>)` — `None` when `args.network = false`. Empty-string sentinels were the root cause of the silent rewrite into `://:PORT`.
- The `worker_cmd` rewrite closure now calls `maybe_rewrite_localhost(s, gateway_ip.as_deref())`.
- The III_INIT_* env-var injection block uses `if let (Some, Some, Some) = ...` so iii-init's `configure_network()` short-circuits cleanly when networking is off.

`crates/iii-worker/tests/vm_args_integration.rs` (+31 / 0)
- `maybe_rewrite_localhost_skips_when_networking_disabled` — pins the no-op behaviour for `None`.
- `maybe_rewrite_localhost_rewrites_when_gateway_present` — pins the substitution path for `Some(gw)`.

## Test plan

- [x] `cargo test -p iii-worker --test vm_args_integration` — both new tests pass
- [x] `cargo test -p iii-worker --tests` — full suite still green
- [ ] CI: full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL rewriting logic to prevent generation of malformed URLs when network connectivity is disabled. The system now conditionally applies URL rewrites based on network availability, ensuring valid URL formats in all scenarios.

* **Tests**
  * Added comprehensive regression tests to validate URL rewriting behavior with both enabled and disabled network configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->