### PR TITLE
Include engine workers in worker listings

### DIFF
--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -3112,16 +3112,11 @@ pub async fn handle_worker_list() -> i32 {
     );
 
     for name in &config_names {
-        let worker_type = match super::config_file::resolve_worker_type(name) {
-            ResolvedWorkerType::Local { .. } => "local",
-            ResolvedWorkerType::Oci { .. } => "oci",
-            ResolvedWorkerType::Binary { .. } => "binary",
-            ResolvedWorkerType::Config => "config",
-        };
+        let worker_type = worker_list_type_label(name);
 
         let running = if is_worker_running(name) {
             "running".green().to_string()
-        } else if worker_type == "config" && engine_running {
+        } else if matches!(worker_type, "config" | "engine") && engine_running {
             "running".green().to_string()
         } else {
             "stopped".dimmed().to_string()
@@ -3152,6 +3147,16 @@ pub async fn handle_worker_list() -> i32 {
 
     eprintln!();
     0
+}
+
+fn worker_list_type_label(name: &str) -> &'static str {
+    match super::config_file::resolve_worker_type(name) {
+        ResolvedWorkerType::Local { .. } => "local",
+        ResolvedWorkerType::Oci { .. } => "oci",
+        ResolvedWorkerType::Binary { .. } => "binary",
+        ResolvedWorkerType::Config if is_any_builtin(name) => "engine",
+        ResolvedWorkerType::Config => "config",
+    }
 }
 
 /// Infers the TYPE label for an orphan worker from on-disk evidence alone.
@@ -3462,6 +3467,83 @@ mod tests {
     #[test]
     fn binary_config_yaml_omits_empty_registry_config() {
         assert_eq!(binary_config_yaml(&serde_json::json!({})), None);
+    }
+
+    #[test]
+    fn worker_list_type_label_marks_configured_builtin_as_engine() {
+        in_temp_dir(|dir| {
+            let _env_guard = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let home = dir.join("home");
+            std::fs::create_dir_all(&home).unwrap();
+            let _home_guard = set_env_var_for_test("HOME", &home);
+            std::fs::write(
+                "config.yaml",
+                "\
+workers:
+  - name: iii-stream
+    config:
+      port: 3112
+",
+            )
+            .unwrap();
+
+            assert_eq!(worker_list_type_label("iii-stream"), "engine");
+        });
+    }
+
+    #[test]
+    fn worker_list_type_label_keeps_non_builtin_config_as_config() {
+        in_temp_dir(|dir| {
+            let _env_guard = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let home = dir.join("home");
+            std::fs::create_dir_all(&home).unwrap();
+            let _home_guard = set_env_var_for_test("HOME", &home);
+            std::fs::write(
+                "config.yaml",
+                "\
+workers:
+  - name: custom-config-only
+    config:
+      enabled: true
+",
+            )
+            .unwrap();
+
+            assert_eq!(worker_list_type_label("custom-config-only"), "config");
+        });
+    }
+
+    #[test]
+    fn worker_list_type_label_preserves_local_oci_and_binary_labels() {
+        in_temp_dir(|dir| {
+            let _env_guard = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let home = dir.join("home");
+            let workers_dir = home.join(".iii/workers");
+            std::fs::create_dir_all(&workers_dir).unwrap();
+            let _home_guard = set_env_var_for_test("HOME", &home);
+            std::fs::write(
+                "config.yaml",
+                "\
+workers:
+  - name: local-dev
+    worker_path: ./worker
+  - name: external-image
+    image: ghcr.io/acme/external:1
+",
+            )
+            .unwrap();
+            std::fs::write(workers_dir.join("downloaded-worker"), "#!/bin/sh\n").unwrap();
+
+            assert_eq!(worker_list_type_label("local-dev"), "local");
+            assert_eq!(worker_list_type_label("external-image"), "oci");
+            assert_eq!(worker_list_type_label("downloaded-worker"), "binary");
+        });
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -3150,7 +3150,11 @@ pub async fn handle_worker_list() -> i32 {
 }
 
 fn worker_list_type_label(name: &str) -> &'static str {
-    match super::config_file::resolve_worker_type(name) {
+    worker_list_type_label_from_resolved(name, super::config_file::resolve_worker_type(name))
+}
+
+fn worker_list_type_label_from_resolved(name: &str, resolved: ResolvedWorkerType) -> &'static str {
+    match resolved {
         ResolvedWorkerType::Local { .. } => "local",
         ResolvedWorkerType::Oci { .. } => "oci",
         ResolvedWorkerType::Binary { .. } => "binary",
@@ -3471,79 +3475,50 @@ mod tests {
 
     #[test]
     fn worker_list_type_label_marks_configured_builtin_as_engine() {
-        in_temp_dir(|dir| {
-            let _env_guard = crate::TEST_ENV_LOCK
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            let home = dir.join("home");
-            std::fs::create_dir_all(&home).unwrap();
-            let _home_guard = set_env_var_for_test("HOME", &home);
-            std::fs::write(
-                "config.yaml",
-                "\
-workers:
-  - name: iii-stream
-    config:
-      port: 3112
-",
-            )
-            .unwrap();
-
-            assert_eq!(worker_list_type_label("iii-stream"), "engine");
-        });
+        assert_eq!(
+            worker_list_type_label_from_resolved("iii-stream", ResolvedWorkerType::Config),
+            "engine"
+        );
     }
 
     #[test]
     fn worker_list_type_label_keeps_non_builtin_config_as_config() {
-        in_temp_dir(|dir| {
-            let _env_guard = crate::TEST_ENV_LOCK
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            let home = dir.join("home");
-            std::fs::create_dir_all(&home).unwrap();
-            let _home_guard = set_env_var_for_test("HOME", &home);
-            std::fs::write(
-                "config.yaml",
-                "\
-workers:
-  - name: custom-config-only
-    config:
-      enabled: true
-",
-            )
-            .unwrap();
-
-            assert_eq!(worker_list_type_label("custom-config-only"), "config");
-        });
+        assert_eq!(
+            worker_list_type_label_from_resolved("custom-config-only", ResolvedWorkerType::Config),
+            "config"
+        );
     }
 
     #[test]
     fn worker_list_type_label_preserves_local_oci_and_binary_labels() {
-        in_temp_dir(|dir| {
-            let _env_guard = crate::TEST_ENV_LOCK
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            let home = dir.join("home");
-            let workers_dir = home.join(".iii/workers");
-            std::fs::create_dir_all(&workers_dir).unwrap();
-            let _home_guard = set_env_var_for_test("HOME", &home);
-            std::fs::write(
-                "config.yaml",
-                "\
-workers:
-  - name: local-dev
-    worker_path: ./worker
-  - name: external-image
-    image: ghcr.io/acme/external:1
-",
-            )
-            .unwrap();
-            std::fs::write(workers_dir.join("downloaded-worker"), "#!/bin/sh\n").unwrap();
-
-            assert_eq!(worker_list_type_label("local-dev"), "local");
-            assert_eq!(worker_list_type_label("external-image"), "oci");
-            assert_eq!(worker_list_type_label("downloaded-worker"), "binary");
-        });
+        assert_eq!(
+            worker_list_type_label_from_resolved(
+                "local-dev",
+                ResolvedWorkerType::Local {
+                    worker_path: "./worker".to_string(),
+                },
+            ),
+            "local"
+        );
+        assert_eq!(
+            worker_list_type_label_from_resolved(
+                "external-image",
+                ResolvedWorkerType::Oci {
+                    image: "ghcr.io/acme/external:1".to_string(),
+                    env: std::collections::HashMap::new(),
+                },
+            ),
+            "oci"
+        );
+        assert_eq!(
+            worker_list_type_label_from_resolved(
+                "downloaded-worker",
+                ResolvedWorkerType::Binary {
+                    binary_path: std::path::PathBuf::from("/tmp/downloaded-worker"),
+                },
+            ),
+            "binary"
+        );
     }
 
     #[test]

--- a/docs/how-to/use-functions-and-triggers.mdx
+++ b/docs/how-to/use-functions-and-triggers.mdx
@@ -845,10 +845,12 @@ The engine built-ins are mandatory and always loaded.
 | Function | Purpose | Parameters |
 |----------|---------|------------|
 | `engine::functions::list` | List all registered functions | `include_internal` (optional, default: `false`) |
-| `engine::workers::list` | List all workers with metrics | `worker_id` (optional) |
+| `engine::workers::list` | List connected SDK workers and in-process engine workers with metrics where available | `worker_id` (optional) |
 | `engine::triggers::list` | List all triggers | `include_internal` (optional, default: `false`) |
 | `engine::workers::register` | Register worker metadata (internal worker call) | `_caller_worker_id`, `runtime` (optional), `version` (optional), `name` (optional), `os` (optional), `telemetry` (optional) |
 | `engine::channels::create` | Create a streaming channel pair | `buffer_size` (optional) |
+
+Built-in engine workers such as `iii-stream` and `iii-state` are included in worker list results. Rows with `internal: true` are mandatory engine internals and can be hidden in user-facing views.
 
 ### Observability
 

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -30,7 +30,7 @@ use crate::{
         inject_baggage_from_context, inject_traceparent_from_context,
     },
     trigger::{Trigger, TriggerRegistry, TriggerType},
-    worker_connections::{WorkerConnection, WorkerConnectionRegistry},
+    worker_connections::{RuntimeWorkerInfo, WorkerConnection, WorkerConnectionRegistry},
     workers::worker::rbac_session::Session,
     workers::{
         engine_fn::TRIGGER_WORKERS_AVAILABLE,
@@ -228,6 +228,7 @@ pub trait EngineTrait: Send + Sync {
 #[derive(Clone)]
 pub struct Engine {
     pub worker_registry: Arc<WorkerConnectionRegistry>,
+    pub runtime_workers: Arc<DashMap<String, RuntimeWorkerInfo>>,
     pub functions: Arc<FunctionsRegistry>,
     pub trigger_registry: Arc<TriggerRegistry>,
     pub service_registry: Arc<ServicesRegistry>,
@@ -276,6 +277,7 @@ impl Engine {
         let active_scope = Arc::new(std::sync::Mutex::new(None));
         Self {
             worker_registry: Arc::new(WorkerConnectionRegistry::new()),
+            runtime_workers: Arc::new(DashMap::new()),
             functions: Arc::new(FunctionsRegistry::with_scope(active_scope.clone())),
             trigger_registry: Arc::new(TriggerRegistry::new()),
             service_registry: Arc::new(ServicesRegistry::new()),
@@ -310,6 +312,21 @@ impl Engine {
     /// drift mid-lifetime.
     pub fn set_worker_manager_port(&self, port: u16) {
         let _ = self.worker_manager_port.set(port);
+    }
+
+    pub fn upsert_runtime_worker(&self, worker: RuntimeWorkerInfo) {
+        self.runtime_workers.insert(worker.id.clone(), worker);
+    }
+
+    pub fn remove_runtime_worker(&self, worker_id: &str) {
+        self.runtime_workers.remove(worker_id);
+    }
+
+    pub fn list_runtime_workers(&self) -> Vec<RuntimeWorkerInfo> {
+        self.runtime_workers
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect()
     }
 
     /// Opens a scope so that registrations made between here and
@@ -1862,6 +1879,26 @@ mod tests {
         {
             Err(serde::ser::Error::custom("serialization exploded"))
         }
+    }
+
+    #[test]
+    fn runtime_worker_registry_upserts_lists_and_removes() {
+        let engine = Engine::new();
+        engine.upsert_runtime_worker(crate::worker_connections::RuntimeWorkerInfo {
+            id: "iii-state".to_string(),
+            name: "iii-state".to_string(),
+            worker_type: "iii-state".to_string(),
+            connected_at: chrono::Utc::now(),
+            function_ids: vec!["state::get".to_string()],
+            internal: false,
+        });
+
+        let workers = engine.list_runtime_workers();
+        assert_eq!(workers.len(), 1);
+        assert_eq!(workers[0].id, "iii-state");
+
+        engine.remove_runtime_worker("iii-state");
+        assert!(engine.list_runtime_workers().is_empty());
     }
 
     #[tokio::test]

--- a/engine/src/worker_connections/mod.rs
+++ b/engine/src/worker_connections/mod.rs
@@ -29,6 +29,16 @@ pub struct WorkerConnectionTelemetryMeta {
     pub framework: Option<String>,
 }
 
+#[derive(Clone, Debug)]
+pub struct RuntimeWorkerInfo {
+    pub id: String,
+    pub name: String,
+    pub worker_type: String,
+    pub connected_at: DateTime<Utc>,
+    pub function_ids: Vec<String>,
+    pub internal: bool,
+}
+
 impl std::fmt::Debug for WorkerConnectionTelemetryMeta {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WorkerConnectionTelemetryMeta")

--- a/engine/src/workers/config.rs
+++ b/engine/src/workers/config.rs
@@ -145,6 +145,62 @@ struct WorkerInfo {
     factory: WorkerFactory,
 }
 
+struct ExternalProcessWorker {
+    inner: Box<dyn Worker>,
+}
+
+impl ExternalProcessWorker {
+    fn new(inner: Box<dyn Worker>) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait::async_trait]
+impl Worker for ExternalProcessWorker {
+    fn name(&self) -> &'static str {
+        self.inner.name()
+    }
+
+    async fn create(_engine: Arc<Engine>, _config: Option<Value>) -> anyhow::Result<Box<dyn Worker>>
+    where
+        Self: Sized,
+    {
+        Err(anyhow::anyhow!(
+            "ExternalProcessWorker::create should not be called directly"
+        ))
+    }
+
+    async fn initialize(&self) -> anyhow::Result<()> {
+        self.inner.initialize().await
+    }
+
+    async fn start_background_tasks(
+        &self,
+        shutdown_rx: tokio::sync::watch::Receiver<bool>,
+        shutdown_tx: tokio::sync::watch::Sender<bool>,
+    ) -> anyhow::Result<()> {
+        self.inner
+            .start_background_tasks(shutdown_rx, shutdown_tx)
+            .await
+    }
+
+    async fn destroy(&self) -> anyhow::Result<()> {
+        self.inner.destroy().await
+    }
+
+    async fn is_alive(&self) -> bool {
+        self.inner.is_alive().await
+    }
+
+    fn is_external_process(&self) -> bool {
+        true
+    }
+
+    fn register_functions(&self, engine: Arc<Engine>) {
+        self.inner.register_functions(engine);
+    }
+}
+
 // =============================================================================
 // WorkerRegistry (unified registry for modules and adapters)
 // =============================================================================
@@ -242,7 +298,7 @@ impl WorkerRegistry {
                 info.binary_path.display()
             );
             let module = super::external::ExternalWorker::new(info, config);
-            return Ok(Box::new(module));
+            return Ok(Box::new(ExternalProcessWorker::new(Box::new(module))));
         }
 
         // 4. Delegate to iii-worker start (handles registry lookup, binary
@@ -318,6 +374,78 @@ pub fn assign_instance_ids(entries: &mut Vec<WorkerEntry>) {
             entry.name = format!("{}#{}", base, count);
         }
         *count += 1;
+    }
+}
+
+fn mandatory_worker_names() -> HashSet<&'static str> {
+    inventory::iter::<WorkerRegistration>
+        .into_iter()
+        .filter(|registration| registration.mandatory)
+        .map(|registration| registration.name)
+        .collect()
+}
+
+pub(crate) fn runtime_worker_info_from_registration(
+    entry: &WorkerEntry,
+    worker: &dyn Worker,
+    registrations: &super::reload::WorkerRegistrations,
+) -> Option<crate::worker_connections::RuntimeWorkerInfo> {
+    if worker.is_external_process() {
+        return None;
+    }
+
+    let worker_type = entry.worker_type().to_string();
+    let mut function_ids = registrations.function_ids.clone();
+    function_ids.sort();
+    function_ids.dedup();
+
+    Some(crate::worker_connections::RuntimeWorkerInfo {
+        id: entry.name.clone(),
+        name: worker_type.clone(),
+        worker_type: worker_type.clone(),
+        connected_at: chrono::Utc::now(),
+        function_ids,
+        internal: mandatory_worker_names().contains(worker_type.as_str()),
+    })
+}
+
+fn remove_runtime_worker_after_start_failure(engine: &Engine, rw: &super::reload::RunningWorker) {
+    engine.remove_runtime_worker(&rw.entry.name);
+}
+
+async fn destroy_running_workers(
+    engine: Arc<Engine>,
+    running: &[super::reload::RunningWorker],
+) -> anyhow::Result<()> {
+    let mut first_error = None;
+
+    for rw in running.iter() {
+        tracing::debug!("Destroying worker: {}", rw.worker.name());
+        let _ = rw.shutdown_tx.send(true);
+        let destroy_result = rw.worker.destroy().await;
+        engine.remove_worker_registrations(&rw.registrations);
+        engine.remove_runtime_worker(&rw.entry.name);
+
+        if let Err(err) = destroy_result {
+            tracing::error!(
+                worker = %rw.entry.name,
+                error = %err,
+                "Failed to destroy worker"
+            );
+            if first_error.is_none() {
+                first_error = Some(anyhow::anyhow!(
+                    "failed to destroy worker '{}': {}",
+                    rw.entry.name,
+                    err
+                ));
+            }
+        }
+    }
+
+    if let Some(err) = first_error {
+        Err(err)
+    } else {
+        Ok(())
     }
 }
 
@@ -514,6 +642,12 @@ impl EngineBuilder {
             let (shutdown_tx, _) = tokio::sync::watch::channel(false);
             let worker_arc: Arc<dyn Worker> = Arc::from(worker);
 
+            if let Some(runtime_worker) =
+                runtime_worker_info_from_registration(&entry, worker_arc.as_ref(), &registrations)
+            {
+                self.engine.upsert_runtime_worker(runtime_worker);
+            }
+
             self.running.push(super::reload::RunningWorker {
                 entry,
                 worker: worker_arc,
@@ -527,12 +661,7 @@ impl EngineBuilder {
 
     pub async fn destroy(self) -> anyhow::Result<()> {
         tracing::warn!("Shutting down engine and destroying workers");
-        for rw in self.running.iter() {
-            tracing::debug!("Destroying worker: {}", rw.worker.name());
-            let _ = rw.shutdown_tx.send(true);
-            rw.worker.destroy().await?;
-            self.engine.remove_worker_registrations(&rw.registrations);
-        }
+        destroy_running_workers(self.engine.clone(), &self.running).await?;
         tracing::warn!("Engine shutdown complete");
         Ok(())
     }
@@ -567,6 +696,7 @@ impl EngineBuilder {
                     error = %e,
                     "Failed to start background tasks for worker"
                 );
+                remove_runtime_worker_after_start_failure(engine.as_ref(), rw);
             }
         }
 
@@ -672,16 +802,13 @@ impl EngineBuilder {
         // Teardown -- inline version of the old `destroy()`. Operates on the
         // local `running` Vec directly so we don't have to reconstruct `self`.
         tracing::warn!("Shutting down engine and destroying workers");
-        for rw in running.iter() {
-            tracing::debug!("Destroying worker: {}", rw.worker.name());
-            let _ = rw.shutdown_tx.send(true);
-            rw.worker.destroy().await?;
-            engine.remove_worker_registrations(&rw.registrations);
-        }
+        let destroy_result = destroy_running_workers(engine.clone(), &running).await;
         tracing::warn!("Engine shutdown complete");
 
         // Drop `global_shutdown_tx` last so the relay task unblocks.
         drop(global_shutdown_tx);
+
+        destroy_result?;
 
         // If the shutdown was caused by a reload failure, propagate the error
         // so the process exits with a non-zero status code.
@@ -1577,6 +1704,236 @@ modules:
 
         builder.destroy().await.expect("destroy engine");
         assert_eq!(DESTROYED.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn engine_builder_tracks_in_process_runtime_workers() {
+        use async_trait::async_trait;
+
+        use crate::engine::{EngineTrait, Handler, RegisterFunctionRequest};
+
+        struct ListedWorker;
+
+        #[async_trait]
+        impl Worker for ListedWorker {
+            fn name(&self) -> &'static str {
+                "ListedWorker"
+            }
+
+            async fn create(
+                _engine: Arc<Engine>,
+                _config: Option<Value>,
+            ) -> anyhow::Result<Box<dyn Worker>> {
+                Ok(Box::new(ListedWorker))
+            }
+
+            async fn initialize(&self) -> anyhow::Result<()> {
+                Ok(())
+            }
+
+            fn register_functions(&self, engine: Arc<Engine>) {
+                engine.register_function_handler(
+                    RegisterFunctionRequest {
+                        function_id: "listed::fn".to_string(),
+                        description: None,
+                        request_format: None,
+                        response_format: None,
+                        metadata: None,
+                    },
+                    Handler::new(|_input| async { crate::function::FunctionResult::NoResult }),
+                );
+            }
+        }
+
+        let builder = EngineBuilder::new()
+            .register_worker::<ListedWorker>("test::Listed")
+            .add_worker("test::Listed", None)
+            .build()
+            .await
+            .expect("build engine");
+        let engine = builder.engine_handle();
+
+        let mut listed_workers = engine
+            .list_runtime_workers()
+            .into_iter()
+            .filter(|worker| worker.id == "test::Listed")
+            .collect::<Vec<_>>();
+        assert_eq!(
+            listed_workers.len(),
+            1,
+            "expected exactly one runtime snapshot for test::Listed"
+        );
+
+        let listed = listed_workers.pop().expect("listed worker snapshot");
+        assert_eq!(listed.name, "test::Listed");
+        assert_eq!(listed.worker_type, "test::Listed");
+        assert_eq!(listed.function_ids, vec!["listed::fn"]);
+        assert!(!listed.internal);
+
+        builder.destroy().await.expect("destroy engine");
+
+        assert!(
+            engine.list_runtime_workers().is_empty(),
+            "runtime snapshots should be removed on destroy"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_background_task_failure_removes_runtime_worker_snapshot() {
+        use async_trait::async_trait;
+
+        struct BackgroundStartFailsWorker;
+
+        #[async_trait]
+        impl Worker for BackgroundStartFailsWorker {
+            fn name(&self) -> &'static str {
+                "BackgroundStartFailsWorker"
+            }
+
+            async fn create(
+                _engine: Arc<Engine>,
+                _config: Option<Value>,
+            ) -> anyhow::Result<Box<dyn Worker>> {
+                Ok(Box::new(BackgroundStartFailsWorker))
+            }
+
+            async fn initialize(&self) -> anyhow::Result<()> {
+                Ok(())
+            }
+
+            async fn start_background_tasks(
+                &self,
+                _shutdown_rx: tokio::sync::watch::Receiver<bool>,
+                _shutdown_tx: tokio::sync::watch::Sender<bool>,
+            ) -> anyhow::Result<()> {
+                Err(anyhow::anyhow!("background start failed"))
+            }
+        }
+
+        let builder = EngineBuilder::new()
+            .register_worker::<BackgroundStartFailsWorker>("test::BackgroundStartFails")
+            .add_worker("test::BackgroundStartFails", None)
+            .build()
+            .await
+            .expect("build engine");
+        let engine = builder.engine_handle();
+        assert!(
+            engine
+                .list_runtime_workers()
+                .iter()
+                .any(|worker| worker.id == "test::BackgroundStartFails"),
+            "runtime snapshot should exist after build"
+        );
+
+        let rw = builder
+            .running()
+            .iter()
+            .find(|rw| rw.entry.name == "test::BackgroundStartFails")
+            .expect("running worker");
+        let (global_shutdown_tx, _) = tokio::sync::watch::channel(false);
+        rw.worker
+            .start_background_tasks(rw.shutdown_tx.subscribe(), global_shutdown_tx)
+            .await
+            .expect_err("background start should fail");
+        remove_runtime_worker_after_start_failure(engine.as_ref(), rw);
+
+        assert!(
+            engine
+                .list_runtime_workers()
+                .iter()
+                .all(|worker| worker.id != "test::BackgroundStartFails"),
+            "runtime snapshot should be removed after background start failure"
+        );
+
+        builder.destroy().await.expect("destroy engine");
+    }
+
+    #[tokio::test]
+    async fn destroy_continues_cleanup_after_worker_destroy_failure() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use async_trait::async_trait;
+
+        static FAILING_DESTROYS: AtomicUsize = AtomicUsize::new(0);
+        static SUCCESSFUL_DESTROYS: AtomicUsize = AtomicUsize::new(0);
+
+        struct DestroyFailsWorker;
+        struct DestroySucceedsWorker;
+
+        #[async_trait]
+        impl Worker for DestroyFailsWorker {
+            fn name(&self) -> &'static str {
+                "DestroyFailsWorker"
+            }
+
+            async fn create(
+                _engine: Arc<Engine>,
+                _config: Option<Value>,
+            ) -> anyhow::Result<Box<dyn Worker>> {
+                Ok(Box::new(DestroyFailsWorker))
+            }
+
+            async fn initialize(&self) -> anyhow::Result<()> {
+                Ok(())
+            }
+
+            async fn destroy(&self) -> anyhow::Result<()> {
+                FAILING_DESTROYS.fetch_add(1, Ordering::SeqCst);
+                Err(anyhow::anyhow!("destroy failed"))
+            }
+        }
+
+        #[async_trait]
+        impl Worker for DestroySucceedsWorker {
+            fn name(&self) -> &'static str {
+                "DestroySucceedsWorker"
+            }
+
+            async fn create(
+                _engine: Arc<Engine>,
+                _config: Option<Value>,
+            ) -> anyhow::Result<Box<dyn Worker>> {
+                Ok(Box::new(DestroySucceedsWorker))
+            }
+
+            async fn initialize(&self) -> anyhow::Result<()> {
+                Ok(())
+            }
+
+            async fn destroy(&self) -> anyhow::Result<()> {
+                SUCCESSFUL_DESTROYS.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        FAILING_DESTROYS.store(0, Ordering::SeqCst);
+        SUCCESSFUL_DESTROYS.store(0, Ordering::SeqCst);
+
+        let builder = EngineBuilder::new()
+            .register_worker::<DestroyFailsWorker>("test::DestroyFails")
+            .register_worker::<DestroySucceedsWorker>("test::DestroySucceeds")
+            .add_worker("test::DestroyFails", None)
+            .add_worker("test::DestroySucceeds", None)
+            .build()
+            .await
+            .expect("build engine");
+        let engine = builder.engine_handle();
+
+        let err = builder
+            .destroy()
+            .await
+            .expect_err("destroy should return the first worker destroy error");
+        let message = err.to_string();
+        assert!(
+            message.contains("test::DestroyFails"),
+            "destroy error should include worker context, got: {message}"
+        );
+        assert_eq!(FAILING_DESTROYS.load(Ordering::SeqCst), 1);
+        assert_eq!(SUCCESSFUL_DESTROYS.load(Ordering::SeqCst), 1);
+        assert!(
+            engine.list_runtime_workers().is_empty(),
+            "all runtime snapshots should be removed even after a destroy failure"
+        );
     }
 
     #[tokio::test]

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -87,6 +87,8 @@ pub struct WorkerInfo {
     pub version: Option<String>,
     pub os: Option<String>,
     pub ip_address: Option<String>,
+    #[serde(default)]
+    pub internal: bool,
     pub status: String,
     pub connected_at_ms: u64,
     pub function_count: usize,
@@ -278,6 +280,7 @@ impl EngineFunctionsWorker {
                 version: w.version.clone(),
                 os: w.os.clone(),
                 ip_address,
+                internal: false,
                 status: w.status.as_str().to_string(),
                 connected_at_ms: w.connected_at.timestamp_millis() as u64,
                 function_count,
@@ -288,6 +291,43 @@ impl EngineFunctionsWorker {
                 isolation: w.isolation.clone(),
             });
         }
+
+        for runtime_worker in self.engine.list_runtime_workers() {
+            if let Some(filter_id) = filter_worker_id
+                && runtime_worker.id != filter_id
+            {
+                continue;
+            }
+
+            let functions = runtime_worker.function_ids.clone();
+            worker_infos.push(WorkerInfo {
+                id: runtime_worker.id,
+                name: Some(runtime_worker.name),
+                runtime: Some("engine".to_string()),
+                version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                os: None,
+                ip_address: None,
+                internal: runtime_worker.internal,
+                status: "available".to_string(),
+                connected_at_ms: runtime_worker.connected_at.timestamp_millis() as u64,
+                function_count: functions.len(),
+                functions,
+                active_invocations: 0,
+                latest_metrics: None,
+                pid: None,
+                isolation: Some("in-process".to_string()),
+            });
+        }
+
+        worker_infos.sort_by(|a, b| {
+            let a_display_name = a.name.as_deref().unwrap_or(a.id.as_str());
+            let b_display_name = b.name.as_deref().unwrap_or(b.id.as_str());
+
+            a_display_name
+                .cmp(b_display_name)
+                .then_with(|| a.id.cmp(&b.id))
+        });
+
         worker_infos
     }
 

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -795,6 +795,57 @@ mod tests {
         assert_eq!(direct.len(), 1);
     }
 
+    #[tokio::test]
+    async fn test_list_worker_infos_includes_runtime_worker_snapshots() {
+        let (engine, module) = setup_engine_and_module();
+
+        engine.upsert_runtime_worker(crate::worker_connections::RuntimeWorkerInfo {
+            id: "iii-state".to_string(),
+            name: "iii-state".to_string(),
+            worker_type: "iii-state".to_string(),
+            connected_at: chrono::Utc::now(),
+            function_ids: vec!["state::get".to_string(), "state::set".to_string()],
+            internal: false,
+        });
+
+        let workers = module.list_worker_infos(None).await;
+
+        assert_eq!(workers.len(), 1);
+        assert_eq!(workers[0].id, "iii-state");
+        assert_eq!(workers[0].name.as_deref(), Some("iii-state"));
+        assert_eq!(workers[0].runtime.as_deref(), Some("engine"));
+        assert_eq!(workers[0].isolation.as_deref(), Some("in-process"));
+        assert_eq!(workers[0].status, "available");
+        assert_eq!(workers[0].function_count, 2);
+        assert_eq!(
+            workers[0].functions,
+            vec!["state::get".to_string(), "state::set".to_string()]
+        );
+        assert!(!workers[0].internal);
+    }
+
+    #[tokio::test]
+    async fn test_list_worker_infos_hides_pidless_socket_but_shows_runtime_snapshot() {
+        let (engine, module) = setup_engine_and_module();
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let socket_worker = crate::worker_connections::WorkerConnection::new(tx);
+        engine.worker_registry.register_worker(socket_worker);
+
+        engine.upsert_runtime_worker(crate::worker_connections::RuntimeWorkerInfo {
+            id: "iii-stream".to_string(),
+            name: "iii-stream".to_string(),
+            worker_type: "iii-stream".to_string(),
+            connected_at: chrono::Utc::now(),
+            function_ids: vec!["stream::list".to_string()],
+            internal: false,
+        });
+
+        let workers = module.list_worker_infos(None).await;
+
+        assert_eq!(workers.len(), 1);
+        assert_eq!(workers[0].id, "iii-stream");
+    }
+
     // ---- register_worker_metadata tests ----
 
     #[tokio::test]

--- a/engine/src/workers/registry_worker.rs
+++ b/engine/src/workers/registry_worker.rs
@@ -438,6 +438,10 @@ impl Worker for ExternalWorkerWrapper {
         self.process.is_alive()
     }
 
+    fn is_external_process(&self) -> bool {
+        true
+    }
+
     fn register_functions(&self, _engine: Arc<Engine>) {
         // External workers register their own functions via the bridge protocol
     }

--- a/engine/src/workers/reload.rs
+++ b/engine/src/workers/reload.rs
@@ -15,7 +15,10 @@ use std::sync::Arc;
 
 use tokio::sync::watch;
 
-use super::config::{EngineConfig, WorkerEntry, WorkerRegistry, assign_instance_ids};
+use super::config::{
+    EngineConfig, WorkerEntry, WorkerRegistry, assign_instance_ids,
+    runtime_worker_info_from_registration,
+};
 use super::registry::WorkerRegistration;
 use super::traits::Worker;
 use crate::engine::Engine;
@@ -238,6 +241,7 @@ impl ReloadManager {
                     );
                 }
                 engine.remove_worker_registrations(&old.registrations);
+                engine.remove_runtime_worker(&old.entry.name);
             }
 
             let rw =
@@ -259,6 +263,7 @@ impl ReloadManager {
                     );
                 }
                 engine.remove_worker_registrations(&removed.registrations);
+                engine.remove_runtime_worker(&removed.entry.name);
             }
         }
 
@@ -312,6 +317,12 @@ impl ReloadManager {
         engine.begin_worker_scope(&entry.name);
         worker_arc.register_functions(engine.clone());
         let registrations = engine.end_worker_scope();
+
+        if let Some(runtime_worker) =
+            runtime_worker_info_from_registration(entry, worker_arc.as_ref(), &registrations)
+        {
+            engine.upsert_runtime_worker(runtime_worker);
+        }
 
         Ok(RunningWorker {
             entry: entry.clone(),

--- a/engine/src/workers/traits.rs
+++ b/engine/src/workers/traits.rs
@@ -86,6 +86,10 @@ pub trait Worker: Send + Sync {
         true
     }
 
+    fn is_external_process(&self) -> bool {
+        false
+    }
+
     /// Registers functions to the engine
     #[allow(unused_variables)]
     fn register_functions(&self, engine: Arc<Engine>) {


### PR DESCRIPTION
## Summary

This change makes worker listings include both connected SDK workers and in-process engine workers. Built-in engine workers are now tracked through the engine lifecycle and merged into the canonical worker list response, while transient WebSocket entries without process metadata remain filtered out.

It also updates `iii worker list` so configured built-in workers are labeled as `engine` instead of the generic `config` label.

## Before and after

### `iii worker list`

Before:

```text
NAME                      TYPE       STATUS
----                      ----       ------
iii-stream                config     running
iii-state                 config     running
```

After:

```text
NAME                      TYPE       STATUS
----                      ----       ------
iii-stream                engine     running
iii-state                 engine     running
```

### `engine::workers::list`

Before:

```json
{
  "workers": [
    "connected SDK workers only; in-process built-ins such as iii-stream and iii-state were absent"
  ]
}
```

After:

```json
{
  "workers": [
    {
      "id": "iii-stream",
      "name": "iii-stream",
      "runtime": "engine",
      "isolation": "in-process",
      "status": "available",
      "internal": false
    },
    {
      "id": "iii-state",
      "name": "iii-state",
      "runtime": "engine",
      "isolation": "in-process",
      "status": "available",
      "internal": false
    }
  ]
}
```

Mandatory engine internals are also represented with `internal: true`, so user-facing views can hide them when needed.

## Validation

Passed:

```bash
cargo fmt --all
cargo fmt --all -- --check
cargo test -p iii workers::engine_fn -- --nocapture
cargo test -p iii workers::config -- --nocapture
cargo test -p iii-worker worker_list_type_label -- --nocapture
cargo test -p iii-worker --test worker_list_discovery_integration -- --nocapture
git diff --check
```

Additional notes:

- `pnpm fmt:check` currently fails before formatting due existing nested Biome root configuration errors and missing `node_modules`.
- Broad `cargo test -p iii` reaches RabbitMQ integration tests that require healthy RabbitMQ test infrastructure; targeted engine suites passed.
- Broad `cargo test -p iii-worker` still exposes an existing parallel global environment flake in `cli::rootfs_cache::tests::canonical_path_is_slug_based_and_stable`; the same test passes serially with `--test-threads=1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Built-in engine workers (e.g., `iii-stream`, `iii-state`) now appear in worker list outputs with runtime status tracking.
  * Worker list operations now include in-process engine workers alongside connected SDK workers.

* **Documentation**
  * Clarified that worker list results include both connected SDK workers and in-process engine workers, with metrics reported where available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->