### PR TITLE
chore(infra/website): add tf-apply pipeline

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -1,0 +1,87 @@
+name: Terraform Apply
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/terraform/website/**'
+      - '.github/workflows/tf-apply.yml'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to apply (default: current default branch)'
+        required: false
+        type: string
+
+concurrency:
+  group: tf-apply-website
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  apply:
+    name: terraform apply (infra/terraform/website)
+    runs-on: ubuntu-latest
+    environment: iii-website-prod-tf-apply
+    timeout-minutes: 15
+
+    env:
+      AWS_REGION: us-east-1
+      TF_IN_AUTOMATION: 'true'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.9.8'
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials (GitHub OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_TF_APPLY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform init
+        working-directory: infra/terraform/website
+        run: terraform init -input=false
+
+      - name: Terraform apply
+        id: apply
+        working-directory: infra/terraform/website
+        env:
+          TF_VAR_alarm_email: ${{ secrets.ALARM_EMAIL }}
+        run: |
+          set -o pipefail
+          terraform apply -input=false -auto-approve -no-color 2>&1 | tee apply.txt
+          {
+            echo 'apply<<TF_APPLY_EOF'
+            tail -c 60000 apply.txt
+            echo 'TF_APPLY_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Job summary
+        if: always()
+        env:
+          APPLY: ${{ steps.apply.outputs.apply }}
+        run: |
+          {
+            echo "## terraform apply — \`infra/terraform/website\`"
+            echo
+            echo "- Commit: \`${{ github.sha }}\`"
+            echo "- Ref: \`${{ inputs.ref || github.ref }}\`"
+            echo
+            echo '<details><summary>Apply output</summary>'
+            echo
+            echo '```'
+            echo "${APPLY:-(no apply output captured)}"
+            echo '```'
+            echo
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -1,0 +1,90 @@
+name: Terraform Apply
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/terraform/website/**'
+      - '.github/workflows/tf-apply.yml'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to apply (default: current default branch)'
+        required: false
+        type: string
+
+concurrency:
+  group: tf-apply-website
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  apply:
+    name: terraform apply (infra/terraform/website)
+    runs-on: ubuntu-latest
+    environment: iii-website-prod-tf-apply
+    timeout-minutes: 15
+
+    env:
+      AWS_REGION: us-east-1
+      TF_IN_AUTOMATION: 'true'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.9.8'
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials (GitHub OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_TF_APPLY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform init
+        working-directory: infra/terraform/website
+        run: terraform init -input=false
+
+      - name: Terraform apply
+        id: apply
+        working-directory: infra/terraform/website
+        env:
+          TF_VAR_alarm_email: ${{ secrets.ALARM_EMAIL }}
+        run: |
+          set -o pipefail
+          terraform apply -input=false -auto-approve -no-color 2>&1 | tee apply.txt
+          {
+            echo 'apply<<TF_APPLY_EOF'
+            tail -c 60000 apply.txt
+            echo 'TF_APPLY_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Job summary
+        if: always()
+        env:
+          APPLY: ${{ steps.apply.outputs.apply }}
+          # Via env, not inline ${{ }}: inputs.ref is free text and would be
+          # expanded into the script body as code (template injection).
+          REF: ${{ inputs.ref || github.ref }}
+        run: |
+          {
+            echo "## terraform apply — \`infra/terraform/website\`"
+            echo
+            echo "- Commit: \`${{ github.sha }}\`"
+            echo "- Ref: \`${REF}\`"
+            echo
+            echo '<details><summary>Apply output</summary>'
+            echo
+            echo '```'
+            echo "${APPLY:-(no apply output captured)}"
+            echo '```'
+            echo
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/infra/terraform/website/iam_github_oidc.tf
+++ b/infra/terraform/website/iam_github_oidc.tf
@@ -101,6 +101,44 @@ resource "aws_iam_role_policy_attachment" "github_deploy_website" {
   policy_arn = aws_iam_policy.github_deploy_website.arn
 }
 
+data "aws_iam_policy_document" "github_tf_apply_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values = [
+        "repo:${var.github_repo}:environment:${var.github_tf_apply_environment}",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_tf_apply" {
+  name                 = "iii-website-prod-github-tf-apply"
+  description          = "Assumed by GitHub Actions from the ${var.github_tf_apply_environment} environment to run `terraform apply` against infra/terraform/website. Configure that environment with required reviewers in repo settings to gate applies."
+  assume_role_policy   = data.aws_iam_policy_document.github_tf_apply_trust.json
+  max_session_duration = 3600
+}
+
+resource "aws_iam_role_policy_attachment" "github_tf_apply_admin" {
+  role       = aws_iam_role.github_tf_apply.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
 # Read-only role for `tf-plan.yml`. Separate from the deploy role so a malicious
 # PR can't accidentally run `terraform apply` with write permissions.
 data "aws_iam_policy_document" "github_tf_plan_trust" {

--- a/infra/terraform/website/iam_github_oidc.tf
+++ b/infra/terraform/website/iam_github_oidc.tf
@@ -87,8 +87,44 @@ resource "aws_iam_role_policy_attachment" "github_deploy_website" {
   policy_arn = aws_iam_policy.github_deploy_website.arn
 }
 
-# Read-only role for `tf-plan.yml`. Separate from the deploy role so a malicious
-# PR can't accidentally run `terraform apply` with write permissions.
+data "aws_iam_policy_document" "github_tf_apply_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values = [
+        "repo:${var.github_repo}:environment:${var.github_tf_apply_environment}",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_tf_apply" {
+  name                 = "iii-website-prod-github-tf-apply"
+  description          = "Assumed by GitHub Actions from the ${var.github_tf_apply_environment} environment to run `terraform apply` against infra/terraform/website. Configure that environment with required reviewers in repo settings to gate applies."
+  assume_role_policy   = data.aws_iam_policy_document.github_tf_apply_trust.json
+  max_session_duration = 3600
+}
+
+resource "aws_iam_role_policy_attachment" "github_tf_apply_admin" {
+  role       = aws_iam_role.github_tf_apply.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
 data "aws_iam_policy_document" "github_tf_plan_trust" {
   statement {
     effect  = "Allow"

--- a/infra/terraform/website/outputs.tf
+++ b/infra/terraform/website/outputs.tf
@@ -43,6 +43,11 @@ output "github_tf_plan_role_arn" {
   value       = aws_iam_role.github_tf_plan.arn
 }
 
+output "github_tf_apply_role_arn" {
+  description = "Admin IAM role ARN assumed by the tf-apply GitHub Actions workflow on push to main — set as repo-level GitHub secret AWS_TF_APPLY_ROLE_ARN"
+  value       = aws_iam_role.github_tf_apply.arn
+}
+
 output "sns_alarms_topic_arn" {
   description = "SNS topic ARN that receives production alarms"
   value       = aws_sns_topic.alarms.arn

--- a/infra/terraform/website/outputs.tf
+++ b/infra/terraform/website/outputs.tf
@@ -38,6 +38,11 @@ output "github_tf_plan_role_arn" {
   value       = aws_iam_role.github_tf_plan.arn
 }
 
+output "github_tf_apply_role_arn" {
+  description = "Admin IAM role ARN assumed by the tf-apply GitHub Actions workflow on push to main — set as repo-level GitHub secret AWS_TF_APPLY_ROLE_ARN"
+  value       = aws_iam_role.github_tf_apply.arn
+}
+
 output "sns_alarms_topic_arn" {
   description = "SNS topic ARN that receives production alarms"
   value       = aws_sns_topic.alarms.arn

--- a/infra/terraform/website/variables.tf
+++ b/infra/terraform/website/variables.tf
@@ -58,6 +58,14 @@ variable "github_environment" {
   default     = "iii-website-prod"
 }
 
+variable "github_tf_apply_environment" {
+  # Distinct from github_environment so the apply env can be configured with
+  # required reviewers without gating routine S3 deploys.
+  description = "GitHub environment scoping the tf-apply role. Configure required reviewers on this env in repo settings to gate applies."
+  type        = string
+  default     = "iii-website-prod-tf-apply"
+}
+
 variable "csp_report_only" {
   description = "Send CSP as report-only instead of enforcing."
   type        = bool

--- a/infra/terraform/website/variables.tf
+++ b/infra/terraform/website/variables.tf
@@ -65,20 +65,19 @@ variable "csp_report_only" {
 }
 
 variable "manage_apex_records" {
-  # Leave false until Phase 4 cutover. When false, the apex records are not managed
-  # by this module (they already exist — manually created in Route53, not
-  # External-DNS-owned). Flip to true after importing the existing records.
+  # Phase 4 cutover is complete (see #1470). Records were imported into state
+  # and Terraform now owns them. Flag retained as an escape hatch for emergency
+  # rollback — set to false to release ownership without destroying the records
+  # (use `terraform state rm` after flipping).
   description = "Whether Terraform manages the iii.dev apex A/AAAA Route53 records."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "manage_www_records" {
-  # Leave false until www.iii.dev has been released by External-DNS (argocd PR
-  # removing the iii-dev-www Ingress has merged + synced). Flip to true after
-  # importing the existing records. Decoupled from apex so the two can be
-  # cut over independently to limit blast radius.
+  # Phase 4 cutover complete; same situation as manage_apex_records. Decoupled
+  # from apex so the two can be released independently if ever needed.
   description = "Whether Terraform manages the www.iii.dev A/AAAA Route53 records."
   type        = bool
-  default     = false
+  default     = true
 }

--- a/infra/terraform/website/variables.tf
+++ b/infra/terraform/website/variables.tf
@@ -58,6 +58,14 @@ variable "github_environment" {
   default     = "iii-website-prod"
 }
 
+variable "github_tf_apply_environment" {
+  # Distinct from github_environment so the apply env can be configured with
+  # required reviewers without gating routine S3 deploys.
+  description = "GitHub environment scoping the tf-apply role. Configure required reviewers on this env in repo settings to gate applies."
+  type        = string
+  default     = "iii-website-prod-tf-apply"
+}
+
 variable "csp_report_only" {
   description = "Send CSP as report-only instead of enforcing."
   type        = bool
@@ -65,18 +73,12 @@ variable "csp_report_only" {
 }
 
 variable "manage_apex_records" {
-  # Phase 4 cutover is complete (see #1470). Records were imported into state
-  # and Terraform now owns them. Flag retained as an escape hatch for emergency
-  # rollback — set to false to release ownership without destroying the records
-  # (use `terraform state rm` after flipping).
   description = "Whether Terraform manages the iii.dev apex A/AAAA Route53 records."
   type        = bool
   default     = true
 }
 
 variable "manage_www_records" {
-  # Phase 4 cutover complete; same situation as manage_apex_records. Decoupled
-  # from apex so the two can be released independently if ever needed.
   description = "Whether Terraform manages the www.iii.dev A/AAAA Route53 records."
   type        = bool
   default     = true


### PR DESCRIPTION
## Summary

Adds a tf-apply pipeline so changes under `infra/terraform/website/` actually deploy on merge to main.

There was no apply pipeline. `tf-plan.yml` runs on PRs but applies were fully manual — which is why the cleanUrls fix from #1576 sat unapplied for hours after merge.

> **Note:** this PR originally also flipped the `manage_apex_records` / `manage_www_records` defaults to `true`. That landed separately via #1918, and this branch has been rebased to contain only the tf-apply work.

## `.github/workflows/tf-apply.yml`

- **Trigger:** push to `main` touching `infra/terraform/website/**` or the workflow itself, plus `workflow_dispatch` for ad-hoc applies on a chosen ref.
- **Concurrency:** `tf-apply-website` with `cancel-in-progress: false` so we never interrupt an in-flight apply.
- **Auth:** new `iii-website-prod-github-tf-apply` IAM role assumed via OIDC. `AdministratorAccess` (the trust scope is the safety boundary). Trust is narrowly conditioned on `repo:iii-hq/iii:environment:iii-website-prod-tf-apply` — a new GitHub environment, separate from the existing `iii-website-prod` env, so repo settings can gate applies behind required reviewers without slowing routine S3 syncs.
- **Output:** apply tail appended to the job summary.

## Test plan

- [x] `terraform validate`, `terraform fmt -check -recursive` clean.
- [x] `terraform plan` against prod after rebase — `3 to add, 1 to change, 0 to destroy`: the two new IAM resources, plus two pre-existing drift items this pipeline exists to catch (recreate `aws_sns_topic_subscription.email`, in-place update of `aws_cloudfront_function.redirects` to match merged repo code).
- [ ] **Bootstrap (one-time, manual):**
  1. `AWS_PROFILE=motia-prod terraform apply` from a laptop — creates the new role.
  2. Grab `github_tf_apply_role_arn` from outputs; set as repo secret `AWS_TF_APPLY_ROLE_ARN`.
  3. Create `iii-website-prod-tf-apply` GitHub environment in repo settings; add required reviewers if you want manual approval gating.
- [ ] After bootstrap, verify the workflow runs green on the next push touching `infra/terraform/website/**`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Terraform apply workflow for the website infrastructure, with manual trigger support and automatic runs on approved main-branch updates.
  * Introduced a separate deployment environment for apply operations, improving control over release access.
  * Added a dedicated access path for apply runs and surfaced its connection details for use in deployment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->