### PR TITLE
fix(ci): pin engine worker publish to the release version

### DIFF
--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -43,37 +43,33 @@ jobs:
       - name: Install pyyaml
         run: pip install --quiet pyyaml
 
+      # Pin the iii CLI to the version we are publishing. Without this the
+      # install script picks "latest stable", which can be older than the
+      # tag being released and may lack features that the publish step
+      # depends on (for example `engine::workers::list` exposing engine
+      # internal workers landed in PR #1585). The install script also
+      # bundles `iii-worker`, which iii-sandbox needs at runtime.
       - name: Install iii CLI
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
         run: |
           set -euo pipefail
+          expected="$VERSION_INPUT"
+          if [[ -z "$expected" && "${GITHUB_REF_NAME:-}" == iii/v* ]]; then
+            expected="${GITHUB_REF_NAME#iii/v}"
+          fi
+          install_args=()
+          if [[ "$expected" == *-* ]]; then
+            install_args+=("--next")
+          fi
           curl -fsSL https://install.iii.dev/iii/main/install.sh -o /tmp/install-iii.sh
-          sh /tmp/install-iii.sh
+          VERSION="$expected" sh /tmp/install-iii.sh "${install_args[@]}"
           {
             echo "$HOME/.local/bin"
             echo "$HOME/.iii/bin"
           } >> "$GITHUB_PATH"
           export PATH="$HOME/.local/bin:$HOME/.iii/bin:$PATH"
           iii --version
-
-      - name: Setup Rust toolchain (iii-sandbox only)
-        if: inputs.worker == 'iii-sandbox'
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install system dependencies for iii-worker (iii-sandbox only)
-        if: inputs.worker == 'iii-sandbox'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libcap-ng-dev
-
-      - name: Build and install iii-worker (iii-sandbox only)
-        if: inputs.worker == 'iii-sandbox'
-        run: |
-          set -euo pipefail
-          cargo build -p iii-worker
-          mkdir -p "$HOME/.local/bin"
-          cp target/debug/iii-worker "$HOME/.local/bin/iii-worker"
-          chmod +x "$HOME/.local/bin/iii-worker"
-          iii-worker --version || true
 
       # Each builtin engine worker has different auto-load semantics
       # (mandatory / enabled_by_default / external). Rather than rely on the


### PR DESCRIPTION
## Why the publish failed

All 10 jobs of `publish-builtin-workers` failed in run [25318682735](https://github.com/iii-hq/iii/actions/runs/25318682735) with:

```
ValueError: expected exactly one worker matching 'iii-http', found 0
```

Root cause: the install step defaulted to "latest stable", which is **v0.11.5**. The `engine::workers::list` integration that surfaces engine internal workers landed in PR #1585 (commit `06d31e21`) and is only available from v0.11.6 onward. Without it, builtin engine workers (no pid, in-process) are filtered out of the response, so `count_worker_matches` returns 0 and `normalize_worker_interface` raises.

## Fix

- Pin `VERSION` for the install script to `inputs.version` or the `iii/v*` tag the workflow is running on, so the publish step uses the binary that's actually being released.
- Pass `--next` when the version is a prerelease (the install script rejects prereleases otherwise).
- Drop the iii-sandbox-only Rust toolchain + `cargo build -p iii-worker` steps — the install script already bundles `iii-worker`, and `dtolnay/rust-toolchain@stable` was failing with `'toolchain' is a required input` on top of being redundant.

## Test plan

- [ ] After merge, retag (or push a new `iii/v0.11.6-next.2`) and confirm `publish-builtin-workers` succeeds for all 10 matrix entries.
- [ ] Verify the iii CLI step's logs show `installed iii v0.11.6-next.1` (or whatever version is being released), not the previous stable.
- [ ] Confirm `engine::workers::list` returns each builtin so `Collect worker interface` doesn't time out at 120s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to improve engine worker publishing reliability with Python 3.12 support and enhanced version pinning for prerelease builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->