### PR TITLE
ci(engine): publish live function/trigger interface for builtin workers

### DIFF
--- a/.github/scripts/build_engine_publish_payload.py
+++ b/.github/scripts/build_engine_publish_payload.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import pathlib
+import re
+import sys
+import tomllib
+from typing import Any
+
+
+def normalize_dependencies(raw_deps: Any) -> list[dict[str, Any]]:
+    if raw_deps in (None, ""):
+        return []
+    if isinstance(raw_deps, dict):
+        return [{"name": name, "version": version} for name, version in raw_deps.items()]
+    if isinstance(raw_deps, list):
+        return raw_deps
+    raise ValueError(f"`dependencies` must be a map or list, got {type(raw_deps).__name__}")
+
+
+def derive_registry_function_name(function_id: str, metadata: dict[str, Any] | None) -> str:
+    metadata = metadata or {}
+    for key in ("registry_name", "name"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    if "::" in function_id:
+        return function_id.rsplit("::", 1)[1]
+    return function_id
+
+
+def _extract_array(payload: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    value = payload.get(key, [])
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"`{key}` must be an array")
+    return value
+
+
+def _read_yaml(path: pathlib.Path) -> Any:
+    import yaml
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _schema_or_empty(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    raise ValueError("function schema fields must be objects or null")
+
+
+def _metadata_or_empty(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _string_or_empty(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _slug(value: Any, fallback: str) -> str:
+    raw = value if isinstance(value, str) else fallback
+    slug = re.sub(r"[^a-z0-9]+", "-", raw.lower()).strip("-")
+    return slug or fallback
+
+
+def _normalize_registry_function(function: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": function.get("name"),
+        "description": _string_or_empty(function.get("description")),
+        "request_schema": _schema_or_empty(function.get("request_schema")),
+        "response_schema": _schema_or_empty(function.get("response_schema")),
+        "metadata": _metadata_or_empty(function.get("metadata")),
+    }
+
+
+def _derive_trigger_name(trigger: dict[str, Any]) -> str:
+    metadata = _metadata_or_empty(trigger.get("metadata"))
+    for key in ("registry_name", "name"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            return _slug(value, "trigger")
+    config = trigger.get("config") if isinstance(trigger.get("config"), dict) else {}
+    api_path = config.get("api_path")
+    if isinstance(api_path, str) and api_path.strip():
+        return _slug(api_path, "trigger")
+    function_id = trigger.get("function_id")
+    if isinstance(function_id, str) and function_id.strip():
+        return _slug(function_id.rsplit("::", 1)[-1], "trigger")
+    return _slug(trigger.get("trigger_type") or trigger.get("name"), "trigger")
+
+
+def _normalize_registry_trigger(trigger: dict[str, Any]) -> dict[str, Any]:
+    config = trigger.get("config") if isinstance(trigger.get("config"), dict) else {}
+    metadata = _metadata_or_empty(trigger.get("metadata")).copy()
+    for source_key, metadata_key in (
+        ("id", "engine_id"),
+        ("trigger_type", "trigger_type"),
+        ("function_id", "function_id"),
+    ):
+        if trigger.get(source_key) is not None:
+            metadata.setdefault(metadata_key, trigger.get(source_key))
+    if config:
+        metadata.setdefault("config", config)
+    return {
+        "name": _derive_trigger_name(trigger),
+        "description": _string_or_empty(trigger.get("description")),
+        "invocation_schema": _schema_or_empty(trigger.get("invocation_schema")),
+        "return_schema": _schema_or_empty(trigger.get("return_schema")),
+        "metadata": metadata,
+    }
+
+
+def normalize_worker_interface(
+    *,
+    worker_name: str,
+    workers_json: dict[str, Any],
+    functions_json: dict[str, Any],
+    triggers_json: dict[str, Any] | None = None,
+) -> dict[str, list[dict[str, Any]]]:
+    workers = _extract_array(workers_json, "workers")
+    matches = [w for w in workers if w.get("name") == worker_name or w.get("id") == worker_name]
+    if len(matches) != 1:
+        raise ValueError(
+            f"expected exactly one worker matching {worker_name!r}, found {len(matches)}"
+        )
+    worker_function_ids = matches[0].get("functions") or []
+    if not isinstance(worker_function_ids, list):
+        raise ValueError("worker `functions` must be an array")
+    functions_by_id = {
+        f.get("function_id"): f
+        for f in _extract_array(functions_json, "functions")
+        if f.get("function_id")
+    }
+    functions = []
+    for function_id in worker_function_ids:
+        details = functions_by_id.get(function_id, {})
+        metadata = details.get("metadata") or {}
+        functions.append(
+            {
+                "name": derive_registry_function_name(function_id, metadata),
+                "description": _string_or_empty(details.get("description")),
+                "request_schema": _schema_or_empty(details.get("request_format")),
+                "response_schema": _schema_or_empty(details.get("response_format")),
+                "metadata": _metadata_or_empty(metadata),
+            }
+        )
+    worker_ids = set(worker_function_ids)
+    triggers = []
+    if triggers_json:
+        for trigger in _extract_array(triggers_json, "triggers"):
+            if trigger.get("function_id") not in worker_ids:
+                continue
+            triggers.append(_normalize_registry_trigger(trigger))
+    return {"functions": functions, "triggers": triggers}
+
+
+def build_payload(
+    *,
+    repo_root: pathlib.Path,
+    worker: str,
+    worker_dir: pathlib.Path,
+    expected_version: str,
+    registry_tag: str,
+    repo_url: str,
+    interface: dict[str, Any],
+) -> dict[str, Any]:
+    engine_manifest = repo_root / "engine" / "Cargo.toml"
+    if not engine_manifest.exists():
+        raise ValueError(f"{engine_manifest} not found")
+    engine_version = tomllib.loads(engine_manifest.read_text(encoding="utf-8"))["package"]["version"]
+    if expected_version and expected_version != engine_version:
+        raise ValueError(
+            f"engine worker version mismatch: input is {expected_version}, engine/Cargo.toml is {engine_version}"
+        )
+
+    manifest_path = repo_root / worker_dir / "iii.worker.yaml"
+    if not manifest_path.exists():
+        raise ValueError(f"{manifest_path} not found")
+    meta = _read_yaml(manifest_path) or {}
+    if meta.get("type") != "engine":
+        raise ValueError(
+            f"{worker}: iii.worker.yaml type must be 'engine' (got {meta.get('type')!r})"
+        )
+
+    readme_path = repo_root / worker_dir / "README.md"
+    readme = readme_path.read_text(encoding="utf-8") if readme_path.exists() else ""
+
+    return {
+        "worker_name": worker,
+        "version": engine_version,
+        "tag": registry_tag or "latest",
+        "type": "engine",
+        "readme": readme,
+        "repo": repo_url,
+        "description": meta.get("description", ""),
+        "dependencies": normalize_dependencies(meta.get("dependencies")),
+        "config": meta.get("config") or {},
+        "functions": [_normalize_registry_function(f) for f in interface.get("functions") or []],
+        "triggers": [_normalize_registry_trigger(t) for t in interface.get("triggers") or []],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--worker", required=True)
+    parser.add_argument("--worker-dir", required=True)
+    parser.add_argument("--expected-version", default="")
+    parser.add_argument("--registry-tag", default="latest")
+    parser.add_argument("--repo-url", required=True)
+    parser.add_argument("--interface-json", required=True)
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--out", default="payload.json")
+    args = parser.parse_args()
+
+    interface = json.loads(pathlib.Path(args.interface_json).read_text(encoding="utf-8"))
+    payload = build_payload(
+        repo_root=pathlib.Path(args.repo_root),
+        worker=args.worker,
+        worker_dir=pathlib.Path(args.worker_dir),
+        expected_version=args.expected_version,
+        registry_tag=args.registry_tag,
+        repo_url=args.repo_url,
+        interface=interface,
+    )
+    pathlib.Path(args.out).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({k: v for k, v in payload.items() if k != "readme"}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/build_engine_publish_payload.py
+++ b/.github/scripts/build_engine_publish_payload.py
@@ -169,7 +169,10 @@ def build_payload(
     engine_manifest = repo_root / "engine" / "Cargo.toml"
     if not engine_manifest.exists():
         raise ValueError(f"{engine_manifest} not found")
-    engine_version = tomllib.loads(engine_manifest.read_text(encoding="utf-8"))["package"]["version"]
+    try:
+        engine_version = tomllib.loads(engine_manifest.read_text(encoding="utf-8"))["package"]["version"]
+    except KeyError as exc:
+        raise ValueError(f"{engine_manifest}: missing [package].version ({exc})") from exc
     if expected_version and expected_version != engine_version:
         raise ValueError(
             f"engine worker version mismatch: input is {expected_version}, engine/Cargo.toml is {engine_version}"

--- a/.github/scripts/build_engine_publish_payload.py
+++ b/.github/scripts/build_engine_publish_payload.py
@@ -65,16 +65,6 @@ def _slug(value: Any, fallback: str) -> str:
     return slug or fallback
 
 
-def _normalize_registry_function(function: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "name": function.get("name"),
-        "description": _string_or_empty(function.get("description")),
-        "request_schema": _schema_or_empty(function.get("request_schema")),
-        "response_schema": _schema_or_empty(function.get("response_schema")),
-        "metadata": _metadata_or_empty(function.get("metadata")),
-    }
-
-
 def _derive_trigger_name(trigger: dict[str, Any]) -> str:
     metadata = _metadata_or_empty(trigger.get("metadata"))
     for key in ("registry_name", "name"):
@@ -200,8 +190,8 @@ def build_payload(
         "description": meta.get("description", ""),
         "dependencies": normalize_dependencies(meta.get("dependencies")),
         "config": meta.get("config") or {},
-        "functions": [_normalize_registry_function(f) for f in interface.get("functions") or []],
-        "triggers": [_normalize_registry_trigger(t) for t in interface.get("triggers") or []],
+        "functions": interface.get("functions") or [],
+        "triggers": interface.get("triggers") or [],
     }
 
 

--- a/.github/scripts/collect_engine_worker_interface.py
+++ b/.github/scripts/collect_engine_worker_interface.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import pathlib
+import subprocess
+import sys
+import time
+
+from build_engine_publish_payload import normalize_worker_interface
+
+
+def count_worker_matches(workers_json: dict[str, object], worker_name: str) -> int:
+    workers = workers_json.get("workers", [])
+    if not isinstance(workers, list):
+        return 0
+    return sum(
+        1
+        for worker in workers
+        if isinstance(worker, dict)
+        and (worker.get("name") == worker_name or worker.get("id") == worker_name)
+    )
+
+
+def run_iii(function_id: str, payload: dict[str, object]) -> dict[str, object]:
+    completed = subprocess.run(
+        [
+            "iii",
+            "trigger",
+            "--function-id",
+            function_id,
+            "--payload",
+            json.dumps(payload),
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def wait_for_worker(worker_name: str, wait_seconds: int) -> dict[str, object]:
+    deadline = time.monotonic() + wait_seconds
+    workers_json = run_iii("engine::workers::list", {})
+    while count_worker_matches(workers_json, worker_name) != 1 and time.monotonic() < deadline:
+        time.sleep(2)
+        workers_json = run_iii("engine::workers::list", {})
+    return workers_json
+
+
+def collect_triggers() -> dict[str, object] | None:
+    try:
+        return run_iii("engine::triggers::list", {"include_internal": True})
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        print(
+            f"::warning::could not collect triggers; publishing triggers=[]: {exc}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--worker", required=True)
+    parser.add_argument("--out", default="worker-interface.json")
+    parser.add_argument("--wait-seconds", type=int, default=0)
+    args = parser.parse_args()
+
+    workers_json = wait_for_worker(args.worker, args.wait_seconds)
+    functions_json = run_iii("engine::functions::list", {"include_internal": True})
+    triggers_json = collect_triggers()
+
+    interface = normalize_worker_interface(
+        worker_name=args.worker,
+        workers_json=workers_json,
+        functions_json=functions_json,
+        triggers_json=triggers_json,
+    )
+    pathlib.Path(args.out).write_text(json.dumps(interface, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(interface, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/collect_engine_worker_interface.py
+++ b/.github/scripts/collect_engine_worker_interface.py
@@ -34,6 +34,7 @@ def run_iii(function_id: str, payload: dict[str, object]) -> dict[str, object]:
         check=True,
         text=True,
         capture_output=True,
+        timeout=60,
     )
     return json.loads(completed.stdout)
 
@@ -50,7 +51,7 @@ def wait_for_worker(worker_name: str, wait_seconds: int) -> dict[str, object]:
 def collect_triggers() -> dict[str, object] | None:
     try:
         return run_iii("engine::triggers::list", {"include_internal": True})
-    except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
         print(
             f"::warning::could not collect triggers; publishing triggers=[]: {exc}",
             file=sys.stderr,

--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -51,15 +51,54 @@ jobs:
           export PATH="$HOME/.local/bin:$HOME/.iii/bin:$PATH"
           iii --version
 
-      # Engine builtin workers (iii-http, iii-state, iii-stream, iii-queue,
-      # iii-pubsub, iii-cron, iii-observability, iii-exec, iii-bridge,
-      # iii-sandbox) are compiled into the iii binary and auto-load on start.
-      # `workers: []` only suppresses external worker config — builtins still
-      # appear in `engine::workers::list`, so no `iii worker add` is needed.
+      - name: Setup Rust toolchain (iii-sandbox only)
+        if: inputs.worker == 'iii-sandbox'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install system dependencies for iii-worker (iii-sandbox only)
+        if: inputs.worker == 'iii-sandbox'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcap-ng-dev
+
+      - name: Build and install iii-worker (iii-sandbox only)
+        if: inputs.worker == 'iii-sandbox'
+        run: |
+          set -euo pipefail
+          cargo build -p iii-worker
+          mkdir -p "$HOME/.local/bin"
+          cp target/debug/iii-worker "$HOME/.local/bin/iii-worker"
+          chmod +x "$HOME/.local/bin/iii-worker"
+          iii-worker --version || true
+
+      # Each builtin engine worker has different auto-load semantics
+      # (mandatory / enabled_by_default / external). Rather than rely on the
+      # ambient default, write a config that explicitly lists only the worker
+      # we are publishing, using its own iii.worker.yaml `config:` block as
+      # the worker's runtime config.
+      - name: Write engine config for ${{ inputs.worker }}
+        env:
+          WORKER: ${{ inputs.worker }}
+          WORKER_DIR: ${{ inputs.worker_dir }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os, pathlib, yaml
+          worker = os.environ["WORKER"]
+          worker_dir = pathlib.Path(os.environ["WORKER_DIR"])
+          manifest = worker_dir / "iii.worker.yaml"
+          meta = yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
+          entry = {"name": worker}
+          if meta.get("config") is not None:
+              entry["config"] = meta["config"]
+          config = {"workers": [entry]}
+          pathlib.Path("config.yaml").write_text(yaml.dump(config, sort_keys=False), encoding="utf-8")
+          PY
+          cat config.yaml
+
       - name: Start III engine
         run: |
           set -euo pipefail
-          printf 'workers: []\n' > config.yaml
           iii --config config.yaml --no-update-check > iii-engine.log 2>&1 &
           echo "$!" > iii-engine.pid
 

--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -51,6 +51,11 @@ jobs:
           export PATH="$HOME/.local/bin:$HOME/.iii/bin:$PATH"
           iii --version
 
+      # Engine builtin workers (iii-http, iii-state, iii-stream, iii-queue,
+      # iii-pubsub, iii-cron, iii-observability, iii-exec, iii-bridge,
+      # iii-sandbox) are compiled into the iii binary and auto-load on start.
+      # `workers: []` only suppresses external worker config — builtins still
+      # appear in `engine::workers::list`, so no `iii worker add` is needed.
       - name: Start III engine
         run: |
           set -euo pipefail
@@ -123,6 +128,8 @@ jobs:
         env:
           API_URL: ${{ inputs.api_url }}
           API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
+          WORKER: ${{ inputs.worker }}
+          PUBLISHED_VERSION: ${{ steps.payload.outputs.version }}
         run: |
           if [[ -z "$API_KEY" ]]; then
             echo "::error::WORKERS_REGISTRY_API_KEY secret is not set"
@@ -140,7 +147,7 @@ jobs:
             exit 1
           fi
           if [[ "$http" == "409" ]]; then
-            echo "::notice::${{ inputs.worker }} v${{ steps.payload.outputs.version }} already published (409) — skipping"
+            echo "::notice::${WORKER} v${PUBLISHED_VERSION} already published (409) — skipping"
           fi
 
       - name: Dump III logs

--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -39,6 +39,61 @@ jobs:
       - name: Install pyyaml
         run: pip install --quiet pyyaml
 
+      - name: Install iii CLI
+        run: |
+          set -euo pipefail
+          curl -fsSL https://install.iii.dev/iii/main/install.sh -o /tmp/install-iii.sh
+          sh /tmp/install-iii.sh
+          {
+            echo "$HOME/.local/bin"
+            echo "$HOME/.iii/bin"
+          } >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$HOME/.iii/bin:$PATH"
+          iii --version
+
+      - name: Start III engine
+        run: |
+          set -euo pipefail
+          printf 'workers: []\n' > config.yaml
+          iii --config config.yaml --no-update-check > iii-engine.log 2>&1 &
+          echo "$!" > iii-engine.pid
+
+          for _ in {1..60}; do
+            if ! kill -0 "$(cat iii-engine.pid)" 2>/dev/null; then
+              echo "::error::iii engine exited before becoming ready"
+              cat iii-engine.log
+              exit 1
+            fi
+            if iii trigger --function-id='engine::workers::list' --payload='{}' >/tmp/iii-workers.json 2>/tmp/iii-trigger.err; then
+              cat /tmp/iii-workers.json
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "::error::iii engine did not become ready"
+          cat /tmp/iii-trigger.err || true
+          cat iii-engine.log || true
+          exit 1
+
+      - name: Collect worker interface
+        env:
+          WORKER: ${{ inputs.worker }}
+        run: |
+          python3 .github/scripts/collect_engine_worker_interface.py \
+            --worker "$WORKER" \
+            --out worker-interface.json \
+            --wait-seconds 120
+
+      - name: Assert worker interface was collected
+        run: |
+          python3 - <<'PY'
+          import json
+          data = json.load(open("worker-interface.json"))
+          if not data.get("functions"):
+              raise SystemExit("no worker functions were collected")
+          PY
+
       - name: Build payload
         id: payload
         env:
@@ -48,58 +103,21 @@ jobs:
           REGISTRY_TAG: ${{ inputs.registry_tag }}
           REPO_URL: ${{ format('https://github.com/{0}', github.repository) }}
         run: |
-          python3 - <<'PY'
-          import json, os, pathlib, sys, tomllib, yaml
-
-          worker = os.environ["WORKER"]
-          worker_dir = pathlib.Path(os.environ["WORKER_DIR"])
-          expected_version = os.environ["VERSION"]
-          ref_name = os.environ.get("GITHUB_REF_NAME", "")
-          reg_tag = os.environ["REGISTRY_TAG"] or "latest"
-          repo_url = os.environ["REPO_URL"]
-
-          engine_manifest = pathlib.Path("engine/Cargo.toml")
-          if not engine_manifest.exists():
-              print("::error::engine/Cargo.toml not found")
-              sys.exit(1)
-          version = tomllib.loads(engine_manifest.read_text())["package"]["version"]
-          if not expected_version and ref_name.startswith("iii/v"):
-              expected_version = ref_name.removeprefix("iii/v")
-          if expected_version and expected_version != version:
-              print(f"::error::engine worker version mismatch: workflow input is {expected_version}, engine/Cargo.toml is {version}")
-              sys.exit(1)
-
-          manifest_path = worker_dir / "iii.worker.yaml"
-          if not manifest_path.exists():
-              print(f"::error::{manifest_path} not found")
-              sys.exit(1)
-
-          meta = yaml.safe_load(manifest_path.read_text()) or {}
-
-          if meta.get("type") != "engine":
-              print(f"::error::{worker}: iii.worker.yaml type must be 'engine' (got {meta.get('type')!r})")
-              sys.exit(1)
-
-          readme_path = worker_dir / "README.md"
-          readme = readme_path.read_text() if readme_path.exists() else ""
-
-          payload = {
-              "worker_name": worker,
-              "version": version,
-              "tag": reg_tag,
-              "type": "engine",
-              "readme": readme,
-              "repo": repo_url,
-              "description": meta.get("description", ""),
-          }
-
-          out = pathlib.Path("payload.json")
-          out.write_text(json.dumps(payload, indent=2))
-          if github_output := os.environ.get("GITHUB_OUTPUT"):
-              with open(github_output, "a", encoding="utf-8") as handle:
-                  handle.write(f"version={version}\n")
-          print(json.dumps({k: payload[k] for k in payload if k != "readme"}, indent=2))
-          PY
+          set -euo pipefail
+          expected="$VERSION"
+          if [[ -z "$expected" && "${GITHUB_REF_NAME:-}" == iii/v* ]]; then
+            expected="${GITHUB_REF_NAME#iii/v}"
+          fi
+          python3 .github/scripts/build_engine_publish_payload.py \
+            --worker "$WORKER" \
+            --worker-dir "$WORKER_DIR" \
+            --expected-version "$expected" \
+            --registry-tag "$REGISTRY_TAG" \
+            --repo-url "$REPO_URL" \
+            --interface-json worker-interface.json \
+            --out payload.json
+          version=$(python3 -c 'import json; print(json.load(open("payload.json"))["version"])')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: POST /publish
         env:
@@ -123,4 +141,18 @@ jobs:
           fi
           if [[ "$http" == "409" ]]; then
             echo "::notice::${{ inputs.worker }} v${{ steps.payload.outputs.version }} already published (409) — skipping"
+          fi
+
+      - name: Dump III logs
+        if: failure()
+        run: |
+          echo "::group::iii engine log"
+          tail -n 200 iii-engine.log || true
+          echo "::endgroup::"
+
+      - name: Stop III engine
+        if: always()
+        run: |
+          if [[ -f iii-engine.pid ]]; then
+            kill "$(cat iii-engine.pid)" 2>/dev/null || true
           fi

--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -36,6 +36,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Install pyyaml
         run: pip install --quiet pyyaml
 


### PR DESCRIPTION
## Summary

Enrich the registry publish payload for builtin (engine) workers so the registry receives the live `functions[]` and `triggers[]` interfaces (descriptions, `request_schema`, `response_schema`), `dependencies[]`, and `config` — matching the shape already used by external workers in the [workers repo](https://github.com/iii-hq/workers).

Previously `_publish-engine-workers.yml` POSTed only `{worker_name, version, tag, type=engine, readme, repo, description}`. The new flow boots a local engine, harvests the live interface via `engine::workers::list` / `engine::functions::list` / `engine::triggers::list`, and sends a payload that includes the function/trigger schemas.

## Approach

Mirrors the pattern that shipped for external workers in the workers repo, applied as a strict subset:
- Always `type: engine` — no `binaries` / `image_tag`.
- Engine version derived from `engine/Cargo.toml`.
- Worker `config:` read inline from each `iii.worker.yaml` (no separate `config.yaml`).
- Per-matrix-entry `config.yaml` is generated before booting the engine (see "Per-worker engine config" below).

## Files

- `.github/scripts/build_engine_publish_payload.py` (new) — composes the POST payload (helpers + CLI).
- `.github/scripts/collect_engine_worker_interface.py` (new) — runs the `iii` CLI against the local engine and normalizes the live interface.
- `.github/workflows/_publish-engine-workers.yml` — rewritten to use both scripts.

`release-iii.yml` is unchanged; the matrix still passes `worker`, `worker_dir`, `registry_tag`.

## Per-worker engine config

The previous draft started the engine with `printf 'workers: []\n' > config.yaml`, which would have failed for 8 of 10 matrix entries: `workers: []` only auto-loads `mandatory` workers (verified at `engine/src/workers/config.rs:595-603`). The fix:
- Generate a per-matrix-entry `config.yaml` listing only the worker we are publishing, sourcing its own `config:` block from `iii.worker.yaml`.
- For `iii-sandbox` (registered as `KNOWN_EXTERNAL`), additionally set up Rust + `libcap-ng-dev` and `cargo build -p iii-worker` so the binary is on `PATH`.

## Backwards compatibility

- Workflow inputs (`worker`, `worker_dir`, `version`, `registry_tag`, `api_url`) are unchanged.
- Payload shape change is purely additive: new keys are `dependencies`, `config`, `functions`, `triggers`. No existing key is removed or renamed.
- HTTP `409` (already published) is still treated as a `::notice::` and exits 0, so re-runs are safe.

## Follow-ups (not in this PR)

- Cache the `cargo build -p iii-worker` step for `iii-sandbox` via `Swatinem/rust-cache@v2` to avoid recompiling on every release.
- Wrap `tomllib.TOMLDecodeError` in `ValueError` for parity with the other structural errors in `build_engine_publish_payload.py`.

## Test plan

- [ ] Trigger a dry-run release via `release-iii.yml` and confirm all 10 matrix jobs reach the `Build payload` step with non-empty `functions[]`.
- [ ] Inspect the payload printed by `Build payload` for at least `iii-http` and `iii-state` and confirm `request_schema` / `response_schema` are populated for the registered functions.
- [ ] Confirm a re-run hits `409` and exits 0 with the `::notice::` annotation.
- [ ] Verify `iii-sandbox` job: rust toolchain installs, `cargo build -p iii-worker` succeeds, sandbox worker appears in `engine::workers::list`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced engine worker publishing automation with improved interface collection and payload generation.
  * Added validation and structured configuration handling for engine worker publishing workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->