### PR TITLE
fix(telemetry): always report client_type as iii_direct in v0.11+

### DIFF
--- a/engine/src/workers/telemetry/mod.rs
+++ b/engine/src/workers/telemetry/mod.rs
@@ -472,10 +472,7 @@ fn collect_worker_data(engine: &Engine) -> WorkerData {
 
     let sdk_telemetry = best_telemetry.map(|(_, t)| t);
 
-    let client_type = sdk_telemetry
-        .as_ref()
-        .and_then(|t| t.framework.clone())
-        .unwrap_or_else(|| environment::detect_client_type().to_string());
+    let client_type = environment::detect_client_type().to_string();
 
     let sdk_languages: Vec<String> = runtime_counts
         .keys()
@@ -1894,6 +1891,7 @@ mod tests {
         let wd = collect_worker_data(&engine);
         assert_eq!(wd.worker_count_total, 1);
         assert_eq!(wd.worker_count_by_framework.get("motia"), Some(&1));
+        assert_eq!(wd.client_type, "iii_direct");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`client_type` was being overridden by the connected worker's `framework` field, so any iii engine hosting a motia-step worker reported `client_type=motia` — even though the engine itself was launched as `iii_direct`. This conflated *engine launcher* with *worker framework* and produced misleading data in Amplitude.

Audit on the last 30 days of `heartbeat` events: ~25 distinct `(project_name, version)` pairs on iii v0.11+ were tagged `client_type=motia`. Several are clearly not motia projects (`@docai/document-service`, `mmedia`, `bachelor-backend`, `aml-agents`) — they're plain iii engines that happen to host a motia-step worker.

Since motia is no longer being released, the launcher distinction is gone. `client_type` now always comes from `detect_client_type()` (which returns `iii_direct` in v0.11+). Worker-level framework visibility is unchanged via `worker_count_by_framework`.

## Changes

- `engine/src/workers/telemetry/mod.rs` — drop the `framework`-based override of `client_type` (4 lines → 1).
- Updated `test_collect_worker_data_motia_framework_counted` to assert `client_type == "iii_direct"` even when a worker reports `framework=motia`.

## Test plan

- [x] `cargo test --lib workers::telemetry` — 143 tests pass
- [ ] After deploy, verify the regression chart in Amplitude trends to zero as users redeploy: https://app.amplitude.com/analytics/motia/chart/zz6tiev7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of client type detection in telemetry collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->