### PR TITLE
fix(iii-worker): remove non-existent `iii start` from helper texts

### DIFF
--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -541,7 +541,7 @@ pub async fn handle_local_add(
         if !engine_running {
             eprintln!(
                 "\n  {} Added {} ({}) to config.yaml, but the engine isn't running.\n  \
-                 --wait cannot observe it boot — run `iii start` in another terminal first.",
+                 --wait cannot observe it boot — run `iii` in another terminal first.",
                 "\u{26A0}".yellow(),
                 worker_name.bold(),
                 "local".dimmed()
@@ -603,7 +603,7 @@ pub async fn handle_local_add(
     } else {
         eprintln!(
             "\n  {} Added {} ({}) to config.yaml, but the engine isn't running.\n  \
-             Start it:  iii start\n  \
+             Start it:  iii\n  \
              Then:      iii worker status {}",
             "\u{26A0}".yellow(),
             worker_name.bold(),

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -1599,7 +1599,7 @@ async fn finish_add(worker_name: &str, rc: i32, wait: bool, brief: bool) -> i32 
         // picked up. A wait would run to timeout. Tell the user instead.
         eprintln!(
             "\n  {} engine not running; start it to observe boot.\n  \
-               Start:         iii start\n  \
+               Start:         iii\n  \
                Then watch:    iii worker status {}",
             "⚠".yellow(),
             worker_name,
@@ -2734,7 +2734,7 @@ pub async fn handle_managed_start(
         if !is_engine_running() {
             eprintln!(
                 "{} '{}' is a builtin served by the iii engine, but the engine isn't running.\n  \
-                 Start the engine:  iii start",
+                 Start the engine:  iii",
                 "error:".red(),
                 worker_name,
             );
@@ -2851,14 +2851,14 @@ pub async fn handle_managed_start(
             if !is_engine_running() {
                 eprintln!(
                     "{} '{}' is an engine builtin, but the engine isn't running.\n  \
-                     Start the engine:  iii start",
+                     Start the engine:  iii",
                     "error:".red(),
                     worker_name,
                 );
                 return 1;
             }
             eprintln!(
-                "  {} '{}' is an engine builtin — it starts automatically with `iii start`.",
+                "  {} '{}' is an engine builtin — it starts automatically with `iii`.",
                 "info:".cyan(),
                 worker_name
             );

--- a/crates/iii-worker/src/cli/status.rs
+++ b/crates/iii-worker/src/cli/status.rs
@@ -253,7 +253,7 @@ impl WorkerStatus {
         match self.phase {
             Phase::NotInConfig => format!("{} {} not in config.yaml", "✗".red(), self.name.bold()),
             Phase::EngineDown => format!(
-                "{} engine not running (start it with `iii start`)",
+                "{} engine not running (start it with `iii`)",
                 "⚠".yellow()
             ),
             Phase::Queued => {
@@ -320,7 +320,7 @@ impl WorkerStatus {
                 "{:>12}  {} {}",
                 "engine:".dimmed(),
                 "stopped".red(),
-                "(run `iii start` in another terminal)".dimmed()
+                "(run `iii` in another terminal)".dimmed()
             )
         };
         out.push(engine_line);
@@ -630,7 +630,7 @@ mod tests {
             phase: Phase::EngineDown,
             ..base
         };
-        assert!(s.headline().contains("iii start"));
+        assert!(s.headline().contains("start it with `iii`"));
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/status.rs
+++ b/crates/iii-worker/src/cli/status.rs
@@ -252,10 +252,9 @@ impl WorkerStatus {
     pub fn headline(&self) -> String {
         match self.phase {
             Phase::NotInConfig => format!("{} {} not in config.yaml", "✗".red(), self.name.bold()),
-            Phase::EngineDown => format!(
-                "{} engine not running (start it with `iii`)",
-                "⚠".yellow()
-            ),
+            Phase::EngineDown => {
+                format!("{} engine not running (start it with `iii`)", "⚠".yellow())
+            }
             Phase::Queued => {
                 // Binary workers don't have a sandbox; the engine spawns
                 // them as plain host processes. Tailor the message so we


### PR DESCRIPTION
## Summary

- `iii start` was never a real subcommand — the engine starts with bare `iii` — but 9 helper texts and a status-headline test still pointed users at it. When the engine was down, every guidance message sent users down a dead end.
- Updated all 9 references across `local_worker.rs`, `managed.rs`, and `status.rs` to recommend `iii` instead (worker-add guidance, builtin-worker errors, engine-down headline, and the engine status line).
- Updated the `EngineDown` headline test to assert on the more specific substring `` start it with `iii` `` (matching just `"iii"` would have been too generic).

## Test plan

- [x] `rg "iii start" crates/` → 0 matches
- [x] `cargo check -p iii-worker` → 0 errors
- [x] `cargo test -p iii-worker --lib cli::status::` → 23 passed
- [ ] Manually trigger an engine-down `iii worker status` and `iii worker add` to confirm the new copy reads naturally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * CLI guidance messages have been updated to consistently recommend using the `iii` command to start the engine. Changes affect messages displayed during worker startup, managed operations, and status states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1628)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->