### PR TITLE
feat(website,blog): add blog links to nav and footers

### DIFF
--- a/blog/src/components/Footer.astro
+++ b/blog/src/components/Footer.astro
@@ -15,6 +15,7 @@ import Logo from './Logo.astro'
       <ul>
         <li><a href="/docs">docs</a></li>
         <li><a href="/docs/quickstart">quickstart</a></li>
+        <li><a href="/blog/">blog</a></li>
         <li><a href="https://github.com/iii-hq/iii" target="_blank" rel="noopener noreferrer">github</a></li>
       </ul>
     </div>

--- a/website/index.html
+++ b/website/index.html
@@ -4362,6 +4362,7 @@
         <a class="nav-link" href="#agents">agents</a>
         <a class="nav-link" href="/manifesto">manifesto</a>
         <a class="nav-link docs" href="/docs">docs</a>
+        <a class="nav-link" href="/blog/">blog</a>
         <a class="nav-link" href="https://workers.iii.dev" target="_blank" rel="noopener noreferrer">registry</a>
       </div>
     </div>
@@ -4422,6 +4423,7 @@
       <a class="mobile-link" href="#agents">agents</a>
       <a class="mobile-link" href="/manifesto">manifesto</a>
       <a class="mobile-link docs" href="/docs">docs</a>
+      <a class="mobile-link" href="/blog/">blog</a>
       <a class="mobile-link" href="https://workers.iii.dev" target="_blank" rel="noopener noreferrer">registry</a>
       <a class="mobile-link" href="https://github.com/iii-hq/iii" target="_blank" rel="noopener noreferrer">
         <span style="display:inline-flex;align-items:center;gap:8px;">
@@ -5723,6 +5725,7 @@ iii.register_function(
         <ul>
           <li><a href="https://iii.dev/docs">docs</a></li>
           <li><a href="https://iii.dev/docs/quickstart">quickstart</a></li>
+          <li><a href="https://iii.dev/blog/">blog</a></li>
           <li><a href="https://github.com/iii-hq/iii">github</a></li>
         </ul>
       </div>


### PR DESCRIPTION
Adds 'blog' to the marketing site's desktop nav, mobile menu, and footer 'developers' column so visitors can find the blog from iii.dev. Also adds 'blog' to the blog's own footer so the developer column structure stays identical across both sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added blog navigation links in the site header, mobile menu, and footer sections for convenient access to blog content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->