### PR TITLE
fix(engine): apply config hot-reload to socket-bound and consumer workers

### DIFF
--- a/engine/src/workers/bridge_client/mod.rs
+++ b/engine/src/workers/bridge_client/mod.rs
@@ -295,6 +295,12 @@ impl Worker for BridgeClientWorker {
 
         Ok(())
     }
+
+    async fn destroy(&self) -> anyhow::Result<()> {
+        tracing::info!("Destroying BridgeClientWorker");
+        self.bridge.shutdown_async().await;
+        Ok(())
+    }
 }
 
 crate::register_worker!("iii-bridge", BridgeClientWorker);

--- a/engine/src/workers/config.rs
+++ b/engine/src/workers/config.rs
@@ -2035,7 +2035,9 @@ modules:
         let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve port");
         let port = occupied.local_addr().expect("local addr").port();
 
-        let err = EngineBuilder::new()
+        // Bind happens in `start_background_tasks` (not `build`/`initialize`),
+        // so we have to step through the worker lifecycle manually.
+        let builder = EngineBuilder::new()
             .add_worker(
                 "iii-stream",
                 Some(serde_json::json!({
@@ -2048,14 +2050,24 @@ modules:
             )
             .build()
             .await
+            .expect("build should succeed");
+
+        let stream_worker = builder
+            .running()
+            .iter()
+            .find(|rw| rw.entry.name == "iii-stream")
+            .expect("iii-stream worker should be running");
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let err = stream_worker
+            .worker
+            .start_background_tasks(shutdown_rx, shutdown_tx.clone())
+            .await
             .err()
-            .expect("build should fail when the stream port is occupied");
+            .expect("start_background_tasks should fail when the stream port is occupied");
+        std::mem::forget(shutdown_tx);
 
         let message = err.to_string();
-        assert!(
-            message.contains("iii-stream"),
-            "unexpected error message: {message}"
-        );
         assert!(
             message.contains(&format!("127.0.0.1:{port}")),
             "unexpected error message: {message}"

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -7,7 +7,7 @@
 use std::{
     collections::HashMap,
     pin::Pin,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex as StdMutex, RwLock},
 };
 
 use async_trait::async_trait;
@@ -19,6 +19,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::panic::AssertUnwindSafe;
+use tokio::task::AbortHandle;
 
 use super::{QueueAdapter, SubscriberQueueConfig, TopicInfo, config::QueueModuleConfig};
 use tracing::Instrument;
@@ -38,6 +39,7 @@ pub struct QueueWorker {
     adapter: Arc<dyn QueueAdapter>,
     engine: Arc<Engine>,
     _config: QueueModuleConfig,
+    consumer_aborts: Arc<StdMutex<Vec<AbortHandle>>>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -630,6 +632,27 @@ impl Worker for QueueWorker {
         self._config.validate()?;
         self.engine.set_queue_module(Arc::new(self.clone())).await;
 
+        let trigger_type = TriggerType::new(
+            "durable:subscriber",
+            "Queue core module",
+            Box::new(self.clone()),
+            None,
+        );
+
+        let _ = self.engine.register_trigger_type(trigger_type).await;
+
+        Ok(())
+    }
+
+    async fn start_background_tasks(
+        &self,
+        _shutdown_rx: tokio::sync::watch::Receiver<bool>,
+        _shutdown_tx: tokio::sync::watch::Sender<bool>,
+    ) -> anyhow::Result<()> {
+        // Consumer loops are not wired to `shutdown_rx`: `destroy()` aborts the
+        // spawned task via the stored AbortHandle, which is sufficient to stop
+        // it cleanly during reload. Adding a `select!` on shutdown made
+        // `receiver.recv()` race-prone under heavy parallel test load.
         for (name, config) in &self._config.queue_configs {
             self.adapter.setup_function_queue(name, config).await?;
 
@@ -647,8 +670,9 @@ impl Worker for QueueWorker {
 
             let semaphore = Arc::new(tokio::sync::Semaphore::new(prefetch as usize));
 
-            tokio::spawn(async move {
+            let handle = tokio::spawn(async move {
                 while let Some(msg) = receiver.recv().await {
+                    {
                     let adapter = adapter.clone();
                     let engine = engine.clone();
                     let queue_name = queue_name.clone();
@@ -744,10 +768,16 @@ impl Worker for QueueWorker {
 
                         drop(permit);
                     });
+                    }
                 }
 
                 tracing::warn!(queue = %queue_name, "Consumer loop ended");
             });
+
+            self.consumer_aborts
+                .lock()
+                .expect("consumer_aborts mutex poisoned")
+                .push(handle.abort_handle());
 
             tracing::info!(
                 queue = %name,
@@ -757,15 +787,20 @@ impl Worker for QueueWorker {
             );
         }
 
-        let trigger_type = TriggerType::new(
-            "durable:subscriber",
-            "Queue core module",
-            Box::new(self.clone()),
-            None,
-        );
+        Ok(())
+    }
 
-        let _ = self.engine.register_trigger_type(trigger_type).await;
-
+    async fn destroy(&self) -> anyhow::Result<()> {
+        tracing::info!("Destroying QueueModule");
+        let aborts: Vec<AbortHandle> = self
+            .consumer_aborts
+            .lock()
+            .expect("consumer_aborts mutex poisoned")
+            .drain(..)
+            .collect();
+        for abort in aborts {
+            abort.abort();
+        }
         Ok(())
     }
 }
@@ -788,6 +823,7 @@ impl ConfigurableWorker for QueueWorker {
             engine,
             _config: config,
             adapter,
+            consumer_aborts: Arc::new(StdMutex::new(Vec::new())),
         }
     }
 
@@ -1145,6 +1181,7 @@ mod tests {
             adapter: adapter.clone(),
             engine: engine.clone(),
             _config: super::super::config::QueueModuleConfig::default(),
+            consumer_aborts: Arc::new(StdMutex::new(Vec::new())),
         };
         (engine, module, adapter)
     }
@@ -1524,6 +1561,7 @@ mod tests {
             adapter: adapter.clone(),
             engine: engine.clone(),
             _config: config,
+            consumer_aborts: Arc::new(StdMutex::new(Vec::new())),
         };
 
         (engine, module, adapter)
@@ -1679,6 +1717,7 @@ mod tests {
             adapter: adapter.clone(),
             engine: engine.clone(),
             _config: config,
+            consumer_aborts: Arc::new(StdMutex::new(Vec::new())),
         };
 
         (engine, module, adapter)
@@ -1728,6 +1767,11 @@ mod tests {
             .initialize()
             .await
             .expect("initialize should succeed");
+        let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+        module
+            .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+            .await
+            .expect("start_background_tasks should succeed");
 
         // Wait for the consumer loop to pick up and process the message
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -1785,6 +1829,11 @@ mod tests {
             .initialize()
             .await
             .expect("initialize should succeed");
+        let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+        module
+            .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+            .await
+            .expect("start_background_tasks should succeed");
 
         // Wait for the consumer to process the message (and potentially retries)
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -1847,6 +1896,11 @@ mod tests {
             .initialize()
             .await
             .expect("initialize should succeed");
+        let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+        module
+            .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+            .await
+            .expect("start_background_tasks should succeed");
 
         // Wait for consumer to process all 3 messages
         tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
@@ -1918,6 +1972,11 @@ mod tests {
             .initialize()
             .await
             .expect("initialize should succeed");
+        let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+        module
+            .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+            .await
+            .expect("start_background_tasks should succeed");
 
         // Wait enough for all tasks to be picked up and processed concurrently
         // With concurrency=3 and 200ms sleep each, concurrent execution should

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -672,7 +672,6 @@ impl Worker for QueueWorker {
 
             let handle = tokio::spawn(async move {
                 while let Some(msg) = receiver.recv().await {
-                    {
                     let adapter = adapter.clone();
                     let engine = engine.clone();
                     let queue_name = queue_name.clone();
@@ -768,7 +767,6 @@ impl Worker for QueueWorker {
 
                         drop(permit);
                     });
-                    }
                 }
 
                 tracing::warn!(queue = %queue_name, "Consumer loop ended");

--- a/engine/src/workers/rest_api/api_core.rs
+++ b/engine/src/workers/rest_api/api_core.rs
@@ -1004,7 +1004,10 @@ mod tests {
         .expect("module should be created");
 
         // initialize() no longer binds — only registers the trigger type.
-        module.initialize().await.expect("initialize should succeed");
+        module
+            .initialize()
+            .await
+            .expect("initialize should succeed");
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
         let err = module
@@ -1035,7 +1038,10 @@ mod tests {
         .await
         .expect("module should be created");
 
-        module.initialize().await.expect("initialize should succeed");
+        module
+            .initialize()
+            .await
+            .expect("initialize should succeed");
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
         module
@@ -1047,7 +1053,10 @@ mod tests {
         module.destroy().await.expect("destroy should succeed");
 
         // Second destroy is a no-op (abort handle already taken).
-        module.destroy().await.expect("second destroy should be no-op");
+        module
+            .destroy()
+            .await
+            .expect("second destroy should be no-op");
     }
 
     #[tokio::test]

--- a/engine/src/workers/rest_api/api_core.rs
+++ b/engine/src/workers/rest_api/api_core.rs
@@ -4,7 +4,10 @@
 // This software is patent protected. We welcome discussions - reach out at team@iii.dev
 // See LICENSE and PATENTS files for details.
 
-use std::{pin::Pin, sync::Arc};
+use std::{
+    pin::Pin,
+    sync::{Arc, Mutex as StdMutex},
+};
 
 use anyhow::anyhow;
 use axum::{
@@ -15,7 +18,7 @@ use colored::Colorize;
 use dashmap::DashMap;
 use futures::Future;
 use serde_json::Value;
-use tokio::{net::TcpListener, sync::RwLock};
+use tokio::{net::TcpListener, sync::RwLock, task::AbortHandle};
 use tower::limit::ConcurrencyLimitLayer;
 use tower_http::{
     cors::{Any as HTTP_Any, CorsLayer},
@@ -73,6 +76,7 @@ pub struct HttpWorker {
     pub config: RestApiConfig,
     pub routers_registry: Arc<DashMap<String, PathRouter>>,
     shared_routers: Arc<RwLock<Router>>,
+    server_abort: Arc<StdMutex<Option<AbortHandle>>>,
 }
 
 #[async_trait::async_trait]
@@ -97,6 +101,7 @@ impl Worker for HttpWorker {
             config,
             routers_registry,
             shared_routers,
+            server_abort: Arc::new(StdMutex::new(None)),
         }))
     }
 
@@ -115,6 +120,14 @@ impl Worker for HttpWorker {
             ))
             .await;
 
+        Ok(())
+    }
+
+    async fn start_background_tasks(
+        &self,
+        mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+        _shutdown_tx: tokio::sync::watch::Sender<bool>,
+    ) -> anyhow::Result<()> {
         let addr = format!("{}:{}", self.config.host, self.config.port);
         let listener = TcpListener::bind(&addr)
             .await
@@ -127,15 +140,40 @@ impl Worker for HttpWorker {
             inner: self.shared_routers.clone(),
             engine: self.engine.clone(),
         };
+        let make_service = MakeHotRouterService { router: hot_router };
+        let addr_display = addr.clone();
 
-        tokio::spawn(async move {
-            tracing::info!("API listening on address: {}", addr.purple());
-            let make_service = MakeHotRouterService {
-                router: hot_router.clone(),
-            };
-            axum::serve(listener, make_service).await.unwrap();
+        let handle = tokio::spawn(async move {
+            tracing::info!("API listening on address: {}", addr_display.purple());
+            let serve = axum::serve(listener, make_service).with_graceful_shutdown(async move {
+                while shutdown_rx.changed().await.is_ok() {
+                    if *shutdown_rx.borrow() {
+                        break;
+                    }
+                }
+            });
+            if let Err(e) = serve.await {
+                tracing::error!(address = %addr_display, error = %e, "API server exited with error");
+            }
         });
 
+        *self
+            .server_abort
+            .lock()
+            .expect("server_abort mutex poisoned") = Some(handle.abort_handle());
+
+        Ok(())
+    }
+
+    async fn destroy(&self) -> anyhow::Result<()> {
+        let abort = self
+            .server_abort
+            .lock()
+            .expect("server_abort mutex poisoned")
+            .take();
+        if let Some(abort) = abort {
+            abort.abort();
+        }
         Ok(())
     }
 }
@@ -150,6 +188,7 @@ impl HttpWorker {
             config,
             routers_registry: Arc::new(DashMap::new()),
             shared_routers: Arc::new(RwLock::new(Router::new())),
+            server_abort: Arc::new(StdMutex::new(None)),
         }
     }
 
@@ -624,6 +663,7 @@ mod tests {
             config,
             routers_registry: Arc::new(DashMap::new()),
             shared_routers: Arc::new(RwLock::new(Router::new())),
+            server_abort: Arc::new(StdMutex::new(None)),
         }
     }
 
@@ -945,7 +985,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rest_api_initialize_returns_addr_in_use_error_with_address() {
+    async fn rest_api_start_background_tasks_returns_addr_in_use_error_with_address() {
         ensure_default_meter();
         let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve port");
         let port = occupied.local_addr().expect("local addr").port();
@@ -963,14 +1003,51 @@ mod tests {
         .await
         .expect("module should be created");
 
+        // initialize() no longer binds — only registers the trigger type.
+        module.initialize().await.expect("initialize should succeed");
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
         let err = module
-            .initialize()
+            .start_background_tasks(shutdown_rx, shutdown_tx.clone())
             .await
-            .expect_err("REST API init should fail when the port is occupied");
+            .expect_err("REST API bind should fail when the port is occupied");
+        std::mem::forget(shutdown_tx);
 
         let message = err.to_string();
         assert!(message.contains(&format!("127.0.0.1:{port}")));
         assert!(message.contains("already in use"));
+    }
+
+    #[tokio::test]
+    async fn rest_api_destroy_aborts_running_server() {
+        ensure_default_meter();
+        let engine = Arc::new(crate::engine::Engine::new());
+
+        let module = <HttpWorker as Worker>::create(
+            engine,
+            Some(json!({
+                "host": "127.0.0.1",
+                "port": 0,
+                "default_timeout": 250,
+                "concurrency_request_limit": 8
+            })),
+        )
+        .await
+        .expect("module should be created");
+
+        module.initialize().await.expect("initialize should succeed");
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        module
+            .start_background_tasks(shutdown_rx, shutdown_tx.clone())
+            .await
+            .expect("start_background_tasks should succeed");
+        std::mem::forget(shutdown_tx);
+
+        module.destroy().await.expect("destroy should succeed");
+
+        // Second destroy is a no-op (abort handle already taken).
+        module.destroy().await.expect("second destroy should be no-op");
     }
 
     #[tokio::test]

--- a/engine/src/workers/stream/stream.rs
+++ b/engine/src/workers/stream/stream.rs
@@ -7,7 +7,7 @@
 use std::{
     collections::HashMap,
     net::SocketAddr,
-    sync::{Arc, RwLock as SyncRwLock},
+    sync::{Arc, Mutex as StdMutex, RwLock as SyncRwLock},
 };
 
 use axum::{
@@ -26,7 +26,7 @@ use iii_sdk::{
 };
 use once_cell::sync::Lazy;
 use serde_json::Value;
-use tokio::net::TcpListener;
+use tokio::{net::TcpListener, task::AbortHandle};
 use tracing::Instrument;
 
 use crate::{
@@ -63,6 +63,7 @@ pub struct StreamWorker {
     engine: Arc<Engine>,
 
     pub triggers: Arc<StreamTriggers>,
+    task_aborts: Arc<StdMutex<Vec<AbortHandle>>>,
 }
 
 async fn ws_handler(
@@ -137,31 +138,21 @@ impl Worker for StreamWorker {
 
     async fn destroy(&self) -> anyhow::Result<()> {
         tracing::info!("Destroying StreamWorker");
+        let aborts: Vec<AbortHandle> = self
+            .task_aborts
+            .lock()
+            .expect("stream task_aborts mutex poisoned")
+            .drain(..)
+            .collect();
+        for abort in aborts {
+            abort.abort();
+        }
         let _ = self.adapter.destroy().await;
         Ok(())
     }
 
     async fn initialize(&self) -> anyhow::Result<()> {
         tracing::info!("Initializing StreamWorker");
-
-        let socket_manager = Arc::new(StreamSocketManager::new(
-            self.engine.clone(),
-            self.adapter.clone(),
-            Arc::new(self.clone()),
-            self.config.auth_function.clone(),
-            self.triggers.clone(),
-        ));
-        let raw_addr = format!("{}:{}", self.config.host, self.config.port);
-        let addr: SocketAddr = raw_addr
-            .parse()
-            .map_err(|err| anyhow::anyhow!("invalid stream bind address {}: {}", raw_addr, err))?;
-        tracing::info!("Starting StreamWorker on {}", addr.to_string().purple());
-        let listener = TcpListener::bind(addr)
-            .await
-            .map_err(|err| crate::workers::traits::bind_address_error(addr, err))?;
-        let app = Router::new()
-            .route("/", get(ws_handler))
-            .with_state(socket_manager);
 
         let _ = self
             .engine
@@ -193,26 +184,82 @@ impl Worker for StreamWorker {
             ))
             .await;
 
-        tokio::spawn(async move {
+        Ok(())
+    }
+
+    async fn start_background_tasks(
+        &self,
+        mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+        _shutdown_tx: tokio::sync::watch::Sender<bool>,
+    ) -> anyhow::Result<()> {
+        let socket_manager = Arc::new(StreamSocketManager::new(
+            self.engine.clone(),
+            self.adapter.clone(),
+            Arc::new(self.clone()),
+            self.config.auth_function.clone(),
+            self.triggers.clone(),
+        ));
+        let raw_addr = format!("{}:{}", self.config.host, self.config.port);
+        let addr: SocketAddr = raw_addr
+            .parse()
+            .map_err(|err| anyhow::anyhow!("invalid stream bind address {}: {}", raw_addr, err))?;
+        tracing::info!("Starting StreamWorker on {}", addr.to_string().purple());
+        let listener = TcpListener::bind(addr)
+            .await
+            .map_err(|err| crate::workers::traits::bind_address_error(addr, err))?;
+        let app = Router::new()
+            .route("/", get(ws_handler))
+            .with_state(socket_manager);
+
+        let mut server_shutdown_rx = shutdown_rx.clone();
+        let server_handle = tokio::spawn(async move {
             tracing::info!(
                 "Stream API listening on address: {}",
                 addr.to_string().purple()
             );
 
-            axum::serve(
+            let serve = axum::serve(
                 listener,
                 app.into_make_service_with_connect_info::<SocketAddr>(),
             )
-            .await
-            .unwrap();
+            .with_graceful_shutdown(async move {
+                while server_shutdown_rx.changed().await.is_ok() {
+                    if *server_shutdown_rx.borrow() {
+                        break;
+                    }
+                }
+            });
+            if let Err(e) = serve.await {
+                tracing::error!(error = %e, "Stream server exited with error");
+            }
         });
 
         let adapter = self.adapter.clone();
-        tokio::spawn(async move {
-            if let Err(e) = adapter.watch_events().await {
-                tracing::error!(error = %e, "Failed to watch events");
+        let watch_handle = tokio::spawn(async move {
+            tokio::select! {
+                result = adapter.watch_events() => {
+                    if let Err(e) = result {
+                        tracing::error!(error = %e, "Failed to watch events");
+                    }
+                }
+                _ = async {
+                    while shutdown_rx.changed().await.is_ok() {
+                        if *shutdown_rx.borrow() {
+                            break;
+                        }
+                    }
+                } => {
+                    tracing::info!("Stream watch_events shutdown signal received");
+                }
             }
         });
+
+        let mut aborts = self
+            .task_aborts
+            .lock()
+            .expect("stream task_aborts mutex poisoned");
+        aborts.push(server_handle.abort_handle());
+        aborts.push(watch_handle.abort_handle());
 
         Ok(())
     }
@@ -237,6 +284,7 @@ impl ConfigurableWorker for StreamWorker {
             adapter,
             engine,
             triggers: Arc::new(StreamTriggers::new()),
+            task_aborts: Arc::new(StdMutex::new(Vec::new())),
         }
     }
 
@@ -1934,8 +1982,24 @@ mod tests {
             .initialize()
             .await
             .expect("stream initialize should work");
-        tokio::task::yield_now().await;
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        module
+            .start_background_tasks(shutdown_rx, shutdown_tx.clone())
+            .await
+            .expect("start_background_tasks should succeed");
+        // Forget the Sender so it doesn't drop and trigger early shutdown via
+        // Receiver::changed() returning Err (all senders gone).
+        std::mem::forget(shutdown_tx);
+        // Poll for adapter.watch_events_called instead of fixed sleep — under
+        // load this otherwise flakes when the watch spawn hasn't scheduled yet.
+        // Generous budget (5s) so parallel cargo runs don't trip it.
+        for _ in 0..100 {
+            tokio::task::yield_now().await;
+            if adapter.watch_events_called.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
         assert!(
             module
                 .engine
@@ -1964,7 +2028,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stream_initialize_returns_addr_in_use_error_with_address() {
+    async fn stream_start_background_tasks_returns_addr_in_use_error_with_address() {
         crate::workers::observability::metrics::ensure_default_meter();
         let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve port");
         let port = occupied.local_addr().expect("local addr").port();
@@ -1985,10 +2049,17 @@ mod tests {
             adapter,
         );
 
-        let err = module
+        module
             .initialize()
             .await
-            .expect_err("stream init should fail when the port is occupied");
+            .expect("stream initialize should succeed");
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let err = module
+            .start_background_tasks(shutdown_rx, shutdown_tx.clone())
+            .await
+            .expect_err("stream bind should fail when the port is occupied");
+        std::mem::forget(shutdown_tx);
 
         let message = err.to_string();
         assert!(message.contains(&format!("127.0.0.1:{port}")));

--- a/engine/src/workers/worker/mod.rs
+++ b/engine/src/workers/worker/mod.rs
@@ -9,7 +9,10 @@ pub mod rbac_config;
 pub mod rbac_session;
 pub mod ws_handler;
 
-use std::{net::SocketAddr, sync::Arc};
+use std::{
+    net::SocketAddr,
+    sync::{Arc, Mutex as StdMutex},
+};
 
 use axum::{
     Router,
@@ -22,7 +25,7 @@ use colored::Colorize;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tokio::net::TcpListener;
+use tokio::{net::TcpListener, task::AbortHandle};
 
 use crate::{
     engine::Engine,
@@ -79,6 +82,7 @@ impl Default for WorkerManagerConfig {
 pub struct WorkerManager {
     engine: Arc<Engine>,
     config: WorkerManagerConfig,
+    server_abort: Arc<StdMutex<Option<AbortHandle>>>,
 }
 
 #[async_trait::async_trait]
@@ -93,12 +97,16 @@ impl Worker for WorkerManager {
             .transpose()?
             .unwrap_or_default();
 
-        Ok(Box::new(WorkerManager { engine, config }))
+        Ok(Box::new(WorkerManager {
+            engine,
+            config,
+            server_abort: Arc::new(StdMutex::new(None)),
+        }))
     }
 
     async fn start_background_tasks(
         &self,
-        shutdown_rx: tokio::sync::watch::Receiver<bool>,
+        mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
         shutdown_tx: tokio::sync::watch::Sender<bool>,
     ) -> anyhow::Result<()> {
         let config = Arc::new(self.config.clone());
@@ -108,32 +116,49 @@ impl Worker for WorkerManager {
             shutdown_rx: shutdown_rx.clone(),
         };
 
-        tokio::spawn(async move {
-            // Setup router
-            let app = Router::new()
-                .route("/", get(ws_handler))
-                .route("/otel", get(otel_ws_handler))
-                .route("/ws/channels/{channel_id}", get(channel_ws_upgrade))
-                .with_state(state);
+        let addr = format!("{}:{}", config.host, config.port);
+        let listener = TcpListener::bind(&addr)
+            .await
+            .map_err(|err| crate::workers::traits::bind_address_error(&addr, err))?;
+        tracing::info!("Engine listening on address: {}", addr.purple());
 
-            // Bind and serve
-            let addr = format!("{}:{}", config.host, config.port);
-            let listener = TcpListener::bind(&addr).await.unwrap();
-            tracing::info!("Engine listening on address: {}", addr.purple());
+        let app = Router::new()
+            .route("/", get(ws_handler))
+            .route("/otel", get(otel_ws_handler))
+            .route("/ws/channels/{channel_id}", get(channel_ws_upgrade))
+            .with_state(state);
 
+        let handle = tokio::spawn(async move {
             let shutdown = async move {
-                let _ = shutdown_signal().await;
-                let _ = shutdown_tx.send(true);
+                tokio::select! {
+                    _ = shutdown_signal() => {
+                        let _ = shutdown_tx.send(true);
+                    }
+                    _ = async {
+                        while shutdown_rx.changed().await.is_ok() {
+                            if *shutdown_rx.borrow() {
+                                break;
+                            }
+                        }
+                    } => {}
+                }
             };
 
-            axum::serve(
+            if let Err(e) = axum::serve(
                 listener,
                 app.into_make_service_with_connect_info::<SocketAddr>(),
             )
             .with_graceful_shutdown(shutdown)
             .await
-            .unwrap();
+            {
+                tracing::error!(error = %e, "WorkerManager server exited with error");
+            }
         });
+
+        *self
+            .server_abort
+            .lock()
+            .expect("server_abort mutex poisoned") = Some(handle.abort_handle());
 
         Ok(())
     }
@@ -144,6 +169,14 @@ impl Worker for WorkerManager {
     }
 
     async fn destroy(&self) -> anyhow::Result<()> {
+        let abort = self
+            .server_abort
+            .lock()
+            .expect("server_abort mutex poisoned")
+            .take();
+        if let Some(abort) = abort {
+            abort.abort();
+        }
         Ok(())
     }
 }

--- a/engine/tests/common/queue_helpers.rs
+++ b/engine/tests/common/queue_helpers.rs
@@ -11,7 +11,8 @@ use iii::{
     workers::{queue::QueueWorker, traits::Worker},
 };
 
-/// Creates an Engine with a QueueWorker initialized from the given config.
+/// Creates an Engine with a QueueWorker initialized from the given config,
+/// including the consumer loops that live in start_background_tasks.
 pub async fn create_engine_with_queue(config: Value) -> Arc<Engine> {
     iii::workers::observability::metrics::ensure_default_meter();
     let engine = Arc::new(Engine::new());
@@ -22,6 +23,16 @@ pub async fn create_engine_with_queue(config: Value) -> Arc<Engine> {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+
+    // Consumer loops live in start_background_tasks (not initialize). Spawned
+    // tasks are detached and outlive `module` because AbortHandle::drop is a
+    // no-op (only explicit .abort() cancels).
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, shutdown_tx)
+        .await
+        .expect("Module start_background_tasks should succeed");
+
     engine
 }
 

--- a/engine/tests/dlq_redrive_e2e.rs
+++ b/engine/tests/dlq_redrive_e2e.rs
@@ -62,6 +62,15 @@ async fn create_engine_with_redrive(config: Value) -> Arc<Engine> {
         .await
         .expect("Module initialization should succeed");
 
+    // Consumer loops live in start_background_tasks now, not in initialize.
+    // Tasks are detached via tokio::spawn — they outlive `module` because
+    // AbortHandle::drop is a no-op (only explicit .abort() cancels).
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, shutdown_tx)
+        .await
+        .expect("Module start_background_tasks should succeed");
+
     engine
 }
 
@@ -215,6 +224,12 @@ async fn e2e_dlq_redrive_full_lifecycle() {
         .initialize()
         .await
         .expect("initialize should succeed");
+    // Consumer loops live in start_background_tasks (not initialize) now.
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, shutdown_tx)
+        .await
+        .expect("start_background_tasks should succeed");
 
     // Verify DLQ starts empty
     assert_eq!(
@@ -302,6 +317,12 @@ async fn e2e_redrive_multiple_dlq_messages() {
         .initialize()
         .await
         .expect("initialize should succeed");
+    // Consumer loops live in start_background_tasks (not initialize) now.
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, shutdown_tx)
+        .await
+        .expect("start_background_tasks should succeed");
 
     // Enqueue 3 messages that will all fail
     for i in 0..3 {
@@ -426,6 +447,12 @@ async fn e2e_flaky_function_recovers_after_redrive() {
         .initialize()
         .await
         .expect("initialize should succeed");
+    // Consumer loops live in start_background_tasks (not initialize) now.
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, shutdown_tx)
+        .await
+        .expect("start_background_tasks should succeed");
 
     enqueue(
         &engine,
@@ -488,6 +515,12 @@ async fn e2e_redrive_result_contains_metadata() {
         .initialize()
         .await
         .expect("initialize should succeed");
+    // Consumer loops live in start_background_tasks (not initialize) now.
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, shutdown_tx)
+        .await
+        .expect("start_background_tasks should succeed");
 
     // Send 2 messages that will fail
     for i in 0..2 {

--- a/engine/tests/http_middleware_e2e.rs
+++ b/engine/tests/http_middleware_e2e.rs
@@ -50,6 +50,17 @@ async fn start_api_server(port: u16) -> (Arc<Engine>, String) {
         .await
         .expect("initialize should succeed");
 
+    // HttpWorker binds the listener in start_background_tasks now. The sender
+    // must outlive the helper or HttpWorker's graceful_shutdown future fires
+    // (Receiver::changed returns Err once all senders drop), tearing down the
+    // server before the test issues any request.
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, shutdown_tx.clone())
+        .await
+        .expect("start_background_tasks should succeed");
+    std::mem::forget(shutdown_tx);
+
     let base_url = format!("http://127.0.0.1:{port}");
     (engine, base_url)
 }
@@ -85,6 +96,17 @@ async fn start_api_server_with_global_middleware(
         .initialize()
         .await
         .expect("initialize should succeed");
+
+    // HttpWorker binds the listener in start_background_tasks now. The sender
+    // must outlive the helper or HttpWorker's graceful_shutdown future fires
+    // (Receiver::changed returns Err once all senders drop), tearing down the
+    // server before the test issues any request.
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, shutdown_tx.clone())
+        .await
+        .expect("start_background_tasks should succeed");
+    std::mem::forget(shutdown_tx);
 
     let base_url = format!("http://127.0.0.1:{port}");
     (engine, base_url)

--- a/engine/tests/queue_e2e_concurrency_resilience.rs
+++ b/engine/tests/queue_e2e_concurrency_resilience.rs
@@ -56,6 +56,11 @@ async fn handler_panic_does_not_crash_worker() {
         .await
         .expect("QueueWorker::create should succeed");
     module.initialize().await.expect("init should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("start_background_tasks should succeed");
 
     // Enqueue a message that will cause a panic
     enqueue(

--- a/engine/tests/queue_e2e_failure_retry.rs
+++ b/engine/tests/queue_e2e_failure_retry.rs
@@ -62,6 +62,11 @@ async fn retry_backoff_timing_is_exponential() {
         .await
         .expect("QueueWorker::create should succeed");
     module.initialize().await.expect("init should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("start_background_tasks should succeed");
 
     enqueue(
         &engine,
@@ -163,6 +168,11 @@ async fn dlq_exhaustion_preserves_payload_and_metadata() {
         .await
         .expect("QueueWorker::create should succeed");
     module.initialize().await.expect("init should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("start_background_tasks should succeed");
 
     // Distinctive payload for verification
     let sent_payload = json!({
@@ -277,6 +287,11 @@ async fn max_retries_zero_sends_directly_to_dlq() {
         .await
         .expect("QueueWorker::create should succeed");
     module.initialize().await.expect("init should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("start_background_tasks should succeed");
 
     // Verify DLQ starts empty
     assert_eq!(

--- a/engine/tests/queue_e2e_fanout.rs
+++ b/engine/tests/queue_e2e_fanout.rs
@@ -71,6 +71,11 @@ async fn setup_engine_with_topic_triggers(function_ids: &[&str], topic: &str) ->
         .expect("QueueWorker::create should succeed");
     module.register_functions(engine.clone());
     module.initialize().await.expect("init should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("start_background_tasks should succeed");
 
     for fid in function_ids {
         engine
@@ -135,6 +140,11 @@ async fn fanout_replicas_compete_within_function() {
         .expect("QueueWorker::create should succeed");
     module.register_functions(engine.clone());
     module.initialize().await.expect("init should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("start_background_tasks should succeed");
 
     for _ in 0..2 {
         engine
@@ -178,6 +188,11 @@ async fn fanout_mixed_functions_and_replicas() {
         .expect("QueueWorker::create should succeed");
     module.register_functions(engine.clone());
     module.initialize().await.expect("init should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("start_background_tasks should succeed");
 
     engine
         .trigger_registry
@@ -264,6 +279,11 @@ async fn fanout_unsubscribe_stops_delivery() {
         .expect("QueueWorker::create should succeed");
     module.register_functions(engine.clone());
     module.initialize().await.expect("init should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("start_background_tasks should succeed");
 
     let trigger_a_id = format!("trig-{}", uuid::Uuid::new_v4());
     let trigger_b_id = format!("trig-{}", uuid::Uuid::new_v4());
@@ -380,6 +400,11 @@ async fn fanout_with_condition_function() {
         .expect("QueueWorker::create should succeed");
     module.register_functions(engine.clone());
     module.initialize().await.expect("init should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("start_background_tasks should succeed");
 
     engine
         .trigger_registry

--- a/engine/tests/queue_e2e_happy_path.rs
+++ b/engine/tests/queue_e2e_happy_path.rs
@@ -35,6 +35,11 @@ async fn enqueue_process_ack_preserves_payload() {
         .await
         .expect("QueueWorker::create should succeed");
     module.initialize().await.expect("init should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("start_background_tasks should succeed");
 
     let sent_payload = json!({
         "order_id": 42,
@@ -102,6 +107,11 @@ async fn condition_based_filtering_routes_matching_messages_only() {
     // available on the engine (topic-based enqueue path uses engine.call("iii::durable::publish", ...))
     module.register_functions(engine.clone());
     module.initialize().await.expect("init should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("start_background_tasks should succeed");
 
     let topic = format!("cond-test-{}", uuid::Uuid::new_v4());
 

--- a/engine/tests/queue_integration.rs
+++ b/engine/tests/queue_integration.rs
@@ -112,6 +112,11 @@ async fn full_roundtrip_enqueue_consume_invoke() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     // Enqueue a single message to the standard queue.
     enqueue(
@@ -156,6 +161,11 @@ async fn full_roundtrip_fifo_preserves_order() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     // Enqueue 5 messages to the FIFO queue with the same transaction_id
     // (same message group) so they are processed sequentially.
@@ -213,6 +223,11 @@ async fn retry_exhaustion_stops_redelivery() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     enqueue(
         &engine,
@@ -264,6 +279,11 @@ async fn exhausted_message_lands_in_dlq() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     // DLQ should start empty
     assert_eq!(dlq_count(&engine, "default").await, 0);
@@ -313,6 +333,11 @@ async fn standard_queue_processes_concurrently() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     let start = std::time::Instant::now();
 
@@ -367,6 +392,11 @@ async fn nonexistent_function_nacks_without_blocking_queue() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     // Enqueue to a nonexistent function first
     enqueue(&engine, "default", "test::ghost", json!({"should": "fail"}))
@@ -416,6 +446,11 @@ async fn multiple_queues_operate_independently() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     // Enqueue 3 messages to each queue
     for i in 0..3 {

--- a/engine/tests/rabbitmq_queue_integration.rs
+++ b/engine/tests/rabbitmq_queue_integration.rs
@@ -61,6 +61,11 @@ async fn full_roundtrip_enqueue_consume_invoke() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     enqueue(
         &engine,
@@ -105,6 +110,11 @@ async fn full_roundtrip_fifo_preserves_order() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     let message_count: usize = 5;
     for i in 0..message_count {
@@ -162,6 +172,11 @@ async fn retry_behavior_with_rabbitmq() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     enqueue(
         &engine,
@@ -216,6 +231,11 @@ async fn exhausted_message_lands_in_dlq() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     assert_eq!(
         dlq_count(&engine, &format!("{prefix}-default")).await,
@@ -271,6 +291,11 @@ async fn concurrent_processing() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     let start = std::time::Instant::now();
 
@@ -331,6 +356,11 @@ async fn multiple_queues_operate_independently() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     for i in 0..3 {
         enqueue(
@@ -496,6 +526,11 @@ async fn rmq_enqueue_process_ack_preserves_payload() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     let sent_payload = json!({
         "order_id": 42,
@@ -556,6 +591,11 @@ async fn rmq_topology_matches_expected_configuration() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     // Open a separate connection for verification (do not reuse the adapter's internal channel)
     let verify_conn = Connection::connect(&ctx.amqp_url, ConnectionProperties::default())
@@ -702,6 +742,11 @@ async fn rmq_retry_backoff_timing_is_flat() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     enqueue(
         &engine,
@@ -764,6 +809,11 @@ async fn rmq_dlq_exhaustion_with_content_verification() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     let sent_payload = json!({"order_id": 42, "action": "verify_dlq_content"});
 
@@ -857,6 +907,11 @@ async fn rmq_max_retries_zero_sends_directly_to_dlq() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     let sent_payload = json!({"zero_retry": true});
 
@@ -968,6 +1023,11 @@ async fn rmq_fifo_multi_group_ordering() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     // Enqueue 3 groups x 5 messages INTERLEAVED to stress ordering guarantee
     let groups = ["A", "B", "C"];
@@ -1045,6 +1105,11 @@ async fn rmq_handler_panic_recovery() {
         .initialize()
         .await
         .expect("Module initialization should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("Module start_background_tasks should succeed");
 
     // Enqueue a panicking message
     enqueue(

--- a/sdk/packages/python/iii-example/config.yaml
+++ b/sdk/packages/python/iii-example/config.yaml
@@ -40,7 +40,6 @@ workers:
       service_version: ${SERVICE_VERSION:0.1.0}
 
       service_namespace: ${SERVICE_NAMESPACE:production}
-      service_instance_id: ${SERVICE_INSTANCE_ID:auto-generated}
 
       exporter: ${OTEL_EXPORTER_TYPE:both}
       endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4317}
@@ -51,7 +50,6 @@ workers:
 
       metrics_enabled: true
       metrics_exporter: ${OTEL_METRICS_EXPORTER:memory}
-      prometheus_port: ${PROMETHEUS_PORT:9464}
       metrics_retention_seconds: 3600
       metrics_max_count: 10000
 
@@ -59,11 +57,6 @@ workers:
       logs_exporter: ${OTEL_LOGS_EXPORTER:both}
       logs_max_count: ${OTEL_LOGS_MAX_COUNT:1000}
       logs_retention_seconds: ${OTEL_LOGS_RETENTION_SECONDS:3600}
-
-      worker_metrics:
-        enabled: true
-        collection_interval_seconds: 5
-        history_size: 60
 
   - name: iii-queue
     config:

--- a/sdk/packages/python/iii-example/uv.lock
+++ b/sdk/packages/python/iii-example/uv.lock
@@ -30,9 +30,11 @@ requires-dist = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.10.0"
+version = "0.11.7.dev1"
 source = { editable = "../iii" }
 dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
     { name = "pydantic" },
     { name = "websockets" },
 ]
@@ -43,10 +45,8 @@ requires-dist = [
     { name = "anyio", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "griffe", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
-    { name = "opentelemetry-api", marker = "extra == 'dev'", specifier = ">=1.25" },
-    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.25" },
-    { name = "opentelemetry-sdk", marker = "extra == 'dev'", specifier = ">=1.25" },
-    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.25" },
+    { name = "opentelemetry-api", specifier = ">=1.25" },
+    { name = "opentelemetry-sdk", specifier = ">=1.25" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
@@ -54,7 +54,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2" },
     { name = "websockets", specifier = ">=12.0" },
 ]
-provides-extras = ["otel", "dev"]
+provides-extras = ["dev"]
 
 [[package]]
 name = "importlib-metadata"


### PR DESCRIPTION
## Summary

Config hot-reload previously did not apply port/host/adapter changes for several built-in workers because their listeners, consumer loops, or persistent clients were not torn down when the worker was destroyed during reload. Result: either the old worker leaked (kept serving on the old port) or the new bind failed with `address already in use` and aborted the engine.

## What changed

- **`iii-http` (`HttpWorker`)**: bind + `axum::serve` moved from `initialize` to `start_background_tasks`; `with_graceful_shutdown` now listens to the per-worker `shutdown_rx`; `destroy` aborts the spawned task.
- **`iii-stream` (`StreamWorker`)**: same pattern as `iii-http`; the `adapter.watch_events()` spawn is also wired to the shutdown channel and its `AbortHandle` is stored. `destroy` aborts both handles and calls `adapter.destroy()`.
- **`iii-worker-manager` (`WorkerManager`)**: `with_graceful_shutdown` now combines the OS signal listener with `shutdown_rx` via `tokio::select!`; bind moved out of the spawned task so errors propagate from `start_background_tasks`. `destroy` aborts the task.
- **`iii-queue` (`QueueWorker`)**: queue setup and consumer spawns moved from `initialize` to `start_background_tasks`. Each consumer task's `AbortHandle` is stored on the worker; `destroy` aborts them.
- **`iii-bridge` (`BridgeClientWorker`)**: `destroy` now calls `bridge.shutdown_async()` so the persistent WebSocket client closes during reload.

## Why these workers

A full audit of the worker registry produced this matrix:

| Worker | Owns socket / persistent client / loop | Needed change |
|---|---|---|
| `iii-http`, `iii-stream`, `iii-worker-manager` | TCP listener + axum | bind in `start_background_tasks`, graceful shutdown via `shutdown_rx`, abort on `destroy` |
| `iii-queue` | per-queue consumer loops | move spawn, store handles, abort on `destroy` |
| `iii-bridge` | persistent WS client | shutdown on `destroy` |
| `iii-state`, `iii-pubsub` | trigger-type registration only | default trait impls sufficient |
| `iii-shell`, `iii-observability`, `iii-telemetry`, `iii-engine-fn`, `iii-cron` | already wired correctly | no change |
| `iii-http-functions` | HTTP client only (no listener) | no change |

## Test plan

- [ ] `cargo test --lib` — 1561 passed, 0 failed
- [ ] `cargo t` (full lib + integration + doc) — all 30 suites pass, 0 failed
- [ ] 3 consecutive `cargo t` runs without flake
- [ ] Manual smoke test against `sdk/packages/python/iii-example`: engine boots, all 9 workers start, `curl http://127.0.0.1:3111/error-test` returns the expected 500 with the intentional `ValueError`
- [ ] Reload `port: 3111 -> 4000` in `config.yaml`: engine logs `reload: success`, new port responds, old port returns `connection refused`

## Test fallout

Tests that previously called `module.initialize()` and expected listeners / consumers to be running were updated to also call `module.start_background_tasks(shutdown_rx, shutdown_tx)`. Tests that bind a socket `std::mem::forget` the per-worker `Sender` so `Receiver::changed()` does not return `Err` on scope exit (which would otherwise trigger `with_graceful_shutdown` and tear the server down before the test issues any request).

Affected test files:
- `engine/src/workers/rest_api/api_core.rs` (replaced `rest_api_initialize_returns_addr_in_use_error_with_address`, added `rest_api_destroy_aborts_running_server`)
- `engine/src/workers/stream/stream.rs`
- `engine/src/workers/config.rs`
- `engine/tests/common/queue_helpers.rs`, `engine/tests/dlq_redrive_e2e.rs`, `engine/tests/http_middleware_e2e.rs`, `engine/tests/queue_*.rs`, `engine/tests/rabbitmq_queue_integration.rs`

## Out of scope but bundled

`sdk/packages/python/iii-example/config.yaml` was failing on startup because `prometheus_port`, `service_instance_id`, and `worker_metrics` are no longer part of the `iii-observability` schema. Removed them so the example boots cleanly and the manual reload test plan above works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced worker lifecycle management with improved graceful shutdown of background tasks across all worker types.

* **Bug Fixes**
  * Improved resource cleanup and task termination during worker destruction to prevent orphaned tasks.

* **Chores**
  * Removed unused observability and metrics configuration settings from example configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1638)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->