### PR TITLE
fix(ci): baseline-diff trigger types + iii-exec stub + full engine log

### DIFF
--- a/.github/scripts/build_engine_publish_payload.py
+++ b/.github/scripts/build_engine_publish_payload.py
@@ -72,6 +72,7 @@ def normalize_worker_interface(
     workers_json: dict[str, Any],
     functions_json: dict[str, Any],
     trigger_types_json: dict[str, Any] | None = None,
+    baseline_trigger_types_json: dict[str, Any] | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     workers = _extract_array(workers_json, "workers")
     matches = [w for w in workers if w.get("name") == worker_name or w.get("id") == worker_name]
@@ -100,11 +101,25 @@ def normalize_worker_interface(
                 "metadata": _metadata_or_empty(metadata),
             }
         )
+
+    # Trigger types are global to the engine — `engine::trigger-types::list`
+    # cannot scope by worker today (see PR #1601 discussion). To keep the
+    # target worker's payload free of types contributed by `mandatory`
+    # workers (notably iii-observability's `log`), diff against a baseline
+    # snapshot taken before the target worker reloaded into the engine.
+    baseline_ids = {
+        tt["id"]
+        for tt in _extract_array(baseline_trigger_types_json or {}, "trigger_types")
+        if isinstance(tt.get("id"), str)
+    }
+
     triggers = []
     if trigger_types_json:
         for trigger_type in _extract_array(trigger_types_json, "trigger_types"):
             tt_id = trigger_type.get("id")
             if not isinstance(tt_id, str) or tt_id.startswith("engine::"):
+                continue
+            if tt_id in baseline_ids:
                 continue
             triggers.append(_normalize_registry_trigger_type(trigger_type))
     return {"functions": functions, "triggers": triggers}

--- a/.github/scripts/collect_engine_worker_interface.py
+++ b/.github/scripts/collect_engine_worker_interface.py
@@ -65,7 +65,14 @@ def main() -> int:
     parser.add_argument("--worker", required=True)
     parser.add_argument("--out", default="worker-interface.json")
     parser.add_argument("--wait-seconds", type=int, default=0)
+    parser.add_argument("--trigger-types-baseline", default="")
     args = parser.parse_args()
+
+    baseline_json = None
+    if args.trigger_types_baseline:
+        baseline_path = pathlib.Path(args.trigger_types_baseline)
+        if baseline_path.exists():
+            baseline_json = json.loads(baseline_path.read_text(encoding="utf-8"))
 
     workers_json = wait_for_worker(args.worker, args.wait_seconds)
     functions_json = run_iii("engine::functions::list", {"include_internal": True})
@@ -76,6 +83,7 @@ def main() -> int:
         workers_json=workers_json,
         functions_json=functions_json,
         trigger_types_json=trigger_types_json,
+        baseline_trigger_types_json=baseline_json,
     )
     pathlib.Path(args.out).write_text(json.dumps(interface, indent=2) + "\n", encoding="utf-8")
     print(json.dumps(interface, indent=2))

--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -197,7 +197,11 @@ jobs:
         if: failure()
         run: |
           echo "::group::iii engine log"
-          tail -n 200 iii-engine.log || true
+          # Full log instead of tail: iii-sandbox spawns iii-worker as a
+          # subprocess whose stderr is forwarded into this file, and the
+          # interesting output is at the start (initial spawn) — a tail
+          # would only show the post-mortem reconnect loop.
+          cat iii-engine.log || true
           echo "::endgroup::"
 
       - name: Stop III engine

--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -71,34 +71,14 @@ jobs:
           export PATH="$HOME/.local/bin:$HOME/.iii/bin:$PATH"
           iii --version
 
-      # Each builtin engine worker has different auto-load semantics
-      # (mandatory / enabled_by_default / external). Rather than rely on the
-      # ambient default, write a config that explicitly lists only the worker
-      # we are publishing, using its own iii.worker.yaml `config:` block as
-      # the worker's runtime config.
-      - name: Write engine config for ${{ inputs.worker }}
-        env:
-          WORKER: ${{ inputs.worker }}
-          WORKER_DIR: ${{ inputs.worker_dir }}
-        run: |
-          set -euo pipefail
-          python3 - <<'PY'
-          import os, pathlib, yaml
-          worker = os.environ["WORKER"]
-          worker_dir = pathlib.Path(os.environ["WORKER_DIR"])
-          manifest = worker_dir / "iii.worker.yaml"
-          meta = yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
-          entry = {"name": worker}
-          if meta.get("config") is not None:
-              entry["config"] = meta["config"]
-          config = {"workers": [entry]}
-          pathlib.Path("config.yaml").write_text(yaml.dump(config, sort_keys=False), encoding="utf-8")
-          PY
-          cat config.yaml
-
+      # Boot the engine with no workers so we can snapshot the trigger
+      # types registered by `mandatory` workers (e.g. iii-observability's
+      # `log` trigger type). The collect step diffs those out so the target
+      # worker's payload only carries the types it actually contributes.
       - name: Start III engine
         run: |
           set -euo pipefail
+          printf 'workers: []\n' > config.yaml
           iii --config config.yaml --no-update-check > iii-engine.log 2>&1 &
           echo "$!" > iii-engine.pid
 
@@ -120,6 +100,38 @@ jobs:
           cat iii-engine.log || true
           exit 1
 
+      - name: Snapshot engine trigger types baseline
+        run: |
+          set -euo pipefail
+          iii trigger \
+            --function-id='engine::trigger-types::list' \
+            --payload='{"include_internal": false}' \
+            > trigger-types-baseline.json
+          cat trigger-types-baseline.json
+
+      # Reload the engine with the target worker by overwriting config.yaml.
+      # The engine watches config.yaml and reloads on change, so the target
+      # worker registers without restarting.
+      - name: Reload engine with target worker (${{ inputs.worker }})
+        env:
+          WORKER: ${{ inputs.worker }}
+          WORKER_DIR: ${{ inputs.worker_dir }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os, pathlib, yaml
+          worker = os.environ["WORKER"]
+          worker_dir = pathlib.Path(os.environ["WORKER_DIR"])
+          manifest = worker_dir / "iii.worker.yaml"
+          meta = yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
+          entry = {"name": worker}
+          if meta.get("config") is not None:
+              entry["config"] = meta["config"]
+          config = {"workers": [entry]}
+          pathlib.Path("config.yaml").write_text(yaml.dump(config, sort_keys=False), encoding="utf-8")
+          PY
+          cat config.yaml
+
       - name: Collect worker interface
         env:
           WORKER: ${{ inputs.worker }}
@@ -127,7 +139,8 @@ jobs:
           python3 .github/scripts/collect_engine_worker_interface.py \
             --worker "$WORKER" \
             --out worker-interface.json \
-            --wait-seconds 120
+            --wait-seconds 120 \
+            --trigger-types-baseline trigger-types-baseline.json
 
       - name: Build payload
         id: payload

--- a/engine/src/workers/shell/iii.worker.yaml
+++ b/engine/src/workers/shell/iii.worker.yaml
@@ -3,3 +3,5 @@ name: iii-exec
 type: engine
 description: Execute shell commands as part of engine startup.
 repo: https://github.com/iii-hq/iii
+config:
+  exec: []


### PR DESCRIPTION
Three follow-ups that didn't make it into PR #1601 before merge.

## 1. Baseline-diff for trigger types

Mirrors [iii-hq/workers @ 184c130](https://github.com/iii-hq/workers/commit/184c130). Every engine worker has been publishing a `log` trigger type that it doesn't actually register. iii-observability's module (`engine/src/workers/observability/mod.rs:1487-1494`) registers `log` as a built-in trigger type without an `engine::` prefix, so neither the engine's own `include_internal: false` filter (`engine_fn/mod.rs:587`) nor the post-#1601 namespace filter catches it; the type leaks into every worker's payload.

`engine::trigger-types::list` cannot scope by worker today (see [discussion on PR #1601](https://github.com/iii-hq/iii/pull/1601#discussion_r3184629675)), so:

1. Boot the engine with `workers: []` so only `mandatory` workers load.
2. Snapshot `engine::trigger-types::list` → `trigger-types-baseline.json`.
3. Overwrite `config.yaml` with the target worker; the engine reloads it via the existing config-watch mechanism.
4. Pass `--trigger-types-baseline` to `collect_engine_worker_interface`. `normalize_worker_interface` excludes any id present in the baseline so the published `triggers[]` is exactly what the target worker contributed.

The baseline arg is optional; missing file is treated as no baseline, preserving stand-alone use of the script.

## 2. iii-exec panics on boot

`engine/src/workers/shell/worker.rs:28` calls `.unwrap()` on the `config: Option<Value>` argument:

```rust
let config: ExecConfig = config.map(serde_json::from_value).transpose()?.unwrap();
```

iii-exec's `iii.worker.yaml` has no `config:` block, so when the publish flow boots the engine with that worker, the engine panics before reload can register the worker. ExecConfig requires `exec: Vec<String>` (no default), and iii-exec registers no functions and no trigger types — its publish payload is always empty interface. Add an empty `config: { exec: [] }` to the manifest so iii-exec loads as a no-op in CI; users continue to override with their own config.yaml in production.

## 3. iii-sandbox post-mortem visibility

The job dumps `tail -n 200 iii-engine.log` on failure. iii-sandbox spawns iii-worker as an external subprocess whose stderr is forwarded into that same file via `external.rs::forward_pipe`, but the engine's reload loop emits a line every ~500ms and a reconnect cycle every ~2s, so by the time the publish step times out the head of the log (which carries the actual subprocess panic / connect error) has scrolled off the 200-line tail. Switch to `cat` so the next tagged run surfaces what is actually killing the subprocess.

Re-run [25375637416/job/74421690316](https://github.com/iii-hq/iii/actions/runs/25375637416/job/74421690316) confirms the iii-sandbox failure is unchanged but the cause is still hidden behind the truncated tail.

## Test plan

- [ ] After merge, bump to `iii/v0.11.6-next.4` and confirm:
  - [ ] `iii-state`, `iii-http`, etc. publish payloads no longer carry a stray `log` trigger type.
  - [ ] `iii-exec` reaches `POST /publish` (no longer panics at boot).
  - [ ] `iii-sandbox` failure log shows the actual subprocess error from the start of the run, enabling a follow-up fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced worker interface generation to more accurately track trigger types by comparing against baseline configurations.
  * Improved error diagnostics by expanding log output during worker publication failures.
  * Established default configuration values for the shell worker to ensure consistent initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->