### PR TITLE
fix(ci): align engine publish payload with registry schema

### DIFF
--- a/.github/scripts/build_engine_publish_payload.py
+++ b/.github/scripts/build_engine_publish_payload.py
@@ -8,16 +8,6 @@ import tomllib
 from typing import Any
 
 
-def normalize_dependencies(raw_deps: Any) -> list[dict[str, Any]]:
-    if raw_deps in (None, ""):
-        return []
-    if isinstance(raw_deps, dict):
-        return [{"name": name, "version": version} for name, version in raw_deps.items()]
-    if isinstance(raw_deps, list):
-        return raw_deps
-    raise ValueError(f"`dependencies` must be a map or list, got {type(raw_deps).__name__}")
-
-
 def derive_registry_function_name(function_id: str, metadata: dict[str, Any] | None) -> str:
     metadata = metadata or {}
     for key in ("registry_name", "name"):
@@ -180,6 +170,9 @@ def build_payload(
     readme_path = repo_root / worker_dir / "README.md"
     readme = readme_path.read_text(encoding="utf-8") if readme_path.exists() else ""
 
+    # The registry's POST /publish schema for `type: engine` only accepts the
+    # base metadata plus `functions` / `triggers`. `dependencies` and `config`
+    # were rejected with HTTP 422 ("Unrecognized key") on iii/v0.11.6-next.2.
     return {
         "worker_name": worker,
         "version": engine_version,
@@ -188,8 +181,6 @@ def build_payload(
         "readme": readme,
         "repo": repo_url,
         "description": meta.get("description", ""),
-        "dependencies": normalize_dependencies(meta.get("dependencies")),
-        "config": meta.get("config") or {},
         "functions": interface.get("functions") or [],
         "triggers": interface.get("triggers") or [],
     }

--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -129,15 +129,6 @@ jobs:
             --out worker-interface.json \
             --wait-seconds 120
 
-      - name: Assert worker interface was collected
-        run: |
-          python3 - <<'PY'
-          import json
-          data = json.load(open("worker-interface.json"))
-          if not data.get("functions"):
-              raise SystemExit("no worker functions were collected")
-          PY
-
       - name: Build payload
         id: payload
         env:


### PR DESCRIPTION
Two distinct failures observed in [run 25325103451](https://github.com/iii-hq/iii/actions/runs/25325103451) for tag \`iii/v0.11.6-next.2\`:

## 1. Workers with functions → HTTP 422 \"Unrecognized key: 'dependencies'\"

\`iii-state\`, \`iii-observability\`, \`iii-queue\`, \`iii-pubsub\`, \`iii-cron\` reached \`POST /publish\` and the registry rejected the payload:

\`\`\`
HTTP 422
{\"error\":\"Unrecognized key: \\\"dependencies\\\"\"}
\`\`\`

The registry's schema for \`type: engine\` only accepts the base metadata plus \`functions\` / \`triggers\`. \`dependencies\` and \`config\` were rejected. Engine workers don't have inter-worker dependencies the way external workers do, and the engine binary owns its configuration, so dropping both fields is the right shape.

## 2. Workers without functions → assertion failed

\`iii-http\` and \`iii-bridge\` failed at \`Assert worker interface was collected\`:

\`\`\`python
if not data.get(\"functions\"):
    raise SystemExit(\"no worker functions were collected\")
\`\`\`

Both workers register only trigger types (\`http\`, \`bridge\`) for other workers to consume — no RPC functions of their own. \`functions: []\` is the correct output for them. \`collect_engine_worker_interface.py\` already raises \`ValueError\` when the worker isn't found in \`engine::workers::list\`, which is the real \"worker didn't load\" guard. The assertion was redundant and actively wrong for infrastructure workers.

## Changes

- Drop \`dependencies\` and \`config\` from the engine publish payload.
- Remove the now-unused \`normalize_dependencies\` helper.
- Remove the \`Assert worker interface was collected\` workflow step.

## Test plan

- [ ] After merge, bump to \`iii/v0.11.6-next.3\` and confirm all 10 \`Publish builtin workers\` jobs succeed.
- [ ] Confirm \`iii-http\` job now reaches \`POST /publish\` (no longer fails at the assertion) and gets \`200\` or \`409\`.
- [ ] Confirm \`iii-state\` POST returns \`200\` (or \`409\` if \`next.2\` had partially published).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated engine registry publish payload to exclude certain fields previously rejected by the schema, streamlining the publishing process.
  * Removed an intermediate validation step from the engine publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->