### PR TITLE
fix(sandbox-daemon): identify worker as iii-sandbox to the engine

### DIFF
--- a/crates/iii-worker/src/sandbox_daemon/mod.rs
+++ b/crates/iii-worker/src/sandbox_daemon/mod.rs
@@ -23,17 +23,28 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, InitOptions, OtelConfig, RegisterFunctionMessage, register_worker};
+use iii_sdk::{
+    IIIError, InitOptions, OtelConfig, RegisterFunctionMessage, WorkerMetadata, register_worker,
+};
 use serde_json::Value;
 
 use crate::sandbox_daemon::config::SandboxConfig;
 
 pub async fn run(config: SandboxConfig, engine_url: &str) -> anyhow::Result<()> {
     tracing::info!(url = %engine_url, "connecting to III engine");
+    // Identify ourselves as `iii-sandbox` so the engine surfaces this
+    // worker by its config-yaml name (and not the auto-detected
+    // `<hostname>:<pid>`) in `engine::workers::list` and friends. The
+    // publish workflow polls by this name to decide when the worker is
+    // ready for interface collection.
     let iii = register_worker(
         engine_url,
         InitOptions {
             otel: Some(OtelConfig::default()),
+            metadata: Some(WorkerMetadata {
+                name: "iii-sandbox".to_string(),
+                ..Default::default()
+            }),
             ..Default::default()
         },
     );


### PR DESCRIPTION
## The bug

Run [25380984349/job/74432654425](https://github.com/iii-hq/iii/actions/runs/25380984349/job/74432654425) is the first one with the full engine-log dump, and it shows iii-sandbox actually works:

```
[02:19:57.090 PM] iii::workers::config Resolved 'iii-sandbox' as external worker
[02:19:59.091 PM] iii::workers::external Spawned external worker 'iii-sandbox' (pid: Some(2415))
[02:19:59.094 PM] iii::worker_connections Worker registered  worker_id: 740c34d8-…
[02:19:59.094 PM] [REGISTERED] Function sandbox::fs::ls
[02:19:59.094 PM] [REGISTERED] Function sandbox::fs::chmod
… 14 functions in total, no unregister
```

The subprocess is alive, connected, and serving the full sandbox interface. The collect step still times out with:

```
ValueError: expected exactly one worker matching 'iii-sandbox', found 0
```

## Why

`SandboxDaemon` calls `register_worker(...)` without `metadata`, so the SDK fills it with `WorkerMetadata::default()` (sdk/packages/rust/iii/src/iii.rs:259-296), where `name = format!("{hostname}:{pid}")` — e.g. `"runner-vm:2415"`. The engine records that as `WorkerInfo.name`.

For in-process engine workers (iii-state, iii-http, …) the engine fills `WorkerInfo.name` from `entry.name` in config.yaml (engine/src/workers/config.rs:402-410), which is why the publish workflow's `count_worker_matches` finds them by `"iii-state"`, `"iii-http"`, etc.

External-process workers like iii-sandbox bypass that path (`is_external_process()` returns `None` from `runtime_worker_info_from_registration`) and surface only via `worker_registry.list_workers()` with the UUID id and the SDK-supplied name. That name is the `<hostname>:<pid>` default — the polling loop never matches `iii-sandbox`.

## Fix

Set `metadata.name = "iii-sandbox"` explicitly when the daemon registers. The publish workflow stays simple (still polls by config-yaml name), and any future tooling that wants to look up the sandbox worker by name keeps working.

## Test plan

- [ ] After merge, bump to a new prerelease and confirm:
  - [ ] `iii-sandbox` reaches `POST /publish` (no longer times out at "found 0").
  - [ ] Engine log shows the worker registered as `iii-sandbox` rather than `<hostname>:<pid>` (visible in `iii worker list` / `engine::workers::list` output).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sandbox worker initialization configuration for improved identification and traceability.
  * Reorganized internal module imports for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->