### PR TITLE
fix(http): stream JSON raw request bodies

### DIFF
--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -48,15 +48,16 @@ async fn fire_engine_telemetry(name: &str, version: &str) {
     let api_url =
         std::env::var("III_API_URL").unwrap_or_else(|_| "https://api.workers.iii.dev".to_string());
     let url = format!("{api_url}/download/{name}");
+    let timeout = std::time::Duration::from_secs(2);
 
-    match HTTP_CLIENT
-        .get(&url)
-        .query(&[("version", version)])
-        .send()
-        .await
+    match tokio::time::timeout(
+        timeout,
+        HTTP_CLIENT.get(&url).query(&[("version", version)]).send(),
+    )
+    .await
     {
-        Ok(resp) if resp.status().as_u16() == 204 => {}
-        Ok(resp) => {
+        Ok(Ok(resp)) if resp.status().as_u16() == 204 => {}
+        Ok(Ok(resp)) => {
             eprintln!(
                 "  {} telemetry for {} returned unexpected status {}",
                 "warn:".yellow(),
@@ -64,12 +65,20 @@ async fn fire_engine_telemetry(name: &str, version: &str) {
                 resp.status()
             );
         }
-        Err(e) => {
+        Ok(Err(e)) => {
             eprintln!(
                 "  {} telemetry for {} failed: {}",
                 "warn:".yellow(),
                 name,
                 e
+            );
+        }
+        Err(_) => {
+            eprintln!(
+                "  {} telemetry for {} timed out after {:?}",
+                "warn:".yellow(),
+                name,
+                timeout
             );
         }
     }

--- a/engine/src/workers/rest_api/views.rs
+++ b/engine/src/workers/rest_api/views.rs
@@ -403,7 +403,6 @@ pub async fn dynamic_handler(
                     if !body_bytes.is_empty() {
                         let _ = req_tx.send(ChannelItem::Binary(body_bytes.clone())).await;
                     }
-                    drop(req_tx);
                 }
                 serde_json::from_slice(&body_bytes).unwrap_or(Value::Null)
             } else if let Some(req_tx) = req_tx {

--- a/engine/src/workers/rest_api/views.rs
+++ b/engine/src/workers/rest_api/views.rs
@@ -399,6 +399,12 @@ pub async fn dynamic_handler(
                     }
                     axum::body::Bytes::from(buf)
                 };
+                if let Some(req_tx) = req_tx {
+                    if !body_bytes.is_empty() {
+                        let _ = req_tx.send(ChannelItem::Binary(body_bytes.clone())).await;
+                    }
+                    drop(req_tx);
+                }
                 serde_json::from_slice(&body_bytes).unwrap_or(Value::Null)
             } else if let Some(req_tx) = req_tx {
                 let mut body = body;
@@ -1477,6 +1483,33 @@ mod tests {
             .unwrap();
     }
 
+    async fn drain_request_body_channel(
+        engine: &Engine,
+        request: &HttpRequest,
+        timeout_message: &'static str,
+    ) -> Vec<u8> {
+        let mut rx = engine
+            .channel_manager
+            .take_receiver(
+                &request.request_body.channel_id,
+                &request.request_body.access_key,
+            )
+            .await
+            .expect("request body receiver");
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            let mut raw = Vec::new();
+            while let Some(item) = rx.recv().await {
+                if let ChannelItem::Binary(bytes) = item {
+                    raw.extend_from_slice(&bytes);
+                }
+            }
+            raw
+        })
+        .await
+        .expect(timeout_message)
+    }
+
     #[tokio::test]
     async fn test_dynamic_handler_route_not_found() {
         let engine = make_test_engine();
@@ -2082,6 +2115,140 @@ mod tests {
         .into_response();
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_handler_json_request_body_channel_reads_raw_bytes() {
+        let engine = make_test_engine();
+        let engine_for_handler = engine.clone();
+
+        engine.register_function_handler(
+            RegisterFunctionRequest {
+                function_id: "test::json_raw_body".to_string(),
+                description: None,
+                request_format: None,
+                response_format: None,
+                metadata: None,
+            },
+            Handler::new(move |input: Value| {
+                let engine = engine_for_handler.clone();
+                async move {
+                    let request: HttpRequest = serde_json::from_value(input).unwrap();
+                    let raw = drain_request_body_channel(
+                        &engine,
+                        &request,
+                        "request body channel should close",
+                    )
+                    .await;
+
+                    FunctionResult::Success(Some(json!({
+                        "status_code": 200,
+                        "body": {
+                            "parsed_body": request.body,
+                            "raw_body": String::from_utf8(raw).unwrap()
+                        }
+                    })))
+                }
+            }),
+        );
+
+        let api_handler = make_test_api_handler(engine.clone());
+        register_test_route(&api_handler, "/json-raw", "POST", "test::json_raw_body").await;
+
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", HeaderValue::from_static("application/json"));
+        let query_params: HashMap<String, String> = HashMap::new();
+
+        let response = dynamic_handler(
+            Method::POST,
+            "/json-raw".parse().unwrap(),
+            headers,
+            axum::extract::Extension(engine),
+            axum::extract::Extension(api_handler),
+            axum::extract::Extension("/json-raw".to_string()),
+            Query(query_params),
+            Body::from(r#"{"key":"value"}"#),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let value: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(value["parsed_body"], json!({"key": "value"}));
+        assert_eq!(value["raw_body"], r#"{"key":"value"}"#);
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_handler_empty_json_request_body_channel_closes() {
+        let engine = make_test_engine();
+        let engine_for_handler = engine.clone();
+
+        engine.register_function_handler(
+            RegisterFunctionRequest {
+                function_id: "test::empty_json_raw_body".to_string(),
+                description: None,
+                request_format: None,
+                response_format: None,
+                metadata: None,
+            },
+            Handler::new(move |input: Value| {
+                let engine = engine_for_handler.clone();
+                async move {
+                    let request: HttpRequest = serde_json::from_value(input).unwrap();
+                    let raw = drain_request_body_channel(
+                        &engine,
+                        &request,
+                        "empty request body channel should close",
+                    )
+                    .await;
+
+                    FunctionResult::Success(Some(json!({
+                        "status_code": 200,
+                        "body": {
+                            "parsed_is_null": request.body.is_null(),
+                            "raw_len": raw.len()
+                        }
+                    })))
+                }
+            }),
+        );
+
+        let api_handler = make_test_api_handler(engine.clone());
+        register_test_route(
+            &api_handler,
+            "/json-raw-empty",
+            "POST",
+            "test::empty_json_raw_body",
+        )
+        .await;
+
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", HeaderValue::from_static("application/json"));
+        let query_params: HashMap<String, String> = HashMap::new();
+
+        let response = dynamic_handler(
+            Method::POST,
+            "/json-raw-empty".parse().unwrap(),
+            headers,
+            axum::extract::Extension(engine),
+            axum::extract::Extension(api_handler),
+            axum::extract::Extension("/json-raw-empty".to_string()),
+            Query(query_params),
+            Body::empty(),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let value: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(value["parsed_is_null"], json!(true));
+        assert_eq!(value["raw_len"], json!(0));
     }
 
     #[tokio::test]

--- a/sdk/packages/node/iii/tests/api-triggers.test.ts
+++ b/sdk/packages/node/iii/tests/api-triggers.test.ts
@@ -73,6 +73,54 @@ describe('API Triggers', () => {
     trigger.unregister()
   })
 
+  it('should expose raw JSON request body through request_body', async () => {
+    const rawJson = '{"z":2, "a":1}'
+
+    const fn = iii.registerFunction(
+      'test.api.json.raw',
+      http(async (req: HttpRequest, response: HttpResponse) => {
+        const rawBody = await req.request_body.readAll()
+
+        response.status(200)
+        response.headers({ 'content-type': 'application/json' })
+        response.stream.end(
+          Buffer.from(
+            JSON.stringify({
+              parsed_body: req.body,
+              raw_body: rawBody.toString('utf-8'),
+            }),
+          ),
+        )
+      }),
+    )
+
+    const trigger = iii.registerTrigger({
+      type: 'http',
+      function_id: fn.id,
+      config: {
+        api_path: 'test/json/raw',
+        http_method: 'POST',
+      },
+    })
+
+    await sleep(300)
+
+    const response = await fetch(`${engineHttpUrl}/test/json/raw`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: rawJson,
+    })
+
+    expect(response.status).toBe(200)
+    const data = (await response.json()) as Record<string, unknown>
+
+    expect(data.parsed_body).toEqual({ z: 2, a: 1 })
+    expect(data.raw_body).toBe(rawJson)
+
+    fn.unregister()
+    trigger.unregister()
+  })
+
   it('should handle path parameters', async () => {
     const fn = iii.registerFunction(
       'test.api.getById',

--- a/sdk/packages/node/iii/tests/api-triggers.test.ts
+++ b/sdk/packages/node/iii/tests/api-triggers.test.ts
@@ -77,7 +77,7 @@ describe('API Triggers', () => {
     const rawJson = '{"z":2, "a":1}'
 
     const fn = iii.registerFunction(
-      'test.api.json.raw',
+      'test::api::json::raw',
       http(async (req: HttpRequest, response: HttpResponse) => {
         const rawBody = await req.request_body.readAll()
 
@@ -98,7 +98,7 @@ describe('API Triggers', () => {
       type: 'http',
       function_id: fn.id,
       config: {
-        api_path: 'test/json/raw',
+        api_path: '/test/json/raw',
         http_method: 'POST',
       },
     })

--- a/sdk/packages/python/iii/tests/test_api_triggers.py
+++ b/sdk/packages/python/iii/tests/test_api_triggers.py
@@ -88,6 +88,54 @@ async def test_post_endpoint_with_body(engine_http_url, iii_client: III):
 
 
 @pytest.mark.asyncio
+async def test_raw_json_request_body(engine_http_url, iii_client: III):
+    raw_json = '{"z":2, "a":1}'
+
+    @http
+    async def handler(req: HttpRequest, response: HttpResponse):
+        raw = await req.request_body.read_all()
+
+        await response.status(200)
+        await response.headers({"content-type": "application/json"})
+        result = json.dumps(
+            {
+                "parsed_body": req.body,
+                "raw_body": raw.decode("utf-8"),
+            }
+        ).encode("utf-8")
+        await response.writer.write(result)
+        await response.writer.close_async()
+
+    fn_ref = iii_client.register_function("test.api.json.raw.py", handler)
+    trigger = iii_client.register_trigger(
+        {
+            "type": "http",
+            "function_id": "test.api.json.raw.py",
+            "config": {
+                "api_path": "test/py/json/raw",
+                "http_method": "POST",
+            },
+        }
+    )
+
+    time.sleep(0.3)
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{engine_http_url}/test/py/json/raw",
+            headers={"content-type": "application/json"},
+            data=raw_json,
+        ) as resp:
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["parsed_body"] == {"z": 2, "a": 1}
+            assert data["raw_body"] == raw_json
+
+    fn_ref.unregister()
+    trigger.unregister()
+
+
+@pytest.mark.asyncio
 async def test_path_parameters(engine_http_url, iii_client: III):
     """Verify path parameters are extracted correctly."""
 

--- a/sdk/packages/python/iii/tests/test_api_triggers.py
+++ b/sdk/packages/python/iii/tests/test_api_triggers.py
@@ -90,6 +90,7 @@ async def test_post_endpoint_with_body(engine_http_url, iii_client: III):
 @pytest.mark.asyncio
 async def test_raw_json_request_body(engine_http_url, iii_client: III):
     raw_json = '{"z":2, "a":1}'
+    function_id = "test::api::json::raw::py"
 
     @http
     async def handler(req: HttpRequest, response: HttpResponse):
@@ -106,13 +107,13 @@ async def test_raw_json_request_body(engine_http_url, iii_client: III):
         await response.writer.write(result)
         await response.writer.close_async()
 
-    fn_ref = iii_client.register_function("test.api.json.raw.py", handler)
+    fn_ref = iii_client.register_function(function_id, handler)
     trigger = iii_client.register_trigger(
         {
             "type": "http",
-            "function_id": "test.api.json.raw.py",
+            "function_id": function_id,
             "config": {
-                "api_path": "test/py/json/raw",
+                "api_path": "/test/py/json/raw",
                 "http_method": "POST",
             },
         }

--- a/sdk/packages/rust/iii/tests/api_triggers.rs
+++ b/sdk/packages/rust/iii/tests/api_triggers.rs
@@ -191,7 +191,7 @@ async fn raw_json_request_body() {
             trigger_type: "http".to_string(),
             function_id: "test::api::json::raw::rs".to_string(),
             config: json!({
-                "api_path": "test/rs/json/raw",
+                "api_path": "/test/rs/json/raw",
                 "http_method": "POST",
             }),
             metadata: None,

--- a/sdk/packages/rust/iii/tests/api_triggers.rs
+++ b/sdk/packages/rust/iii/tests/api_triggers.rs
@@ -110,6 +110,112 @@ async fn post_endpoint_with_body() {
 }
 
 #[tokio::test]
+async fn raw_json_request_body() {
+    let iii = common::shared_iii();
+    let raw_json = r#"{"z":2, "a":1}"#;
+
+    let iii_for_handler = iii.clone();
+    iii.register_function((
+        RegisterFunctionMessage::with_id("test::api::json::raw::rs".to_string()),
+        move |input: Value| {
+            let iii = iii_for_handler.clone();
+            async move {
+                let parsed_body = input.get("body").cloned().unwrap_or(Value::Null);
+                let refs = iii_sdk::extract_channel_refs(&input);
+
+                let writer_ref = refs
+                    .iter()
+                    .find(|(_, r)| matches!(r.direction, iii_sdk::ChannelDirection::Write))
+                    .map(|(_, r)| r.clone())
+                    .expect("missing writer ref");
+
+                let reader_ref = refs
+                    .iter()
+                    .find(|(k, r)| {
+                        k.contains("request_body")
+                            && matches!(r.direction, iii_sdk::ChannelDirection::Read)
+                    })
+                    .map(|(_, r)| r.clone())
+                    .expect("missing reader ref");
+
+                let writer = iii_sdk::ChannelWriter::new(iii.address(), &writer_ref);
+                let reader = iii_sdk::ChannelReader::new(iii.address(), &reader_ref);
+                let raw = reader
+                    .read_all()
+                    .await
+                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+
+                writer
+                    .send_message(
+                        &serde_json::to_string(&json!({
+                            "type": "set_status", "status_code": 200
+                        }))
+                        .unwrap(),
+                    )
+                    .await
+                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+
+                writer
+                    .send_message(
+                        &serde_json::to_string(&json!({
+                            "type": "set_headers", "headers": {"content-type": "application/json"}
+                        }))
+                        .unwrap(),
+                    )
+                    .await
+                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+
+                let response_body = serde_json::to_vec(&json!({
+                    "parsed_body": parsed_body,
+                    "raw_body": String::from_utf8(raw)
+                        .map_err(|e| IIIError::Handler(e.to_string()))?,
+                }))
+                .map_err(|e| IIIError::Handler(e.to_string()))?;
+
+                writer
+                    .write(&response_body)
+                    .await
+                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                writer
+                    .close()
+                    .await
+                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+
+                Ok(Value::Null)
+            }
+        },
+    ));
+
+    let _trigger = iii
+        .register_trigger(RegisterTriggerInput {
+            trigger_type: "http".to_string(),
+            function_id: "test::api::json::raw::rs".to_string(),
+            config: json!({
+                "api_path": "test/rs/json/raw",
+                "http_method": "POST",
+            }),
+            metadata: None,
+        })
+        .expect("register trigger");
+
+    common::settle().await;
+    sleep(Duration::from_millis(500)).await;
+
+    let resp = common::http_client()
+        .post(format!("{}/test/rs/json/raw", common::engine_http_url()))
+        .header("content-type", "application/json")
+        .body(raw_json.to_string())
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 200);
+    let data: Value = resp.json().await.expect("json parse");
+    assert_eq!(data["parsed_body"], json!({"z": 2, "a": 1}));
+    assert_eq!(data["raw_body"], raw_json);
+}
+
+#[tokio::test]
 async fn path_parameters() {
     let iii = common::shared_iii();
 


### PR DESCRIPTION
## Summary
- Write buffered JSON request bytes into the `request_body` channel before invoking the handler.
- Close the request body sender for empty JSON bodies so `readAll` / `read_all` resolves.
- Add HTTP handler regressions for raw JSON and empty JSON request body channels.

## Tests
- `cargo fmt --package iii`
- `cargo test -p iii workers::rest_api::views::tests::test_dynamic_handler -- --nocapture`

Closes #1631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON request bodies are streamed to handlers' raw request channels and channels close correctly for empty JSON bodies.

* **Tests**
  * Added end-to-end tests (Node, Python, Rust) verifying handlers receive both parsed JSON and the original raw request bytes, including empty bodies.

* **Chores**
  * Telemetry download request now times out after 2 seconds and emits a clear timeout message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1632)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->