### PR TITLE
fix(rust-sdk): drop duplicate registration frames on first WS connect

### DIFF
--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -1309,10 +1309,42 @@ impl III {
 
                     queue.extend(self.collect_registrations());
                     Self::dedupe_registrations(&mut queue);
+
+                    // Snapshot the registration keys we're about to send so
+                    // we can drop duplicate copies still pending in `rx`.
+                    // These are leftover from `register_*` calls made by user
+                    // threads before the WS handshake completed: each call
+                    // both inserts into the in-memory map (replayed via
+                    // `collect_registrations`) AND queues into `outbound`.
+                    let snapshot_ids: HashSet<String> =
+                        queue.iter().filter_map(Self::registration_key).collect();
+
                     if let Err(err) = self.flush_queue(&mut ws_tx, &mut queue).await {
                         tracing::warn!(error = %err, "failed to flush queue");
                         sleep(Duration::from_secs(2)).await;
                         continue;
+                    }
+
+                    // Drain pre-connect leftovers from `rx`, dropping
+                    // register duplicates and preserving everything else
+                    // (invocations, results, channel ops, and any
+                    // registrations added after the snapshot was taken).
+                    let shutdown =
+                        Self::drain_pre_connect_duplicates(&mut rx, &mut queue, &snapshot_ids);
+                    if shutdown {
+                        self.inner.running.store(false, Ordering::SeqCst);
+                        return;
+                    }
+
+                    if !queue.is_empty() {
+                        if let Err(err) = self.flush_queue(&mut ws_tx, &mut queue).await {
+                            tracing::warn!(
+                                error = %err,
+                                "failed to flush post-drain queue"
+                            );
+                            sleep(Duration::from_secs(2)).await;
+                            continue;
+                        }
                     }
 
                     // Auto-register worker metadata on connect (like Node SDK)
@@ -1393,26 +1425,65 @@ impl III {
         messages
     }
 
+    /// Returns a stable identity key for a registration message, or `None`
+    /// for non-registration messages (invocations, ping/pong, etc.).
+    ///
+    /// Used both to deduplicate within `queue` and to detect leftover
+    /// pre-connect register messages in `rx` whose state has already been
+    /// re-sent via `collect_registrations()`.
+    fn registration_key(message: &Message) -> Option<String> {
+        match message {
+            Message::RegisterTriggerType { id, .. } => Some(format!("trigger_type:{id}")),
+            Message::RegisterTrigger { id, .. } => Some(format!("trigger:{id}")),
+            Message::RegisterFunction { id, .. } => Some(format!("function:{id}")),
+            Message::RegisterService { id, .. } => Some(format!("service:{id}")),
+            _ => None,
+        }
+    }
+
+    /// Drain everything currently pending in the outbound `rx` channel,
+    /// dropping register messages whose keys are already covered by
+    /// `snapshot_ids` (already sent via `collect_registrations()`),
+    /// and pushing every other message onto `queue` for re-flushing.
+    ///
+    /// Returns `true` if a `Shutdown` signal was observed during the
+    /// drain — the caller should then stop the connection loop.
+    fn drain_pre_connect_duplicates(
+        rx: &mut mpsc::UnboundedReceiver<Outbound>,
+        queue: &mut Vec<Message>,
+        snapshot_ids: &HashSet<String>,
+    ) -> bool {
+        loop {
+            match rx.try_recv() {
+                Ok(Outbound::Message(msg)) => {
+                    let is_dup = Self::registration_key(&msg)
+                        .map(|k| snapshot_ids.contains(&k))
+                        .unwrap_or(false);
+                    if is_dup {
+                        continue;
+                    }
+                    queue.push(msg);
+                }
+                Ok(Outbound::Shutdown) => return true,
+                Err(_) => return false,
+            }
+        }
+    }
+
     fn dedupe_registrations(queue: &mut Vec<Message>) {
         let mut seen = HashSet::new();
         let mut deduped_rev = Vec::with_capacity(queue.len());
 
         for message in queue.iter().rev() {
-            let key = match message {
-                Message::RegisterTriggerType { id, .. } => format!("trigger_type:{id}"),
-                Message::RegisterTrigger { id, .. } => format!("trigger:{id}"),
-                Message::RegisterFunction { id, .. } => {
-                    format!("function:{id}")
+            match Self::registration_key(message) {
+                Some(key) => {
+                    if seen.insert(key) {
+                        deduped_rev.push(message.clone());
+                    }
                 }
-                Message::RegisterService { id, .. } => format!("service:{id}"),
-                _ => {
+                None => {
                     deduped_rev.push(message.clone());
-                    continue;
                 }
-            };
-
-            if seen.insert(key) {
-                deduped_rev.push(message.clone());
             }
         }
 
@@ -1957,5 +2028,163 @@ mod tests {
         assert_eq!(detect_project_name(Some(tmp.clone())), Some(basename));
 
         std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    fn make_register_function(id: &str) -> Message {
+        Message::RegisterFunction {
+            id: id.to_string(),
+            description: None,
+            request_format: None,
+            response_format: None,
+            metadata: None,
+            invocation: None,
+        }
+    }
+
+    fn make_register_trigger(id: &str) -> Message {
+        Message::RegisterTrigger {
+            id: id.to_string(),
+            trigger_type: "demo".to_string(),
+            function_id: "fn".to_string(),
+            config: json!({}),
+            metadata: None,
+        }
+    }
+
+    fn make_register_trigger_type(id: &str) -> Message {
+        Message::RegisterTriggerType {
+            id: id.to_string(),
+            description: "tt".to_string(),
+            trigger_request_format: None,
+            call_request_format: None,
+        }
+    }
+
+    fn make_register_service(id: &str) -> Message {
+        Message::RegisterService {
+            id: id.to_string(),
+            name: "svc".to_string(),
+            description: None,
+            parent_service_id: None,
+        }
+    }
+
+    fn make_invoke(function_id: &str) -> Message {
+        Message::InvokeFunction {
+            invocation_id: None,
+            function_id: function_id.to_string(),
+            data: json!({}),
+            traceparent: None,
+            baggage: None,
+            action: None,
+        }
+    }
+
+    #[test]
+    fn registration_key_returns_typed_keys_for_register_messages() {
+        assert_eq!(
+            III::registration_key(&make_register_function("greet")),
+            Some("function:greet".to_string())
+        );
+        assert_eq!(
+            III::registration_key(&make_register_trigger("t1")),
+            Some("trigger:t1".to_string())
+        );
+        assert_eq!(
+            III::registration_key(&make_register_trigger_type("tt1")),
+            Some("trigger_type:tt1".to_string())
+        );
+        assert_eq!(
+            III::registration_key(&make_register_service("svc1")),
+            Some("service:svc1".to_string())
+        );
+    }
+
+    #[test]
+    fn registration_key_returns_none_for_non_register_messages() {
+        assert_eq!(III::registration_key(&make_invoke("f")), None);
+        assert_eq!(III::registration_key(&Message::Ping), None);
+        assert_eq!(III::registration_key(&Message::Pong), None);
+        assert_eq!(
+            III::registration_key(&Message::WorkerRegistered {
+                worker_id: "w".to_string()
+            }),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_pre_connect_duplicates_drops_only_known_register_ids() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<Outbound>();
+
+        tx.send(Outbound::Message(make_register_function("dup-fn")))
+            .unwrap();
+        tx.send(Outbound::Message(make_invoke("some::fn"))).unwrap();
+        tx.send(Outbound::Message(make_register_function("new-fn")))
+            .unwrap();
+        tx.send(Outbound::Message(Message::Pong)).unwrap();
+        tx.send(Outbound::Message(make_register_trigger("dup-trig")))
+            .unwrap();
+        tx.send(Outbound::Message(make_register_trigger("new-trig")))
+            .unwrap();
+        tx.send(Outbound::Message(make_register_service("dup-svc")))
+            .unwrap();
+
+        let snapshot_ids: HashSet<String> = [
+            "function:dup-fn".to_string(),
+            "trigger:dup-trig".to_string(),
+            "service:dup-svc".to_string(),
+        ]
+        .into_iter()
+        .collect();
+
+        let mut queue: Vec<Message> = Vec::new();
+        let shutdown = III::drain_pre_connect_duplicates(&mut rx, &mut queue, &snapshot_ids);
+
+        assert!(!shutdown);
+        let kept_keys: Vec<Option<String>> = queue.iter().map(III::registration_key).collect();
+        assert_eq!(
+            kept_keys,
+            vec![
+                None,
+                Some("function:new-fn".to_string()),
+                None,
+                Some("trigger:new-trig".to_string()),
+            ],
+            "kept queue mismatch: {queue:#?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_pre_connect_duplicates_signals_shutdown() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<Outbound>();
+
+        tx.send(Outbound::Message(make_register_function("a")))
+            .unwrap();
+        tx.send(Outbound::Shutdown).unwrap();
+        tx.send(Outbound::Message(make_register_function("b")))
+            .unwrap();
+
+        let snapshot_ids: HashSet<String> = ["function:a".to_string()].into_iter().collect();
+        let mut queue: Vec<Message> = Vec::new();
+        let shutdown = III::drain_pre_connect_duplicates(&mut rx, &mut queue, &snapshot_ids);
+
+        assert!(shutdown, "expected shutdown signal to be reported");
+        assert!(
+            queue.is_empty(),
+            "queue must be empty when shutdown short-circuits the drain: {queue:#?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_pre_connect_duplicates_returns_false_on_empty_channel() {
+        let (_tx, mut rx) = mpsc::unbounded_channel::<Outbound>();
+        let snapshot_ids: HashSet<String> = HashSet::new();
+        let mut queue: Vec<Message> = Vec::new();
+
+        let shutdown = III::drain_pre_connect_duplicates(&mut rx, &mut queue, &snapshot_ids);
+
+        assert!(!shutdown);
+        assert!(queue.is_empty());
     }
 }

--- a/sdk/packages/rust/iii/tests/common/mock_engine.rs
+++ b/sdk/packages/rust/iii/tests/common/mock_engine.rs
@@ -1,0 +1,191 @@
+#![allow(dead_code)]
+
+//! Lightweight in-process WebSocket mock of the III engine, used by SDK
+//! integration tests that need to assert on the wire-level frames the SDK
+//! emits without depending on a running engine.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::Value;
+use tokio::net::TcpListener;
+use tokio::sync::{Notify, broadcast};
+use tokio::task::AbortHandle;
+use tokio_tungstenite::accept_async;
+use tokio_tungstenite::tungstenite::Message;
+
+pub struct MockEngine {
+    url: String,
+    received: Arc<Mutex<Vec<Value>>>,
+    new_message: Arc<Notify>,
+    close_active: broadcast::Sender<()>,
+    accept_task: AbortHandle,
+}
+
+impl MockEngine {
+    /// Bind to `127.0.0.1:0` and start accepting WebSocket connections.
+    /// Every text/binary frame is decoded as JSON and appended to the
+    /// internal buffer, observable via [`MockEngine::received_messages`].
+    pub async fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind mock engine");
+        let addr = listener.local_addr().expect("local addr");
+        let url = format!("ws://{}", addr);
+
+        let received = Arc::new(Mutex::new(Vec::<Value>::new()));
+        let new_message = Arc::new(Notify::new());
+        let (close_active, _) = broadcast::channel::<()>(16);
+
+        let received_acc = received.clone();
+        let new_message_acc = new_message.clone();
+        let close_active_acc = close_active.clone();
+
+        let accept_task = tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let Ok(ws) = accept_async(stream).await else {
+                    continue;
+                };
+                let (mut tx, mut rx) = ws.split();
+                let mut close_rx = close_active_acc.subscribe();
+                let received = received_acc.clone();
+                let new_message = new_message_acc.clone();
+
+                tokio::spawn(async move {
+                    loop {
+                        tokio::select! {
+                            _ = close_rx.recv() => {
+                                let _ = tx.close().await;
+                                return;
+                            }
+                            msg = rx.next() => {
+                                match msg {
+                                    Some(Ok(Message::Text(txt))) => {
+                                        if let Ok(value) = serde_json::from_str::<Value>(txt.as_str()) {
+                                            received.lock().unwrap().push(value);
+                                            new_message.notify_waiters();
+                                        }
+                                    }
+                                    Some(Ok(Message::Binary(bytes))) => {
+                                        let s = String::from_utf8_lossy(&bytes).to_string();
+                                        if let Ok(value) = serde_json::from_str::<Value>(&s) {
+                                            received.lock().unwrap().push(value);
+                                            new_message.notify_waiters();
+                                        }
+                                    }
+                                    Some(Ok(Message::Ping(payload))) => {
+                                        let _ = tx.send(Message::Pong(payload)).await;
+                                    }
+                                    Some(Ok(_)) => {}
+                                    Some(Err(_)) | None => return,
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        })
+        .abort_handle();
+
+        Self {
+            url,
+            received,
+            new_message,
+            close_active,
+            accept_task,
+        }
+    }
+
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    pub fn received_messages(&self) -> Vec<Value> {
+        self.received.lock().unwrap().clone()
+    }
+
+    /// Close the currently active WebSocket connection (if any). The
+    /// SDK will see the close, transition to `Reconnecting`, and the
+    /// mock will accept the next handshake on the same listener.
+    pub fn close_active_connection(&self) {
+        let _ = self.close_active.send(());
+    }
+
+    /// Wait until `predicate` returns true on the current message list,
+    /// or until `timeout` elapses. Returns the final snapshot.
+    pub async fn wait_for(
+        &self,
+        predicate: impl Fn(&[Value]) -> bool,
+        timeout: Duration,
+    ) -> Vec<Value> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let notified = self.new_message.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            {
+                let snap = self.received.lock().unwrap();
+                if predicate(&snap) {
+                    return snap.clone();
+                }
+            }
+
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return self.received.lock().unwrap().clone();
+            }
+            let _ = tokio::time::timeout(remaining, notified).await;
+        }
+    }
+
+    /// Convenience: wait until at least `count` total messages have been
+    /// received, or `timeout` elapses.
+    pub async fn wait_for_count(&self, count: usize, timeout: Duration) -> Vec<Value> {
+        self.wait_for(move |msgs| msgs.len() >= count, timeout)
+            .await
+    }
+
+    /// Reset the recorded messages buffer. Useful between phases of a
+    /// test (e.g. after asserting the initial registration set, before
+    /// triggering a reconnect).
+    pub fn clear(&self) {
+        self.received.lock().unwrap().clear();
+    }
+}
+
+impl Drop for MockEngine {
+    fn drop(&mut self) {
+        self.accept_task.abort();
+    }
+}
+
+/// Returns the message `type` field if present and a string.
+pub fn message_type(msg: &Value) -> Option<&str> {
+    msg.get("type").and_then(|v| v.as_str())
+}
+
+/// Returns the `id` field if present and a string.
+pub fn message_id(msg: &Value) -> Option<&str> {
+    msg.get("id").and_then(|v| v.as_str())
+}
+
+/// Count occurrences of messages with `type == message_type` AND `id == id`.
+pub fn count_register(msgs: &[Value], message_type_str: &str, id: &str) -> usize {
+    msgs.iter()
+        .filter(|m| {
+            self::message_type(m) == Some(message_type_str) && self::message_id(m) == Some(id)
+        })
+        .count()
+}
+
+/// Count messages with the given `type` regardless of id.
+pub fn count_type(msgs: &[Value], message_type_str: &str) -> usize {
+    msgs.iter()
+        .filter(|m| self::message_type(m) == Some(message_type_str))
+        .count()
+}

--- a/sdk/packages/rust/iii/tests/common/mod.rs
+++ b/sdk/packages/rust/iii/tests/common/mod.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)]
 
+pub mod mock_engine;
+
 use std::sync::OnceLock;
 use std::time::Duration;
 

--- a/sdk/packages/rust/iii/tests/registration_dedup.rs
+++ b/sdk/packages/rust/iii/tests/registration_dedup.rs
@@ -1,0 +1,283 @@
+//! Wire-level tests for the SDK's registration replay logic.
+//!
+//! These tests do NOT require a running engine. They use an in-process
+//! WebSocket mock (see `tests/common/mock_engine.rs`) and assert on the
+//! exact frames the SDK emits during connect, reconnect, and post-connect
+//! registration calls.
+//!
+//! The bug fixed by the registration drain: prior to the fix, every
+//! `register_*` call queued a register frame in the outbound mpsc channel
+//! AND inserted into the in-memory map. On the first connection, the
+//! connection loop replayed the in-memory map (frame #1) and then the
+//! select! loop drained the leftover queued copies (frame #2 — duplicate).
+
+mod common;
+
+use std::time::Duration;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use iii_sdk::{
+    III, IIIConnectionState, InitOptions, RegisterFunction, RegisterServiceMessage,
+    RegisterTriggerInput, RegisterTriggerType, TriggerConfig, TriggerHandler, register_worker,
+};
+
+use common::mock_engine::{MockEngine, count_register, count_type};
+
+#[derive(Deserialize, JsonSchema)]
+struct GreetInput {
+    name: String,
+}
+
+fn greet(input: GreetInput) -> Result<String, String> {
+    Ok(format!("Hello, {}", input.name))
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct EchoInput {
+    payload: Value,
+}
+
+fn echo(input: EchoInput) -> Result<Value, String> {
+    Ok(input.payload)
+}
+
+struct NoopHandler;
+
+#[async_trait::async_trait]
+impl TriggerHandler for NoopHandler {
+    async fn register_trigger(&self, _: TriggerConfig) -> Result<(), iii_sdk::IIIError> {
+        Ok(())
+    }
+    async fn unregister_trigger(&self, _: TriggerConfig) -> Result<(), iii_sdk::IIIError> {
+        Ok(())
+    }
+}
+
+/// Wait until `predicate` is satisfied, then sleep briefly and confirm it
+/// still holds — guards against late-arriving duplicates.
+async fn assert_stable(
+    mock: &MockEngine,
+    predicate: impl Fn(&[Value]) -> bool + Copy,
+    grace: Duration,
+    timeout: Duration,
+) -> Vec<Value> {
+    let _ = mock.wait_for(predicate, timeout).await;
+    tokio::time::sleep(grace).await;
+    let snap = mock.received_messages();
+    assert!(
+        predicate(&snap),
+        "predicate stopped holding after grace period: {snap:#?}"
+    );
+    snap
+}
+
+async fn shutdown(iii: &III) {
+    iii.shutdown_async().await;
+}
+
+#[tokio::test]
+async fn single_function_before_connect_sends_one_registerfunction() {
+    let mock = MockEngine::start().await;
+    let iii = register_worker(mock.url(), InitOptions::default());
+
+    iii.register_function(RegisterFunction::new("dedup::greet", greet));
+
+    let msgs = assert_stable(
+        &mock,
+        |msgs| count_register(msgs, "registerfunction", "dedup::greet") >= 1,
+        Duration::from_millis(400),
+        Duration::from_secs(5),
+    )
+    .await;
+
+    let count = count_register(&msgs, "registerfunction", "dedup::greet");
+    assert_eq!(
+        count, 1,
+        "expected exactly one RegisterFunction frame, got {count}.\nframes: {msgs:#?}"
+    );
+
+    shutdown(&iii).await;
+}
+
+#[tokio::test]
+async fn multiple_functions_before_connect_each_sent_once() {
+    let mock = MockEngine::start().await;
+    let iii = register_worker(mock.url(), InitOptions::default());
+
+    iii.register_function(RegisterFunction::new("dedup::a", greet));
+    iii.register_function(RegisterFunction::new("dedup::b", echo));
+    iii.register_function(RegisterFunction::new("dedup::c", greet));
+
+    let msgs = assert_stable(
+        &mock,
+        |msgs| {
+            count_register(msgs, "registerfunction", "dedup::a") >= 1
+                && count_register(msgs, "registerfunction", "dedup::b") >= 1
+                && count_register(msgs, "registerfunction", "dedup::c") >= 1
+        },
+        Duration::from_millis(400),
+        Duration::from_secs(5),
+    )
+    .await;
+
+    for id in ["dedup::a", "dedup::b", "dedup::c"] {
+        let count = count_register(&msgs, "registerfunction", id);
+        assert_eq!(
+            count, 1,
+            "expected exactly one RegisterFunction frame for {id}, got {count}.\nframes: {msgs:#?}"
+        );
+    }
+
+    shutdown(&iii).await;
+}
+
+#[tokio::test]
+async fn mixed_registration_types_each_sent_once() {
+    let mock = MockEngine::start().await;
+    let iii = register_worker(mock.url(), InitOptions::default());
+
+    iii.register_function(RegisterFunction::new("dedup::mixed::fn", greet));
+    iii.register_service(RegisterServiceMessage {
+        id: "dedup::mixed::svc".to_string(),
+        name: "mixed-svc".to_string(),
+        description: None,
+        parent_service_id: None,
+    });
+    let trigger_type = iii.register_trigger_type(RegisterTriggerType::new(
+        "dedup::mixed::tt",
+        "noop",
+        NoopHandler,
+    ));
+    drop(trigger_type);
+    let trigger = iii
+        .register_trigger(RegisterTriggerInput {
+            trigger_type: "dedup::mixed::tt".to_string(),
+            function_id: "dedup::mixed::fn".to_string(),
+            config: json!({"foo": "bar"}),
+            metadata: None,
+        })
+        .expect("register trigger");
+    drop(trigger);
+
+    let msgs = assert_stable(
+        &mock,
+        |msgs| {
+            count_register(msgs, "registerfunction", "dedup::mixed::fn") >= 1
+                && count_register(msgs, "registerservice", "dedup::mixed::svc") >= 1
+                && count_register(msgs, "registertriggertype", "dedup::mixed::tt") >= 1
+                && count_type(msgs, "registertrigger") >= 1
+        },
+        Duration::from_millis(400),
+        Duration::from_secs(5),
+    )
+    .await;
+
+    assert_eq!(
+        count_register(&msgs, "registerfunction", "dedup::mixed::fn"),
+        1,
+        "RegisterFunction sent multiple times: {msgs:#?}"
+    );
+    assert_eq!(
+        count_register(&msgs, "registerservice", "dedup::mixed::svc"),
+        1,
+        "RegisterService sent multiple times: {msgs:#?}"
+    );
+    assert_eq!(
+        count_register(&msgs, "registertriggertype", "dedup::mixed::tt"),
+        1,
+        "RegisterTriggerType sent multiple times: {msgs:#?}"
+    );
+    assert_eq!(
+        count_type(&msgs, "registertrigger"),
+        1,
+        "RegisterTrigger sent multiple times: {msgs:#?}"
+    );
+
+    shutdown(&iii).await;
+}
+
+#[tokio::test]
+async fn register_after_connected_sends_one_frame() {
+    let mock = MockEngine::start().await;
+    let iii = register_worker(mock.url(), InitOptions::default());
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while iii.get_connection_state() != IIIConnectionState::Connected {
+        if tokio::time::Instant::now() >= deadline {
+            panic!("never reached Connected state");
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let _ = mock
+        .wait_for(
+            |msgs| count_type(msgs, "invokefunction") >= 1,
+            Duration::from_secs(5),
+        )
+        .await;
+
+    iii.register_function(RegisterFunction::new("dedup::late", greet));
+
+    let msgs = assert_stable(
+        &mock,
+        |msgs| count_register(msgs, "registerfunction", "dedup::late") >= 1,
+        Duration::from_millis(400),
+        Duration::from_secs(5),
+    )
+    .await;
+
+    let count = count_register(&msgs, "registerfunction", "dedup::late");
+    assert_eq!(
+        count, 1,
+        "expected exactly one RegisterFunction frame for late registration, got {count}.\nframes: {msgs:#?}"
+    );
+
+    shutdown(&iii).await;
+}
+
+#[tokio::test]
+async fn reconnect_resends_each_registration_once() {
+    let mock = MockEngine::start().await;
+    let iii = register_worker(mock.url(), InitOptions::default());
+
+    iii.register_function(RegisterFunction::new("dedup::reconnect::a", greet));
+    iii.register_function(RegisterFunction::new("dedup::reconnect::b", echo));
+
+    let _ = assert_stable(
+        &mock,
+        |msgs| {
+            count_register(msgs, "registerfunction", "dedup::reconnect::a") >= 1
+                && count_register(msgs, "registerfunction", "dedup::reconnect::b") >= 1
+        },
+        Duration::from_millis(400),
+        Duration::from_secs(5),
+    )
+    .await;
+
+    mock.clear();
+    mock.close_active_connection();
+
+    let msgs = assert_stable(
+        &mock,
+        |msgs| {
+            count_register(msgs, "registerfunction", "dedup::reconnect::a") >= 1
+                && count_register(msgs, "registerfunction", "dedup::reconnect::b") >= 1
+        },
+        Duration::from_millis(500),
+        Duration::from_secs(10),
+    )
+    .await;
+
+    for id in ["dedup::reconnect::a", "dedup::reconnect::b"] {
+        let count = count_register(&msgs, "registerfunction", id);
+        assert_eq!(
+            count, 1,
+            "expected exactly one RegisterFunction frame for {id} on reconnect, got {count}.\nframes: {msgs:#?}"
+        );
+    }
+
+    shutdown(&iii).await;
+}


### PR DESCRIPTION
## What

After the WS handshake completes, drain the outbound `mpsc` channel of any leftover register frames whose IDs are already covered by the `collect_registrations()` snapshot we just flushed, then re-flush anything that's not a duplicate (invocations, results, registrations made after the snapshot). Implemented in `run_connection` with two new helpers (`registration_key`, `drain_pre_connect_duplicates`) on `III` in `sdk/packages/rust/iii/src/iii.rs`.

## Why

Every `register_*` call wrote to two places: the in-memory map (replayed via `collect_registrations` on connect) AND the unbounded `outbound` channel (read by the connection `select!` loop). `send_message` only checked `running`, which `connect()` flips to `true` *before* the WS handshake, so any `register_function` call between `register_worker` and handshake-complete sat in `rx` waiting.

On the first connection the loop sent every registration twice: once via the `collect_registrations` snapshot through `flush_queue`, and again when the `select!` loop drained the leftover frames from `rx`. The engine's developer console therefore logged every registration twice on initial connect. Reconnects were unaffected because no user-thread queueing happens between disconnect and reconnect — `collect_registrations` is the sole source.

The Node SDK avoids this with `skipIfClosed: true` on every register/unregister `sendMessage`; the Rust SDK had no equivalent. Rather than introduce locking changes to `register_function_inner`, the drain step is localized to `run_connection` and handles all races: `collect_registrations` and `register_function_inner` already serialize on the same `functions` mutex, so any register frame in `rx` whose key matches the snapshot is provably a pre-snapshot duplicate (new registrations panic on duplicate IDs).

## Notes

- New file: `sdk/packages/rust/iii/tests/common/mock_engine.rs` — small in-process WebSocket mock (binds `127.0.0.1:0`, records every JSON frame, supports `close_active_connection()` to force reconnect).
- New file: `sdk/packages/rust/iii/tests/registration_dedup.rs` — 5 wire-level integration tests: single function before connect, multiple functions before connect, mixed types (function/service/trigger type/trigger), register after `Connected`, and reconnect.
- 5 unit tests added to `src/iii.rs` covering `registration_key` (each `Register*` variant + `None` for non-register messages) and `drain_pre_connect_duplicates` (drops only known IDs, preserves invocations/pings/new registrations, signals shutdown, returns cleanly on empty channel).
- Verified the 3 "before-connect" integration tests fail with `left: 2, right: 1` against unfixed `iii.rs`; all 5 pass with the fix. The 2 "after-connect" / "reconnect" tests pass either way — they're guardrails to ensure the fix doesn't regress those paths.
- No public SDK API change. No changes to engine config, protocol, or other SDKs.
- The Python SDK may have the same bug (not investigated in this PR); follow-up if confirmed.

---

- [ ] I am licensing the entirety of this PR under Apache 2 and have all necessary rights to the code I am contributing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved WebSocket connection handling to more precisely deduplicate and flush registration messages during the initial handshake, with enhanced handling of shutdown scenarios.

* **Tests**
  * Added comprehensive integration tests validating registration replay and deduplication behavior across connect, reconnect, and mixed registration scenarios.
  * Added testing infrastructure supporting WebSocket mock engine for local integration testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->