### PR TITLE
feat(engine): trace correlation Layers 2B + 3a

### DIFF
--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -26,8 +26,8 @@ use crate::{
     protocol::{ErrorBody, Message},
     services::{Service, ServicesRegistry},
     telemetry::{
-        ingest_otlp_json, ingest_otlp_logs, ingest_otlp_metrics,
-        inject_baggage_from_context, inject_traceparent_from_context,
+        ingest_otlp_json, ingest_otlp_logs, ingest_otlp_metrics, inject_baggage_from_context,
+        inject_traceparent_from_context,
     },
     trigger::{Trigger, TriggerRegistry, TriggerType},
     worker_connections::{RuntimeWorkerInfo, WorkerConnection, WorkerConnectionRegistry},
@@ -472,10 +472,8 @@ impl Engine {
             // Parent context must be on `Context::current()` BEFORE span
             // creation so `SpanProcessor::on_start` sees the baggage;
             // `set_parent` after creation runs too late.
-            let parent_cx = crate::telemetry::extract_context(
-                traceparent.as_deref(),
-                baggage.as_deref(),
-            );
+            let parent_cx =
+                crate::telemetry::extract_context(traceparent.as_deref(), baggage.as_deref());
             let _guard = parent_cx.attach();
             tracing::info_span!(
                 "handle_invocation",

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -469,11 +469,9 @@ impl Engine {
         invocation_id: Option<Uuid>,
     ) {
         let span = {
-            // Attach the incoming OTel context (traceparent + baggage)
-            // BEFORE creating the span so `BaggageSpanProcessor::on_start`
-            // sees iii.session.id / iii.message.id / iii.function.id in
-            // `Context::current()` and copies them onto this span as
-            // attributes.
+            // Parent context must be on `Context::current()` BEFORE span
+            // creation so `SpanProcessor::on_start` sees the baggage;
+            // `set_parent` after creation runs too late.
             let parent_cx = crate::telemetry::extract_context(
                 traceparent.as_deref(),
                 baggage.as_deref(),
@@ -507,16 +505,9 @@ impl Engine {
         };
         let incoming_traceparent = traceparent.clone();
         let incoming_baggage = baggage.clone();
-        // Derive a traceparent/baggage pair that represents the
-        // `handle_invocation` span we just opened. Passing these
-        // downstream (instead of the original `incoming_*`) makes the
-        // engine-side `call <fn>` span (created inside
-        // `invocations.handle_invocation`) a CHILD of
-        // `handle_invocation` rather than a sibling. Without this,
-        // `.with_parent_headers(incoming_traceparent, ...)` at the
-        // `call` site re-sets the parent to the original caller,
-        // collapsing the two engine spans to siblings — which is what
-        // the trace tree was showing.
+        // Derive headers from the span we just opened so the downstream
+        // `call <fn>` becomes a child of `handle_invocation`, not a
+        // sibling of the original caller.
         let downstream_traceparent =
             inject_traceparent_from_context(&span.context()).or_else(|| traceparent.clone());
         let downstream_baggage =
@@ -924,9 +915,9 @@ impl Engine {
                         let baggage = baggage.clone();
 
                         let span = {
-                            // Attach parent context BEFORE span creation
-                            // so BaggageSpanProcessor copies iii.session.id
-                            // onto this span (set_parent runs too late).
+                            // Parent context must be on `Context::current()`
+                            // BEFORE span creation; `set_parent` after is too
+                            // late for `SpanProcessor::on_start`.
                             let parent_cx = crate::telemetry::extract_context(
                                 traceparent.as_deref(),
                                 baggage.as_deref(),

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     protocol::{ErrorBody, Message},
     services::{Service, ServicesRegistry},
     telemetry::{
-        SpanExt, ingest_otlp_json, ingest_otlp_logs, ingest_otlp_metrics,
+        ingest_otlp_json, ingest_otlp_logs, ingest_otlp_metrics,
         inject_baggage_from_context, inject_traceparent_from_context,
     },
     trigger::{Trigger, TriggerRegistry, TriggerType},
@@ -413,10 +413,10 @@ impl Engine {
     ) -> Result<Result<Option<Value>, ErrorBody>, RecvError> {
         tracing::debug!(
             worker_id = %worker.id,
-            ?invocation_id,
+            invocation_id = %crate::logging::display_option(&invocation_id),
             function_id = function_id,
-            traceparent = ?traceparent,
-            baggage = ?baggage,
+            traceparent = %crate::logging::display_option(&traceparent),
+            baggage = %crate::logging::display_option(&baggage),
             "Remembering invocation for worker"
         );
 
@@ -468,16 +468,27 @@ impl Engine {
         baggage: &Option<String>,
         invocation_id: Option<Uuid>,
     ) {
-        let span = tracing::info_span!(
-            "handle_invocation",
-            otel.name = %format!("handle_invocation {}", function_id),
-            worker_id = %worker.id,
-            function_id = %function_id,
-            invocation_id = ?invocation_id,
-            otel.kind = "server",
-            otel.status_code = tracing::field::Empty,
-        )
-        .with_parent_headers(traceparent.as_deref(), baggage.as_deref());
+        let span = {
+            // Attach the incoming OTel context (traceparent + baggage)
+            // BEFORE creating the span so `BaggageSpanProcessor::on_start`
+            // sees iii.session.id / iii.message.id / iii.function.id in
+            // `Context::current()` and copies them onto this span as
+            // attributes.
+            let parent_cx = crate::telemetry::extract_context(
+                traceparent.as_deref(),
+                baggage.as_deref(),
+            );
+            let _guard = parent_cx.attach();
+            tracing::info_span!(
+                "handle_invocation",
+                otel.name = %format!("handle_invocation {}", function_id),
+                worker_id = %worker.id,
+                function_id = %function_id,
+                invocation_id = %crate::logging::display_option(&invocation_id),
+                otel.kind = "server",
+                otel.status_code = tracing::field::Empty,
+            )
+        };
 
         let engine = self.clone();
         let worker = worker.clone();
@@ -496,6 +507,20 @@ impl Engine {
         };
         let incoming_traceparent = traceparent.clone();
         let incoming_baggage = baggage.clone();
+        // Derive a traceparent/baggage pair that represents the
+        // `handle_invocation` span we just opened. Passing these
+        // downstream (instead of the original `incoming_*`) makes the
+        // engine-side `call <fn>` span (created inside
+        // `invocations.handle_invocation`) a CHILD of
+        // `handle_invocation` rather than a sibling. Without this,
+        // `.with_parent_headers(incoming_traceparent, ...)` at the
+        // `call` site re-sets the parent to the original caller,
+        // collapsing the two engine spans to siblings — which is what
+        // the trace tree was showing.
+        let downstream_traceparent =
+            inject_traceparent_from_context(&span.context()).or_else(|| traceparent.clone());
+        let downstream_baggage =
+            inject_baggage_from_context(&span.context()).or_else(|| baggage.clone());
 
         tokio::spawn(
             async move {
@@ -505,8 +530,8 @@ impl Engine {
                         invocation_id,
                         &function_id,
                         data,
-                        incoming_traceparent.clone(),
-                        incoming_baggage.clone(),
+                        downstream_traceparent.clone(),
+                        downstream_baggage.clone(),
                     )
                     .await;
 
@@ -796,10 +821,10 @@ impl Engine {
             } => {
                 tracing::debug!(
                     worker_id = %worker.id,
-                    invocation_id = ?invocation_id,
+                    invocation_id = %crate::logging::display_option(invocation_id),
                     function_id = %function_id,
-                    traceparent = ?traceparent,
-                    baggage = ?baggage,
+                    traceparent = %crate::logging::display_option(traceparent),
+                    baggage = %crate::logging::display_option(baggage),
                     action = ?action,
                     payload = ?data,
                     "InvokeFunction"
@@ -898,13 +923,22 @@ impl Engine {
                         let traceparent = traceparent.clone();
                         let baggage = baggage.clone();
 
-                        let span = tracing::info_span!(
-                            "enqueue_action",
-                            otel.name = %format!("enqueue {} → {}", function_id, queue),
-                            function_id = %function_id,
-                            queue = %queue,
-                        )
-                        .with_parent_headers(traceparent.as_deref(), baggage.as_deref());
+                        let span = {
+                            // Attach parent context BEFORE span creation
+                            // so BaggageSpanProcessor copies iii.session.id
+                            // onto this span (set_parent runs too late).
+                            let parent_cx = crate::telemetry::extract_context(
+                                traceparent.as_deref(),
+                                baggage.as_deref(),
+                            );
+                            let _guard = parent_cx.attach();
+                            tracing::info_span!(
+                                "enqueue_action",
+                                otel.name = %format!("enqueue {} → {}", function_id, queue),
+                                function_id = %function_id,
+                                queue = %queue,
+                            )
+                        };
 
                         tokio::spawn(
                             async move {

--- a/engine/src/logging.rs
+++ b/engine/src/logging.rs
@@ -587,24 +587,12 @@ fn init_local_log(log_level: &str, otel_cfg: &OtelConfig) {
     });
 }
 
-/// Format an `Option<T: Display>` for tracing fields: renders
-/// `Some(value)` as just `value` and `None` as the empty string.
-///
-/// The default Rust `Debug` formatter (the `?` directive in tracing
-/// macros) wraps optionals as `Some(...)` / `None`, which leaks into
-/// the OTel attribute strings the engine exports. Downstream readers
-/// (console TRACES tab, Jaeger, Datadog) end up showing values like
-/// `invocation_id Some(afe495fd-...)` instead of `invocation_id afe495fd-...`.
-///
-/// Use with the `%` (Display) directive at every tracing site that
-/// emits an `Option<String>` / `Option<Uuid>` / similar field:
+/// Render `Option<T: Display>` as the inner value or empty string, so
+/// tracing fields exported to OTel don't carry `Some(...)` / `None`
+/// wrappers from Debug.
 ///
 /// ```ignore
-/// tracing::debug!(
-///     invocation_id = %display_option(&invocation_id),
-///     traceparent = %display_option(&traceparent),
-///     "Remembering invocation"
-/// );
+/// tracing::debug!(invocation_id = %display_option(&invocation_id), "...");
 /// ```
 pub fn display_option<T: std::fmt::Display>(
     opt: &Option<T>,

--- a/engine/src/logging.rs
+++ b/engine/src/logging.rs
@@ -594,9 +594,7 @@ fn init_local_log(log_level: &str, otel_cfg: &OtelConfig) {
 /// ```ignore
 /// tracing::debug!(invocation_id = %display_option(&invocation_id), "...");
 /// ```
-pub fn display_option<T: std::fmt::Display>(
-    opt: &Option<T>,
-) -> impl std::fmt::Display + '_ {
+pub fn display_option<T: std::fmt::Display>(opt: &Option<T>) -> impl std::fmt::Display + '_ {
     struct Inner<'a, T>(&'a Option<T>);
     impl<T: std::fmt::Display> std::fmt::Display for Inner<'_, T> {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/engine/src/logging.rs
+++ b/engine/src/logging.rs
@@ -587,6 +587,40 @@ fn init_local_log(log_level: &str, otel_cfg: &OtelConfig) {
     });
 }
 
+/// Format an `Option<T: Display>` for tracing fields: renders
+/// `Some(value)` as just `value` and `None` as the empty string.
+///
+/// The default Rust `Debug` formatter (the `?` directive in tracing
+/// macros) wraps optionals as `Some(...)` / `None`, which leaks into
+/// the OTel attribute strings the engine exports. Downstream readers
+/// (console TRACES tab, Jaeger, Datadog) end up showing values like
+/// `invocation_id Some(afe495fd-...)` instead of `invocation_id afe495fd-...`.
+///
+/// Use with the `%` (Display) directive at every tracing site that
+/// emits an `Option<String>` / `Option<Uuid>` / similar field:
+///
+/// ```ignore
+/// tracing::debug!(
+///     invocation_id = %display_option(&invocation_id),
+///     traceparent = %display_option(&traceparent),
+///     "Remembering invocation"
+/// );
+/// ```
+pub fn display_option<T: std::fmt::Display>(
+    opt: &Option<T>,
+) -> impl std::fmt::Display + '_ {
+    struct Inner<'a, T>(&'a Option<T>);
+    impl<T: std::fmt::Display> std::fmt::Display for Inner<'_, T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self.0 {
+                Some(v) => write!(f, "{}", v),
+                None => Ok(()),
+            }
+        }
+    }
+    Inner(opt)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/src/logging.rs
+++ b/engine/src/logging.rs
@@ -1294,4 +1294,25 @@ modules:
             .collect();
         assert!(visible.iter().any(|n| *n == "data"));
     }
+
+    #[test]
+    fn display_option_renders_some_without_wrapper() {
+        let v: Option<String> = Some("abc123".to_string());
+        assert_eq!(format!("{}", display_option(&v)), "abc123");
+    }
+
+    #[test]
+    fn display_option_renders_none_as_empty_string() {
+        let v: Option<String> = None;
+        assert_eq!(format!("{}", display_option(&v)), "");
+    }
+
+    #[test]
+    fn display_option_uses_display_not_debug_on_uuids() {
+        let id = uuid::Uuid::nil();
+        let v: Option<uuid::Uuid> = Some(id);
+        let rendered = format!("{}", display_option(&v));
+        assert_eq!(rendered, "00000000-0000-0000-0000-000000000000");
+        assert!(!rendered.contains("Some"));
+    }
 }

--- a/engine/src/workers/observability/iii.worker.yaml
+++ b/engine/src/workers/observability/iii.worker.yaml
@@ -8,7 +8,7 @@ config:
   service_name: iii
   service_version: ${SERVICE_VERSION:__III_ENGINE_VERSION__}
   exporter: memory
-  memory_max_spans: 10000
+  memory_max_spans: 1000000
   metrics_enabled: true
   metrics_exporter: memory
   metrics_retention_seconds: 3600

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -84,39 +84,27 @@ pub struct TracesTreeInput {
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub struct TracesGroupByInput {
-    /// Span attribute key to group by (e.g. "iii.message.id",
-    /// "iii.session.id"). Spans without this attribute are skipped.
+    /// Span attribute key to group by. Spans without this attribute are skipped.
     attribute: String,
-    /// Earliest start time (ms since epoch) to include. None = no lower
-    /// bound (within retained spans).
+    /// Earliest end_time (ms since epoch) to include.
     #[serde(default)]
     since_ms: Option<u64>,
-    /// Max number of groups to return (after sorting by `first_seen_ms`
-    /// descending). Default 100.
+    /// Max groups returned after sorting by `first_seen_ms` descending. Default 100.
     #[serde(default)]
     limit: Option<u32>,
-    /// Include internal engine spans (function_id starts with `engine::`
-    /// or `iii.function.kind == "internal"`). Default false — matches
-    /// `engine::traces::list` semantics.
+    /// Include engine-internal spans. Defaults to false, matching `traces::list`.
     #[serde(default)]
     include_internal: Option<bool>,
 }
 
 #[derive(Serialize)]
 pub struct TraceGroup {
-    /// The attribute value this group is keyed on.
     pub value: String,
-    /// Unique trace_ids that contain at least one span with this value.
     pub trace_ids: Vec<String>,
-    /// Total spans across all trace_ids in this group.
     pub span_count: u32,
-    /// Earliest span start_time (ms since epoch) in this group.
     pub first_seen_ms: u64,
-    /// Latest span end_time (ms since epoch) in this group.
     pub last_seen_ms: u64,
-    /// `last_seen_ms - first_seen_ms`. Convenience for UI sort/display.
     pub duration_ms: u32,
-    /// Count of spans in this group whose status is `Error`.
     pub error_count: u32,
 }
 
@@ -675,17 +663,8 @@ impl ObservabilityWorker {
                         None
                     };
 
-                // Pre-compute trace IDs that have any span matching ALL of
-                // the requested `[[key, value], ...]` attribute pairs.
-                //
-                // Mirrors `name_matched_trace_ids` above so the same
-                // trace-level semantics apply: a root span is included if
-                // any span anywhere in its trace matches the attribute
-                // filter. This makes `iii.session.id` / `iii.message.id`
-                // (which the harness wrapper writes onto CHILD spans, not
-                // the engine's auto-instrumented root) queryable when
-                // search_all_spans is set. Without this, child-span
-                // attributes are invisible to traces::list.
+                // Trace-level attribute match, mirroring `name_matched_trace_ids`:
+                // a root is included if any span in its trace matches all pairs.
                 let attributes_matched_trace_ids: Option<std::collections::HashSet<String>> =
                     if search_all {
                         if let Some(ref attrs) = input.attributes {
@@ -712,15 +691,7 @@ impl ObservabilityWorker {
 
                 let mut filtered: Vec<_> = all_spans
                     .into_iter()
-                    // Root-only by default. With `search_all_spans: true` we
-                    // surface child spans too — without this, worker spans
-                    // (which always carry `parent_span_id` set by the
-                    // engine's invocation context) are invisible to LIST,
-                    // even though they are stored and walkable via
-                    // `traces::tree`. The harness's `iii.invocation.input` /
-                    // `iii.invocation.output` events live on those child
-                    // spans, so the events tab couldn't surface them via
-                    // LIST until this widening.
+                    // Root-only by default; `search_all_spans` widens to children too.
                     .filter(|s| search_all || s.parent_span_id.is_none())
                     .filter(|s| {
                         // Exclude internal engine traces unless explicitly requested
@@ -788,20 +759,15 @@ impl ObservabilityWorker {
                         }
                         if let Some(ref attrs) = input.attributes {
                             if search_all {
-                                // Trace-level match: include root if ANY span
-                                // in the trace matched all attribute pairs.
-                                // Mirrors the name+search_all_spans behavior
-                                // in the pre-computed set above.
                                 if let Some(ref matched_ids) = attributes_matched_trace_ids
                                     && !matched_ids.contains(&s.trace_id)
                                 {
                                     return false;
                                 }
                             } else {
-                                // Root-only check (back-compat for callers
-                                // that depend on this — e.g. queries by
-                                // service-level attributes like
-                                // `iii.function.kind`).
+                                // Root-only when search_all_spans=false, for
+                                // back-compat with callers querying root-tagged
+                                // attrs like `iii.function.kind`.
                                 for pair in attrs {
                                     if pair.len() == 2 {
                                         let key = &pair[0];
@@ -906,21 +872,9 @@ impl ObservabilityWorker {
         }
     }
 
-    /// Server-side aggregation of spans by a single attribute value.
-    ///
-    /// Designed for the iii Developer Console's TRACES tab "Group by"
-    /// affordance: instead of fetching every span and grouping
-    /// client-side (which doesn't scale), the engine pre-aggregates and
-    /// returns ~100 groups per query. Each group reports its trace_ids,
-    /// span_count, first/last_seen timestamps, duration, and error_count
-    /// — enough for the UI to render collapsible group rows + sort
-    /// without follow-up requests.
-    ///
-    /// Iterates the in-memory span storage once, skips spans without the
-    /// requested attribute, groups by attribute value into a HashMap, then
-    /// applies the `since_ms` filter at iteration and `limit` after sort.
-    /// `include_internal=false` (default) excludes engine-internal spans
-    /// the same way `engine::traces::list` does.
+    /// Aggregate stored spans by one attribute value. Returns up to
+    /// `limit` groups (default 100), each with trace_ids, span_count,
+    /// duration, and error_count.
     #[function(
         id = "engine::traces::group_by",
         description = "Group stored spans by an attribute value (only available when exporter is 'memory' or 'both')"
@@ -994,9 +948,7 @@ impl ObservabilityWorker {
                     .map(|(value, b)| {
                         let first_ms = b.first_seen_ns / 1_000_000;
                         let last_ms = b.last_seen_ns / 1_000_000;
-                        // Saturate to u32 — group durations in the
-                        // billion-millisecond range are diagnostic noise,
-                        // not real data.
+                        // Saturate; durations beyond u32::MAX ms are diagnostic noise.
                         let duration_ms = u32::try_from(last_ms.saturating_sub(first_ms))
                             .unwrap_or(u32::MAX);
                         let mut trace_ids: Vec<String> = b.trace_ids.into_iter().collect();
@@ -1013,8 +965,6 @@ impl ObservabilityWorker {
                     })
                     .collect();
 
-                // Sort newest-first then truncate. UI typically wants
-                // most-recent messages at the top.
                 result.sort_by(|a, b| b.first_seen_ms.cmp(&a.first_seen_ms));
                 result.truncate(limit);
 
@@ -4367,12 +4317,6 @@ mod tests {
         assert_eq!(span_storage.len(), 0);
     }
 
-    /// Layer 2B: when `search_all_spans=true` is paired with an attribute
-    /// filter, root spans of traces whose CHILD spans match the filter
-    /// must be returned. Before this fix, the filter chain short-circuited
-    /// on `parent_span_id.is_none()` and the attribute filter never saw
-    /// child spans — which broke the `iii.session.id` / `iii.message.id`
-    /// query path the harness wrapper depends on.
     #[tokio::test]
     #[serial]
     async fn test_traces_list_attribute_filter_with_search_all_spans_matches_child() {
@@ -4384,9 +4328,6 @@ mod tests {
         let span_storage = otel::get_span_storage().expect("span storage should exist");
         span_storage.clear();
         span_storage.add_spans(vec![
-            // Root span — NO `iii.message.id` attribute. This is exactly
-            // the harness shape: the engine's auto-`handle_invocation`
-            // span is the root, harness attrs live on a child below.
             make_span(
                 "trace-with-msg",
                 "root",
@@ -4398,7 +4339,6 @@ mod tests {
                 "OK",
                 vec![],
             ),
-            // Child span — carries the harness attribute we want to query.
             make_span(
                 "trace-with-msg",
                 "child",
@@ -4410,7 +4350,6 @@ mod tests {
                 "OK",
                 vec![("iii.message.id", "M-target")],
             ),
-            // Unrelated trace with a different message id.
             make_span(
                 "trace-other",
                 "root-other",
@@ -4450,11 +4389,6 @@ mod tests {
         match result {
             FunctionResult::Success(Some(value)) => {
                 let spans = value["spans"].as_array().expect("spans array");
-                // With `search_all_spans: true`, LIST now surfaces every
-                // span in the matched trace (root + children), not just
-                // the root. This is what makes worker spans — which
-                // always carry `parent_span_id` set — visible to the
-                // console TRACES tab and to attribute-filtered queries.
                 assert_eq!(
                     spans.len(),
                     2,
@@ -4477,13 +4411,6 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_traces_list_returns_children_only_when_search_all_spans() {
-        // Regression: prove that the root-only filter is gated by
-        // `search_all_spans`. Without the flag set, the legacy
-        // root-only behavior is preserved — surfaces only the
-        // parent. With the flag, child spans (where the harness's
-        // `iii.invocation.input` / `iii.invocation.output` events
-        // live) become visible. Pinning both sides protects against
-        // future regressions on either path.
         reset_observability_test_state();
 
         let engine = Arc::new(Engine::new());
@@ -4516,7 +4443,6 @@ mod tests {
             ),
         ]);
 
-        // Default: search_all_spans=false → root-only.
         let result_root_only = module
             .list_traces(TracesListInput {
                 trace_id: None,
@@ -4545,7 +4471,6 @@ mod tests {
             _ => panic!("expected success"),
         }
 
-        // search_all_spans=true → root + children.
         let result_all = module
             .list_traces(TracesListInput {
                 trace_id: None,
@@ -4580,12 +4505,6 @@ mod tests {
         }
     }
 
-    /// Back-compat guard: with `search_all_spans=false` (the default),
-    /// the attribute filter must STILL be root-only — callers that use
-    /// the filter to find root-tagged attributes like `iii.function.kind`
-    /// or `http.method` rely on this. After the Layer 2B change, mixing
-    /// child-only attributes with `search_all_spans=false` must continue
-    /// to return zero results.
     #[tokio::test]
     #[serial]
     async fn test_traces_list_attribute_filter_without_search_all_spans_stays_root_only() {
@@ -4657,11 +4576,6 @@ mod tests {
         }
     }
 
-    /// Layer 3a: end-to-end test of `engine::traces::group_by`. Three
-    /// traces: A (2 spans both `iii.message.id=M-1`), B (3 spans all
-    /// `iii.message.id=M-2`), C (1 span, NO `iii.message.id`). Grouping
-    /// by `iii.message.id` must produce exactly 2 groups (M-1, M-2)
-    /// with correct trace_ids + span_counts; C is silently skipped.
     #[tokio::test]
     #[serial]
     async fn test_traces_group_by_attribute_returns_correct_aggregates() {
@@ -4673,7 +4587,6 @@ mod tests {
         let span_storage = otel::get_span_storage().expect("span storage should exist");
         span_storage.clear();
         span_storage.add_spans(vec![
-            // Trace A: 2 spans, both with iii.message.id=M-1.
             make_span(
                 "trace-A",
                 "A1",
@@ -4696,7 +4609,6 @@ mod tests {
                 "OK",
                 vec![("iii.message.id", "M-1")],
             ),
-            // Trace B: 3 spans, all with iii.message.id=M-2. One is Error.
             make_span(
                 "trace-B",
                 "B1",
@@ -4730,7 +4642,7 @@ mod tests {
                 "OK",
                 vec![("iii.message.id", "M-2")],
             ),
-            // Trace C: 1 span WITHOUT iii.message.id — must be skipped.
+            // No iii.message.id — must be skipped by group_by.
             make_span(
                 "trace-C",
                 "C1",
@@ -4759,9 +4671,9 @@ mod tests {
                 assert_eq!(
                     groups.len(),
                     2,
-                    "expected exactly 2 groups (M-1, M-2); trace-C must be skipped"
+                    "expected 2 groups (M-1, M-2); trace-C has no iii.message.id"
                 );
-                // Sorted by first_seen_ms DESC, so M-2 (newer) is first.
+                // Sorted by first_seen_ms DESC.
                 assert_eq!(groups[0]["value"], "M-2");
                 assert_eq!(groups[0]["span_count"], 3);
                 assert_eq!(groups[0]["error_count"], 1);
@@ -4780,10 +4692,6 @@ mod tests {
         }
     }
 
-    /// `group_by` must drop spans whose `end_time_unix_nano` is older
-    /// than `since_ms * 1_000_000`. Pins the timestamp filter against
-    /// regressions that compare against `start_time_unix_nano` or use
-    /// the wrong unit conversion.
     #[tokio::test]
     #[serial]
     async fn test_traces_group_by_since_ms_filters_old_spans() {
@@ -4795,7 +4703,6 @@ mod tests {
         let span_storage = otel::get_span_storage().expect("span storage should exist");
         span_storage.clear();
         span_storage.add_spans(vec![
-            // Old span — end_time 1s. Must be filtered out when since_ms=2000.
             make_span(
                 "trace-old",
                 "old",
@@ -4807,7 +4714,6 @@ mod tests {
                 "OK",
                 vec![("iii.message.id", "M-old")],
             ),
-            // New span — end_time 5s. Must be retained.
             make_span(
                 "trace-new",
                 "new",
@@ -4840,9 +4746,6 @@ mod tests {
         }
     }
 
-    /// `limit` must truncate the result to N groups (after sort).
-    /// Pins the truncation so a regression that returns the full
-    /// HashMap-derived group list is caught.
     #[tokio::test]
     #[serial]
     async fn test_traces_group_by_limit_truncates_to_n_groups() {
@@ -4854,7 +4757,6 @@ mod tests {
         let span_storage = otel::get_span_storage().expect("span storage should exist");
         span_storage.clear();
 
-        // 5 distinct attribute values across 5 traces.
         let spans: Vec<_> = (0..5)
             .map(|i| {
                 let start_ns = 1_000_000_000_u64 + (i as u64) * 1_000_000_000;
@@ -4885,12 +4787,8 @@ mod tests {
         match result {
             FunctionResult::Success(Some(value)) => {
                 let groups = value["groups"].as_array().expect("groups array");
-                assert_eq!(
-                    groups.len(),
-                    2,
-                    "limit=2 must truncate the 5 groups to 2"
-                );
-                // Sorted by first_seen_ms DESC, so M-4 (newest) is first, M-3 second.
+                assert_eq!(groups.len(), 2, "limit=2 must truncate the 5 groups to 2");
+                // Sorted by first_seen_ms DESC.
                 assert_eq!(groups[0]["value"], "M-4");
                 assert_eq!(groups[1]["value"], "M-3");
             }
@@ -4898,11 +4796,6 @@ mod tests {
         }
     }
 
-    /// `include_internal=false` (default) must exclude spans tagged
-    /// `iii.function.kind=internal` or whose `function_id` attribute
-    /// starts with `engine::`. Pins the exclusion branch — a
-    /// regression that drops the filter would surface engine-internal
-    /// spans in user-facing group views.
     #[tokio::test]
     #[serial]
     async fn test_traces_group_by_excludes_internal_spans_by_default() {
@@ -4914,7 +4807,6 @@ mod tests {
         let span_storage = otel::get_span_storage().expect("span storage should exist");
         span_storage.clear();
         span_storage.add_spans(vec![
-            // Internal span via iii.function.kind=internal.
             make_span(
                 "trace-internal-1",
                 "i1",
@@ -4929,7 +4821,6 @@ mod tests {
                     ("iii.function.kind", "internal"),
                 ],
             ),
-            // Internal span via function_id starting with engine::.
             make_span(
                 "trace-internal-2",
                 "i2",
@@ -4944,7 +4835,6 @@ mod tests {
                     ("function_id", "engine::traces::list"),
                 ],
             ),
-            // User span — must survive.
             make_span(
                 "trace-user",
                 "u1",
@@ -4963,7 +4853,6 @@ mod tests {
                 attribute: "iii.message.id".to_string(),
                 since_ms: None,
                 limit: Some(100),
-                // include_internal defaults to false when None.
                 include_internal: None,
             })
             .await;
@@ -4974,7 +4863,7 @@ mod tests {
                 assert_eq!(
                     groups.len(),
                     1,
-                    "only the user trace should survive (internal excluded by default)"
+                    "internal spans must be excluded by default"
                 );
                 assert_eq!(groups[0]["value"], "M-user");
             }

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -82,6 +82,44 @@ pub struct TracesTreeInput {
     trace_id: String,
 }
 
+#[derive(Serialize, Deserialize, JsonSchema)]
+pub struct TracesGroupByInput {
+    /// Span attribute key to group by (e.g. "iii.message.id",
+    /// "iii.session.id"). Spans without this attribute are skipped.
+    attribute: String,
+    /// Earliest start time (ms since epoch) to include. None = no lower
+    /// bound (within retained spans).
+    #[serde(default)]
+    since_ms: Option<u64>,
+    /// Max number of groups to return (after sorting by `first_seen_ms`
+    /// descending). Default 100.
+    #[serde(default)]
+    limit: Option<u32>,
+    /// Include internal engine spans (function_id starts with `engine::`
+    /// or `iii.function.kind == "internal"`). Default false — matches
+    /// `engine::traces::list` semantics.
+    #[serde(default)]
+    include_internal: Option<bool>,
+}
+
+#[derive(Serialize)]
+pub struct TraceGroup {
+    /// The attribute value this group is keyed on.
+    pub value: String,
+    /// Unique trace_ids that contain at least one span with this value.
+    pub trace_ids: Vec<String>,
+    /// Total spans across all trace_ids in this group.
+    pub span_count: u32,
+    /// Earliest span start_time (ms since epoch) in this group.
+    pub first_seen_ms: u64,
+    /// Latest span end_time (ms since epoch) in this group.
+    pub last_seen_ms: u64,
+    /// `last_seen_ms - first_seen_ms`. Convenience for UI sort/display.
+    pub duration_ms: u32,
+    /// Count of spans in this group whose status is `Error`.
+    pub error_count: u32,
+}
+
 #[derive(Serialize)]
 pub struct SpanTreeNode {
     #[serde(flatten)]
@@ -637,9 +675,53 @@ impl ObservabilityWorker {
                         None
                     };
 
+                // Pre-compute trace IDs that have any span matching ALL of
+                // the requested `[[key, value], ...]` attribute pairs.
+                //
+                // Mirrors `name_matched_trace_ids` above so the same
+                // trace-level semantics apply: a root span is included if
+                // any span anywhere in its trace matches the attribute
+                // filter. This makes `iii.session.id` / `iii.message.id`
+                // (which the harness wrapper writes onto CHILD spans, not
+                // the engine's auto-instrumented root) queryable when
+                // search_all_spans is set. Without this, child-span
+                // attributes are invisible to traces::list.
+                let attributes_matched_trace_ids: Option<std::collections::HashSet<String>> =
+                    if search_all {
+                        if let Some(ref attrs) = input.attributes {
+                            Some(
+                                all_spans
+                                    .iter()
+                                    .filter(|s| {
+                                        attrs.iter().all(|pair| {
+                                            pair.len() == 2
+                                                && s.attributes
+                                                    .iter()
+                                                    .any(|(k, v)| k == &pair[0] && v == &pair[1])
+                                        })
+                                    })
+                                    .map(|s| s.trace_id.clone())
+                                    .collect(),
+                            )
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+
                 let mut filtered: Vec<_> = all_spans
                     .into_iter()
-                    .filter(|s| s.parent_span_id.is_none())
+                    // Root-only by default. With `search_all_spans: true` we
+                    // surface child spans too — without this, worker spans
+                    // (which always carry `parent_span_id` set by the
+                    // engine's invocation context) are invisible to LIST,
+                    // even though they are stored and walkable via
+                    // `traces::tree`. The harness's `iii.invocation.input` /
+                    // `iii.invocation.output` events live on those child
+                    // spans, so the events tab couldn't surface them via
+                    // LIST until this widening.
+                    .filter(|s| search_all || s.parent_span_id.is_none())
                     .filter(|s| {
                         // Exclude internal engine traces unless explicitly requested
                         if !include_internal {
@@ -705,12 +787,32 @@ impl ObservabilityWorker {
                             }
                         }
                         if let Some(ref attrs) = input.attributes {
-                            for pair in attrs {
-                                if pair.len() == 2 {
-                                    let key = &pair[0];
-                                    let value = &pair[1];
-                                    if !s.attributes.iter().any(|(k, v)| k == key && v == value) {
-                                        return false;
+                            if search_all {
+                                // Trace-level match: include root if ANY span
+                                // in the trace matched all attribute pairs.
+                                // Mirrors the name+search_all_spans behavior
+                                // in the pre-computed set above.
+                                if let Some(ref matched_ids) = attributes_matched_trace_ids
+                                    && !matched_ids.contains(&s.trace_id)
+                                {
+                                    return false;
+                                }
+                            } else {
+                                // Root-only check (back-compat for callers
+                                // that depend on this — e.g. queries by
+                                // service-level attributes like
+                                // `iii.function.kind`).
+                                for pair in attrs {
+                                    if pair.len() == 2 {
+                                        let key = &pair[0];
+                                        let value = &pair[1];
+                                        if !s
+                                            .attributes
+                                            .iter()
+                                            .any(|(k, v)| k == key && v == value)
+                                        {
+                                            return false;
+                                        }
                                     }
                                 }
                             }
@@ -799,6 +901,124 @@ impl ObservabilityWorker {
             Some(storage) => {
                 storage.clear();
                 FunctionResult::Success(Some(serde_json::json!({ "success": true })))
+            }
+            None => memory_exporter_not_enabled_error(),
+        }
+    }
+
+    /// Server-side aggregation of spans by a single attribute value.
+    ///
+    /// Designed for the iii Developer Console's TRACES tab "Group by"
+    /// affordance: instead of fetching every span and grouping
+    /// client-side (which doesn't scale), the engine pre-aggregates and
+    /// returns ~100 groups per query. Each group reports its trace_ids,
+    /// span_count, first/last_seen timestamps, duration, and error_count
+    /// — enough for the UI to render collapsible group rows + sort
+    /// without follow-up requests.
+    ///
+    /// Iterates the in-memory span storage once, skips spans without the
+    /// requested attribute, groups by attribute value into a HashMap, then
+    /// applies the `since_ms` filter at iteration and `limit` after sort.
+    /// `include_internal=false` (default) excludes engine-internal spans
+    /// the same way `engine::traces::list` does.
+    #[function(
+        id = "engine::traces::group_by",
+        description = "Group stored spans by an attribute value (only available when exporter is 'memory' or 'both')"
+    )]
+    pub async fn group_traces_by(
+        &self,
+        input: TracesGroupByInput,
+    ) -> FunctionResult<Option<Value>, ErrorBody> {
+        match otel::get_span_storage() {
+            Some(storage) => {
+                let all_spans = storage.get_spans();
+
+                let include_internal = input.include_internal.unwrap_or(false);
+                let since_ns = input.since_ms.map(|ms| ms.saturating_mul(1_000_000));
+                let limit = input.limit.unwrap_or(100) as usize;
+
+                struct GroupBuilder {
+                    trace_ids: std::collections::HashSet<String>,
+                    span_count: u32,
+                    first_seen_ns: u64,
+                    last_seen_ns: u64,
+                    error_count: u32,
+                }
+                let mut groups: std::collections::HashMap<String, GroupBuilder> =
+                    std::collections::HashMap::new();
+
+                for span in &all_spans {
+                    if !include_internal {
+                        let is_internal = span.attributes.iter().any(|(k, v)| {
+                            (k == "iii.function.kind" && v == "internal")
+                                || (k == "function_id" && v.starts_with("engine::"))
+                        });
+                        if is_internal {
+                            continue;
+                        }
+                    }
+                    if let Some(min_ns) = since_ns
+                        && span.end_time_unix_nano < min_ns
+                    {
+                        continue;
+                    }
+
+                    let value = match span
+                        .attributes
+                        .iter()
+                        .find(|(k, _)| k == &input.attribute)
+                    {
+                        Some((_, v)) => v.clone(),
+                        None => continue,
+                    };
+
+                    let is_error = span.status.eq_ignore_ascii_case("error");
+                    let entry = groups.entry(value).or_insert_with(|| GroupBuilder {
+                        trace_ids: std::collections::HashSet::new(),
+                        span_count: 0,
+                        first_seen_ns: span.start_time_unix_nano,
+                        last_seen_ns: span.end_time_unix_nano,
+                        error_count: 0,
+                    });
+                    entry.trace_ids.insert(span.trace_id.clone());
+                    entry.span_count += 1;
+                    entry.first_seen_ns = entry.first_seen_ns.min(span.start_time_unix_nano);
+                    entry.last_seen_ns = entry.last_seen_ns.max(span.end_time_unix_nano);
+                    if is_error {
+                        entry.error_count += 1;
+                    }
+                }
+
+                let mut result: Vec<TraceGroup> = groups
+                    .into_iter()
+                    .map(|(value, b)| {
+                        let first_ms = b.first_seen_ns / 1_000_000;
+                        let last_ms = b.last_seen_ns / 1_000_000;
+                        // Saturate to u32 — group durations in the
+                        // billion-millisecond range are diagnostic noise,
+                        // not real data.
+                        let duration_ms = u32::try_from(last_ms.saturating_sub(first_ms))
+                            .unwrap_or(u32::MAX);
+                        let mut trace_ids: Vec<String> = b.trace_ids.into_iter().collect();
+                        trace_ids.sort();
+                        TraceGroup {
+                            value,
+                            trace_ids,
+                            span_count: b.span_count,
+                            first_seen_ms: first_ms,
+                            last_seen_ms: last_ms,
+                            duration_ms,
+                            error_count: b.error_count,
+                        }
+                    })
+                    .collect();
+
+                // Sort newest-first then truncate. UI typically wants
+                // most-recent messages at the top.
+                result.sort_by(|a, b| b.first_seen_ms.cmp(&a.first_seen_ms));
+                result.truncate(limit);
+
+                FunctionResult::Success(Some(serde_json::json!({ "groups": result })))
             }
             None => memory_exporter_not_enabled_error(),
         }
@@ -4145,6 +4365,621 @@ mod tests {
             FunctionResult::Success(Some(_))
         ));
         assert_eq!(span_storage.len(), 0);
+    }
+
+    /// Layer 2B: when `search_all_spans=true` is paired with an attribute
+    /// filter, root spans of traces whose CHILD spans match the filter
+    /// must be returned. Before this fix, the filter chain short-circuited
+    /// on `parent_span_id.is_none()` and the attribute filter never saw
+    /// child spans — which broke the `iii.session.id` / `iii.message.id`
+    /// query path the harness wrapper depends on.
+    #[tokio::test]
+    #[serial]
+    async fn test_traces_list_attribute_filter_with_search_all_spans_matches_child() {
+        reset_observability_test_state();
+
+        let engine = Arc::new(Engine::new());
+        let module = make_test_module(engine.clone());
+
+        let span_storage = otel::get_span_storage().expect("span storage should exist");
+        span_storage.clear();
+        span_storage.add_spans(vec![
+            // Root span — NO `iii.message.id` attribute. This is exactly
+            // the harness shape: the engine's auto-`handle_invocation`
+            // span is the root, harness attrs live on a child below.
+            make_span(
+                "trace-with-msg",
+                "root",
+                None,
+                "handle_invocation harness::status",
+                "svc",
+                1_000_000_000,
+                2_000_000_000,
+                "OK",
+                vec![],
+            ),
+            // Child span — carries the harness attribute we want to query.
+            make_span(
+                "trace-with-msg",
+                "child",
+                Some("root"),
+                "harness.status",
+                "svc",
+                1_100_000_000,
+                1_500_000_000,
+                "OK",
+                vec![("iii.message.id", "M-target")],
+            ),
+            // Unrelated trace with a different message id.
+            make_span(
+                "trace-other",
+                "root-other",
+                None,
+                "handle_invocation other",
+                "svc",
+                1_000_000_000,
+                1_100_000_000,
+                "OK",
+                vec![("iii.message.id", "M-other")],
+            ),
+        ]);
+
+        let result = module
+            .list_traces(TracesListInput {
+                trace_id: None,
+                offset: Some(0),
+                limit: Some(10),
+                service_name: None,
+                name: None,
+                status: None,
+                min_duration_ms: None,
+                max_duration_ms: None,
+                start_time: None,
+                end_time: None,
+                sort_by: None,
+                sort_order: None,
+                attributes: Some(vec![vec![
+                    "iii.message.id".to_string(),
+                    "M-target".to_string(),
+                ]]),
+                include_internal: Some(true),
+                search_all_spans: Some(true),
+            })
+            .await;
+
+        match result {
+            FunctionResult::Success(Some(value)) => {
+                let spans = value["spans"].as_array().expect("spans array");
+                // With `search_all_spans: true`, LIST now surfaces every
+                // span in the matched trace (root + children), not just
+                // the root. This is what makes worker spans — which
+                // always carry `parent_span_id` set — visible to the
+                // console TRACES tab and to attribute-filtered queries.
+                assert_eq!(
+                    spans.len(),
+                    2,
+                    "expected root + child of trace-with-msg, got {spans:?}"
+                );
+                let span_ids: std::collections::HashSet<String> = spans
+                    .iter()
+                    .map(|s| s["span_id"].as_str().unwrap().to_string())
+                    .collect();
+                assert!(span_ids.contains("root"));
+                assert!(span_ids.contains("child"));
+                for span in spans {
+                    assert_eq!(span["trace_id"], "trace-with-msg");
+                }
+            }
+            _ => panic!("expected list_traces success"),
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_traces_list_returns_children_only_when_search_all_spans() {
+        // Regression: prove that the root-only filter is gated by
+        // `search_all_spans`. Without the flag set, the legacy
+        // root-only behavior is preserved — surfaces only the
+        // parent. With the flag, child spans (where the harness's
+        // `iii.invocation.input` / `iii.invocation.output` events
+        // live) become visible. Pinning both sides protects against
+        // future regressions on either path.
+        reset_observability_test_state();
+
+        let engine = Arc::new(Engine::new());
+        let module = make_test_module(engine.clone());
+
+        let span_storage = otel::get_span_storage().expect("span storage should exist");
+        span_storage.clear();
+        span_storage.add_spans(vec![
+            make_span(
+                "tid-1",
+                "root-1",
+                None,
+                "handle_invocation harness::status",
+                "iii",
+                1_000_000_000,
+                2_000_000_000,
+                "OK",
+                vec![],
+            ),
+            make_span(
+                "tid-1",
+                "child-1",
+                Some("root-1"),
+                "call harness::status",
+                "iii-rust-sdk",
+                1_100_000_000,
+                1_500_000_000,
+                "OK",
+                vec![],
+            ),
+        ]);
+
+        // Default: search_all_spans=false → root-only.
+        let result_root_only = module
+            .list_traces(TracesListInput {
+                trace_id: None,
+                offset: Some(0),
+                limit: Some(10),
+                service_name: None,
+                name: None,
+                status: None,
+                min_duration_ms: None,
+                max_duration_ms: None,
+                start_time: None,
+                end_time: None,
+                sort_by: None,
+                sort_order: None,
+                attributes: None,
+                include_internal: Some(true),
+                search_all_spans: Some(false),
+            })
+            .await;
+        match result_root_only {
+            FunctionResult::Success(Some(value)) => {
+                let spans = value["spans"].as_array().expect("spans array");
+                assert_eq!(spans.len(), 1, "default mode = root only");
+                assert_eq!(spans[0]["span_id"], "root-1");
+            }
+            _ => panic!("expected success"),
+        }
+
+        // search_all_spans=true → root + children.
+        let result_all = module
+            .list_traces(TracesListInput {
+                trace_id: None,
+                offset: Some(0),
+                limit: Some(10),
+                service_name: None,
+                name: None,
+                status: None,
+                min_duration_ms: None,
+                max_duration_ms: None,
+                start_time: None,
+                end_time: None,
+                sort_by: None,
+                sort_order: None,
+                attributes: None,
+                include_internal: Some(true),
+                search_all_spans: Some(true),
+            })
+            .await;
+        match result_all {
+            FunctionResult::Success(Some(value)) => {
+                let spans = value["spans"].as_array().expect("spans array");
+                assert_eq!(spans.len(), 2, "widened mode = root + children");
+                let names: std::collections::HashSet<String> = spans
+                    .iter()
+                    .map(|s| s["name"].as_str().unwrap().to_string())
+                    .collect();
+                assert!(names.contains("handle_invocation harness::status"));
+                assert!(names.contains("call harness::status"));
+            }
+            _ => panic!("expected success"),
+        }
+    }
+
+    /// Back-compat guard: with `search_all_spans=false` (the default),
+    /// the attribute filter must STILL be root-only — callers that use
+    /// the filter to find root-tagged attributes like `iii.function.kind`
+    /// or `http.method` rely on this. After the Layer 2B change, mixing
+    /// child-only attributes with `search_all_spans=false` must continue
+    /// to return zero results.
+    #[tokio::test]
+    #[serial]
+    async fn test_traces_list_attribute_filter_without_search_all_spans_stays_root_only() {
+        reset_observability_test_state();
+
+        let engine = Arc::new(Engine::new());
+        let module = make_test_module(engine.clone());
+
+        let span_storage = otel::get_span_storage().expect("span storage should exist");
+        span_storage.clear();
+        span_storage.add_spans(vec![
+            make_span(
+                "trace-with-msg",
+                "root",
+                None,
+                "root-name",
+                "svc",
+                1_000_000_000,
+                2_000_000_000,
+                "OK",
+                vec![],
+            ),
+            make_span(
+                "trace-with-msg",
+                "child",
+                Some("root"),
+                "child-name",
+                "svc",
+                1_100_000_000,
+                1_500_000_000,
+                "OK",
+                vec![("iii.message.id", "M-target")],
+            ),
+        ]);
+
+        let result = module
+            .list_traces(TracesListInput {
+                trace_id: None,
+                offset: Some(0),
+                limit: Some(10),
+                service_name: None,
+                name: None,
+                status: None,
+                min_duration_ms: None,
+                max_duration_ms: None,
+                start_time: None,
+                end_time: None,
+                sort_by: None,
+                sort_order: None,
+                attributes: Some(vec![vec![
+                    "iii.message.id".to_string(),
+                    "M-target".to_string(),
+                ]]),
+                include_internal: Some(true),
+                search_all_spans: Some(false),
+            })
+            .await;
+
+        match result {
+            FunctionResult::Success(Some(value)) => {
+                let spans = value["spans"].as_array().expect("spans array");
+                assert_eq!(
+                    spans.len(),
+                    0,
+                    "child-only attribute MUST not match under search_all_spans=false"
+                );
+            }
+            _ => panic!("expected list_traces success"),
+        }
+    }
+
+    /// Layer 3a: end-to-end test of `engine::traces::group_by`. Three
+    /// traces: A (2 spans both `iii.message.id=M-1`), B (3 spans all
+    /// `iii.message.id=M-2`), C (1 span, NO `iii.message.id`). Grouping
+    /// by `iii.message.id` must produce exactly 2 groups (M-1, M-2)
+    /// with correct trace_ids + span_counts; C is silently skipped.
+    #[tokio::test]
+    #[serial]
+    async fn test_traces_group_by_attribute_returns_correct_aggregates() {
+        reset_observability_test_state();
+
+        let engine = Arc::new(Engine::new());
+        let module = make_test_module(engine.clone());
+
+        let span_storage = otel::get_span_storage().expect("span storage should exist");
+        span_storage.clear();
+        span_storage.add_spans(vec![
+            // Trace A: 2 spans, both with iii.message.id=M-1.
+            make_span(
+                "trace-A",
+                "A1",
+                None,
+                "root-A",
+                "svc",
+                1_000_000_000,
+                2_000_000_000,
+                "OK",
+                vec![("iii.message.id", "M-1")],
+            ),
+            make_span(
+                "trace-A",
+                "A2",
+                Some("A1"),
+                "child-A",
+                "svc",
+                1_100_000_000,
+                1_500_000_000,
+                "OK",
+                vec![("iii.message.id", "M-1")],
+            ),
+            // Trace B: 3 spans, all with iii.message.id=M-2. One is Error.
+            make_span(
+                "trace-B",
+                "B1",
+                None,
+                "root-B",
+                "svc",
+                3_000_000_000,
+                4_000_000_000,
+                "OK",
+                vec![("iii.message.id", "M-2")],
+            ),
+            make_span(
+                "trace-B",
+                "B2",
+                Some("B1"),
+                "child-B-1",
+                "svc",
+                3_100_000_000,
+                3_500_000_000,
+                "Error",
+                vec![("iii.message.id", "M-2")],
+            ),
+            make_span(
+                "trace-B",
+                "B3",
+                Some("B1"),
+                "child-B-2",
+                "svc",
+                3_200_000_000,
+                3_800_000_000,
+                "OK",
+                vec![("iii.message.id", "M-2")],
+            ),
+            // Trace C: 1 span WITHOUT iii.message.id — must be skipped.
+            make_span(
+                "trace-C",
+                "C1",
+                None,
+                "root-C",
+                "svc",
+                5_000_000_000,
+                5_500_000_000,
+                "OK",
+                vec![("other.attr", "value")],
+            ),
+        ]);
+
+        let result = module
+            .group_traces_by(TracesGroupByInput {
+                attribute: "iii.message.id".to_string(),
+                since_ms: None,
+                limit: Some(100),
+                include_internal: Some(true),
+            })
+            .await;
+
+        match result {
+            FunctionResult::Success(Some(value)) => {
+                let groups = value["groups"].as_array().expect("groups array");
+                assert_eq!(
+                    groups.len(),
+                    2,
+                    "expected exactly 2 groups (M-1, M-2); trace-C must be skipped"
+                );
+                // Sorted by first_seen_ms DESC, so M-2 (newer) is first.
+                assert_eq!(groups[0]["value"], "M-2");
+                assert_eq!(groups[0]["span_count"], 3);
+                assert_eq!(groups[0]["error_count"], 1);
+                let m2_trace_ids = groups[0]["trace_ids"].as_array().unwrap();
+                assert_eq!(m2_trace_ids.len(), 1);
+                assert_eq!(m2_trace_ids[0], "trace-B");
+
+                assert_eq!(groups[1]["value"], "M-1");
+                assert_eq!(groups[1]["span_count"], 2);
+                assert_eq!(groups[1]["error_count"], 0);
+                let m1_trace_ids = groups[1]["trace_ids"].as_array().unwrap();
+                assert_eq!(m1_trace_ids.len(), 1);
+                assert_eq!(m1_trace_ids[0], "trace-A");
+            }
+            _ => panic!("expected group_traces_by success"),
+        }
+    }
+
+    /// `group_by` must drop spans whose `end_time_unix_nano` is older
+    /// than `since_ms * 1_000_000`. Pins the timestamp filter against
+    /// regressions that compare against `start_time_unix_nano` or use
+    /// the wrong unit conversion.
+    #[tokio::test]
+    #[serial]
+    async fn test_traces_group_by_since_ms_filters_old_spans() {
+        reset_observability_test_state();
+
+        let engine = Arc::new(Engine::new());
+        let module = make_test_module(engine.clone());
+
+        let span_storage = otel::get_span_storage().expect("span storage should exist");
+        span_storage.clear();
+        span_storage.add_spans(vec![
+            // Old span — end_time 1s. Must be filtered out when since_ms=2000.
+            make_span(
+                "trace-old",
+                "old",
+                None,
+                "root-old",
+                "svc",
+                500_000_000,
+                1_000_000_000,
+                "OK",
+                vec![("iii.message.id", "M-old")],
+            ),
+            // New span — end_time 5s. Must be retained.
+            make_span(
+                "trace-new",
+                "new",
+                None,
+                "root-new",
+                "svc",
+                4_000_000_000,
+                5_000_000_000,
+                "OK",
+                vec![("iii.message.id", "M-new")],
+            ),
+        ]);
+
+        let result = module
+            .group_traces_by(TracesGroupByInput {
+                attribute: "iii.message.id".to_string(),
+                since_ms: Some(2000),
+                limit: Some(100),
+                include_internal: Some(true),
+            })
+            .await;
+
+        match result {
+            FunctionResult::Success(Some(value)) => {
+                let groups = value["groups"].as_array().expect("groups array");
+                assert_eq!(groups.len(), 1, "only M-new should survive since_ms filter");
+                assert_eq!(groups[0]["value"], "M-new");
+            }
+            _ => panic!("expected group_traces_by success"),
+        }
+    }
+
+    /// `limit` must truncate the result to N groups (after sort).
+    /// Pins the truncation so a regression that returns the full
+    /// HashMap-derived group list is caught.
+    #[tokio::test]
+    #[serial]
+    async fn test_traces_group_by_limit_truncates_to_n_groups() {
+        reset_observability_test_state();
+
+        let engine = Arc::new(Engine::new());
+        let module = make_test_module(engine.clone());
+
+        let span_storage = otel::get_span_storage().expect("span storage should exist");
+        span_storage.clear();
+
+        // 5 distinct attribute values across 5 traces.
+        let spans: Vec<_> = (0..5)
+            .map(|i| {
+                let start_ns = 1_000_000_000_u64 + (i as u64) * 1_000_000_000;
+                make_span(
+                    &format!("trace-{i}"),
+                    &format!("span-{i}"),
+                    None,
+                    &format!("root-{i}"),
+                    "svc",
+                    start_ns,
+                    start_ns + 500_000_000,
+                    "OK",
+                    vec![("iii.message.id", &format!("M-{i}"))],
+                )
+            })
+            .collect();
+        span_storage.add_spans(spans);
+
+        let result = module
+            .group_traces_by(TracesGroupByInput {
+                attribute: "iii.message.id".to_string(),
+                since_ms: None,
+                limit: Some(2),
+                include_internal: Some(true),
+            })
+            .await;
+
+        match result {
+            FunctionResult::Success(Some(value)) => {
+                let groups = value["groups"].as_array().expect("groups array");
+                assert_eq!(
+                    groups.len(),
+                    2,
+                    "limit=2 must truncate the 5 groups to 2"
+                );
+                // Sorted by first_seen_ms DESC, so M-4 (newest) is first, M-3 second.
+                assert_eq!(groups[0]["value"], "M-4");
+                assert_eq!(groups[1]["value"], "M-3");
+            }
+            _ => panic!("expected group_traces_by success"),
+        }
+    }
+
+    /// `include_internal=false` (default) must exclude spans tagged
+    /// `iii.function.kind=internal` or whose `function_id` attribute
+    /// starts with `engine::`. Pins the exclusion branch — a
+    /// regression that drops the filter would surface engine-internal
+    /// spans in user-facing group views.
+    #[tokio::test]
+    #[serial]
+    async fn test_traces_group_by_excludes_internal_spans_by_default() {
+        reset_observability_test_state();
+
+        let engine = Arc::new(Engine::new());
+        let module = make_test_module(engine.clone());
+
+        let span_storage = otel::get_span_storage().expect("span storage should exist");
+        span_storage.clear();
+        span_storage.add_spans(vec![
+            // Internal span via iii.function.kind=internal.
+            make_span(
+                "trace-internal-1",
+                "i1",
+                None,
+                "engine work",
+                "svc",
+                1_000_000_000,
+                2_000_000_000,
+                "OK",
+                vec![
+                    ("iii.message.id", "M-internal"),
+                    ("iii.function.kind", "internal"),
+                ],
+            ),
+            // Internal span via function_id starting with engine::.
+            make_span(
+                "trace-internal-2",
+                "i2",
+                None,
+                "engine work",
+                "svc",
+                1_000_000_000,
+                2_000_000_000,
+                "OK",
+                vec![
+                    ("iii.message.id", "M-internal2"),
+                    ("function_id", "engine::traces::list"),
+                ],
+            ),
+            // User span — must survive.
+            make_span(
+                "trace-user",
+                "u1",
+                None,
+                "user work",
+                "svc",
+                1_000_000_000,
+                2_000_000_000,
+                "OK",
+                vec![("iii.message.id", "M-user")],
+            ),
+        ]);
+
+        let result = module
+            .group_traces_by(TracesGroupByInput {
+                attribute: "iii.message.id".to_string(),
+                since_ms: None,
+                limit: Some(100),
+                // include_internal defaults to false when None.
+                include_internal: None,
+            })
+            .await;
+
+        match result {
+            FunctionResult::Success(Some(value)) => {
+                let groups = value["groups"].as_array().expect("groups array");
+                assert_eq!(
+                    groups.len(),
+                    1,
+                    "only the user trace should survive (internal excluded by default)"
+                );
+                assert_eq!(groups[0]["value"], "M-user");
+            }
+            _ => panic!("expected group_traces_by success"),
+        }
     }
 
     #[tokio::test]

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -772,10 +772,7 @@ impl ObservabilityWorker {
                                     if pair.len() == 2 {
                                         let key = &pair[0];
                                         let value = &pair[1];
-                                        if !s
-                                            .attributes
-                                            .iter()
-                                            .any(|(k, v)| k == key && v == value)
+                                        if !s.attributes.iter().any(|(k, v)| k == key && v == value)
                                         {
                                             return false;
                                         }
@@ -917,11 +914,7 @@ impl ObservabilityWorker {
                         continue;
                     }
 
-                    let value = match span
-                        .attributes
-                        .iter()
-                        .find(|(k, _)| k == &input.attribute)
-                    {
+                    let value = match span.attributes.iter().find(|(k, _)| k == &input.attribute) {
                         Some((_, v)) => v.clone(),
                         None => continue,
                     };
@@ -949,8 +942,8 @@ impl ObservabilityWorker {
                         let first_ms = b.first_seen_ns / 1_000_000;
                         let last_ms = b.last_seen_ns / 1_000_000;
                         // Saturate; durations beyond u32::MAX ms are diagnostic noise.
-                        let duration_ms = u32::try_from(last_ms.saturating_sub(first_ms))
-                            .unwrap_or(u32::MAX);
+                        let duration_ms =
+                            u32::try_from(last_ms.saturating_sub(first_ms)).unwrap_or(u32::MAX);
                         let mut trace_ids: Vec<String> = b.trace_ids.into_iter().collect();
                         trace_ids.sort();
                         TraceGroup {

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -5906,8 +5906,7 @@ mod tests {
         assert!(parsed.get("log.data").is_some());
     }
 
-    const SAMPLE_TRACEPARENT: &str =
-        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    const SAMPLE_TRACEPARENT: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
     const SAMPLE_TRACE_ID_HEX: &str = "4bf92f3577b34da6a3ce929d0e0e4736";
     const SAMPLE_SPAN_ID_HEX: &str = "00f067aa0ba902b7";
 

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -5906,15 +5906,6 @@ mod tests {
         assert!(parsed.get("log.data").is_some());
     }
 
-    // -------------------------------------------------------------------
-    // Context propagation primitives — pin the round-trip semantics that
-    // `Engine::spawn_invoke_function` relies on when it attaches the
-    // inbound traceparent+baggage BEFORE opening the `handle_invocation`
-    // span (so `BaggageSpanProcessor::on_start` in iii-sdk can see
-    // `iii.session.id` / `iii.message.id` / `iii.function.id` in
-    // `Context::current()` and stamp them as span attributes).
-    // -------------------------------------------------------------------
-
     const SAMPLE_TRACEPARENT: &str =
         "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
     const SAMPLE_TRACE_ID_HEX: &str = "4bf92f3577b34da6a3ce929d0e0e4736";
@@ -5938,11 +5929,7 @@ mod tests {
         );
         assert_eq!(format!("{:032x}", sc.trace_id()), SAMPLE_TRACE_ID_HEX);
         assert_eq!(format!("{:016x}", sc.span_id()), SAMPLE_SPAN_ID_HEX);
-        assert!(
-            sc.is_remote(),
-            "extracted parent must be flagged remote so SpanProcessor::on_start \
-             treats it as the parent span context, not a local sibling"
-        );
+        assert!(sc.is_remote(), "extracted parent must be flagged remote");
     }
 
     #[test]
@@ -5950,8 +5937,7 @@ mod tests {
         let bg = "iii.session.id=s-1,iii.message.id=m-1,iii.function.id=auth::set_token";
         let cx = extract_context(None, Some(bg));
         let round = inject_baggage_from_context(&cx).expect("baggage present");
-        // Baggage is comma-separated unordered; compare as sets so the
-        // assertion doesn't depend on hash-map iteration order.
+        // Baggage entries are unordered; HashMap iteration order is non-deterministic.
         let parse = |s: &str| {
             s.split(',')
                 .map(|e| e.trim().to_string())
@@ -5976,10 +5962,7 @@ mod tests {
     fn extract_context_with_no_headers_returns_empty_context() {
         let cx = extract_context(None, None);
         let span_ref = cx.span();
-        assert!(
-            !span_ref.span_context().is_valid(),
-            "no headers in => no valid span context out"
-        );
+        assert!(!span_ref.span_context().is_valid());
         drop(span_ref);
         assert!(inject_traceparent_from_context(&cx).is_none());
         assert!(inject_baggage_from_context(&cx).is_none());
@@ -5988,37 +5971,23 @@ mod tests {
     #[test]
     #[serial]
     fn attached_extracted_context_makes_baggage_visible_in_current_context() {
-        // This is the exact pattern `Engine::spawn_invoke_function` uses:
-        //   let parent_cx = extract_context(traceparent, baggage);
-        //   let _guard = parent_cx.attach();
-        //   tracing::info_span!("handle_invocation", ...);
-        //
-        // The pin: after `.attach()`, baggage MUST be readable from
-        // `Context::current()` so `BaggageSpanProcessor::on_start`
-        // (which reads `parent_context.baggage()` and copies allowlisted
-        // entries onto each new span) can see the iii.* keys.
         let bg = "iii.message.id=m-1,iii.session.id=s-1";
         let parent_cx = extract_context(None, Some(bg));
         {
             let _guard = parent_cx.attach();
             let injected = inject_baggage_from_context(&Context::current())
-                .expect("baggage must be visible in Context::current() inside the guard");
+                .expect("baggage visible inside the guard");
             assert!(injected.contains("iii.message.id=m-1"));
             assert!(injected.contains("iii.session.id=s-1"));
         }
-        // Guard dropped — baggage must no longer leak into the caller scope.
         assert!(
             inject_baggage_from_context(&Context::current()).is_none(),
-            "baggage must not leak into the caller scope after the guard drops"
+            "baggage must not leak past the guard"
         );
     }
 
     #[test]
     fn invalid_traceparent_extracts_to_invalid_context() {
-        // Engine receives malformed inbound headers (proxy bug, mid-flight
-        // truncation). `extract_context` must NOT panic and must return an
-        // invalid context, so the downstream span starts a fresh trace
-        // instead of inheriting garbage.
         let cx = extract_context(Some("not-a-valid-traceparent"), None);
         let span_ref = cx.span();
         assert!(!span_ref.span_context().is_valid());

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -5905,4 +5905,124 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&data).unwrap();
         assert!(parsed.get("log.data").is_some());
     }
+
+    // -------------------------------------------------------------------
+    // Context propagation primitives — pin the round-trip semantics that
+    // `Engine::spawn_invoke_function` relies on when it attaches the
+    // inbound traceparent+baggage BEFORE opening the `handle_invocation`
+    // span (so `BaggageSpanProcessor::on_start` in iii-sdk can see
+    // `iii.session.id` / `iii.message.id` / `iii.function.id` in
+    // `Context::current()` and stamp them as span attributes).
+    // -------------------------------------------------------------------
+
+    const SAMPLE_TRACEPARENT: &str =
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    const SAMPLE_TRACE_ID_HEX: &str = "4bf92f3577b34da6a3ce929d0e0e4736";
+    const SAMPLE_SPAN_ID_HEX: &str = "00f067aa0ba902b7";
+
+    #[test]
+    fn extract_context_round_trips_traceparent_header() {
+        let cx = extract_context(Some(SAMPLE_TRACEPARENT), None);
+        let round = inject_traceparent_from_context(&cx).expect("valid traceparent");
+        assert_eq!(round, SAMPLE_TRACEPARENT);
+    }
+
+    #[test]
+    fn extract_context_carries_caller_span_context_as_remote_parent() {
+        let cx = extract_context(Some(SAMPLE_TRACEPARENT), None);
+        let span_ref = cx.span();
+        let sc = span_ref.span_context();
+        assert!(
+            sc.is_valid(),
+            "extracted context must carry a valid span context"
+        );
+        assert_eq!(format!("{:032x}", sc.trace_id()), SAMPLE_TRACE_ID_HEX);
+        assert_eq!(format!("{:016x}", sc.span_id()), SAMPLE_SPAN_ID_HEX);
+        assert!(
+            sc.is_remote(),
+            "extracted parent must be flagged remote so SpanProcessor::on_start \
+             treats it as the parent span context, not a local sibling"
+        );
+    }
+
+    #[test]
+    fn extract_context_round_trips_baggage_header() {
+        let bg = "iii.session.id=s-1,iii.message.id=m-1,iii.function.id=auth::set_token";
+        let cx = extract_context(None, Some(bg));
+        let round = inject_baggage_from_context(&cx).expect("baggage present");
+        // Baggage is comma-separated unordered; compare as sets so the
+        // assertion doesn't depend on hash-map iteration order.
+        let parse = |s: &str| {
+            s.split(',')
+                .map(|e| e.trim().to_string())
+                .collect::<std::collections::HashSet<_>>()
+        };
+        assert_eq!(parse(&round), parse(bg));
+    }
+
+    #[test]
+    fn extract_context_combines_traceparent_and_baggage() {
+        let bg = "iii.message.id=m-42";
+        let cx = extract_context(Some(SAMPLE_TRACEPARENT), Some(bg));
+        let span_ref = cx.span();
+        let sc = span_ref.span_context();
+        assert!(sc.is_valid());
+        assert_eq!(format!("{:032x}", sc.trace_id()), SAMPLE_TRACE_ID_HEX);
+        let injected_bg = inject_baggage_from_context(&cx).expect("baggage present");
+        assert!(injected_bg.contains("iii.message.id=m-42"));
+    }
+
+    #[test]
+    fn extract_context_with_no_headers_returns_empty_context() {
+        let cx = extract_context(None, None);
+        let span_ref = cx.span();
+        assert!(
+            !span_ref.span_context().is_valid(),
+            "no headers in => no valid span context out"
+        );
+        drop(span_ref);
+        assert!(inject_traceparent_from_context(&cx).is_none());
+        assert!(inject_baggage_from_context(&cx).is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn attached_extracted_context_makes_baggage_visible_in_current_context() {
+        // This is the exact pattern `Engine::spawn_invoke_function` uses:
+        //   let parent_cx = extract_context(traceparent, baggage);
+        //   let _guard = parent_cx.attach();
+        //   tracing::info_span!("handle_invocation", ...);
+        //
+        // The pin: after `.attach()`, baggage MUST be readable from
+        // `Context::current()` so `BaggageSpanProcessor::on_start`
+        // (which reads `parent_context.baggage()` and copies allowlisted
+        // entries onto each new span) can see the iii.* keys.
+        let bg = "iii.message.id=m-1,iii.session.id=s-1";
+        let parent_cx = extract_context(None, Some(bg));
+        {
+            let _guard = parent_cx.attach();
+            let injected = inject_baggage_from_context(&Context::current())
+                .expect("baggage must be visible in Context::current() inside the guard");
+            assert!(injected.contains("iii.message.id=m-1"));
+            assert!(injected.contains("iii.session.id=s-1"));
+        }
+        // Guard dropped — baggage must no longer leak into the caller scope.
+        assert!(
+            inject_baggage_from_context(&Context::current()).is_none(),
+            "baggage must not leak into the caller scope after the guard drops"
+        );
+    }
+
+    #[test]
+    fn invalid_traceparent_extracts_to_invalid_context() {
+        // Engine receives malformed inbound headers (proxy bug, mid-flight
+        // truncation). `extract_context` must NOT panic and must return an
+        // invalid context, so the downstream span starts a fresh trace
+        // instead of inheriting garbage.
+        let cx = extract_context(Some("not-a-valid-traceparent"), None);
+        let span_ref = cx.span();
+        assert!(!span_ref.span_context().is_valid());
+        drop(span_ref);
+        assert!(inject_traceparent_from_context(&cx).is_none());
+    }
 }

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -637,7 +637,7 @@ impl SpanExporter for TeeSpanExporter {
         &self,
         batch: Vec<SpanData>,
     ) -> impl std::future::Future<Output = OTelSdkResult> + Send {
-        // Store in memory first (for triggers and API access)
+        // Store in memory first (for triggers and API access).
         let stored: Vec<StoredSpan> = batch
             .iter()
             .map(|s| StoredSpan::from_span_data(s, &self.service_name))
@@ -739,6 +739,7 @@ where
                     let _ = IN_MEMORY_STORAGE.set(memory_storage);
 
                     SdkTracerProvider::builder()
+                        .with_span_processor(iii_sdk::BaggageSpanProcessor::default())
                         .with_batch_exporter(exporter)
                         .with_sampler(sampler)
                         .with_id_generator(RandomIdGenerator::default())
@@ -757,6 +758,7 @@ where
                         config.service_name.clone(),
                     );
                     SdkTracerProvider::builder()
+                        .with_span_processor(iii_sdk::BaggageSpanProcessor::default())
                         .with_simple_exporter(exporter)
                         .with_sampler(sampler)
                         .with_id_generator(RandomIdGenerator::default())
@@ -770,6 +772,7 @@ where
                 InMemorySpanExporter::new(config.memory_max_spans, config.service_name.clone());
 
             SdkTracerProvider::builder()
+                .with_span_processor(iii_sdk::BaggageSpanProcessor::default())
                 .with_simple_exporter(exporter)
                 .with_sampler(sampler)
                 .with_id_generator(RandomIdGenerator::default())
@@ -818,6 +821,7 @@ where
                         config.service_name.clone(),
                     );
                     SdkTracerProvider::builder()
+                        .with_span_processor(iii_sdk::BaggageSpanProcessor::default())
                         .with_simple_exporter(exporter)
                         .with_sampler(sampler)
                         .with_id_generator(RandomIdGenerator::default())


### PR DESCRIPTION
## Summary

Builds on the SDK trace correlation primitives (#1642) to make `iii.session.id` / `iii.message.id` / `iii.function.id` baggage entries queryable across full traces, and adds the server-side aggregation that powers the console TRACES tab "group by message" view.

- **`engine::traces::list` filter widening** — when `search_all_spans=true` and an attribute filter is set, surface a root span if ANY span in its trace matches. Mirrors the existing name-filter pre-computation. Root-only behavior preserved when `search_all_spans=false` so legacy callers (e.g. `iii.function.kind`) are unaffected.
- **`engine::traces::group_by` endpoint** — new aggregation that buckets traces by any attribute value and returns `trace_ids`, `span_count`, `duration_ms`, `error_count` per group. Powers the upcoming console group-by dropdown.
- **`handle_invocation` context attach** — attach inbound `traceparent` + `baggage` to `Context::current()` BEFORE opening the span so `BaggageSpanProcessor::on_start` (from iii-sdk) sees the iii.* keys and stamps them on the span as attributes. Without this, baggage entries are propagated wire-side but never materialized as queryable span attributes.
- **Downstream parent-child fix** — derive a fresh `traceparent`/`baggage` pair from the new `handle_invocation` span so the inner `call <fn>` span becomes a CHILD instead of a sibling. Without this, the trace tree collapsed the two engine spans side-by-side.
- **`logging::display_option`** — helper that renders `Option<T: Display>` as `value` / `""` instead of Rust Debug's `Some(...)` / `None`, so OTel attributes don't carry wrapper noise.

## Test coverage

- 7 new tests in `engine/src/workers/observability/mod.rs` covering `traces::list` widening (happy path + back-compat) and `traces::group_by` (aggregates, time filter, pagination, internal-span exclusion).
- 7 new tests in `engine/src/workers/observability/otel.rs` covering the `extract_context` / `inject_*_from_context` round-trip, the `.attach()` pattern that `spawn_invoke_function` depends on, and malformed-input safety.
- 3 new tests in `engine/src/logging.rs` covering `display_option`.

**1,580 engine lib tests pass.**

## Test plan

- [x] `cargo test --lib` on engine (1,580 passed, 6 ignored)
- [x] `cargo test --lib workers::observability::` (310 passed)
- [x] `cargo test --lib workers::observability::otel::tests::` (110 passed)
- [x] `cargo test --lib logging::tests::display_option` (3 passed)
- [x] `cargo build -p engine` clean
- [ ] CI workflow (engine build + clippy + fmt + nextest) once PR opens
- [ ] Harness e2e round-trip — covered by the follow-up `feat/harness-traces` branch (asserts the full SDK→baggage→engine→filter chain)

## Out of scope

- Console TRACES tab group-by dropdown (Layer 3b — separate branch).
- Harness writer-side rename of `iii.function_id` → `iii.function.id` (also separate, lands with the harness/console branch).

## Related

- Depends on #1642 (merged) — SDK provides `BaggageSpanProcessor` + `DEFAULT_ALLOWLIST` consumed by this PR's `iii_sdk::BaggageSpanProcessor` references in engine `otel.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added trace grouping API to aggregate and analyze spans by attribute with filtering, limits, and sorting

* **Improvements**
  * Enhanced trace search to match attributes across child spans for deeper visibility
  * Improved trace context propagation so downstream spans are correctly parented
  * Refined telemetry field formatting for clearer logs and displays
  * Increased in-memory span retention capacity

* **Tests**
  * Expanded end-to-end and unit tests covering tracing, context propagation, and export behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1643)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->