### PR TITLE
chore(ci): bump skills-and-validation to v0.4 + switch AI judge to Sonnet

### DIFF
--- a/.github/workflows/skill-check.yml
+++ b/.github/workflows/skill-check.yml
@@ -8,7 +8,10 @@ on:
       - ".skill-check.yaml"
       - ".github/workflows/skill-check.yml"
   push:
-    branches: [main]
+    # dx-improves is included so a merge into the working branch
+    # populates the base-ref AI skip-cache; subsequent PRs against
+    # dx-improves then restore from it instead of starting cold.
+    branches: [main, dx-improves]
     paths:
       - "docs/**/*.md"
       - "docs/**/*.mdx"

--- a/.github/workflows/skill-check.yml
+++ b/.github/workflows/skill-check.yml
@@ -18,6 +18,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write          # for the persistent AI skip-cache (v0.3+)
 
 jobs:
   verify:
@@ -28,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run iii-skill-check
-        uses: iii-hq/skills-and-validation@v0.2
+        uses: iii-hq/skills-and-validation@v0.3
         with:
           write: true
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/skill-check.yml
+++ b/.github/workflows/skill-check.yml
@@ -32,7 +32,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run iii-skill-check
-        uses: iii-hq/skills-and-validation@v0.3
+        uses: iii-hq/skills-and-validation@v0.4
         with:
           write: true
+          scope: pr-diff
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.skill-check.yaml
+++ b/.skill-check.yaml
@@ -10,6 +10,6 @@ docs:
     - "docs/changelog/**"
 ai_check:
   provider: anthropic
-  model: claude-opus-4-7
+  model: claude-sonnet-4-6
   api_key_env_var: ANTHROPIC_API_KEY
   max_tokens: 6000


### PR DESCRIPTION
## Summary
- Bump \`iii-hq/skills-and-validation@v0.2\` → \`@v0.3\` in \`.github/workflows/skill-check.yml\`
- Add \`actions: write\` permission so the new persistent AI skip-cache (v0.3.0+) can save across runs
- Switch \`ai_check.model\` from \`claude-opus-4-7\` to \`claude-sonnet-4-6\` — Opus is overkill for the per-file judge task

## Context
v0.3.0 adds a SHA-256-keyed pass-cache for the AI layer that persists across PR runs via \`actions/cache\`. Hash inputs cover artifact text, project rules, system prompt, model, and doc type — so a rule edit (or this model swap) busts the cache automatically. Only PASS verdicts are recorded; FAILs always re-run.

v0.3.1 adds explicit \`[ai-cache] hit: <path>\` logging so a cache hit is visible in the workflow log (the floating \`@v0.3\` tag picks this up automatically).

Verified end-to-end on iii-hq/skills-test#7 — three successive PR pushes show cache restore → save → restore → hit lines for previously-PASSing artifacts.

## Test plan
- [ ] First push: cache miss (model swap invalidated every prior entry); full AI validation under Sonnet; save step records new hashes for PASSes
- [ ] Second push: cache restore hits; previously-passing artifacts log \`[ai-cache] hit: ...\` and skip the API call
- [ ] No regression in the failure surface that v0.2 was already flagging on PR #1633 — the same files should still fail (different model verdict possible; if Sonnet ratifies any of the prior FAILs as PASS, that's a finding to discuss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)