### PR TITLE
feat(engine): expose generated HTTP functions as worker groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,6 +2544,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
  "uuid",
  "which",
  "winapi",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -120,6 +120,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 dashmap = "6"
 indexmap = { version = "2", features = ["serde"] }
 redis = { version = "1.0.1", features = ["tokio-comp", "connection-manager"] }
+url = { workspace = true }
 lapin = { version = "3", optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 async-trait = "0.1.89"

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -4,7 +4,10 @@
 // This software is patent protected. We welcome discussions - reach out at team@iii.dev
 // See LICENSE and PATENTS files for details.
 
-use std::{net::SocketAddr, sync::Arc};
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+};
 
 use axum::{
     extract::ws::{Message as WsMessage, WebSocket},
@@ -280,6 +283,15 @@ fn is_loopback_http_url(value: &str) -> bool {
     })
 }
 
+fn is_trusted_bridge_session(session: &Session) -> bool {
+    session.trusted_internal
+        || session.ip_address.eq_ignore_ascii_case("localhost")
+        || session
+            .ip_address
+            .parse::<IpAddr>()
+            .is_ok_and(|ip| ip.is_loopback())
+}
+
 fn trusted_virtual_worker_name(
     worker: &WorkerConnection,
     metadata: &mut Option<Value>,
@@ -288,7 +300,7 @@ fn trusted_virtual_worker_name(
     worker
         .session
         .as_ref()
-        .is_some_and(|session| session.trusted_internal)
+        .is_some_and(|session| is_trusted_bridge_session(session))
         .then_some(name)
 }
 
@@ -2412,6 +2424,91 @@ mod tests {
             .expect("unregister external function should succeed");
 
         assert!(!engine.virtual_workers.contains_worker("hackernews"));
+    }
+
+    #[tokio::test]
+    async fn test_local_external_function_virtual_worker_bridge_is_internal() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+
+        let http_functions_config = HttpFunctionsConfig {
+            security: SecurityConfig {
+                require_https: false,
+                block_private_ips: false,
+                url_allowlist: vec!["*".to_string()],
+            },
+        };
+        let http_functions_module = HttpFunctionsWorker::create(
+            engine.clone(),
+            Some(serde_json::to_value(&http_functions_config).expect("serialize config")),
+        )
+        .await
+        .expect("create module");
+        http_functions_module
+            .initialize()
+            .await
+            .expect("initialize module");
+
+        let (tx, _rx) = mpsc::channel::<Outbound>(8);
+        let worker = WorkerConnection::with_session(
+            tx,
+            crate::workers::worker::rbac_session::Session {
+                engine: engine.clone(),
+                config: Arc::new(crate::workers::worker::WorkerManagerConfig::default()),
+                ip_address: "127.0.0.1".to_string(),
+                session_id: uuid::Uuid::new_v4(),
+                allowed_functions: vec![],
+                forbidden_functions: vec![],
+                allowed_trigger_types: None,
+                allow_function_registration: true,
+                allow_trigger_type_registration: true,
+                trusted_internal: false,
+                context: json!({}),
+                function_registration_prefix: None,
+            },
+        );
+        let register_msg = Message::RegisterFunction {
+            id: "local_api::echo".to_string(),
+            description: Some("echo".to_string()),
+            request_format: None,
+            response_format: None,
+            metadata: Some(json!({
+                "spec": { "source": "http://127.0.0.1/openapi.json" },
+                "iii": { "virtualWorker": { "name": "local-api" } }
+            })),
+            invocation: Some(HttpInvocationRef {
+                url: "http://127.0.0.1/local-api/echo".to_string(),
+                method: crate::invocation::method::HttpMethod::Post,
+                timeout_ms: Some(30000),
+                headers: HashMap::new(),
+                auth: None,
+            }),
+        };
+
+        engine
+            .router_msg(&worker, &register_msg)
+            .await
+            .expect("register external function should succeed");
+
+        let virtual_worker = engine
+            .virtual_workers
+            .get("local-api")
+            .expect("virtual worker should be tracked internally");
+        assert_eq!(virtual_worker.name, "local-api");
+        assert!(virtual_worker.trusted_internal);
+        assert!(virtual_worker.function_ids.contains("local_api::echo"));
+
+        let http_module = engine
+            .service_registry
+            .get_service::<HttpFunctionsWorker>("http_functions")
+            .expect("http_functions service registered");
+        assert!(
+            http_module
+                .http_functions()
+                .get("local_api::echo")
+                .expect("http function config should exist")
+                .trusted_internal
+        );
     }
 
     #[tokio::test]

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -2343,7 +2343,7 @@ mod tests {
             request_format: None,
             response_format: None,
             metadata: Some(json!({
-                "artifact": { "source": "https://example.com/openapi.json" },
+                "spec": { "source": "https://example.com/openapi.json" },
                 "iii": { "virtualWorker": { "name": "hackernews" } }
             })),
             invocation: Some(HttpInvocationRef {
@@ -2378,7 +2378,7 @@ mod tests {
             .expect("function should be visible as a normal function");
         assert_eq!(
             function.metadata,
-            Some(json!({ "artifact": { "source": "https://example.com/openapi.json" } }))
+            Some(json!({ "spec": { "source": "https://example.com/openapi.json" } }))
         );
 
         let http_module = engine
@@ -2391,7 +2391,7 @@ mod tests {
                 .get("hackernews::top_stories")
                 .expect("http function config should exist")
                 .metadata,
-            Some(json!({ "artifact": { "source": "https://example.com/openapi.json" } }))
+            Some(json!({ "spec": { "source": "https://example.com/openapi.json" } }))
         );
         assert!(
             http_module
@@ -2445,7 +2445,7 @@ mod tests {
             request_format: None,
             response_format: None,
             metadata: Some(json!({
-                "artifact": { "source": "https://example.com/openapi.json" },
+                "spec": { "source": "https://example.com/openapi.json" },
                 "iii": { "virtualWorker": { "name": "hackernews" } }
             })),
             invocation: Some(HttpInvocationRef {
@@ -2469,7 +2469,7 @@ mod tests {
             .expect("function should still be visible as a normal function");
         assert_eq!(
             function.metadata,
-            Some(json!({ "artifact": { "source": "https://example.com/openapi.json" } }))
+            Some(json!({ "spec": { "source": "https://example.com/openapi.json" } }))
         );
 
         let http_module = engine

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -18,7 +18,7 @@ use serde_json::Value;
 use tokio::sync::{mpsc, oneshot::error::RecvError};
 use tracing::Instrument;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
-use url::Url;
+use url::{Host, Url};
 use uuid::Uuid;
 
 use crate::{
@@ -272,8 +272,10 @@ fn resolve_registration_id(worker: &WorkerConnection, id: &str) -> String {
 fn is_loopback_http_url(value: &str) -> bool {
     Url::parse(value).ok().is_some_and(|url| {
         url.scheme() == "http"
-            && url.host_str().is_some_and(|host| {
-                host.eq_ignore_ascii_case("localhost") || host == "127.0.0.1" || host == "::1"
+            && url.host().is_some_and(|host| match host {
+                Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
+                Host::Ipv4(addr) => addr.is_loopback(),
+                Host::Ipv6(addr) => addr.is_loopback(),
             })
     })
 }
@@ -1937,6 +1939,16 @@ mod tests {
         {
             Err(serde::ser::Error::custom("serialization exploded"))
         }
+    }
+
+    #[test]
+    fn loopback_http_url_matches_ipv4_ipv6_and_localhost() {
+        assert!(super::is_loopback_http_url("http://localhost/worker"));
+        assert!(super::is_loopback_http_url("http://127.0.0.1/worker"));
+        assert!(super::is_loopback_http_url("http://127.0.0.2/worker"));
+        assert!(super::is_loopback_http_url("http://[::1]/worker"));
+        assert!(!super::is_loopback_http_url("https://localhost/worker"));
+        assert!(!super::is_loopback_http_url("http://example.com/worker"));
     }
 
     #[test]

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -278,6 +278,18 @@ fn is_loopback_http_url(value: &str) -> bool {
     })
 }
 
+fn trusted_virtual_worker_name(
+    worker: &WorkerConnection,
+    metadata: &mut Option<Value>,
+) -> Option<String> {
+    let name = take_virtual_worker_name(metadata)?;
+    worker
+        .session
+        .as_ref()
+        .is_some_and(|session| session.trusted_internal)
+        .then_some(name)
+}
+
 impl Default for Engine {
     fn default() -> Self {
         Self::new()
@@ -1183,7 +1195,8 @@ impl Engine {
                 }
 
                 reg_id = resolve_registration_id(worker, &reg_id);
-                let virtual_worker_name = take_virtual_worker_name(&mut reg_metadata);
+                let virtual_worker_name = trusted_virtual_worker_name(worker, &mut reg_metadata);
+                let trusted_virtual_worker = virtual_worker_name.is_some();
 
                 // Claim ownership BEFORE mutating any engine-global state. An
                 // old worker's `cleanup_worker` running on another task can
@@ -1210,6 +1223,7 @@ impl Engine {
                             function_id = %reg_id,
                             "HTTP functions module not loaded"
                         );
+                        self.service_registry.remove_function_from_services(&reg_id);
                         self.release_external_function_if_owner(&worker.id, &reg_id);
                         return Ok(());
                     };
@@ -1225,9 +1239,8 @@ impl Engine {
                         request_format: req.clone(),
                         response_format: res.clone(),
                         metadata: reg_metadata.clone(),
-                        trusted_internal: virtual_worker_name
-                            .as_ref()
-                            .is_some_and(|_| is_loopback_http_url(&invocation.url)),
+                        trusted_internal: trusted_virtual_worker
+                            && is_loopback_http_url(&invocation.url),
                         registered_at: Some(Utc::now()),
                         updated_at: None,
                     };
@@ -1239,13 +1252,18 @@ impl Engine {
                             error = ?err,
                             "Failed to register HTTP invocation function"
                         );
+                        self.service_registry.remove_function_from_services(&reg_id);
                         self.release_external_function_if_owner(&worker.id, &reg_id);
                         return Ok(());
                     }
 
                     if let Some(worker_name) = virtual_worker_name {
-                        self.virtual_workers
-                            .claim_function(worker_name, worker.id, &reg_id);
+                        self.virtual_workers.claim_function(
+                            worker_name,
+                            worker.id,
+                            trusted_virtual_worker,
+                            &reg_id,
+                        );
                     } else {
                         self.virtual_workers.remove_function(&reg_id);
                     }
@@ -1265,8 +1283,12 @@ impl Engine {
                 );
 
                 if let Some(worker_name) = virtual_worker_name {
-                    self.virtual_workers
-                        .claim_function(worker_name, worker.id, &reg_id);
+                    self.virtual_workers.claim_function(
+                        worker_name,
+                        worker.id,
+                        trusted_virtual_worker,
+                        &reg_id,
+                    );
                 } else {
                     self.virtual_workers.remove_function(&reg_id);
                 }
@@ -2108,6 +2130,7 @@ mod tests {
             allowed_trigger_types: None,
             allow_function_registration: true,
             allow_trigger_type_registration: true,
+            trusted_internal: false,
             context: serde_json::json!({}),
             function_registration_prefix: Some(prefix.to_string()),
         }
@@ -2285,7 +2308,23 @@ mod tests {
             .expect("initialize module");
 
         let (tx, _rx) = mpsc::channel::<Outbound>(8);
-        let worker = WorkerConnection::new(tx);
+        let worker = WorkerConnection::with_session(
+            tx,
+            crate::workers::worker::rbac_session::Session {
+                engine: engine.clone(),
+                config: Arc::new(crate::workers::worker::WorkerManagerConfig::default()),
+                ip_address: "127.0.0.1".to_string(),
+                session_id: uuid::Uuid::new_v4(),
+                allowed_functions: vec![],
+                forbidden_functions: vec![],
+                allowed_trigger_types: None,
+                allow_function_registration: true,
+                allow_trigger_type_registration: true,
+                trusted_internal: true,
+                context: json!({}),
+                function_registration_prefix: None,
+            },
+        );
         let register_msg = Message::RegisterFunction {
             id: "hackernews::top_stories".to_string(),
             description: Some("top stories".to_string()),
@@ -2296,7 +2335,7 @@ mod tests {
                 "iii": { "virtualWorker": { "name": "hackernews" } }
             })),
             invocation: Some(HttpInvocationRef {
-                url: "http://example.com/hackernews/top-stories".to_string(),
+                url: "http://127.0.0.1/hackernews/top-stories".to_string(),
                 method: crate::invocation::method::HttpMethod::Post,
                 timeout_ms: Some(30000),
                 headers: HashMap::new(),
@@ -2314,6 +2353,7 @@ mod tests {
             .get("hackernews")
             .expect("virtual worker should be tracked internally");
         assert_eq!(virtual_worker.name, "hackernews");
+        assert!(virtual_worker.trusted_internal);
         assert!(
             virtual_worker
                 .function_ids
@@ -2341,6 +2381,13 @@ mod tests {
                 .metadata,
             Some(json!({ "artifact": { "source": "https://example.com/openapi.json" } }))
         );
+        assert!(
+            http_module
+                .http_functions()
+                .get("hackernews::top_stories")
+                .expect("http function config should exist")
+                .trusted_internal
+        );
 
         engine
             .router_msg(
@@ -2353,6 +2400,77 @@ mod tests {
             .expect("unregister external function should succeed");
 
         assert!(!engine.virtual_workers.contains_worker("hackernews"));
+    }
+
+    #[tokio::test]
+    async fn test_untrusted_worker_virtual_worker_metadata_is_ignored() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+
+        let http_functions_config = HttpFunctionsConfig {
+            security: SecurityConfig {
+                require_https: false,
+                block_private_ips: false,
+                url_allowlist: vec!["*".to_string()],
+            },
+        };
+        let http_functions_module = HttpFunctionsWorker::create(
+            engine.clone(),
+            Some(serde_json::to_value(&http_functions_config).expect("serialize config")),
+        )
+        .await
+        .expect("create module");
+        http_functions_module
+            .initialize()
+            .await
+            .expect("initialize module");
+
+        let (tx, _rx) = mpsc::channel::<Outbound>(8);
+        let worker = WorkerConnection::new(tx);
+        let register_msg = Message::RegisterFunction {
+            id: "hackernews::latest".to_string(),
+            description: Some("latest stories".to_string()),
+            request_format: None,
+            response_format: None,
+            metadata: Some(json!({
+                "artifact": { "source": "https://example.com/openapi.json" },
+                "iii": { "virtualWorker": { "name": "hackernews" } }
+            })),
+            invocation: Some(HttpInvocationRef {
+                url: "http://127.0.0.1/hackernews/latest".to_string(),
+                method: crate::invocation::method::HttpMethod::Post,
+                timeout_ms: Some(30000),
+                headers: HashMap::new(),
+                auth: None,
+            }),
+        };
+
+        engine
+            .router_msg(&worker, &register_msg)
+            .await
+            .expect("register external function should succeed");
+
+        assert!(engine.virtual_workers.get("hackernews").is_none());
+        let function = engine
+            .functions
+            .get("hackernews::latest")
+            .expect("function should still be visible as a normal function");
+        assert_eq!(
+            function.metadata,
+            Some(json!({ "artifact": { "source": "https://example.com/openapi.json" } }))
+        );
+
+        let http_module = engine
+            .service_registry
+            .get_service::<HttpFunctionsWorker>("http_functions")
+            .expect("http_functions service registered");
+        assert!(
+            !http_module
+                .http_functions()
+                .get("hackernews::latest")
+                .expect("http function config should exist")
+                .trusted_internal
+        );
     }
 
     #[tokio::test]
@@ -2951,6 +3069,62 @@ mod tests {
                 .has_external_function_id("external.without_module")
                 .await
         );
+        assert!(!engine.service_registry.services.contains_key("external"));
+    }
+
+    #[tokio::test]
+    async fn test_router_msg_register_http_invocation_failure_rolls_back_service() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        let http_functions_module = HttpFunctionsWorker::create(
+            engine.clone(),
+            Some(serde_json::to_value(HttpFunctionsConfig::default()).expect("serialize config")),
+        )
+        .await
+        .expect("create module");
+        http_functions_module
+            .initialize()
+            .await
+            .expect("initialize module");
+
+        let (tx, _rx) = mpsc::channel::<Outbound>(8);
+        let worker = WorkerConnection::new(tx);
+        let register_message = Message::RegisterFunction {
+            id: "external.invalid_url".to_string(),
+            description: Some("external function".to_string()),
+            request_format: None,
+            response_format: None,
+            metadata: None,
+            invocation: Some(HttpInvocationRef {
+                url: "http://example.com/lambda".to_string(),
+                method: crate::invocation::method::HttpMethod::Post,
+                timeout_ms: Some(30000),
+                headers: HashMap::new(),
+                auth: None,
+            }),
+        };
+
+        engine
+            .router_msg(&worker, &register_message)
+            .await
+            .expect("register message should not fail");
+
+        assert!(engine.functions.get("external.invalid_url").is_none());
+        assert!(
+            !worker
+                .has_external_function_id("external.invalid_url")
+                .await
+        );
+        let http_module = engine
+            .service_registry
+            .get_service::<HttpFunctionsWorker>("http_functions")
+            .expect("http_functions service registered");
+        assert!(
+            !http_module
+                .http_functions()
+                .contains_key("external.invalid_url")
+        );
+        assert!(!engine.service_registry.services.contains_key("external"));
     }
 
     #[tokio::test]

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -26,6 +26,7 @@ use uuid::Uuid;
 
 use crate::{
     function::{Function, FunctionHandler, FunctionResult, FunctionsRegistry},
+    generated_workers::{GeneratedWorkerRegistry, take_generated_worker_name},
     invocation::{InvocationHandler, http_function::HttpFunctionConfig},
     protocol::{ErrorBody, Message},
     services::{Service, ServicesRegistry},
@@ -34,7 +35,6 @@ use crate::{
         inject_baggage_from_context, inject_traceparent_from_context,
     },
     trigger::{Trigger, TriggerRegistry, TriggerType},
-    virtual_workers::{VirtualWorkerRegistry, take_virtual_worker_name},
     worker_connections::{RuntimeWorkerInfo, WorkerConnection, WorkerConnectionRegistry},
     workers::worker::rbac_session::Session,
     workers::{
@@ -250,7 +250,7 @@ pub struct Engine {
     /// HTTP-invocation variant of `function_owners`, separate because external
     /// functions live in their own per-worker set on `WorkerConnection`.
     pub(crate) external_function_owners: Arc<DashMap<String, Uuid>>,
-    pub(crate) virtual_workers: Arc<VirtualWorkerRegistry>,
+    pub(crate) generated_workers: Arc<GeneratedWorkerRegistry>,
     pub(crate) active_scope: Arc<std::sync::Mutex<Option<crate::workers::reload::ScopeBuilder>>>,
     /// Effective `iii-worker-manager` port, resolved from config at build
     /// time. Set once by `EngineBuilder::build`; subsequent reads see the
@@ -292,11 +292,11 @@ fn is_trusted_bridge_session(session: &Session) -> bool {
             .is_ok_and(|ip| ip.is_loopback())
 }
 
-fn trusted_virtual_worker_name(
+fn trusted_generated_worker_name(
     worker: &WorkerConnection,
     metadata: &mut Option<Value>,
 ) -> Option<String> {
-    let name = take_virtual_worker_name(metadata)?;
+    let name = take_generated_worker_name(metadata)?;
     worker
         .session
         .as_ref()
@@ -324,7 +324,7 @@ impl Engine {
             queue_module: Arc::new(tokio::sync::RwLock::new(None)),
             function_owners: Arc::new(DashMap::new()),
             external_function_owners: Arc::new(DashMap::new()),
-            virtual_workers: Arc::new(VirtualWorkerRegistry::new()),
+            generated_workers: Arc::new(GeneratedWorkerRegistry::new()),
             active_scope,
             worker_manager_port: Arc::new(std::sync::OnceLock::new()),
         }
@@ -433,7 +433,7 @@ impl Engine {
 
     fn remove_function(&self, function_id: &str) {
         self.functions.remove(function_id);
-        self.virtual_workers.remove_function(function_id);
+        self.generated_workers.remove_function(function_id);
     }
 
     fn remove_function_from_engine(&self, function_id: &str) {
@@ -1101,7 +1101,7 @@ impl Engine {
                         );
                         return Ok(());
                     }
-                    self.virtual_workers.remove_function(&resolved_id);
+                    self.generated_workers.remove_function(&resolved_id);
                     if let Some(http_module) = self
                         .service_registry
                         .get_service::<HttpFunctionsWorker>("http_functions")
@@ -1209,8 +1209,9 @@ impl Engine {
                 }
 
                 reg_id = resolve_registration_id(worker, &reg_id);
-                let virtual_worker_name = trusted_virtual_worker_name(worker, &mut reg_metadata);
-                let trusted_virtual_worker = virtual_worker_name.is_some();
+                let generated_worker_name =
+                    trusted_generated_worker_name(worker, &mut reg_metadata);
+                let trusted_generated_worker = generated_worker_name.is_some();
 
                 // Claim ownership BEFORE mutating any engine-global state. An
                 // old worker's `cleanup_worker` running on another task can
@@ -1253,7 +1254,7 @@ impl Engine {
                         request_format: req.clone(),
                         response_format: res.clone(),
                         metadata: reg_metadata.clone(),
-                        trusted_internal: trusted_virtual_worker
+                        trusted_internal: trusted_generated_worker
                             && is_loopback_http_url(&invocation.url),
                         registered_at: Some(Utc::now()),
                         updated_at: None,
@@ -1271,15 +1272,15 @@ impl Engine {
                         return Ok(());
                     }
 
-                    if let Some(worker_name) = virtual_worker_name {
-                        self.virtual_workers.claim_function(
+                    if let Some(worker_name) = generated_worker_name {
+                        self.generated_workers.claim_function(
                             worker_name,
                             worker.id,
-                            trusted_virtual_worker,
+                            trusted_generated_worker,
                             &reg_id,
                         );
                     } else {
-                        self.virtual_workers.remove_function(&reg_id);
+                        self.generated_workers.remove_function(&reg_id);
                     }
                     worker.include_external_function_id(&reg_id).await;
                     return Ok(());
@@ -1296,15 +1297,15 @@ impl Engine {
                     Box::new(worker.clone()),
                 );
 
-                if let Some(worker_name) = virtual_worker_name {
-                    self.virtual_workers.claim_function(
+                if let Some(worker_name) = generated_worker_name {
+                    self.generated_workers.claim_function(
                         worker_name,
                         worker.id,
-                        trusted_virtual_worker,
+                        trusted_generated_worker,
                         &reg_id,
                     );
                 } else {
-                    self.virtual_workers.remove_function(&reg_id);
+                    self.generated_workers.remove_function(&reg_id);
                 }
                 worker.include_function_id(&reg_id).await;
                 Ok(())
@@ -1652,7 +1653,7 @@ impl Engine {
                     .remove_if(function_id, |_, owner| *owner == worker.id)
                     .is_some()
                 {
-                    self.virtual_workers.remove_function(function_id);
+                    self.generated_workers.remove_function(function_id);
                 }
             }
         }
@@ -2309,7 +2310,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_external_function_virtual_worker_is_internal() {
+    async fn test_external_function_generated_worker_is_internal() {
         ensure_default_meter();
         let engine = Arc::new(Engine::new());
 
@@ -2356,7 +2357,7 @@ mod tests {
             response_format: None,
             metadata: Some(json!({
                 "spec": { "source": "https://example.com/openapi.json" },
-                "iii": { "virtualWorker": { "name": "hackernews" } }
+                "iii": { "generatedWorker": { "name": "hackernews" } }
             })),
             invocation: Some(HttpInvocationRef {
                 url: "http://127.0.0.1/hackernews/top-stories".to_string(),
@@ -2372,14 +2373,14 @@ mod tests {
             .await
             .expect("register external function should succeed");
 
-        let virtual_worker = engine
-            .virtual_workers
+        let generated_worker = engine
+            .generated_workers
             .get("hackernews")
-            .expect("virtual worker should be tracked internally");
-        assert_eq!(virtual_worker.name, "hackernews");
-        assert!(virtual_worker.trusted_internal);
+            .expect("generated worker should be tracked internally");
+        assert_eq!(generated_worker.name, "hackernews");
+        assert!(generated_worker.trusted_internal);
         assert!(
-            virtual_worker
+            generated_worker
                 .function_ids
                 .contains("hackernews::top_stories")
         );
@@ -2423,11 +2424,11 @@ mod tests {
             .await
             .expect("unregister external function should succeed");
 
-        assert!(!engine.virtual_workers.contains_worker("hackernews"));
+        assert!(!engine.generated_workers.contains_worker("hackernews"));
     }
 
     #[tokio::test]
-    async fn test_local_external_function_virtual_worker_bridge_is_internal() {
+    async fn test_local_external_function_generated_worker_bridge_is_internal() {
         ensure_default_meter();
         let engine = Arc::new(Engine::new());
 
@@ -2474,7 +2475,7 @@ mod tests {
             response_format: None,
             metadata: Some(json!({
                 "spec": { "source": "http://127.0.0.1/openapi.json" },
-                "iii": { "virtualWorker": { "name": "local-api" } }
+                "iii": { "generatedWorker": { "name": "local-api" } }
             })),
             invocation: Some(HttpInvocationRef {
                 url: "http://127.0.0.1/local-api/echo".to_string(),
@@ -2490,13 +2491,13 @@ mod tests {
             .await
             .expect("register external function should succeed");
 
-        let virtual_worker = engine
-            .virtual_workers
+        let generated_worker = engine
+            .generated_workers
             .get("local-api")
-            .expect("virtual worker should be tracked internally");
-        assert_eq!(virtual_worker.name, "local-api");
-        assert!(virtual_worker.trusted_internal);
-        assert!(virtual_worker.function_ids.contains("local_api::echo"));
+            .expect("generated worker should be tracked internally");
+        assert_eq!(generated_worker.name, "local-api");
+        assert!(generated_worker.trusted_internal);
+        assert!(generated_worker.function_ids.contains("local_api::echo"));
 
         let http_module = engine
             .service_registry
@@ -2512,7 +2513,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_untrusted_worker_virtual_worker_metadata_is_ignored() {
+    async fn test_untrusted_worker_generated_worker_metadata_is_ignored() {
         ensure_default_meter();
         let engine = Arc::new(Engine::new());
 
@@ -2543,7 +2544,7 @@ mod tests {
             response_format: None,
             metadata: Some(json!({
                 "spec": { "source": "https://example.com/openapi.json" },
-                "iii": { "virtualWorker": { "name": "hackernews" } }
+                "iii": { "generatedWorker": { "name": "hackernews" } }
             })),
             invocation: Some(HttpInvocationRef {
                 url: "http://127.0.0.1/hackernews/latest".to_string(),
@@ -2559,7 +2560,7 @@ mod tests {
             .await
             .expect("register external function should succeed");
 
-        assert!(engine.virtual_workers.get("hackernews").is_none());
+        assert!(engine.generated_workers.get("hackernews").is_none());
         let function = engine
             .functions
             .get("hackernews::latest")

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -18,6 +18,7 @@ use serde_json::Value;
 use tokio::sync::{mpsc, oneshot::error::RecvError};
 use tracing::Instrument;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
+use url::Url;
 use uuid::Uuid;
 
 use crate::{
@@ -30,6 +31,7 @@ use crate::{
         inject_baggage_from_context, inject_traceparent_from_context,
     },
     trigger::{Trigger, TriggerRegistry, TriggerType},
+    virtual_workers::{VirtualWorkerRegistry, take_virtual_worker_name},
     worker_connections::{RuntimeWorkerInfo, WorkerConnection, WorkerConnectionRegistry},
     workers::worker::rbac_session::Session,
     workers::{
@@ -245,6 +247,7 @@ pub struct Engine {
     /// HTTP-invocation variant of `function_owners`, separate because external
     /// functions live in their own per-worker set on `WorkerConnection`.
     pub(crate) external_function_owners: Arc<DashMap<String, Uuid>>,
+    pub(crate) virtual_workers: Arc<VirtualWorkerRegistry>,
     pub(crate) active_scope: Arc<std::sync::Mutex<Option<crate::workers::reload::ScopeBuilder>>>,
     /// Effective `iii-worker-manager` port, resolved from config at build
     /// time. Set once by `EngineBuilder::build`; subsequent reads see the
@@ -264,6 +267,15 @@ fn resolve_registration_id(worker: &WorkerConnection, id: &str) -> String {
     } else {
         id.to_string()
     }
+}
+
+fn is_loopback_http_url(value: &str) -> bool {
+    Url::parse(value).ok().is_some_and(|url| {
+        url.scheme() == "http"
+            && url.host_str().is_some_and(|host| {
+                host.eq_ignore_ascii_case("localhost") || host == "127.0.0.1" || host == "::1"
+            })
+    })
 }
 
 impl Default for Engine {
@@ -286,6 +298,7 @@ impl Engine {
             queue_module: Arc::new(tokio::sync::RwLock::new(None)),
             function_owners: Arc::new(DashMap::new()),
             external_function_owners: Arc::new(DashMap::new()),
+            virtual_workers: Arc::new(VirtualWorkerRegistry::new()),
             active_scope,
             worker_manager_port: Arc::new(std::sync::OnceLock::new()),
         }
@@ -394,6 +407,7 @@ impl Engine {
 
     fn remove_function(&self, function_id: &str) {
         self.functions.remove(function_id);
+        self.virtual_workers.remove_function(function_id);
     }
 
     fn remove_function_from_engine(&self, function_id: &str) {
@@ -1061,6 +1075,7 @@ impl Engine {
                         );
                         return Ok(());
                     }
+                    self.virtual_workers.remove_function(&resolved_id);
                     if let Some(http_module) = self
                         .service_registry
                         .get_service::<HttpFunctionsWorker>("http_functions")
@@ -1168,6 +1183,7 @@ impl Engine {
                 }
 
                 reg_id = resolve_registration_id(worker, &reg_id);
+                let virtual_worker_name = take_virtual_worker_name(&mut reg_metadata);
 
                 // Claim ownership BEFORE mutating any engine-global state. An
                 // old worker's `cleanup_worker` running on another task can
@@ -1209,6 +1225,9 @@ impl Engine {
                         request_format: req.clone(),
                         response_format: res.clone(),
                         metadata: reg_metadata.clone(),
+                        trusted_internal: virtual_worker_name
+                            .as_ref()
+                            .is_some_and(|_| is_loopback_http_url(&invocation.url)),
                         registered_at: Some(Utc::now()),
                         updated_at: None,
                     };
@@ -1224,6 +1243,12 @@ impl Engine {
                         return Ok(());
                     }
 
+                    if let Some(worker_name) = virtual_worker_name {
+                        self.virtual_workers
+                            .claim_function(worker_name, worker.id, &reg_id);
+                    } else {
+                        self.virtual_workers.remove_function(&reg_id);
+                    }
                     worker.include_external_function_id(&reg_id).await;
                     return Ok(());
                 }
@@ -1239,6 +1264,12 @@ impl Engine {
                     Box::new(worker.clone()),
                 );
 
+                if let Some(worker_name) = virtual_worker_name {
+                    self.virtual_workers
+                        .claim_function(worker_name, worker.id, &reg_id);
+                } else {
+                    self.virtual_workers.remove_function(&reg_id);
+                }
                 worker.include_function_id(&reg_id).await;
                 Ok(())
             }
@@ -1580,8 +1611,13 @@ impl Engine {
                 // CAS-release ownership. A racing claim will have overwritten
                 // the entry with a new owner id; that predicate fails and we
                 // leave their ownership intact.
-                self.external_function_owners
-                    .remove_if(function_id, |_, owner| *owner == worker.id);
+                if self
+                    .external_function_owners
+                    .remove_if(function_id, |_, owner| *owner == worker.id)
+                    .is_some()
+                {
+                    self.virtual_workers.remove_function(function_id);
+                }
             }
         }
 
@@ -2223,6 +2259,100 @@ mod tests {
                 .contains_key("test-prefix::my_lambda"),
             "http module must drop the prefixed registration on unregister (iii-hq/iii#1508)"
         );
+    }
+
+    #[tokio::test]
+    async fn test_external_function_virtual_worker_is_internal() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+
+        let http_functions_config = HttpFunctionsConfig {
+            security: SecurityConfig {
+                require_https: false,
+                block_private_ips: false,
+                url_allowlist: vec!["*".to_string()],
+            },
+        };
+        let http_functions_module = HttpFunctionsWorker::create(
+            engine.clone(),
+            Some(serde_json::to_value(&http_functions_config).expect("serialize config")),
+        )
+        .await
+        .expect("create module");
+        http_functions_module
+            .initialize()
+            .await
+            .expect("initialize module");
+
+        let (tx, _rx) = mpsc::channel::<Outbound>(8);
+        let worker = WorkerConnection::new(tx);
+        let register_msg = Message::RegisterFunction {
+            id: "hackernews::top_stories".to_string(),
+            description: Some("top stories".to_string()),
+            request_format: None,
+            response_format: None,
+            metadata: Some(json!({
+                "artifact": { "source": "https://example.com/openapi.json" },
+                "iii": { "virtualWorker": { "name": "hackernews" } }
+            })),
+            invocation: Some(HttpInvocationRef {
+                url: "http://example.com/hackernews/top-stories".to_string(),
+                method: crate::invocation::method::HttpMethod::Post,
+                timeout_ms: Some(30000),
+                headers: HashMap::new(),
+                auth: None,
+            }),
+        };
+
+        engine
+            .router_msg(&worker, &register_msg)
+            .await
+            .expect("register external function should succeed");
+
+        let virtual_worker = engine
+            .virtual_workers
+            .get("hackernews")
+            .expect("virtual worker should be tracked internally");
+        assert_eq!(virtual_worker.name, "hackernews");
+        assert!(
+            virtual_worker
+                .function_ids
+                .contains("hackernews::top_stories")
+        );
+
+        let function = engine
+            .functions
+            .get("hackernews::top_stories")
+            .expect("function should be visible as a normal function");
+        assert_eq!(
+            function.metadata,
+            Some(json!({ "artifact": { "source": "https://example.com/openapi.json" } }))
+        );
+
+        let http_module = engine
+            .service_registry
+            .get_service::<HttpFunctionsWorker>("http_functions")
+            .expect("http_functions service registered");
+        assert_eq!(
+            http_module
+                .http_functions()
+                .get("hackernews::top_stories")
+                .expect("http function config should exist")
+                .metadata,
+            Some(json!({ "artifact": { "source": "https://example.com/openapi.json" } }))
+        );
+
+        engine
+            .router_msg(
+                &worker,
+                &Message::UnregisterFunction {
+                    id: "hackernews::top_stories".to_string(),
+                },
+            )
+            .await
+            .expect("unregister external function should succeed");
+
+        assert!(!engine.virtual_workers.contains_worker("hackernews"));
     }
 
     #[tokio::test]

--- a/engine/src/generated_workers.rs
+++ b/engine/src/generated_workers.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct VirtualWorkerInfo {
+pub(crate) struct GeneratedWorkerInfo {
     pub name: String,
     pub owner_worker_id: Uuid,
     pub trusted_internal: bool,
@@ -22,13 +22,13 @@ pub(crate) struct VirtualWorkerInfo {
 }
 
 #[derive(Default)]
-pub(crate) struct VirtualWorkerRegistry {
-    workers: DashMap<String, VirtualWorkerInfo>,
+pub(crate) struct GeneratedWorkerRegistry {
+    workers: DashMap<String, GeneratedWorkerInfo>,
     function_to_worker: DashMap<String, String>,
     mutation_lock: Mutex<()>,
 }
 
-impl VirtualWorkerRegistry {
+impl GeneratedWorkerRegistry {
     pub(crate) fn new() -> Self {
         Self::default()
     }
@@ -60,7 +60,7 @@ impl VirtualWorkerRegistry {
                 info.trusted_internal = trusted_internal;
                 info.function_ids.insert(function_id.clone());
             })
-            .or_insert_with(|| VirtualWorkerInfo {
+            .or_insert_with(|| GeneratedWorkerInfo {
                 name: worker_name,
                 owner_worker_id,
                 trusted_internal,
@@ -79,7 +79,7 @@ impl VirtualWorkerRegistry {
         self.function_to_worker.contains_key(function_id)
     }
 
-    pub(crate) fn list(&self) -> Vec<VirtualWorkerInfo> {
+    pub(crate) fn list(&self) -> Vec<GeneratedWorkerInfo> {
         self.workers
             .iter()
             .map(|entry| entry.value().clone())
@@ -87,7 +87,7 @@ impl VirtualWorkerRegistry {
     }
 
     #[cfg(test)]
-    pub(crate) fn get(&self, worker_name: &str) -> Option<VirtualWorkerInfo> {
+    pub(crate) fn get(&self, worker_name: &str) -> Option<GeneratedWorkerInfo> {
         self.workers
             .get(worker_name)
             .map(|entry| entry.value().clone())
@@ -116,12 +116,14 @@ impl VirtualWorkerRegistry {
     }
 }
 
-pub(crate) fn take_virtual_worker_name(metadata: &mut Option<Value>) -> Option<String> {
+pub(crate) fn take_generated_worker_name(metadata: &mut Option<Value>) -> Option<String> {
     let value = metadata.as_mut()?;
     let object = value.as_object_mut()?;
     let iii = object.get_mut("iii")?;
     let iii_object = iii.as_object_mut()?;
-    let hint = iii_object.remove("virtualWorker")?;
+    let hint = iii_object
+        .remove("generatedWorker")
+        .or_else(|| iii_object.remove("virtualWorker"))?;
     let name = match hint {
         Value::String(value) => non_empty(value),
         Value::Object(object) => object
@@ -161,14 +163,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn take_virtual_worker_name_strips_internal_metadata() {
+    fn take_generated_worker_name_strips_internal_metadata() {
         let mut metadata = Some(serde_json::json!({
             "spec": { "source": "https://example.com/openapi.json" },
-            "iii": { "virtualWorker": { "name": "hackernews" } }
+            "iii": { "generatedWorker": { "name": "hackernews" } }
         }));
 
         assert_eq!(
-            take_virtual_worker_name(&mut metadata),
+            take_generated_worker_name(&mut metadata),
             Some("hackernews".to_string())
         );
         assert_eq!(
@@ -180,8 +182,27 @@ mod tests {
     }
 
     #[test]
-    fn virtual_worker_registry_removes_empty_worker() {
-        let registry = VirtualWorkerRegistry::new();
+    fn take_generated_worker_name_accepts_legacy_private_hint() {
+        let mut metadata = Some(serde_json::json!({
+            "spec": { "source": "https://example.com/openapi.json" },
+            "iii": { "virtualWorker": { "name": "hackernews" } }
+        }));
+
+        assert_eq!(
+            take_generated_worker_name(&mut metadata),
+            Some("hackernews".to_string())
+        );
+        assert_eq!(
+            metadata,
+            Some(serde_json::json!({
+                "spec": { "source": "https://example.com/openapi.json" }
+            }))
+        );
+    }
+
+    #[test]
+    fn generated_worker_registry_removes_empty_worker() {
+        let registry = GeneratedWorkerRegistry::new();
         let owner = Uuid::new_v4();
 
         registry.claim_function("hn", owner, true, "hn::top_stories");
@@ -192,8 +213,8 @@ mod tests {
     }
 
     #[test]
-    fn virtual_worker_registry_reclaim_moves_function_between_workers() {
-        let registry = VirtualWorkerRegistry::new();
+    fn generated_worker_registry_reclaim_moves_function_between_workers() {
+        let registry = GeneratedWorkerRegistry::new();
         let first_owner = Uuid::new_v4();
         let second_owner = Uuid::new_v4();
 

--- a/engine/src/invocation/http_function.rs
+++ b/engine/src/invocation/http_function.rs
@@ -34,6 +34,8 @@ pub struct HttpFunctionConfig {
     pub response_format: Option<Value>,
     #[serde(default)]
     pub metadata: Option<Value>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub trusted_internal: bool,
     #[serde(default)]
     pub registered_at: Option<DateTime<Utc>>,
     #[serde(default)]
@@ -42,6 +44,10 @@ pub struct HttpFunctionConfig {
 
 fn default_method() -> HttpMethod {
     HttpMethod::Post
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[cfg(test)]

--- a/engine/src/invocation/http_invoker.rs
+++ b/engine/src/invocation/http_invoker.rs
@@ -39,6 +39,7 @@ pub struct HttpEndpointParams<'a> {
     pub timeout_ms: &'a Option<u64>,
     pub headers: &'a HashMap<String, String>,
     pub auth: &'a Option<HttpAuth>,
+    pub trusted_internal: bool,
 }
 
 pub struct HttpInvokerConfig {
@@ -247,7 +248,9 @@ impl HttpInvoker {
         caller_function: Option<&str>,
         trace_id: Option<&str>,
     ) -> Result<Option<Value>, ErrorBody> {
-        self.validate_url(endpoint.url).await?;
+        if !endpoint.trusted_internal {
+            self.validate_url(endpoint.url).await?;
+        }
         let (timestamp, body) = self.prepare_request(&data)?;
 
         let mut request = self.build_base_request(
@@ -459,6 +462,7 @@ mod tests {
             timeout_ms: &timeout_ms,
             headers: &headers,
             auth: &no_auth,
+            trusted_internal: false,
         };
         let payload = br#"{"hello":"world"}"#.to_vec();
         let timestamp = 1_700_000_000;
@@ -648,6 +652,7 @@ mod tests {
             timeout_ms: &timeout_ms,
             headers: &headers,
             auth: &auth,
+            trusted_internal: false,
         };
 
         let success = invoker
@@ -696,6 +701,7 @@ mod tests {
             timeout_ms: &empty_timeout,
             headers: &empty_headers,
             auth: &no_auth,
+            trusted_internal: false,
         };
         let empty = invoker
             .invoke_http(
@@ -718,6 +724,7 @@ mod tests {
             timeout_ms: &invalid_timeout,
             headers: &invalid_headers,
             auth: &no_auth,
+            trusted_internal: false,
         };
         let invalid = invoker
             .invoke_http(
@@ -740,6 +747,7 @@ mod tests {
             timeout_ms: &error_timeout,
             headers: &error_headers,
             auth: &no_auth,
+            trusted_internal: false,
         };
         let error = invoker
             .invoke_http(
@@ -775,6 +783,7 @@ mod tests {
             timeout_ms: &timeout_ms,
             headers: &headers,
             auth: &auth,
+            trusted_internal: false,
         };
 
         invoker
@@ -837,6 +846,7 @@ mod tests {
             timeout_ms: &timeout_ms,
             headers: &headers,
             auth: &no_auth,
+            trusted_internal: false,
         };
 
         let error = invoker

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -9,6 +9,7 @@ pub mod condition;
 pub mod config;
 pub mod engine;
 pub mod function;
+pub(crate) mod generated_workers;
 pub mod invocation;
 pub mod logging;
 pub mod protocol;
@@ -17,7 +18,6 @@ pub mod telemetry;
 pub mod trigger;
 pub mod trigger_formats;
 pub(crate) mod update_ops;
-pub(crate) mod virtual_workers;
 pub mod worker_connections;
 
 pub mod workers {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -17,6 +17,7 @@ pub mod telemetry;
 pub mod trigger;
 pub mod trigger_formats;
 pub(crate) mod update_ops;
+pub(crate) mod virtual_workers;
 pub mod worker_connections;
 
 pub mod workers {

--- a/engine/src/virtual_workers.rs
+++ b/engine/src/virtual_workers.rs
@@ -79,6 +79,13 @@ impl VirtualWorkerRegistry {
         self.function_to_worker.contains_key(function_id)
     }
 
+    pub(crate) fn list(&self) -> Vec<VirtualWorkerInfo> {
+        self.workers
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect()
+    }
+
     #[cfg(test)]
     pub(crate) fn get(&self, worker_name: &str) -> Option<VirtualWorkerInfo> {
         self.workers

--- a/engine/src/virtual_workers.rs
+++ b/engine/src/virtual_workers.rs
@@ -156,7 +156,7 @@ mod tests {
     #[test]
     fn take_virtual_worker_name_strips_internal_metadata() {
         let mut metadata = Some(serde_json::json!({
-            "artifact": { "source": "https://example.com/openapi.json" },
+            "spec": { "source": "https://example.com/openapi.json" },
             "iii": { "virtualWorker": { "name": "hackernews" } }
         }));
 
@@ -167,7 +167,7 @@ mod tests {
         assert_eq!(
             metadata,
             Some(serde_json::json!({
-                "artifact": { "source": "https://example.com/openapi.json" }
+                "spec": { "source": "https://example.com/openapi.json" }
             }))
         );
     }

--- a/engine/src/virtual_workers.rs
+++ b/engine/src/virtual_workers.rs
@@ -1,0 +1,164 @@
+use std::collections::HashSet;
+
+use dashmap::DashMap;
+use serde_json::Value;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VirtualWorkerInfo {
+    pub name: String,
+    pub owner_worker_id: Uuid,
+    pub function_ids: HashSet<String>,
+}
+
+#[derive(Default)]
+pub(crate) struct VirtualWorkerRegistry {
+    workers: DashMap<String, VirtualWorkerInfo>,
+    function_to_worker: DashMap<String, String>,
+}
+
+impl VirtualWorkerRegistry {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn claim_function(
+        &self,
+        worker_name: impl Into<String>,
+        owner_worker_id: Uuid,
+        function_id: &str,
+    ) {
+        let worker_name = worker_name.into();
+        let function_id = function_id.to_string();
+
+        if let Some((_, previous_worker)) = self
+            .function_to_worker
+            .insert(function_id.clone(), worker_name.clone())
+            .map(|previous| (function_id.clone(), previous))
+            && previous_worker != worker_name
+        {
+            self.remove_from_worker(&previous_worker, &function_id);
+        }
+
+        self.workers
+            .entry(worker_name.clone())
+            .and_modify(|info| {
+                info.owner_worker_id = owner_worker_id;
+                info.function_ids.insert(function_id.clone());
+            })
+            .or_insert_with(|| VirtualWorkerInfo {
+                name: worker_name,
+                owner_worker_id,
+                function_ids: HashSet::from([function_id]),
+            });
+    }
+
+    pub(crate) fn remove_function(&self, function_id: &str) -> Option<String> {
+        let (_, worker_name) = self.function_to_worker.remove(function_id)?;
+        self.remove_from_worker(&worker_name, function_id);
+        Some(worker_name)
+    }
+
+    pub(crate) fn contains_function(&self, function_id: &str) -> bool {
+        self.function_to_worker.contains_key(function_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get(&self, worker_name: &str) -> Option<VirtualWorkerInfo> {
+        self.workers
+            .get(worker_name)
+            .map(|entry| entry.value().clone())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains_worker(&self, worker_name: &str) -> bool {
+        self.workers.contains_key(worker_name)
+    }
+
+    fn remove_from_worker(&self, worker_name: &str, function_id: &str) {
+        let mut should_remove_worker = false;
+        if let Some(mut info) = self.workers.get_mut(worker_name) {
+            info.function_ids.remove(function_id);
+            should_remove_worker = info.function_ids.is_empty();
+        }
+        if should_remove_worker {
+            self.workers.remove(worker_name);
+        }
+    }
+}
+
+pub(crate) fn take_virtual_worker_name(metadata: &mut Option<Value>) -> Option<String> {
+    let value = metadata.as_mut()?;
+    let object = value.as_object_mut()?;
+    let iii = object.get_mut("iii")?;
+    let iii_object = iii.as_object_mut()?;
+    let hint = iii_object.remove("virtualWorker")?;
+    let name = match hint {
+        Value::String(value) => non_empty(value),
+        Value::Object(object) => object
+            .get("name")
+            .and_then(Value::as_str)
+            .and_then(|value| non_empty(value.to_string()))
+            .or_else(|| {
+                object
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .and_then(|value| non_empty(value.to_string()))
+            }),
+        _ => None,
+    };
+
+    if iii_object.is_empty() {
+        object.remove("iii");
+    }
+    if object.is_empty() {
+        *metadata = None;
+    }
+
+    name
+}
+
+fn non_empty(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn take_virtual_worker_name_strips_internal_metadata() {
+        let mut metadata = Some(serde_json::json!({
+            "artifact": { "source": "https://example.com/openapi.json" },
+            "iii": { "virtualWorker": { "name": "hackernews" } }
+        }));
+
+        assert_eq!(
+            take_virtual_worker_name(&mut metadata),
+            Some("hackernews".to_string())
+        );
+        assert_eq!(
+            metadata,
+            Some(serde_json::json!({
+                "artifact": { "source": "https://example.com/openapi.json" }
+            }))
+        );
+    }
+
+    #[test]
+    fn virtual_worker_registry_removes_empty_worker() {
+        let registry = VirtualWorkerRegistry::new();
+        let owner = Uuid::new_v4();
+
+        registry.claim_function("hn", owner, "hn::top_stories");
+        assert!(registry.contains_worker("hn"));
+
+        registry.remove_function("hn::top_stories");
+        assert!(!registry.contains_worker("hn"));
+    }
+}

--- a/engine/src/virtual_workers.rs
+++ b/engine/src/virtual_workers.rs
@@ -4,7 +4,10 @@
 // This software is patent protected. We welcome discussions - reach out at team@iii.dev
 // See LICENSE and PATENTS files for details.
 
-use std::collections::HashSet;
+use std::{
+    collections::HashSet,
+    sync::{Mutex, MutexGuard},
+};
 
 use dashmap::DashMap;
 use serde_json::Value;
@@ -22,6 +25,7 @@ pub(crate) struct VirtualWorkerInfo {
 pub(crate) struct VirtualWorkerRegistry {
     workers: DashMap<String, VirtualWorkerInfo>,
     function_to_worker: DashMap<String, String>,
+    mutation_lock: Mutex<()>,
 }
 
 impl VirtualWorkerRegistry {
@@ -36,6 +40,7 @@ impl VirtualWorkerRegistry {
         trusted_internal: bool,
         function_id: &str,
     ) {
+        let _guard = self.lock_mutation();
         let worker_name = worker_name.into();
         let function_id = function_id.to_string();
 
@@ -64,6 +69,7 @@ impl VirtualWorkerRegistry {
     }
 
     pub(crate) fn remove_function(&self, function_id: &str) -> Option<String> {
+        let _guard = self.lock_mutation();
         let (_, worker_name) = self.function_to_worker.remove(function_id)?;
         self.remove_from_worker(&worker_name, function_id);
         Some(worker_name)
@@ -94,6 +100,12 @@ impl VirtualWorkerRegistry {
         if should_remove_worker {
             self.workers.remove(worker_name);
         }
+    }
+
+    fn lock_mutation(&self) -> MutexGuard<'_, ()> {
+        self.mutation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 }
 
@@ -170,5 +182,27 @@ mod tests {
 
         registry.remove_function("hn::top_stories");
         assert!(!registry.contains_worker("hn"));
+    }
+
+    #[test]
+    fn virtual_worker_registry_reclaim_moves_function_between_workers() {
+        let registry = VirtualWorkerRegistry::new();
+        let first_owner = Uuid::new_v4();
+        let second_owner = Uuid::new_v4();
+
+        registry.claim_function("hn", first_owner, true, "shared::top_stories");
+        registry.claim_function("ph", second_owner, false, "shared::top_stories");
+
+        assert!(!registry.contains_worker("hn"));
+        let worker = registry.get("ph").expect("new worker should own function");
+        assert_eq!(worker.owner_worker_id, second_owner);
+        assert!(!worker.trusted_internal);
+        assert!(worker.function_ids.contains("shared::top_stories"));
+        assert_eq!(
+            registry.remove_function("shared::top_stories"),
+            Some("ph".to_string())
+        );
+        assert!(!registry.contains_function("shared::top_stories"));
+        assert!(!registry.contains_worker("ph"));
     }
 }

--- a/engine/src/virtual_workers.rs
+++ b/engine/src/virtual_workers.rs
@@ -1,3 +1,9 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
 use std::collections::HashSet;
 
 use dashmap::DashMap;
@@ -8,6 +14,7 @@ use uuid::Uuid;
 pub(crate) struct VirtualWorkerInfo {
     pub name: String,
     pub owner_worker_id: Uuid,
+    pub trusted_internal: bool,
     pub function_ids: HashSet<String>,
 }
 
@@ -26,6 +33,7 @@ impl VirtualWorkerRegistry {
         &self,
         worker_name: impl Into<String>,
         owner_worker_id: Uuid,
+        trusted_internal: bool,
         function_id: &str,
     ) {
         let worker_name = worker_name.into();
@@ -44,11 +52,13 @@ impl VirtualWorkerRegistry {
             .entry(worker_name.clone())
             .and_modify(|info| {
                 info.owner_worker_id = owner_worker_id;
+                info.trusted_internal = trusted_internal;
                 info.function_ids.insert(function_id.clone());
             })
             .or_insert_with(|| VirtualWorkerInfo {
                 name: worker_name,
                 owner_worker_id,
+                trusted_internal,
                 function_ids: HashSet::from([function_id]),
             });
     }
@@ -155,7 +165,7 @@ mod tests {
         let registry = VirtualWorkerRegistry::new();
         let owner = Uuid::new_v4();
 
-        registry.claim_function("hn", owner, "hn::top_stories");
+        registry.claim_function("hn", owner, true, "hn::top_stories");
         assert!(registry.contains_worker("hn"));
 
         registry.remove_function("hn::top_stories");

--- a/engine/src/worker_connections/mod.rs
+++ b/engine/src/worker_connections/mod.rs
@@ -410,6 +410,7 @@ mod tests {
             allowed_trigger_types: Some(vec![]),
             allow_function_registration: false,
             allow_trigger_type_registration: false,
+            trusted_internal: false,
             context: serde_json::json!({}),
             function_registration_prefix: None,
         };

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -89,8 +89,6 @@ pub struct WorkerInfo {
     pub ip_address: Option<String>,
     #[serde(default)]
     pub internal: bool,
-    #[serde(default)]
-    pub virtual_worker: bool,
     pub status: String,
     pub connected_at_ms: u64,
     pub function_count: usize,
@@ -288,7 +286,6 @@ impl EngineFunctionsWorker {
                 os: w.os.clone(),
                 ip_address,
                 internal: false,
-                virtual_worker: false,
                 status: w.status.as_str().to_string(),
                 connected_at_ms: w.connected_at.timestamp_millis() as u64,
                 function_count,
@@ -316,7 +313,6 @@ impl EngineFunctionsWorker {
                 os: None,
                 ip_address: None,
                 internal: runtime_worker.internal,
-                virtual_worker: false,
                 status: "available".to_string(),
                 connected_at_ms: runtime_worker.connected_at.timestamp_millis() as u64,
                 function_count: functions.len(),
@@ -329,10 +325,9 @@ impl EngineFunctionsWorker {
         }
 
         for virtual_worker in self.engine.virtual_workers.list() {
-            let worker_id = format!("virtual:{}", virtual_worker.name);
+            let worker_id = virtual_worker.name.clone();
             if let Some(filter_id) = filter_worker_id
                 && filter_id != worker_id
-                && filter_id != virtual_worker.name
             {
                 continue;
             }
@@ -352,7 +347,6 @@ impl EngineFunctionsWorker {
                 os: None,
                 ip_address: None,
                 internal: false,
-                virtual_worker: true,
                 status: "available".to_string(),
                 connected_at_ms: chrono::Utc::now().timestamp_millis() as u64,
                 function_count: functions.len(),
@@ -360,7 +354,7 @@ impl EngineFunctionsWorker {
                 active_invocations: 0,
                 latest_metrics: None,
                 pid: None,
-                isolation: Some("virtual".to_string()),
+                isolation: None,
             });
         }
 
@@ -907,7 +901,6 @@ mod tests {
             vec!["state::get".to_string(), "state::set".to_string()]
         );
         assert!(!workers[0].internal);
-        assert!(!workers[0].virtual_worker);
     }
 
     #[tokio::test]
@@ -933,7 +926,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_list_worker_infos_includes_virtual_worker_group() {
+    async fn test_list_worker_infos_includes_generated_group_without_virtual_public_shape() {
         let (engine, module) = setup_engine_and_module();
         let owner = uuid::Uuid::new_v4();
 
@@ -953,12 +946,11 @@ mod tests {
         let workers = module.list_worker_infos(None).await;
 
         assert_eq!(workers.len(), 1);
-        assert_eq!(workers[0].id, "virtual:converted-api-worker");
+        assert_eq!(workers[0].id, "converted-api-worker");
         assert_eq!(workers[0].name.as_deref(), Some("converted-api-worker"));
-        assert!(workers[0].virtual_worker);
         assert!(!workers[0].internal);
         assert_eq!(workers[0].runtime.as_deref(), Some("engine"));
-        assert_eq!(workers[0].isolation.as_deref(), Some("virtual"));
+        assert_eq!(workers[0].isolation, None);
         assert_eq!(workers[0].function_count, 2);
         assert_eq!(
             workers[0].functions,

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -89,6 +89,8 @@ pub struct WorkerInfo {
     pub ip_address: Option<String>,
     #[serde(default)]
     pub internal: bool,
+    #[serde(default)]
+    pub virtual_worker: bool,
     pub status: String,
     pub connected_at_ms: u64,
     pub function_count: usize,
@@ -286,6 +288,7 @@ impl EngineFunctionsWorker {
                 os: w.os.clone(),
                 ip_address,
                 internal: false,
+                virtual_worker: false,
                 status: w.status.as_str().to_string(),
                 connected_at_ms: w.connected_at.timestamp_millis() as u64,
                 function_count,
@@ -313,6 +316,7 @@ impl EngineFunctionsWorker {
                 os: None,
                 ip_address: None,
                 internal: runtime_worker.internal,
+                virtual_worker: false,
                 status: "available".to_string(),
                 connected_at_ms: runtime_worker.connected_at.timestamp_millis() as u64,
                 function_count: functions.len(),
@@ -321,6 +325,42 @@ impl EngineFunctionsWorker {
                 latest_metrics: None,
                 pid: None,
                 isolation: Some("in-process".to_string()),
+            });
+        }
+
+        for virtual_worker in self.engine.virtual_workers.list() {
+            let worker_id = format!("virtual:{}", virtual_worker.name);
+            if let Some(filter_id) = filter_worker_id
+                && filter_id != worker_id
+                && filter_id != virtual_worker.name
+            {
+                continue;
+            }
+
+            let mut functions = virtual_worker
+                .function_ids
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>();
+            functions.sort();
+
+            worker_infos.push(WorkerInfo {
+                id: worker_id,
+                name: Some(virtual_worker.name),
+                runtime: Some("engine".to_string()),
+                version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                os: None,
+                ip_address: None,
+                internal: false,
+                virtual_worker: true,
+                status: "available".to_string(),
+                connected_at_ms: chrono::Utc::now().timestamp_millis() as u64,
+                function_count: functions.len(),
+                functions,
+                active_invocations: 0,
+                latest_metrics: None,
+                pid: None,
+                isolation: Some("virtual".to_string()),
             });
         }
 
@@ -867,6 +907,7 @@ mod tests {
             vec!["state::get".to_string(), "state::set".to_string()]
         );
         assert!(!workers[0].internal);
+        assert!(!workers[0].virtual_worker);
     }
 
     #[tokio::test]
@@ -889,6 +930,43 @@ mod tests {
 
         assert_eq!(workers.len(), 1);
         assert_eq!(workers[0].id, "iii-stream");
+    }
+
+    #[tokio::test]
+    async fn test_list_worker_infos_includes_virtual_worker_group() {
+        let (engine, module) = setup_engine_and_module();
+        let owner = uuid::Uuid::new_v4();
+
+        engine.virtual_workers.claim_function(
+            "context7-stdio-worker",
+            owner,
+            true,
+            "context7_stdio::resolve_library_id",
+        );
+        engine.virtual_workers.claim_function(
+            "context7-stdio-worker",
+            owner,
+            true,
+            "context7_stdio::query_docs",
+        );
+
+        let workers = module.list_worker_infos(None).await;
+
+        assert_eq!(workers.len(), 1);
+        assert_eq!(workers[0].id, "virtual:context7-stdio-worker");
+        assert_eq!(workers[0].name.as_deref(), Some("context7-stdio-worker"));
+        assert!(workers[0].virtual_worker);
+        assert!(!workers[0].internal);
+        assert_eq!(workers[0].runtime.as_deref(), Some("engine"));
+        assert_eq!(workers[0].isolation.as_deref(), Some("virtual"));
+        assert_eq!(workers[0].function_count, 2);
+        assert_eq!(
+            workers[0].functions,
+            vec![
+                "context7_stdio::query_docs".to_string(),
+                "context7_stdio::resolve_library_id".to_string()
+            ]
+        );
     }
 
     // ---- register_worker_metadata tests ----

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -938,23 +938,23 @@ mod tests {
         let owner = uuid::Uuid::new_v4();
 
         engine.virtual_workers.claim_function(
-            "context7-stdio-worker",
+            "converted-api-worker",
             owner,
             true,
-            "context7_stdio::resolve_library_id",
+            "converted_api::get_user",
         );
         engine.virtual_workers.claim_function(
-            "context7-stdio-worker",
+            "converted-api-worker",
             owner,
             true,
-            "context7_stdio::query_docs",
+            "converted_api::list_users",
         );
 
         let workers = module.list_worker_infos(None).await;
 
         assert_eq!(workers.len(), 1);
-        assert_eq!(workers[0].id, "virtual:context7-stdio-worker");
-        assert_eq!(workers[0].name.as_deref(), Some("context7-stdio-worker"));
+        assert_eq!(workers[0].id, "virtual:converted-api-worker");
+        assert_eq!(workers[0].name.as_deref(), Some("converted-api-worker"));
         assert!(workers[0].virtual_worker);
         assert!(!workers[0].internal);
         assert_eq!(workers[0].runtime.as_deref(), Some("engine"));
@@ -963,8 +963,8 @@ mod tests {
         assert_eq!(
             workers[0].functions,
             vec![
-                "context7_stdio::query_docs".to_string(),
-                "context7_stdio::resolve_library_id".to_string()
+                "converted_api::get_user".to_string(),
+                "converted_api::list_users".to_string()
             ]
         );
     }

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -266,7 +266,12 @@ impl EngineFunctionsWorker {
                 continue;
             }
 
-            let functions = w.get_function_ids().await;
+            let functions = w
+                .get_function_ids()
+                .await
+                .into_iter()
+                .filter(|function_id| !self.engine.virtual_workers.contains_function(function_id))
+                .collect::<Vec<_>>();
             let function_count = functions.len();
             let active_invocations = w.invocation_count().await;
             // Query latest metrics from OTEL storage

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -270,7 +270,7 @@ impl EngineFunctionsWorker {
                 .get_function_ids()
                 .await
                 .into_iter()
-                .filter(|function_id| !self.engine.virtual_workers.contains_function(function_id))
+                .filter(|function_id| !self.engine.generated_workers.contains_function(function_id))
                 .collect::<Vec<_>>();
             let function_count = functions.len();
             let active_invocations = w.invocation_count().await;
@@ -324,15 +324,15 @@ impl EngineFunctionsWorker {
             });
         }
 
-        for virtual_worker in self.engine.virtual_workers.list() {
-            let worker_id = virtual_worker.name.clone();
+        for generated_worker in self.engine.generated_workers.list() {
+            let worker_id = generated_worker.name.clone();
             if let Some(filter_id) = filter_worker_id
                 && filter_id != worker_id
             {
                 continue;
             }
 
-            let mut functions = virtual_worker
+            let mut functions = generated_worker
                 .function_ids
                 .iter()
                 .cloned()
@@ -341,7 +341,7 @@ impl EngineFunctionsWorker {
 
             worker_infos.push(WorkerInfo {
                 id: worker_id,
-                name: Some(virtual_worker.name),
+                name: Some(generated_worker.name),
                 runtime: Some("engine".to_string()),
                 version: Some(env!("CARGO_PKG_VERSION").to_string()),
                 os: None,
@@ -926,17 +926,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_list_worker_infos_includes_generated_group_without_virtual_public_shape() {
+    async fn test_list_worker_infos_includes_generated_group_without_private_public_shape() {
         let (engine, module) = setup_engine_and_module();
         let owner = uuid::Uuid::new_v4();
 
-        engine.virtual_workers.claim_function(
+        engine.generated_workers.claim_function(
             "converted-api-worker",
             owner,
             true,
             "converted_api::get_user",
         );
-        engine.virtual_workers.claim_function(
+        engine.generated_workers.claim_function(
             "converted-api-worker",
             owner,
             true,

--- a/engine/src/workers/http_functions/mod.rs
+++ b/engine/src/workers/http_functions/mod.rs
@@ -66,6 +66,7 @@ impl HttpFunctionsWorker {
                     timeout_ms: &timeout_ms,
                     headers: &headers,
                     auth: &auth,
+                    trusted_internal: config.trusted_internal,
                 };
 
                 match invoker
@@ -90,15 +91,17 @@ impl HttpFunctionsWorker {
         &self,
         config: HttpFunctionConfig,
     ) -> Result<(), ErrorBody> {
-        self.http_invoker
-            .url_validator()
-            .validate(&config.url)
-            .await
-            .map_err(|e| ErrorBody {
-                code: "url_validation_failed".into(),
-                message: e.to_string(),
-                stacktrace: None,
-            })?;
+        if !config.trusted_internal {
+            self.http_invoker
+                .url_validator()
+                .validate(&config.url)
+                .await
+                .map_err(|e| ErrorBody {
+                    code: "url_validation_failed".into(),
+                    message: e.to_string(),
+                    stacktrace: None,
+                })?;
+        }
 
         let auth = config.auth.as_ref().map(resolve_auth_ref).transpose()?;
 
@@ -174,7 +177,11 @@ impl Worker for HttpFunctionsWorker {
     }
 }
 
-crate::register_worker!("iii-http-functions", HttpFunctionsWorker);
+crate::register_worker!(
+    "iii-http-functions",
+    HttpFunctionsWorker,
+    enabled_by_default = true
+);
 
 #[cfg(test)]
 mod tests {
@@ -321,6 +328,7 @@ mod tests {
             request_format: None,
             response_format: None,
             metadata: None,
+            trusted_internal: false,
             registered_at: None,
             updated_at: None,
         }

--- a/engine/src/workers/worker/rbac_session.rs
+++ b/engine/src/workers/worker/rbac_session.rs
@@ -41,6 +41,7 @@ pub struct Session {
     pub allowed_trigger_types: Option<Vec<String>>,
     pub allow_trigger_type_registration: bool,
     pub allow_function_registration: bool,
+    pub trusted_internal: bool,
     pub context: Value,
     pub function_registration_prefix: Option<String>,
 }
@@ -57,6 +58,8 @@ pub(crate) struct AuthResult {
     allow_trigger_type_registration: bool,
     #[serde(default = "default_true")]
     allow_function_registration: bool,
+    #[serde(default)]
+    trusted_internal: bool,
     #[serde(default = "default_context")]
     context: Value,
     #[serde(default)]
@@ -80,6 +83,7 @@ impl Session {
                 allowed_trigger_types: None,
                 allow_trigger_type_registration: true,
                 allow_function_registration: true,
+                trusted_internal: false,
                 context: json!({}),
                 function_registration_prefix: None,
             });
@@ -138,6 +142,7 @@ pub async fn handle_session(
         allowed_trigger_types: auth.allowed_trigger_types,
         allow_trigger_type_registration: auth.allow_trigger_type_registration,
         allow_function_registration: auth.allow_function_registration,
+        trusted_internal: auth.trusted_internal,
         context: auth.context,
         function_registration_prefix: auth.function_registration_prefix,
     })

--- a/engine/tests/generated_worker_bridge_e2e.rs
+++ b/engine/tests/generated_worker_bridge_e2e.rs
@@ -114,7 +114,7 @@ fn register_generated_http_function(url: String) -> Message {
                 "workerName": "generated-docs-worker"
             },
             "iii": {
-                "virtualWorker": {
+                "generatedWorker": {
                     "name": "generated-docs-worker"
                 }
             }
@@ -190,7 +190,10 @@ async fn generated_bridge_registers_triggerable_function_and_normal_worker_group
     assert_eq!(generated_worker.get("runtime"), Some(&json!("engine")));
     assert_eq!(generated_worker.get("internal"), Some(&json!(false)));
     assert_eq!(generated_worker.get("function_count"), Some(&json!(1)));
+    assert!(generated_worker.get("generated_worker").is_none());
+    assert!(generated_worker.get("generatedWorker").is_none());
     assert!(generated_worker.get("virtual_worker").is_none());
+    assert!(generated_worker.get("virtualWorker").is_none());
     assert!(generated_worker.get("isolation").is_none());
 
     let function_list = engine

--- a/engine/tests/generated_worker_bridge_e2e.rs
+++ b/engine/tests/generated_worker_bridge_e2e.rs
@@ -1,0 +1,258 @@
+use std::sync::{Arc, Mutex};
+
+use axum::{Json, Router, body::Bytes, extract::State, http::StatusCode, routing::post};
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use iii::{
+    engine::{Engine, EngineTrait, Outbound},
+    invocation::method::HttpMethod,
+    protocol::{HttpInvocationRef, Message},
+    worker_connections::WorkerConnection,
+    workers::{
+        engine_fn::EngineFunctionsWorker,
+        http_functions::{HttpFunctionsWorker, config::HttpFunctionsConfig},
+        observability::metrics::ensure_default_meter,
+        traits::Worker,
+        worker::{WorkerManagerConfig, rbac_session::Session},
+    },
+};
+
+#[derive(Clone, Default)]
+struct RequestCapture {
+    body: Arc<Mutex<Option<Value>>>,
+}
+
+async fn spawn_success_server(capture: RequestCapture) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let addr = listener.local_addr().expect("resolve local addr");
+
+    async fn success_handler(
+        State(capture): State<RequestCapture>,
+        body: Bytes,
+    ) -> (StatusCode, Json<Value>) {
+        *capture.body.lock().expect("lock body") = Some(if body.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&body).expect("request body should be valid json")
+        });
+        (StatusCode::OK, Json(json!({ "ok": true })))
+    }
+
+    let app = Router::new()
+        .route("/success", post(success_handler))
+        .with_state(capture);
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test app");
+    });
+
+    format!("http://{addr}")
+}
+
+async fn engine_with_discovery_and_http_functions() -> Arc<Engine> {
+    ensure_default_meter();
+    let engine = Arc::new(Engine::new());
+
+    let engine_functions = EngineFunctionsWorker::create(engine.clone(), None)
+        .await
+        .expect("create engine functions worker");
+    engine_functions
+        .initialize()
+        .await
+        .expect("initialize engine functions worker");
+    engine_functions.register_functions(engine.clone());
+
+    let http_functions = HttpFunctionsWorker::create(
+        engine.clone(),
+        Some(serde_json::to_value(HttpFunctionsConfig::default()).expect("serialize config")),
+    )
+    .await
+    .expect("create http functions worker");
+    http_functions
+        .initialize()
+        .await
+        .expect("initialize http functions worker");
+
+    engine
+}
+
+fn worker_with_session(engine: Arc<Engine>, ip_address: &str) -> WorkerConnection {
+    let (tx, _rx) = mpsc::channel::<Outbound>(8);
+    WorkerConnection::with_session(
+        tx,
+        Session {
+            engine,
+            config: Arc::new(WorkerManagerConfig::default()),
+            ip_address: ip_address.to_string(),
+            session_id: Uuid::new_v4(),
+            allowed_functions: vec![],
+            forbidden_functions: vec![],
+            allowed_trigger_types: None,
+            allow_function_registration: true,
+            allow_trigger_type_registration: true,
+            trusted_internal: false,
+            context: json!({}),
+            function_registration_prefix: None,
+        },
+    )
+}
+
+fn register_generated_http_function(url: String) -> Message {
+    Message::RegisterFunction {
+        id: "generated_docs::search".to_string(),
+        description: Some("Search generated docs".to_string()),
+        request_format: None,
+        response_format: None,
+        metadata: Some(json!({
+            "spec": {
+                "source": "http://127.0.0.1/openapi.json",
+                "sourceType": "openapi",
+                "workerName": "generated-docs-worker"
+            },
+            "iii": {
+                "virtualWorker": {
+                    "name": "generated-docs-worker"
+                }
+            }
+        })),
+        invocation: Some(HttpInvocationRef {
+            url,
+            method: HttpMethod::Post,
+            timeout_ms: Some(30_000),
+            headers: Default::default(),
+            auth: None,
+        }),
+    }
+}
+
+fn workers_array(value: &Value) -> &[Value] {
+    value
+        .get("workers")
+        .and_then(Value::as_array)
+        .expect("workers array")
+}
+
+fn functions_array(value: &Value) -> &[Value] {
+    value
+        .get("functions")
+        .and_then(Value::as_array)
+        .expect("functions array")
+}
+
+#[tokio::test]
+async fn generated_bridge_registers_triggerable_function_and_normal_worker_group() {
+    let engine = engine_with_discovery_and_http_functions().await;
+    let capture = RequestCapture::default();
+    let base_url = spawn_success_server(capture.clone()).await;
+    let worker = worker_with_session(engine.clone(), "127.0.0.1");
+    let register_message = register_generated_http_function(format!("{base_url}/success"));
+
+    engine
+        .router_msg(&worker, &register_message)
+        .await
+        .expect("register generated function");
+
+    let result = engine
+        .call(
+            "generated_docs::search",
+            json!({
+                "query": "rust"
+            }),
+        )
+        .await
+        .expect("generated function call succeeds")
+        .expect("generated function returns a result");
+
+    assert_eq!(result, json!({ "ok": true }));
+    assert_eq!(
+        *capture.body.lock().expect("lock body"),
+        Some(json!({ "query": "rust" }))
+    );
+
+    let workers = engine
+        .call("engine::workers::list", json!({}))
+        .await
+        .expect("workers list succeeds")
+        .expect("workers list result");
+    let generated_worker = workers_array(&workers)
+        .iter()
+        .find(|worker| worker.get("name").and_then(Value::as_str) == Some("generated-docs-worker"))
+        .expect("generated worker group is listed");
+
+    assert_eq!(
+        generated_worker.get("id"),
+        Some(&json!("generated-docs-worker"))
+    );
+    assert_eq!(generated_worker.get("runtime"), Some(&json!("engine")));
+    assert_eq!(generated_worker.get("internal"), Some(&json!(false)));
+    assert_eq!(generated_worker.get("function_count"), Some(&json!(1)));
+    assert!(generated_worker.get("virtual_worker").is_none());
+    assert!(generated_worker.get("isolation").is_none());
+
+    let function_list = engine
+        .call(
+            "engine::functions::list",
+            json!({
+                "include_internal": true
+            }),
+        )
+        .await
+        .expect("functions list succeeds")
+        .expect("functions list result");
+    let generated_function = functions_array(&function_list)
+        .iter()
+        .find(|function| {
+            function.get("function_id").and_then(Value::as_str) == Some("generated_docs::search")
+        })
+        .expect("generated function is listed");
+    let metadata = generated_function
+        .get("metadata")
+        .expect("metadata is present");
+
+    assert_eq!(
+        metadata.pointer("/spec/workerName"),
+        Some(&json!("generated-docs-worker"))
+    );
+    assert!(metadata.get("iii").is_none());
+}
+
+#[tokio::test]
+async fn remote_worker_cannot_register_loopback_generated_bridge() {
+    let engine = engine_with_discovery_and_http_functions().await;
+    let worker = worker_with_session(engine.clone(), "203.0.113.10");
+    let register_message =
+        register_generated_http_function("http://127.0.0.1/generated/search".to_string());
+
+    engine
+        .router_msg(&worker, &register_message)
+        .await
+        .expect("registration failure is contained");
+
+    assert!(engine.functions.get("generated_docs::search").is_none());
+    let http_functions = engine
+        .service_registry
+        .get_service::<HttpFunctionsWorker>("http_functions")
+        .expect("http functions service");
+    assert!(
+        !http_functions
+            .http_functions()
+            .contains_key("generated_docs::search")
+    );
+
+    let workers = engine
+        .call("engine::workers::list", json!({}))
+        .await
+        .expect("workers list succeeds")
+        .expect("workers list result");
+
+    assert!(
+        workers_array(&workers)
+            .iter()
+            .all(|worker| worker.get("name").and_then(Value::as_str)
+                != Some("generated-docs-worker"))
+    );
+}

--- a/engine/tests/http_e2e_error_handling.rs
+++ b/engine/tests/http_e2e_error_handling.rs
@@ -26,6 +26,7 @@ fn make_endpoint<'a>(
         timeout_ms,
         headers,
         auth,
+        trusted_internal: false,
     }
 }
 

--- a/engine/tests/http_e2e_security.rs
+++ b/engine/tests/http_e2e_security.rs
@@ -23,6 +23,7 @@ fn make_endpoint<'a>(
         timeout_ms,
         headers,
         auth,
+        trusted_internal: false,
     }
 }
 

--- a/engine/tests/rbac_infrastructure_e2e.rs
+++ b/engine/tests/rbac_infrastructure_e2e.rs
@@ -74,6 +74,7 @@ fn session_with(
         allowed_trigger_types: None,
         allow_function_registration: true,
         allow_trigger_type_registration: true,
+        trusted_internal: false,
         context: json!({}),
         function_registration_prefix: None,
     }

--- a/sdk/packages/node/iii/tests/http-external-functions.test.ts
+++ b/sdk/packages/node/iii/tests/http-external-functions.test.ts
@@ -2,7 +2,7 @@ import { createServer, type IncomingHttpHeaders } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { describe, expect, it } from 'vitest'
 import { EngineFunctions } from '../src/iii-constants'
-import type { FunctionInfo } from '../src/iii-types'
+import type { FunctionInfo, WorkerInfo } from '../src/iii-types'
 import { execute, iii, sleep } from './utils'
 
 type CapturedWebhook = {
@@ -131,6 +131,98 @@ function uniqueTopic(prefix: string): string {
 }
 
 describe('HTTP external functions', () => {
+  it('exposes generated HTTP functions as a normal engine worker group', async () => {
+    await execute(async () =>
+      iii.trigger<Record<string, never>, { functions: FunctionInfo[] }>({
+        function_id: EngineFunctions.LIST_FUNCTIONS,
+        payload: {},
+      }),
+    )
+
+    const webhookProbe = new WebhookProbe()
+    await webhookProbe.start()
+
+    const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 10)}`
+    const workerName = `generated-node-${suffix}`
+    const functionId = `generated_node_${suffix}::search`
+    const payload = { query: 'hooks', limit: 3 }
+    let httpFn: { unregister(): void } | undefined
+
+    try {
+      httpFn = iii.registerFunction(
+        functionId,
+        {
+          url: webhookProbe.url('/generated'),
+          method: 'POST',
+          timeout_ms: 3000,
+        },
+        {
+          description: 'Generated OpenAPI search function',
+          metadata: {
+            spec: {
+              schema: 'spec-to-worker.http-invocation.v1',
+              sourceType: 'openapi',
+              source: 'https://example.test/openapi.json',
+              workerName,
+            },
+            iii: { virtualWorker: { name: workerName } },
+          },
+        },
+      )
+      await sleep(300)
+
+      const result = await execute(async () =>
+        iii.trigger<typeof payload, { ok: boolean }>({
+          function_id: functionId,
+          payload,
+        }),
+      )
+      const webhook = await webhookProbe.waitForWebhook(7000)
+
+      expect(result).toEqual({ ok: true })
+      expect(webhook.method).toBe('POST')
+      expect(webhook.url).toBe('/generated')
+      expect(webhook.body).toMatchObject(payload)
+
+      const workersResult = await execute(async () =>
+        iii.trigger<Record<string, never>, { workers: WorkerInfo[] }>({
+          function_id: EngineFunctions.LIST_WORKERS,
+          payload: {},
+        }),
+      )
+      const worker = workersResult.workers.find(w => w.id === workerName)
+      expect(worker).toBeDefined()
+      expect(worker?.name).toBe(workerName)
+      expect(worker?.runtime).toBe('engine')
+      expect(worker?.function_count).toBe(1)
+      expect(worker?.functions).toContain(functionId)
+
+      const workerPublicShape = worker as unknown as Record<string, unknown>
+      expect(workerPublicShape.internal).toBe(false)
+      expect(workerPublicShape.virtual_worker).toBeUndefined()
+      expect(workerPublicShape.virtualWorker).toBeUndefined()
+      expect(workerPublicShape.isolation).toBeUndefined()
+
+      const functionsResult = await execute(async () =>
+        iii.trigger<Record<string, boolean>, { functions: FunctionInfo[] }>({
+          function_id: EngineFunctions.LIST_FUNCTIONS,
+          payload: { include_internal: true },
+        }),
+      )
+      const registered = functionsResult.functions.find(f => f.function_id === functionId)
+      expect(registered?.metadata).toMatchObject({
+        spec: {
+          sourceType: 'openapi',
+          workerName,
+        },
+      })
+      expect((registered?.metadata as Record<string, unknown> | undefined)?.iii).toBeUndefined()
+    } finally {
+      httpFn?.unregister()
+      await webhookProbe.close()
+    }
+  })
+
   it('delivers queue events to an externally registered HTTP function', async () => {
     await execute(async () =>
       iii.trigger<Record<string, never>, { functions: FunctionInfo[] }>({

--- a/sdk/packages/node/iii/tests/http-external-functions.test.ts
+++ b/sdk/packages/node/iii/tests/http-external-functions.test.ts
@@ -165,7 +165,7 @@ describe('HTTP external functions', () => {
               source: 'https://example.test/openapi.json',
               workerName,
             },
-            iii: { virtualWorker: { name: workerName } },
+            iii: { generatedWorker: { name: workerName } },
           },
         },
       )
@@ -199,6 +199,8 @@ describe('HTTP external functions', () => {
 
       const workerPublicShape = worker as unknown as Record<string, unknown>
       expect(workerPublicShape.internal).toBe(false)
+      expect(workerPublicShape.generated_worker).toBeUndefined()
+      expect(workerPublicShape.generatedWorker).toBeUndefined()
       expect(workerPublicShape.virtual_worker).toBeUndefined()
       expect(workerPublicShape.virtualWorker).toBeUndefined()
       expect(workerPublicShape.isolation).toBeUndefined()

--- a/sdk/packages/python/iii/tests/test_http_external_functions_integration.py
+++ b/sdk/packages/python/iii/tests/test_http_external_functions_integration.py
@@ -282,6 +282,77 @@ def test_unregister_removes_function_from_sent_messages(monkeypatch: pytest.Monk
 
 
 @pytest.mark.asyncio
+async def test_exposes_generated_http_functions_as_normal_engine_worker_group() -> None:
+    client = _make_integration_client()
+
+    probe = WebhookProbe()
+    await probe.start()
+
+    suffix = f"{int(time.time() * 1000)}_{random.randrange(1_000_000)}"
+    worker_name = f"generated-python-{suffix}"
+    function_id = f"generated_python_{suffix}::search"
+    payload = {"query": "sessions", "limit": 4}
+    http_fn = None
+
+    try:
+        http_fn = client.register_function(
+            function_id,
+            HttpInvocationConfig(url=probe.url("/generated"), method="POST", timeout_ms=3000),
+            description="Generated MCP search function",
+            metadata={
+                "spec": {
+                    "schema": "spec-to-worker.http-invocation.v1",
+                    "sourceType": "mcp",
+                    "source": "stdio:npx -y some-mcp-server",
+                    "workerName": worker_name,
+                },
+                "iii": {"virtualWorker": {"name": worker_name}},
+            },
+        )
+        time.sleep(0.5)
+
+        result = await asyncio.to_thread(client.trigger, {"function_id": function_id, "payload": payload})
+        webhook = await probe.wait_for_webhook(7.0)
+
+        assert result == {"ok": True}
+        assert webhook["method"] == "POST"
+        assert webhook["url"] == "/generated"
+        assert webhook["body"]["query"] == payload["query"]
+        assert webhook["body"]["limit"] == payload["limit"]
+
+        workers_result = client.trigger({"function_id": "engine::workers::list", "payload": {}})
+        worker = next((w for w in workers_result.get("workers", []) if w.get("id") == worker_name), None)
+
+        assert worker is not None, f"{worker_name} not found in workers list"
+        assert worker["name"] == worker_name
+        assert worker["runtime"] == "engine"
+        assert worker["function_count"] == 1
+        assert function_id in worker["functions"]
+        assert worker.get("internal") is False
+        assert "virtual_worker" not in worker
+        assert "virtualWorker" not in worker
+        assert "isolation" not in worker
+
+        functions_result = client.trigger(
+            {"function_id": "engine::functions::list", "payload": {"include_internal": True}}
+        )
+        registered = next(
+            (f for f in functions_result.get("functions", []) if f.get("function_id") == function_id),
+            None,
+        )
+
+        assert registered is not None, f"{function_id} not found in functions list"
+        assert registered["metadata"]["spec"]["sourceType"] == "mcp"
+        assert registered["metadata"]["spec"]["workerName"] == worker_name
+        assert "iii" not in registered["metadata"]
+    finally:
+        if http_fn:
+            http_fn.unregister()
+        await probe.close()
+        client.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_delivers_queue_events_to_external_http_function() -> None:
     client = _make_integration_client()
 

--- a/sdk/packages/python/iii/tests/test_http_external_functions_integration.py
+++ b/sdk/packages/python/iii/tests/test_http_external_functions_integration.py
@@ -306,7 +306,7 @@ async def test_exposes_generated_http_functions_as_normal_engine_worker_group() 
                     "source": "stdio:npx -y some-mcp-server",
                     "workerName": worker_name,
                 },
-                "iii": {"virtualWorker": {"name": worker_name}},
+                "iii": {"generatedWorker": {"name": worker_name}},
             },
         )
         time.sleep(0.5)
@@ -329,6 +329,8 @@ async def test_exposes_generated_http_functions_as_normal_engine_worker_group() 
         assert worker["function_count"] == 1
         assert function_id in worker["functions"]
         assert worker.get("internal") is False
+        assert "generated_worker" not in worker
+        assert "generatedWorker" not in worker
         assert "virtual_worker" not in worker
         assert "virtualWorker" not in worker
         assert "isolation" not in worker

--- a/sdk/packages/rust/iii/tests/http_external_functions.rs
+++ b/sdk/packages/rust/iii/tests/http_external_functions.rs
@@ -13,7 +13,7 @@ use tokio::net::TcpListener;
 
 use iii_sdk::{
     FunctionInfo, HttpInvocationConfig, HttpMethod, RegisterFunctionMessage, RegisterTriggerInput,
-    TriggerRequest,
+    TriggerRequest, WorkerInfo,
 };
 
 fn unique_function_id(prefix: &str) -> String {
@@ -113,7 +113,7 @@ impl WebhookProbe {
             serde_json::from_slice(body_bytes).ok()
         };
 
-        let response = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 10\r\n\r\n{\"ok\":true}";
+        let response = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 11\r\n\r\n{\"ok\":true}";
         let _ = stream.write_all(response).await;
 
         CapturedWebhook {
@@ -127,6 +127,128 @@ impl WebhookProbe {
     async fn wait_for_webhook(&self, timeout: Duration) -> Option<CapturedWebhook> {
         tokio::time::timeout(timeout, self.accept_one()).await.ok()
     }
+}
+
+#[tokio::test]
+async fn exposes_generated_http_functions_as_normal_engine_worker_group() {
+    let iii = common::shared_iii();
+
+    let probe = WebhookProbe::start().await;
+    let suffix = format!(
+        "{}_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+        uuid::Uuid::new_v4().simple()
+    );
+    let worker_name = format!("generated-rust-{suffix}");
+    let function_id = format!("generated_rust_{suffix}::search");
+    let payload = json!({"query": "traces", "limit": 5});
+
+    let mut message = RegisterFunctionMessage::with_id(function_id.clone())
+        .with_description("Generated HTTP search function".to_string());
+    message.metadata = Some(json!({
+        "spec": {
+            "schema": "spec-to-worker.http-invocation.v1",
+            "sourceType": "http",
+            "source": "https://example.test/api",
+            "workerName": worker_name
+        },
+        "iii": { "virtualWorker": { "name": worker_name } }
+    }));
+
+    let http_fn = iii.register_function((
+        message,
+        HttpInvocationConfig {
+            url: probe.url(),
+            method: HttpMethod::Post,
+            timeout_ms: Some(3000),
+            headers: HashMap::new(),
+            auth: None,
+        },
+    ));
+    common::settle().await;
+
+    let trigger_future = iii.trigger(TriggerRequest {
+        function_id: function_id.clone(),
+        payload: payload.clone(),
+        action: None,
+        timeout_ms: None,
+    });
+    let webhook_future = probe.wait_for_webhook(Duration::from_secs(7));
+    let (result, webhook) = tokio::join!(trigger_future, webhook_future);
+    let result = result.expect("generated function trigger failed");
+    let webhook = webhook.expect("no webhook received");
+
+    assert_eq!(result["ok"], true);
+    assert_eq!(webhook.method, "POST");
+    assert_eq!(webhook.url, "/webhook");
+    assert_eq!(webhook.body.as_ref().unwrap()["query"], "traces");
+    assert_eq!(webhook.body.as_ref().unwrap()["limit"], 5);
+
+    let workers_result = iii
+        .trigger(TriggerRequest {
+            function_id: "engine::workers::list".to_string(),
+            payload: json!({}),
+            action: None,
+            timeout_ms: None,
+        })
+        .await
+        .expect("worker discovery request failed");
+    let worker_values = workers_result
+        .get("workers")
+        .and_then(Value::as_array)
+        .expect("workers array");
+    let worker_value = worker_values
+        .iter()
+        .find(|worker| worker.get("id").and_then(Value::as_str) == Some(worker_name.as_str()))
+        .expect("generated worker group not found");
+    let worker: WorkerInfo =
+        serde_json::from_value(worker_value.clone()).expect("deserialize worker");
+
+    assert_eq!(worker.id, worker_name);
+    assert_eq!(worker.name.as_deref(), Some(worker_name.as_str()));
+    assert_eq!(worker.runtime.as_deref(), Some("engine"));
+    assert_eq!(worker.function_count, 1);
+    assert_eq!(worker.functions, vec![function_id.clone()]);
+    assert!(
+        !worker_value
+            .get("internal")
+            .and_then(Value::as_bool)
+            .unwrap_or(true)
+    );
+    assert!(worker_value.get("virtual_worker").is_none());
+    assert!(worker_value.get("virtualWorker").is_none());
+    assert!(worker_value.get("isolation").is_none());
+
+    let functions_result = iii
+        .trigger(TriggerRequest {
+            function_id: "engine::functions::list".to_string(),
+            payload: json!({"include_internal": true}),
+            action: None,
+            timeout_ms: None,
+        })
+        .await
+        .expect("function discovery request failed");
+    let functions: Vec<FunctionInfo> = serde_json::from_value(
+        functions_result
+            .get("functions")
+            .cloned()
+            .unwrap_or(Value::Array(vec![])),
+    )
+    .expect("deserialize functions");
+    let registered = functions
+        .iter()
+        .find(|function| function.function_id == function_id)
+        .expect("generated function not found");
+    let metadata = registered.metadata.as_ref().expect("function metadata");
+
+    assert_eq!(metadata["spec"]["sourceType"], "http");
+    assert_eq!(metadata["spec"]["workerName"], worker_name);
+    assert!(metadata.get("iii").is_none());
+
+    http_fn.unregister();
 }
 
 #[tokio::test]

--- a/sdk/packages/rust/iii/tests/http_external_functions.rs
+++ b/sdk/packages/rust/iii/tests/http_external_functions.rs
@@ -155,7 +155,7 @@ async fn exposes_generated_http_functions_as_normal_engine_worker_group() {
             "source": "https://example.test/api",
             "workerName": worker_name
         },
-        "iii": { "virtualWorker": { "name": worker_name } }
+        "iii": { "generatedWorker": { "name": worker_name } }
     }));
 
     let http_fn = iii.register_function((
@@ -218,6 +218,8 @@ async fn exposes_generated_http_functions_as_normal_engine_worker_group() {
             .and_then(Value::as_bool)
             .unwrap_or(true)
     );
+    assert!(worker_value.get("generated_worker").is_none());
+    assert!(worker_value.get("generatedWorker").is_none());
     assert!(worker_value.get("virtual_worker").is_none());
     assert!(worker_value.get("virtualWorker").is_none());
     assert!(worker_value.get("isolation").is_none());


### PR DESCRIPTION
## Summary

- track generated worker groups for externally registered functions without starting generated worker processes
- expose converted OpenAPI/MCP sources as normal engine-runtime worker groups in `engine::workers::list`
- keep generated functions directly triggerable through normal iii function ids
- consume and strip the private `metadata.iii.generatedWorker` hint before public function metadata is stored
- accept the older private `metadata.iii.virtualWorker` key as a compatibility alias
- trust local generated-function bridges only when both the registering worker session and invocation URL are loopback
- enable `iii-http-functions` by default so converted OpenAPI/MCP calls can register without extra config
- cover the generated HTTP worker-group path from the Node, Python, and Rust SDK test suites

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p iii --test generated_worker_bridge_e2e`
- `cargo test -p iii generated_worker --lib`
- `cargo test -p iii test_list_worker_infos_includes_generated_group_without_private_public_shape --lib`
- `cargo test -p iii http_functions --lib`
- `cargo check -p iii --tests`
- `cargo test -p iii --test http_e2e_security`
- `cargo test -p iii --test http_e2e_error_handling`
- `cargo fmt -p iii-sdk -- --check`
- `pnpm install --filter iii-sdk --frozen-lockfile`
- `pnpm --filter iii-sdk exec tsc --noEmit`
- `python3 -m compileall -q sdk/packages/python/iii/src sdk/packages/python/iii/tests/test_http_external_functions_integration.py`
- `cargo test -p iii-sdk --test http_external_functions exposes_generated_http_functions --no-run`
- spec-to-worker repo: `cargo fmt`, `cargo test`, `cargo clippy --all-targets --all-features -- -D warnings`

## Spec-to-Worker E2E Contract

The paired worker PR is iii-experimental/spec-to-worker#13. It now uses generic fixtures and docs instead of Context7-specific examples. The expected contract is:

- OpenAPI conversion registers normal iii functions for each operation
- MCP HTTP conversion registers normal iii functions for each discovered tool
- MCP stdio conversion registers normal iii functions for each discovered tool
- `engine::workers::list` shows the generated source as a normal engine-runtime worker group
- public worker/function payloads do not expose private routing metadata or generated process details
- no generated worker process is started; routing remains engine-owned through HTTP invocation

## Notes

`spec-to-worker::convert` registers normal iii functions backed by HTTP invocation. The engine exposes a user-facing worker grouping for discovery, while routing remains engine-owned and no backing worker process is started for that group. Other workers see ordinary worker/function shapes, not private generated routing details.