### PR TITLE
fix(telemetry): correct client_type and auto-detect project_name across engine + SDKs

### DIFF
--- a/engine/src/workers/telemetry/mod.rs
+++ b/engine/src/workers/telemetry/mod.rs
@@ -472,10 +472,7 @@ fn collect_worker_data(engine: &Engine) -> WorkerData {
 
     let sdk_telemetry = best_telemetry.map(|(_, t)| t);
 
-    let client_type = sdk_telemetry
-        .as_ref()
-        .and_then(|t| t.framework.clone())
-        .unwrap_or_else(|| environment::detect_client_type().to_string());
+    let client_type = environment::detect_client_type().to_string();
 
     let sdk_languages: Vec<String> = runtime_counts
         .keys()
@@ -1894,6 +1891,7 @@ mod tests {
         let wd = collect_worker_data(&engine);
         assert_eq!(wd.worker_count_total, 1);
         assert_eq!(wd.worker_count_by_framework.get("motia"), Some(&1));
+        assert_eq!(wd.client_type, "iii_direct");
     }
 
     #[test]

--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -29,6 +29,7 @@ import {
 } from './iii-types'
 import { registerWorkerGauges, stopWorkerGauges } from './otel-worker-gauges'
 import type { IStream } from './stream'
+import { detectProjectName } from './utils'
 import {
   extractContext,
   getLogger,
@@ -497,7 +498,7 @@ class Sdk implements ISdk {
         isolation: process.env.III_ISOLATION || null,
         telemetry: {
           language,
-          project_name: telemetryOpts?.project_name,
+          project_name: telemetryOpts?.project_name ?? detectProjectName(),
           framework: telemetryOpts?.framework?.trim() || 'iii-node',
           amplitude_api_key: telemetryOpts?.amplitude_api_key,
         },

--- a/sdk/packages/node/iii/src/utils.ts
+++ b/sdk/packages/node/iii/src/utils.ts
@@ -1,5 +1,34 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
 import type { StreamChannelRef } from './iii-types'
 import type { ApiResponse, HttpRequest, HttpResponse, InternalHttpRequest } from './types'
+
+/**
+ * Returns a project identifier for telemetry, derived from the current working
+ * directory. Reads `package.json` `name` if present at `cwd`; otherwise falls
+ * back to the basename of `cwd`. Returns `undefined` only when both signals
+ * are unavailable (e.g. cwd is the filesystem root).
+ *
+ * No directory walking — only inspects `cwd` itself, so the SDK never reads
+ * files outside the user's explicit working directory.
+ */
+export function detectProjectName(cwd: string = process.cwd()): string | undefined {
+  try {
+    const manifest = path.join(cwd, 'package.json')
+    if (fs.existsSync(manifest)) {
+      const parsed = JSON.parse(fs.readFileSync(manifest, 'utf8')) as { name?: unknown }
+      if (typeof parsed.name === 'string') {
+        const trimmed = parsed.name.trim()
+        if (trimmed) return trimmed
+      }
+    }
+  } catch {
+    // fall through to directory-name fallback
+  }
+
+  const base = path.basename(cwd).trim()
+  return base || undefined
+}
 
 /**
  * Safely stringify a value, handling circular references, BigInt, and other edge cases.

--- a/sdk/packages/node/iii/tests/register-worker-metadata.test.ts
+++ b/sdk/packages/node/iii/tests/register-worker-metadata.test.ts
@@ -1,3 +1,6 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { registerWorker } from '../src/iii'
 
@@ -55,5 +58,77 @@ describe('registerWorkerMetadata — isolation field', () => {
     expect(sdk.trigger).toHaveBeenCalledOnce()
     const call = sdk.trigger.mock.calls[0][0]
     expect(call.payload.isolation).toBeNull()
+  })
+})
+
+describe('registerWorkerMetadata — project_name auto-detection', () => {
+  let tmpDir: string
+  let originalCwd: string
+
+  beforeEach(() => {
+    originalCwd = process.cwd()
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'iii-project-name-'))
+    process.chdir(tmpDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('reads project_name from package.json in cwd', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ name: '@scope/my-app' }))
+    const sdk = registerWorker('ws://127.0.0.1:0') as unknown as InternalSdk
+    sdk.trigger = vi.fn()
+
+    sdk.registerWorkerMetadata()
+
+    const call = sdk.trigger.mock.calls[0][0]
+    expect(call.payload.telemetry.project_name).toBe('@scope/my-app')
+  })
+
+  it('falls back to cwd basename when package.json is absent', () => {
+    const sdk = registerWorker('ws://127.0.0.1:0') as unknown as InternalSdk
+    sdk.trigger = vi.fn()
+
+    sdk.registerWorkerMetadata()
+
+    const call = sdk.trigger.mock.calls[0][0]
+    expect(call.payload.telemetry.project_name).toBe(path.basename(tmpDir))
+  })
+
+  it('falls back to cwd basename when package.json has no name field', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ version: '1.0.0' }))
+    const sdk = registerWorker('ws://127.0.0.1:0') as unknown as InternalSdk
+    sdk.trigger = vi.fn()
+
+    sdk.registerWorkerMetadata()
+
+    const call = sdk.trigger.mock.calls[0][0]
+    expect(call.payload.telemetry.project_name).toBe(path.basename(tmpDir))
+  })
+
+  it('falls back to cwd basename when package.json is malformed', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), '{ not json')
+    const sdk = registerWorker('ws://127.0.0.1:0') as unknown as InternalSdk
+    sdk.trigger = vi.fn()
+
+    sdk.registerWorkerMetadata()
+
+    const call = sdk.trigger.mock.calls[0][0]
+    expect(call.payload.telemetry.project_name).toBe(path.basename(tmpDir))
+  })
+
+  it('user-provided telemetry.project_name overrides auto-detection', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ name: 'auto-detected' }))
+    const sdk = registerWorker('ws://127.0.0.1:0', {
+      telemetry: { project_name: 'explicit-override' },
+    }) as unknown as InternalSdk
+    sdk.trigger = vi.fn()
+
+    sdk.registerWorkerMetadata()
+
+    const call = sdk.trigger.mock.calls[0][0]
+    expect(call.payload.telemetry.project_name).toBe('explicit-override')
   })
 })

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -92,10 +92,12 @@ def _detect_project_name(cwd: str | None = None) -> str | None:
     try:
         manifest = os.path.join(cwd, "pyproject.toml")
         if os.path.isfile(manifest):
+            import importlib
+
             try:
-                import tomllib  # Python 3.11+
+                tomllib = importlib.import_module("tomllib")  # Python 3.11+
             except ImportError:
-                tomllib = None  # type: ignore[assignment]
+                tomllib = None
             if tomllib is not None:
                 with open(manifest, "rb") as fh:
                     data = tomllib.load(fh)

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -77,6 +77,38 @@ def _resolve_format(fmt: Any) -> Any | None:
     return fmt
 
 
+def _detect_project_name(cwd: str | None = None) -> str | None:
+    """Return a project identifier for telemetry, derived from the current working directory.
+
+    Reads ``[project] name`` from ``pyproject.toml`` if present at ``cwd``;
+    otherwise falls back to the basename of ``cwd``. Returns ``None`` only
+    when both signals are unavailable (e.g. cwd is the filesystem root, or
+    the Python runtime has no TOML parser and no readable cwd basename).
+
+    No directory walking — only inspects ``cwd`` itself, so the SDK never
+    reads files outside the user's explicit working directory.
+    """
+    cwd = cwd or os.getcwd()
+    try:
+        manifest = os.path.join(cwd, "pyproject.toml")
+        if os.path.isfile(manifest):
+            try:
+                import tomllib  # Python 3.11+
+            except ImportError:
+                tomllib = None  # type: ignore[assignment]
+            if tomllib is not None:
+                with open(manifest, "rb") as fh:
+                    data = tomllib.load(fh)
+                name = data.get("project", {}).get("name")
+                if isinstance(name, str) and name.strip():
+                    return name.strip()
+    except Exception:
+        pass
+
+    base = os.path.basename(cwd).strip()
+    return base or None
+
+
 class _TraceContextError(Exception):
     """Wraps a handler exception with the response traceparent from the active span."""
 
@@ -1163,7 +1195,10 @@ class III:
 
         telemetry: dict[str, Any] = {
             "language": language,
-            "project_name": telemetry_opts.project_name if telemetry_opts else None,
+            "project_name": (
+                (telemetry_opts.project_name if telemetry_opts else None)
+                or _detect_project_name()
+            ),
             "framework": (telemetry_opts.framework if telemetry_opts else None) or "iii-py",
             "amplitude_api_key": (
                 telemetry_opts.amplitude_api_key if telemetry_opts else None

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -88,8 +88,8 @@ def _detect_project_name(cwd: str | None = None) -> str | None:
     No directory walking — only inspects ``cwd`` itself, so the SDK never
     reads files outside the user's explicit working directory.
     """
-    cwd = cwd or os.getcwd()
     try:
+        cwd = cwd or os.getcwd()
         manifest = os.path.join(cwd, "pyproject.toml")
         if os.path.isfile(manifest):
             import importlib
@@ -107,6 +107,8 @@ def _detect_project_name(cwd: str | None = None) -> str | None:
     except Exception:
         pass
 
+    if not cwd:
+        return None
     base = os.path.basename(cwd).strip()
     return base or None
 

--- a/sdk/packages/python/iii/tests/test_worker_metadata.py
+++ b/sdk/packages/python/iii/tests/test_worker_metadata.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -9,6 +10,14 @@ import pytest
 from iii import InitOptions
 from iii.iii import III, _detect_project_name
 from iii.iii_constants import TelemetryOptions
+
+# pyproject.toml parsing relies on stdlib tomllib (Python 3.11+).
+# On 3.10 the SDK intentionally falls back to the cwd basename, so
+# tests that assert the parsed name are skipped on that runtime.
+requires_tomllib = pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="pyproject.toml parsing requires stdlib tomllib (Python 3.11+)",
+)
 
 
 def _call_metadata_method(options: InitOptions | None = None) -> dict[str, object]:
@@ -38,6 +47,7 @@ def test_get_worker_metadata_forwards_iii_isolation_env_var(
     assert metadata["isolation"] == "docker"
 
 
+@requires_tomllib
 def test_detect_project_name_reads_pyproject_name(tmp_path: Path) -> None:
     (tmp_path / "pyproject.toml").write_text('[project]\nname = "my-pkg"\n')
 
@@ -66,6 +76,7 @@ def test_detect_project_name_falls_back_to_cwd_basename_when_pyproject_malformed
     assert _detect_project_name(str(tmp_path)) == tmp_path.name
 
 
+@requires_tomllib
 def test_get_worker_metadata_auto_detects_project_name_from_pyproject(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/sdk/packages/python/iii/tests/test_worker_metadata.py
+++ b/sdk/packages/python/iii/tests/test_worker_metadata.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+import json
+import os
+from pathlib import Path
+
 import pytest
 
 from iii import InitOptions
-from iii.iii import III
+from iii.iii import III, _detect_project_name
+from iii.iii_constants import TelemetryOptions
 
 
-def _call_metadata_method() -> dict[str, object]:
+def _call_metadata_method(options: InitOptions | None = None) -> dict[str, object]:
     stub = III.__new__(III)
-    stub._options = InitOptions()
+    stub._options = options or InitOptions()
     return stub._get_worker_metadata()
 
 
@@ -31,3 +36,67 @@ def test_get_worker_metadata_forwards_iii_isolation_env_var(
     metadata = _call_metadata_method()
 
     assert metadata["isolation"] == "docker"
+
+
+def test_detect_project_name_reads_pyproject_name(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "my-pkg"\n')
+
+    assert _detect_project_name(str(tmp_path)) == "my-pkg"
+
+
+def test_detect_project_name_falls_back_to_cwd_basename_when_no_manifest(
+    tmp_path: Path,
+) -> None:
+    assert _detect_project_name(str(tmp_path)) == tmp_path.name
+
+
+def test_detect_project_name_falls_back_to_cwd_basename_when_name_missing(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "pyproject.toml").write_text('[project]\nversion = "1.0.0"\n')
+
+    assert _detect_project_name(str(tmp_path)) == tmp_path.name
+
+
+def test_detect_project_name_falls_back_to_cwd_basename_when_pyproject_malformed(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "pyproject.toml").write_text("not valid toml [[[")
+
+    assert _detect_project_name(str(tmp_path)) == tmp_path.name
+
+
+def test_get_worker_metadata_auto_detects_project_name_from_pyproject(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "auto-detected-pkg"\n')
+    monkeypatch.chdir(tmp_path)
+
+    metadata = _call_metadata_method()
+
+    assert metadata["telemetry"]["project_name"] == "auto-detected-pkg"  # type: ignore[index]
+
+
+def test_get_worker_metadata_user_provided_project_name_wins(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "auto-detected-pkg"\n')
+    monkeypatch.chdir(tmp_path)
+    options = InitOptions(telemetry=TelemetryOptions(project_name="explicit-override"))
+
+    metadata = _call_metadata_method(options)
+
+    assert metadata["telemetry"]["project_name"] == "explicit-override"  # type: ignore[index]
+
+
+def test_get_worker_metadata_falls_back_to_cwd_basename_without_pyproject(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    metadata = _call_metadata_method()
+
+    assert metadata["telemetry"]["project_name"] == tmp_path.name  # type: ignore[index]

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -306,10 +306,10 @@ pub(crate) fn detect_project_name(cwd: Option<std::path::PathBuf>) -> Option<Str
     let cwd = cwd.or_else(|| std::env::current_dir().ok())?;
 
     let manifest = cwd.join("Cargo.toml");
-    if let Ok(content) = std::fs::read_to_string(&manifest)
-        && let Some(name) = parse_cargo_package_name(&content)
-    {
-        return Some(name);
+    if let Ok(content) = std::fs::read_to_string(&manifest) {
+        if let Some(name) = parse_cargo_package_name(&content) {
+            return Some(name);
+        }
     }
 
     cwd.file_name()

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -275,6 +275,8 @@ impl Default for WorkerMetadata {
             .filter(|s| !s.is_empty())
             .map(|s| s.split('.').next().unwrap_or(&s).to_string());
 
+        let project_name = detect_project_name(None);
+
         Self {
             runtime: "rust".to_string(),
             version: SDK_VERSION.to_string(),
@@ -283,6 +285,7 @@ impl Default for WorkerMetadata {
             pid: Some(pid),
             telemetry: Some(WorkerTelemetryMeta {
                 language,
+                project_name,
                 ..Default::default()
             }),
             isolation: std::env::var("III_ISOLATION")
@@ -290,6 +293,59 @@ impl Default for WorkerMetadata {
                 .filter(|s| !s.is_empty()),
         }
     }
+}
+
+/// Returns a project identifier for telemetry, derived from the current
+/// working directory. Reads `[package] name` from `Cargo.toml` if present at
+/// `cwd`; otherwise falls back to the basename of `cwd`. Returns `None`
+/// only when both signals are unavailable.
+///
+/// No directory walking — only inspects `cwd` itself, so the SDK never
+/// reads files outside the user's explicit working directory.
+pub(crate) fn detect_project_name(cwd: Option<std::path::PathBuf>) -> Option<String> {
+    let cwd = cwd.or_else(|| std::env::current_dir().ok())?;
+
+    let manifest = cwd.join("Cargo.toml");
+    if let Ok(content) = std::fs::read_to_string(&manifest)
+        && let Some(name) = parse_cargo_package_name(&content)
+    {
+        return Some(name);
+    }
+
+    cwd.file_name()
+        .and_then(|n| n.to_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Minimal parser for the `name` key inside the `[package]` table of a
+/// `Cargo.toml` file. Avoids adding a TOML dependency for a single field.
+fn parse_cargo_package_name(content: &str) -> Option<String> {
+    let mut in_package = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(stripped) = trimmed.strip_prefix('[') {
+            in_package = stripped.trim_end_matches(']').trim() == "package";
+            continue;
+        }
+        if !in_package {
+            continue;
+        }
+        let Some(rest) = trimmed.strip_prefix("name") else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(rest) = rest.strip_prefix('=') else {
+            continue;
+        };
+        let rest = rest.trim().strip_prefix('"')?;
+        let end = rest.find('"')?;
+        let name = rest[..end].trim();
+        if !name.is_empty() {
+            return Some(name.to_string());
+        }
+    }
+    None
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -1835,5 +1891,71 @@ mod tests {
                 None => std::env::remove_var("III_ISOLATION"),
             }
         }
+    }
+
+    #[test]
+    fn parse_cargo_package_name_extracts_name_field() {
+        let toml = "[package]\nname = \"my-crate\"\nversion = \"1.0.0\"\n";
+        assert_eq!(parse_cargo_package_name(toml), Some("my-crate".to_string()));
+    }
+
+    #[test]
+    fn parse_cargo_package_name_ignores_other_tables() {
+        let toml = "[dependencies]\nname = \"not-the-package\"\n[package]\nname = \"the-pkg\"\n";
+        assert_eq!(parse_cargo_package_name(toml), Some("the-pkg".to_string()));
+    }
+
+    #[test]
+    fn parse_cargo_package_name_returns_none_when_missing() {
+        let toml = "[package]\nversion = \"1.0.0\"\n";
+        assert_eq!(parse_cargo_package_name(toml), None);
+    }
+
+    #[test]
+    fn parse_cargo_package_name_returns_none_when_blank() {
+        let toml = "[package]\nname = \"\"\n";
+        assert_eq!(parse_cargo_package_name(toml), None);
+    }
+
+    #[test]
+    fn detect_project_name_reads_cargo_toml_in_cwd() {
+        let tmp = std::env::temp_dir().join(format!("iii-rust-detect-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::write(
+            tmp.join("Cargo.toml"),
+            "[package]\nname = \"detected-crate\"\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            detect_project_name(Some(tmp.clone())),
+            Some("detected-crate".to_string())
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn detect_project_name_falls_back_to_dir_basename_without_cargo_toml() {
+        let tmp = std::env::temp_dir().join(format!("iii-rust-fallback-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let basename = tmp.file_name().unwrap().to_str().unwrap().to_string();
+        assert_eq!(detect_project_name(Some(tmp.clone())), Some(basename));
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn detect_project_name_falls_back_to_dir_basename_when_cargo_toml_lacks_name() {
+        let tmp =
+            std::env::temp_dir().join(format!("iii-rust-fallback-noname-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::write(tmp.join("Cargo.toml"), "[package]\nversion = \"1.0.0\"\n").unwrap();
+
+        let basename = tmp.file_name().unwrap().to_str().unwrap().to_string();
+        assert_eq!(detect_project_name(Some(tmp.clone())), Some(basename));
+
+        std::fs::remove_dir_all(&tmp).ok();
     }
 }


### PR DESCRIPTION
## Why

While auditing Amplitude `heartbeat` events for iii v0.11+, two data-quality bugs surfaced that together make the telemetry nearly unusable for answering basic questions like *"how many distinct projects are running iii?"* and *"is the engine being launched directly or wrapped by something?"*

### Bug 1 — `client_type` is conflated with worker framework

`client_type` is supposed to identify *how the engine was launched* (e.g. directly via iii vs. wrapped by an external framework). Instead, the engine overrides it with the connected worker's `framework` field. So an iii engine that happens to host a motia-step worker reports `client_type=motia` even though the engine itself was launched as `iii_direct`.

Last 90 days, this causes `client_type` to take **six** values, only one of which is correct:

| client_type | what it actually means |
|---|---|
| `iii_direct` | iii engine, no framework on workers (correct) |
| `iii-node`   | iii engine + Node SDK worker (bug, should be `iii_direct`) |
| `iii-py`     | iii engine + Python SDK worker (bug) |
| `iii-rust`   | iii engine + Rust SDK worker (bug) |
| `motia`      | iii engine + motia-step worker (bug) |
| `nvent`      | iii engine + custom `nvent` worker (bug) |

Concretely, the same engine can flip between `iii_direct` and `iii-node` *within the same minute* depending on whether its SDK worker has finished its WebSocket handshake when the heartbeat fires. This double-counts users across the `client_type` dimension and drowns the legitimate `iii_direct` count under five bogus buckets.

Motia is no longer being released, so the original launcher distinction is gone — every v0.11+ engine is `iii_direct`.

### Bug 2 — `project_name` is almost never populated

Each SDK only sent `telemetry.project_name` when the user explicitly passed it in SDK options. In practice almost no one does. Result: nearly every iii v0.11+ engine in Amplitude reports `project_name=(none)`, making it impossible to count distinct projects.

## What this PR does

### Engine fix — `client_type`

`engine/src/workers/telemetry/mod.rs` no longer overrides `client_type` with the worker's framework. It always uses `detect_client_type()`, which returns `iii_direct` in v0.11+. Worker-level framework visibility is unchanged via the existing `worker_count_by_framework` field.

```rust
// Before
let client_type = sdk_telemetry
    .as_ref()
    .and_then(|t| t.framework.clone())
    .unwrap_or_else(|| environment::detect_client_type().to_string());

// After
let client_type = environment::detect_client_type().to_string();
```

### SDK fix — `project_name` auto-detection

All three SDKs now derive `project_name` from the current working directory using this resolution order:

1. **User-provided** `telemetry.project_name` (unchanged, highest priority)
2. **Manifest at `cwd`** — language-appropriate file:
   - Node: `package.json` `name`
   - Python: `pyproject.toml` `[project] name`
   - Rust: `Cargo.toml` `[package] name`
3. **`cwd` basename**

**Design notes:**

- **No directory walking.** Only inspects `cwd` itself — the SDK never reads files outside the user's explicit working directory. This addresses the concern about walking too far up or accidentally picking up an unrelated parent project's manifest.
- **Always returns something** (unless `cwd` is the filesystem root). The dir-name fallback means even users without a manifest get a meaningful identifier instead of `(none)`.
- **Rust avoids a new TOML dependency.** A small inline parser handles the `[package] name` field — adding a full TOML crate for one field wasn't worth it.
- **Python uses stdlib `tomllib`** (3.11+). On 3.10 the import fails gracefully and we fall back to the cwd basename.

## Files changed

**Engine:**
- `engine/src/workers/telemetry/mod.rs` — drop framework→client_type override; update existing motia-framework test to assert `client_type == "iii_direct"`.

**Node SDK:**
- `sdk/packages/node/iii/src/utils.ts` — new `detectProjectName(cwd?)` helper.
- `sdk/packages/node/iii/src/iii.ts` — wire it into `registerWorkerMetadata`.
- `sdk/packages/node/iii/tests/register-worker-metadata.test.ts` — 5 new tests.

**Python SDK:**
- `sdk/packages/python/iii/src/iii/iii.py` — new `_detect_project_name(cwd?)` helper, wired into `_get_worker_metadata`.
- `sdk/packages/python/iii/tests/test_worker_metadata.py` — 7 new tests.

**Rust SDK:**
- `sdk/packages/rust/iii/src/iii.rs` — new `detect_project_name(cwd?)` and `parse_cargo_package_name` helpers, wired into `WorkerMetadata::default`. 6 new unit tests.

## Test plan

- [x] Engine: `cargo test --lib workers::telemetry` — 143 pass
- [x] Node SDK: `bun test tests/register-worker-metadata.test.ts` — 8 pass (3 existing + 5 new)
- [x] Python SDK: `uv run pytest tests/test_worker_metadata.py` — 9 pass (2 existing + 7 new)
- [x] Rust SDK: `cargo test --lib` — 66 pass (60 existing + 6 new)
- [ ] After release + redeploy, verify in Amplitude:
  - Regression chart for the client_type bug trends to zero: https://app.amplitude.com/analytics/motia/chart/zz6tiev7
  - `project_name=(none)` count drops materially for v0.11+ heartbeats

## Rollout notes

The two fixes are independent:
- The engine fix ships server-side and takes effect for all heartbeats as soon as it's deployed.
- The SDK fix only takes effect once users upgrade their SDK and redeploy. Until then their engines will continue reporting `project_name=(none)` (no regression).

Historical events in Amplitude keep their bogus `client_type` values until they age out of the 90-day rolling window. If immediate clean dashboards are needed, an Amplitude transformation can backfill `client_type ∈ {iii-node, iii-py, iii-rust, motia, nvent}` → `iii_direct` for events with `iii_version` prefix `0.11`. Otherwise the data self-corrects within ~3 months.

Replaces #1594 and #1595.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SDKs now auto-populate telemetry project name from common project manifests (with a fallback to the directory basename).
  * Worker telemetry now determines client type consistently from the runtime environment.
* **Tests**
  * Added cross-language tests verifying project-name auto-detection, fallbacks, and explicit overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->