### PR TITLE
fix(state,stream): support nested append paths in atomic update ops

### DIFF
--- a/console/packages/console-frontend/src/api/types/shared.ts
+++ b/console/packages/console-frontend/src/api/types/shared.ts
@@ -12,6 +12,11 @@ export type StreamUpdateOp =
   // array of literal segments (nested path). Path may be omitted to
   // target the root value.
   | { type: 'merge'; path?: string | string[]; value: unknown }
+  // Append (issue #1552) mirrors merge's path shape — single string
+  // for first-level keys, array for nested paths, omitted for root.
+  // Per-op errors include `append.path.*` (validation), `append.target_not_object`,
+  // and `append.type_mismatch` (case-2: existing object/scalar at the leaf).
+  | { type: 'append'; path?: string | string[]; value: unknown }
 
 export type StreamUpdateOpError = {
   op_index: number
@@ -23,8 +28,10 @@ export type StreamUpdateOpError = {
 export type StreamUpdateResult = {
   old_value?: unknown
   new_value: unknown
-  // Per-op errors. Currently emitted only by `merge` for validation
-  // rejections (depth/size/proto-pollution). Field omitted when empty.
+  // Per-op errors. Emitted by `merge` and `append` for validation
+  // rejections (depth/size/proto-pollution) and by `append` for the
+  // case-2 `append.type_mismatch` and `append.target_not_object`
+  // surfaces. Field omitted when empty.
   errors?: StreamUpdateOpError[]
 }
 

--- a/docs/workers/iii-state.mdx
+++ b/docs/workers/iii-state.mdx
@@ -208,7 +208,7 @@ name: bridge
 
         **Append at a nested missing leaf is always an array.** When `append` walks to a missing leaf at the end of an array-form path, it creates `[value]` regardless of the value's type — including string values, which would be kept as a string under the legacy single-string path's string-concat tier. This is the core fix for [issue #1552](https://github.com/iii-hq/iii/issues/1552).
 
-        **Behavior change worth noting (issue #1552 case 2):** `append` at a path whose existing leaf is a JSON object or scalar (number/boolean) — i.e. a value that can't be appended to — now returns a structured `append.type_mismatch` error in the response `errors` array. Previously this would silently no-op when reached via the single-string path. Existing callers using `path: ""` or `path: "field"` against array, string, null, or missing-field leaves are unaffected.
+        **Note on `append.type_mismatch` for nested paths:** the structured `append.type_mismatch` error for object/scalar leaves shipped in #1555 for the single-string-path case. The nested-path form added here returns the same error code with the same shape, so consumers parsing `errors[]` need no new branches. Callers using `path: ""` or `path: "field"` against array, string, null, or missing-field leaves are unaffected.
 
         Validation: invalid update inputs are rejected with a structured error in the response's `errors` array. Reasons include path depth > 32 segments, segment > 256 bytes, value depth > 16, > 1024 top-level keys, type mismatches, non-object targets, or any segment / top-level key matching `__proto__` / `constructor` / `prototype`. Successfully applied ops still reflect in `new_value`.
       </ResponseField>

--- a/docs/workers/iii-state.mdx
+++ b/docs/workers/iii-state.mdx
@@ -182,26 +182,33 @@ name: bridge
         | `merge` | `{ "type": "merge", "path": ["sessions", "abc"], "value": { "ts": "chunk" } }` | Shallow-merge an object at the root or at any nested path. |
         | `increment` | `{ "type": "increment", "path": "count", "by": 1 }` | Add `by` to a numeric field. |
         | `decrement` | `{ "type": "decrement", "path": "count", "by": 1 }` | Subtract `by` from a numeric field. |
-        | `append` | `{ "type": "append", "path": "events", "value": { "kind": "chunk" } }` | Push one element to an array or concatenate a string value. |
+        | `append` | `{ "type": "append", "path": ["sessions", "abc", "events"], "value": { "kind": "chunk" } }` | Push one element to an array (or concatenate a string) at the root, a first-level field, or any nested path. |
         | `remove` | `{ "type": "remove", "path": "status" }` | Remove a field from the current object. |
 
-        For `set`, `increment`, `decrement`, `append`, and `remove`, paths are first-level field names. For example, `user.name` updates the field named `user.name`; it does not traverse into `{ "user": { "name": ... } }`.
+        For `set`, `increment`, `decrement`, and `remove`, paths are first-level field names. For example, `user.name` updates the field named `user.name`; it does not traverse into `{ "user": { "name": ... } }`.
 
-        For `merge`, `path` accepts either a single string (legacy / first-level field) or an array of literal segments for nested merge:
+        For `merge` and `append`, `path` accepts either a single string (legacy / first-level field) or an array of literal segments for nested traversal:
 
         ```json
-        // Root merge (existing behavior, unchanged).
+        // Root merge / append (existing behavior, unchanged).
         { "type": "merge", "path": "", "value": { "status": "active" } }
+        { "type": "append", "path": "", "value": "first" }
 
-        // First-level merge into the field named "session-abc".
+        // First-level merge / append into the field named "session-abc".
         { "type": "merge", "path": "session-abc", "value": { "author": "alice" } }
+        { "type": "append", "path": "events", "value": { "kind": "chunk" } }
 
-        // Nested merge: walks "sessions" → "abc", auto-creating
-        // missing or non-object intermediates as it goes.
+        // Nested merge / append: walks the segments, auto-creating
+        // missing or non-object intermediates along the way.
         { "type": "merge", "path": ["sessions", "abc"], "value": { "ts": "chunk" } }
+        { "type": "append", "path": ["sessions", "abc", "events"], "value": { "kind": "chunk" } }
         ```
 
         Each array element is a *literal* key. `["a.b"]` writes a single key named `"a.b"`, not `a → b`.
+
+        **Append at a nested missing leaf is always an array.** When `append` walks to a missing leaf at the end of an array-form path, it creates `[value]` regardless of the value's type — including string values, which would be kept as a string under the legacy single-string path's string-concat tier. This is the core fix for [issue #1552](https://github.com/iii-hq/iii/issues/1552).
+
+        **Behavior change worth noting (issue #1552 case 2):** `append` at a path whose existing leaf is a JSON object or scalar (number/boolean) — i.e. a value that can't be appended to — now returns a structured `append.type_mismatch` error in the response `errors` array. Previously this would silently no-op when reached via the single-string path. Existing callers using `path: ""` or `path: "field"` against array, string, null, or missing-field leaves are unaffected.
 
         Validation: invalid update inputs are rejected with a structured error in the response's `errors` array. Reasons include path depth > 32 segments, segment > 256 bytes, value depth > 16, > 1024 top-level keys, type mismatches, non-object targets, or any segment / top-level key matching `__proto__` / `constructor` / `prototype`. Successfully applied ops still reflect in `new_value`.
       </ResponseField>
@@ -238,6 +245,8 @@ Each `state::update` op may add an entry to the response `errors` array. Operati
 | `<op>.path.segment_too_long` | A path segment is longer than 256 bytes | Shorten the field name or merge path segment. |
 | `merge.path.too_deep` | A nested merge path has more than 32 segments | Reduce the nested path depth. |
 | `merge.path.empty_segment` | A nested merge path array contains an empty segment | Remove the empty segment. |
+| `append.path.too_deep` | A nested append path has more than 32 segments | Reduce the nested path depth. |
+| `append.path.empty_segment` | A nested append path array contains an empty segment | Remove the empty segment. |
 | `merge.value.not_an_object` | `merge` value is not a JSON object | Pass an object as the merge value. |
 | `merge.value.too_deep` | `merge` value has JSON nesting deeper than 16 levels | Flatten the value. |
 | `merge.value.too_many_keys` | `merge` value has more than 1024 top-level keys | Split the write into smaller updates. |

--- a/docs/workers/iii-state.mdx
+++ b/docs/workers/iii-state.mdx
@@ -206,7 +206,11 @@ name: bridge
 
         Each array element is a *literal* key. `["a.b"]` writes a single key named `"a.b"`, not `a → b`.
 
+        For root operations (no path), the SDK encoders omit the `path` field from the wire payload entirely (e.g. `{ "type": "append", "value": "first" }`) rather than emitting `"path": null`. Servers accept either form on input — `null`, missing, and empty string all route to the root.
+
         **Append at a nested missing leaf is always an array.** When `append` walks to a missing leaf at the end of an array-form path, it creates `[value]` regardless of the value's type — including string values, which would be kept as a string under the legacy single-string path's string-concat tier. This is the core fix for [issue #1552](https://github.com/iii-hq/iii/issues/1552).
+
+        **Append walks through array intermediates by replacing them with objects.** When the path traverses an existing non-object intermediate (array, scalar, or null), the engine replaces it with a fresh `{}` and continues — mirroring `merge`'s `walk_or_create` semantics. So `{"a": [1,2,3]}` + `append(["a", "b"], 42)` yields `{"a": {"b": [42]}}` (the prior array at `a` is dropped). Callers that need to preserve the array should pre-check with `state.get` rather than relying on append to error.
 
         **Note on `append.type_mismatch` for nested paths:** the structured `append.type_mismatch` error for object/scalar leaves shipped in #1555 for the single-string-path case. The nested-path form added here returns the same error code with the same shape, so consumers parsing `errors[]` need no new branches. Callers using `path: ""` or `path: "field"` against array, string, null, or missing-field leaves are unaffected.
 

--- a/engine/src/update_ops.rs
+++ b/engine/src/update_ops.rs
@@ -254,6 +254,16 @@ fn path_label(path: &str) -> &str {
     if path.is_empty() { "root" } else { path }
 }
 
+fn path_label_segments(segments: &[String]) -> String {
+    if segments.is_empty() {
+        "root".to_string()
+    } else {
+        // Bracketed form to keep the literal-segment contract visible —
+        // never a dot-joined form, since dots are not separators in iii.
+        format!("[{}]", segments.join(", "))
+    }
+}
+
 fn increment_number(value: &Value, by: i64) -> Option<Value> {
     if let Some(num) = value.as_i64()
         && let Some(sum) = num.checked_add(by)
@@ -493,34 +503,69 @@ pub(crate) fn apply_update_ops(
                 }
             }
             UpdateOp::Append { path, value } => {
-                let segments = field_path_segments(&path.0);
+                // Validation order is load-bearing (SDD §10):
+                //   1. validate_op_path  (bounds + proto-pollution rejection)
+                //   2. root-is-object    (before walk_or_create can mutate)
+                //   3. walk_or_create    (nested only — auto-creates intermediates)
+                //   4. leaf-type matrix  (FR-11)
+                let segments = merge_path_segments(path);
                 if !validate_op_path("append", op_index, segments, &mut errors) {
                     continue;
                 }
-                if path.0.is_empty() {
+                if segments.is_empty() {
+                    // Root append (path absent / Single("") / Segments([]))
+                    // — legacy semantics preserved (initial_append_value
+                    // wraps non-strings into a one-element array, keeps
+                    // strings as strings for the string-concat tier).
                     if using_missing_default {
                         current = Value::Null;
                     }
                     if append_to_target(&mut current, value, "root", op_index, &mut errors) {
                         using_missing_default = false;
                     }
-                } else if let Value::Object(ref mut map) = current {
-                    if let Some(existing_val) = map.get_mut(&path.0) {
-                        append_to_target(existing_val, value, &path.0, op_index, &mut errors);
-                    } else {
-                        map.insert(path.0.clone(), initial_append_value(value));
-                    }
-                    using_missing_default = false;
-                } else {
+                } else if !matches!(current, Value::Object(_)) {
+                    // Step 2: non-empty path requires object root.
                     errors.push(err(
                         op_index,
                         ERR_APPEND_TARGET_NOT_OBJECT,
                         format!(
                             "Cannot append at path '{}': target is {}, expected object.",
-                            path_label(&path.0),
+                            path_label_segments(segments),
                             json_type_name(&current)
                         ),
                     ));
+                } else if segments.len() == 1 {
+                    // Single-segment path: back-compat with the old
+                    // `FieldPath` shape — `initial_append_value` keeps
+                    // string-concat tier for missing leaves.
+                    let leaf_key = &segments[0];
+                    if let Value::Object(ref mut map) = current {
+                        if let Some(existing_val) = map.get_mut(leaf_key) {
+                            append_to_target(existing_val, value, leaf_key, op_index, &mut errors);
+                        } else {
+                            map.insert(leaf_key.clone(), initial_append_value(value));
+                        }
+                        using_missing_default = false;
+                    }
+                } else {
+                    // Nested path: walk parent (creating intermediates),
+                    // then operate on the leaf key. FR-11 nested-path rule:
+                    // missing leaf → ALWAYS array (no string-concat tier).
+                    let (leaf_key, parent_segments) = segments.split_last().unwrap();
+                    if let Some(parent_map) = walk_or_create(&mut current, parent_segments) {
+                        if let Some(existing_val) = parent_map.get_mut(leaf_key) {
+                            append_to_target(existing_val, value, leaf_key, op_index, &mut errors);
+                        } else {
+                            // FR-11: nested-path missing leaf is always an array.
+                            parent_map.insert(leaf_key.clone(), Value::Array(vec![value.clone()]));
+                        }
+                        using_missing_default = false;
+                    } else {
+                        tracing::warn!(
+                            path = ?segments,
+                            "Append operation could not resolve parent path"
+                        );
+                    }
                 }
             }
             UpdateOp::Remove { path } => {
@@ -911,10 +956,14 @@ mod tests {
 
     #[test]
     fn dotted_paths_are_first_level_fields() {
+        // Dotted strings are ALWAYS literal segments — never traversed
+        // as `user.name`. This regression test locks the legacy
+        // FieldPath-style literal-key contract through the
+        // FieldPath → MergePath compatibility shim.
         let updated = run(
             Some(json!({ "user.name": ["A"], "user": { "name": ["B"] } })),
             &[UpdateOp::Append {
-                path: FieldPath("user.name".to_string()),
+                path: Some(FieldPath("user.name".to_string()).into()),
                 value: json!("C"),
             }],
         );
@@ -1258,5 +1307,172 @@ mod tests {
 
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0].code, super::ERR_VALUE_TOO_DEEP);
+    }
+
+    // ───────────────────────── nested-path append (issue #1552) ─────────────────────────
+
+    #[test]
+    fn append_segments_path_walks_and_pushes_to_existing_array() {
+        // UC-1: the new happy path. `Segments(["entityId","buffer"])`
+        // walks the parent and pushes onto the existing array.
+        let updated = run(
+            Some(json!({ "entityId": { "buffer": ["a"] } })),
+            &[UpdateOp::append_at_path(["entityId", "buffer"], json!("b"))],
+        );
+
+        assert_eq!(updated, json!({ "entityId": { "buffer": ["a", "b"] } }));
+    }
+
+    #[test]
+    fn append_segments_path_creates_intermediate_object() {
+        // FR-3: walk_or_create auto-creates missing intermediate objects.
+        let updated = run(
+            Some(json!({})),
+            &[UpdateOp::append_at_path(["entityId", "buffer"], json!("a"))],
+        );
+
+        assert_eq!(updated, json!({ "entityId": { "buffer": ["a"] } }));
+    }
+
+    #[test]
+    fn append_segments_missing_leaf_string_value_becomes_array() {
+        // FR-11 + B1 carve-out + UC-5: nested-path missing leaf is
+        // ALWAYS an array, even when the value is a string. This
+        // diverges from single-path's `initial_append_value` which
+        // would keep the string as a string for the concat tier.
+        let updated = run(
+            Some(json!({ "entityId": {} })),
+            &[UpdateOp::append_at_path(["entityId", "buffer"], json!("x"))],
+        );
+
+        // Compare with the single-path equivalent which keeps "x" as a string.
+        let single = run(Some(json!({})), &[UpdateOp::append("buffer", json!("x"))]);
+
+        assert_eq!(updated, json!({ "entityId": { "buffer": ["x"] } }));
+        assert_eq!(single, json!({ "buffer": "x" })); // back-compat preserved
+    }
+
+    #[test]
+    fn append_dotted_string_path_keeps_literal_segment_semantics() {
+        // UC-3: `Single("entityId.buffer")` is ONE literal key, never
+        // dot-traversed. Mirrors iii's existing FieldPath contract.
+        let updated = run(
+            Some(json!({ "entityId": { "buffer": ["nested"] } })),
+            &[UpdateOp::append("entityId.buffer", json!("flat"))],
+        );
+
+        // The dotted-string append targets the literal "entityId.buffer"
+        // key at root, NOT the nested array. The nested array is
+        // untouched; a new top-level key is created.
+        assert_eq!(
+            updated,
+            json!({
+                "entityId": { "buffer": ["nested"] },
+                "entityId.buffer": "flat",
+            })
+        );
+    }
+
+    #[test]
+    fn append_segments_path_object_leaf_returns_type_mismatch() {
+        // UC-6 + Case-2 transition: existing object at the leaf can't
+        // accept an append. Previously this silently no-op'd at the
+        // single-path level; now nested append produces a structured
+        // error and leaves state unchanged.
+        let (updated, errors) = apply_update_ops(
+            Some(json!({ "entityId": { "buffer": { "x": "y" } } })),
+            &[UpdateOp::append_at_path(
+                ["entityId", "buffer"],
+                json!("z"),
+            )],
+        );
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, super::ERR_APPEND_TYPE_MISMATCH);
+        // State unchanged: the object at the leaf was not mutated.
+        assert_eq!(
+            updated,
+            json!({ "entityId": { "buffer": { "x": "y" } } })
+        );
+    }
+
+    #[test]
+    fn append_segments_path_non_object_root_returns_target_not_object() {
+        // IMP-003 root-not-object: validation order must check root
+        // is an object BEFORE walk_or_create can mutate it. With a
+        // top-level array as state, append["a","b"] should reject.
+        let (updated, errors) = apply_update_ops(
+            Some(json!([1, 2, 3])),
+            &[UpdateOp::append_at_path(["a", "b"], json!("x"))],
+        );
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, super::ERR_APPEND_TARGET_NOT_OBJECT);
+        // State unchanged: walk_or_create did NOT replace the array root.
+        assert_eq!(updated, json!([1, 2, 3]));
+    }
+
+    // ───────────────────── proto-pollution at root/intermediate/leaf (B3) ─────────────────────
+
+    #[test]
+    fn append_proto_polluted_at_root_segment_rejected() {
+        let (updated, errors) = apply_update_ops(
+            Some(json!({})),
+            &[UpdateOp::append_at_path(["__proto__"], json!("x"))],
+        );
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, "append.path.proto_polluted");
+        assert_eq!(updated, json!({}));
+    }
+
+    #[test]
+    fn append_proto_polluted_at_intermediate_segment_rejected() {
+        let (updated, errors) = apply_update_ops(
+            Some(json!({})),
+            &[UpdateOp::append_at_path(["a", "constructor", "b"], json!("x"))],
+        );
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, "append.path.proto_polluted");
+        // State must be unchanged — validation runs BEFORE walk_or_create
+        // can create intermediate objects (validate-before-mutate audit).
+        assert_eq!(updated, json!({}));
+    }
+
+    #[test]
+    fn append_proto_polluted_at_leaf_segment_rejected() {
+        let (updated, errors) = apply_update_ops(
+            Some(json!({ "safe": {} })),
+            &[UpdateOp::append_at_path(["safe", "prototype"], json!("x"))],
+        );
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, "append.path.proto_polluted");
+        assert_eq!(updated, json!({ "safe": {} }));
+    }
+
+    // ───────────────────────── multi-op batch semantics (FR-13) ─────────────────────────
+
+    #[test]
+    fn multi_op_partial_failure_retains_prior_successes() {
+        // FR-13: skip-failed semantics. op-0 succeeds, op-1 fails on
+        // proto-pollution, op-2 succeeds. Both successful ops are
+        // reflected in new_value; op-1's error is in errors[] with the
+        // correct original-array op_index (1, not the post-skip 0).
+        let (updated, errors) = apply_update_ops(
+            Some(json!({ "buffer": [] })),
+            &[
+                UpdateOp::append("buffer", json!("first")),
+                UpdateOp::append_at_path(["__proto__", "polluted"], json!(true)),
+                UpdateOp::append("buffer", json!("third")),
+            ],
+        );
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].op_index, 1);
+        assert_eq!(errors[0].code, "append.path.proto_polluted");
+        // op-0 and op-2 effects retained, op-1 skipped.
+        assert_eq!(updated, json!({ "buffer": ["first", "third"] }));
     }
 }

--- a/engine/src/update_ops.rs
+++ b/engine/src/update_ops.rs
@@ -1381,19 +1381,13 @@ mod tests {
         // error and leaves state unchanged.
         let (updated, errors) = apply_update_ops(
             Some(json!({ "entityId": { "buffer": { "x": "y" } } })),
-            &[UpdateOp::append_at_path(
-                ["entityId", "buffer"],
-                json!("z"),
-            )],
+            &[UpdateOp::append_at_path(["entityId", "buffer"], json!("z"))],
         );
 
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0].code, super::ERR_APPEND_TYPE_MISMATCH);
         // State unchanged: the object at the leaf was not mutated.
-        assert_eq!(
-            updated,
-            json!({ "entityId": { "buffer": { "x": "y" } } })
-        );
+        assert_eq!(updated, json!({ "entityId": { "buffer": { "x": "y" } } }));
     }
 
     #[test]
@@ -1430,7 +1424,10 @@ mod tests {
     fn append_proto_polluted_at_intermediate_segment_rejected() {
         let (updated, errors) = apply_update_ops(
             Some(json!({})),
-            &[UpdateOp::append_at_path(["a", "constructor", "b"], json!("x"))],
+            &[UpdateOp::append_at_path(
+                ["a", "constructor", "b"],
+                json!("x"),
+            )],
         );
 
         assert_eq!(errors.len(), 1);

--- a/engine/src/workers/redis.rs
+++ b/engine/src/workers/redis.rs
@@ -107,6 +107,14 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
         return path
     end
 
+    -- Bracket-notation label for nested-segment paths. Mirrors the Rust
+    -- helper `path_label_segments` in `engine/src/update_ops.rs` so the
+    -- error messages produced by the two adapters match byte-for-byte.
+    local function path_label_segments(segments)
+        if segments == nil or #segments == 0 then return 'root' end
+        return '[' .. table.concat(segments, ', ') .. ']'
+    end
+
     local function field_path_segments(path)
         if path == nil or path == '' then return {} end
         return { path }
@@ -359,23 +367,63 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
               end
             end
         elseif op.type == 'append' then
-            local path = get_path(op.path)
-            if validate_op_path('append', zero_index, field_path_segments(path)) then
-              if path == '' or path == nil then
-                local changed, next_value = append_to_target(using_missing_default and cjson.null or current, op.value, 'root', zero_index)
+            -- Validation order is load-bearing (mirror of update_ops.rs):
+            --   1. validate_op_path  (bounds + proto-pollution)
+            --   2. root-is-object    (before walk_or_create can mutate)
+            --   3. walk_or_create    (nested only)
+            --   4. leaf-type matrix  (FR-11)
+            local segments = merge_path_segments(op.path)
+            if validate_op_path('append', zero_index, segments) then
+              if #segments == 0 then
+                -- Root append: legacy semantics preserved.
+                local target_root = using_missing_default and cjson.null or current
+                local changed, next_value = append_to_target(target_root, op.value, 'root', zero_index)
                 if changed then
                     current = next_value
                     using_missing_default = false
                 end
-              elseif type(current) == 'table' and current ~= cjson.null then
-                    local changed, next_value = append_to_target(current[path], op.value, path, zero_index)
-                    if changed then
-                        current[path] = next_value
-                        using_missing_default = false
-                    end
-              else
+              elseif type(current) ~= 'table' or current == cjson.null or is_array(current) then
+                -- Non-empty path requires object root (IMP-003).
                 push_error(zero_index, 'append.target_not_object',
-                    "Cannot append at path '" .. path_label(path) .. "': target is " .. json_type_name(current) .. ", expected object.")
+                    "Cannot append at path '" .. path_label_segments(segments) .. "': target is " .. json_type_name(current) .. ", expected object.")
+              elseif #segments == 1 then
+                -- Single-segment path: back-compat with the legacy
+                -- single-string `FieldPath` semantics — `initial_append_value`
+                -- keeps the string-concat tier for missing leaves.
+                local leaf_key = segments[1]
+                local existing_val = current[leaf_key]
+                if existing_val ~= nil and existing_val ~= cjson.null then
+                    local changed, next_value = append_to_target(existing_val, op.value, leaf_key, zero_index)
+                    if changed then
+                        current[leaf_key] = next_value
+                    end
+                else
+                    current[leaf_key] = initial_append_value(op.value)
+                end
+                using_missing_default = false
+              else
+                -- Nested path: walk parent (creating intermediates), then
+                -- operate on the leaf key. FR-11 nested-path rule: missing
+                -- leaf is ALWAYS an array (no string-concat tier).
+                local parent_segments = {}
+                for i = 1, #segments - 1 do
+                    parent_segments[i] = segments[i]
+                end
+                local leaf_key = segments[#segments]
+                local parent_map = walk_or_create(current, parent_segments)
+                if parent_map ~= nil then
+                    local existing_val = parent_map[leaf_key]
+                    if existing_val ~= nil and existing_val ~= cjson.null then
+                        local changed, next_value = append_to_target(existing_val, op.value, leaf_key, zero_index)
+                        if changed then
+                            parent_map[leaf_key] = next_value
+                        end
+                    else
+                        -- FR-11: nested-path missing leaf is always an array.
+                        parent_map[leaf_key] = { op.value }
+                    end
+                    using_missing_default = false
+                end
               end
             end
         elseif op.type == 'remove' then

--- a/engine/src/workers/redis.rs
+++ b/engine/src/workers/redis.rs
@@ -220,6 +220,12 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
     end
 
     local function is_array(value)
+        -- cjson loses the empty-array vs. empty-object distinction across
+        -- the encode/decode roundtrip (both materialize as a `{}` Lua
+        -- table). Treat empty tables as objects here so that an empty
+        -- document root passes the nested-append IMP-003 gate (matching
+        -- the Rust path's `Value::Object({})` initialization), and so
+        -- `json_type_name` and `is_array` agree on the empty-table case.
         if type(value) ~= 'table' then
             return false
         end
@@ -234,7 +240,7 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
             end
             count = count + 1
         end
-        return count == max
+        return count == max and count > 0
     end
 
     local function append_to_target(target, value, path, op_index)

--- a/engine/src/workers/redis.rs
+++ b/engine/src/workers/redis.rs
@@ -194,16 +194,39 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
         return true
     end
 
-    -- Walk segments inside `root`, replacing or auto-creating non-object
-    -- intermediates. Returns the target object table for shallow merge.
+    -- "Object shape" check used at the IMP-003 root gate and inside
+    -- `walk_or_create` to decide whether to walk into a node or replace
+    -- it. Mirrors `json_type_name`'s convention (`value[1] ~= nil`
+    -- means array, otherwise object) so empty Lua tables count as
+    -- objects here. Aligns the Lua walk with the Rust path, which uses
+    -- `matches!(v, Value::Object(_))` and replaces non-object
+    -- intermediates (including arrays) with `Value::Object(Map::new())`.
+    --
+    -- Defined before `walk_or_create` (and other consumers) so the
+    -- closure resolves it as an upvalue rather than a missing global.
+    local function is_object_shape(value)
+        if type(value) ~= 'table' or value == cjson.null then
+            return false
+        end
+        return value[1] == nil
+    end
+
+    -- Walk segments inside `root`, replacing any non-object intermediate
+    -- (null, scalar, OR array) with a fresh empty object. Mirrors the
+    -- Rust `walk_or_create` (engine/src/update_ops.rs) which calls
+    -- `*entry = Value::Object(Map::new())` whenever the intermediate is
+    -- not already a `Value::Object(_)`. Without the array branch, Lua
+    -- would walk into an existing array intermediate and produce a
+    -- corrupted mixed-key form like `{1=1, 2=2, b=[42]}` for state
+    -- `{"a": [1,2,3]}` + nested append `["a","b"]`.
     local function walk_or_create(root, segments)
-        if type(root) ~= 'table' or root == cjson.null then
+        if not is_object_shape(root) then
             return nil  -- caller normalises root before invoking
         end
         local node = root
         for _, seg in ipairs(segments) do
             local next_node = node[seg]
-            if type(next_node) ~= 'table' or next_node == cjson.null then
+            if not is_object_shape(next_node) then
                 next_node = {}
                 node[seg] = next_node
             end
@@ -219,13 +242,18 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
         return {value}
     end
 
+    -- Used by `append_to_target` to decide whether an existing leaf is
+    -- appendable as an array. cjson loses the empty-`[]` vs empty-`{}`
+    -- distinction across the encode/decode roundtrip (both materialise
+    -- as a `{}` Lua table; Redis cjson does not expose `array_mt`), so
+    -- this heuristic accepts empty tables as arrays. That matches the
+    -- common case where users append into a freshly-stored `[]` leaf
+    -- (e.g. `{"buffer": []}` + `append("buffer", x)`); the dual case
+    -- where the leaf is stored as `{}` is documented as a known
+    -- limitation of the Lua path. The IMP-003 root gate and
+    -- `walk_or_create` use `is_object_shape` instead, so empty-document
+    -- nested append still works.
     local function is_array(value)
-        -- cjson loses the empty-array vs. empty-object distinction across
-        -- the encode/decode roundtrip (both materialize as a `{}` Lua
-        -- table). Treat empty tables as objects here so that an empty
-        -- document root passes the nested-append IMP-003 gate (matching
-        -- the Rust path's `Value::Object({})` initialization), and so
-        -- `json_type_name` and `is_array` agree on the empty-table case.
         if type(value) ~= 'table' then
             return false
         end
@@ -240,7 +268,7 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
             end
             count = count + 1
         end
-        return count == max and count > 0
+        return count == max
     end
 
     local function append_to_target(target, value, path, op_index)
@@ -388,8 +416,11 @@ pub const JSON_UPDATE_SCRIPT: &str = r#"
                     current = next_value
                     using_missing_default = false
                 end
-              elseif type(current) ~= 'table' or current == cjson.null or is_array(current) then
-                -- Non-empty path requires object root (IMP-003).
+              elseif not is_object_shape(current) then
+                -- Non-empty path requires object root (IMP-003). Empty
+                -- Lua tables count as objects per `is_object_shape`, so
+                -- empty-document nested append succeeds (matching the
+                -- Rust path's `Value::Object({})` initialization).
                 push_error(zero_index, 'append.target_not_object',
                     "Cannot append at path '" .. path_label_segments(segments) .. "': target is " .. json_type_name(current) .. ", expected object.")
               elseif #segments == 1 then

--- a/engine/tests/state_stream_update_e2e.rs
+++ b/engine/tests/state_stream_update_e2e.rs
@@ -610,3 +610,98 @@ async fn nested_append_segments_path_round_trips_via_merge_path_segments() {
     assert!(result.errors.is_empty());
     assert_eq!(result.new_value, json!({ "a": { "b": [42] } }));
 }
+
+// ─────────── #1612 review feedback (ytallo's gherkin scenarios) ───────────
+
+#[tokio::test]
+async fn append_existing_empty_array_at_single_segment_pushes_value() {
+    // Scenario A from #1612 review: `{"buffer": []}` + `append("buffer", "x")`
+    // must produce `{"buffer": ["x"]}` with no errors. Pre-existing
+    // empty arrays are the most common "ready to receive its first
+    // element" leaf shape in stream-buffer use cases.
+    let store = fresh_store().await;
+    let key = "empty-leaf".to_string();
+    store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![set_op("buffer", json!([]))],
+        )
+        .await;
+
+    let result = store
+        .update(
+            SCOPE.to_string(),
+            key,
+            vec![UpdateOp::append("buffer", json!("x"))],
+        )
+        .await;
+
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert_eq!(result.new_value, json!({ "buffer": ["x"] }));
+}
+
+#[tokio::test]
+async fn append_root_when_state_is_empty_array_pushes_value() {
+    // Scenario B: state at the key is `[]`, root append `"x"` → `["x"]`.
+    // The root branch routes through `append_to_target`, which treats
+    // an existing array as a push target.
+    let store = fresh_store().await;
+    let key = "empty-root-array".to_string();
+    store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![UpdateOp::Set {
+                path: iii_sdk::FieldPath::from(""),
+                value: Some(json!([])),
+            }],
+        )
+        .await;
+
+    let result = store
+        .update(
+            SCOPE.to_string(),
+            key,
+            vec![UpdateOp::append_root(json!("x"))],
+        )
+        .await;
+
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert_eq!(result.new_value, json!(["x"]));
+}
+
+#[tokio::test]
+async fn nested_append_replaces_array_intermediate_with_object() {
+    // Scenario C: `{"a": [1,2,3]}` + nested append `["a", "b"]` 42.
+    // `walk_or_create` replaces the array intermediate with a fresh
+    // object (Rust-parity outcome) — the destructive replace mirrors
+    // merge's semantics and ytallo's gherkin accepts either this OR
+    // a strict-error outcome, but explicitly forbids the corrupted
+    // mixed-key form `{"a": {"1": 1, "2": 2, "3": 3, "b": [42]}}`.
+    let store = fresh_store().await;
+    let key = "array-intermediate".to_string();
+    store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![set_op("a", json!([1, 2, 3]))],
+        )
+        .await;
+
+    let result = store
+        .update(
+            SCOPE.to_string(),
+            key,
+            vec![UpdateOp::append_at_path(["a", "b"], json!(42))],
+        )
+        .await;
+
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert_eq!(result.new_value, json!({ "a": { "b": [42] } }));
+    // Negative assertion the gherkin specifically calls out.
+    assert_ne!(
+        result.new_value,
+        json!({ "a": { "1": 1, "2": 2, "3": 3, "b": [42] } })
+    );
+}

--- a/engine/tests/state_stream_update_e2e.rs
+++ b/engine/tests/state_stream_update_e2e.rs
@@ -404,3 +404,209 @@ async fn remove_missing_path_remains_idempotent_and_silent() {
     assert!(result.errors.is_empty());
     assert_eq!(result.new_value, json!({}));
 }
+
+// ─────────── nested-path append (issue #1552 RifkiSalim repros) ───────────
+
+#[tokio::test]
+async fn issue_1552_case1_dotted_string_keeps_literal_segment() {
+    // Case 1 from the report: `path: "entityId.buffer"` is treated as a
+    // single literal key — the dotted string is NOT traversed. This
+    // matches iii's existing FieldPath literal-segment contract on the
+    // other state ops.
+    let store = fresh_store().await;
+    let key = "case1".to_string();
+
+    // Pre-populate so we can prove the dotted string doesn't traverse
+    // into the nested buffer.
+    let _ = store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![set_op("entityId", json!({ "buffer": ["nested"] }))],
+        )
+        .await;
+
+    let result = store
+        .update(
+            SCOPE.to_string(),
+            key,
+            vec![UpdateOp::append("entityId.buffer", json!("flat"))],
+        )
+        .await;
+
+    assert!(result.errors.is_empty());
+    assert_eq!(
+        result.new_value,
+        json!({
+            "entityId": { "buffer": ["nested"] },
+            "entityId.buffer": "flat",
+        })
+    );
+}
+
+#[tokio::test]
+async fn issue_1552_case2_object_value_returns_type_mismatch() {
+    // Case 2 from the report: object value at a parent-path append used
+    // to silently no-op when the leaf was an object. After this PR it
+    // returns a structured `append.type_mismatch` error and leaves
+    // state unchanged. This is the documented behavior change.
+    let store = fresh_store().await;
+    let key = "case2".to_string();
+
+    let _ = store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![set_op("entityId", json!({ "buffer": { "x": "y" } }))],
+        )
+        .await;
+
+    let result = store
+        .update(
+            SCOPE.to_string(),
+            key,
+            vec![UpdateOp::append_at_path(["entityId", "buffer"], json!("z"))],
+        )
+        .await;
+
+    assert_structured_error(&result.errors, 0, "append.type_mismatch", "buffer");
+    assert_eq!(
+        result.new_value,
+        json!({ "entityId": { "buffer": { "x": "y" } } })
+    );
+}
+
+#[tokio::test]
+async fn issue_1552_case3_array_path_appends_to_nested_array() {
+    // Case 3 from the report: array-form path `["entityId", "buffer"]`
+    // is the new happy path. It walks the parent (auto-creating
+    // intermediates if needed) and pushes onto the nested array.
+    let store = fresh_store().await;
+    let key = "case3".to_string();
+
+    let _ = store
+        .update(
+            SCOPE.to_string(),
+            key.clone(),
+            vec![set_op("entityId", json!({ "buffer": ["a"] }))],
+        )
+        .await;
+
+    let result = store
+        .update(
+            SCOPE.to_string(),
+            key,
+            vec![UpdateOp::append_at_path(["entityId", "buffer"], json!("b"))],
+        )
+        .await;
+
+    assert!(result.errors.is_empty());
+    assert_eq!(
+        result.new_value,
+        json!({ "entityId": { "buffer": ["a", "b"] } })
+    );
+}
+
+#[tokio::test]
+async fn nested_append_creates_intermediate_objects_through_kv_store() {
+    // FR-3 + UC-5 through the KV-store path: walk_or_create auto-creates
+    // missing intermediate objects, and the leaf becomes an array even
+    // when the value is a string (FR-11 nested-path missing-leaf rule).
+    let store = fresh_store().await;
+    let key = "nested-create".to_string();
+
+    let result = store
+        .update(
+            SCOPE.to_string(),
+            key,
+            vec![UpdateOp::append_at_path(
+                ["session", "abc", "events"],
+                json!("first"),
+            )],
+        )
+        .await;
+
+    assert!(result.errors.is_empty());
+    assert_eq!(
+        result.new_value,
+        json!({ "session": { "abc": { "events": ["first"] } } })
+    );
+}
+
+#[tokio::test]
+async fn nested_append_proto_pollution_rejected_at_intermediate_segment() {
+    // B3 expansion through KV-store path: __proto__ at an intermediate
+    // segment is rejected, and crucially, walk_or_create is NOT called
+    // — state remains untouched. The validate-before-mutate audit
+    // (FR-2 + step 1 of validation order) is the load-bearing invariant.
+    let store = fresh_store().await;
+    let key = "proto-mid".to_string();
+
+    let result = store
+        .update(
+            SCOPE.to_string(),
+            key,
+            vec![UpdateOp::append_at_path(
+                ["safe", "__proto__", "x"],
+                json!("never"),
+            )],
+        )
+        .await;
+
+    assert_structured_error(&result.errors, 0, "append.path.proto_polluted", "__proto__");
+    assert_eq!(result.new_value, json!({}));
+}
+
+#[tokio::test]
+async fn nested_append_multi_op_partial_failure_retains_prior_successes() {
+    // FR-13 through KV-store path: skip-failed semantics. op-0 succeeds
+    // (creates intermediate object + array leaf), op-1 fails on
+    // proto-pollution, op-2 succeeds (appends to the array op-0 created).
+    // The error in errors[] carries the original op_index (1).
+    let store = fresh_store().await;
+    let key = "multi-op".to_string();
+
+    let result = store
+        .update(
+            SCOPE.to_string(),
+            key,
+            vec![
+                UpdateOp::append_at_path(["session", "abc", "events"], json!("first")),
+                UpdateOp::append_at_path(["__proto__", "polluted"], json!(true)),
+                UpdateOp::append_at_path(["session", "abc", "events"], json!("third")),
+            ],
+        )
+        .await;
+
+    assert_eq!(result.errors.len(), 1);
+    assert_eq!(result.errors[0].op_index, 1);
+    assert_eq!(result.errors[0].code, "append.path.proto_polluted");
+    assert_eq!(
+        result.new_value,
+        json!({ "session": { "abc": { "events": ["first", "third"] } } })
+    );
+}
+
+#[tokio::test]
+async fn nested_append_segments_path_round_trips_via_merge_path_segments() {
+    // Constructor-level smoke: `Some(MergePath::Segments(...))` and
+    // `UpdateOp::append_at_path(...)` produce equivalent ops. This is
+    // the legacy-friendly path for callers that want to build a
+    // `MergePath` value directly rather than via the helper.
+    let store = fresh_store().await;
+    let key = "round-trip".to_string();
+
+    let result = store
+        .update(
+            SCOPE.to_string(),
+            key,
+            vec![UpdateOp::Append {
+                path: Some(MergePath::Segments(vec!["a".to_string(), "b".to_string()])),
+                value: json!(42),
+            }],
+        )
+        .await;
+
+    assert!(result.errors.is_empty());
+    assert_eq!(result.new_value, json!({ "a": { "b": [42] } }));
+}

--- a/engine/tests/state_stream_update_redis_e2e.rs
+++ b/engine/tests/state_stream_update_redis_e2e.rs
@@ -1,0 +1,173 @@
+// Redis-backed parity lane for `state::update` / `stream::update`.
+//
+// Sister to `state_stream_update_e2e.rs`, which exercises the
+// in-memory `BuiltinKvStore` (Rust `apply_update_ops` path). This file
+// drives the same scenarios through `StateRedisAdapter`, exercising
+// the embedded Lua script in `engine/src/workers/redis.rs`. The two
+// paths must produce identical results — the empty-table cjson
+// roundtrip ambiguity, array-as-intermediate handling, and root-shape
+// rules are the load-bearing parity points reviewed in PR #1612.
+//
+// Gating: tests skip cleanly when no Redis is reachable. Set
+// `TEST_REDIS_URL` (default `redis://localhost:6379`) to opt in.
+//
+//   docker run -d --rm -p 6379:6379 redis:7-alpine
+//   TEST_REDIS_URL=redis://localhost:6379 \
+//     cargo test -p iii --test state_stream_update_redis_e2e \
+//     -- --include-ignored
+
+use serde_json::json;
+
+use iii::workers::state::adapters::{StateAdapter, redis_adapter::StateRedisAdapter};
+use iii_sdk::UpdateOp;
+
+const SCOPE: &str = "audio::transcripts";
+
+fn redis_url() -> String {
+    std::env::var("TEST_REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string())
+}
+
+async fn try_adapter() -> Option<StateRedisAdapter> {
+    StateRedisAdapter::new(redis_url()).await.ok()
+}
+
+async fn fresh_key(adapter: &StateRedisAdapter, key: &str) {
+    let _ = adapter.delete(SCOPE, key).await;
+}
+
+// Thin wrapper that mimics the `set_op` helper from the in-memory
+// e2e file. Building the op via the SDK keeps the wire shape under
+// test (root issue from #1612 was a wire-format divergence).
+fn set_op(path: &str, value: serde_json::Value) -> UpdateOp {
+    UpdateOp::Set {
+        path: iii_sdk::FieldPath::from(path),
+        value: Some(value),
+    }
+}
+
+#[tokio::test]
+#[ignore = "redis-parity: requires reachable Redis at TEST_REDIS_URL (default redis://localhost:6379)"]
+async fn redis_append_existing_empty_array_at_single_segment_pushes_value() {
+    // Scenario A: `{"buffer": []}` + `append("buffer", "x")`.
+    let Some(adapter) = try_adapter().await else {
+        eprintln!("[skip] redis-parity: cannot reach {}", redis_url());
+        return;
+    };
+    let key = "redis-empty-leaf";
+    fresh_key(&adapter, key).await;
+
+    adapter
+        .update(SCOPE, key, vec![set_op("buffer", json!([]))])
+        .await
+        .unwrap();
+
+    let result = adapter
+        .update(SCOPE, key, vec![UpdateOp::append("buffer", json!("x"))])
+        .await
+        .unwrap();
+
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert_eq!(result.new_value, json!({ "buffer": ["x"] }));
+
+    fresh_key(&adapter, key).await;
+}
+
+#[tokio::test]
+#[ignore = "redis-parity: requires reachable Redis at TEST_REDIS_URL"]
+async fn redis_append_root_when_state_is_empty_array_pushes_value() {
+    // Scenario B: state at the key is `[]`, root append `"x"` → `["x"]`.
+    let Some(adapter) = try_adapter().await else {
+        eprintln!("[skip] redis-parity: cannot reach {}", redis_url());
+        return;
+    };
+    let key = "redis-empty-root-array";
+    fresh_key(&adapter, key).await;
+
+    adapter.set(SCOPE, key, json!([])).await.unwrap();
+
+    let result = adapter
+        .update(SCOPE, key, vec![UpdateOp::append_root(json!("x"))])
+        .await
+        .unwrap();
+
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert_eq!(result.new_value, json!(["x"]));
+
+    fresh_key(&adapter, key).await;
+}
+
+#[tokio::test]
+#[ignore = "redis-parity: requires reachable Redis at TEST_REDIS_URL"]
+async fn redis_nested_append_replaces_array_intermediate_with_object() {
+    // Scenario C: `{"a": [1,2,3]}` + nested append `["a","b"]` 42.
+    // The Lua walk_or_create must replace the array intermediate with
+    // a fresh object — without this fix, Lua walks into the array and
+    // produces the corrupted mixed-key form `{"a": {"1":1,"2":2,"3":3,"b":[42]}}`
+    // that ytallo specifically forbade.
+    let Some(adapter) = try_adapter().await else {
+        eprintln!("[skip] redis-parity: cannot reach {}", redis_url());
+        return;
+    };
+    let key = "redis-array-intermediate";
+    fresh_key(&adapter, key).await;
+
+    adapter
+        .update(SCOPE, key, vec![set_op("a", json!([1, 2, 3]))])
+        .await
+        .unwrap();
+
+    let result = adapter
+        .update(
+            SCOPE,
+            key,
+            vec![UpdateOp::append_at_path(["a", "b"], json!(42))],
+        )
+        .await
+        .unwrap();
+
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert_eq!(result.new_value, json!({ "a": { "b": [42] } }));
+    // Negative assertion the gherkin specifically calls out.
+    assert_ne!(
+        result.new_value,
+        json!({ "a": { "1": 1, "2": 2, "3": 3, "b": [42] } })
+    );
+
+    fresh_key(&adapter, key).await;
+}
+
+#[tokio::test]
+#[ignore = "redis-parity: requires reachable Redis at TEST_REDIS_URL"]
+async fn redis_nested_append_happy_path_through_lua_script() {
+    // Scenario D: no state at the key, nested append at
+    // `["session","abc","events"]` value `"first"`. Validates the
+    // empty-document path through the Lua IMP-003 root gate
+    // (`is_object_shape` admits empty Lua tables) and the
+    // walk_or_create + missing-leaf-as-array tier.
+    let Some(adapter) = try_adapter().await else {
+        eprintln!("[skip] redis-parity: cannot reach {}", redis_url());
+        return;
+    };
+    let key = "redis-nested-create";
+    fresh_key(&adapter, key).await;
+
+    let result = adapter
+        .update(
+            SCOPE,
+            key,
+            vec![UpdateOp::append_at_path(
+                ["session", "abc", "events"],
+                json!("first"),
+            )],
+        )
+        .await
+        .unwrap();
+
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert_eq!(
+        result.new_value,
+        json!({ "session": { "abc": { "events": ["first"] } } })
+    );
+
+    fresh_key(&adapter, key).await;
+}

--- a/sdk/packages/node/iii-browser/src/stream.ts
+++ b/sdk/packages/node/iii-browser/src/stream.ts
@@ -102,8 +102,10 @@ export type StreamUpdateResult<TData> = {
   /** New value after the update. */
   new_value: TData
   /**
-   * Per-op errors. Currently emitted only by the `merge` op when
-   * input violates validation bounds. Field omitted when empty.
+   * Per-op errors. Emitted by `merge` and `append` for validation
+   * rejections (path/value bounds, proto-pollution segments) and by
+   * `append` for the `append.type_mismatch` and
+   * `append.target_not_object` surfaces. Field omitted when empty.
    */
   errors?: UpdateOpError[]
 }

--- a/sdk/packages/node/iii-browser/src/stream.ts
+++ b/sdk/packages/node/iii-browser/src/stream.ts
@@ -136,11 +136,27 @@ export type UpdateDecrement = {
   by: number
 }
 
-/** Append an element to an array or concatenate a string. */
+/**
+ * Append an element to an array, concatenate a string, or push a new
+ * value at a nested path. The target is the root (when `path` is
+ * omitted, empty, or `[]`), a single first-level key (when `path` is
+ * a non-empty string), or an arbitrary nested location (when `path`
+ * is an array of literal segments). See {@link MergePath}.
+ *
+ * Engine semantics: missing/null intermediates along a nested path are
+ * auto-created; missing leaves on a nested path always become arrays
+ * (no string-concat tier); existing object/scalar leaves return
+ * `append.type_mismatch`. Each path segment is a literal key —
+ * `["a.b"]` targets a single key named `"a.b"`, not `a → b`.
+ */
 export type UpdateAppend = {
   type: 'append'
-  /** First-level field path. Use an empty string to target the root value. */
-  path: string
+  /**
+   * Optional path to the append target. Accepts a single first-level
+   * key (legacy `string`) or an array of literal segments for nested
+   * append. See {@link MergePath} (the same shape is reused).
+   */
+  path?: MergePath
   /** Value to append. String targets only accept string values. */
   // biome-ignore lint/suspicious/noExplicitAny: any is fine here
   value: any

--- a/sdk/packages/node/iii-browser/tests/exports.test.ts
+++ b/sdk/packages/node/iii-browser/tests/exports.test.ts
@@ -32,6 +32,32 @@ describe('Package Exports', () => {
     expect(ops[0]).toEqual({ type: 'append', path: 'chunks', value: 'hello' })
   })
 
+  it('should type append with nested array path (issue #1552 case 3)', () => {
+    // Closes issue #1552: array-form path is the new happy path. The
+    // TS shape mirrors UpdateMerge's MergePath = string | string[].
+    const op = {
+      type: 'append',
+      path: ['entityId', 'buffer'],
+      value: 'chunk',
+    } satisfies UpdateAppend
+    const ops: UpdateOp[] = [op]
+
+    expect(ops[0]).toEqual({
+      type: 'append',
+      path: ['entityId', 'buffer'],
+      value: 'chunk',
+    })
+  })
+
+  it('should type append with omitted path (root append)', () => {
+    // Path is now optional — omitted, empty string, and empty array all
+    // route to root append in the engine.
+    const op = { type: 'append', value: 'first' } satisfies UpdateAppend
+    const ops: UpdateOp[] = [op]
+
+    expect(ops[0]).toEqual({ type: 'append', value: 'first' })
+  })
+
   it('should import state module', async () => {
     const stateModule = await import('../src/state')
     expect(stateModule).toBeDefined()

--- a/sdk/packages/node/iii/src/stream.ts
+++ b/sdk/packages/node/iii/src/stream.ts
@@ -102,11 +102,13 @@ export type StreamUpdateResult<TData> = {
   /** New value after the update. */
   new_value: TData
   /**
-   * Per-op errors. Currently emitted only by the `merge` op when input
-   * violates the validation bounds (path depth/size, value depth, or
-   * a `__proto__`/`constructor`/`prototype` segment or top-level key).
-   * Successfully applied ops are still reflected in `new_value`. The
-   * field is omitted from the JSON wire when empty.
+   * Per-op errors. Emitted by `merge` and `append` for validation
+   * rejections (path depth/size, value depth, or a
+   * `__proto__`/`constructor`/`prototype` segment or top-level key)
+   * and by `append` for the case-2 `append.type_mismatch` and
+   * `append.target_not_object` surfaces. Successfully applied ops are
+   * still reflected in `new_value`. The field is omitted from the
+   * JSON wire when empty.
    */
   errors?: UpdateOpError[]
 }

--- a/sdk/packages/node/iii/src/stream.ts
+++ b/sdk/packages/node/iii/src/stream.ts
@@ -139,11 +139,41 @@ export type UpdateDecrement = {
   by: number
 }
 
-/** Append an element to an array or concatenate a string. */
+/**
+ * Append an element to an array, concatenate a string, or push a new
+ * value at a nested path. The target is the root (when `path` is
+ * omitted, empty, or `[]`), a single first-level key (when `path` is
+ * a non-empty string), or an arbitrary nested location (when `path`
+ * is an array of literal segments).
+ *
+ * Engine semantics:
+ *   - Missing or non-object intermediates along a nested path are
+ *     auto-replaced with `{}` so a stray `null` or scalar never blocks
+ *     future appends.
+ *   - At the leaf:
+ *       - missing/null + nested path → `[value]` (always an array)
+ *       - missing/null + single-string path → string-as-string for the
+ *         string-concat tier, otherwise `[value]`
+ *       - existing array → push
+ *       - existing string + string value → concatenate
+ *       - existing object/scalar at the leaf → `append.type_mismatch`
+ *   - Each path segment is a literal key. `["a.b"]` targets a single
+ *     key named `"a.b"`, not `a → b`.
+ *
+ * Validation: invalid paths (depth > 32 segments, segment > 256
+ * bytes, or any `__proto__`/`constructor`/`prototype` segment) are
+ * rejected with a structured error in the `errors` field of the
+ * `state::update` / `stream::update` response. The append does not
+ * apply when an error is returned for that op.
+ */
 export type UpdateAppend = {
   type: 'append'
-  /** First-level field path. Use an empty string to target the root value. */
-  path: string
+  /**
+   * Optional path to the append target. Accepts a single first-level
+   * key (legacy `string`) or an array of literal segments for nested
+   * append. See {@link MergePath} (the same shape is reused).
+   */
+  path?: MergePath
   /** Value to append. String targets only accept string values. */
   // biome-ignore lint/suspicious/noExplicitAny: any is fine here
   value: any

--- a/sdk/packages/python/iii/src/iii/stream.py
+++ b/sdk/packages/python/iii/src/iii/stream.py
@@ -156,10 +156,44 @@ class UpdateDecrement(BaseModel):
 
 
 class UpdateAppend(BaseModel):
-    """Append operation for stream update."""
+    """Append an element to an array, concatenate a string, or push at a nested path.
+
+    The target is the root (when ``path`` is omitted, an empty string,
+    or an empty list), a single first-level key (when ``path`` is a
+    non-empty string), or an arbitrary nested location (when ``path``
+    is a list of literal segments).
+
+    Path forms accepted (mirrors :class:`UpdateMerge` after #1547):
+      - ``None`` / ``""`` / ``[]``: append at the root.
+      - ``"foo"``: append at the first-level key ``foo``. A dotted
+        string like ``"a.b"`` is the literal key ``"a.b"``, *not*
+        traversed as ``a -> b``.
+      - ``["a", "b", "c"]``: nested path; each element is a literal
+        segment.
+
+    Engine semantics:
+      - Missing/non-object intermediates along a nested path are
+        auto-created/replaced with ``{}``.
+      - At the leaf:
+          - missing/null + nested path -> ``[value]`` (always an array)
+          - missing/null + single-string path -> string-as-string for
+            the string-concat tier, otherwise ``[value]``
+          - existing array -> push
+          - existing string + string value -> concatenate
+          - existing object/scalar at the leaf -> ``append.type_mismatch``
+
+    Validation: invalid paths (depth > 32 segments, segment > 256
+    bytes, or any ``__proto__`` / ``constructor`` / ``prototype``
+    segment) are rejected with a structured error in the ``errors``
+    field of the ``state::update`` / ``stream::update`` response. The
+    append does not apply when an error is returned for that op.
+    """
 
     type: str = "append"
-    path: str
+    # Optional. Accepts a single string (legacy / first-level key) or
+    # a list of literal segments (nested append). ``None`` / ``""`` /
+    # ``[]`` all route to root append.
+    path: str | list[str] | None = None
     value: Any
 
 

--- a/sdk/packages/python/iii/src/iii/stream.py
+++ b/sdk/packages/python/iii/src/iii/stream.py
@@ -117,11 +117,13 @@ class StreamUpdateResult(BaseModel, Generic[TData]):
 
     old_value: TData | None = None
     new_value: TData
-    # Per-op errors. Currently emitted only by the ``merge`` op for
-    # validation rejections. Field is omitted from the JSON wire when
-    # empty. ``default_factory`` is used (not ``= []``) to keep
-    # Pydantic's parameterized-Generic + default handling well-behaved
-    # across Python versions.
+    # Per-op errors. Emitted by ``merge`` and ``append`` for validation
+    # rejections (path/value bounds, proto-pollution segments) and by
+    # ``append`` for the ``append.type_mismatch`` and
+    # ``append.target_not_object`` surfaces. Field is omitted from the
+    # JSON wire when empty. ``default_factory`` is used (not ``= []``)
+    # to keep Pydantic's parameterized-Generic + default handling
+    # well-behaved across Python versions.
     errors: list[UpdateOpError] = Field(default_factory=list)
 
 

--- a/sdk/packages/python/iii/src/iii/stream.py
+++ b/sdk/packages/python/iii/src/iii/stream.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Generic, List, Literal, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_serializer
 
 TData = TypeVar("TData")
 
@@ -198,6 +198,17 @@ class UpdateAppend(BaseModel):
     path: str | list[str] | None = None
     value: Any
 
+    @model_serializer(mode="wrap")
+    def _omit_none_path(self, handler):  # type: ignore[no-untyped-def]
+        # Drop ``path: None`` from the wire so cross-SDK consumers see
+        # the field absent rather than ``null``. Mirrors the Rust
+        # ``#[serde(skip_serializing_if = "Option::is_none")]`` on
+        # ``UpdateOp::Append.path``.
+        data = handler(self)
+        if data.get("path") is None:
+            data.pop("path", None)
+        return data
+
 
 class UpdateRemove(BaseModel):
     """Remove operation for stream update."""
@@ -240,6 +251,16 @@ class UpdateMerge(BaseModel):
     # input -> str, array input -> list[str].
     path: str | list[str] | None = None
     value: Any
+
+    @model_serializer(mode="wrap")
+    def _omit_none_path(self, handler):  # type: ignore[no-untyped-def]
+        # Mirrors the same skip-when-none rule applied to
+        # ``UpdateOp::Merge.path`` in the Rust SDK so cross-SDK wire
+        # payloads are byte-identical for root merges.
+        data = handler(self)
+        if data.get("path") is None:
+            data.pop("path", None)
+        return data
 
 
 UpdateOp = UpdateSet | UpdateIncrement | UpdateDecrement | UpdateAppend | UpdateRemove | UpdateMerge

--- a/sdk/packages/python/iii/tests/test_stream_models.py
+++ b/sdk/packages/python/iii/tests/test_stream_models.py
@@ -11,6 +11,50 @@ def test_update_append_model_serializes() -> None:
     assert op.model_dump() == {"type": "append", "path": "chunks", "value": {"text": "hello"}}
 
 
+def test_update_append_with_array_path_round_trips() -> None:
+    """Closes issue #1552 case 3: nested-path array form is the new happy path."""
+    op = UpdateAppend(path=["entityId", "buffer"], value="chunk")
+    dumped = op.model_dump()
+    assert dumped == {
+        "type": "append",
+        "path": ["entityId", "buffer"],
+        "value": "chunk",
+    }
+    parsed = UpdateAppend.model_validate(json.loads(json.dumps(dumped)))
+    assert parsed.path == ["entityId", "buffer"]
+
+
+def test_update_append_without_path_round_trips() -> None:
+    """Path is now optional. Omitted -> None on both sides; mirrors UpdateMerge."""
+    op = UpdateAppend(value="first")
+    dumped = op.model_dump()
+    assert dumped == {"type": "append", "path": None, "value": "first"}
+    parsed = UpdateAppend.model_validate(json.loads(json.dumps(dumped)))
+    assert parsed.path is None
+
+
+def test_update_append_with_explicit_none_path() -> None:
+    """Symmetric with Rust's serde-default: explicit None and missing field both yield None."""
+    op = UpdateAppend(path=None, value=42)
+    assert op.path is None
+    parsed = UpdateAppend.model_validate({"type": "append", "value": 42})
+    assert parsed.path is None
+
+
+def test_update_append_with_empty_string_path() -> None:
+    """Empty string is preserved as `Single("")` — engine maps it to root append."""
+    op = UpdateAppend(path="", value="x")
+    dumped = op.model_dump()
+    assert dumped["path"] == ""
+
+
+def test_update_append_with_dotted_string_keeps_literal_segment() -> None:
+    """`"a.b"` is a single literal key, never traversed as `a -> b`."""
+    op = UpdateAppend(path="entityId.buffer", value="literal")
+    parsed = UpdateAppend.model_validate(json.loads(json.dumps(op.model_dump())))
+    assert parsed.path == "entityId.buffer"
+
+
 def test_update_merge_with_string_path_round_trips() -> None:
     op = UpdateMerge(path="session-abc", value={"author": "alice"})
     dumped = op.model_dump()

--- a/sdk/packages/python/iii/tests/test_stream_models.py
+++ b/sdk/packages/python/iii/tests/test_stream_models.py
@@ -25,20 +25,30 @@ def test_update_append_with_array_path_round_trips() -> None:
 
 
 def test_update_append_without_path_round_trips() -> None:
-    """Path is now optional. Omitted -> None on both sides; mirrors UpdateMerge."""
+    """Root append omits ``path`` from the wire (parity with the Rust
+    ``skip_serializing_if = "Option::is_none"`` on
+    ``UpdateOp::Append.path`` — surfaced in #1612 review)."""
     op = UpdateAppend(value="first")
     dumped = op.model_dump()
-    assert dumped == {"type": "append", "path": None, "value": "first"}
+    assert dumped == {"type": "append", "value": "first"}
+    assert "path" not in dumped
     parsed = UpdateAppend.model_validate(json.loads(json.dumps(dumped)))
     assert parsed.path is None
 
 
 def test_update_append_with_explicit_none_path() -> None:
-    """Symmetric with Rust's serde-default: explicit None and missing field both yield None."""
+    """Explicit ``None`` and missing field both round-trip through a
+    wire payload that has no ``path`` key. ``path: null`` payloads
+    coming from older clients still deserialize for backward compat."""
     op = UpdateAppend(path=None, value=42)
     assert op.path is None
+    assert op.model_dump() == {"type": "append", "value": 42}
     parsed = UpdateAppend.model_validate({"type": "append", "value": 42})
     assert parsed.path is None
+    parsed_null = UpdateAppend.model_validate(
+        {"type": "append", "path": None, "value": 42}
+    )
+    assert parsed_null.path is None
 
 
 def test_update_append_with_empty_string_path() -> None:
@@ -81,11 +91,18 @@ def test_update_merge_with_array_path_round_trips() -> None:
 
 
 def test_update_merge_without_path_round_trips() -> None:
+    """Same wire-format rule as ``UpdateAppend``: root merge omits the
+    ``path`` key entirely. ``path: null`` payloads still deserialize."""
     op = UpdateMerge(value={"x": 1})
     dumped = op.model_dump()
-    assert dumped == {"type": "merge", "path": None, "value": {"x": 1}}
+    assert dumped == {"type": "merge", "value": {"x": 1}}
+    assert "path" not in dumped
     parsed = UpdateMerge.model_validate(json.loads(json.dumps(dumped)))
     assert parsed.path is None
+    parsed_null = UpdateMerge.model_validate(
+        {"type": "merge", "path": None, "value": {"x": 1}}
+    )
+    assert parsed_null.path is None
 
 
 def test_update_op_error_round_trip() -> None:

--- a/sdk/packages/rust/iii/src/stream.rs
+++ b/sdk/packages/rust/iii/src/stream.rs
@@ -70,7 +70,7 @@ impl UpdateBuilder {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::FieldPath;
+    use crate::types::MergePath;
 
     use super::*;
 
@@ -82,11 +82,14 @@ mod tests {
 
         assert_eq!(ops.len(), 1);
         match &ops[0] {
-            UpdateOp::Append { path, value } => {
-                assert_eq!(path, &FieldPath("chunks".to_string()));
+            UpdateOp::Append {
+                path: Some(MergePath::Single(s)),
+                value,
+            } => {
+                assert_eq!(s, "chunks");
                 assert_eq!(value, &serde_json::json!("hello"));
             }
-            other => panic!("expected append op, got {other:?}"),
+            other => panic!("expected single-string append, got {other:?}"),
         }
     }
 }

--- a/sdk/packages/rust/iii/src/types.rs
+++ b/sdk/packages/rust/iii/src/types.rs
@@ -120,6 +120,7 @@ pub enum UpdateOp {
     /// omitted (root merge), a single first-level key, or an array of
     /// literal segments for nested merge. See [`MergePath`].
     Merge {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         path: Option<MergePath>,
         value: Value,
     },
@@ -135,6 +136,7 @@ pub enum UpdateOp {
     /// first-level key, or an array of literal segments for nested
     /// append. See [`MergePath`] for the variant shape.
     Append {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         path: Option<MergePath>,
         value: Value,
     },
@@ -477,12 +479,13 @@ mod tests {
         let op = UpdateOp::append_root(serde_json::json!("first"));
         let encoded = serde_json::to_value(&op).unwrap();
 
-        // path is None, so it serializes as null (mirrors merge precedent).
+        // `path` is None, so it is omitted entirely from the JSON
+        // wire format (no explicit `null`). Cross-SDK consumers (Node
+        // / Python / browser) decode the `path?` field as absent.
         assert_eq!(
             encoded,
             serde_json::json!({
                 "type": "append",
-                "path": null,
                 "value": "first",
             })
         );
@@ -603,12 +606,14 @@ mod tests {
         let op = UpdateOp::merge(serde_json::json!({"x": 1}));
         let encoded = serde_json::to_value(&op).unwrap();
 
-        // path is None, so it serializes as null.
+        // `path` is None, so it is omitted from the JSON wire format
+        // (no explicit `null`). Cross-SDK consumers decode `path?` as
+        // absent. `path: null` payloads still deserialize via the
+        // `#[serde(default)]` attribute.
         assert_eq!(
             encoded,
             serde_json::json!({
                 "type": "merge",
-                "path": null,
                 "value": {"x": 1},
             })
         );

--- a/sdk/packages/rust/iii/src/types.rs
+++ b/sdk/packages/rust/iii/src/types.rs
@@ -61,6 +61,10 @@ impl From<String> for FieldPath {
 /// `Segments` so a JSON string deserializes into `Single` rather than
 /// failing the array match first.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+// VARIANT-ORDER-LOAD-BEARING: `Single` MUST precede `Segments` for serde
+// untagged deserialization to route bare strings to `MergePath::Single`.
+// Reordering breaks wire compatibility — string payloads would deserialize
+// as one-element `Segments`. Locked by `merge_path_single_variant_deserializes_string_first`.
 #[serde(untagged)]
 pub enum MergePath {
     Single(String),
@@ -91,6 +95,17 @@ impl From<Vec<&str>> for MergePath {
     }
 }
 
+// Compatibility shim for callers that constructed paths via `FieldPath`
+// before `Append.path` widened to `Option<MergePath>` in PR #1552-fix.
+// `impl From<FieldPath> for Option<MergePath>` would violate Rust orphan
+// rules (both `From` and `Option` are foreign); call sites needing the
+// `Option` wrapping use `.map(Into::into)` or `Some(fp.into())`.
+impl From<FieldPath> for MergePath {
+    fn from(value: FieldPath) -> Self {
+        Self::Single(value.0)
+    }
+}
+
 /// Operations that can be performed atomically on a stream value
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "lowercase")]
@@ -115,8 +130,14 @@ pub enum UpdateOp {
     /// Decrement numeric value
     Decrement { path: FieldPath, by: i64 },
 
-    /// Append an element to an array or concatenate a string
-    Append { path: FieldPath, value: Value },
+    /// Append an element to an array or concatenate a string at the
+    /// optional path. Path may be omitted (root append), a single
+    /// first-level key, or an array of literal segments for nested
+    /// append. See [`MergePath`] for the variant shape.
+    Append {
+        path: Option<MergePath>,
+        value: Value,
+    },
 
     /// Remove a field
     Remove { path: FieldPath },
@@ -147,10 +168,35 @@ impl UpdateOp {
         }
     }
 
-    /// Create an Append operation
-    pub fn append(path: impl Into<FieldPath>, value: impl Into<Value>) -> Self {
+    /// Create an Append operation at a specific path. Accepts a single
+    /// first-level key (`"foo"`) or any type that converts into
+    /// [`MergePath`] (e.g. `Vec<String>` for nested paths).
+    pub fn append(path: impl Into<MergePath>, value: impl Into<Value>) -> Self {
         Self::Append {
-            path: path.into(),
+            path: Some(path.into()),
+            value: value.into(),
+        }
+    }
+
+    /// Create an Append operation at the root level (no path).
+    pub fn append_root(value: impl Into<Value>) -> Self {
+        Self::Append {
+            path: None,
+            value: value.into(),
+        }
+    }
+
+    /// Create an Append operation at a nested path of literal segments.
+    /// Convenience wrapper for `append(vec!["a", "b"], v)`.
+    pub fn append_at_path<I, S>(segments: I, value: impl Into<Value>) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self::Append {
+            path: Some(MergePath::Segments(
+                segments.into_iter().map(Into::into).collect(),
+            )),
             value: value.into(),
         }
     }
@@ -388,12 +434,112 @@ mod tests {
 
         let decoded: UpdateOp = serde_json::from_value(encoded).unwrap();
         match decoded {
-            UpdateOp::Append { path, value } => {
-                assert_eq!(path.0, "chunks");
+            UpdateOp::Append {
+                path: Some(MergePath::Single(s)),
+                value,
+            } => {
+                assert_eq!(s, "chunks");
                 assert_eq!(value, serde_json::json!({"text": "hello"}));
             }
-            other => panic!("expected append op, got {other:?}"),
+            other => panic!("expected single-string append, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn append_with_segments_path_round_trips_as_array() {
+        let op = UpdateOp::append_at_path(["entityId", "buffer"], serde_json::json!("chunk"));
+        let encoded = serde_json::to_value(&op).unwrap();
+
+        assert_eq!(
+            encoded,
+            serde_json::json!({
+                "type": "append",
+                "path": ["entityId", "buffer"],
+                "value": "chunk",
+            })
+        );
+
+        let decoded: UpdateOp = serde_json::from_value(encoded).unwrap();
+        match decoded {
+            UpdateOp::Append {
+                path: Some(MergePath::Segments(segs)),
+                value,
+            } => {
+                assert_eq!(segs, vec!["entityId", "buffer"]);
+                assert_eq!(value, serde_json::json!("chunk"));
+            }
+            other => panic!("expected segments append, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn append_with_root_path_round_trips() {
+        let op = UpdateOp::append_root(serde_json::json!("first"));
+        let encoded = serde_json::to_value(&op).unwrap();
+
+        // path is None, so it serializes as null (mirrors merge precedent).
+        assert_eq!(
+            encoded,
+            serde_json::json!({
+                "type": "append",
+                "path": null,
+                "value": "first",
+            })
+        );
+
+        let decoded: UpdateOp = serde_json::from_value(encoded).unwrap();
+        match decoded {
+            UpdateOp::Append { path: None, value } => {
+                assert_eq!(value, serde_json::json!("first"));
+            }
+            other => panic!("expected root append, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn append_path_omitted_deserializes_as_none() {
+        // Wire payloads that pre-date this change may omit `path` entirely
+        // (effectively root append). Guard against that breaking. Also
+        // covers explicit `null` and missing-field deserialization paths.
+        for raw in [
+            r#"{"type":"append","value":"x"}"#,
+            r#"{"type":"append","path":null,"value":"x"}"#,
+        ] {
+            let op: UpdateOp = serde_json::from_str(raw).unwrap_or_else(|e| {
+                panic!("expected to parse {raw:?} as UpdateOp::Append, got {e}")
+            });
+            match op {
+                UpdateOp::Append { path: None, value } => {
+                    assert_eq!(value, serde_json::json!("x"));
+                }
+                other => panic!("expected root append for {raw:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn append_field_path_into_merge_path_compat() {
+        // Legacy callers constructed paths via `FieldPath`; the
+        // `From<FieldPath> for MergePath` shim keeps them compiling.
+        let fp = FieldPath::new("legacy");
+        let mp: MergePath = fp.into();
+        assert_eq!(mp, MergePath::Single("legacy".to_string()));
+    }
+
+    #[test]
+    fn merge_path_single_variant_deserializes_string_first() {
+        // Regression for VARIANT-ORDER-LOAD-BEARING: bare JSON strings
+        // must deserialize to `MergePath::Single`, not a one-element
+        // `Segments`. If the variant order in `MergePath` is ever
+        // reordered (alphabetized, auto-formatted) this test fails.
+        let single: MergePath = serde_json::from_str(r#""foo""#).unwrap();
+        assert_eq!(single, MergePath::Single("foo".to_string()));
+
+        let segments: MergePath = serde_json::from_str(r#"["a","b"]"#).unwrap();
+        assert_eq!(
+            segments,
+            MergePath::Segments(vec!["a".to_string(), "b".to_string()])
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #1552.

## Summary

- `state::update`'s `append` op rejects nested paths at the type-deserialization boundary. RifkiSalim's three repros in #1552 currently behave like this against `origin/main` (`1cdc9d4a`): dotted strings key on `"entityId.buffer"` literally; parent-path appends with object values return `append.type_mismatch` (this transition shipped in #1555, see below); array-form paths fail upstream of the apply loop with `expected string, received sequence`.
- Root cause is a type asymmetry: `UpdateOp::Append.path` is `FieldPath` (single literal-string segment) at `engine/src/update_ops.rs:495` and `sdk/packages/rust/iii/src/types.rs:119`, while `UpdateOp::Merge.path` is `Option<MergePath>` (`Single | Segments`) since #1547. PR #1547 generalized only `Merge`. This PR closes the gap with the same shape.
- Switches `UpdateOp::Append.path` to `Option<MergePath>` and routes the apply loop through `validate_op_path("append", …)` so bounds + `__proto__` / `constructor` / `prototype` rejection match the merge surface. The Lua mirror in `engine/src/workers/redis.rs` is updated lockstep so the in-memory and Redis-backed paths produce identical `(old_value, new_value, errors)` tuples for the same input.

A regression test (`merge_path_single_variant_deserializes_string_first` at `sdk/packages/rust/iii/src/types.rs`) couples `MergePath`'s untagged-enum variant order to a JSON-string deserialization assertion — alphabetizing or auto-formatter reordering the variants fails the build before it can break wire compat. A second test (`append_segments_missing_leaf_string_value_becomes_array`) locks the FR-11 nested-vs-single-path divergence so the issue #1552 fix can't drift back to the legacy single-path string-concat tier.

**Note on `append.type_mismatch` for nested paths:** the structured `append.type_mismatch` error for object/scalar leaves shipped in #1555 ("Surface state update failures consistently", `@ytallo`, Apr 28) for the single-string-path case. The nested-path form added here returns the same error code with the same shape, so consumers parsing `errors[]` need no new branches. Pre-PR, an array-form path failed earlier than the apply loop — at JSON deserialization — so it never reached the type-matrix at all. Callers using `path: ""` or `path: "field"` against array, string, null, or missing-field leaves are unaffected.

The Rust SDK signature change (`UpdateOp::Append.path: FieldPath → Option<MergePath>`) is a compile-time break for downstream callers constructing the variant literally. Same posture #1547 took on `Merge`. I asked about this on #1552 ([comment](https://github.com/iii-hq/iii/issues/1552#issuecomment-4393196506)) and shipped the change with `impl From<FieldPath> for MergePath` + `impl From<&str>` shims so call sites using `.into()` keep compiling — only literal struct construction breaks. PR is **draft until `@ytallo` confirms** the public-API posture; no 24h fallback.

## What changed

**Engine** (`engine/src/`):
- `update_ops.rs` — `Append` match arm rewritten to a 4-step validation order (validate_op_path → root-is-object check → walk_or_create on parent for nested paths → leaf-type matrix). New `path_label_segments` helper formats nested paths in bracket notation `[a, b]` so error messages keep the literal-segment contract visible. 9 new unit tests cover walk-and-push, intermediate auto-creation, missing-leaf string→array (the FR-11 nested-vs-single divergence), dotted-string literal-key behavior, object-leaf type-mismatch, non-object-root rejection, `__proto__` / `constructor` / `prototype` at root / intermediate / leaf positions, and multi-op partial-failure preserving prior successes.
- `workers/redis.rs` — Lua append branch in `JSON_UPDATE_SCRIPT` consumes `merge_path_segments(op.path)` (already handled string|array|nil for merge) and routes through the same four cases. New `path_label_segments` Lua helper paralleling the Rust side keeps error messages byte-identical across adapters.

**Tests** (`engine/tests/state_stream_update_e2e.rs`):
- 7 new e2e cases through `BuiltinKvStore`: 3 RifkiSalim repros verbatim (case 1 dotted-string literal, case 2 nested-path type_mismatch, case 3 array-path happy path) + intermediate auto-creation + proto-pollution validate-before-mutate audit + multi-op partial-failure with `op_index` preservation + a constructor-level round-trip via `MergePath::Segments`.

**SDKs** (`sdk/packages/`):
- `rust/iii/src/types.rs` — new `Option<MergePath>` field shape; `From<&str>` and `From<FieldPath>` for `MergePath`; new `append`, `append_root`, `append_at_path` constructors mirroring the merge surface. `VARIANT-ORDER-LOAD-BEARING` comment above `MergePath`. 8 new round-trip + serde-default + variant-order tests.
- `node/iii/src/stream.ts` and `node/iii-browser/src/stream.ts` — `UpdateAppend.path?: MergePath` (reusing the existing `MergePath = string | string[]` alias from #1547). Browser SDK's `tests/exports.test.ts` gets 2 TS-level smoke tests covering the array-form path and omitted-path.
- `python/iii/src/iii/stream.py` — `UpdateAppend.path: str | list[str] | None = None` via pydantic smart-union. 5 new round-trip tests covering array path, omitted path, explicit `None`, empty string, and dotted-string literal.
- `console/packages/console-frontend/src/api/types/shared.ts` — adds the `append` variant to the `StreamUpdateOp` union (it was previously omitted) with the same `path?: string | string[]` shape as merge.

**Docs** (`docs/workers/iii-state.mdx`):
- Operations table's append example switched to the nested-path form. Merge + append now share a paragraph + side-by-side code examples covering root / first-level / nested paths. New explicit note on the FR-11 nested-vs-single divergence for missing leaves. Note on `append.type_mismatch` clarifying it's the same shape as #1555's surface, just reachable from nested paths now. Two new error-code rows: `append.path.too_deep` and `append.path.empty_segment` mirror the merge surface.

## Test plan

- [x] `cargo test -p iii update_ops:: --lib` — 54 passed (9 new for nested append + leaf matrix + multi-op + root-not-object + proto-pollution at three positions).
- [x] `cargo test -p iii --test state_stream_update_e2e` — 20 passed (7 new: 3 RifkiSalim repros + 4 nested-append behaviors via the KV-store path).
- [x] `cargo test -p iii-sdk --lib` — 71 passed (8 new: 5 round-trip + 1 variant-order regression + 1 serde-defaults + 1 `From<FieldPath>` compat shim).
- [x] `cargo clippy -p iii-sdk --all-targets --all-features -- -D warnings` — clean (the active CI gate).
- [x] `cargo fmt --all --check` — clean.
- [x] `pnpm --filter iii-sdk exec tsc --noEmit` — clean.
- [x] `pnpm --filter iii-browser-sdk exec vitest run tests/exports.test.ts` — 7 passed (2 new for nested + root append).
- [x] `cd sdk/packages/python/iii && uv run pytest tests/test_stream_models.py` — 11 passed (5 new round-trip).
- [x] `cd sdk/packages/python/iii && uv run mypy src` — clean.
- [x] `cd sdk/packages/python/iii && uv run ruff check src/iii/stream.py tests/test_stream_models.py` — clean (existing baseline ruff issues in the wider tree are pre-existing on `main` and unrelated to this PR).
- [ ] **Manual cross-impl parity (maintainer-side):** the Rust ↔ Lua parity invariants are documented in `engine/src/workers/redis.rs` and `engine/src/update_ops.rs` validation-order comment blocks. The repro is a 3-op fixture batch covering happy nested append + `__proto__` rejection + Case-2 type-mismatch, run through both `BuiltinKvStore` and the Redis adapter. The harness here didn't ship Redis test infra so I'm flagging this for your local run rather than leaving an `[x]` I can't honestly stand behind.

## Notes

- One concern per PR per `CONTRIBUTING.md`. `UpdateOp::Set.path`, `Remove.path`, `Increment.path`, `Decrement.path` all share the same `FieldPath` limitation but are out of scope here. Happy to take that as a follow-up if the shape lands.
- `append_at_path` is a Rust-SDK-only ergonomic helper for now (mirrors `merge_at_path` from #1547). If you'd prefer cross-SDK helper symmetry I can add Node / Python equivalents in this PR or a follow-up.
- Rebased mental model after seeing #1555 in the post-#1547 history (caught in the issue thread): #1555 already populated structured errors for append's previously-silent-no-op cases; this PR is strictly the type-shape extension to enable nested paths. No conflicts in the diff.

---

- [x] I am licensing the entirety of this PR under Apache 2 and have all necessary rights to the code I am contributing.

Ridden with [Loa](https://github.com/0xHoneyJar/loa)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Append now supports root, first-level, or nested-array paths; missing nested leaves are auto-created as arrays and legacy single-segment behavior is preserved. Root appends omit the path field on the wire.

* **Documentation**
  * Expanded docs and SDK docstrings to clarify path shapes, nested-append semantics, and new append error codes (append.type_mismatch, append.target_not_object, path.*).

* **Tests**
  * Added unit and end-to-end tests for nested append, dotted-string literal keys, proto-pollution rejection, partial-failure semantics, and SDK serialization/typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->