### PR TITLE
feat(engine,iii-worker): forward iii-config.yaml config: block to binary workers

### DIFF
--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -5,6 +5,7 @@
 // See LICENSE and PATENTS files for details.
 
 use clap::{Args, Parser, Subcommand};
+use std::path::PathBuf;
 
 /// Default engine WebSocket port (must match engine's DEFAULT_PORT).
 pub const DEFAULT_PORT: u16 = 49134;
@@ -104,6 +105,11 @@ pub enum Commands {
         /// non-default manager ports don't silently break connectivity.
         #[arg(long, default_value_t = DEFAULT_PORT)]
         port: u16,
+
+        /// YAML config forwarded to the spawned worker binary as `--config <path>`.
+        /// Binary workers only; OCI workers warn and ignore.
+        #[arg(long, value_name = "PATH")]
+        config: Option<PathBuf>,
     },
 
     /// Stop a managed worker container
@@ -129,6 +135,10 @@ pub enum Commands {
         /// semantics as `start --port`.
         #[arg(long, default_value_t = DEFAULT_PORT)]
         port: u16,
+
+        /// Same as `start --config`.
+        #[arg(long, value_name = "PATH")]
+        config: Option<PathBuf>,
     },
 
     /// List all workers and their status

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -2705,7 +2705,12 @@ async fn wait_for_ready(worker_name: &str, port: u16) {
 /// auto-spawn path in `registry_worker::ExternalWorkerProcess::spawn` passes
 /// the configured `iii-worker-manager` port so non-default manager ports
 /// don't silently break connectivity for external workers.
-pub async fn handle_managed_start(worker_name: &str, wait: bool, port: u16) -> i32 {
+pub async fn handle_managed_start(
+    worker_name: &str,
+    wait: bool,
+    port: u16,
+    config: Option<&std::path::Path>,
+) -> i32 {
     if let Err(e) = super::registry::validate_worker_name(worker_name) {
         eprintln!("{} {}", "error:".red(), e);
         return 1;
@@ -2743,6 +2748,12 @@ pub async fn handle_managed_start(worker_name: &str, wait: bool, port: u16) -> i
     }
     let local_outcome = match super::config_file::resolve_worker_type(worker_name) {
         ResolvedWorkerType::Oci { image, env } => {
+            if config.is_some() {
+                tracing::warn!(
+                    worker = %worker_name,
+                    "--config ignored for OCI workers (requires VM-mount support)"
+                );
+            }
             let worker_def = WorkerDef::Managed {
                 image,
                 env,
@@ -2750,11 +2761,19 @@ pub async fn handle_managed_start(worker_name: &str, wait: bool, port: u16) -> i
             };
             StartOutcome::Exit(start_oci_worker(worker_name, &worker_def, port).await)
         }
-        ResolvedWorkerType::Local { worker_path } => StartOutcome::Exit(
-            super::local_worker::start_local_worker(worker_name, &worker_path, port).await,
-        ),
+        ResolvedWorkerType::Local { worker_path } => {
+            if config.is_some() {
+                tracing::warn!(
+                    worker = %worker_name,
+                    "--config ignored for local-source workers"
+                );
+            }
+            StartOutcome::Exit(
+                super::local_worker::start_local_worker(worker_name, &worker_path, port).await,
+            )
+        }
         ResolvedWorkerType::Binary { binary_path } => {
-            StartOutcome::Exit(start_binary_worker(worker_name, &binary_path).await)
+            StartOutcome::Exit(start_binary_worker(worker_name, &binary_path, config).await)
         }
         ResolvedWorkerType::Config => StartOutcome::FallThrough,
     };
@@ -2796,7 +2815,7 @@ pub async fn handle_managed_start(worker_name: &str, wait: bool, port: u16) -> i
             match binary_download::download_and_install_binary(worker_name, binary_info).await {
                 Ok(installed_path) => {
                     eprintln!("  {} Installed successfully", "✓".green());
-                    let rc = start_binary_worker(worker_name, &installed_path).await;
+                    let rc = start_binary_worker(worker_name, &installed_path, config).await;
                     return finish_start(worker_name, rc, wait, port).await;
                 }
                 Err(e) => {
@@ -2891,7 +2910,12 @@ async fn finish_start(worker_name: &str, rc: i32, wait: bool, port: u16) -> i32 
 /// NOT abort the restart -- the most common reason stop "fails" here is
 /// "already not running," which returns 0. Start's exit code becomes the
 /// command's exit code.
-pub async fn handle_managed_restart(worker_name: &str, wait: bool, port: u16) -> i32 {
+pub async fn handle_managed_restart(
+    worker_name: &str,
+    wait: bool,
+    port: u16,
+    config: Option<&std::path::Path>,
+) -> i32 {
     if let Err(e) = super::registry::validate_worker_name(worker_name) {
         eprintln!("{} {}", "error:".red(), e);
         return 1;
@@ -2907,7 +2931,7 @@ pub async fn handle_managed_restart(worker_name: &str, wait: bool, port: u16) ->
         );
     }
 
-    handle_managed_start(worker_name, wait, port).await
+    handle_managed_start(worker_name, wait, port, config).await
 }
 
 async fn start_oci_worker(worker_name: &str, worker_def: &WorkerDef, port: u16) -> i32 {
@@ -2953,7 +2977,11 @@ async fn start_oci_worker(worker_name: &str, worker_def: &WorkerDef, port: u16) 
     }
 }
 
-async fn start_binary_worker(worker_name: &str, binary_path: &std::path::Path) -> i32 {
+async fn start_binary_worker(
+    worker_name: &str,
+    binary_path: &std::path::Path,
+    config: Option<&std::path::Path>,
+) -> i32 {
     // Kill any stale process from a previous engine run
     kill_stale_worker(worker_name).await;
 
@@ -2985,6 +3013,9 @@ async fn start_binary_worker(worker_name: &str, binary_path: &std::path::Path) -
     eprintln!("  Starting {} (binary)...", worker_name.bold());
 
     let mut cmd = tokio::process::Command::new(binary_path);
+    if let Some(cfg_path) = config {
+        cmd.arg("--config").arg(cfg_path);
+    }
     cmd.stdout(stdout_file).stderr(stderr_file);
 
     #[cfg(unix)]

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -98,7 +98,16 @@ async fn main() -> anyhow::Result<()> {
             worker_name,
             no_wait,
             port,
-        } => iii_worker::cli::managed::handle_managed_start(&worker_name, !no_wait, port).await,
+            config,
+        } => {
+            iii_worker::cli::managed::handle_managed_start(
+                &worker_name,
+                !no_wait,
+                port,
+                config.as_deref(),
+            )
+            .await
+        }
         Commands::Stop { worker_name } => {
             iii_worker::cli::managed::handle_managed_stop(&worker_name).await
         }
@@ -106,7 +115,16 @@ async fn main() -> anyhow::Result<()> {
             worker_name,
             no_wait,
             port,
-        } => iii_worker::cli::managed::handle_managed_restart(&worker_name, !no_wait, port).await,
+            config,
+        } => {
+            iii_worker::cli::managed::handle_managed_restart(
+                &worker_name,
+                !no_wait,
+                port,
+                config.as_deref(),
+            )
+            .await
+        }
         Commands::List => iii_worker::cli::managed::handle_worker_list().await,
         Commands::Sync { frozen } => iii_worker::cli::managed::handle_worker_sync(frozen).await,
         Commands::Verify { strict } => iii_worker::cli::managed::handle_worker_verify(strict).await,

--- a/crates/iii-worker/tests/config_managed_integration.rs
+++ b/crates/iii-worker/tests/config_managed_integration.rs
@@ -170,6 +170,7 @@ async fn handle_managed_start_builtin_short_circuits() {
             "iii-http",
             false,
             iii_worker::DEFAULT_PORT,
+            None,
         )
         .await;
         assert!(
@@ -197,6 +198,7 @@ async fn handle_managed_start_unconfigured_builtin_fails() {
             "iii-http",
             false,
             iii_worker::DEFAULT_PORT,
+            None,
         )
         .await;
         assert_ne!(
@@ -218,6 +220,7 @@ async fn handle_managed_start_unconfigured_optional_builtin_fails() {
             "iii-exec",
             false,
             iii_worker::DEFAULT_PORT,
+            None,
         )
         .await;
         assert_ne!(
@@ -447,6 +450,7 @@ async fn handle_managed_restart_invalid_name_fails_fast() {
             "bad name with spaces",
             false,
             iii_worker::DEFAULT_PORT,
+            None,
         )
         .await;
         assert_eq!(
@@ -479,6 +483,7 @@ async fn handle_managed_restart_on_not_running_surfaces_start_rc() {
             "iii-http",
             false,
             iii_worker::DEFAULT_PORT,
+            None,
         )
         .await;
         // Builtin start short-circuits with rc=0 or rc=1 depending on whether

--- a/crates/iii-worker/tests/worker_integration.rs
+++ b/crates/iii-worker/tests/worker_integration.rs
@@ -149,10 +149,7 @@ fn start_subcommand_accepts_engine_config_flag() {
     ])
     .expect("engine's --config spawn form must parse");
     match cli.command {
-        Commands::Start {
-            config,
-            ..
-        } => {
+        Commands::Start { config, .. } => {
             assert_eq!(
                 config.as_deref().and_then(|p| p.to_str()),
                 Some("/tmp/iii-pdfkit-config.yaml"),

--- a/crates/iii-worker/tests/worker_integration.rs
+++ b/crates/iii-worker/tests/worker_integration.rs
@@ -85,6 +85,7 @@ fn start_subcommand_matches_engine_spawn_args() {
             worker_name,
             no_wait,
             port,
+            config,
         } => {
             assert_eq!(worker_name, "image-resize");
             assert!(!no_wait, "bare human invocation keeps default wait=true");
@@ -93,6 +94,7 @@ fn start_subcommand_matches_engine_spawn_args() {
                 iii_worker::DEFAULT_PORT,
                 "bare form must default to DEFAULT_PORT"
             );
+            assert!(config.is_none(), "bare human form has no --config");
         }
         _ => panic!("expected Start"),
     }
@@ -122,10 +124,40 @@ fn start_subcommand_accepts_port_flag_from_engine_spawn() {
             worker_name,
             no_wait,
             port,
+            config,
         } => {
             assert_eq!(worker_name, "pdfkit");
             assert!(no_wait, "engine auto-spawn must pass --no-wait");
             assert_eq!(port, 49199, "--port must surface the custom port");
+            assert!(config.is_none(), "no --config in this spawn form");
+        }
+        _ => panic!("expected Start"),
+    }
+}
+
+#[test]
+fn start_subcommand_accepts_engine_config_flag() {
+    let cli = Cli::try_parse_from([
+        "iii-worker",
+        "start",
+        "pdfkit",
+        "--port",
+        "49134",
+        "--no-wait",
+        "--config",
+        "/tmp/iii-pdfkit-config.yaml",
+    ])
+    .expect("engine's --config spawn form must parse");
+    match cli.command {
+        Commands::Start {
+            config,
+            ..
+        } => {
+            assert_eq!(
+                config.as_deref().and_then(|p| p.to_str()),
+                Some("/tmp/iii-pdfkit-config.yaml"),
+                "--config must surface the engine-supplied path"
+            );
         }
         _ => panic!("expected Start"),
     }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -34,6 +34,7 @@ pub mod workers {
     pub mod registry_worker;
     pub mod reload;
     pub mod rest_api;
+    pub mod secure_temp;
     pub mod shell;
     pub mod state;
     pub mod stream;

--- a/engine/src/workers/config.rs
+++ b/engine/src/workers/config.rs
@@ -253,9 +253,10 @@ impl WorkerRegistry {
         //    back to DEFAULT_PORT via `worker_manager_port()`.
         let port = engine.worker_manager_port();
         tracing::info!(worker = %name, port = port, "Starting external worker via iii-worker");
-        let process = super::registry_worker::ExternalWorkerProcess::spawn(name, port)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to start worker '{}': {}", name, e))?;
+        let process =
+            super::registry_worker::ExternalWorkerProcess::spawn(name, port, config.as_ref())
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to start worker '{}': {}", name, e))?;
         Ok(Box::new(
             super::registry_worker::ExternalWorkerWrapper::new(process),
         ))

--- a/engine/src/workers/external.rs
+++ b/engine/src/workers/external.rs
@@ -221,15 +221,12 @@ impl Worker for ExternalWorker {
         mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
         _shutdown_tx: tokio::sync::watch::Sender<bool>,
     ) -> anyhow::Result<()> {
-        // Write config to a temp file if we have config
         let config_path = if let Some(ref config) = self.config {
-            let yaml = serde_yaml::to_string(config)?;
-            let temp_dir = std::env::temp_dir();
-            let config_path = temp_dir.join(format!("iii-{}-config.yaml", self.name));
-            std::fs::write(&config_path, &yaml)?;
-            tracing::debug!("Wrote external worker config to {}", config_path.display());
-            *self.config_file.lock().await = Some(config_path.clone());
-            Some(config_path)
+            let path = crate::workers::secure_temp::write_engine_config_temp(&self.name, config)
+                .map_err(|e| anyhow::anyhow!(e))?;
+            tracing::debug!("Wrote external worker config to {}", path.display());
+            *self.config_file.lock().await = Some(path.clone());
+            Some(path)
         } else {
             None
         };

--- a/engine/src/workers/registry_worker.rs
+++ b/engine/src/workers/registry_worker.rs
@@ -17,7 +17,10 @@ use std::{
 use serde_json::Value;
 use tokio::sync::Mutex;
 
-use crate::{engine::Engine, workers::traits::Worker};
+use crate::{
+    engine::Engine,
+    workers::{secure_temp, traits::Worker},
+};
 
 // =============================================================================
 // Path helpers
@@ -106,20 +109,24 @@ fn read_pid_hardened(path: &std::path::Path) -> Option<u32> {
 ///
 /// Any drift here silently breaks the non-default `iii-worker-manager` port
 /// case — the exact bug this module exists to fix.
-fn spawn_args(worker_name: &str, port: u16) -> [String; 5] {
-    // `--no-wait` keeps the child process short-lived. Without it the default
-    // `wait=true` path pulls `wait_for_ready` → `watch_until_ready`, which
-    // eprintln's a 500ms status-panel redraw loop into the engine-redirected
-    // stderr.log. `iii worker logs -f` then tails that noise interleaved with
-    // the VM's actual console output. The engine already probes liveness via
-    // `is_alive`, so blocking the child on the panel loop is pure pollution.
-    [
+fn spawn_args(worker_name: &str, port: u16, config_path: Option<&std::path::Path>) -> Vec<String> {
+    // `--no-wait` keeps the child short-lived. Without it the default
+    // `wait_for_ready` → `watch_until_ready` path eprintln's a 500ms
+    // status-panel redraw loop into the engine-redirected stderr.log,
+    // which `iii worker logs -f` then tails as noise. Engine probes
+    // liveness via `is_alive`, so the panel loop is pure pollution.
+    let mut args: Vec<String> = vec![
         "start".into(),
         worker_name.into(),
         "--port".into(),
         port.to_string(),
         "--no-wait".into(),
-    ]
+    ];
+    if let Some(path) = config_path {
+        args.push("--config".into());
+        args.push(path.to_string_lossy().into_owned());
+    }
+    args
 }
 
 // =============================================================================
@@ -164,6 +171,10 @@ pub struct ExternalWorkerProcess {
     /// this instant to cover the gap between `iii-worker start` exiting and
     /// the detached VM writing its pidfile.
     pub spawned_at: std::time::Instant,
+    /// Tracked so `stop` (and `Drop`, on panic) can unlink the temp config
+    /// written by `spawn`. `std::sync::Mutex` rather than `tokio::sync::Mutex`
+    /// because the lock is held for nanoseconds and `Drop` is not async.
+    pub config_file: std::sync::Mutex<Option<PathBuf>>,
 }
 
 /// How long after spawn we trust "still booting, no pidfile yet" as alive.
@@ -186,7 +197,7 @@ impl ExternalWorkerProcess {
     /// behavior; when it runs on a non-default port (e.g. SDK integration
     /// tests with multiple `iii-worker-manager` entries), the spawned worker
     /// no longer silently connects to the wrong port.
-    pub async fn spawn(name: &str, port: u16) -> Result<Self, String> {
+    pub async fn spawn(name: &str, port: u16, config: Option<&Value>) -> Result<Self, String> {
         let worker_binary = resolve_iii_worker_binary()
             .ok_or_else(|| {
                 "iii-worker binary not found. Install with `iii update worker` or place in ~/.local/bin/".to_string()
@@ -204,7 +215,12 @@ impl ExternalWorkerProcess {
         let stderr_file = std::fs::File::create(logs_dir.join("stderr.log"))
             .map_err(|e| format!("Failed to create stderr log: {}", e))?;
 
-        let args = spawn_args(name, port);
+        let config_path = match config {
+            Some(cfg) => Some(secure_temp::write_engine_config_temp(name, cfg)?),
+            None => None,
+        };
+
+        let args = spawn_args(name, port, config_path.as_deref());
         let mut cmd = tokio::process::Command::new(&worker_binary);
         cmd.args(&args).stdout(stdout_file).stderr(stderr_file);
 
@@ -216,6 +232,7 @@ impl ExternalWorkerProcess {
             worker = %name,
             pid = ?child.id(),
             port = port,
+            config = ?config_path.as_ref().map(|p| p.display().to_string()),
             "Worker starting via iii-worker (logs: `iii worker logs {}`)", name
         );
 
@@ -223,6 +240,7 @@ impl ExternalWorkerProcess {
             name: name.to_string(),
             child: Arc::new(Mutex::new(Some(child))),
             spawned_at: std::time::Instant::now(),
+            config_file: std::sync::Mutex::new(config_path),
         })
     }
 
@@ -308,8 +326,31 @@ impl ExternalWorkerProcess {
             tracing::warn!(worker = %self.name, "Cannot stop worker: iii-worker binary not found");
         }
 
-        // Clean up the child handle if it's still around
         let _ = self.child.lock().await.take();
+
+        if let Some(path) = self.config_file.lock().expect("poisoned").take() {
+            if let Err(e) = std::fs::remove_file(&path) {
+                tracing::warn!(
+                    worker = %self.name,
+                    config_path = %path.display(),
+                    error = %e,
+                    "failed to remove temp config"
+                );
+            }
+        }
+    }
+}
+
+/// Best-effort cleanup if the engine drops the process without calling
+/// `stop` (panic, abort during shutdown). `stop` already `take()`s the
+/// path so the happy path is a no-op here.
+impl Drop for ExternalWorkerProcess {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = self.config_file.lock() {
+            if let Some(path) = guard.take() {
+                let _ = std::fs::remove_file(&path);
+            }
+        }
     }
 }
 
@@ -459,6 +500,7 @@ mod tests {
             name: name.to_string(),
             child: Arc::new(Mutex::new(None)),
             spawned_at,
+            config_file: std::sync::Mutex::new(None),
         }
     }
 
@@ -537,6 +579,7 @@ mod tests {
             name: "booting-worker".to_string(),
             child: Arc::new(Mutex::new(None)),
             spawned_at: std::time::Instant::now(),
+            config_file: std::sync::Mutex::new(None),
         };
         assert!(
             process.is_alive(),
@@ -550,6 +593,7 @@ mod tests {
             name: "test-worker".to_string(),
             child: Arc::new(Mutex::new(None)),
             spawned_at: std::time::Instant::now(),
+            config_file: std::sync::Mutex::new(None),
         };
         let wrapper = ExternalWorkerWrapper::new(process);
         assert_eq!(wrapper.name(), "ExternalWorker(test-worker)");
@@ -570,9 +614,49 @@ mod tests {
             name: "init-test".to_string(),
             child: Arc::new(Mutex::new(None)),
             spawned_at: std::time::Instant::now(),
+            config_file: std::sync::Mutex::new(None),
         };
         let wrapper = ExternalWorkerWrapper::new(process);
         assert!(wrapper.initialize().await.is_ok());
+    }
+
+    /// Drop catches the "panic before stop()" path. Without it, a panic
+    /// during engine shutdown leaks the secret-bearing temp config.
+    #[test]
+    fn drop_removes_tracked_temp_config_when_stop_was_skipped() {
+        let temp_path = std::env::temp_dir().join("iii-test-drop-cleanup-config.yaml");
+        std::fs::write(&temp_path, "stub: 1\n").unwrap();
+
+        {
+            let _process = ExternalWorkerProcess {
+                name: "test-drop-cleanup".to_string(),
+                child: Arc::new(Mutex::new(None)),
+                spawned_at: std::time::Instant::now(),
+                config_file: std::sync::Mutex::new(Some(temp_path.clone())),
+            };
+            // process drops here without stop() being called
+        }
+
+        assert!(!temp_path.exists());
+    }
+
+    #[tokio::test]
+    async fn stop_removes_tracked_temp_config() {
+        let name = "test-stop-cleanup";
+        let temp_path = std::env::temp_dir().join(format!("iii-{}-stop-config.yaml", name));
+        std::fs::write(&temp_path, "stub: 1\n").unwrap();
+
+        let process = ExternalWorkerProcess {
+            name: name.to_string(),
+            child: Arc::new(Mutex::new(None)),
+            spawned_at: std::time::Instant::now(),
+            config_file: std::sync::Mutex::new(Some(temp_path.clone())),
+        };
+
+        process.stop().await;
+
+        assert!(!temp_path.exists());
+        assert!(process.config_file.lock().unwrap().is_none());
     }
 
     #[tokio::test]
@@ -581,6 +665,7 @@ mod tests {
             name: "destroy-test".to_string(),
             child: Arc::new(Mutex::new(None)),
             spawned_at: std::time::Instant::now(),
+            config_file: std::sync::Mutex::new(None),
         };
         let wrapper = ExternalWorkerWrapper::new(process);
         assert!(wrapper.destroy().await.is_ok());
@@ -594,7 +679,7 @@ mod tests {
     /// regression this whole module exists to fix.
     #[test]
     fn spawn_args_emit_start_name_port_in_order() {
-        let args = spawn_args("pdfkit", 49199);
+        let args = spawn_args("pdfkit", 49199, None);
         assert_eq!(
             args,
             [
@@ -612,7 +697,7 @@ mod tests {
     /// `~/.iii/logs/<name>/stderr.log` (visible via `iii worker logs -f`).
     #[test]
     fn spawn_args_always_passes_no_wait() {
-        let args = spawn_args("anything", 1234);
+        let args = spawn_args("anything", 1234, None);
         assert!(
             args.iter().any(|a| a == "--no-wait"),
             "engine spawn must include --no-wait to avoid polluting stderr.log"
@@ -623,8 +708,35 @@ mod tests {
     fn spawn_args_default_port_serializes_as_digits() {
         // Pin that port formatting is decimal digits, not something clap
         // would reject like "0x1234". u16::MAX is the boundary case.
-        let args = spawn_args("x", u16::MAX);
+        let args = spawn_args("x", u16::MAX, None);
         assert_eq!(args[3], "65535");
+    }
+
+    #[test]
+    fn spawn_args_appends_config_path_when_present() {
+        let path = std::path::Path::new("/tmp/iii-pdfkit-config.yaml");
+        let args = spawn_args("pdfkit", 49134, Some(path));
+        assert_eq!(
+            args,
+            [
+                "start".to_string(),
+                "pdfkit".to_string(),
+                "--port".to_string(),
+                "49134".to_string(),
+                "--no-wait".to_string(),
+                "--config".to_string(),
+                "/tmp/iii-pdfkit-config.yaml".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn spawn_args_omits_config_flag_when_absent() {
+        let args = spawn_args("anything", 1234, None);
+        assert!(
+            !args.iter().any(|a| a == "--config"),
+            "no --config flag must be emitted when the engine has no config block"
+        );
     }
 
     /// Intern cache caps the Box::leak growth: the same worker name must

--- a/engine/src/workers/secure_temp.rs
+++ b/engine/src/workers/secure_temp.rs
@@ -1,0 +1,112 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at support@motia.dev
+// See LICENSE and PATENTS files for details.
+
+//! Shared helpers for serializing worker config blocks to a temp YAML file
+//! consumed by spawned workers via `--config <path>`. Used by both the
+//! in-process spawn path (`external.rs`) and the via-iii-worker path
+//! (`registry_worker.rs`).
+
+use std::path::PathBuf;
+
+use serde_json::Value;
+
+/// Per-engine deterministic path: `iii-{name}-{pid}-config.yaml`.
+///
+/// The `{pid}` segment scopes the file to a single engine instance so two
+/// engines on the same host running a worker with the same name (e.g. parent
+/// repo + worktree) don't collide on a shared `/tmp` path.
+pub fn temp_config_path(name: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("iii-{}-{}-config.yaml", name, std::process::id()))
+}
+
+pub fn write_engine_config_temp(name: &str, cfg: &Value) -> Result<PathBuf, String> {
+    let yaml = serde_yaml::to_string(cfg)
+        .map_err(|e| format!("serialize config for '{}': {}", name, e))?;
+    let path = temp_config_path(name);
+    write_secure(&path, &yaml)
+        .map_err(|e| format!("write config for '{}' to {}: {}", name, path.display(), e))?;
+    Ok(path)
+}
+
+/// `unlink` + `create_new` + `mode(0o600)` because `OpenOptions::mode` is
+/// honored only on file creation: opening a stale `0o644` file with
+/// `create + truncate` keeps the loose perms and leaks secrets the worker
+/// config can carry. Sticky-bit `/tmp` blocks unlinking foreign-owned files,
+/// so an attacker squatting our deterministic path makes `create_new` fail
+/// with `EEXIST` instead of silently writing through.
+#[cfg(unix)]
+pub fn write_secure(path: &std::path::Path, content: &str) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    let _ = std::fs::remove_file(path);
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)?;
+    f.write_all(content.as_bytes())
+}
+
+#[cfg(not(unix))]
+pub fn write_secure(path: &std::path::Path, content: &str) -> std::io::Result<()> {
+    std::fs::write(path, content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn temp_config_path_includes_name_and_pid() {
+        let p = temp_config_path("pdfkit");
+        let name = p.file_name().unwrap().to_string_lossy().into_owned();
+        assert!(name.starts_with("iii-pdfkit-"));
+        assert!(name.ends_with("-config.yaml"));
+        assert!(name.contains(&std::process::id().to_string()));
+    }
+
+    #[test]
+    fn write_engine_config_temp_roundtrips_yaml() {
+        let cfg = serde_json::json!({"host": "127.0.0.1", "port": 9000, "tls": true});
+        let path = write_engine_config_temp("test-roundtrip-shared", &cfg).expect("write");
+
+        let parsed: serde_json::Value =
+            serde_yaml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(parsed, cfg);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_engine_config_temp_sets_owner_only_perms() {
+        use std::os::unix::fs::PermissionsExt;
+        let path = write_engine_config_temp("test-perms-shared", &serde_json::json!({"x": 1}))
+            .expect("write");
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "got {:o}", mode);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Regression: `OpenOptions::mode` is honored only on creation, so a
+    /// stale `0o644` file must NOT keep its loose perms across the next
+    /// write. `write_secure` enforces this via `unlink` + `create_new`.
+    #[cfg(unix)]
+    #[test]
+    fn write_secure_overwrites_stale_perms() {
+        use std::os::unix::fs::PermissionsExt;
+        let path = std::env::temp_dir().join("iii-test-stale-secure-config.yaml");
+        std::fs::write(&path, "stale").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        write_secure(&path, "fresh").unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "got {:o}", mode);
+
+        let _ = std::fs::remove_file(&path);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the config-delivery gap for binary workers spawned through the `iii-worker` supervisor path. Previously only the in-process `ExternalWorker` flow (`engine/src/workers/external.rs`) wrote a temp YAML and threaded `--config <path>` to the spawned binary. Workers like `database` (resolved via iii-worker's binary-spawn path) had no engine-side config-delivery channel and silently fell back to a CWD-relative `./config.yaml` via their own CLI default.

## What changed

**Engine** (`engine/src/workers/`)
- New shared module `secure_temp.rs` owns the temp-config write contract for both spawn paths.
- `registry_worker::ExternalWorkerProcess::spawn` now serializes the config block to a per-engine temp YAML (`iii-{name}-{pid}-config.yaml`) and appends `--config <path>` to the argv.
- Path is tracked on `ExternalWorkerProcess::config_file`; both `stop()` (graceful shutdown) and `Drop` (panic fallback) unlink it.
- Both spawn paths now write with `0o600` via `unlink + create_new + mode`. `OpenOptions::mode` is honored only on file *creation*, so a stale `0o644` file (from before this PR, or pre-created by a same-host attacker squatting the deterministic `/tmp` path) would otherwise inherit loose perms when truncated and rewritten — leaking secrets the worker config can carry. unlink + create_new defeats stale-mode reuse and refuses to write through a foreign-owned squat (sticky bit blocks the unlink; create_new then fails with EEXIST).
- Pid suffix scopes the temp path to a single engine instance so two engines on the same host running a worker with the same name (parent repo + worktree, dev + CI on a shared runner) don't collide.

**iii-worker** (`crates/iii-worker/src/cli/`)
- `Start` and `Restart` accept `--config <path>` and forward it to `start_binary_worker`, which appends `--config <path>` to the spawned worker binary's argv.
- OCI and local-source workers warn-and-ignore (VM-mount support tracked as follow-up).

## Test plan

- [x] `cargo test -p iii --lib workers::` passes (1130 tests)
- [x] `cargo test -p iii-worker` passes (943 tests, 7 ignored)
- [x] New `secure_temp` test module: path naming convention, YAML round-trip, `0o600` on Unix, stale-perm regression
- [x] `registry_worker::stop_removes_tracked_temp_config` — `stop()` unlinks the tracked file
- [x] `registry_worker::drop_removes_tracked_temp_config_when_stop_was_skipped` — panic-path cleanup via `Drop`
- [x] `iii-worker::start_subcommand_accepts_engine_config_flag` — clap parses `--config <path>`
- [x] Engine spawn → iii-worker → binary worker contract pinned by mirrored argv tests on both sides
- [ ] Manual smoke: spawn a real binary worker (e.g. `database`) with a `config:` block in iii-config.yaml; confirm the worker reads from the threaded `--config` path rather than falling back to `./config.yaml`

## Follow-ups (out of scope)

- OCI / local-source `--config` transport — likely env-var (`III_WORKER_CONFIG_JSON`) since VM-mount is heavier
- Engine-side `worker_name` validation (currently only iii-worker validates; engine interpolates name into the path verbatim)
- Loud OCI failure on `--config` ignore (currently `tracing::warn!` buried in worker stderr)
- Startup sweep for orphaned temp configs after SIGKILL / OOM (Drop catches panics, not aborts)
- `O_NOFOLLOW` for same-uid symlink-to-nonexistent attack hardening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `--config <PATH>` argument to the `iii worker start` and `iii worker restart` commands, enabling configuration files to be passed to worker processes at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->