### PR TITLE
ci: skip CI on website-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'skills/**'
+      - 'website/**'
       - '**/*.md'
       - '**/*.mdx'
       - '.cursor/**'
@@ -14,6 +15,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'skills/**'
+      - 'website/**'
       - '**/*.md'
       - '**/*.mdx'
       - '.cursor/**'

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'skills/**'
+      - 'website/**'
       - '**/*.md'
       - '**/*.mdx'
       - '.cursor/**'
@@ -14,6 +15,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'skills/**'
+      - 'website/**'
       - '**/*.md'
       - '**/*.mdx'
       - '.cursor/**'


### PR DESCRIPTION
## Summary
- Add `website/**` to `paths-ignore` for both `push` and `pull_request` triggers in `ci.yml` and `license-check.yml`
- Website-only PRs/pushes will no longer trigger engine, SDK, worker, console, or license-header jobs
- `deploy-website.yml` is unaffected — it uses a `paths:` allowlist that includes `website/**`, so deploys still run

## Test plan
- [ ] Open this PR — confirm that CI and License Header Check do **not** run (changes are limited to `.github/workflows/**`, so they should still run on this PR; verify behavior on a follow-up website-only PR)
- [ ] Land a follow-up PR touching only `website/**` and confirm CI and License Header Check are skipped while `deploy-website` still triggers on merge to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflows to skip unnecessary checks when only website content is modified, improving pipeline efficiency for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->