### PR TITLE
ci: scope license agreement check to engine PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,9 +9,3 @@
 ## Notes
 
 <!-- Anything reviewers should know (breaking changes, migration steps, etc.) -->
-
----
-
-<!-- This box must be checked in order to submit a PR -->
-
-- [ ] I am licensing the entirety of this PR under Apache 2 and have all necessary rights to the code I am contributing.

--- a/.github/scripts/license-agreement-check.mjs
+++ b/.github/scripts/license-agreement-check.mjs
@@ -2,25 +2,24 @@ import { readFile } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 
 export const AGREEMENT_TEXT =
-  'I am licensing the entirety of this PR under Apache 2 and have all necessary rights to the code I am contributing.';
+  'I agree that my contributions in this PR to the engine code are licensed under Apache 2.0.';
 export const ACKNOWLEDGEMENT_PHRASE = AGREEMENT_TEXT;
 export const STATUS_CONTEXT = 'license-agreement';
 export const STICKY_COMMENT_MARKER = '<!-- iii-license-agreement-check -->';
+export const ENGINE_PATH_PREFIX = 'engine/';
 
 const TEAM_PERMISSIONS = new Set(['write', 'maintain', 'admin']);
 const BOT_LOGINS = new Set(['github-actions[bot]']);
 
-export function hasCheckedLicenseAgreement(body = '') {
-  return String(body ?? '')
-    .split(/\r?\n/)
-    .some((line) => {
-      const match = line.match(/^\s*-\s*\[[xX]\]\s*(.*)$/);
-      return match && normalizeAgreementText(match[1]) === normalizeAgreementText(AGREEMENT_TEXT);
-    });
-}
-
 export function normalizeAgreementText(value = '') {
   return value.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+export function touchesEnginePaths(files = []) {
+  return files.some((file) => {
+    const name = typeof file === 'string' ? file : (file?.filename ?? '');
+    return name.startsWith(ENGINE_PATH_PREFIX);
+  });
 }
 
 export function isTeamPermission(permission = '') {
@@ -58,15 +57,20 @@ export function findStickyComment(comments = []) {
   );
 }
 
-export function evaluateAgreement({ body = '', comments = [], permission = '', prAuthor = '' }) {
+export function evaluateAgreement({
+  comments = [],
+  permission = '',
+  prAuthor = '',
+  changedFiles = [],
+} = {}) {
   const teamMember = isTeamPermission(permission);
-  const bodyAcknowledged = hasCheckedLicenseAgreement(body);
+  const engineTouched = touchesEnginePaths(changedFiles);
   const commentAcknowledged = hasAgreementComment(comments, prAuthor);
-  const acknowledged = teamMember || bodyAcknowledged || commentAcknowledged;
+  const acknowledged = !engineTouched || teamMember || commentAcknowledged;
 
   return {
     acknowledged,
-    bodyAcknowledged,
+    engineTouched,
     commentAcknowledged,
     teamMember,
   };
@@ -77,25 +81,20 @@ export function buildPendingComment(prAuthor) {
     STICKY_COMMENT_MARKER,
     '## License agreement required',
     '',
-    `@${prAuthor}, thanks for contributing. Before this PR can be merged, please acknowledge the contributor license agreement:`,
+    `@${prAuthor}, this PR touches engine code. For us to accept it, we need your explicit confirmation in this thread that you license your changes to the engine portion of the codebase under Apache 2.0.`,
+    '',
+    'Please reply with:',
     '',
     `> ${AGREEMENT_TEXT}`,
-    '',
-    'You can satisfy this requirement in either of these ways:',
-    '',
-    `- Check the license agreement box in the PR description.`,
-    `- Reply to this PR with exactly: ${ACKNOWLEDGEMENT_PHRASE}`,
   ].join('\n');
 }
 
-export function buildSatisfiedComment(prAuthor, source) {
-  const sourceLabel = source === 'comment' ? 'PR comment' : 'PR description checkbox';
-
+export function buildSatisfiedComment(prAuthor) {
   return [
     STICKY_COMMENT_MARKER,
     '## License agreement recorded',
     '',
-    `@${prAuthor}, the license agreement acknowledgement has been recorded from the ${sourceLabel}.`,
+    `@${prAuthor}, the engine license agreement has been recorded from your PR reply.`,
     '',
     `> ${AGREEMENT_TEXT}`,
   ].join('\n');
@@ -180,6 +179,21 @@ async function listIssueComments({ owner, repo, issueNumber }) {
   }
 }
 
+async function listPullRequestFiles({ owner, repo, pullNumber }) {
+  const files = [];
+
+  for (let page = 1; ; page += 1) {
+    const batch = await githubRequest(
+      `/repos/${owner}/${repo}/pulls/${pullNumber}/files?per_page=100&page=${page}`,
+    );
+    files.push(...batch);
+
+    if (batch.length < 100) {
+      return files;
+    }
+  }
+}
+
 async function upsertStickyComment({ owner, repo, issueNumber, comments, body }) {
   const stickyComment = findStickyComment(comments);
 
@@ -244,13 +258,33 @@ export async function run() {
   const { issueNumber, pullRequest } = prContext;
   const prAuthor = pullRequest.user.login;
   const headSha = pullRequest.head.sha;
+  const changedFiles = await listPullRequestFiles({
+    owner,
+    repo,
+    pullNumber: pullRequest.number,
+  });
+
+  if (!touchesEnginePaths(changedFiles)) {
+    await createCommitStatus({
+      owner,
+      repo,
+      sha: headSha,
+      state: 'success',
+      description: 'PR does not touch engine code; license agreement not required.',
+    });
+    console.log(
+      `Skipping license agreement check for PR #${pullRequest.number}; no engine files touched.`,
+    );
+    return;
+  }
+
   const comments = await listIssueComments({ owner, repo, issueNumber });
   const permission = await getPermission({ owner, repo, username: prAuthor });
   const result = evaluateAgreement({
-    body: pullRequest.body || '',
     comments,
     permission,
     prAuthor,
+    changedFiles,
   });
 
   if (result.teamMember) {
@@ -266,13 +300,12 @@ export async function run() {
   }
 
   if (result.acknowledged) {
-    const source = result.commentAcknowledged ? 'comment' : 'body';
     await upsertStickyComment({
       owner,
       repo,
       issueNumber,
       comments,
-      body: buildSatisfiedComment(prAuthor, source),
+      body: buildSatisfiedComment(prAuthor),
     });
     await createCommitStatus({
       owner,
@@ -281,7 +314,7 @@ export async function run() {
       state: 'success',
       description: 'License agreement acknowledged.',
     });
-    console.log(`License agreement acknowledged by ${prAuthor} through ${source}.`);
+    console.log(`License agreement acknowledged by ${prAuthor} through PR comment.`);
     return;
   }
 
@@ -300,7 +333,7 @@ export async function run() {
     description: 'License agreement acknowledgement required.',
   });
   console.error(
-    `::error::License agreement acknowledgement required. ${prAuthor} must check the PR description box or reply with the exact acknowledgement phrase.`,
+    `::error::License agreement acknowledgement required. ${prAuthor} must reply with the exact acknowledgement phrase.`,
   );
   process.exitCode = 1;
 }

--- a/.github/scripts/license-agreement-check.mjs
+++ b/.github/scripts/license-agreement-check.mjs
@@ -17,8 +17,13 @@ export function normalizeAgreementText(value = '') {
 
 export function touchesEnginePaths(files = []) {
   return files.some((file) => {
-    const name = typeof file === 'string' ? file : (file?.filename ?? '');
-    return name.startsWith(ENGINE_PATH_PREFIX);
+    if (typeof file === 'string') {
+      return file.startsWith(ENGINE_PATH_PREFIX);
+    }
+    if (file?.filename?.startsWith(ENGINE_PATH_PREFIX)) {
+      return true;
+    }
+    return Boolean(file?.previous_filename?.startsWith(ENGINE_PATH_PREFIX));
   });
 }
 

--- a/.github/scripts/license-agreement-check.test.mjs
+++ b/.github/scripts/license-agreement-check.test.mjs
@@ -7,42 +7,10 @@ import {
   evaluateAgreement,
   findStickyComment,
   hasAgreementComment,
-  hasCheckedLicenseAgreement,
   isAgreementComment,
   isTeamPermission,
+  touchesEnginePaths,
 } from './license-agreement-check.mjs';
-
-test('detects a checked Apache license agreement in the PR body', () => {
-  const body = [
-    '## What',
-    'A contribution',
-    '',
-    '- [x] I am licensing the entirety of this PR under Apache 2 and have all necessary rights to the code I am contributing.',
-  ].join('\n');
-
-  assert.equal(hasCheckedLicenseAgreement(body), true);
-});
-
-test('detects an uppercase checked Apache license agreement in the PR body', () => {
-  const body = `- [X] ${ACKNOWLEDGEMENT_PHRASE}`;
-
-  assert.equal(hasCheckedLicenseAgreement(body), true);
-});
-
-test('handles a null PR body', () => {
-  assert.equal(hasCheckedLicenseAgreement(null), false);
-});
-
-test('rejects an unchecked Apache license agreement in the PR body', () => {
-  const body =
-    '- [ ] I am licensing the entirety of this PR under Apache 2 and have all necessary rights to the code I am contributing.';
-
-  assert.equal(hasCheckedLicenseAgreement(body), false);
-});
-
-test('rejects checked tasks that do not mention licensing and Apache', () => {
-  assert.equal(hasCheckedLicenseAgreement('- [x] Tests pass locally'), false);
-});
 
 test('accepts the exact acknowledgement phrase from the PR author', () => {
   const comment = {
@@ -119,49 +87,94 @@ test('classifies read, triage, and none permissions as external contributors', (
   assert.equal(isTeamPermission('none'), false);
 });
 
-test('passes team members without an acknowledgement', () => {
+test('touchesEnginePaths returns true for engine src changes', () => {
+  assert.equal(touchesEnginePaths([{ filename: 'engine/src/foo.rs' }]), true);
+});
+
+test('touchesEnginePaths returns true for top-level engine files', () => {
+  assert.equal(touchesEnginePaths([{ filename: 'engine/Cargo.toml' }]), true);
+});
+
+test('touchesEnginePaths returns false for non-engine changes', () => {
+  assert.equal(
+    touchesEnginePaths([{ filename: 'console/x.ts' }, { filename: 'docs/y.md' }]),
+    false,
+  );
+});
+
+test('touchesEnginePaths returns false for empty list', () => {
+  assert.equal(touchesEnginePaths([]), false);
+});
+
+test('touchesEnginePaths accepts plain string entries', () => {
+  assert.equal(touchesEnginePaths(['engine/src/foo.rs']), true);
+  assert.equal(touchesEnginePaths(['console/foo.ts']), false);
+});
+
+test('touchesEnginePaths does not match unrelated paths that contain "engine"', () => {
+  assert.equal(touchesEnginePaths([{ filename: 'docs/engine-overview.md' }]), false);
+  assert.equal(touchesEnginePaths([{ filename: 'crates/engine-utils/src/lib.rs' }]), false);
+});
+
+test('passes any PR that does not touch engine code regardless of permission', () => {
   const result = evaluateAgreement({
-    body: '',
     comments: [],
-    permission: 'write',
-    prAuthor: 'team-member',
+    permission: 'none',
+    prAuthor: 'external-user',
+    changedFiles: [{ filename: 'docs/intro.md' }],
   });
 
   assert.deepEqual(result, {
     acknowledged: true,
-    bodyAcknowledged: false,
+    engineTouched: false,
+    commentAcknowledged: false,
+    teamMember: false,
+  });
+});
+
+test('passes team members touching engine code without an acknowledgement', () => {
+  const result = evaluateAgreement({
+    comments: [],
+    permission: 'write',
+    prAuthor: 'team-member',
+    changedFiles: [{ filename: 'engine/src/lib.rs' }],
+  });
+
+  assert.deepEqual(result, {
+    acknowledged: true,
+    engineTouched: true,
     commentAcknowledged: false,
     teamMember: true,
   });
 });
 
-test('passes external contributors with an acknowledgement comment', () => {
+test('passes external contributors touching engine code with an acknowledgement comment', () => {
   const result = evaluateAgreement({
-    body: '',
     comments: [{ body: ACKNOWLEDGEMENT_PHRASE, user: { login: 'external-user' } }],
     permission: 'read',
     prAuthor: 'external-user',
+    changedFiles: [{ filename: 'engine/src/lib.rs' }],
   });
 
   assert.deepEqual(result, {
     acknowledged: true,
-    bodyAcknowledged: false,
+    engineTouched: true,
     commentAcknowledged: true,
     teamMember: false,
   });
 });
 
-test('fails external contributors without body or comment acknowledgement', () => {
+test('fails external contributors touching engine code without acknowledgement', () => {
   const result = evaluateAgreement({
-    body: '',
     comments: [],
     permission: 'none',
     prAuthor: 'external-user',
+    changedFiles: [{ filename: 'engine/src/lib.rs' }],
   });
 
   assert.deepEqual(result, {
     acknowledged: false,
-    bodyAcknowledged: false,
+    engineTouched: true,
     commentAcknowledged: false,
     teamMember: false,
   });

--- a/.github/scripts/license-agreement-check.test.mjs
+++ b/.github/scripts/license-agreement-check.test.mjs
@@ -116,6 +116,24 @@ test('touchesEnginePaths does not match unrelated paths that contain "engine"', 
   assert.equal(touchesEnginePaths([{ filename: 'crates/engine-utils/src/lib.rs' }]), false);
 });
 
+test('touchesEnginePaths detects files renamed out of engine/', () => {
+  assert.equal(
+    touchesEnginePaths([
+      { filename: 'other/x.rs', previous_filename: 'engine/x.rs', status: 'renamed' },
+    ]),
+    true,
+  );
+});
+
+test('touchesEnginePaths detects files renamed into engine/', () => {
+  assert.equal(
+    touchesEnginePaths([
+      { filename: 'engine/x.rs', previous_filename: 'other/x.rs', status: 'renamed' },
+    ]),
+    true,
+  );
+});
+
 test('passes any PR that does not touch engine code regardless of permission', () => {
   const result = evaluateAgreement({
     comments: [],
@@ -162,6 +180,23 @@ test('passes external contributors touching engine code with an acknowledgement 
     commentAcknowledged: true,
     teamMember: false,
   });
+});
+
+test('accepts acknowledgement with normalized case and whitespace', () => {
+  const result = evaluateAgreement({
+    comments: [
+      {
+        body: `  ${ACKNOWLEDGEMENT_PHRASE.toUpperCase()}  `,
+        user: { login: 'external-user' },
+      },
+    ],
+    permission: 'read',
+    prAuthor: 'external-user',
+    changedFiles: [{ filename: 'engine/src/lib.rs' }],
+  });
+
+  assert.equal(result.acknowledged, true);
+  assert.equal(result.commentAcknowledged, true);
 });
 
 test('fails external contributors touching engine code without acknowledgement', () => {


### PR DESCRIPTION
## What

Narrow the contributor license agreement check to PRs that actually touch `engine/**`, and switch from a PR-description checkbox to an explicit in-thread reply from the PR author.

When the check fires, the bot now posts:

> This PR touches engine code. For us to accept it, we need your explicit confirmation in this thread that you license your changes to the engine portion of the codebase under Apache 2.0.
>
> Please reply with:
>  "I agree that my contributions in this PR to the engine code are licensed under Apache 2.0."

The PR passes once the author replies with that exact sentence in a top-level PR comment.

## Why

The agreement only matters for the engine portion of the codebase, which is licensed differently from the rest of the repo. Asking every contributor (docs, blog, website, console, SDK, infra…) to tick an Apache-2 box was both noisy and misleading — the rest of the repo is already Apache 2 by default and the engine subtree has its own license. Scoping the check to engine PRs and requiring an explicit thread reply makes the intent clear and the policy enforceable.

## Notes

- **Status context unchanged.** The commit-status context stays `license-agreement` so existing branch-protection rules continue to apply.
- **Team members remain exempt.** Anyone with `write`/`maintain`/`admin` permission still skips the check.
- **PR template.** The Apache 2 checkbox and surrounding boilerplate were removed; the template is now just What / Why / Notes.
- **Engine boundary.** Any change under `engine/**` triggers the check. This is broader than `engine/licenserc.toml`'s header-scope (`engine/src/**/*.rs`, `engine/function-macros/src/**/*.rs`) on purpose — the contribution agreement covers the whole engine subtree (Cargo manifests, build files, tests, etc.).
- **Non-engine PRs.** Pass with a success commit status described as "PR does not touch engine code; license agreement not required." No sticky comment is posted.
- **Acceptance is exact-match.** Leading/trailing whitespace and case are normalized; embedded matches and bot-authored comments are rejected (existing behavior, retained).

## Test plan

- [x] Unit tests pass locally: `node --test .github/scripts/license-agreement-check.test.mjs` (19/19).
- [ ] Open a PR touching only `docs/**` from an external account → `license-agreement` status reports success with the "does not touch engine code" description; no sticky comment is posted.
- [ ] Open a PR touching `engine/src/**` from an external account → sticky comment appears with the engine prompt; `license-agreement` status fails.
- [ ] Reply to that PR with the exact agreement phrase → workflow re-runs on `issue_comment`, sticky updates to "recorded", status flips to success.
- [ ] Reply with a near-miss (extra word / different punctuation) → status remains failure.
- [ ] Open an engine-touching PR from a team-member account → status succeeds with the "iii team member" description; no prompt is posted.
- [ ] Confirm in the GitHub UI that the required check is still named `license-agreement`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the manual PR checkbox that required contributors to confirm a blanket Apache-2 license acknowledgement.
  * License verification now evaluates changed files to decide whether an explicit acknowledgement is needed, reducing unnecessary prompts for non-engine changes.

* **Tests**
  * Updated unit tests to cover the new file-based license detection and revised evaluation outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1641)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->