### PR TITLE
fix(ci): honor bump type when current version is pre-release

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -110,18 +110,37 @@ jobs:
             fi
 
             local new_base
+            local apply_bump=0
             if [[ "$PRERELEASE" != "none" && "$current_pre" == "$PRERELEASE" ]]; then
-              # Same pre-release channel: keep base, increment counter
-              # e.g. 0.12.0-next.1 → 0.12.0-next.2
-              new_base="$base"
+              # Same pre-release channel.
+              # bump=patch (default): keep base, increment counter
+              #   e.g. 0.12.0-next.1 → 0.12.0-next.2
+              # bump=minor/major: bump base off the pre-release base, reset counter
+              #   e.g. 0.12.0-next.1 + minor → 0.13.0-next.1
+              if [[ "$bump_type" == "patch" ]]; then
+                new_base="$base"
+              else
+                apply_bump=1
+              fi
             elif [[ "$PRERELEASE" == "none" && -n "$current_pre" ]]; then
-              # Promoting pre-release to stable: use base as-is
-              # e.g. 0.12.0-next.3 → 0.12.0
-              new_base="$base"
+              # Promoting pre-release to stable.
+              # bump=patch (default): promote pending pre-release base as-is
+              #   e.g. 0.12.0-next.3 → 0.12.0
+              # bump=minor/major: caller changed intent, bump off the base
+              #   e.g. 0.11.7-next.4 + minor → 0.12.0
+              if [[ "$bump_type" == "patch" ]]; then
+                new_base="$base"
+              else
+                apply_bump=1
+              fi
             else
               # Stable → stable bump, or stable → new pre-release
               # e.g. 0.11.0 + minor → 0.12.0
               # e.g. 0.11.0 + minor + next → 0.12.0-next.1
+              apply_bump=1
+            fi
+
+            if [[ "$apply_bump" -eq 1 ]]; then
               case "$bump_type" in
                 major) major=$((major + 1)); minor=0; patch=0 ;;
                 minor) minor=$((minor + 1)); patch=0 ;;


### PR DESCRIPTION
## Summary

`create-tag.yml`'s `bump_version()` ignored the `bump` input whenever the current version carried a pre-release suffix. Both the *same pre-release channel* branch and the *promote to stable* branch fell through to `new_base="$base"` without ever inspecting `$bump_type`, so the `case "$bump_type"` block at the bottom of that conditional ran only on the "stable → stable" path.

### Repro

Current version: `0.11.7-next.4` (see commit `34da736b`).

Workflow inputs:
- `bump = minor`
- `prerelease = none`

Expected: `0.12.0`. Actual: `0.11.7`. The minor bump silently became a patch-shaped no-op promotion.

### Fix

Apply the bump whenever the caller explicitly asked for `minor`/`major`, even on the promote / same-channel paths. The `patch` default still preserves the existing shortcut behavior so that the standard "iterate prereleases" and "promote pending pre-release" flows keep working without surprises.

| Current | `bump` | `prerelease` | Before | After |
|---------|--------|--------------|--------|-------|
| `0.11.7-next.4` | `minor` | `none` | `0.11.7` | `0.12.0` |
| `0.11.7-next.4` | `patch` | `none` | `0.11.7` | `0.11.7` |
| `0.11.7-next.4` | `minor` | `next` | `0.11.7-next.5` | `0.12.0-next.1` |
| `0.12.0-next.1` | `patch` | `next` | `0.12.0-next.2` | `0.12.0-next.2` |
| `0.11.0` | `minor` | `none` | `0.12.0` | `0.12.0` |

## Test plan

- [ ] Run the `Create Tag` workflow with `dry_run = true`, `target = iii`, `bump = minor`, `prerelease = none` and confirm the computed tag is `iii/v0.12.0`.
- [ ] Re-run with `bump = minor`, `prerelease = next` and confirm `iii/v0.12.0-next.1`.
- [ ] Re-run with `bump = patch`, `prerelease = next` and confirm the next-counter increments rather than bumping the base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**No user-visible changes.** This release includes internal workflow improvements to version management automation. No end-user features, functionality, or behavior have been affected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1648)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->