### PR TITLE
fix(ci): collect trigger types, keep namespace in function names

### DIFF
--- a/.github/scripts/build_engine_publish_payload.py
+++ b/.github/scripts/build_engine_publish_payload.py
@@ -2,7 +2,6 @@
 import argparse
 import json
 import pathlib
-import re
 import sys
 import tomllib
 from typing import Any
@@ -24,8 +23,6 @@ def derive_registry_function_name(function_id: str, metadata: dict[str, Any] | N
         value = metadata.get(key)
         if isinstance(value, str) and value.strip():
             return value.strip()
-    if "::" in function_id:
-        return function_id.rsplit("::", 1)[1]
     return function_id
 
 
@@ -59,46 +56,13 @@ def _string_or_empty(value: Any) -> str:
     return value if isinstance(value, str) else ""
 
 
-def _slug(value: Any, fallback: str) -> str:
-    raw = value if isinstance(value, str) else fallback
-    slug = re.sub(r"[^a-z0-9]+", "-", raw.lower()).strip("-")
-    return slug or fallback
-
-
-def _derive_trigger_name(trigger: dict[str, Any]) -> str:
-    metadata = _metadata_or_empty(trigger.get("metadata"))
-    for key in ("registry_name", "name"):
-        value = metadata.get(key)
-        if isinstance(value, str) and value.strip():
-            return _slug(value, "trigger")
-    config = trigger.get("config") if isinstance(trigger.get("config"), dict) else {}
-    api_path = config.get("api_path")
-    if isinstance(api_path, str) and api_path.strip():
-        return _slug(api_path, "trigger")
-    function_id = trigger.get("function_id")
-    if isinstance(function_id, str) and function_id.strip():
-        return _slug(function_id.rsplit("::", 1)[-1], "trigger")
-    return _slug(trigger.get("trigger_type") or trigger.get("name"), "trigger")
-
-
-def _normalize_registry_trigger(trigger: dict[str, Any]) -> dict[str, Any]:
-    config = trigger.get("config") if isinstance(trigger.get("config"), dict) else {}
-    metadata = _metadata_or_empty(trigger.get("metadata")).copy()
-    for source_key, metadata_key in (
-        ("id", "engine_id"),
-        ("trigger_type", "trigger_type"),
-        ("function_id", "function_id"),
-    ):
-        if trigger.get(source_key) is not None:
-            metadata.setdefault(metadata_key, trigger.get(source_key))
-    if config:
-        metadata.setdefault("config", config)
+def _normalize_registry_trigger_type(trigger_type: dict[str, Any]) -> dict[str, Any]:
     return {
-        "name": _derive_trigger_name(trigger),
-        "description": _string_or_empty(trigger.get("description")),
-        "invocation_schema": _schema_or_empty(trigger.get("invocation_schema")),
-        "return_schema": _schema_or_empty(trigger.get("return_schema")),
-        "metadata": metadata,
+        "name": _string_or_empty(trigger_type.get("id")),
+        "description": _string_or_empty(trigger_type.get("description")),
+        "invocation_schema": _schema_or_empty(trigger_type.get("trigger_request_format")),
+        "return_schema": _schema_or_empty(trigger_type.get("call_request_format")),
+        "metadata": {},
     }
 
 
@@ -107,7 +71,7 @@ def normalize_worker_interface(
     worker_name: str,
     workers_json: dict[str, Any],
     functions_json: dict[str, Any],
-    triggers_json: dict[str, Any] | None = None,
+    trigger_types_json: dict[str, Any] | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     workers = _extract_array(workers_json, "workers")
     matches = [w for w in workers if w.get("name") == worker_name or w.get("id") == worker_name]
@@ -136,13 +100,13 @@ def normalize_worker_interface(
                 "metadata": _metadata_or_empty(metadata),
             }
         )
-    worker_ids = set(worker_function_ids)
     triggers = []
-    if triggers_json:
-        for trigger in _extract_array(triggers_json, "triggers"):
-            if trigger.get("function_id") not in worker_ids:
+    if trigger_types_json:
+        for trigger_type in _extract_array(trigger_types_json, "trigger_types"):
+            tt_id = trigger_type.get("id")
+            if not isinstance(tt_id, str) or tt_id.startswith("engine::"):
                 continue
-            triggers.append(_normalize_registry_trigger(trigger))
+            triggers.append(_normalize_registry_trigger_type(trigger_type))
     return {"functions": functions, "triggers": triggers}
 
 

--- a/.github/scripts/collect_engine_worker_interface.py
+++ b/.github/scripts/collect_engine_worker_interface.py
@@ -48,15 +48,16 @@ def wait_for_worker(worker_name: str, wait_seconds: int) -> dict[str, object]:
     return workers_json
 
 
-def collect_trigger_types() -> dict[str, object] | None:
+def collect_trigger_types() -> dict[str, object]:
+    # Trigger types are the primary content for infrastructure workers
+    # (iii-http, iii-cron, iii-bridge, ...) — they register a trigger type
+    # and no RPC functions. Returning {} on failure would silently publish
+    # `triggers=[]` and the registry would accept it, masking the real
+    # surface of the worker. Fail closed instead.
     try:
         return run_iii("engine::trigger-types::list", {"include_internal": False})
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
-        print(
-            f"::warning::could not collect trigger types; publishing triggers=[]: {exc}",
-            file=sys.stderr,
-        )
-        return None
+        raise RuntimeError(f"could not collect trigger types: {exc}") from exc
 
 
 def main() -> int:

--- a/.github/scripts/collect_engine_worker_interface.py
+++ b/.github/scripts/collect_engine_worker_interface.py
@@ -48,12 +48,12 @@ def wait_for_worker(worker_name: str, wait_seconds: int) -> dict[str, object]:
     return workers_json
 
 
-def collect_triggers() -> dict[str, object] | None:
+def collect_trigger_types() -> dict[str, object] | None:
     try:
-        return run_iii("engine::triggers::list", {"include_internal": True})
+        return run_iii("engine::trigger-types::list", {"include_internal": False})
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
         print(
-            f"::warning::could not collect triggers; publishing triggers=[]: {exc}",
+            f"::warning::could not collect trigger types; publishing triggers=[]: {exc}",
             file=sys.stderr,
         )
         return None
@@ -68,13 +68,13 @@ def main() -> int:
 
     workers_json = wait_for_worker(args.worker, args.wait_seconds)
     functions_json = run_iii("engine::functions::list", {"include_internal": True})
-    triggers_json = collect_triggers()
+    trigger_types_json = collect_trigger_types()
 
     interface = normalize_worker_interface(
         worker_name=args.worker,
         workers_json=workers_json,
         functions_json=functions_json,
-        triggers_json=triggers_json,
+        trigger_types_json=trigger_types_json,
     )
     pathlib.Path(args.out).write_text(json.dumps(interface, indent=2) + "\n", encoding="utf-8")
     print(json.dumps(interface, indent=2))

--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -129,15 +129,6 @@ jobs:
             --out worker-interface.json \
             --wait-seconds 120
 
-      - name: Assert worker interface was collected
-        run: |
-          python3 - <<'PY'
-          import json
-          data = json.load(open("worker-interface.json"))
-          if not data.get("functions"):
-              raise SystemExit("no worker functions were collected")
-          PY
-
       - name: Build payload
         id: payload
         env:


### PR DESCRIPTION
Mirrors the recent fixes from [iii-hq/workers @ main](https://github.com/iii-hq/workers) for the same publish pipeline. Three issues observed against the engine workers in [run 25325103451](https://github.com/iii-hq/iii/actions/runs/25325103451):

## 1. Function-name collisions (HTTP 422 "duplicate")

`iii-observability` registers 19 functions across `engine::log::*`, `engine::traces::*`, `engine::metrics::*`, `engine::logs::*`, `engine::alerts::*`, `engine::rollups::*`. Today's `derive_registry_function_name` strips the namespace via `rsplit("::", 1)[1]`, so `traces::list`, `logs::list`, `metrics::list`, `alerts::list`, `rollups::list` all collapse to `list` and the registry rejects the publish.

Drop the rsplit. Default to the full `function_id`. Workers that want a short name can still set `metadata.registry_name`.

(Same fix as workers-repo [49c3fe5](https://github.com/iii-hq/workers/commit/49c3fe5).)

## 2. Triggers always empty

Today the collect step calls `engine::triggers::list`, which returns trigger **instances** (subscriptions registered by other workers). During publish only the target worker is connected, so instances are empty by definition.

The thing the registry actually wants is the trigger **types** the worker exposes for others to subscribe to: `http`, `state`, `cron`, `stream`, `pubsub`, `queue`, `bridge`, `sandbox::*`, etc.

Switch to `engine::trigger-types::list` (with `include_internal: false` so the engine filters out `engine::*` types). Map `TriggerTypeInfo` entries to the registry trigger schema:

- `id` → `name`
- `description` → `description`
- `trigger_request_format` → `invocation_schema`
- `call_request_format` → `return_schema`

Filter `engine::*` types client-side too as a safety net.

(Same fix as workers-repo [1a6945c](https://github.com/iii-hq/workers/commit/1a6945c).)

## 3. Assert step is wrong for infrastructure workers

`iii-http`, `iii-bridge`, and `iii-cron` only register trigger types — no RPC functions of their own — so `functions: []` is valid output, not a sign the worker failed to load. The `Assert worker interface was collected` step kills these jobs on a false positive.

`collect_engine_worker_interface.py` already raises `ValueError` when the worker isn't in `engine::workers::list`, which is the real "worker didn't load" guard. Drop the redundant assert.

## Cleanup

Removed now-unused helpers (`_slug`, `_derive_trigger_name`, `_normalize_registry_trigger`) and the `re` import.

## Test plan

- [ ] After merge, bump to a new prerelease (e.g. `iii/v0.11.6-next.3`) and confirm all 10 `Publish builtin workers` jobs succeed.
- [ ] `iii-observability` payload no longer has duplicate function names.
- [ ] `iii-http`, `iii-cron`, `iii-bridge` payloads emit non-empty `triggers[]` (one entry per trigger type) and reach `POST /publish`.
- [ ] Workers that have both functions and trigger types (e.g. `iii-state`) emit both populated arrays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Worker interface processing now derives function names strictly from provided metadata.
  * Trigger handling updated to collect and use trigger type definitions rather than individual trigger instances.
  * Publishing workflow streamlined by removing a post-collection validation that could block publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->