### PR TITLE
docs(console): extract how-to content from reference, reduce duplication

### DIFF
--- a/docs/console/index.mdx
+++ b/docs/console/index.mdx
@@ -13,29 +13,15 @@ graph LR
     B[Browser] -->|HTTP :3113| C
 ```
 
-## Installation
-
-Install the console binary:
-
-```bash
-curl -fsSL https://install.iii.dev/console/main/install.sh | sh
-```
-
-Verify the installation:
-
-```bash
-iii-console --help
-```
-
 ## Quick Start
 
-Start the console while your iii engine is running:
+The console comes preinstalled with iii, start it with:
 
 ```bash
-iii-console
+iii console
 ```
 
-Then open your browser to [http://localhost:3113](http://localhost:3113).
+Then open your browser to [http://127.0.0.1:3113](http://127.0.0.1:3113).
 
 <Warning title="Engine must be running">
   The console connects to a running iii engine instance. Make sure your engine is started before launching the console.
@@ -61,7 +47,7 @@ The Workers page lists every worker process currently connected to the engine, w
 | Active     | Number of currently in-flight invocations                                |
 | Connected  | Time since the worker connected                                         |
 
-Click a worker to open a detail panel showing full metadata, telemetry (language, project, framework), live metrics, and the list of functions the worker has registered.
+The worker detail panel shows full metadata, telemetry (language, project, framework), live metrics, and the list of functions the worker has registered.
 
 <img src="/assets/console-workers-detail.png" alt="iii Console Workers page with a selected worker detail panel showing runtime, version, OS, metrics, and registered functions" />
 
@@ -88,28 +74,11 @@ Use the **search bar** at the top to filter functions by name.
 
 ### Invoking Functions
 
-You can invoke any function directly from the console:
+The detail panel includes a JSON editor for invoking functions directly. Enter a payload, click **Invoke**, and view the result inline. The console sends requests via `POST /_console/invoke`.
 
-1. Click on a function to open its detail panel
-2. Enter a JSON payload in the input editor
-3. Click **Invoke**
-4. View the result or error in real time
-
-This is useful for:
-
-- **Testing** a function during development without wiring up a trigger
-- **Debugging** by sending specific payloads to reproduce an issue
-- **Ad-hoc operations** like running a migration function manually
-
-For example, to invoke a function `users::getProfile`:
-
-```json
-{
-  "user_id": "user-123"
-}
-```
-
-The console sends the payload to the engine via `POST /_console/invoke` and displays the JSON response or error inline.
+<Info title="How-to guide">
+  See [Use the Console](/how-to/use-console#invoke-a-function) for step-by-step instructions.
+</Info>
 
 <Info title="Function must be registered">
   Only functions that are currently registered and connected via an active worker will appear in the list. If a function is missing, check that its worker process is running.
@@ -117,7 +86,7 @@ The console sends the payload to the engine via `POST /_console/invoke` and disp
 
 ## Triggers
 
-The Triggers page shows every trigger registered with the engine and provides interactive tools to test each trigger type. Triggers are grouped by kind (HTTP, CRON, QUEUE) with a total count badge and per-type filter tabs.
+The Triggers page shows every trigger registered with the engine and provides interactive tools to test each trigger type. Triggers are grouped by kind (`http`, `cron`, `event`, `state`) with a total count badge and per-type filter tabs.
 
 <img src="/assets/console-triggers-http-test.png" alt="iii Console Triggers page showing HTTP triggers and the request builder for testing a selected endpoint" />
 
@@ -128,32 +97,19 @@ The Triggers page shows every trigger registered with the engine and provides in
 | Path / Config | HTTP path, cron schedule, or event name                 |
 | Status       | Active, Error, or Inactive                               |
 
-### Testing HTTP Triggers
+### Testing Triggers
 
-For HTTP-type triggers, the console provides a built-in request builder:
+The console provides interactive testing tools for each trigger type:
 
-1. Select the **HTTP method** (GET, POST, PUT, DELETE, PATCH)
-2. The **path** is pre-filled from the trigger configuration
-3. Add **query parameters** as key-value pairs
-4. Enter a **request body** (for POST/PUT/PATCH) as JSON
-5. Click **Send** to execute the request
+| Trigger Type | Testing Tool |
+|--------------|--------------|
+| HTTP | Request builder with method selection, query params, and JSON body |
+| Cron | Schedule viewer with **Trigger Now** button for immediate execution |
+| Event | Event emitter with pre-filled event name and JSON payload input |
 
-The response is displayed inline with status code, headers, and body. For example, for a trigger registered at `POST /api/users`:
-
-```json
-{
-  "name": "Alice",
-  "email": "alice@example.com"
-}
-```
-
-### Testing Cron Triggers
-
-Cron triggers display their schedule expression (e.g. `0 */5 * * * * *`). You can view the configured schedule and click **Trigger Now** to manually fire the cron job immediately. This is useful for testing scheduled tasks without waiting for the next scheduled run.
-
-### Testing Event Triggers
-
-For event-type triggers, the console provides an event emitter: the event name is pre-filled, you enter a JSON payload, and click **Emit** to publish the event.
+<Info title="How-to guide">
+  See [Use the Console](/how-to/use-console#test-an-http-trigger) for step-by-step instructions on testing each trigger type.
+</Info>
 
 <Info title="Trigger types">
   The available trigger types depend on which workers are loaded in your engine configuration. See [Trigger Types](/architecture/trigger-types) and [Workers](/workers) for the full list.
@@ -174,9 +130,17 @@ Select a group from the left panel to see all its key-value items. Each item sho
 
 ### Managing State
 
-- **Add** — Click **Add Item**, enter the scope, key, and JSON value, then save. Persisted via `state::set`.
-- **Edit** — Click an existing item, modify the JSON value, and save. Fires `state:updated` triggers if registered.
-- **Delete** — Click the delete icon and confirm. Fires `state:deleted` triggers if registered.
+The console supports full CRUD operations on state entries:
+
+| Operation | Behavior |
+|-----------|----------|
+| Add | Persisted via `state::set` |
+| Edit | Fires `state:updated` triggers if registered |
+| Delete | Fires `state:deleted` triggers if registered |
+
+<Info title="How-to guide">
+  See [Use the Console](/how-to/use-console#manage-state-entries) for step-by-step instructions.
+</Info>
 
 <Info title="State persistence">
   State persistence depends on your engine's State worker configuration. With `in_memory` storage, state is lost on engine restart. With `file_based` or `RedisAdapter`, state persists across restarts. See [State Worker](/workers/iii-state) for configuration details.
@@ -215,7 +179,16 @@ The Queues page lists durable queue topics, subscriber counts, queued message co
 | Retries     | Messages scheduled for retry                     |
 | Dead Letters | Messages that exhausted retry handling          |
 
-Click a topic to open the detail panel. The **Overview** tab shows live topic stats and includes a JSON publisher for sending a test message. The **Dead Letters** tab shows failed messages for that topic and supports retrying or deleting individual entries.
+The topic detail panel has two tabs:
+
+| Tab | Content |
+|-----|---------|
+| Overview | Live topic stats and a JSON publisher for sending test messages |
+| Dead Letters | Failed messages with retry and delete options |
+
+<Info title="How-to guide">
+  See [Use the Console](/how-to/use-console#send-a-test-message-to-a-queue) for step-by-step instructions on testing queues and managing dead letters.
+</Info>
 
 ## Traces
 
@@ -241,13 +214,15 @@ The Traces page provides full OpenTelemetry trace visualization with multiple vi
 
 ### View Modes
 
-Click on a trace to open the detail view with four visualization modes:
+The trace detail view provides five visualization modes:
 
-- **Waterfall Chart** — Timeline view showing every span laid out horizontally by start time and duration. This is the default view and is best for understanding the sequential and parallel flow of operations.
-- **Flame Graph** — Stack-based visualization where each span is stacked on its parent. Wider bars indicate longer duration. Useful for identifying which operations consume the most time.
-- **Service Breakdown** — Groups spans by service name with aggregate statistics: total spans, average duration, and error rate. Useful for identifying which service is the bottleneck.
-- **Trace Map** — Topology graph showing how services communicate. Nodes represent services and edges represent span parent-child relationships across service boundaries. Useful for understanding distributed call patterns.
-- **Flow** — Node-based execution flow showing parent-child span relationships in the selected trace.
+| Mode | Description |
+|------|-------------|
+| Waterfall Chart | Timeline view with spans laid out by start time and duration. Default view for sequential/parallel flow analysis. |
+| Flame Graph | Stack-based view where each span is stacked on its parent. Wider bars indicate longer duration. |
+| Service Breakdown | Aggregate statistics grouped by service: total spans, average duration, error rate. |
+| Trace Map | Topology graph showing service communication via parent-child span relationships. |
+| Flow | Node-based execution flow showing parent-child span relationships. |
 
 <img src="/assets/console-traces-flame-graph.png" alt="iii Console Traces page showing the flame graph view for a selected trace" />
 
@@ -257,7 +232,7 @@ Click on a trace to open the detail view with four visualization modes:
 
 ### Span Details
 
-Click on any span to open the detail panel:
+The span detail panel includes the following tabs:
 
 | Tab       | Content                                             |
 |-----------|-----------------------------------------------------|
@@ -281,6 +256,10 @@ Click on any span to open the detail panel:
 
 Multiple filters are combined with AND logic. Pagination controls at the bottom allow browsing large result sets.
 
+<Info title="How-to guide">
+  See [Use the Console](/how-to/use-console#inspect-a-trace) for step-by-step instructions on inspecting traces and spans.
+</Info>
+
 ## Logs
 
 The Logs page provides a viewer for structured OpenTelemetry logs collected by the engine. Logs are displayed in reverse chronological order. Each entry shows a timestamp, severity level, service name, trace/span context, and message. A severity filter toggle, full-text search, and time-range controls let you zero in on specific log entries. The source breakdown at the bottom shows which services are contributing the most log volume.
@@ -289,6 +268,10 @@ The Logs page provides a viewer for structured OpenTelemetry logs collected by t
 
 <Info title="Observability worker required">
   Log collection requires the Observability worker with `logs_enabled: true`. See [Observability Worker](/workers/iii-observability) for configuration.
+</Info>
+
+<Info title="Console vs console output">
+  The iii Console (this web UI) is separate from the engine's `logs_console_output` setting. The `logs_console_output` option controls whether OTLP logs are also printed to the engine process's stdout — it does not affect the Logs page here.
 </Info>
 
 ### Log Viewer
@@ -300,7 +283,7 @@ The Logs page provides a viewer for structured OpenTelemetry logs collected by t
 | Service   | The service that produced the log          |
 | Message   | The log body/message content               |
 
-Click on a log entry to expand and see the full JSON payload, including attributes, trace/span IDs, and resource metadata.
+Expanding a log entry reveals the full JSON payload, including attributes, trace/span IDs, and resource metadata.
 
 ### Log Filtering
 
@@ -354,11 +337,11 @@ The flow diagram uses an auto-layout algorithm (Dagre) to arrange nodes and edge
 
 Edges show the data flow direction between components — from triggers to the functions they invoke, and from functions to the state or queues they interact with.
 
-- **Pan and zoom** — scroll to zoom, drag to pan
-- **Click a node** — view its details (function ID, trigger config, etc.)
-- **Auto-layout** — the graph arranges itself automatically using a directed-graph layout
+The graph uses auto-layout (Dagre) and supports pan, zoom, and node inspection. Layout configuration is saved to the engine's state store and restored on next visit.
 
-Layout configuration is saved to the engine's state store and restored on next visit.
+<Info title="How-to guide">
+  See [Use the Console](/how-to/use-console#navigate-the-flow-graph) for navigation instructions.
+</Info>
 
 ## Configuration
 

--- a/docs/console/index.mdx
+++ b/docs/console/index.mdx
@@ -106,7 +106,7 @@ The console provides interactive testing tools for each trigger type:
 | HTTP | Request builder with method selection, query params, and JSON body |
 | Cron | Schedule viewer with **Trigger Now** button for immediate execution |
 | Event | Event emitter with pre-filled event name and JSON payload input |
-
+| State | Update/delete entries in **States** to fire `state:updated` / `state:deleted` triggers |
 <Info title="How-to guide">
   See [Use the Console](/how-to/use-console#test-an-http-trigger) for step-by-step instructions on testing each trigger type.
 </Info>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -103,15 +103,15 @@
                       "how-to/developing-sandbox-workers"
                     ]
                   },
+                  {
+                    "group": "Console & Observability",
+                    "pages": ["how-to/use-console", "how-to/observability-and-logs"]
+                  },
                   "how-to/use-iii-in-the-browser",
                   "how-to/configure-engine",
-                  "how-to/observability-and-logs",
                   {
                     "group": "HTTP",
-                    "pages": [
-                      "how-to/expose-http-endpoint",
-                      "how-to/use-http-middleware"
-                    ]
+                    "pages": ["how-to/expose-http-endpoint", "how-to/use-http-middleware"]
                   },
                   {
                     "group": "Queues",

--- a/docs/how-to/observability-and-logs.mdx
+++ b/docs/how-to/observability-and-logs.mdx
@@ -307,7 +307,7 @@ Your iii application is now fully observable:
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Console" href="/console/index" icon="desktop">
+  <Card title="Console" href="/console" icon="desktop">
     Full iii Console feature reference
   </Card>
   <Card title="OpenTelemetry Integration" href="/advanced/telemetry" icon="signal">

--- a/docs/how-to/observability-and-logs.mdx
+++ b/docs/how-to/observability-and-logs.mdx
@@ -7,11 +7,13 @@ description: 'How to use structured logging, configure observability, and inspec
 
 Make your iii application fully observable: correlate every log entry to the exact trace that produced it, inspect execution timelines to find bottlenecks, and optionally export all telemetry to third-party tools like Grafana, Jaeger, or Datadog.
 
-## Why use the iii Logger
+## The iii Logger
 
 Every iii SDK ships a `Logger` class that emits logs as OpenTelemetry LogRecords. Each log call automatically captures the active **trace ID** and **span ID**, linking the log entry to the distributed trace that produced it.
 
-Language-native logging functions — `console.log` in Node, `print()` in Python, `tracing::info!` in Rust — write to stdout but are **not connected to traces**. This means you cannot find them in the iii Console's trace detail view, and they are invisible to any OTLP-based observability backend.
+<Warning title="Native logging is not trace-correlated">
+  Language-native logging functions such as `console.log` in Node, `print()` in Python, `tracing::info!` in Rust write to stdout but are not connected to iii traces. This means you cannot find them in the iii Console's trace detail view, and they are invisible to any OTLP-based observability backend.
+</Warning>
 
 | Approach | Where it appears | Trace correlation |
 |---|---|---|
@@ -277,57 +279,21 @@ graph LR
   The `endpoint` field can also be set via the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable. See the [Observability worker reference](/workers/iii-observability) for the full list of configuration fields and environment variable overrides.
 </Info>
 
-## Using iii Console
+## Viewing Logs in iii Console
 
-The iii Console is a web UI for inspecting traces, logs, metrics, and more. It comes included with every iii installation — no separate setup required. It connects to a running iii engine and gives you full operational visibility.
+Once you've instrumented your code with the Logger, view trace-correlated logs in the iii Console.
 
-### Launch
+<Info title="How-to guide">
+  See [Use the Console](/how-to/use-console#inspect-a-trace) for step-by-step instructions on navigating traces and viewing span details.
+</Info>
 
-Start the console while your engine is running:
-
-```bash
-iii-console
-```
-
-Open [http://localhost:3113](http://localhost:3113) in your browser.
-
-<Warning>
-  The console connects to a running iii engine instance. Make sure your engine is started before launching the console. By default it expects the engine at `127.0.0.1:3111`.
-</Warning>
-
-### Inspecting traces
-
-Navigate to the **Traces** page to see all collected traces. Each trace shows its root operation, duration, service name, span count, and status.
-
-Click on a trace to open the detail view with four visualization modes:
-
-- **Waterfall Chart** — timeline showing every span by start time and duration. Best for understanding sequential and parallel flow.
-- **Flame Graph** — stack-based view where wider bars mean longer duration. Best for spotting time-consuming operations.
-- **Service Breakdown** — aggregate stats per service (total spans, average duration, error rate). Best for identifying bottleneck services.
-- **Trace Map** — topology graph showing cross-service communication patterns.
-- **Flow** — node graph showing parent-child span relationships for the selected trace.
-
-<img src="/assets/console-traces-waterfall.png" alt="iii Console Traces waterfall view showing span timing and selected span details" />
-
-<img src="/assets/console-traces-flame-graph.png" alt="iii Console Traces flame graph view showing relative span duration within a trace" />
-
-<img src="/assets/console-traces-map.png" alt="iii Console Traces map view showing service relationships in a selected trace" />
-
-<img src="/assets/console-traces-flow.png" alt="iii Console Traces flow view showing parent-child span relationships as connected nodes" />
-
-### Inspecting logs per trace
-
-Click on any span in the trace view to open the detail drawer. Switch to the **Logs** tab to see every log entry that was emitted during that span's execution. Each entry includes the severity level, timestamp, message, and structured attributes.
+Navigate to **Traces**, select a trace, and open the **Logs** tab on any span to see every log entry from that execution — with severity, timestamp, message, and structured attributes you attached.
 
 <img src="/assets/console-logs-detail.png" alt="Trace and log inspection in iii Console with structured log details and context data" />
 
-You can also use the dedicated **Logs** page for a full log viewer with severity filters, full-text search, and time-range controls. If a log entry has a `trace_id`, you can click it to jump directly to the corresponding trace.
+The dedicated **Logs** page provides a full log viewer with severity filters, full-text search, and time-range controls. If a log entry has a `trace_id`, click it to jump directly to the corresponding trace.
 
-### Identifying bottlenecks
-
-Use the waterfall chart to spot long-running spans. Switch to the flame graph to see which operations consume the most time relative to the total trace duration. The service breakdown view aggregates performance stats so you can identify which service needs optimization.
-
-For more details on all console features, see the [Console reference](/console/index).
+For the full console feature set, see the [Console reference](/console).
 
 ## Result
 

--- a/docs/how-to/use-console.mdx
+++ b/docs/how-to/use-console.mdx
@@ -9,6 +9,20 @@ The iii Console provides interactive tools for testing and debugging your iii en
   For a complete overview of all console pages and their features, see the [Console Reference](/console).
 </Info>
 
+## Start the Console
+
+The console comes preinstalled with iii. Start it with:
+
+```bash
+iii console
+```
+
+Then open your browser to [http://127.0.0.1:3113](http://127.0.0.1:3113).
+
+<Warning title="Engine must be running">
+  The console connects to a running iii engine instance. Make sure your engine is started before launching the console. By default it expects the engine at `127.0.0.1:3111`.
+</Warning>
+
 ## Invoke a Function
 
 You can invoke any registered function directly from the console without wiring up a trigger.

--- a/docs/how-to/use-console.mdx
+++ b/docs/how-to/use-console.mdx
@@ -1,0 +1,167 @@
+---
+title: 'Use the Console'
+description: 'Test functions, triggers, state, and queues interactively from the iii Console.'
+---
+
+The iii Console provides interactive tools for testing and debugging your iii engine in real time. This guide covers common tasks you can perform from the console UI.
+
+<Info title="Console reference">
+  For a complete overview of all console pages and their features, see the [Console Reference](/console).
+</Info>
+
+## Invoke a Function
+
+You can invoke any registered function directly from the console without wiring up a trigger.
+
+1. Open the **Functions** page from the sidebar
+2. Click on a function to open its detail panel
+3. Enter a JSON payload in the input editor
+4. Click **Invoke**
+5. View the result or error in real time
+
+For example, to invoke `users::getProfile`:
+
+```json
+{
+  "user_id": "user-123"
+}
+```
+
+The console sends the payload to the engine via `POST /_console/invoke` and displays the JSON response inline.
+
+This is useful for:
+
+- **Testing** a function during development without wiring up a trigger
+- **Debugging** by sending specific payloads to reproduce an issue
+- **Ad-hoc operations** like running a migration function manually
+
+## Test an HTTP Trigger
+
+The console provides a built-in request builder for HTTP-type triggers.
+
+1. Open the **Triggers** page from the sidebar
+2. Select an HTTP trigger from the list
+3. Select the **HTTP method** (GET, POST, PUT, DELETE, PATCH)
+4. The **path** is pre-filled from the trigger configuration
+5. Add **query parameters** as key-value pairs
+6. Enter a **request body** (for POST/PUT/PATCH) as JSON
+7. Click **Send** to execute the request
+
+The response is displayed inline with status code, headers, and body.
+
+For example, for a trigger registered at `POST /api/users`:
+
+```json
+{
+  "name": "Alice",
+  "email": "alice@example.com"
+}
+```
+
+## Test a Cron Trigger
+
+You can manually fire a cron job without waiting for its next scheduled run.
+
+1. Open the **Triggers** page from the sidebar
+2. Select a cron trigger from the list
+3. View the configured schedule expression (e.g. `0 */5 * * * * *`)
+4. Click **Trigger Now** to fire the cron job immediately
+
+## Test an Event Trigger
+
+The console provides an event emitter for event-type triggers.
+
+1. Open the **Triggers** page from the sidebar
+2. Select an event trigger from the list
+3. The event name is pre-filled from the trigger configuration
+4. Enter a JSON payload
+5. Click **Emit** to publish the event
+
+## Manage State Entries
+
+The States page lets you create, edit, and delete key-value state entries.
+
+### Add a State Entry
+
+1. Open the **States** page from the sidebar
+2. Click **Add Item**
+3. Enter the scope, key, and JSON value
+4. Click **Save**
+
+The entry is persisted via `state::set`.
+
+### Edit a State Entry
+
+1. Select a group from the left panel
+2. Click an existing item
+3. Modify the JSON value in the detail panel
+4. Click **Save**
+
+If you have `state:updated` triggers registered, they will fire automatically.
+
+### Delete a State Entry
+
+1. Select a group from the left panel
+2. Click the delete icon on the item
+3. Confirm the deletion
+
+If you have `state:deleted` triggers registered, they will fire automatically.
+
+## Inspect a Trace
+
+The Traces page provides multiple visualization modes for understanding distributed operations.
+
+1. Open the **Traces** page from the sidebar
+2. Use filters to find a specific trace (by ID, service, span name, status, or duration)
+3. Click on a trace to open the detail view
+4. Select a visualization mode:
+   - **Waterfall Chart** — Timeline view of spans by start time and duration
+   - **Flame Graph** — Stack-based view where wider bars indicate longer duration
+   - **Service Breakdown** — Aggregate stats grouped by service
+   - **Trace Map** — Topology graph of service communication
+   - **Flow** — Node-based parent-child span relationships
+
+### View Span Details
+
+1. Click on any span in the trace visualization
+2. The detail panel shows:
+   - **Info** — Span name, service, duration, status, IDs
+   - **Tags** — Span attributes as key-value pairs
+   - **Logs** — Events attached to the span
+   - **Errors** — Error messages and stack traces
+   - **Baggage** — Trace context baggage
+
+## Navigate the Flow Graph
+
+The Flow page shows an interactive graph of your system architecture.
+
+<Warning title="Feature flag required">
+  Enable the Flow page by starting the console with `--enable-flow` or setting `III_ENABLE_FLOW=true`.
+</Warning>
+
+1. Open the **Flow** page from the sidebar
+2. **Pan** — drag to move the viewport
+3. **Zoom** — scroll to zoom in/out
+4. **Inspect** — click a node to view its details (function ID, trigger config, etc.)
+
+The layout is auto-arranged using a directed-graph algorithm (Dagre) and saved to the engine's state store.
+
+## Send a Test Message to a Queue
+
+The Queues page includes a JSON publisher for testing.
+
+1. Open the **Queues** page from the sidebar
+2. Click a topic to open the detail panel
+3. In the **Overview** tab, enter a JSON payload
+4. Click **Publish** to send the message
+
+## Manage Dead Letters
+
+Failed messages that exhausted retry handling appear in the Dead Letters tab.
+
+1. Open the **Queues** page from the sidebar
+2. Click a topic to open the detail panel
+3. Select the **Dead Letters** tab
+4. For each failed message, you can:
+   - **Retry** — redrive the message back to the queue
+   - **Delete** — discard the message permanently


### PR DESCRIPTION
## What

- Create docs/how-to/use-console.mdx with step-by-step instructions for invoking functions, testing triggers, managing state, inspecting traces, navigating flow graph, and managing queues/dead letters
- Refactor docs/console/index.mdx to pure reference format with links to how-to guide, fix trigger terminology (http/cron/event/state), add console vs logs_console_output disambiguation
- Trim docs/how-to/observability-and-logs.mdx "Using iii Console" section to avoid duplication, link to how-to and reference instead
- Add "Console & Observability" group to docs navigation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Console Quick Start updated: console is preinstalled, new startup command and default URL (127.0.0.1:3113).
  * New "Use the Console" how-to: function invocation, trigger testing (HTTP/Cron/Event/State), state CRUD, trace inspection, flow graph interaction, and queue testing.
  * Reorganized Workers, Triggers, States, Queues, Traces, and Flow docs into consolidated tables/guides with how-to links.
  * Streamlined observability/logging guidance and clarified console vs. console output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->