### PR TITLE
feat(console): traces page on iii-browser-sdk + portability/quality pass

### DIFF
--- a/console/packages/console-frontend/package.json
+++ b/console/packages/console-frontend/package.json
@@ -10,10 +10,12 @@
     "dev:standalone": "vite --host",
     "build": "tsc -b && vite build",
     "build:binary": "vite build --mode binary",
-    "preview": "vite preview",
+    "format": "biome format src --write",
     "lint": "biome check src",
     "lint:fix": "biome check src --write",
-    "format": "biome format src --write"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
@@ -31,6 +33,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "dagre": "^0.8.5",
+    "iii-browser-sdk": "workspace:*",
     "lucide-react": "^0.563.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
@@ -53,6 +56,7 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^4",
     "typescript": "^5",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^2.1.0"
   }
 }

--- a/console/packages/console-frontend/src/api/config.ts
+++ b/console/packages/console-frontend/src/api/config.ts
@@ -2,6 +2,7 @@ export interface ConsoleConfig {
   engineHost: string
   enginePort: number
   wsPort: number
+  bridgePort: number
   consolePort: number
   version: string
   enableFlow?: boolean
@@ -36,6 +37,13 @@ export function getStreamsWs(): string {
   const c = getConfig()
   const host = typeof window !== 'undefined' ? window.location.host : `localhost:${c.consolePort}`
   return `${wsProtocol}//${host}/ws/streams`
+}
+
+export function getEngineBridgeWs(): string {
+  const wsProtocol =
+    typeof window !== 'undefined' && window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  const c = getConfig()
+  return `${wsProtocol}//${c.engineHost}:${c.bridgePort}`
 }
 
 export function getEngineBaseUrl(): string {

--- a/console/packages/console-frontend/src/api/engine-sdk-provider.tsx
+++ b/console/packages/console-frontend/src/api/engine-sdk-provider.tsx
@@ -1,0 +1,40 @@
+import { type ISdk, registerWorker } from 'iii-browser-sdk'
+import { createContext, type ReactNode, useContext, useEffect, useState } from 'react'
+import { getEngineBridgeWs } from './config'
+
+const EngineSdkContext = createContext<ISdk | null>(null)
+
+export function useEngineSdk(): ISdk {
+  const sdk = useContext(EngineSdkContext)
+  if (!sdk) {
+    throw new Error('useEngineSdk must be used within an EngineSdkProvider')
+  }
+  return sdk
+}
+
+interface EngineSdkProviderProps {
+  children: ReactNode
+}
+
+export function EngineSdkProvider({ children }: EngineSdkProviderProps) {
+  // ConfigProvider gates render until config is loaded (see config-provider.tsx),
+  // so getConfig() inside getEngineBridgeWs() is safe at mount time. useState
+  // with a lazy initializer is invoked exactly once per mount even in
+  // React 18 StrictMode, so we don't accidentally open two WebSockets in dev.
+  const [sdk] = useState(() =>
+    registerWorker(getEngineBridgeWs(), {
+      invocationTimeoutMs: 30_000,
+    }),
+  )
+
+  // Close the WebSocket and cancel pending invocations on unmount (HMR teardown
+  // or conditional render of the provider). Without this, the SDK reconnects
+  // forever in the background.
+  useEffect(() => {
+    return () => {
+      void sdk.shutdown()
+    }
+  }, [sdk])
+
+  return <EngineSdkContext.Provider value={sdk}>{children}</EngineSdkContext.Provider>
+}

--- a/console/packages/console-frontend/src/api/engine-sdk-provider.tsx
+++ b/console/packages/console-frontend/src/api/engine-sdk-provider.tsx
@@ -14,27 +14,63 @@ export function useEngineSdk(): ISdk {
 
 interface EngineSdkProviderProps {
   children: ReactNode
+  /**
+   * Pre-built SDK to expose via context. When provided, the provider
+   * skips bridge-URL resolution and the consumer owns the SDK lifecycle
+   * (no implicit `shutdown()` on unmount). Useful for embedding the
+   * traces feature in a different host app or for swapping in a mock
+   * SDK in tests/Storybook.
+   *
+   * Must be stable across renders; toggling between provided/internal
+   * SDK mid-mount is not supported.
+   */
+  sdk?: ISdk
+  /**
+   * Override the bridge WebSocket URL. Ignored when `sdk` is provided.
+   * Defaults to `getEngineBridgeWs()`, which reads `engineHost` +
+   * `bridgePort` from the runtime `ConfigProvider`. Pass this when you
+   * want to use the iii-browser-sdk transport without depending on the
+   * console's `ConfigProvider` chain.
+   */
+  bridgeUrl?: string
 }
 
-export function EngineSdkProvider({ children }: EngineSdkProviderProps) {
-  // ConfigProvider gates render until config is loaded (see config-provider.tsx),
-  // so getConfig() inside getEngineBridgeWs() is safe at mount time. useState
-  // with a lazy initializer is invoked exactly once per mount even in
-  // React 18 StrictMode, so we don't accidentally open two WebSockets in dev.
-  const [sdk] = useState(() =>
-    registerWorker(getEngineBridgeWs(), {
+export function EngineSdkProvider({
+  children,
+  sdk: externalSdk,
+  bridgeUrl,
+}: EngineSdkProviderProps) {
+  // When `externalSdk` is provided, the consumer owns lifecycle and we
+  // skip `registerWorker` entirely. Otherwise we create our own SDK
+  // exactly once per mount — `useState` with a lazy initializer is
+  // invoked once even in React 18 StrictMode, so we don't open two
+  // WebSockets in dev.
+  const [internalSdk] = useState<ISdk | null>(() => {
+    if (externalSdk) return null
+    return registerWorker(bridgeUrl ?? getEngineBridgeWs(), {
       invocationTimeoutMs: 30_000,
-    }),
-  )
+    })
+  })
 
-  // Close the WebSocket and cancel pending invocations on unmount (HMR teardown
-  // or conditional render of the provider). Without this, the SDK reconnects
-  // forever in the background.
+  // Close the internally-owned WebSocket on unmount (HMR teardown or
+  // conditional provider remount). When `externalSdk` is provided we
+  // never created an SDK to shut down.
   useEffect(() => {
+    if (!internalSdk) return
     return () => {
-      void sdk.shutdown()
+      void internalSdk.shutdown()
     }
-  }, [sdk])
+  }, [internalSdk])
+
+  const sdk = externalSdk ?? internalSdk
+  if (!sdk) {
+    // Unreachable: either `externalSdk` was provided or the initializer
+    // built `internalSdk`. Kept as a defensive guard so the context
+    // value is never `null` past this line.
+    throw new Error(
+      'EngineSdkProvider: no SDK available. Pass `sdk`, pass `bridgeUrl`, or mount under ConfigProvider.',
+    )
+  }
 
   return <EngineSdkContext.Provider value={sdk}>{children}</EngineSdkContext.Provider>
 }

--- a/console/packages/console-frontend/src/api/index.ts
+++ b/console/packages/console-frontend/src/api/index.ts
@@ -11,6 +11,7 @@ export type { ConsoleConfig } from './config'
 export {
   getConfig,
   getDevtoolsApi,
+  getEngineBridgeWs,
   getManagementApi,
   getStreamsWs,
   setConfig,
@@ -76,11 +77,19 @@ export type {
   SpanLink,
   SpanTreeNode,
   StoredSpan,
+  TraceGroup,
   TracesFilterParams,
+  TracesGroupByParams,
+  TracesGroupByResponse,
   TracesResponse,
   TraceTreeResponse,
 } from './observability/traces'
-export { clearTraces, fetchTraces, fetchTraceTree } from './observability/traces'
+export {
+  clearTraces,
+  fetchTraces,
+  fetchTracesGroupBy,
+  fetchTraceTree,
+} from './observability/traces'
 // Queries (React Query)
 export * from './queries'
 // Queues & DLQ

--- a/console/packages/console-frontend/src/api/observability/traces.test.ts
+++ b/console/packages/console-frontend/src/api/observability/traces.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ISdk, TriggerRequest } from 'iii-browser-sdk'
+import { clearTraces, fetchTraces, fetchTracesGroupBy, fetchTraceTree } from './traces'
+
+function makeSdkStub(
+  responder: (req: TriggerRequest<unknown>) => unknown | Promise<unknown>,
+): { sdk: ISdk; trigger: ReturnType<typeof vi.fn> } {
+  const trigger = vi.fn(async (req: TriggerRequest<unknown>) => responder(req))
+  // Only `trigger` is exercised; the rest of ISdk is unused in these tests.
+  const sdk = { trigger } as unknown as ISdk
+  return { sdk, trigger }
+}
+
+describe('fetchTraces', () => {
+  it('invokes engine::traces::list with defaulted offset and limit', async () => {
+    const expected = { spans: [], total: 0, offset: 0, limit: 100 }
+    const { sdk, trigger } = makeSdkStub(() => expected)
+
+    const result = await fetchTraces(sdk)
+
+    expect(trigger).toHaveBeenCalledTimes(1)
+    const call = trigger.mock.calls[0][0]
+    expect(call.function_id).toBe('engine::traces::list')
+    expect(call.payload).toMatchObject({ offset: 0, limit: 100 })
+    expect(call.timeoutMs).toBe(5000)
+    expect(result).toEqual(expected)
+  })
+
+  it('forwards caller-supplied filters (include_internal, search_all_spans, name)', async () => {
+    const { sdk, trigger } = makeSdkStub(() => ({ spans: [], total: 0, offset: 0, limit: 50 }))
+
+    await fetchTraces(sdk, {
+      include_internal: true,
+      search_all_spans: true,
+      name: 'foo',
+      limit: 50,
+    })
+
+    const payload = trigger.mock.calls[0][0].payload as Record<string, unknown>
+    expect(payload.include_internal).toBe(true)
+    expect(payload.search_all_spans).toBe(true)
+    expect(payload.name).toBe('foo')
+    expect(payload.limit).toBe(50)
+    expect(payload.offset).toBe(0)
+  })
+
+  it('returns an empty TracesResponse when the engine reports memory exporter not enabled', async () => {
+    const { sdk } = makeSdkStub(() => {
+      throw new Error('Memory exporter is not enabled')
+    })
+
+    const result = await fetchTraces(sdk, { limit: 25 })
+
+    expect(result).toEqual({ spans: [], total: 0, offset: 0, limit: 25 })
+  })
+
+  it('rethrows any other error as an Error instance', async () => {
+    const { sdk } = makeSdkStub(() => {
+      throw new Error('something else')
+    })
+
+    await expect(fetchTraces(sdk)).rejects.toThrow('something else')
+  })
+})
+
+describe('fetchTraceTree', () => {
+  it('invokes engine::traces::tree with the given trace_id', async () => {
+    const expected = { roots: [] }
+    const { sdk, trigger } = makeSdkStub(() => expected)
+
+    const result = await fetchTraceTree(sdk, 'abc123')
+
+    expect(trigger).toHaveBeenCalledTimes(1)
+    const call = trigger.mock.calls[0][0]
+    expect(call.function_id).toBe('engine::traces::tree')
+    expect(call.payload).toEqual({ trace_id: 'abc123' })
+    expect(call.timeoutMs).toBe(10000)
+    expect(result).toEqual(expected)
+  })
+
+  it('returns { roots: [] } when the engine reports memory exporter not enabled', async () => {
+    const { sdk } = makeSdkStub(() => {
+      throw new Error('memory exporter not enabled')
+    })
+
+    const result = await fetchTraceTree(sdk, 'abc123')
+
+    expect(result).toEqual({ roots: [] })
+  })
+
+  it('rethrows any other error as an Error instance', async () => {
+    const { sdk } = makeSdkStub(() => {
+      throw new Error('something else')
+    })
+
+    await expect(fetchTraceTree(sdk, 'abc123')).rejects.toThrow('something else')
+  })
+})
+
+describe('clearTraces', () => {
+  it('invokes engine::traces::clear with empty payload and returns success', async () => {
+    const { sdk, trigger } = makeSdkStub(() => ({ success: true }))
+
+    const result = await clearTraces(sdk)
+
+    expect(trigger).toHaveBeenCalledTimes(1)
+    const call = trigger.mock.calls[0][0]
+    expect(call.function_id).toBe('engine::traces::clear')
+    expect(call.payload).toEqual({})
+    expect(call.timeoutMs).toBe(5000)
+    expect(result).toEqual({ success: true })
+  })
+
+  it('rethrows engine errors as Error', async () => {
+    const { sdk } = makeSdkStub(() => {
+      throw new Error('boom')
+    })
+
+    await expect(clearTraces(sdk)).rejects.toThrow('boom')
+  })
+
+  it('does not swallow memory-exporter-not-enabled errors (unlike fetch functions)', async () => {
+    const { sdk } = makeSdkStub(() => {
+      throw new Error('Memory exporter is not enabled')
+    })
+
+    await expect(clearTraces(sdk)).rejects.toThrow('Memory exporter is not enabled')
+  })
+})
+
+describe('fetchTracesGroupBy', () => {
+  it('invokes engine::traces::group_by with the given attribute', async () => {
+    const expected = {
+      groups: [
+        {
+          value: 'msg-1',
+          trace_ids: ['t1', 't2'],
+          span_count: 5,
+          first_seen_ms: 1000,
+          last_seen_ms: 2000,
+          duration_ms: 1000,
+          error_count: 0,
+        },
+      ],
+    }
+    const { sdk, trigger } = makeSdkStub(() => expected)
+
+    const result = await fetchTracesGroupBy(sdk, { attribute: 'iii.message.id' })
+
+    expect(trigger).toHaveBeenCalledTimes(1)
+    const call = trigger.mock.calls[0][0]
+    expect(call.function_id).toBe('engine::traces::group_by')
+    expect(call.payload).toEqual({ attribute: 'iii.message.id' })
+    expect(call.timeoutMs).toBe(5000)
+    expect(result).toEqual(expected)
+  })
+
+  it('forwards optional filters (since_ms, limit, include_internal)', async () => {
+    const { sdk, trigger } = makeSdkStub(() => ({ groups: [] }))
+
+    await fetchTracesGroupBy(sdk, {
+      attribute: 'iii.session.id',
+      since_ms: 1_700_000_000_000,
+      limit: 25,
+      include_internal: true,
+    })
+
+    expect(trigger.mock.calls[0][0].payload).toEqual({
+      attribute: 'iii.session.id',
+      since_ms: 1_700_000_000_000,
+      limit: 25,
+      include_internal: true,
+    })
+  })
+
+  it('strips undefined optional fields from the payload', async () => {
+    const { sdk, trigger } = makeSdkStub(() => ({ groups: [] }))
+
+    await fetchTracesGroupBy(sdk, {
+      attribute: 'iii.function.id',
+      since_ms: undefined,
+      limit: undefined,
+    })
+
+    expect(trigger.mock.calls[0][0].payload).toEqual({ attribute: 'iii.function.id' })
+  })
+
+  it('returns { groups: [] } when the engine reports memory exporter not enabled', async () => {
+    const { sdk } = makeSdkStub(() => {
+      throw new Error('memory exporter not enabled')
+    })
+
+    const result = await fetchTracesGroupBy(sdk, { attribute: 'iii.message.id' })
+
+    expect(result).toEqual({ groups: [] })
+  })
+
+  it('rethrows any other error (e.g. function_not_found from older engines) as Error', async () => {
+    const { sdk } = makeSdkStub(() => {
+      throw new Error('function_not_found: engine::traces::group_by')
+    })
+
+    await expect(
+      fetchTracesGroupBy(sdk, { attribute: 'iii.message.id' }),
+    ).rejects.toThrow('function_not_found: engine::traces::group_by')
+  })
+})

--- a/console/packages/console-frontend/src/api/observability/traces.test.ts
+++ b/console/packages/console-frontend/src/api/observability/traces.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it, vi } from 'vitest'
 import type { ISdk, TriggerRequest } from 'iii-browser-sdk'
+import { describe, expect, it, vi } from 'vitest'
 import { clearTraces, fetchTraces, fetchTracesGroupBy, fetchTraceTree } from './traces'
 
-function makeSdkStub(
-  responder: (req: TriggerRequest<unknown>) => unknown | Promise<unknown>,
-): { sdk: ISdk; trigger: ReturnType<typeof vi.fn> } {
+function makeSdkStub(responder: (req: TriggerRequest<unknown>) => unknown | Promise<unknown>): {
+  sdk: ISdk
+  trigger: ReturnType<typeof vi.fn>
+} {
   const trigger = vi.fn(async (req: TriggerRequest<unknown>) => responder(req))
   // Only `trigger` is exercised; the rest of ISdk is unused in these tests.
   const sdk = { trigger } as unknown as ISdk
@@ -200,8 +201,8 @@ describe('fetchTracesGroupBy', () => {
       throw new Error('function_not_found: engine::traces::group_by')
     })
 
-    await expect(
-      fetchTracesGroupBy(sdk, { attribute: 'iii.message.id' }),
-    ).rejects.toThrow('function_not_found: engine::traces::group_by')
+    await expect(fetchTracesGroupBy(sdk, { attribute: 'iii.message.id' })).rejects.toThrow(
+      'function_not_found: engine::traces::group_by',
+    )
   })
 })

--- a/console/packages/console-frontend/src/api/observability/traces.ts
+++ b/console/packages/console-frontend/src/api/observability/traces.ts
@@ -1,5 +1,4 @@
-import { getDevtoolsApi, getManagementApi } from '../config'
-import { unwrapResponse } from '../utils'
+import type { ISdk } from 'iii-browser-sdk'
 
 export interface SpanEvent {
   name: string
@@ -57,7 +56,6 @@ export interface TracesFilterParams {
   search_all_spans?: boolean
 }
 
-// Tree API types (engine.traces.tree)
 export interface SpanTreeNode {
   trace_id: string
   span_id: string
@@ -80,55 +78,133 @@ export interface TraceTreeResponse {
   roots: SpanTreeNode[]
 }
 
-async function postWithFallback<T>(path: string, body: unknown, errorMsg: string): Promise<T> {
-  const init: RequestInit = {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  }
+export interface TracesGroupByParams {
+  /** Span attribute key to group by, e.g. "iii.message.id". */
+  attribute: string
+  /** Earliest end_time (ms since epoch) to include. Omit for no lower bound. */
+  since_ms?: number
+  /** Max groups returned after sorting by `first_seen_ms` descending. Default 100 server-side. */
+  limit?: number
+  /** Include engine-internal spans. Defaults to false server-side, matching `traces::list`. */
+  include_internal?: boolean
+}
 
-  const primaryBase = getDevtoolsApi()
-  const fallbackBase = getManagementApi()
-  const hasFallback = primaryBase !== fallbackBase
+export interface TraceGroup {
+  /** The attribute value this group is keyed on. */
+  value: string
+  trace_ids: string[]
+  span_count: number
+  first_seen_ms: number
+  last_seen_ms: number
+  duration_ms: number
+  error_count: number
+}
+
+export interface TracesGroupByResponse {
+  groups: TraceGroup[]
+}
+
+const FN_LIST = 'engine::traces::list'
+const FN_TREE = 'engine::traces::tree'
+const FN_CLEAR = 'engine::traces::clear'
+const FN_GROUP_BY = 'engine::traces::group_by'
+
+const LIST_TIMEOUT_MS = 5_000
+const TREE_TIMEOUT_MS = 10_000
+const CLEAR_TIMEOUT_MS = 5_000
+const GROUP_BY_TIMEOUT_MS = 5_000
+
+function stripUndefined<T extends Record<string, unknown>>(obj: T): T {
+  return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined)) as T
+}
+
+function isMemoryExporterNotEnabled(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err)
+  return /memory exporter (is )?not enabled/i.test(msg)
+}
+
+function asError(err: unknown, fallback: string): Error {
+  if (err instanceof Error) return err
+  return new Error(typeof err === 'string' ? err : fallback)
+}
+
+export async function fetchTraces(
+  sdk: ISdk,
+  options?: TracesFilterParams,
+): Promise<TracesResponse> {
+  const offset = options?.offset ?? 0
+  const limit = options?.limit ?? 100
+  const payload = stripUndefined({ ...options, offset, limit })
 
   try {
-    const res = await fetch(`${primaryBase}${path}`, init)
-    if (res.ok) return unwrapResponse<T>(res)
-    if (!hasFallback) throw new Error(errorMsg)
-    console.warn(`[traces] Primary API returned ${res.status} for ${path}, trying fallback`)
+    return await sdk.trigger<typeof payload, TracesResponse>({
+      function_id: FN_LIST,
+      payload,
+      timeoutMs: LIST_TIMEOUT_MS,
+    })
   } catch (err) {
-    if (!hasFallback) throw err instanceof Error ? err : new Error(errorMsg)
-    console.warn(`[traces] Primary API failed for ${path}, falling through to fallback`, err)
+    if (isMemoryExporterNotEnabled(err)) {
+      return { spans: [], total: 0, offset, limit }
+    }
+    throw asError(err, 'Failed to fetch traces')
   }
-
-  const res = await fetch(`${fallbackBase}${path}`, init)
-  if (!res.ok) throw new Error(errorMsg)
-  return unwrapResponse<T>(res)
 }
 
-function stripUndefined(obj: Record<string, unknown>): Record<string, unknown> {
-  return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined))
+export async function fetchTraceTree(
+  sdk: ISdk,
+  traceId: string,
+): Promise<TraceTreeResponse> {
+  try {
+    return await sdk.trigger<{ trace_id: string }, TraceTreeResponse>({
+      function_id: FN_TREE,
+      payload: { trace_id: traceId },
+      timeoutMs: TREE_TIMEOUT_MS,
+    })
+  } catch (err) {
+    if (isMemoryExporterNotEnabled(err)) {
+      return { roots: [] }
+    }
+    throw asError(err, 'Failed to fetch trace tree')
+  }
 }
 
-export async function fetchTraces(options?: TracesFilterParams): Promise<TracesResponse> {
-  const body = stripUndefined({
-    ...options,
-    offset: options?.offset ?? 0,
-    limit: options?.limit ?? 100,
-  })
-
-  return postWithFallback<TracesResponse>('/otel/traces', body, 'Failed to fetch traces')
+export async function clearTraces(sdk: ISdk): Promise<{ success: boolean }> {
+  try {
+    await sdk.trigger<Record<string, never>, { success: boolean }>({
+      function_id: FN_CLEAR,
+      payload: {},
+      timeoutMs: CLEAR_TIMEOUT_MS,
+    })
+    return { success: true }
+  } catch (err) {
+    throw asError(err, 'Failed to clear traces')
+  }
 }
 
-export async function fetchTraceTree(traceId: string): Promise<TraceTreeResponse> {
-  return postWithFallback<TraceTreeResponse>(
-    '/otel/traces/tree',
-    { trace_id: traceId },
-    'Failed to fetch trace tree',
-  )
-}
-
-export async function clearTraces(): Promise<{ success: boolean }> {
-  await postWithFallback('/otel/traces/clear', {}, 'Failed to clear traces')
-  return { success: true }
+/**
+ * Server-side aggregation by attribute value. Calls the engine function
+ * `engine::traces::group_by`. When the memory exporter is not enabled,
+ * returns an empty group list so the UI degrades to the same "OTel not
+ * configured" path as `fetchTraces`. When the engine itself doesn't
+ * expose `group_by` (older deploy), the error is rethrown — callers
+ * (see `useTraceGroups`) detect it via `isGroupByUnavailable` and hide
+ * the group-by affordance.
+ */
+export async function fetchTracesGroupBy(
+  sdk: ISdk,
+  params: TracesGroupByParams,
+): Promise<TracesGroupByResponse> {
+  const payload = stripUndefined({ ...params })
+  try {
+    return await sdk.trigger<typeof payload, TracesGroupByResponse>({
+      function_id: FN_GROUP_BY,
+      payload,
+      timeoutMs: GROUP_BY_TIMEOUT_MS,
+    })
+  } catch (err) {
+    if (isMemoryExporterNotEnabled(err)) {
+      return { groups: [] }
+    }
+    throw asError(err, 'Failed to fetch trace groups')
+  }
 }

--- a/console/packages/console-frontend/src/api/observability/traces.ts
+++ b/console/packages/console-frontend/src/api/observability/traces.ts
@@ -1,3 +1,32 @@
+/**
+ * Engine transport for the TRACES tab.
+ *
+ *   useTraceData ──┐
+ *   useTraceGroups ┼─► fetchTraces / fetchTraceTree / fetchTracesGroupBy / clearTraces
+ *   routes/traces ─┤        │
+ *   SessionDetail ─┘        ▼
+ *                   ISdk.trigger({ function_id, payload, timeoutMs })
+ *                           │
+ *                           ▼                (engine bridge_port WebSocket)
+ *                   ┌───────────────────────────────────────────┐
+ *                   │ engine::traces::list      LIST_TIMEOUT_MS │
+ *                   │ engine::traces::tree      TREE_TIMEOUT_MS │
+ *                   │ engine::traces::clear     CLEAR_TIMEOUT_MS│
+ *                   │ engine::traces::group_by  GROUP_BY_TIMEOUT│
+ *                   └───────────────────────────────────────────┘
+ *
+ * Error policy:
+ * - list/tree/group_by swallow "memory exporter not enabled" and return
+ *   empty results so the UI degrades to "OTel not configured" rather
+ *   than a hard error.
+ * - clear rethrows that error — calling clear on a missing exporter is
+ *   programmer error, not a steady state.
+ * - All other errors rethrow as `Error` instances (see `asError`).
+ *
+ * Function IDs are exported as `TRACES_RPC_FUNCTIONS` so a port has a
+ * single discoverable place to change them.
+ */
+
 import type { ISdk } from 'iii-browser-sdk'
 
 export interface SpanEvent {
@@ -104,10 +133,29 @@ export interface TracesGroupByResponse {
   groups: TraceGroup[]
 }
 
-const FN_LIST = 'engine::traces::list'
-const FN_TREE = 'engine::traces::tree'
-const FN_CLEAR = 'engine::traces::clear'
-const FN_GROUP_BY = 'engine::traces::group_by'
+/**
+ * Engine RPC function IDs this module depends on. Exported as a typed
+ * record so a port of the traces feature has a single discoverable
+ * surface for the engine contract — change the engine names here, not
+ * scattered across call sites.
+ *
+ * Compatibility:
+ * - `list`, `tree`, `clear` shipped with the initial trace exporter.
+ * - `group_by` was added later; an older engine returns `function_not_found`
+ *   and `useTraceGroups` falls back to the flat-list view (see
+ *   `isGroupByUnavailable` in `lib/groupTraces.ts`).
+ */
+export const TRACES_RPC_FUNCTIONS = {
+  list: 'engine::traces::list',
+  tree: 'engine::traces::tree',
+  clear: 'engine::traces::clear',
+  groupBy: 'engine::traces::group_by',
+} as const
+
+const FN_LIST = TRACES_RPC_FUNCTIONS.list
+const FN_TREE = TRACES_RPC_FUNCTIONS.tree
+const FN_CLEAR = TRACES_RPC_FUNCTIONS.clear
+const FN_GROUP_BY = TRACES_RPC_FUNCTIONS.groupBy
 
 const LIST_TIMEOUT_MS = 5_000
 const TREE_TIMEOUT_MS = 10_000

--- a/console/packages/console-frontend/src/api/observability/traces.ts
+++ b/console/packages/console-frontend/src/api/observability/traces.ts
@@ -198,10 +198,7 @@ export async function fetchTraces(
   }
 }
 
-export async function fetchTraceTree(
-  sdk: ISdk,
-  traceId: string,
-): Promise<TraceTreeResponse> {
+export async function fetchTraceTree(sdk: ISdk, traceId: string): Promise<TraceTreeResponse> {
   try {
     return await sdk.trigger<{ trace_id: string }, TraceTreeResponse>({
       function_id: FN_TREE,

--- a/console/packages/console-frontend/src/api/queries.ts
+++ b/console/packages/console-frontend/src/api/queries.ts
@@ -1,4 +1,5 @@
 import { queryOptions } from '@tanstack/react-query'
+import type { ISdk } from 'iii-browser-sdk'
 import { fetchAlerts } from './alerts/alerts'
 import { fetchSamplingRules } from './alerts/sampling'
 import {
@@ -196,17 +197,20 @@ export const otelLogsQuery = (options?: {
 }
 
 // OTEL traces with options
-export const otelTracesQuery = (options?: { trace_id?: string; offset?: number; limit?: number }) =>
+export const otelTracesQuery = (
+  sdk: ISdk,
+  options?: { trace_id?: string; offset?: number; limit?: number },
+) =>
   queryOptions({
     queryKey: ['otel-traces', options],
-    queryFn: () => fetchTraces(options),
+    queryFn: () => fetchTraces(sdk, options),
   })
 
 // OTEL trace tree (single trace with nested children)
-export const otelTraceTreeQuery = (traceId: string) =>
+export const otelTraceTreeQuery = (sdk: ISdk, traceId: string) =>
   queryOptions({
     queryKey: ['otel-trace-tree', traceId],
-    queryFn: () => fetchTraceTree(traceId),
+    queryFn: () => fetchTraceTree(sdk, traceId),
     enabled: !!traceId,
   })
 

--- a/console/packages/console-frontend/src/components/traces/AttributesFilter.tsx
+++ b/console/packages/console-frontend/src/components/traces/AttributesFilter.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Check, Plus, Tag, X } from 'lucide-react'
 import { useState } from 'react'
 

--- a/console/packages/console-frontend/src/components/traces/AttributesFilter.tsx
+++ b/console/packages/console-frontend/src/components/traces/AttributesFilter.tsx
@@ -76,7 +76,7 @@ export function AttributesFilter({ value, onChange }: AttributesFilterProps) {
   return (
     <div className="space-y-2">
       {draft.length === 0 ? (
-        <div className="text-xs text-[#5B5B5B] italic font-mono">
+        <div className="text-xs text-muted italic font-mono">
           Filter by span attributes (e.g. http.request.method = POST)
         </div>
       ) : (
@@ -84,7 +84,7 @@ export function AttributesFilter({ value, onChange }: AttributesFilterProps) {
           {draft.map(({ id, key, val }) => (
             <div
               key={id}
-              className="group flex items-center gap-2 bg-[#0A0A0A] border border-[#1D1D1D] rounded-md p-2 hover:border-[#2D2D2D] transition-colors"
+              className="group flex items-center gap-2 bg-sidebar border border-border-subtle rounded-md p-2 hover:border-border transition-colors"
             >
               <input
                 type="text"
@@ -92,21 +92,21 @@ export function AttributesFilter({ value, onChange }: AttributesFilterProps) {
                 value={key}
                 onChange={(e) => handleKeyChange(id, e.target.value)}
                 onKeyDown={handleKeyDown}
-                className="flex-1 bg-transparent border-none text-xs text-[#F4F4F4] placeholder-[#5B5B5B] focus:outline-none font-mono"
+                className="flex-1 bg-transparent border-none text-xs text-foreground placeholder-muted focus:outline-none font-mono"
               />
-              <span className="text-[#5B5B5B] text-xs font-mono">=</span>
+              <span className="text-muted text-xs font-mono">=</span>
               <input
                 type="text"
                 placeholder="value"
                 value={val}
                 onChange={(e) => handleValueChange(id, e.target.value)}
                 onKeyDown={handleKeyDown}
-                className="flex-1 bg-transparent border-none text-xs text-[#F4F4F4] placeholder-[#5B5B5B] focus:outline-none font-mono"
+                className="flex-1 bg-transparent border-none text-xs text-foreground placeholder-muted focus:outline-none font-mono"
               />
               <button
                 type="button"
                 onClick={() => handleRemove(id)}
-                className="p-1 text-[#5B5B5B] hover:text-red-400 hover:bg-[#141414] rounded transition-all opacity-0 group-hover:opacity-100"
+                className="p-1 text-muted hover:text-red-400 hover:bg-elevated rounded transition-all opacity-0 group-hover:opacity-100"
                 title="Remove"
               >
                 <X className="w-3 h-3" />
@@ -121,7 +121,7 @@ export function AttributesFilter({ value, onChange }: AttributesFilterProps) {
           <button
             type="button"
             onClick={handleAdd}
-            className="flex items-center gap-1 px-2 py-1 text-xs font-mono text-[#F3F724] hover:bg-[#141414] rounded transition-colors"
+            className="flex items-center gap-1 px-2 py-1 text-xs font-mono text-accent hover:bg-elevated rounded transition-colors"
           >
             <Plus className="w-3 h-3" />
             Add
@@ -146,7 +146,7 @@ export function AttributesFilter({ value, onChange }: AttributesFilterProps) {
                 key={attr}
                 type="button"
                 onClick={() => handleSuggestionClick(attr)}
-                className="flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-mono text-[#9CA3AF] bg-[#0A0A0A] border border-[#1D1D1D] rounded hover:border-[#F3F724] hover:text-[#F3F724] transition-colors"
+                className="flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-mono text-secondary bg-sidebar border border-border-subtle rounded hover:border-accent hover:text-accent transition-colors"
                 title={`Add ${attr}`}
               >
                 <Tag className="w-2.5 h-2.5" />

--- a/console/packages/console-frontend/src/components/traces/FlameGraph.tsx
+++ b/console/packages/console-frontend/src/components/traces/FlameGraph.tsx
@@ -1,3 +1,22 @@
+/**
+ * Flame-graph view: spans rendered to a <canvas> for performance.
+ *
+ * THEMING NOTE — hex literals below (line ~22, ~164, ~194, ~339, etc.)
+ * are CSS color strings passed into `ctx.fillStyle` / `ctx.strokeStyle`.
+ * Canvas does not pick up Tailwind classes or CSS custom properties
+ * directly. To make this view re-theme under `[data-theme="light"]`,
+ * a future refactor should:
+ *
+ *   const root = getComputedStyle(document.documentElement)
+ *   const accent  = root.getPropertyValue('--accent').trim()
+ *   const success = root.getPropertyValue('--success').trim()
+ *   // ... pass into draw calls
+ *
+ * Recompute on theme change via a `theme` context or a
+ * `MutationObserver` on `<html data-theme>`. Until then, FlameGraph
+ * renders in fixed dark-mode colors regardless of host theme.
+ */
+
 import { Minus, Plus, RotateCcw } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
 import { getServiceColor, SPAN_STATUS_COLORS } from '@/lib/traceColors'
@@ -464,7 +483,7 @@ export function FlameGraph({ data, onSpanClick, selectedSpanId }: FlameGraphProp
   return (
     <div className="flex flex-col h-full">
       {/* Compact toolbar */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-[#1D1D1D] bg-[#0A0A0A] flex-shrink-0">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-border-subtle bg-sidebar flex-shrink-0">
         <div className="flex items-center gap-1.5">
           <span className="text-[10px] text-gray-500 uppercase tracking-wider mr-1">Color</span>
           <button
@@ -472,8 +491,8 @@ export function FlameGraph({ data, onSpanClick, selectedSpanId }: FlameGraphProp
             onClick={() => dispatch({ type: 'SET_COLOR_BY', colorBy: 'status' })}
             className={`px-2 py-0.5 text-[10px] rounded transition-colors ${
               colorBy === 'status'
-                ? 'bg-[#F3F724] text-black font-semibold'
-                : 'bg-[#141414] text-gray-500 hover:text-gray-300 border border-[#1D1D1D]'
+                ? 'bg-accent text-black font-semibold'
+                : 'bg-elevated text-gray-500 hover:text-gray-300 border border-border-subtle'
             }`}
           >
             Status
@@ -483,15 +502,15 @@ export function FlameGraph({ data, onSpanClick, selectedSpanId }: FlameGraphProp
             onClick={() => dispatch({ type: 'SET_COLOR_BY', colorBy: 'service' })}
             className={`px-2 py-0.5 text-[10px] rounded transition-colors ${
               colorBy === 'service'
-                ? 'bg-[#F3F724] text-black font-semibold'
-                : 'bg-[#141414] text-gray-500 hover:text-gray-300 border border-[#1D1D1D]'
+                ? 'bg-accent text-black font-semibold'
+                : 'bg-elevated text-gray-500 hover:text-gray-300 border border-border-subtle'
             }`}
           >
             Service
           </button>
 
           {/* Inline legend */}
-          <div className="w-px h-3.5 bg-[#1D1D1D] mx-1.5" />
+          <div className="w-px h-3.5 bg-border-subtle mx-1.5" />
           {colorBy === 'status' ? (
             <div className="flex items-center gap-2.5">
               <div className="flex items-center gap-1">
@@ -539,7 +558,7 @@ export function FlameGraph({ data, onSpanClick, selectedSpanId }: FlameGraphProp
             type="button"
             onClick={zoomOut}
             disabled={zoomLevel <= 1}
-            className="p-1 rounded hover:bg-[#141414] text-gray-500 hover:text-gray-300 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            className="p-1 rounded hover:bg-elevated text-gray-500 hover:text-gray-300 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             title="Zoom out"
           >
             <Minus className="w-3 h-3" />
@@ -548,7 +567,7 @@ export function FlameGraph({ data, onSpanClick, selectedSpanId }: FlameGraphProp
             type="button"
             onClick={zoomIn}
             disabled={zoomLevel >= 20}
-            className="p-1 rounded hover:bg-[#141414] text-gray-500 hover:text-gray-300 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            className="p-1 rounded hover:bg-elevated text-gray-500 hover:text-gray-300 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             title="Zoom in"
           >
             <Plus className="w-3 h-3" />
@@ -557,7 +576,7 @@ export function FlameGraph({ data, onSpanClick, selectedSpanId }: FlameGraphProp
             type="button"
             onClick={handleReset}
             disabled={zoomLevel === 1 && panOffset === 0}
-            className="p-1 rounded hover:bg-[#141414] text-gray-500 hover:text-gray-300 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            className="p-1 rounded hover:bg-elevated text-gray-500 hover:text-gray-300 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             title="Reset view"
           >
             <RotateCcw className="w-3 h-3" />
@@ -567,7 +586,7 @@ export function FlameGraph({ data, onSpanClick, selectedSpanId }: FlameGraphProp
 
       {/* Minimap (only when zoomed) */}
       {zoomLevel > 1 && (
-        <div className="border-b border-[#1D1D1D] flex-shrink-0 px-0">
+        <div className="border-b border-border-subtle flex-shrink-0 px-0">
           <canvas
             ref={minimapRef}
             onClick={handleMinimapClick}
@@ -598,7 +617,7 @@ export function FlameGraph({ data, onSpanClick, selectedSpanId }: FlameGraphProp
             top: tooltipPos.y + 12,
           }}
         >
-          <div className="bg-[#141414] border border-[#2D2D2D] rounded-lg px-3 py-2.5 shadow-xl shadow-black/50 min-w-[200px] max-w-[280px]">
+          <div className="bg-elevated border border-border rounded-lg px-3 py-2.5 shadow-xl shadow-black/50 min-w-[200px] max-w-[280px]">
             {/* Span name */}
             <div className="font-semibold text-[12px] text-white leading-tight mb-1.5 break-all">
               {hoveredNode.span.name}
@@ -624,7 +643,7 @@ export function FlameGraph({ data, onSpanClick, selectedSpanId }: FlameGraphProp
             <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-[10px]">
               <div className="flex justify-between">
                 <span className="text-gray-500">Duration</span>
-                <span className="text-[#F3F724] font-mono font-semibold">
+                <span className="text-accent font-mono font-semibold">
                   {formatDuration(hoveredNode.span.duration_ms)}
                 </span>
               </div>
@@ -650,9 +669,9 @@ export function FlameGraph({ data, onSpanClick, selectedSpanId }: FlameGraphProp
             </div>
 
             {/* Trace percentage bar */}
-            <div className="mt-2 h-1 rounded-full bg-[#1D1D1D] overflow-hidden">
+            <div className="mt-2 h-1 rounded-full bg-border-subtle overflow-hidden">
               <div
-                className="h-full rounded-full bg-[#F3F724] transition-all duration-150"
+                className="h-full rounded-full bg-accent transition-all duration-150"
                 style={{ width: `${Math.max(1, Number.parseFloat(tracePercent))}%`, opacity: 0.7 }}
               />
             </div>
@@ -670,7 +689,7 @@ export function FlameGraph({ data, onSpanClick, selectedSpanId }: FlameGraphProp
 
       {/* Keyboard hint */}
       {zoomLevel <= 1 && (
-        <div className="flex-shrink-0 px-4 py-1.5 text-[9px] text-gray-600 text-center border-t border-[#1D1D1D]">
+        <div className="flex-shrink-0 px-4 py-1.5 text-[9px] text-gray-600 text-center border-t border-border-subtle">
           Ctrl+Scroll to zoom | Scroll to pan | Click to select
         </div>
       )}

--- a/console/packages/console-frontend/src/components/traces/FlowView.tsx
+++ b/console/packages/console-frontend/src/components/traces/FlowView.tsx
@@ -28,18 +28,19 @@ const MINIMAP_H = 100
 
 const SPAN_TYPE_STYLES: Record<string, string> = {
   trigger: 'text-green-400 bg-green-500/10',
-  enqueue: 'text-[#F3F724] bg-[#F3F724]/10',
+  enqueue: 'text-accent bg-accent/10',
   function: 'text-cyan-400 bg-cyan-500/10',
 }
 
 function getNodeBorderClass(isSelected: boolean, isError: boolean): string {
   if (isSelected) {
-    return 'border-[#F3F724] shadow-[0_0_12px_rgba(243,247,36,0.2)] ring-1 ring-[#F3F724]/30'
+    // Accent-tinted glow via color-mix so it re-themes under [data-theme="light"].
+    return 'border-accent shadow-[0_0_12px_color-mix(in_srgb,var(--accent)_20%,transparent)] ring-1 ring-accent/30'
   }
   if (isError) {
-    return 'border-[#EF4444]/40 hover:border-[#EF4444]/70'
+    return 'border-error/40 hover:border-error/70'
   }
-  return 'border-[#1D1D1D] hover:border-[#3D3D3D]'
+  return 'border-border-subtle hover:border-border'
 }
 
 function buildTree(spans: VisualizationSpan[]): LayoutNode[] {
@@ -232,7 +233,7 @@ export function FlowView({ data, onSpanClick, selectedSpanId }: FlowViewProps) {
   }, [totalWidth, totalHeight])
 
   return (
-    <div className="relative w-full h-full overflow-hidden bg-[#080808]" ref={containerRef}>
+    <div className="relative w-full h-full overflow-hidden bg-sidebar" ref={containerRef}>
       {/* Header row */}
       <div className="absolute top-0 left-0 right-0 z-10 flex items-center justify-between px-4 py-2.5 pointer-events-none">
         <span className="text-[10px] text-gray-500 uppercase tracking-wider font-medium pointer-events-auto">
@@ -296,7 +297,7 @@ export function FlowView({ data, onSpanClick, selectedSpanId }: FlowViewProps) {
           {layoutNodes.map((node) => {
             const span = node.span
             const svc = getServiceName(span)
-            const color = colorByService.get(svc) ?? '#666666'
+            const color = colorByService.get(svc) ?? 'var(--muted)'
             const type = classifySpanType(span)
             const isSelected = selectedSpanId === span.span_id
             const isError = span.status === 'error'
@@ -309,7 +310,7 @@ export function FlowView({ data, onSpanClick, selectedSpanId }: FlowViewProps) {
                   e.stopPropagation()
                   onSpanClick(span)
                 }}
-                className={`absolute rounded-lg border transition-all duration-150 text-left group cursor-pointer ${getNodeBorderClass(isSelected, isError)} bg-[#0E0E0E] hover:bg-[#141414]`}
+                className={`absolute rounded-lg border transition-all duration-150 text-left group cursor-pointer ${getNodeBorderClass(isSelected, isError)} bg-elevated hover:bg-elevated`}
                 style={{
                   left: node.x,
                   top: node.y,
@@ -359,7 +360,7 @@ export function FlowView({ data, onSpanClick, selectedSpanId }: FlowViewProps) {
 
                 {/* Error indicator */}
                 {isError && (
-                  <div className="absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-[#EF4444] border border-[#0E0E0E]" />
+                  <div className="absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-error border border-elevated" />
                 )}
               </button>
             )
@@ -372,21 +373,21 @@ export function FlowView({ data, onSpanClick, selectedSpanId }: FlowViewProps) {
         <button
           type="button"
           onClick={() => setZoom((z) => Math.min(3, z * 1.2))}
-          className="w-7 h-7 flex items-center justify-center rounded bg-[#141414] border border-[#1D1D1D] text-gray-400 hover:text-white hover:border-[#3D3D3D] transition-colors"
+          className="w-7 h-7 flex items-center justify-center rounded bg-elevated border border-border-subtle text-gray-400 hover:text-white hover:border-border transition-colors"
         >
           <Plus className="w-3.5 h-3.5" />
         </button>
         <button
           type="button"
           onClick={() => setZoom((z) => Math.max(0.1, z * 0.8))}
-          className="w-7 h-7 flex items-center justify-center rounded bg-[#141414] border border-[#1D1D1D] text-gray-400 hover:text-white hover:border-[#3D3D3D] transition-colors"
+          className="w-7 h-7 flex items-center justify-center rounded bg-elevated border border-border-subtle text-gray-400 hover:text-white hover:border-border transition-colors"
         >
           <Minus className="w-3.5 h-3.5" />
         </button>
         <button
           type="button"
           onClick={fitView}
-          className="w-7 h-7 flex items-center justify-center rounded bg-[#141414] border border-[#1D1D1D] text-gray-400 hover:text-white hover:border-[#3D3D3D] transition-colors"
+          className="w-7 h-7 flex items-center justify-center rounded bg-elevated border border-border-subtle text-gray-400 hover:text-white hover:border-border transition-colors"
         >
           <Maximize2 className="w-3 h-3" />
         </button>
@@ -394,7 +395,7 @@ export function FlowView({ data, onSpanClick, selectedSpanId }: FlowViewProps) {
 
       {/* Minimap - bottom right */}
       <div
-        className="absolute bottom-10 right-4 z-10 rounded border border-[#1D1D1D] bg-[#0A0A0A]/90 overflow-hidden"
+        className="absolute bottom-10 right-4 z-10 rounded border border-border-subtle bg-sidebar/90 overflow-hidden"
         style={{ width: MINIMAP_W, height: MINIMAP_H }}
       >
         <svg width={MINIMAP_W} height={MINIMAP_H} role="img" aria-label="Flow minimap">
@@ -432,20 +433,20 @@ export function FlowView({ data, onSpanClick, selectedSpanId }: FlowViewProps) {
       </div>
 
       {/* Legend - bottom center */}
-      <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 flex items-center gap-4 px-3 py-1.5 rounded bg-[#0A0A0A]/80 border border-[#1D1D1D]">
+      <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 flex items-center gap-4 px-3 py-1.5 rounded bg-sidebar/80 border border-border-subtle">
         <span className="text-[9px] text-gray-600 mr-1">Click to select</span>
         <span className="text-[9px] text-gray-600">Scroll to zoom</span>
         <span className="text-[9px] text-gray-600">Drag to pan</span>
-        <div className="w-px h-3 bg-[#1D1D1D]" />
+        <div className="w-px h-3 bg-border-subtle" />
         {services.map(([name, color]) => (
           <div key={name} className="flex items-center gap-1">
             <div className="w-2 h-2 rounded-sm flex-shrink-0" style={{ backgroundColor: color }} />
             <span className="text-[9px] font-mono text-gray-500">{name}</span>
           </div>
         ))}
-        <div className="w-px h-3 bg-[#1D1D1D]" />
+        <div className="w-px h-3 bg-border-subtle" />
         <div className="flex items-center gap-1">
-          <div className="w-2 h-2 rounded-full bg-[#EF4444] flex-shrink-0" />
+          <div className="w-2 h-2 rounded-full bg-error flex-shrink-0" />
           <span className="text-[9px] font-mono text-gray-500">Error</span>
         </div>
       </div>

--- a/console/packages/console-frontend/src/components/traces/ServiceBreakdown.tsx
+++ b/console/packages/console-frontend/src/components/traces/ServiceBreakdown.tsx
@@ -77,12 +77,12 @@ export function ServiceBreakdown({ data }: ServiceBreakdownProps) {
   }, [data])
 
   return (
-    <div className="bg-[#0A0A0A]">
+    <div className="bg-sidebar">
       {/* Collapsible header */}
       <button
         type="button"
         onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-center gap-2 px-4 py-2.5 hover:bg-[#141414] transition-colors text-left"
+        className="w-full flex items-center gap-2 px-4 py-2.5 hover:bg-elevated transition-colors text-left"
         aria-label="Toggle services section"
         aria-expanded={isExpanded}
       >
@@ -117,7 +117,7 @@ export function ServiceBreakdown({ data }: ServiceBreakdownProps) {
                   className="w-2 h-2 rounded-sm flex-shrink-0"
                   style={{ backgroundColor: service.color }}
                 />
-                <span className="text-[11px] text-[#F4F4F4] truncate flex-1 font-medium">
+                <span className="text-[11px] text-foreground truncate flex-1 font-medium">
                   {service.name}
                 </span>
                 <span className="text-[10px] font-mono text-gray-500">
@@ -127,13 +127,13 @@ export function ServiceBreakdown({ data }: ServiceBreakdownProps) {
                   {formatDuration(service.totalDuration)}
                 </span>
                 {service.errorCount > 0 && (
-                  <span className="text-[10px] font-mono text-[#EF4444] font-semibold">
+                  <span className="text-[10px] font-mono text-error font-semibold">
                     {service.errorCount} err
                   </span>
                 )}
               </div>
               {/* Proportional bar */}
-              <div className="h-1 rounded-full bg-[#141414] overflow-hidden ml-4">
+              <div className="h-1 rounded-full bg-elevated overflow-hidden ml-4">
                 <div
                   className="h-full rounded-full transition-all duration-300"
                   style={{

--- a/console/packages/console-frontend/src/components/traces/SessionDetailPanel.tsx
+++ b/console/packages/console-frontend/src/components/traces/SessionDetailPanel.tsx
@@ -1,0 +1,210 @@
+// Session detail panel: stacked vertical view of every trace inside a
+// session-level group.
+//
+// When the user clicks a group row in the TRACES tab (with `Group by`
+// active), `TraceGroupsView` previously surfaced only the FIRST trace in
+// `group.trace_ids`. That caused a confusing UX: the row would say
+// "26 spans" but the right-side detail panel would show 4 (just the
+// first trace). This component fixes that by fetching every trace in
+// the group in parallel and rendering each as a collapsible card with
+// its own mini-waterfall.
+//
+// Each TraceCard reuses the existing render path
+// (`treeToWaterfallData` + `WaterfallChart`) so spans behave identically
+// to the single-trace view. Span clicks bubble up via `onSpanClick`,
+// keeping the right-side span detail panel working unchanged.
+
+import { useQueries } from '@tanstack/react-query'
+import { ChevronDown, ChevronRight, Clock, Loader2, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+
+import { fetchTraceTree, type TraceGroup, type TraceTreeResponse } from '@/api/observability/traces'
+import { useEngineSdk } from '@/api/engine-sdk-provider'
+import { WaterfallChart } from '@/components/traces/WaterfallChart'
+import {
+  treeToWaterfallData,
+  type VisualizationSpan,
+  type WaterfallData,
+} from '@/lib/traceTransform'
+
+interface SessionDetailPanelProps {
+  group: TraceGroup
+  onClose: () => void
+  onSpanClick: (span: VisualizationSpan) => void
+  selectedSpanId?: string
+}
+
+interface TraceFetchResult {
+  trace_id: string
+  data?: WaterfallData
+  isLoading: boolean
+  error?: string
+}
+
+export function SessionDetailPanel({
+  group,
+  onClose,
+  onSpanClick,
+  selectedSpanId,
+}: SessionDetailPanelProps) {
+  // Fetch every trace in the group concurrently. React Query handles
+  // dedup + caching automatically — if the user opens the same session
+  // twice, the second open is instant.
+  const sdk = useEngineSdk()
+  const queries = useQueries({
+    queries: group.trace_ids.map((traceId) => ({
+      queryKey: ['trace-tree', traceId],
+      queryFn: () => fetchTraceTree(sdk, traceId),
+      staleTime: 30_000,
+    })),
+  })
+
+  const traces: TraceFetchResult[] = useMemo(
+    () =>
+      group.trace_ids.map((traceId, idx): TraceFetchResult => {
+        const q = queries[idx]
+        if (q.isLoading) return { trace_id: traceId, isLoading: true }
+        if (q.isError)
+          return {
+            trace_id: traceId,
+            isLoading: false,
+            error: q.error instanceof Error ? q.error.message : 'Failed to load',
+          }
+        const data = q.data ? buildWaterfall(q.data) : undefined
+        return { trace_id: traceId, isLoading: false, data }
+      }),
+    [group.trace_ids, queries],
+  )
+
+  const totalSpans = group.span_count
+  const traceCount = group.trace_ids.length
+  const errorCount = group.error_count
+  const durationSec = (group.duration_ms / 1000).toFixed(2)
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Header */}
+      <div className="border-b border-border px-4 py-3 flex items-center gap-3 flex-shrink-0">
+        <div className="flex-1 min-w-0">
+          <div className="text-[11px] font-medium text-foreground truncate">
+            session <span className="font-mono">{group.value}</span>
+          </div>
+          <div className="flex items-center gap-3 mt-0.5 text-[10px] text-muted">
+            <span>
+              {traceCount} trace{traceCount === 1 ? '' : 's'}
+            </span>
+            <span>•</span>
+            <span>{totalSpans} spans</span>
+            <span>•</span>
+            <span className="flex items-center gap-1">
+              <Clock className="w-3 h-3" />
+              {durationSec}s
+            </span>
+            {errorCount > 0 && (
+              <>
+                <span>•</span>
+                <span className="text-red-400">
+                  {errorCount} error{errorCount === 1 ? '' : 's'}
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close session detail"
+          className="text-muted hover:text-foreground transition-colors p-1"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Stacked trace cards */}
+      <div className="flex-1 overflow-y-auto min-h-0">
+        {traces.map((trace, idx) => (
+          <TraceCard
+            key={trace.trace_id}
+            index={idx + 1}
+            trace={trace}
+            onSpanClick={onSpanClick}
+            selectedSpanId={selectedSpanId}
+            // Auto-expand the first card so the user sees content
+            // immediately. Subsequent cards stay collapsed to keep the
+            // initial render light for sessions with many traces.
+            defaultOpen={idx === 0}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface TraceCardProps {
+  index: number
+  trace: TraceFetchResult
+  onSpanClick: (span: VisualizationSpan) => void
+  selectedSpanId?: string
+  defaultOpen: boolean
+}
+
+function TraceCard({ index, trace, onSpanClick, selectedSpanId, defaultOpen }: TraceCardProps) {
+  const [open, setOpen] = useState(defaultOpen)
+
+  const headerLabel = trace.data?.spans[0]?.name ?? 'loading…'
+  const durationMs = trace.data?.total_duration_ms ?? 0
+  const spanCount = trace.data?.span_count ?? 0
+  const tracePreview = trace.trace_id.slice(0, 12)
+
+  return (
+    <div className="border-b border-border">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full px-4 py-2.5 flex items-center gap-2 text-left hover:bg-dark-gray/50 transition-colors"
+      >
+        {open ? (
+          <ChevronDown className="w-3.5 h-3.5 text-muted flex-shrink-0" />
+        ) : (
+          <ChevronRight className="w-3.5 h-3.5 text-muted flex-shrink-0" />
+        )}
+        <span className="text-[10px] font-mono text-muted w-6 flex-shrink-0">#{index}</span>
+        <span className="text-[12px] truncate text-foreground flex-1">{headerLabel}</span>
+        <span className="text-[10px] font-mono text-muted flex-shrink-0">{tracePreview}…</span>
+        <span className="text-[10px] text-muted flex-shrink-0 w-12 text-right">
+          {spanCount > 0 ? `${spanCount} sp` : ''}
+        </span>
+        <span className="text-[10px] text-muted flex-shrink-0 w-16 text-right">
+          {durationMs > 0 ? `${durationMs.toFixed(0)}ms` : ''}
+        </span>
+      </button>
+
+      {open && (
+        <div className="bg-sidebar/40">
+          {trace.isLoading && (
+            <div className="flex items-center justify-center py-6 gap-2 text-[11px] text-muted">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              Loading trace…
+            </div>
+          )}
+          {trace.error && (
+            <div className="px-4 py-3 text-[11px] text-red-400">{trace.error}</div>
+          )}
+          {trace.data && (
+            <WaterfallChart
+              data={trace.data}
+              onSpanClick={onSpanClick}
+              selectedSpanId={selectedSpanId}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function buildWaterfall(resp: TraceTreeResponse): WaterfallData | undefined {
+  if (!resp.roots || resp.roots.length === 0) return undefined
+  const wf = treeToWaterfallData(resp.roots)
+  return wf ?? undefined
+}

--- a/console/packages/console-frontend/src/components/traces/SessionDetailPanel.tsx
+++ b/console/packages/console-frontend/src/components/traces/SessionDetailPanel.tsx
@@ -5,18 +5,34 @@
 // active), `TraceGroupsView` previously surfaced only the FIRST trace in
 // `group.trace_ids`. That caused a confusing UX: the row would say
 // "26 spans" but the right-side detail panel would show 4 (just the
-// first trace). This component fixes that by fetching every trace in
-// the group in parallel and rendering each as a collapsible card with
-// its own mini-waterfall.
+// first trace). This component fixes that by rendering one collapsible
+// card per trace in the group; each card fetches its own tree on first
+// expand (lazy), so opening a 100-trace session no longer fires 100
+// simultaneous WebSocket calls.
+//
+// Fetch strategy:
+//
+//   Group click
+//        │
+//        ▼
+//   SessionDetailPanel mounts (no network)
+//        │
+//        ├── TraceCard #1   open=true ──► useQuery enabled ──► fetchTraceTree
+//        ├── TraceCard #2   open=false ─┐
+//        ├── TraceCard #3   open=false  ├── idle, no network until user clicks
+//        └── ...                        ┘
+//
+//   On user click → setOpen(true) → useQuery enabled → fetchTraceTree
+//   On subsequent re-open → TanStack Query cache (30s staleTime) → instant
 //
 // Each TraceCard reuses the existing render path
 // (`treeToWaterfallData` + `WaterfallChart`) so spans behave identically
 // to the single-trace view. Span clicks bubble up via `onSpanClick`,
 // keeping the right-side span detail panel working unchanged.
 
-import { useQueries } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { ChevronDown, ChevronRight, Clock, Loader2, X } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 
 import { fetchTraceTree, type TraceGroup, type TraceTreeResponse } from '@/api/observability/traces'
 import { useEngineSdk } from '@/api/engine-sdk-provider'
@@ -26,6 +42,7 @@ import {
   type VisualizationSpan,
   type WaterfallData,
 } from '@/lib/traceTransform'
+import type { ISdk } from 'iii-browser-sdk'
 
 interface SessionDetailPanelProps {
   group: TraceGroup
@@ -34,47 +51,13 @@ interface SessionDetailPanelProps {
   selectedSpanId?: string
 }
 
-interface TraceFetchResult {
-  trace_id: string
-  data?: WaterfallData
-  isLoading: boolean
-  error?: string
-}
-
 export function SessionDetailPanel({
   group,
   onClose,
   onSpanClick,
   selectedSpanId,
 }: SessionDetailPanelProps) {
-  // Fetch every trace in the group concurrently. React Query handles
-  // dedup + caching automatically — if the user opens the same session
-  // twice, the second open is instant.
   const sdk = useEngineSdk()
-  const queries = useQueries({
-    queries: group.trace_ids.map((traceId) => ({
-      queryKey: ['trace-tree', traceId],
-      queryFn: () => fetchTraceTree(sdk, traceId),
-      staleTime: 30_000,
-    })),
-  })
-
-  const traces: TraceFetchResult[] = useMemo(
-    () =>
-      group.trace_ids.map((traceId, idx): TraceFetchResult => {
-        const q = queries[idx]
-        if (q.isLoading) return { trace_id: traceId, isLoading: true }
-        if (q.isError)
-          return {
-            trace_id: traceId,
-            isLoading: false,
-            error: q.error instanceof Error ? q.error.message : 'Failed to load',
-          }
-        const data = q.data ? buildWaterfall(q.data) : undefined
-        return { trace_id: traceId, isLoading: false, data }
-      }),
-    [group.trace_ids, queries],
-  )
 
   const totalSpans = group.span_count
   const traceCount = group.trace_ids.length
@@ -103,7 +86,7 @@ export function SessionDetailPanel({
             {errorCount > 0 && (
               <>
                 <span>•</span>
-                <span className="text-red-400">
+                <span className="text-error">
                   {errorCount} error{errorCount === 1 ? '' : 's'}
                 </span>
               </>
@@ -120,18 +103,19 @@ export function SessionDetailPanel({
         </button>
       </div>
 
-      {/* Stacked trace cards */}
+      {/* Stacked trace cards. Each owns its own fetch (lazy, on first
+          expand) so opening a session with N traces doesn't fire N
+          parallel WebSocket calls. The first card auto-opens so the
+          user sees content immediately. */}
       <div className="flex-1 overflow-y-auto min-h-0">
-        {traces.map((trace, idx) => (
+        {group.trace_ids.map((traceId, idx) => (
           <TraceCard
-            key={trace.trace_id}
+            key={traceId}
+            sdk={sdk}
             index={idx + 1}
-            trace={trace}
+            traceId={traceId}
             onSpanClick={onSpanClick}
             selectedSpanId={selectedSpanId}
-            // Auto-expand the first card so the user sees content
-            // immediately. Subsequent cards stay collapsed to keep the
-            // initial render light for sessions with many traces.
             defaultOpen={idx === 0}
           />
         ))}
@@ -141,20 +125,41 @@ export function SessionDetailPanel({
 }
 
 interface TraceCardProps {
+  sdk: ISdk
   index: number
-  trace: TraceFetchResult
+  traceId: string
   onSpanClick: (span: VisualizationSpan) => void
   selectedSpanId?: string
   defaultOpen: boolean
 }
 
-function TraceCard({ index, trace, onSpanClick, selectedSpanId, defaultOpen }: TraceCardProps) {
+function TraceCard({
+  sdk,
+  index,
+  traceId,
+  onSpanClick,
+  selectedSpanId,
+  defaultOpen,
+}: TraceCardProps) {
   const [open, setOpen] = useState(defaultOpen)
 
-  const headerLabel = trace.data?.spans[0]?.name ?? 'loading…'
-  const durationMs = trace.data?.total_duration_ms ?? 0
-  const spanCount = trace.data?.span_count ?? 0
-  const tracePreview = trace.trace_id.slice(0, 12)
+  // Lazy fetch: only enabled when the card has been opened at least
+  // once. `staleTime: 30s` keeps re-opens instant; TanStack Query's
+  // cache also dedupes if the same trace appears in two groups
+  // (different attribute values, overlapping trace_ids).
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['trace-tree', traceId],
+    queryFn: () => fetchTraceTree(sdk, traceId),
+    staleTime: 30_000,
+    enabled: open,
+  })
+
+  const waterfall = data ? buildWaterfall(data) : undefined
+  const headerLabel = waterfall?.spans[0]?.name ?? (open ? 'loading…' : 'click to load')
+  const durationMs = waterfall?.total_duration_ms ?? 0
+  const spanCount = waterfall?.span_count ?? 0
+  const tracePreview = traceId.slice(0, 12)
+  const errorMessage = error instanceof Error ? error.message : error ? 'Failed to load' : null
 
   return (
     <div className="border-b border-border">
@@ -181,18 +186,18 @@ function TraceCard({ index, trace, onSpanClick, selectedSpanId, defaultOpen }: T
 
       {open && (
         <div className="bg-sidebar/40">
-          {trace.isLoading && (
+          {isLoading && (
             <div className="flex items-center justify-center py-6 gap-2 text-[11px] text-muted">
               <Loader2 className="w-3.5 h-3.5 animate-spin" />
               Loading trace…
             </div>
           )}
-          {trace.error && (
-            <div className="px-4 py-3 text-[11px] text-red-400">{trace.error}</div>
+          {errorMessage && (
+            <div className="px-4 py-3 text-[11px] text-error">{errorMessage}</div>
           )}
-          {trace.data && (
+          {waterfall && (
             <WaterfallChart
-              data={trace.data}
+              data={waterfall}
               onSpanClick={onSpanClick}
               selectedSpanId={selectedSpanId}
             />

--- a/console/packages/console-frontend/src/components/traces/SessionDetailPanel.tsx
+++ b/console/packages/console-frontend/src/components/traces/SessionDetailPanel.tsx
@@ -31,18 +31,17 @@
 // keeping the right-side span detail panel working unchanged.
 
 import { useQuery } from '@tanstack/react-query'
+import type { ISdk } from 'iii-browser-sdk'
 import { ChevronDown, ChevronRight, Clock, Loader2, X } from 'lucide-react'
 import { useState } from 'react'
-
-import { fetchTraceTree, type TraceGroup, type TraceTreeResponse } from '@/api/observability/traces'
 import { useEngineSdk } from '@/api/engine-sdk-provider'
+import { fetchTraceTree, type TraceGroup, type TraceTreeResponse } from '@/api/observability/traces'
 import { WaterfallChart } from '@/components/traces/WaterfallChart'
 import {
   treeToWaterfallData,
   type VisualizationSpan,
   type WaterfallData,
 } from '@/lib/traceTransform'
-import type { ISdk } from 'iii-browser-sdk'
 
 interface SessionDetailPanelProps {
   group: TraceGroup
@@ -192,9 +191,7 @@ function TraceCard({
               Loading trace…
             </div>
           )}
-          {errorMessage && (
-            <div className="px-4 py-3 text-[11px] text-error">{errorMessage}</div>
-          )}
+          {errorMessage && <div className="px-4 py-3 text-[11px] text-error">{errorMessage}</div>}
           {waterfall && (
             <WaterfallChart
               data={waterfall}

--- a/console/packages/console-frontend/src/components/traces/SpanBaggageTab.tsx
+++ b/console/packages/console-frontend/src/components/traces/SpanBaggageTab.tsx
@@ -21,7 +21,7 @@ export function SpanBaggageTab({ span }: SpanBaggageTabProps) {
   if (baggageEntries.length === 0) {
     return (
       <div className="p-8 text-center">
-        <div className="w-10 h-10 mb-3 mx-auto rounded-lg bg-[#141414] border border-[#1D1D1D] flex items-center justify-center">
+        <div className="w-10 h-10 mb-3 mx-auto rounded-lg bg-elevated border border-border-subtle flex items-center justify-center">
           <Package className="w-5 h-5 text-gray-600" />
         </div>
         <p className="text-sm text-gray-400">No baggage context</p>
@@ -36,13 +36,13 @@ export function SpanBaggageTab({ span }: SpanBaggageTabProps) {
   return (
     <div className="p-5 space-y-3">
       <div className="flex items-center gap-2 px-1">
-        <Package className="w-3.5 h-3.5 text-[#F3F724]" />
+        <Package className="w-3.5 h-3.5 text-accent" />
         <span className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider">
           W3C Baggage Context
         </span>
       </div>
 
-      <div className="bg-[#141414] rounded-lg border border-[#1D1D1D] divide-y divide-[#1D1D1D]/50">
+      <div className="bg-elevated rounded-lg border border-border-subtle divide-y divide-border-subtle/50">
         {baggageEntries.map(([key, value]) => (
           <button
             key={key}
@@ -54,17 +54,17 @@ export function SpanBaggageTab({ span }: SpanBaggageTabProps) {
               )
             }
             aria-label={`Copy ${key} to clipboard`}
-            className="w-full px-4 py-2.5 hover:bg-[#1A1A1A] transition-colors text-left group"
+            className="w-full px-4 py-2.5 hover:bg-hover transition-colors text-left group"
           >
             <div className="flex items-start justify-between gap-3">
               <div className="flex-1 min-w-0">
-                <div className="text-[11px] font-mono text-[#F3F724] mb-0.5">{key}</div>
+                <div className="text-[11px] font-mono text-accent mb-0.5">{key}</div>
                 <div className="text-[12px] text-gray-300 break-all font-mono">
                   {typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value)}
                 </div>
               </div>
               {copiedKey === key ? (
-                <span className="text-[10px] text-[#22C55E] flex-shrink-0 mt-0.5">copied</span>
+                <span className="text-[10px] text-success flex-shrink-0 mt-0.5">copied</span>
               ) : (
                 <Copy className="w-3 h-3 text-gray-600 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0 mt-0.5" />
               )}

--- a/console/packages/console-frontend/src/components/traces/SpanErrorsTab.tsx
+++ b/console/packages/console-frontend/src/components/traces/SpanErrorsTab.tsx
@@ -38,10 +38,10 @@ export function SpanErrorsTab({ span }: SpanErrorsTabProps) {
   if (!hasError) {
     return (
       <div className="p-8 text-center">
-        <div className="w-12 h-12 mb-3 mx-auto rounded-full bg-[#22C55E]/10 border border-[#22C55E]/20 flex items-center justify-center">
-          <CheckCircle2 className="w-6 h-6 text-[#22C55E]" />
+        <div className="w-12 h-12 mb-3 mx-auto rounded-full bg-success/10 border border-success/20 flex items-center justify-center">
+          <CheckCircle2 className="w-6 h-6 text-success" />
         </div>
-        <p className="text-sm font-medium text-[#F4F4F4]">No errors</p>
+        <p className="text-sm font-medium text-foreground">No errors</p>
         <p className="text-[11px] text-gray-500 mt-1">This span completed successfully</p>
       </div>
     )
@@ -50,14 +50,14 @@ export function SpanErrorsTab({ span }: SpanErrorsTabProps) {
   return (
     <div className="p-5 space-y-4">
       {/* Error banner */}
-      <div className="bg-[#EF4444]/5 border border-[#EF4444]/15 rounded-lg p-4">
+      <div className="bg-error/5 border border-error/15 rounded-lg p-4">
         <div className="flex items-start gap-3">
-          <div className="w-8 h-8 rounded-lg bg-[#EF4444]/10 border border-[#EF4444]/20 flex items-center justify-center flex-shrink-0">
-            <AlertCircle className="w-4 h-4 text-[#EF4444]" />
+          <div className="w-8 h-8 rounded-lg bg-error/10 border border-error/20 flex items-center justify-center flex-shrink-0">
+            <AlertCircle className="w-4 h-4 text-error" />
           </div>
           <div className="flex-1 min-w-0">
             {displayType && (
-              <div className="text-sm font-semibold text-[#EF4444] font-mono mb-1">
+              <div className="text-sm font-semibold text-error font-mono mb-1">
                 {displayType}
               </div>
             )}
@@ -83,10 +83,10 @@ export function SpanErrorsTab({ span }: SpanErrorsTabProps) {
             <button
               type="button"
               onClick={copyStackTrace}
-              className="flex items-center gap-1.5 px-2 py-1 text-[10px] text-gray-500 hover:text-gray-300 hover:bg-[#1D1D1D] rounded transition-colors"
+              className="flex items-center gap-1.5 px-2 py-1 text-[10px] text-gray-500 hover:text-gray-300 hover:bg-border-subtle rounded transition-colors"
             >
               {copiedKey === 'stackTrace' ? (
-                <span className="text-[#22C55E]">Copied</span>
+                <span className="text-success">Copied</span>
               ) : (
                 <>
                   <Copy className="w-2.5 h-2.5" />
@@ -95,7 +95,7 @@ export function SpanErrorsTab({ span }: SpanErrorsTabProps) {
               )}
             </button>
           </div>
-          <div className="bg-[#141414] rounded-lg border border-[#1D1D1D] overflow-hidden">
+          <div className="bg-elevated rounded-lg border border-border-subtle overflow-hidden">
             <pre className="p-4 text-[11px] font-mono text-gray-300 whitespace-pre-wrap break-words overflow-x-auto leading-[1.6] max-h-[400px] overflow-y-auto">
               {displayStack.split('\n').map((line, i) => {
                 const isFrameLine =
@@ -107,9 +107,9 @@ export function SpanErrorsTab({ span }: SpanErrorsTabProps) {
                     className={`${
                       isFrameLine
                         ? hasLineNumber
-                          ? 'text-gray-300 hover:bg-[#1A1A1A]'
+                          ? 'text-gray-300 hover:bg-hover'
                           : 'text-gray-400'
-                        : 'text-[#EF4444] font-medium'
+                        : 'text-error font-medium'
                     } px-1 -mx-1 rounded`}
                   >
                     {line}
@@ -122,7 +122,7 @@ export function SpanErrorsTab({ span }: SpanErrorsTabProps) {
       )}
 
       {!displayMessage && !displayType && !displayStack && (
-        <div className="bg-[#141414] rounded-lg border border-[#1D1D1D] p-4 text-center">
+        <div className="bg-elevated rounded-lg border border-border-subtle p-4 text-center">
           <p className="text-sm text-gray-400">No additional error details</p>
           <p className="text-[11px] text-gray-600 mt-1">
             The span is marked as error but no error attributes were recorded

--- a/console/packages/console-frontend/src/components/traces/SpanErrorsTab.tsx
+++ b/console/packages/console-frontend/src/components/traces/SpanErrorsTab.tsx
@@ -57,9 +57,7 @@ export function SpanErrorsTab({ span }: SpanErrorsTabProps) {
           </div>
           <div className="flex-1 min-w-0">
             {displayType && (
-              <div className="text-sm font-semibold text-error font-mono mb-1">
-                {displayType}
-              </div>
+              <div className="text-sm font-semibold text-error font-mono mb-1">{displayType}</div>
             )}
             {displayMessage && (
               <div className="text-sm text-gray-300 break-words leading-relaxed">

--- a/console/packages/console-frontend/src/components/traces/SpanInfoTab.tsx
+++ b/console/packages/console-frontend/src/components/traces/SpanInfoTab.tsx
@@ -20,10 +20,10 @@ export function SpanInfoTab({ span, traceData }: SpanInfoTabProps) {
         <div className="text-[10px] font-semibold text-gray-500 uppercase tracking-wider mb-2.5">
           Timing
         </div>
-        <div className="bg-[#141414] rounded-lg border border-[#1D1D1D] overflow-hidden">
+        <div className="bg-elevated rounded-lg border border-border-subtle overflow-hidden">
           <div className="px-4 pt-4 pb-3">
             <div className="flex items-baseline justify-between mb-2">
-              <span className="font-mono text-xl font-bold text-[#F3F724]">
+              <span className="font-mono text-xl font-bold text-accent">
                 {formatDuration(span.duration_ms)}
               </span>
               {traceData && (
@@ -32,17 +32,17 @@ export function SpanInfoTab({ span, traceData }: SpanInfoTabProps) {
                 </span>
               )}
             </div>
-            <div className="h-1.5 bg-[#0A0A0A] rounded-full overflow-hidden">
+            <div className="h-1.5 bg-sidebar rounded-full overflow-hidden">
               <div
                 className="h-full rounded-full transition-all duration-300"
                 style={{
                   width: `${Math.min(100, Math.max(2, tracePercent))}%`,
-                  background: 'linear-gradient(90deg, #F3F724, #D4D520)',
+                  background: 'linear-gradient(90deg, var(--accent), var(--accent-hover))',
                 }}
               />
             </div>
           </div>
-          <div className="border-t border-[#1D1D1D] px-4 py-2.5 flex items-center justify-between">
+          <div className="border-t border-border-subtle px-4 py-2.5 flex items-center justify-between">
             <span className="text-[11px] text-gray-500">Position in trace</span>
             <span className="text-[11px] font-mono text-gray-400">
               {span.start_percent.toFixed(1)}% →{' '}
@@ -57,18 +57,18 @@ export function SpanInfoTab({ span, traceData }: SpanInfoTabProps) {
         <div className="text-[10px] font-semibold text-gray-500 uppercase tracking-wider mb-2.5">
           Status
         </div>
-        <div className="bg-[#141414] rounded-lg border border-[#1D1D1D] px-4 py-3">
+        <div className="bg-elevated rounded-lg border border-border-subtle px-4 py-3">
           <div className="flex items-center gap-2.5">
             <div
               className={`w-2.5 h-2.5 rounded-full ${
                 span.status === 'ok'
-                  ? 'bg-[#22C55E]'
+                  ? 'bg-success'
                   : span.status === 'error'
-                    ? 'bg-[#EF4444]'
+                    ? 'bg-error'
                     : 'bg-gray-500'
               }`}
             />
-            <span className="font-mono text-sm font-semibold text-[#F4F4F4]">
+            <span className="font-mono text-sm font-semibold text-foreground">
               {span.status.toUpperCase()}
             </span>
           </div>
@@ -80,21 +80,21 @@ export function SpanInfoTab({ span, traceData }: SpanInfoTabProps) {
         <div className="text-[10px] font-semibold text-gray-500 uppercase tracking-wider mb-2.5">
           Service & Operation
         </div>
-        <div className="bg-[#141414] rounded-lg border border-[#1D1D1D] divide-y divide-[#1D1D1D]">
+        <div className="bg-elevated rounded-lg border border-border-subtle divide-y divide-border-subtle">
           <div className="px-4 py-2.5 flex items-center justify-between">
             <span className="text-[11px] text-gray-500">Service</span>
-            <span className="text-sm text-[#F4F4F4] font-medium">{service}</span>
+            <span className="text-sm text-foreground font-medium">{service}</span>
           </div>
           <div className="px-4 py-2.5 flex items-center justify-between gap-4">
             <span className="text-[11px] text-gray-500 flex-shrink-0">Operation</span>
-            <span className="text-sm text-[#F4F4F4] font-mono truncate" title={span.name}>
+            <span className="text-sm text-foreground font-mono truncate" title={span.name}>
               {span.name}
             </span>
           </div>
           {span.depth === 0 && (
             <div className="px-4 py-2.5 flex items-center justify-between">
               <span className="text-[11px] text-gray-500">Type</span>
-              <span className="text-[11px] px-2 py-0.5 bg-[#F3F724]/10 text-[#F3F724] rounded font-medium">
+              <span className="text-[11px] px-2 py-0.5 bg-accent/10 text-accent rounded font-medium">
                 ROOT SPAN
               </span>
             </div>
@@ -107,7 +107,7 @@ export function SpanInfoTab({ span, traceData }: SpanInfoTabProps) {
         <div className="text-[10px] font-semibold text-gray-500 uppercase tracking-wider mb-2.5">
           Identifiers
         </div>
-        <div className="bg-[#141414] rounded-lg border border-[#1D1D1D] divide-y divide-[#1D1D1D]">
+        <div className="bg-elevated rounded-lg border border-border-subtle divide-y divide-border-subtle">
           {[
             { label: 'Trace ID', value: span.trace_id, field: 'traceId' },
             { label: 'Span ID', value: span.span_id, field: 'spanId' },
@@ -119,7 +119,7 @@ export function SpanInfoTab({ span, traceData }: SpanInfoTabProps) {
               key={field}
               type="button"
               onClick={() => copyToClipboard(field, value)}
-              className="w-full px-4 py-2.5 flex items-center justify-between hover:bg-[#1A1A1A] transition-colors group text-left"
+              className="w-full px-4 py-2.5 flex items-center justify-between hover:bg-hover transition-colors group text-left"
             >
               <span className="text-[11px] text-gray-500 flex-shrink-0">{label}</span>
               <div className="flex items-center gap-2 min-w-0 ml-4">
@@ -127,7 +127,7 @@ export function SpanInfoTab({ span, traceData }: SpanInfoTabProps) {
                   {value}
                 </span>
                 {copiedField === field ? (
-                  <span className="text-[10px] text-[#22C55E] flex-shrink-0">copied</span>
+                  <span className="text-[10px] text-success flex-shrink-0">copied</span>
                 ) : (
                   <Copy className="w-3 h-3 text-gray-600 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0" />
                 )}
@@ -142,10 +142,10 @@ export function SpanInfoTab({ span, traceData }: SpanInfoTabProps) {
         <div className="text-[10px] font-semibold text-gray-500 uppercase tracking-wider mb-2.5">
           Hierarchy
         </div>
-        <div className="bg-[#141414] rounded-lg border border-[#1D1D1D] divide-y divide-[#1D1D1D]">
+        <div className="bg-elevated rounded-lg border border-border-subtle divide-y divide-border-subtle">
           <div className="px-4 py-2.5 flex items-center justify-between">
             <span className="text-[11px] text-gray-500">Depth</span>
-            <span className="text-sm font-mono text-[#F4F4F4]">{span.depth}</span>
+            <span className="text-sm font-mono text-foreground">{span.depth}</span>
           </div>
           {span.flags !== undefined && (
             <div className="px-4 py-2.5 flex items-center justify-between">

--- a/console/packages/console-frontend/src/components/traces/SpanLinksTab.tsx
+++ b/console/packages/console-frontend/src/components/traces/SpanLinksTab.tsx
@@ -23,11 +23,11 @@ export function SpanLinksTab({ span, onNavigateToTrace }: SpanLinksTabProps) {
           key={`${link.trace_id}-${link.span_id}-${i}`}
           type="button"
           onClick={() => onNavigateToTrace?.(link.trace_id)}
-          className="w-full flex items-center gap-2 px-3 py-2 bg-[#141414] border border-[#1D1D1D] rounded hover:bg-[#1A1A1A] hover:border-[#252525] transition-colors text-left group"
+          className="w-full flex items-center gap-2 px-3 py-2 bg-elevated border border-border-subtle rounded hover:bg-hover hover:border-border-subtle transition-colors text-left group"
         >
-          <ExternalLink className="w-3 h-3 text-gray-500 group-hover:text-[#F3F724] flex-shrink-0" />
+          <ExternalLink className="w-3 h-3 text-gray-500 group-hover:text-accent flex-shrink-0" />
           <div className="flex-1 min-w-0">
-            <div className="text-[11px] font-mono text-gray-300 truncate group-hover:text-[#F4F4F4]">
+            <div className="text-[11px] font-mono text-gray-300 truncate group-hover:text-foreground">
               {link.trace_id.slice(0, 16)}...
             </div>
             <div className="text-[10px] font-mono text-gray-600">
@@ -35,7 +35,7 @@ export function SpanLinksTab({ span, onNavigateToTrace }: SpanLinksTabProps) {
             </div>
           </div>
           {link.attributes && Object.keys(link.attributes).length > 0 && (
-            <span className="text-[9px] text-gray-600 bg-[#1D1D1D] px-1.5 py-0.5 rounded flex-shrink-0">
+            <span className="text-[9px] text-gray-600 bg-border-subtle px-1.5 py-0.5 rounded flex-shrink-0">
               +{Object.keys(link.attributes).length} attrs
             </span>
           )}

--- a/console/packages/console-frontend/src/components/traces/SpanLogsTab.tsx
+++ b/console/packages/console-frontend/src/components/traces/SpanLogsTab.tsx
@@ -73,12 +73,7 @@ export function SpanLogsTab({ span }: SpanLogsTabProps) {
               <div className="border-t border-[#1D1D1D]/50 px-4 py-2.5">
                 <div className="space-y-1.5">
                   {attrEntries.map(([key, value]) => (
-                    <div key={key} className="flex items-start gap-2 text-[11px]">
-                      <span className="text-gray-500 font-mono flex-shrink-0">{key}</span>
-                      <span className="text-gray-300 font-mono break-all">
-                        {typeof value === 'object' ? JSON.stringify(value) : String(value)}
-                      </span>
-                    </div>
+                    <EventAttributeRow key={key} attrKey={key} value={value} />
                   ))}
                 </div>
               </div>
@@ -92,4 +87,55 @@ export function SpanLogsTab({ span }: SpanLogsTabProps) {
       </div>
     </div>
   )
+}
+
+/**
+ * Render one event attribute row. When the value is a JSON-encoded string
+ * (typically `iii.payload.json` written by the iii-sdk auto-capture), parse
+ * and pretty-print it inside a <pre> block. Everything else renders as a
+ * single-line label/value pair, matching the previous behavior.
+ *
+ * Keeps DOM cost low: pretty-printing only runs when the value clearly
+ * looks like a JSON object/array (`{`/`[` prefix after trim) AND
+ * JSON.parse succeeds. Strings that are bare numbers / booleans / plain
+ * text fall through to the simple renderer.
+ */
+function EventAttributeRow({ attrKey, value }: { attrKey: string; value: unknown }) {
+  const formatted = formatPossibleJson(value)
+  if (formatted !== null) {
+    return (
+      <div className="flex flex-col gap-1 text-[11px]">
+        <span className="text-gray-500 font-mono">{attrKey}</span>
+        <pre className="text-gray-300 font-mono text-[10.5px] leading-snug bg-[#0A0A0A] border border-[#1D1D1D]/60 rounded-md px-3 py-2 overflow-x-auto whitespace-pre">
+          {formatted}
+        </pre>
+      </div>
+    )
+  }
+  return (
+    <div className="flex items-start gap-2 text-[11px]">
+      <span className="text-gray-500 font-mono flex-shrink-0">{attrKey}</span>
+      <span className="text-gray-300 font-mono break-all">
+        {typeof value === 'object' ? JSON.stringify(value) : String(value)}
+      </span>
+    </div>
+  )
+}
+
+function formatPossibleJson(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return null
+  const first = trimmed[0]
+  // Quick filter: only attempt to parse strings that look like a JSON
+  // object/array. Bare quoted strings (`"hi"`) are still valid JSON but
+  // pretty-printing a single string adds no value and would just put
+  // quotes around it.
+  if (first !== '{' && first !== '[') return null
+  try {
+    const parsed = JSON.parse(trimmed)
+    return JSON.stringify(parsed, null, 2)
+  } catch {
+    return null
+  }
 }

--- a/console/packages/console-frontend/src/components/traces/SpanLogsTab.tsx
+++ b/console/packages/console-frontend/src/components/traces/SpanLogsTab.tsx
@@ -15,11 +15,11 @@ export function SpanLogsTab({ span }: SpanLogsTabProps) {
   if (sortedEvents.length === 0) {
     return (
       <div className="p-8 text-center">
-        <div className="w-10 h-10 mb-3 mx-auto rounded-lg bg-[#141414] border border-[#1D1D1D] flex items-center justify-center">
-          <Clock className="w-5 h-5 text-gray-600" />
+        <div className="w-10 h-10 mb-3 mx-auto rounded-lg bg-elevated border border-border-subtle flex items-center justify-center">
+          <Clock className="w-5 h-5 text-muted" />
         </div>
-        <p className="text-sm text-gray-400">No events recorded</p>
-        <p className="text-[11px] text-gray-600 mt-1">
+        <p className="text-sm text-secondary">No events recorded</p>
+        <p className="text-[11px] text-muted mt-1">
           This span has no logged events or exceptions
         </p>
       </div>
@@ -40,7 +40,7 @@ export function SpanLogsTab({ span }: SpanLogsTabProps) {
           <div
             key={`${event.name}-${event.timestamp_unix_nano}`}
             className={`rounded-lg border overflow-hidden ${
-              isException ? 'bg-[#EF4444]/5 border-[#EF4444]/15' : 'bg-[#141414] border-[#1D1D1D]'
+              isException ? 'bg-error/5 border-error/15' : 'bg-elevated border-border-subtle'
             }`}
           >
             <div className="px-4 py-3">
@@ -48,29 +48,29 @@ export function SpanLogsTab({ span }: SpanLogsTabProps) {
                 <div className="flex-1 min-w-0">
                   <div
                     className={`text-sm font-semibold mb-0.5 ${
-                      isException ? 'text-[#EF4444]' : 'text-[#F4F4F4]'
+                      isException ? 'text-error' : 'text-foreground'
                     }`}
                   >
                     {event.name}
                   </div>
-                  <div className="flex items-center gap-2 text-[10px] font-mono text-gray-500">
+                  <div className="flex items-center gap-2 text-[10px] font-mono text-muted">
                     <span>{formatTimestamp(eventMs)}</span>
                     {index > 0 && (
                       <>
-                        <span className="text-gray-600">&middot;</span>
-                        <span className="text-gray-400">{formatRelative(offsetMs)}</span>
+                        <span className="text-muted">&middot;</span>
+                        <span className="text-secondary">{formatRelative(offsetMs)}</span>
                       </>
                     )}
                   </div>
                 </div>
-                <span className="text-[10px] font-mono text-gray-600 flex-shrink-0 px-1.5 py-0.5 bg-[#0A0A0A] rounded">
+                <span className="text-[10px] font-mono text-muted flex-shrink-0 px-1.5 py-0.5 bg-sidebar rounded">
                   #{index + 1}
                 </span>
               </div>
             </div>
 
             {attrEntries.length > 0 && (
-              <div className="border-t border-[#1D1D1D]/50 px-4 py-2.5">
+              <div className="border-t border-border-subtle/50 px-4 py-2.5">
                 <div className="space-y-1.5">
                   {attrEntries.map(([key, value]) => (
                     <EventAttributeRow key={key} attrKey={key} value={value} />
@@ -82,7 +82,7 @@ export function SpanLogsTab({ span }: SpanLogsTabProps) {
         )
       })}
 
-      <div className="text-[10px] text-gray-600 text-center pt-2">
+      <div className="text-[10px] text-muted text-center pt-2">
         {sortedEvents.length} event{sortedEvents.length !== 1 ? 's' : ''}
       </div>
     </div>
@@ -105,8 +105,8 @@ function EventAttributeRow({ attrKey, value }: { attrKey: string; value: unknown
   if (formatted !== null) {
     return (
       <div className="flex flex-col gap-1 text-[11px]">
-        <span className="text-gray-500 font-mono">{attrKey}</span>
-        <pre className="text-gray-300 font-mono text-[10.5px] leading-snug bg-[#0A0A0A] border border-[#1D1D1D]/60 rounded-md px-3 py-2 overflow-x-auto whitespace-pre">
+        <span className="text-muted font-mono">{attrKey}</span>
+        <pre className="text-foreground/80 font-mono text-[10.5px] leading-snug bg-sidebar border border-border-subtle/60 rounded-md px-3 py-2 overflow-x-auto whitespace-pre">
           {formatted}
         </pre>
       </div>
@@ -114,8 +114,8 @@ function EventAttributeRow({ attrKey, value }: { attrKey: string; value: unknown
   }
   return (
     <div className="flex items-start gap-2 text-[11px]">
-      <span className="text-gray-500 font-mono flex-shrink-0">{attrKey}</span>
-      <span className="text-gray-300 font-mono break-all">
+      <span className="text-muted font-mono flex-shrink-0">{attrKey}</span>
+      <span className="text-foreground/80 font-mono break-all">
         {typeof value === 'object' ? JSON.stringify(value) : String(value)}
       </span>
     </div>

--- a/console/packages/console-frontend/src/components/traces/SpanLogsTab.tsx
+++ b/console/packages/console-frontend/src/components/traces/SpanLogsTab.tsx
@@ -1,4 +1,5 @@
 import { Clock } from 'lucide-react'
+import { formatPossibleJson } from '@/lib/formatPossibleJson'
 import type { VisualizationSpan } from '@/lib/traceTransform'
 import { toMs } from '@/lib/traceTransform'
 import { formatRelative, formatTimestamp } from '@/lib/traceUtils'
@@ -95,10 +96,9 @@ export function SpanLogsTab({ span }: SpanLogsTabProps) {
  * and pretty-print it inside a <pre> block. Everything else renders as a
  * single-line label/value pair, matching the previous behavior.
  *
- * Keeps DOM cost low: pretty-printing only runs when the value clearly
- * looks like a JSON object/array (`{`/`[` prefix after trim) AND
- * JSON.parse succeeds. Strings that are bare numbers / booleans / plain
- * text fall through to the simple renderer.
+ * Detection lives in `lib/formatPossibleJson.ts` so the heuristic is
+ * testable in isolation and reusable for any other JSON-in-attribute
+ * surface (e.g., span attributes panel, log lines).
  */
 function EventAttributeRow({ attrKey, value }: { attrKey: string; value: unknown }) {
   const formatted = formatPossibleJson(value)
@@ -120,22 +120,4 @@ function EventAttributeRow({ attrKey, value }: { attrKey: string; value: unknown
       </span>
     </div>
   )
-}
-
-function formatPossibleJson(value: unknown): string | null {
-  if (typeof value !== 'string') return null
-  const trimmed = value.trim()
-  if (trimmed.length === 0) return null
-  const first = trimmed[0]
-  // Quick filter: only attempt to parse strings that look like a JSON
-  // object/array. Bare quoted strings (`"hi"`) are still valid JSON but
-  // pretty-printing a single string adds no value and would just put
-  // quotes around it.
-  if (first !== '{' && first !== '[') return null
-  try {
-    const parsed = JSON.parse(trimmed)
-    return JSON.stringify(parsed, null, 2)
-  } catch {
-    return null
-  }
 }

--- a/console/packages/console-frontend/src/components/traces/SpanLogsTab.tsx
+++ b/console/packages/console-frontend/src/components/traces/SpanLogsTab.tsx
@@ -20,9 +20,7 @@ export function SpanLogsTab({ span }: SpanLogsTabProps) {
           <Clock className="w-5 h-5 text-muted" />
         </div>
         <p className="text-sm text-secondary">No events recorded</p>
-        <p className="text-[11px] text-muted mt-1">
-          This span has no logged events or exceptions
-        </p>
+        <p className="text-[11px] text-muted mt-1">This span has no logged events or exceptions</p>
       </div>
     )
   }

--- a/console/packages/console-frontend/src/components/traces/SpanOtelLogsTab.tsx
+++ b/console/packages/console-frontend/src/components/traces/SpanOtelLogsTab.tsx
@@ -11,13 +11,19 @@ interface SpanOtelLogsTabProps {
   span: VisualizationSpan
 }
 
+// OTel severity palette. `accent` values feed inline `style` props (CSS
+// strings, not Tailwind classes) and re-theme via `var(--token)`. The
+// warn level uses an iii-specific amber (#F59E0B) because the global
+// `--warning` token is yellow (= accent), which collides with brand
+// signal. A future refactor could promote this to a `--severity-warn`
+// design token.
 const SEVERITY_STYLES = {
   error: {
     label: 'ERROR',
-    text: 'text-[#EF4444]',
-    badge: 'bg-[#EF4444]/15 text-[#EF4444] border-[#EF4444]/20',
-    accent: '#EF4444',
-    cardBg: 'bg-[#EF4444]/5',
+    text: 'text-error',
+    badge: 'bg-error/15 text-error border-error/20',
+    accent: 'var(--error)',
+    cardBg: 'bg-error/5',
   },
   warn: {
     label: 'WARN',
@@ -28,17 +34,17 @@ const SEVERITY_STYLES = {
   },
   info: {
     label: 'INFO',
-    text: 'text-[#3B82F6]',
-    badge: 'bg-[#3B82F6]/15 text-[#3B82F6] border-[#3B82F6]/20',
-    accent: '#3B82F6',
-    cardBg: 'bg-[#141414]',
+    text: 'text-info',
+    badge: 'bg-info/15 text-info border-info/20',
+    accent: 'var(--info)',
+    cardBg: 'bg-elevated',
   },
   debug: {
     label: 'DEBUG',
-    text: 'text-gray-400',
-    badge: 'bg-gray-500/10 text-gray-400 border-gray-500/20',
-    accent: '#6B7280',
-    cardBg: 'bg-[#141414]',
+    text: 'text-muted',
+    badge: 'bg-muted/10 text-muted border-muted/20',
+    accent: 'var(--muted)',
+    cardBg: 'bg-elevated',
   },
 } as const
 
@@ -104,7 +110,7 @@ function JsonValue({ value }: { value: unknown }) {
         <span className="font-mono">{expanded ? 'collapse' : `${lineCount} lines`}</span>
       </button>
       {expanded ? (
-        <pre className="mt-1.5 p-2.5 bg-[#0A0A0A] border border-[#1D1D1D] rounded text-[10px] font-mono text-gray-300 overflow-x-auto leading-relaxed whitespace-pre-wrap break-all">
+        <pre className="mt-1.5 p-2.5 bg-sidebar border border-border-subtle rounded text-[10px] font-mono text-gray-300 overflow-x-auto leading-relaxed whitespace-pre-wrap break-all">
           {pretty}
         </pre>
       ) : (
@@ -126,7 +132,7 @@ function CopyableValue({ label, value }: { label: string; value: string }) {
     >
       <span className="truncate">{value}</span>
       {isCopied ? (
-        <span className="text-[#22C55E] text-[9px] flex-shrink-0">copied</span>
+        <span className="text-success text-[9px] flex-shrink-0">copied</span>
       ) : (
         <Copy className="w-2.5 h-2.5 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0" />
       )}
@@ -155,7 +161,7 @@ function LogCard({ log, index, firstLogMs }: { log: OtelLog; index: number; firs
   }
 
   return (
-    <div className={`rounded-lg border border-[#1D1D1D] overflow-hidden ${severity.cardBg}`}>
+    <div className={`rounded-lg border border-border-subtle overflow-hidden ${severity.cardBg}`}>
       {/* Severity accent + message */}
       <div className="flex">
         <div
@@ -181,7 +187,7 @@ function LogCard({ log, index, firstLogMs }: { log: OtelLog; index: number; firs
             {log.service_name && (
               <>
                 <span className="text-gray-600">&middot;</span>
-                <span className="px-1 py-0.5 bg-[#1D1D1D] rounded text-gray-400">
+                <span className="px-1 py-0.5 bg-border-subtle rounded text-gray-400">
                   {log.service_name}
                 </span>
               </>
@@ -190,7 +196,7 @@ function LogCard({ log, index, firstLogMs }: { log: OtelLog; index: number; firs
 
           {/* Inline meta attributes (short values) */}
           {metaAttrs.length > 0 && (
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-2.5 pt-2.5 border-t border-[#1D1D1D]/50">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-2.5 pt-2.5 border-t border-border-subtle/50">
               {metaAttrs.map(([key, value]) => (
                 <div key={key} className="flex items-center gap-1.5 text-[10px]">
                   <span className="text-gray-600 font-mono">{key}</span>
@@ -202,7 +208,7 @@ function LogCard({ log, index, firstLogMs }: { log: OtelLog; index: number; firs
 
           {/* Expandable data attributes (JSON / long values) */}
           {dataAttrs.length > 0 && (
-            <div className="mt-2.5 pt-2.5 border-t border-[#1D1D1D]/50 space-y-2">
+            <div className="mt-2.5 pt-2.5 border-t border-border-subtle/50 space-y-2">
               {dataAttrs.map(([key, value]) => (
                 <div key={key}>
                   <span className="text-[10px] text-gray-600 font-mono">{key}</span>
@@ -242,7 +248,7 @@ export function SpanOtelLogsTab({ span }: SpanOtelLogsTabProps) {
   if (isLoading) {
     return (
       <div className="p-8 text-center">
-        <div className="w-5 h-5 mx-auto mb-2 border-2 border-gray-600 border-t-[#F3F724] rounded-full animate-spin" />
+        <div className="w-5 h-5 mx-auto mb-2 border-2 border-gray-600 border-t-accent rounded-full animate-spin" />
         <p className="text-[11px] text-gray-500">Loading logs...</p>
       </div>
     )
@@ -251,7 +257,7 @@ export function SpanOtelLogsTab({ span }: SpanOtelLogsTabProps) {
   if (logs.length === 0) {
     return (
       <div className="p-8 text-center">
-        <div className="w-10 h-10 mb-3 mx-auto rounded-lg bg-[#141414] border border-[#1D1D1D] flex items-center justify-center">
+        <div className="w-10 h-10 mb-3 mx-auto rounded-lg bg-elevated border border-border-subtle flex items-center justify-center">
           <FileText className="w-5 h-5 text-gray-600" />
         </div>
         <p className="text-sm text-gray-400">No logs found</p>
@@ -271,8 +277,8 @@ export function SpanOtelLogsTab({ span }: SpanOtelLogsTabProps) {
         </span>
         <div className="flex items-center gap-2">
           {errorCount > 0 && (
-            <span className="flex items-center gap-1 text-[9px] font-mono text-[#EF4444]">
-              <span className="w-1.5 h-1.5 rounded-full bg-[#EF4444]" />
+            <span className="flex items-center gap-1 text-[9px] font-mono text-error">
+              <span className="w-1.5 h-1.5 rounded-full bg-error" />
               {errorCount} errors
             </span>
           )}

--- a/console/packages/console-frontend/src/components/traces/SpanPanel.tsx
+++ b/console/packages/console-frontend/src/components/traces/SpanPanel.tsx
@@ -65,9 +65,9 @@ export function SpanPanel({
   const statusConfig = STATUS_CONFIG[span.status] ?? STATUS_CONFIG.default
 
   return (
-    <div className="h-full bg-[#0A0A0A] overflow-hidden flex flex-col animate-panel-in">
+    <div className="h-full bg-sidebar overflow-hidden flex flex-col animate-panel-in">
       {/* Compact header */}
-      <div className="flex-shrink-0 border-b border-[#1D1D1D]">
+      <div className="flex-shrink-0 border-b border-border-subtle">
         {/* Row 1: service badge + span name + close */}
         <div className="flex items-center gap-2 px-4 pt-3 pb-1.5">
           <div
@@ -81,7 +81,7 @@ export function SpanPanel({
             {service}
           </div>
           <h2
-            className="text-sm font-semibold text-[#F4F4F4] leading-tight truncate flex-1 min-w-0"
+            className="text-sm font-semibold text-foreground leading-tight truncate flex-1 min-w-0"
             title={span.name}
           >
             {span.name}
@@ -89,7 +89,7 @@ export function SpanPanel({
           <button
             type="button"
             onClick={onClose}
-            className="p-1 hover:bg-[#1D1D1D] rounded-md transition-colors group flex-shrink-0"
+            className="p-1 hover:bg-border-subtle rounded-md transition-colors group flex-shrink-0"
             aria-label="Close panel (Esc)"
             title="Close (Esc)"
           >
@@ -106,23 +106,23 @@ export function SpanPanel({
           >
             <span>{span.span_id.slice(0, 12)}</span>
             {copiedField === 'spanId' ? (
-              <span className="text-[#22C55E] text-[9px]">copied</span>
+              <span className="text-success text-[9px]">copied</span>
             ) : (
               <Copy className="w-2.5 h-2.5 opacity-0 group-hover:opacity-100 transition-opacity" />
             )}
           </button>
 
-          <div className="w-px h-3 bg-[#1D1D1D]" />
+          <div className="w-px h-3 bg-border-subtle" />
 
-          <div className="flex items-center gap-1 px-2 py-0.5 bg-[#141414] border border-[#1D1D1D] rounded">
-            <Clock className="w-2.5 h-2.5 text-[#F3F724]" />
-            <span className="text-[11px] font-mono font-semibold text-[#F3F724]">
+          <div className="flex items-center gap-1 px-2 py-0.5 bg-elevated border border-border-subtle rounded">
+            <Clock className="w-2.5 h-2.5 text-accent" />
+            <span className="text-[11px] font-mono font-semibold text-accent">
               {formatDuration(span.duration_ms)}
             </span>
           </div>
 
           {traceContext && traceContext.childSpans.length > 0 && (
-            <div className="flex items-center gap-1 px-2 py-0.5 bg-[#141414] border border-[#1D1D1D] rounded">
+            <div className="flex items-center gap-1 px-2 py-0.5 bg-elevated border border-border-subtle rounded">
               <Zap className="w-2.5 h-2.5 text-gray-400" />
               <span className="text-[10px] font-mono text-gray-400">
                 self {formatDuration(traceContext.selfTime)}
@@ -149,13 +149,13 @@ export function SpanPanel({
             </span>
           </div>
 
-          <div className="flex items-center gap-1 px-2 py-0.5 bg-[#141414] border border-[#1D1D1D] rounded">
+          <div className="flex items-center gap-1 px-2 py-0.5 bg-elevated border border-border-subtle rounded">
             <Layers className="w-2.5 h-2.5 text-gray-400" />
             <span className="text-[10px] font-mono text-gray-400">d:{span.depth}</span>
           </div>
 
           {traceContext && traceContext.childSpans.length > 0 && (
-            <div className="flex items-center gap-1 px-2 py-0.5 bg-[#141414] border border-[#1D1D1D] rounded">
+            <div className="flex items-center gap-1 px-2 py-0.5 bg-elevated border border-border-subtle rounded">
               <span className="text-[10px] font-mono text-gray-400">
                 {traceContext.childSpans.length} child
                 {traceContext.childSpans.length !== 1 ? 'ren' : ''}
@@ -170,11 +170,11 @@ export function SpanPanel({
             <button
               type="button"
               onClick={() => traceContext.parentSpan && onNavigateToSpan(traceContext.parentSpan)}
-              className="flex items-center gap-1.5 w-full px-2.5 py-1.5 bg-[#141414] border border-[#1D1D1D] rounded hover:bg-[#1A1A1A] hover:border-[#252525] transition-colors group text-left"
+              className="flex items-center gap-1.5 w-full px-2.5 py-1.5 bg-elevated border border-border-subtle rounded hover:bg-hover hover:border-border-subtle transition-colors group text-left"
             >
-              <ArrowUp className="w-3 h-3 text-gray-500 group-hover:text-[#F3F724] transition-colors flex-shrink-0" />
+              <ArrowUp className="w-3 h-3 text-gray-500 group-hover:text-accent transition-colors flex-shrink-0" />
               <span className="text-[10px] text-gray-500 flex-shrink-0">parent</span>
-              <span className="text-[10px] text-gray-300 truncate group-hover:text-[#F4F4F4] transition-colors">
+              <span className="text-[10px] text-gray-300 truncate group-hover:text-foreground transition-colors">
                 {traceContext.parentSpan.name}
               </span>
               <span className="text-[9px] font-mono text-gray-600 ml-auto flex-shrink-0">
@@ -195,7 +195,7 @@ export function SpanPanel({
             <TabsTrigger value="tags" className="text-[11px]">
               Attributes
               {attrCount > 0 && (
-                <span className="ml-1 px-1 py-0.5 text-[9px] bg-[#1D1D1D] rounded font-mono">
+                <span className="ml-1 px-1 py-0.5 text-[9px] bg-border-subtle rounded font-mono">
                   {attrCount}
                 </span>
               )}
@@ -203,7 +203,7 @@ export function SpanPanel({
             <TabsTrigger value="logs" className="text-[11px]">
               Events
               {eventCount > 0 && (
-                <span className="ml-1 px-1 py-0.5 text-[9px] bg-[#1D1D1D] rounded font-mono">
+                <span className="ml-1 px-1 py-0.5 text-[9px] bg-border-subtle rounded font-mono">
                   {eventCount}
                 </span>
               )}
@@ -217,7 +217,7 @@ export function SpanPanel({
             <TabsTrigger value="otel-logs" className="text-[11px]">
               Logs
               {logCount > 0 && (
-                <span className="ml-1 px-1 py-0.5 text-[9px] bg-[#1D1D1D] rounded font-mono">
+                <span className="ml-1 px-1 py-0.5 text-[9px] bg-border-subtle rounded font-mono">
                   {logCount}
                 </span>
               )}
@@ -228,7 +228,7 @@ export function SpanPanel({
             {linkCount > 0 && (
               <TabsTrigger value="links" className="text-[11px]">
                 Links
-                <span className="ml-1 px-1 py-0.5 text-[9px] bg-[#1D1D1D] rounded font-mono">
+                <span className="ml-1 px-1 py-0.5 text-[9px] bg-border-subtle rounded font-mono">
                   {linkCount}
                 </span>
               </TabsTrigger>

--- a/console/packages/console-frontend/src/components/traces/SpanTagsTab.tsx
+++ b/console/packages/console-frontend/src/components/traces/SpanTagsTab.tsx
@@ -102,7 +102,7 @@ export function SpanTagsTab({ span }: SpanTagsTabProps) {
   if (entries.length === 0) {
     return (
       <div className="p-8 text-center">
-        <div className="w-10 h-10 mb-3 mx-auto rounded-lg bg-[#141414] border border-[#1D1D1D] flex items-center justify-center">
+        <div className="w-10 h-10 mb-3 mx-auto rounded-lg bg-elevated border border-border-subtle flex items-center justify-center">
           <Search className="w-5 h-5 text-gray-600" />
         </div>
         <p className="text-sm text-gray-400">No attributes found</p>
@@ -122,7 +122,7 @@ export function SpanTagsTab({ span }: SpanTagsTabProps) {
           placeholder="Filter attributes..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="w-full pl-9 pr-4 py-2 bg-[#141414] border border-[#1D1D1D] rounded-md text-sm text-[#F4F4F4] placeholder-gray-600 focus:outline-none focus:border-[#F3F724]/50 transition-colors"
+          className="w-full pl-9 pr-4 py-2 bg-elevated border border-border-subtle rounded-md text-sm text-foreground placeholder-gray-600 focus:outline-none focus:border-accent/50 transition-colors"
         />
       </div>
 
@@ -133,12 +133,12 @@ export function SpanTagsTab({ span }: SpanTagsTabProps) {
           return (
             <div
               key={group.namespace}
-              className="bg-[#141414] rounded-lg border border-[#1D1D1D] overflow-hidden"
+              className="bg-elevated rounded-lg border border-border-subtle overflow-hidden"
             >
               <button
                 type="button"
                 onClick={() => toggleGroup(group.namespace)}
-                className="w-full flex items-center gap-2 px-4 py-2.5 hover:bg-[#1A1A1A] transition-colors text-left"
+                className="w-full flex items-center gap-2 px-4 py-2.5 hover:bg-hover transition-colors text-left"
               >
                 <ChevronRight
                   className={`w-3 h-3 text-gray-500 transition-transform ${isCollapsed ? '' : 'rotate-90'}`}
@@ -152,17 +152,17 @@ export function SpanTagsTab({ span }: SpanTagsTabProps) {
               </button>
 
               {!isCollapsed && (
-                <div className="border-t border-[#1D1D1D] divide-y divide-[#1D1D1D]/50">
+                <div className="border-t border-border-subtle divide-y divide-border-subtle/50">
                   {group.entries.map(([key, value]) => (
                     <button
                       key={key}
                       type="button"
                       onClick={() => copyToClipboard(key, value)}
-                      className="w-full px-4 py-2 hover:bg-[#1A1A1A] transition-colors text-left group"
+                      className="w-full px-4 py-2 hover:bg-hover transition-colors text-left group"
                     >
                       <div className="flex items-start justify-between gap-3">
                         <div className="flex-1 min-w-0">
-                          <div className="text-[11px] font-mono text-[#F3F724] mb-0.5">{key}</div>
+                          <div className="text-[11px] font-mono text-accent mb-0.5">{key}</div>
                           <div className="text-[12px] text-gray-300 break-all font-mono leading-relaxed">
                             {typeof value === 'object'
                               ? JSON.stringify(value, null, 2)
@@ -170,7 +170,7 @@ export function SpanTagsTab({ span }: SpanTagsTabProps) {
                           </div>
                         </div>
                         {copiedKey === key ? (
-                          <span className="text-[10px] text-[#22C55E] flex-shrink-0 mt-0.5">
+                          <span className="text-[10px] text-success flex-shrink-0 mt-0.5">
                             copied
                           </span>
                         ) : (
@@ -185,23 +185,23 @@ export function SpanTagsTab({ span }: SpanTagsTabProps) {
           )
         })
       ) : (
-        <div className="bg-[#141414] rounded-lg border border-[#1D1D1D] divide-y divide-[#1D1D1D]/50">
+        <div className="bg-elevated rounded-lg border border-border-subtle divide-y divide-border-subtle/50">
           {filteredEntries.map(([key, value]) => (
             <button
               key={key}
               type="button"
               onClick={() => copyToClipboard(key, value)}
-              className="w-full px-4 py-2.5 hover:bg-[#1A1A1A] transition-colors text-left group"
+              className="w-full px-4 py-2.5 hover:bg-hover transition-colors text-left group"
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="flex-1 min-w-0">
-                  <div className="text-[11px] font-mono text-[#F3F724] mb-0.5">{key}</div>
+                  <div className="text-[11px] font-mono text-accent mb-0.5">{key}</div>
                   <div className="text-[12px] text-gray-300 break-all font-mono leading-relaxed">
                     {typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value)}
                   </div>
                 </div>
                 {copiedKey === key ? (
-                  <span className="text-[10px] text-[#22C55E] flex-shrink-0 mt-0.5">copied</span>
+                  <span className="text-[10px] text-success flex-shrink-0 mt-0.5">copied</span>
                 ) : (
                   <Copy className="w-3 h-3 text-gray-600 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0 mt-0.5" />
                 )}

--- a/console/packages/console-frontend/src/components/traces/TraceFilters.tsx
+++ b/console/packages/console-frontend/src/components/traces/TraceFilters.tsx
@@ -6,6 +6,7 @@ import {
   CircleDot,
   Clock,
   Hash,
+  Layers,
   Search,
   Server,
   Tags,
@@ -16,6 +17,8 @@ import {
 } from 'lucide-react'
 import { useEffect, useReducer, useRef, useState } from 'react'
 import type { TraceFilterState } from '@/hooks/useTraceFilters'
+import type { GroupByOption } from '@/lib/groupTraces'
+import { groupByLabel } from '@/lib/groupTraces'
 import { AttributesFilter } from './AttributesFilter'
 
 interface TraceFiltersProps {
@@ -58,7 +61,22 @@ const statusOptions = [
   { label: 'Unset', value: 'unset' },
 ]
 
-type PopoverType = 'status' | 'timeRange' | 'duration' | 'service' | 'operation' | 'sort' | null
+type PopoverType =
+  | 'status'
+  | 'timeRange'
+  | 'duration'
+  | 'service'
+  | 'operation'
+  | 'sort'
+  | 'groupBy'
+  | null
+
+const groupByOptions: Array<{ label: string; value: GroupByOption }> = [
+  { label: groupByLabel('none'), value: 'none' },
+  { label: groupByLabel('iii.message.id'), value: 'iii.message.id' },
+  { label: groupByLabel('iii.session.id'), value: 'iii.session.id' },
+  { label: groupByLabel('iii.function.id'), value: 'iii.function.id' },
+]
 
 // --- Temp Inputs Reducer ---
 interface TempInputsState {
@@ -196,6 +214,7 @@ export function TraceFilters({
   const serviceRef = useRef<HTMLDivElement>(null)
   const operationRef = useRef<HTMLDivElement>(null)
   const sortRef = useRef<HTMLDivElement>(null)
+  const groupByRef = useRef<HTMLDivElement>(null)
 
   useClickOutside(statusRef, () => openPopover === 'status' && setOpenPopover(null))
   useClickOutside(timeRangeRef, () => openPopover === 'timeRange' && setOpenPopover(null))
@@ -203,6 +222,7 @@ export function TraceFilters({
   useClickOutside(serviceRef, () => openPopover === 'service' && setOpenPopover(null))
   useClickOutside(operationRef, () => openPopover === 'operation' && setOpenPopover(null))
   useClickOutside(sortRef, () => openPopover === 'sort' && setOpenPopover(null))
+  useClickOutside(groupByRef, () => openPopover === 'groupBy' && setOpenPopover(null))
 
   const togglePopover = (popover: PopoverType) => {
     setOpenPopover(openPopover === popover ? null : popover)
@@ -649,6 +669,44 @@ export function TraceFilters({
               >
                 Descending
               </button>
+            </div>
+          )}
+        </div>
+
+        {/* Group By */}
+        <div ref={groupByRef} className="relative">
+          <button
+            type="button"
+            onClick={() => togglePopover('groupBy')}
+            className={`flex items-center gap-1.5 px-2.5 py-1 text-[11px] rounded-md transition-colors ${
+              filters.groupBy && filters.groupBy !== 'none'
+                ? 'bg-yellow/10 border border-yellow/30 text-yellow'
+                : 'bg-[#141414] border border-[#1D1D1D] text-muted hover:border-[#2D2D2D] hover:text-foreground'
+            }`}
+            title="Group spans by an attribute value (server-side aggregation)"
+          >
+            <Layers className="w-3 h-3" />
+            {groupByLabel(filters.groupBy ?? 'none')}
+          </button>
+          {openPopover === 'groupBy' && (
+            <div className="absolute top-full mt-1 left-0 bg-[#141414] border border-[#1D1D1D] rounded-md shadow-lg z-20 min-w-[180px]">
+              {groupByOptions.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => {
+                    onFilterChange('groupBy', option.value)
+                    setOpenPopover(null)
+                  }}
+                  className={`w-full px-3 py-1.5 text-left text-[11px] hover:bg-[#1A1A1A] transition-colors first:rounded-t-md last:rounded-b-md ${
+                    (filters.groupBy ?? 'none') === option.value
+                      ? 'text-yellow'
+                      : 'text-muted hover:text-foreground'
+                  }`}
+                >
+                  {option.label}
+                </button>
+              ))}
             </div>
           )}
         </div>

--- a/console/packages/console-frontend/src/components/traces/TraceFilters.tsx
+++ b/console/packages/console-frontend/src/components/traces/TraceFilters.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   AlertTriangle,
   ArrowUpDown,
@@ -404,7 +402,7 @@ export function TraceFilters({
             value={searchQuery}
             onChange={(e) => onSearchChange?.(e.target.value)}
             placeholder="Search traces..."
-            className="w-44 pl-7 pr-7 py-1 bg-[#0A0A0A] border border-[#1D1D1D] rounded-md text-[11px] text-foreground placeholder-[#5B5B5B] focus:outline-none focus:border-yellow/50 transition-colors"
+            className="w-44 pl-7 pr-7 py-1 bg-sidebar border border-border-subtle rounded-md text-[11px] text-foreground placeholder-muted focus:outline-none focus:border-yellow/50 transition-colors"
           />
           {searchQuery && (
             <button
@@ -417,7 +415,7 @@ export function TraceFilters({
           )}
         </div>
 
-        <div className="w-px h-5 bg-[#1D1D1D]" />
+        <div className="w-px h-5 bg-border-subtle" />
 
         {/* Status */}
         <div ref={statusRef} className="relative">
@@ -427,14 +425,14 @@ export function TraceFilters({
             className={`flex items-center gap-1.5 px-2.5 py-1 text-[11px] rounded-md transition-colors ${
               filters.status
                 ? 'bg-yellow/10 border border-yellow/30 text-yellow'
-                : 'bg-[#141414] border border-[#1D1D1D] text-muted hover:border-[#2D2D2D] hover:text-foreground'
+                : 'bg-elevated border border-border-subtle text-muted hover:border-border hover:text-foreground'
             }`}
           >
             <CircleDot className="w-3 h-3" />
             Status
           </button>
           {openPopover === 'status' && (
-            <div className="absolute top-full mt-1 left-0 bg-[#141414] border border-[#1D1D1D] rounded-md shadow-lg z-20 min-w-[100px]">
+            <div className="absolute top-full mt-1 left-0 bg-elevated border border-border-subtle rounded-md shadow-lg z-20 min-w-[100px]">
               {statusOptions.map((option) => (
                 <button
                   key={option.label}
@@ -442,7 +440,7 @@ export function TraceFilters({
                   onClick={() =>
                     handleStatusChange(option.value as 'ok' | 'error' | 'unset' | null)
                   }
-                  className="w-full px-3 py-1.5 text-left text-[11px] text-muted hover:bg-[#1A1A1A] hover:text-foreground first:rounded-t-md last:rounded-b-md transition-colors"
+                  className="w-full px-3 py-1.5 text-left text-[11px] text-muted hover:bg-hover hover:text-foreground first:rounded-t-md last:rounded-b-md transition-colors"
                 >
                   {option.label}
                 </button>
@@ -459,20 +457,20 @@ export function TraceFilters({
             className={`flex items-center gap-1.5 px-2.5 py-1 text-[11px] rounded-md transition-colors ${
               filters.startTime && filters.endTime
                 ? 'bg-yellow/10 border border-yellow/30 text-yellow'
-                : 'bg-[#141414] border border-[#1D1D1D] text-muted hover:border-[#2D2D2D] hover:text-foreground'
+                : 'bg-elevated border border-border-subtle text-muted hover:border-border hover:text-foreground'
             }`}
           >
             <Clock className="w-3 h-3" />
             Time Range
           </button>
           {openPopover === 'timeRange' && (
-            <div className="absolute top-full mt-1 left-0 bg-[#141414] border border-[#1D1D1D] rounded-md shadow-lg z-20 min-w-[110px]">
+            <div className="absolute top-full mt-1 left-0 bg-elevated border border-border-subtle rounded-md shadow-lg z-20 min-w-[110px]">
               {timeRangePresets.map((preset) => (
                 <button
                   key={preset.label}
                   type="button"
                   onClick={() => handleTimeRangeChange(preset.value)}
-                  className="w-full px-3 py-1.5 text-left text-[11px] text-muted hover:bg-[#1A1A1A] hover:text-foreground first:rounded-t-md last:rounded-b-md transition-colors"
+                  className="w-full px-3 py-1.5 text-left text-[11px] text-muted hover:bg-hover hover:text-foreground first:rounded-t-md last:rounded-b-md transition-colors"
                 >
                   {preset.label}
                 </button>
@@ -489,14 +487,14 @@ export function TraceFilters({
             className={`flex items-center gap-1.5 px-2.5 py-1 text-[11px] rounded-md transition-colors ${
               filters.minDurationMs || filters.maxDurationMs
                 ? 'bg-yellow/10 border border-yellow/30 text-yellow'
-                : 'bg-[#141414] border border-[#1D1D1D] text-muted hover:border-[#2D2D2D] hover:text-foreground'
+                : 'bg-elevated border border-border-subtle text-muted hover:border-border hover:text-foreground'
             }`}
           >
             <Timer className="w-3 h-3" />
             Duration
           </button>
           {openPopover === 'duration' && (
-            <div className="absolute top-full mt-1 left-0 bg-[#141414] border border-[#1D1D1D] rounded-md shadow-lg z-20 p-3 min-w-[200px]">
+            <div className="absolute top-full mt-1 left-0 bg-elevated border border-border-subtle rounded-md shadow-lg z-20 p-3 min-w-[200px]">
               <div className="flex items-center gap-2">
                 <input
                   type="number"
@@ -506,7 +504,7 @@ export function TraceFilters({
                     dispatchTempInputs({ type: 'SET_MIN_DURATION', payload: e.target.value })
                   }
                   onKeyDown={(e) => handleKeyDown(e, handleDurationApply)}
-                  className="w-20 px-2 py-1 bg-[#0A0A0A] border border-[#1D1D1D] rounded text-[11px] text-foreground placeholder-[#5B5B5B] focus:outline-none focus:border-yellow transition-colors"
+                  className="w-20 px-2 py-1 bg-sidebar border border-border-subtle rounded text-[11px] text-foreground placeholder-muted focus:outline-none focus:border-yellow transition-colors"
                 />
                 <span className="text-[11px] text-muted">-</span>
                 <input
@@ -517,7 +515,7 @@ export function TraceFilters({
                     dispatchTempInputs({ type: 'SET_MAX_DURATION', payload: e.target.value })
                   }
                   onKeyDown={(e) => handleKeyDown(e, handleDurationApply)}
-                  className="w-20 px-2 py-1 bg-[#0A0A0A] border border-[#1D1D1D] rounded text-[11px] text-foreground placeholder-[#5B5B5B] focus:outline-none focus:border-yellow transition-colors"
+                  className="w-20 px-2 py-1 bg-sidebar border border-border-subtle rounded text-[11px] text-foreground placeholder-muted focus:outline-none focus:border-yellow transition-colors"
                 />
                 <span className="text-[11px] text-muted">ms</span>
               </div>
@@ -540,14 +538,14 @@ export function TraceFilters({
             className={`flex items-center gap-1.5 px-2.5 py-1 text-[11px] rounded-md transition-colors ${
               filters.serviceName
                 ? 'bg-yellow/10 border border-yellow/30 text-yellow'
-                : 'bg-[#141414] border border-[#1D1D1D] text-muted hover:border-[#2D2D2D] hover:text-foreground'
+                : 'bg-elevated border border-border-subtle text-muted hover:border-border hover:text-foreground'
             }`}
           >
             <Server className="w-3 h-3" />
             Service
           </button>
           {openPopover === 'service' && (
-            <div className="absolute top-full mt-1 left-0 bg-[#141414] border border-[#1D1D1D] rounded-md shadow-lg z-20 p-3 min-w-[220px]">
+            <div className="absolute top-full mt-1 left-0 bg-elevated border border-border-subtle rounded-md shadow-lg z-20 p-3 min-w-[220px]">
               <input
                 type="text"
                 placeholder="e.g., api-*, backend"
@@ -556,7 +554,7 @@ export function TraceFilters({
                   dispatchTempInputs({ type: 'SET_SERVICE_NAME', payload: e.target.value })
                 }
                 onKeyDown={(e) => handleKeyDown(e, handleServiceApply)}
-                className="w-full px-2 py-1.5 bg-[#0A0A0A] border border-[#1D1D1D] rounded text-[11px] text-foreground placeholder-[#5B5B5B] focus:outline-none focus:border-yellow transition-colors"
+                className="w-full px-2 py-1.5 bg-sidebar border border-border-subtle rounded text-[11px] text-foreground placeholder-muted focus:outline-none focus:border-yellow transition-colors"
               />
               <button
                 type="button"
@@ -577,14 +575,14 @@ export function TraceFilters({
             className={`flex items-center gap-1.5 px-2.5 py-1 text-[11px] rounded-md transition-colors ${
               filters.operationName
                 ? 'bg-yellow/10 border border-yellow/30 text-yellow'
-                : 'bg-[#141414] border border-[#1D1D1D] text-muted hover:border-[#2D2D2D] hover:text-foreground'
+                : 'bg-elevated border border-border-subtle text-muted hover:border-border hover:text-foreground'
             }`}
           >
             <Workflow className="w-3 h-3" />
             Operation
           </button>
           {openPopover === 'operation' && (
-            <div className="absolute top-full mt-1 left-0 bg-[#141414] border border-[#1D1D1D] rounded-md shadow-lg z-20 p-3 min-w-[220px]">
+            <div className="absolute top-full mt-1 left-0 bg-elevated border border-border-subtle rounded-md shadow-lg z-20 p-3 min-w-[220px]">
               <input
                 type="text"
                 placeholder="e.g., GET *, POST /api/*"
@@ -593,7 +591,7 @@ export function TraceFilters({
                   dispatchTempInputs({ type: 'SET_OPERATION_NAME', payload: e.target.value })
                 }
                 onKeyDown={(e) => handleKeyDown(e, handleOperationApply)}
-                className="w-full px-2 py-1.5 bg-[#0A0A0A] border border-[#1D1D1D] rounded text-[11px] text-foreground placeholder-[#5B5B5B] focus:outline-none focus:border-yellow transition-colors"
+                className="w-full px-2 py-1.5 bg-sidebar border border-border-subtle rounded text-[11px] text-foreground placeholder-muted focus:outline-none focus:border-yellow transition-colors"
               />
               <button
                 type="button"
@@ -614,15 +612,15 @@ export function TraceFilters({
             className={`flex items-center gap-1.5 px-2.5 py-1 text-[11px] rounded-md transition-colors ${
               filters.sortBy !== 'start_time' || filters.sortOrder !== 'desc'
                 ? 'bg-yellow/10 border border-yellow/30 text-yellow'
-                : 'bg-[#141414] border border-[#1D1D1D] text-muted hover:border-[#2D2D2D] hover:text-foreground'
+                : 'bg-elevated border border-border-subtle text-muted hover:border-border hover:text-foreground'
             }`}
           >
             <ArrowUpDown className="w-3 h-3" />
             {getSortLabel()} · {filters.sortOrder === 'asc' ? 'Asc' : 'Desc'}
           </button>
           {openPopover === 'sort' && (
-            <div className="absolute top-full mt-1 left-0 bg-[#141414] border border-[#1D1D1D] rounded-md shadow-lg z-20 min-w-[140px]">
-              <div className="px-3 py-1.5 text-[10px] text-[#5B5B5B] uppercase tracking-wider">
+            <div className="absolute top-full mt-1 left-0 bg-elevated border border-border-subtle rounded-md shadow-lg z-20 min-w-[140px]">
+              <div className="px-3 py-1.5 text-[10px] text-muted uppercase tracking-wider">
                 Sort by
               </div>
               {sortByOptions.map((option) => (
@@ -632,7 +630,7 @@ export function TraceFilters({
                   onClick={() =>
                     handleSortChange(option.value as 'start_time' | 'duration' | 'service_name')
                   }
-                  className={`w-full px-3 py-1.5 text-left text-[11px] hover:bg-[#1A1A1A] transition-colors ${
+                  className={`w-full px-3 py-1.5 text-left text-[11px] hover:bg-hover transition-colors ${
                     filters.sortBy === option.value
                       ? 'text-yellow'
                       : 'text-muted hover:text-foreground'
@@ -641,8 +639,8 @@ export function TraceFilters({
                   {option.label}
                 </button>
               ))}
-              <div className="border-t border-[#1D1D1D] my-1" />
-              <div className="px-3 py-1.5 text-[10px] text-[#5B5B5B] uppercase tracking-wider">
+              <div className="border-t border-border-subtle my-1" />
+              <div className="px-3 py-1.5 text-[10px] text-muted uppercase tracking-wider">
                 Order
               </div>
               <button
@@ -651,7 +649,7 @@ export function TraceFilters({
                   onFilterChange('sortOrder', 'asc')
                   setOpenPopover(null)
                 }}
-                className={`w-full px-3 py-1.5 text-left text-[11px] hover:bg-[#1A1A1A] transition-colors ${
+                className={`w-full px-3 py-1.5 text-left text-[11px] hover:bg-hover transition-colors ${
                   filters.sortOrder === 'asc' ? 'text-yellow' : 'text-muted hover:text-foreground'
                 }`}
               >
@@ -663,7 +661,7 @@ export function TraceFilters({
                   onFilterChange('sortOrder', 'desc')
                   setOpenPopover(null)
                 }}
-                className={`w-full px-3 py-1.5 text-left text-[11px] hover:bg-[#1A1A1A] last:rounded-b-md transition-colors ${
+                className={`w-full px-3 py-1.5 text-left text-[11px] hover:bg-hover last:rounded-b-md transition-colors ${
                   filters.sortOrder === 'desc' ? 'text-yellow' : 'text-muted hover:text-foreground'
                 }`}
               >
@@ -681,7 +679,7 @@ export function TraceFilters({
             className={`flex items-center gap-1.5 px-2.5 py-1 text-[11px] rounded-md transition-colors ${
               filters.groupBy && filters.groupBy !== 'none'
                 ? 'bg-yellow/10 border border-yellow/30 text-yellow'
-                : 'bg-[#141414] border border-[#1D1D1D] text-muted hover:border-[#2D2D2D] hover:text-foreground'
+                : 'bg-elevated border border-border-subtle text-muted hover:border-border hover:text-foreground'
             }`}
             title="Group spans by an attribute value (server-side aggregation)"
           >
@@ -689,7 +687,7 @@ export function TraceFilters({
             {groupByLabel(filters.groupBy ?? 'none')}
           </button>
           {openPopover === 'groupBy' && (
-            <div className="absolute top-full mt-1 left-0 bg-[#141414] border border-[#1D1D1D] rounded-md shadow-lg z-20 min-w-[180px]">
+            <div className="absolute top-full mt-1 left-0 bg-elevated border border-border-subtle rounded-md shadow-lg z-20 min-w-[180px]">
               {groupByOptions.map((option) => (
                 <button
                   key={option.value}
@@ -698,7 +696,7 @@ export function TraceFilters({
                     onFilterChange('groupBy', option.value)
                     setOpenPopover(null)
                   }}
-                  className={`w-full px-3 py-1.5 text-left text-[11px] hover:bg-[#1A1A1A] transition-colors first:rounded-t-md last:rounded-b-md ${
+                  className={`w-full px-3 py-1.5 text-left text-[11px] hover:bg-hover transition-colors first:rounded-t-md last:rounded-b-md ${
                     (filters.groupBy ?? 'none') === option.value
                       ? 'text-yellow'
                       : 'text-muted hover:text-foreground'
@@ -718,7 +716,7 @@ export function TraceFilters({
           className={`flex items-center gap-1.5 px-2.5 py-1 text-[11px] rounded-md transition-colors ${
             filters.attributes && filters.attributes.length > 0
               ? 'bg-yellow/10 border border-yellow/30 text-yellow'
-              : 'bg-[#141414] border border-[#1D1D1D] text-muted hover:border-[#2D2D2D] hover:text-foreground'
+              : 'bg-elevated border border-border-subtle text-muted hover:border-border hover:text-foreground'
           }`}
         >
           <Tags className="w-3 h-3" />
@@ -750,7 +748,7 @@ export function TraceFilters({
 
       {/* Attributes Panel (Expandable) */}
       {showAttributesPanel && (
-        <div className="p-4 bg-[#141414] border border-[#1D1D1D] rounded-lg">
+        <div className="p-4 bg-elevated border border-border-subtle rounded-lg">
           <AttributesFilter value={filters.attributes || []} onChange={handleAttributesChange} />
         </div>
       )}
@@ -764,7 +762,7 @@ export function TraceFilters({
               key={filter.key}
               type="button"
               onClick={() => removeFilter(filter.key)}
-              className="flex items-center gap-1 px-1.5 py-0.5 bg-[#1A1A1A] border border-[#2D2D2D] hover:border-yellow/30 rounded text-[10px] text-muted hover:text-foreground transition-colors group"
+              className="flex items-center gap-1 px-1.5 py-0.5 bg-hover border border-border hover:border-yellow/30 rounded text-[10px] text-muted hover:text-foreground transition-colors group"
             >
               <span>{filter.label}</span>
               <X className="w-2.5 h-2.5 opacity-50 group-hover:opacity-100 group-hover:text-yellow transition-all" />
@@ -773,7 +771,7 @@ export function TraceFilters({
           <button
             type="button"
             onClick={onClear}
-            className="text-[10px] text-[#5B5B5B] hover:text-foreground transition-colors ml-1"
+            className="text-[10px] text-muted hover:text-foreground transition-colors ml-1"
           >
             Clear all
           </button>

--- a/console/packages/console-frontend/src/components/traces/TraceGroupsView.tsx
+++ b/console/packages/console-frontend/src/components/traces/TraceGroupsView.tsx
@@ -1,0 +1,140 @@
+// Renders the server-aggregated group-by view for the TRACES tab.
+//
+// Used when `filters.groupBy !== 'none'`. The route swaps this in place of
+// the flat WaterfallChart list. Each row collapses one attribute-value's
+// worth of spans across multiple traces and shows summary metadata
+// (span_count, duration, error_count). Clicking a group row drills down
+// to a single trace via the existing trace-detail panel; for v1, we
+// surface the first trace_id in the group.
+//
+// If the engine doesn't expose `engine::traces::group_by` (older deploy
+// or `iii-observability` not running), the `unavailable` flag from the
+// hook surfaces a soft fallback message — the user can switch back to
+// "No grouping" without seeing an error toast.
+
+import { Layers, Loader2 } from 'lucide-react'
+
+import type { TraceGroup } from '@/api/observability/traces'
+import { useTraceGroups } from '@/hooks/useTraceGroups'
+import type { GroupByAttribute } from '@/lib/groupTraces'
+import { groupHeading, summarizeGroup } from '@/lib/groupTraces'
+
+interface TraceGroupsViewProps {
+  attribute: GroupByAttribute
+  showSystem: boolean
+  isPaused: boolean
+  onSelectTrace: (traceId: string) => void
+  /**
+   * Called with the full TraceGroup when a row is clicked. Routes that
+   * want a session-style multi-trace detail panel use this; older
+   * call-sites can ignore it and rely solely on `onSelectTrace`.
+   */
+  onSelectGroup?: (group: TraceGroup) => void
+  selectedTraceId: string | null
+}
+
+export function TraceGroupsView({
+  attribute,
+  showSystem,
+  isPaused,
+  onSelectTrace,
+  onSelectGroup,
+  selectedTraceId,
+}: TraceGroupsViewProps) {
+  const { groups, isLoading, unavailable } = useTraceGroups({
+    groupBy: attribute,
+    includeInternal: showSystem,
+    isPaused,
+  })
+
+  if (unavailable) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 px-6 text-center text-[12px] text-muted">
+        <Layers className="w-6 h-6 mb-2 opacity-50" />
+        <div className="font-medium text-foreground mb-1">Group-by not available</div>
+        <div className="max-w-md">
+          The engine doesn't expose <code className="text-yellow">engine::traces::group_by</code>.
+          Either the engine is older than the version that introduced it, or the
+          <code className="text-yellow"> iii-observability</code> worker is not configured.
+          Switch &quot;Group by&quot; back to &quot;No grouping&quot; to use the flat trace list.
+        </div>
+      </div>
+    )
+  }
+
+  if (isLoading && groups.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-12 text-[12px] text-muted gap-2">
+        <Loader2 className="w-4 h-4 animate-spin" />
+        Loading groups…
+      </div>
+    )
+  }
+
+  if (groups.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 px-6 text-center text-[12px] text-muted">
+        <Layers className="w-6 h-6 mb-2 opacity-50" />
+        <div>No spans match this attribute yet.</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col">
+      {groups.map((group) => (
+        <GroupRow
+          key={`${attribute}:${group.value}`}
+          attribute={attribute}
+          group={group}
+          isSelected={selectedTraceId !== null && group.trace_ids.includes(selectedTraceId)}
+          onClick={() => {
+            // Surface the full group when a session-aware container is
+            // wired in (routes/traces.tsx). For row-highlight purposes
+            // we also push the first trace_id into the legacy
+            // single-trace selection so isSelected styling still works.
+            const firstTrace = group.trace_ids[0]
+            if (firstTrace) onSelectTrace(firstTrace)
+            if (onSelectGroup) onSelectGroup(group)
+          }}
+        />
+      ))}
+    </div>
+  )
+}
+
+interface GroupRowProps {
+  attribute: GroupByAttribute
+  group: TraceGroup
+  isSelected: boolean
+  onClick: () => void
+}
+
+function GroupRow({ attribute, group, isSelected, onClick }: GroupRowProps) {
+  const heading = groupHeading(group, attribute)
+  const summary = summarizeGroup(group)
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-2 px-3 py-2 text-left border-b border-[#1D1D1D]/60 transition-colors ${
+        isSelected ? 'bg-[#F3F724]/[0.06] border-l-2 border-l-[#F3F724]' : 'hover:bg-[#1D1D1D]/50'
+      }`}
+      title={`${heading} (${group.trace_ids.length} trace${group.trace_ids.length === 1 ? '' : 's'})`}
+    >
+      <Layers
+        className={`w-3.5 h-3.5 flex-shrink-0 ${
+          group.error_count > 0 ? 'text-red-400' : 'text-muted'
+        }`}
+      />
+      <span
+        className={`font-mono text-[12px] truncate ${
+          isSelected ? 'text-[#F3F724]' : 'text-foreground'
+        }`}
+      >
+        {heading}
+      </span>
+      <span className="ml-auto text-[11px] text-muted flex-shrink-0">{summary}</span>
+    </button>
+  )
+}

--- a/console/packages/console-frontend/src/components/traces/TraceGroupsView.tsx
+++ b/console/packages/console-frontend/src/components/traces/TraceGroupsView.tsx
@@ -117,8 +117,10 @@ function GroupRow({ attribute, group, isSelected, onClick }: GroupRowProps) {
     <button
       type="button"
       onClick={onClick}
-      className={`flex items-center gap-2 px-3 py-2 text-left border-b border-[#1D1D1D]/60 transition-colors ${
-        isSelected ? 'bg-[#F3F724]/[0.06] border-l-2 border-l-[#F3F724]' : 'hover:bg-[#1D1D1D]/50'
+      className={`flex items-center gap-2 px-3 py-2 text-left border-b border-border-subtle/60 transition-colors ${
+        isSelected
+          ? 'bg-accent/[0.06] border-l-2 border-l-accent'
+          : 'hover:bg-border-subtle/50'
       }`}
       title={`${heading} (${group.trace_ids.length} trace${group.trace_ids.length === 1 ? '' : 's'})`}
     >
@@ -129,7 +131,7 @@ function GroupRow({ attribute, group, isSelected, onClick }: GroupRowProps) {
       />
       <span
         className={`font-mono text-[12px] truncate ${
-          isSelected ? 'text-[#F3F724]' : 'text-foreground'
+          isSelected ? 'text-accent' : 'text-foreground'
         }`}
       >
         {heading}

--- a/console/packages/console-frontend/src/components/traces/TraceGroupsView.tsx
+++ b/console/packages/console-frontend/src/components/traces/TraceGroupsView.tsx
@@ -55,8 +55,8 @@ export function TraceGroupsView({
         <div className="max-w-md">
           The engine doesn't expose <code className="text-yellow">engine::traces::group_by</code>.
           Either the engine is older than the version that introduced it, or the
-          <code className="text-yellow"> iii-observability</code> worker is not configured.
-          Switch &quot;Group by&quot; back to &quot;No grouping&quot; to use the flat trace list.
+          <code className="text-yellow"> iii-observability</code> worker is not configured. Switch
+          &quot;Group by&quot; back to &quot;No grouping&quot; to use the flat trace list.
         </div>
       </div>
     )
@@ -118,9 +118,7 @@ function GroupRow({ attribute, group, isSelected, onClick }: GroupRowProps) {
       type="button"
       onClick={onClick}
       className={`flex items-center gap-2 px-3 py-2 text-left border-b border-border-subtle/60 transition-colors ${
-        isSelected
-          ? 'bg-accent/[0.06] border-l-2 border-l-accent'
-          : 'hover:bg-border-subtle/50'
+        isSelected ? 'bg-accent/[0.06] border-l-2 border-l-accent' : 'hover:bg-border-subtle/50'
       }`}
       title={`${heading} (${group.trace_ids.length} trace${group.trace_ids.length === 1 ? '' : 's'})`}
     >

--- a/console/packages/console-frontend/src/components/traces/TraceHeader.tsx
+++ b/console/packages/console-frontend/src/components/traces/TraceHeader.tsx
@@ -124,9 +124,7 @@ export function TraceHeader({ data, traceId, onClose, onSpanClick }: TraceHeader
         {hasErrors && (
           <div className="flex items-center gap-1 px-2 py-0.5 bg-error/10 border border-error/20 rounded">
             <AlertCircle className="w-2.5 h-2.5 text-error" />
-            <span className="text-[10px] font-mono font-semibold text-error">
-              {errorCount} err
-            </span>
+            <span className="text-[10px] font-mono font-semibold text-error">{errorCount} err</span>
           </div>
         )}
       </div>

--- a/console/packages/console-frontend/src/components/traces/TraceHeader.tsx
+++ b/console/packages/console-frontend/src/components/traces/TraceHeader.tsx
@@ -65,14 +65,14 @@ export function TraceHeader({ data, traceId, onClose, onSpanClick }: TraceHeader
   const rootService = rootSpan ? getServiceName(rootSpan) : 'trace'
 
   return (
-    <div className="bg-[#0A0A0A] border-b border-[#1D1D1D] flex-shrink-0">
+    <div className="bg-sidebar border-b border-border-subtle flex-shrink-0">
       {/* Row 1: service badge + operation name + close */}
       <div className="flex items-center gap-2 px-4 pt-3 pb-1.5">
-        <div className="px-1.5 py-0.5 rounded text-[10px] font-medium tracking-wide flex-shrink-0 bg-[#22C55E]/8 text-[#22C55E] border border-[#22C55E]/15">
+        <div className="px-1.5 py-0.5 rounded text-[10px] font-medium tracking-wide flex-shrink-0 bg-success/10 text-success border border-success/20">
           {rootService}
         </div>
         <h2
-          className="text-sm font-semibold text-[#F4F4F4] leading-tight truncate flex-1 min-w-0"
+          className="text-sm font-semibold text-foreground leading-tight truncate flex-1 min-w-0"
           title={rootSpan?.name || 'Trace Details'}
         >
           {rootSpan?.name || 'Trace Details'}
@@ -80,7 +80,7 @@ export function TraceHeader({ data, traceId, onClose, onSpanClick }: TraceHeader
         <button
           type="button"
           onClick={onClose}
-          className="p-1 hover:bg-[#1D1D1D] rounded-md transition-colors group flex-shrink-0"
+          className="p-1 hover:bg-border-subtle rounded-md transition-colors group flex-shrink-0"
           aria-label="Close trace detail"
           title="Close (Esc)"
         >
@@ -97,34 +97,34 @@ export function TraceHeader({ data, traceId, onClose, onSpanClick }: TraceHeader
         >
           <span>{traceId.substring(0, 12)}</span>
           {copied ? (
-            <span className="text-[#22C55E] text-[9px]">copied</span>
+            <span className="text-success text-[9px]">copied</span>
           ) : (
             <Copy className="w-2.5 h-2.5 opacity-0 group-hover:opacity-100 transition-opacity" />
           )}
         </button>
 
-        <div className="w-px h-3 bg-[#1D1D1D]" />
+        <div className="w-px h-3 bg-border-subtle" />
 
-        <div className="flex items-center gap-1 px-2 py-0.5 bg-[#141414] border border-[#1D1D1D] rounded">
-          <Clock className="w-2.5 h-2.5 text-[#F3F724]" />
-          <span className="text-[11px] font-mono font-semibold text-[#F3F724]">
+        <div className="flex items-center gap-1 px-2 py-0.5 bg-elevated border border-border-subtle rounded">
+          <Clock className="w-2.5 h-2.5 text-accent" />
+          <span className="text-[11px] font-mono font-semibold text-accent">
             {formatDuration(data.total_duration_ms)}
           </span>
         </div>
 
-        <div className="flex items-center gap-1 px-2 py-0.5 bg-[#141414] border border-[#1D1D1D] rounded">
+        <div className="flex items-center gap-1 px-2 py-0.5 bg-elevated border border-border-subtle rounded">
           <Layers className="w-2.5 h-2.5 text-gray-400" />
           <span className="text-[10px] font-mono text-gray-400">{data.span_count} spans</span>
         </div>
 
-        <div className="flex items-center gap-1 px-2 py-0.5 bg-[#141414] border border-[#1D1D1D] rounded">
+        <div className="flex items-center gap-1 px-2 py-0.5 bg-elevated border border-border-subtle rounded">
           <span className="text-[10px] font-mono text-gray-400">{serviceCount} svc</span>
         </div>
 
         {hasErrors && (
-          <div className="flex items-center gap-1 px-2 py-0.5 bg-[#EF4444]/8 border border-[#EF4444]/15 rounded">
-            <AlertCircle className="w-2.5 h-2.5 text-[#EF4444]" />
-            <span className="text-[10px] font-mono font-semibold text-[#EF4444]">
+          <div className="flex items-center gap-1 px-2 py-0.5 bg-error/10 border border-error/20 rounded">
+            <AlertCircle className="w-2.5 h-2.5 text-error" />
+            <span className="text-[10px] font-mono font-semibold text-error">
               {errorCount} err
             </span>
           </div>
@@ -134,7 +134,7 @@ export function TraceHeader({ data, traceId, onClose, onSpanClick }: TraceHeader
       {/* Service distribution bar */}
       {serviceList.length > 1 && (
         <div className="px-4 pb-2.5">
-          <div className="flex h-1.5 rounded-full overflow-hidden bg-[#141414] border border-[#1D1D1D]">
+          <div className="flex h-1.5 rounded-full overflow-hidden bg-elevated border border-border-subtle">
             {serviceList.map((svc) => {
               const svcDuration = serviceDurations.get(svc) || 0
               const pct = (svcDuration / data.total_duration_ms) * 100
@@ -176,7 +176,7 @@ export function TraceHeader({ data, traceId, onClose, onSpanClick }: TraceHeader
               <button
                 type="button"
                 onClick={() => onSpanClick?.(span)}
-                className="text-[10px] font-mono text-gray-400 hover:text-white truncate max-w-[120px] flex-shrink-0 px-1 py-0.5 rounded hover:bg-[#1D1D1D] transition-colors"
+                className="text-[10px] font-mono text-gray-400 hover:text-white truncate max-w-[120px] flex-shrink-0 px-1 py-0.5 rounded hover:bg-border-subtle transition-colors"
                 title={span.name}
               >
                 {span.name}

--- a/console/packages/console-frontend/src/components/traces/TraceMap.tsx
+++ b/console/packages/console-frontend/src/components/traces/TraceMap.tsx
@@ -1,3 +1,13 @@
+/**
+ * Service-graph view: nodes rendered to a <canvas> for performance.
+ *
+ * THEMING NOTE — same canvas-hex limitation as FlameGraph; see that
+ * file's header for the recommended refactor pattern (read CSS custom
+ * properties via getComputedStyle and pass into draw calls). Until
+ * applied, TraceMap renders in fixed dark-mode colors regardless of
+ * host theme.
+ */
+
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { getServiceColor } from '@/lib/traceColors'
 import type { VisualizationSpan, WaterfallData } from '@/lib/traceTransform'
@@ -322,10 +332,10 @@ export function TraceMap({ data, onSpanClick }: TraceMapProps) {
   return (
     <div className="flex flex-col h-full">
       {/* Toolbar */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-[#1D1D1D] bg-[#141414]/30 flex-shrink-0">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-border-subtle bg-elevated/30 flex-shrink-0">
         <div className="flex items-center gap-2 text-xs text-gray-400">
           <span>{nodes.length} services</span>
-          <span className="text-[#1D1D1D]">•</span>
+          <span className="text-border-subtle">•</span>
           <span>{edges.length} connections</span>
         </div>
         <div className="text-xs text-gray-400">Click a node to view service details</div>
@@ -344,7 +354,7 @@ export function TraceMap({ data, onSpanClick }: TraceMapProps) {
         {/* Tooltip */}
         {hoveredNode && (
           <div
-            className="fixed z-50 px-3 py-2 bg-[#141414] border border-[#1D1D1D] rounded-lg shadow-xl pointer-events-none"
+            className="fixed z-50 px-3 py-2 bg-elevated border border-border-subtle rounded-lg shadow-xl pointer-events-none"
             style={{
               left: tooltipPos.x + 12,
               top: tooltipPos.y + 12,
@@ -352,19 +362,19 @@ export function TraceMap({ data, onSpanClick }: TraceMapProps) {
           >
             <div className="flex items-center gap-2 mb-2">
               <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: hoveredNode.color }} />
-              <span className="text-sm font-semibold text-[#F4F4F4]">{hoveredNode.name}</span>
+              <span className="text-sm font-semibold text-foreground">{hoveredNode.name}</span>
             </div>
             <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
               <span className="text-gray-400">Spans:</span>
-              <span className="text-[#F4F4F4] font-mono">{hoveredNode.spanCount}</span>
+              <span className="text-foreground font-mono">{hoveredNode.spanCount}</span>
               <span className="text-gray-400">Duration:</span>
-              <span className="text-[#F4F4F4] font-mono">
+              <span className="text-foreground font-mono">
                 {formatDuration(hoveredNode.totalDuration)}
               </span>
               {hoveredNode.errorCount > 0 && (
                 <>
                   <span className="text-gray-400">Errors:</span>
-                  <span className="text-[#EF4444] font-mono">{hoveredNode.errorCount}</span>
+                  <span className="text-error font-mono">{hoveredNode.errorCount}</span>
                 </>
               )}
             </div>
@@ -373,7 +383,7 @@ export function TraceMap({ data, onSpanClick }: TraceMapProps) {
       </div>
 
       {/* Legend */}
-      <div className="px-4 py-2 border-t border-[#1D1D1D] bg-[#141414]/30 flex items-center gap-6 text-xs text-gray-400 flex-shrink-0">
+      <div className="px-4 py-2 border-t border-border-subtle bg-elevated/30 flex items-center gap-6 text-xs text-gray-400 flex-shrink-0">
         <span className="font-medium">Services:</span>
         {nodes.slice(0, 6).map((node) => (
           <span key={node.id} className="flex items-center gap-1.5">

--- a/console/packages/console-frontend/src/components/traces/ViewSwitcher.tsx
+++ b/console/packages/console-frontend/src/components/traces/ViewSwitcher.tsx
@@ -16,7 +16,7 @@ export function ViewSwitcher({ currentView, onViewChange }: ViewSwitcherProps) {
   ]
 
   return (
-    <div className="inline-flex items-center gap-0.5 bg-[#0A0A0A] rounded-md p-0.5 border border-[#1D1D1D]">
+    <div className="inline-flex items-center gap-0.5 bg-sidebar rounded-md p-0.5 border border-border-subtle">
       {views.map(({ id, label, icon: Icon }) => {
         const isActive = currentView === id
         return (
@@ -28,8 +28,8 @@ export function ViewSwitcher({ currentView, onViewChange }: ViewSwitcherProps) {
               flex items-center gap-1.5 px-3 py-1.5 rounded-[5px] transition-all duration-150
               ${
                 isActive
-                  ? 'bg-[#F3F724] text-black font-semibold shadow-[0_0_8px_rgba(243,247,36,0.15)]'
-                  : 'text-gray-500 hover:text-gray-300 hover:bg-[#141414]'
+                  ? 'bg-accent text-black font-semibold shadow-[0_0_8px_rgba(243,247,36,0.15)]'
+                  : 'text-gray-500 hover:text-gray-300 hover:bg-elevated'
               }
             `}
           >

--- a/console/packages/console-frontend/src/components/traces/WaterfallChart.tsx
+++ b/console/packages/console-frontend/src/components/traces/WaterfallChart.tsx
@@ -1,5 +1,11 @@
 import { ChevronRight } from 'lucide-react'
 import { useEffect, useMemo, useReducer, useRef, useState } from 'react'
+import {
+  formatSpanLabel,
+  getSpanKindIndicator,
+  isEngineRoutingPair,
+  isEngineRoutingSpan,
+} from '@/lib/spanLabel'
 import type { VisualizationSpan, WaterfallData } from '@/lib/traceTransform'
 import { formatDuration } from '@/lib/traceUtils'
 
@@ -75,17 +81,55 @@ function buildSpanTree(spans: VisualizationSpan[]): SpanNode[] {
   return roots
 }
 
-function flattenTree(nodes: SpanNode[], expandedIds: Set<string>): SpanNode[] {
-  const result: SpanNode[] = []
+interface FlatSpanRow extends SpanNode {
+  displayDepth: number
+  mergedRouting: boolean
+}
 
-  function traverse(node: SpanNode) {
-    result.push(node)
-    if (expandedIds.has(node.span_id)) {
-      node.children.forEach(traverse)
+interface FlattenOptions {
+  expandedIds: Set<string>
+  hideEngineRouting: boolean
+  collapseEngineRoutingPairs: boolean
+}
+
+function flattenTree(nodes: SpanNode[], opts: FlattenOptions): FlatSpanRow[] {
+  const result: FlatSpanRow[] = []
+
+  function traverse(node: SpanNode, depthOffset: number) {
+    const hidden = opts.hideEngineRouting && isEngineRoutingSpan(node)
+
+    let mergedRouting = false
+    let descendants = node.children
+    if (
+      !hidden &&
+      opts.collapseEngineRoutingPairs &&
+      node.children.length === 1 &&
+      isEngineRoutingPair(node, node.children[0])
+    ) {
+      mergedRouting = true
+      descendants = node.children[0].children
+    }
+
+    if (!hidden) {
+      result.push({
+        ...node,
+        displayDepth: Math.max(0, node.depth - depthOffset),
+        mergedRouting,
+      })
+    }
+
+    const nextOffset = hidden ? depthOffset + 1 : depthOffset
+    const childrenVisible = hidden || opts.expandedIds.has(node.span_id)
+    if (childrenVisible) {
+      for (const child of descendants) {
+        traverse(child, nextOffset)
+      }
     }
   }
 
-  nodes.forEach(traverse)
+  for (const node of nodes) {
+    traverse(node, 0)
+  }
   return result
 }
 
@@ -128,10 +172,29 @@ function displayReducer(state: DisplayState, action: DisplayAction): DisplayStat
   }
 }
 
+const HIDE_ENGINE_KEY = 'iii-trace-hide-engine-routing'
+const COLLAPSE_PAIRS_KEY = 'iii-trace-collapse-engine-pairs'
+
 export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallChartProps) {
   const [displayState, dispatch] = useReducer(displayReducer, initialDisplayState)
   const { expandedIds, showCriticalPath, hoveredSpanId, scrollPosition } = displayState
   const containerRef = useRef<HTMLDivElement>(null)
+
+  const [hideEngineRouting, setHideEngineRouting] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false
+    return window.localStorage.getItem(HIDE_ENGINE_KEY) === '1'
+  })
+  const [collapseEngineRoutingPairs, setCollapseEngineRoutingPairs] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false
+    return window.localStorage.getItem(COLLAPSE_PAIRS_KEY) === '1'
+  })
+
+  useEffect(() => {
+    window.localStorage.setItem(HIDE_ENGINE_KEY, hideEngineRouting ? '1' : '0')
+  }, [hideEngineRouting])
+  useEffect(() => {
+    window.localStorage.setItem(COLLAPSE_PAIRS_KEY, collapseEngineRoutingPairs ? '1' : '0')
+  }, [collapseEngineRoutingPairs])
 
   // Span column resize
   const [spanColWidth, setSpanColWidth] = useState(() => {
@@ -201,7 +264,15 @@ export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallC
     dispatch({ type: 'SET_ALL_EXPANDED', ids: allIds })
   }, [data.spans])
 
-  const visibleSpans = useMemo(() => flattenTree(spanTree, expandedIds), [spanTree, expandedIds])
+  const visibleSpans = useMemo(
+    () =>
+      flattenTree(spanTree, {
+        expandedIds,
+        hideEngineRouting,
+        collapseEngineRoutingPairs,
+      }),
+    [spanTree, expandedIds, hideEngineRouting, collapseEngineRoutingPairs],
+  )
 
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
     dispatch({ type: 'SET_SCROLL', position: e.currentTarget.scrollTop })
@@ -255,6 +326,30 @@ export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallC
             />
             Show critical path
           </label>
+          <label
+            className="flex items-center gap-2 text-xs text-gray-400 cursor-pointer"
+            title="Merge each engine handle_invocation+call pair into one row"
+          >
+            <input
+              type="checkbox"
+              checked={collapseEngineRoutingPairs}
+              onChange={(e) => setCollapseEngineRoutingPairs(e.target.checked)}
+              className="rounded border-[#1D1D1D] bg-[#141414] text-[#F3F724] focus:ring-[#F3F724]/30"
+            />
+            Collapse routing pairs
+          </label>
+          <label
+            className="flex items-center gap-2 text-xs text-gray-400 cursor-pointer"
+            title="Hide engine handle_invocation / call spans entirely"
+          >
+            <input
+              type="checkbox"
+              checked={hideEngineRouting}
+              onChange={(e) => setHideEngineRouting(e.target.checked)}
+              className="rounded border-[#1D1D1D] bg-[#141414] text-[#F3F724] focus:ring-[#F3F724]/30"
+            />
+            Hide engine routing
+          </label>
         </div>
         <div className="text-xs text-gray-400">
           {visibleSpans.length} of {data.span_count} spans
@@ -295,11 +390,17 @@ export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallC
       <div className="flex flex-1 overflow-hidden">
         <div ref={containerRef} className="flex-1 overflow-y-auto" onScroll={handleScroll}>
           {visibleSpans.map((span) => {
-            const hasChildren = span.children.length > 0
+            const effectiveChildren = span.mergedRouting
+              ? (span.children[0]?.children ?? [])
+              : span.children
+            const hasChildren = effectiveChildren.length > 0
             const isExpanded = expandedIds.has(span.span_id)
             const isCritical = showCriticalPath && span.isCriticalPath
             const isSelected = selectedSpanId === span.span_id
             const isHovered = hoveredSpanId === span.span_id
+            const isEngineDim = !isSelected && isEngineRoutingSpan(span)
+            const kindIndicator = getSpanKindIndicator(span.kind)
+            const displayLabel = formatSpanLabel(span)
 
             const getBarStyle = (): React.CSSProperties => {
               if (isCritical) return { background: 'linear-gradient(to right, #F97316, #FB923C)' }
@@ -332,9 +433,11 @@ export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallC
                 onMouseEnter={() => dispatch({ type: 'SET_HOVERED_SPAN', spanId: span.span_id })}
                 onMouseLeave={() => dispatch({ type: 'SET_HOVERED_SPAN', spanId: null })}
               >
-                <div className="flex items-center gap-1.5 min-w-0">
-                  <div className="flex-shrink-0 flex" style={{ width: span.depth * 16 }}>
-                    {Array.from({ length: span.depth }).map((_, i) => (
+                <div
+                  className={`flex items-center gap-1.5 min-w-0 ${isEngineDim ? 'opacity-60' : ''}`}
+                >
+                  <div className="flex-shrink-0 flex" style={{ width: span.displayDepth * 16 }}>
+                    {Array.from({ length: span.displayDepth }).map((_, i) => (
                       <div
                         key={`${span.span_id}-indent-${i}`}
                         className="w-4 h-6 border-l border-[#1D1D1D]/50"
@@ -369,9 +472,12 @@ export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallC
                       {span.service_name}
                     </span>
                   )}
-                  {span.kind && span.kind !== 'unspecified' && (
-                    <span className="flex-shrink-0 px-1.5 py-0.5 text-[10px] font-medium rounded border border-[#1D1D1D] bg-[#141414] text-gray-400 leading-none capitalize">
-                      {span.kind.toLowerCase()}
+                  {kindIndicator && (
+                    <span
+                      className="flex-shrink-0 text-[11px] text-gray-500 leading-none w-3 text-center"
+                      title={kindIndicator.label}
+                    >
+                      {kindIndicator.icon}
                     </span>
                   )}
 
@@ -379,8 +485,16 @@ export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallC
                     className={`text-[13px] font-medium truncate ${isSelected ? 'text-[#F3F724]' : 'text-[#F4F4F4]'}`}
                     title={span.name}
                   >
-                    {span.name}
+                    {displayLabel}
                   </span>
+                  {span.mergedRouting && (
+                    <span
+                      className="flex-shrink-0 px-1 py-0.5 text-[9px] font-medium rounded border border-[#1D1D1D] bg-[#141414] text-gray-500 leading-none"
+                      title="Merged: this row hides the engine 'call' child of a handle_invocation pair"
+                    >
+                      +1
+                    </span>
+                  )}
 
                   <span className="font-mono text-[11px] text-gray-400 flex-shrink-0 ml-auto">
                     {formatDuration(span.duration_ms)}

--- a/console/packages/console-frontend/src/components/traces/WaterfallChart.tsx
+++ b/console/packages/console-frontend/src/components/traces/WaterfallChart.tsx
@@ -1,3 +1,43 @@
+/**
+ * Waterfall view for a single trace's spans.
+ *
+ * Data flow:
+ *
+ *   props.data (WaterfallData)
+ *        │
+ *        ▼
+ *   buildSpanTree(spans)            ← parent/child linking, marks critical path
+ *        │
+ *        ▼
+ *   useReducer<DisplayState>        ← expand/collapse + critical-path toggle
+ *        │
+ *        ▼
+ *   flattenTree(tree, opts)         ← respects expandedIds, hideEngineRouting,
+ *        │                            collapseEngineRoutingPairs; emits depth-offset
+ *        │                            adjusted rows so hidden parents don't leave gaps
+ *        ▼
+ *   visibleSpans: FlatSpanRow[]
+ *        │
+ *        ▼
+ *   Per-row render: indent guides, kind indicator, status pill, name,
+ *                   duration, bar (status-colored or critical-path orange),
+ *                   merged-routing `+1` chip when applicable
+ *
+ * Persistent state (localStorage):
+ *   iii-trace-hide-engine-routing       boolean checkbox
+ *   iii-trace-collapse-engine-pairs     boolean checkbox
+ *   iii-span-col-width                  resizer position
+ *
+ * Theming: all colors flow from CSS custom properties defined in
+ * `styles/globals.css` (var(--success), var(--error), var(--muted),
+ * var(--accent), var(--border-subtle), ...). Only the critical-path
+ * orange (#F97316) is a literal — iii-specific signal, not a theme color.
+ *
+ * Engine-routing heuristics (hide/collapse) live in `lib/spanLabel.ts`.
+ * A porter targeting a different trace producer should override that
+ * module or pass a `routingConfig` prop (not yet implemented).
+ */
+
 import { ChevronRight } from 'lucide-react'
 import { useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import {
@@ -300,64 +340,64 @@ export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallC
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between px-3 py-2 border-b border-[#1D1D1D] bg-[#141414]/30">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border-subtle bg-elevated/30">
         <div className="flex items-center gap-2">
           <button
             type="button"
             onClick={expandAll}
-            className="px-2 py-1 text-xs text-gray-400 hover:text-[#F4F4F4] hover:bg-[#1D1D1D] rounded transition-colors"
+            className="px-2 py-1 text-xs text-secondary hover:text-foreground hover:bg-border-subtle rounded transition-colors"
           >
             Expand all
           </button>
           <button
             type="button"
             onClick={collapseAll}
-            className="px-2 py-1 text-xs text-gray-400 hover:text-[#F4F4F4] hover:bg-[#1D1D1D] rounded transition-colors"
+            className="px-2 py-1 text-xs text-secondary hover:text-foreground hover:bg-border-subtle rounded transition-colors"
           >
             Collapse all
           </button>
-          <div className="w-px h-4 bg-[#1D1D1D] mx-1" />
-          <label className="flex items-center gap-2 text-xs text-gray-400 cursor-pointer">
+          <div className="w-px h-4 bg-border-subtle mx-1" />
+          <label className="flex items-center gap-2 text-xs text-secondary cursor-pointer">
             <input
               type="checkbox"
               checked={showCriticalPath}
               onChange={(e) => dispatch({ type: 'SET_CRITICAL_PATH', value: e.target.checked })}
-              className="rounded border-[#1D1D1D] bg-[#141414] text-[#F3F724] focus:ring-[#F3F724]/30"
+              className="rounded border-border-subtle bg-elevated text-accent focus:ring-accent/30"
             />
             Show critical path
           </label>
           <label
-            className="flex items-center gap-2 text-xs text-gray-400 cursor-pointer"
+            className="flex items-center gap-2 text-xs text-secondary cursor-pointer"
             title="Merge each engine handle_invocation+call pair into one row"
           >
             <input
               type="checkbox"
               checked={collapseEngineRoutingPairs}
               onChange={(e) => setCollapseEngineRoutingPairs(e.target.checked)}
-              className="rounded border-[#1D1D1D] bg-[#141414] text-[#F3F724] focus:ring-[#F3F724]/30"
+              className="rounded border-border-subtle bg-elevated text-accent focus:ring-accent/30"
             />
             Collapse routing pairs
           </label>
           <label
-            className="flex items-center gap-2 text-xs text-gray-400 cursor-pointer"
+            className="flex items-center gap-2 text-xs text-secondary cursor-pointer"
             title="Hide engine handle_invocation / call spans entirely"
           >
             <input
               type="checkbox"
               checked={hideEngineRouting}
               onChange={(e) => setHideEngineRouting(e.target.checked)}
-              className="rounded border-[#1D1D1D] bg-[#141414] text-[#F3F724] focus:ring-[#F3F724]/30"
+              className="rounded border-border-subtle bg-elevated text-accent focus:ring-accent/30"
             />
             Hide engine routing
           </label>
         </div>
-        <div className="text-xs text-gray-400">
+        <div className="text-xs text-secondary">
           {visibleSpans.length} of {data.span_count} spans
         </div>
       </div>
 
       <div
-        className="grid gap-4 px-3 py-2 text-[11px] font-semibold text-gray-400 uppercase tracking-wide border-b border-[#1D1D1D] bg-[#141414]/50"
+        className="grid gap-4 px-3 py-2 text-[11px] font-semibold text-secondary uppercase tracking-wide border-b border-border-subtle bg-elevated/50"
         style={{ gridTemplateColumns: `${spanColWidth}px 1fr` }}
       >
         <div className="flex items-center relative">
@@ -375,7 +415,7 @@ export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallC
             className="absolute right-[-11px] top-0 bottom-0 w-[7px] cursor-col-resize z-10 group"
             title="Drag to resize, double-click to reset"
           >
-            <div className="absolute left-[3px] top-0 bottom-0 w-[1px] bg-[#1D1D1D] group-hover:bg-accent/50 transition-colors" />
+            <div className="absolute left-[3px] top-0 bottom-0 w-[1px] bg-border-subtle group-hover:bg-accent/50 transition-colors" />
           </div>
         </div>
         <div className="flex justify-between">
@@ -402,19 +442,23 @@ export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallC
             const kindIndicator = getSpanKindIndicator(span.kind)
             const displayLabel = formatSpanLabel(span)
 
+            // Bar colors flow from the design tokens (`--success`, `--error`,
+            // `--muted`) so the waterfall re-themes correctly under
+            // [data-theme="light"] or in any host that overrides the
+            // CSS custom properties. The critical-path orange is
+            // intentionally a literal — it's iii-specific signal, not a
+            // theme color, and stays constant across light/dark.
             const getBarStyle = (): React.CSSProperties => {
-              if (isCritical) return { background: 'linear-gradient(to right, #F97316, #FB923C)' }
-              if (span.status === 'error')
-                return { background: 'linear-gradient(to right, #EF4444, #DC2626)' }
-              if (span.status === 'ok')
-                return { background: 'linear-gradient(to right, #22C55E, #16A34A)' }
-              return { background: 'linear-gradient(to right, #6B7280, #4B5563)' }
+              if (isCritical) return { background: '#F97316' }
+              if (span.status === 'error') return { background: 'var(--error)' }
+              if (span.status === 'ok') return { background: 'var(--success)' }
+              return { background: 'var(--muted)' }
             }
 
-            const statusColors = {
-              ok: '#22C55E',
-              error: '#EF4444',
-              unset: '#6B7280',
+            const statusColors: Record<typeof span.status, string> = {
+              ok: 'var(--success)',
+              error: 'var(--error)',
+              unset: 'var(--muted)',
             }
 
             const barStyle = getBarStyle()
@@ -425,7 +469,7 @@ export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallC
                 type="button"
                 className={`
                   grid gap-4 px-3 py-1 items-center transition-colors cursor-pointer w-full text-left
-                  ${isSelected ? 'bg-[#F3F724]/[0.06] border-l-2 border-l-[#F3F724]' : isHovered ? 'bg-[#1D1D1D]' : 'hover:bg-[#1D1D1D]/50'}
+                  ${isSelected ? 'bg-accent/[0.06] border-l-2 border-l-accent' : isHovered ? 'bg-border-subtle' : 'hover:bg-border-subtle/50'}
                   ${isCritical && !isSelected ? 'bg-orange-500/5' : ''}
                 `}
                 style={{ gridTemplateColumns: `${spanColWidth}px 1fr` }}
@@ -440,7 +484,7 @@ export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallC
                     {Array.from({ length: span.displayDepth }).map((_, i) => (
                       <div
                         key={`${span.span_id}-indent-${i}`}
-                        className="w-4 h-6 border-l border-[#1D1D1D]/50"
+                        className="w-4 h-6 border-l border-border-subtle/50"
                       />
                     ))}
                   </div>
@@ -452,7 +496,7 @@ export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallC
                         e.stopPropagation()
                         toggleExpand(span.span_id)
                       }}
-                      className="w-4 h-4 flex items-center justify-center text-gray-400 hover:text-[#F4F4F4] flex-shrink-0"
+                      className="w-4 h-4 flex items-center justify-center text-secondary hover:text-foreground flex-shrink-0"
                     >
                       <ChevronRight
                         className={`w-3 h-3 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
@@ -468,13 +512,13 @@ export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallC
                   />
 
                   {span.service_name && (
-                    <span className="flex-shrink-0 px-1.5 py-0.5 text-[10px] font-medium rounded border border-[#1D1D1D] bg-[#1D1D1D]/50 text-gray-300 leading-none">
+                    <span className="flex-shrink-0 px-1.5 py-0.5 text-[10px] font-medium rounded border border-border-subtle bg-border-subtle/50 text-foreground/80 leading-none">
                       {span.service_name}
                     </span>
                   )}
                   {kindIndicator && (
                     <span
-                      className="flex-shrink-0 text-[11px] text-gray-500 leading-none w-3 text-center"
+                      className="flex-shrink-0 text-[11px] text-muted leading-none w-3 text-center"
                       title={kindIndicator.label}
                     >
                       {kindIndicator.icon}
@@ -482,35 +526,49 @@ export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallC
                   )}
 
                   <span
-                    className={`text-[13px] font-medium truncate ${isSelected ? 'text-[#F3F724]' : 'text-[#F4F4F4]'}`}
+                    className={`text-[13px] font-medium truncate ${isSelected ? 'text-accent' : 'text-foreground'}`}
                     title={span.name}
                   >
                     {displayLabel}
                   </span>
                   {span.mergedRouting && (
                     <span
-                      className="flex-shrink-0 px-1 py-0.5 text-[9px] font-medium rounded border border-[#1D1D1D] bg-[#141414] text-gray-500 leading-none"
+                      className="flex-shrink-0 px-1 py-0.5 text-[9px] font-medium rounded border border-border-subtle bg-elevated text-muted leading-none"
                       title="Merged: this row hides the engine 'call' child of a handle_invocation pair"
                     >
                       +1
                     </span>
                   )}
 
-                  <span className="font-mono text-[11px] text-gray-400 flex-shrink-0 ml-auto">
+                  <span className="font-mono text-[11px] text-secondary flex-shrink-0 ml-auto">
                     {formatDuration(span.duration_ms)}
                   </span>
                 </div>
 
-                <div className="relative h-6 rounded bg-[linear-gradient(90deg,transparent_0%,transparent_25%,#1D1D1D_25%,#1D1D1D_25.1%,transparent_25.1%,transparent_50%,#1D1D1D_50%,#1D1D1D_50.1%,transparent_50.1%,transparent_75%,#1D1D1D_75%,#1D1D1D_75.1%,transparent_75.1%)]">
+                <div
+                  className="relative h-6 rounded"
+                  style={{
+                    background:
+                      'linear-gradient(90deg, transparent 0%, transparent 25%, var(--border-subtle) 25%, var(--border-subtle) 25.1%, transparent 25.1%, transparent 50%, var(--border-subtle) 50%, var(--border-subtle) 50.1%, transparent 50.1%, transparent 75%, var(--border-subtle) 75%, var(--border-subtle) 75.1%, transparent 75.1%)',
+                  }}>
                   <div
                     className={`
                       absolute h-4 top-1 rounded-[3px] min-w-[3px] transition-all duration-150
-                      ${isSelected ? 'scale-y-[1.3] shadow-[0_0_6px_rgba(243,247,36,0.4)]' : isHovered ? 'scale-y-[1.2] shadow-[0_0_0_2px_rgba(243,247,36,0.3)]' : ''}
+                      ${isSelected ? 'scale-y-[1.3]' : isHovered ? 'scale-y-[1.2]' : ''}
                     `}
                     style={{
                       ...barStyle,
                       left: `${span.start_percent}%`,
                       width: `${Math.max(0.5, span.width_percent)}%`,
+                      // Accent-tinted shadows via color-mix so they re-theme
+                      // under [data-theme="light"]. Modern browsers only;
+                      // the console targets the same set as the rest of
+                      // the app.
+                      boxShadow: isSelected
+                        ? '0 0 6px color-mix(in srgb, var(--accent) 40%, transparent)'
+                        : isHovered
+                          ? '0 0 0 2px color-mix(in srgb, var(--accent) 30%, transparent)'
+                          : undefined,
                     }}
                   />
                 </div>
@@ -520,15 +578,15 @@ export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallC
         </div>
 
         {contentHeight > (containerRef.current?.clientHeight || 0) && (
-          <div className="w-16 border-l border-[#1D1D1D] bg-[#141414]/50 flex-shrink-0 relative p-2">
-            <div className="text-[9px] text-gray-400 uppercase tracking-wider mb-2">Map</div>
+          <div className="w-16 border-l border-border-subtle bg-elevated/50 flex-shrink-0 relative p-2">
+            <div className="text-[9px] text-secondary uppercase tracking-wider mb-2">Map</div>
             <div
-              className="relative bg-[#1D1D1D] rounded overflow-hidden"
+              className="relative bg-border-subtle rounded overflow-hidden"
               style={{ height: miniMapHeight }}
             >
               {data.spans.map((span, i) => {
                 const isError = span.status === 'error'
-                const barColor = isError ? '#EF4444' : '#6B7280'
+                const barColor = isError ? 'var(--error)' : 'var(--muted)'
 
                 return (
                   <div
@@ -545,7 +603,7 @@ export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallC
                 )
               })}
               <div
-                className="absolute left-0 right-0 bg-[#F3F724]/20 border border-[#F3F724]/40 rounded-sm"
+                className="absolute left-0 right-0 bg-accent/20 border border-accent/40 rounded-sm"
                 style={{
                   top: thumbPosition,
                   height: thumbHeight,

--- a/console/packages/console-frontend/src/components/traces/WaterfallChart.tsx
+++ b/console/packages/console-frontend/src/components/traces/WaterfallChart.tsx
@@ -40,12 +40,8 @@
 
 import { ChevronRight } from 'lucide-react'
 import { useEffect, useMemo, useReducer, useRef, useState } from 'react'
-import {
-  formatSpanLabel,
-  getSpanKindIndicator,
-  isEngineRoutingPair,
-  isEngineRoutingSpan,
-} from '@/lib/spanLabel'
+import { formatSpanLabel, getSpanKindIndicator, isEngineRoutingSpan } from '@/lib/spanLabel'
+import { buildSpanTree, flattenTree } from '@/lib/spanTree'
 import type { VisualizationSpan, WaterfallData } from '@/lib/traceTransform'
 import { formatDuration } from '@/lib/traceUtils'
 
@@ -53,124 +49,6 @@ interface WaterfallChartProps {
   data: WaterfallData
   onSpanClick: (span: VisualizationSpan) => void
   selectedSpanId?: string | null
-}
-
-interface SpanNode extends VisualizationSpan {
-  children: SpanNode[]
-  isExpanded: boolean
-  isCriticalPath: boolean
-}
-
-function buildSpanTree(spans: VisualizationSpan[]): SpanNode[] {
-  const spanMap = new Map<string, SpanNode>()
-  const roots: SpanNode[] = []
-
-  spans.forEach((span) => {
-    spanMap.set(span.span_id, {
-      ...span,
-      children: [],
-      isExpanded: true,
-      isCriticalPath: false,
-    })
-  })
-
-  spans.forEach((span) => {
-    const node = spanMap.get(span.span_id)
-    if (!node) return
-    if (span.parent_span_id && spanMap.has(span.parent_span_id)) {
-      spanMap.get(span.parent_span_id)?.children.push(node)
-    } else {
-      roots.push(node)
-    }
-  })
-
-  function markCriticalPath(node: SpanNode): number {
-    if (node.children.length === 0) {
-      node.isCriticalPath = true
-      return node.duration_ms
-    }
-
-    let maxDuration = 0
-    let criticalChild: SpanNode | null = null
-
-    node.children.forEach((child) => {
-      const duration = markCriticalPath(child)
-      if (duration > maxDuration) {
-        maxDuration = duration
-        criticalChild = child
-      }
-    })
-
-    node.isCriticalPath = true
-    node.children.forEach((child) => {
-      if (child !== criticalChild) {
-        unmarkCriticalPath(child)
-      }
-    })
-
-    return node.duration_ms + maxDuration
-  }
-
-  function unmarkCriticalPath(node: SpanNode) {
-    node.isCriticalPath = false
-    node.children.forEach(unmarkCriticalPath)
-  }
-
-  roots.forEach(markCriticalPath)
-
-  return roots
-}
-
-interface FlatSpanRow extends SpanNode {
-  displayDepth: number
-  mergedRouting: boolean
-}
-
-interface FlattenOptions {
-  expandedIds: Set<string>
-  hideEngineRouting: boolean
-  collapseEngineRoutingPairs: boolean
-}
-
-function flattenTree(nodes: SpanNode[], opts: FlattenOptions): FlatSpanRow[] {
-  const result: FlatSpanRow[] = []
-
-  function traverse(node: SpanNode, depthOffset: number) {
-    const hidden = opts.hideEngineRouting && isEngineRoutingSpan(node)
-
-    let mergedRouting = false
-    let descendants = node.children
-    if (
-      !hidden &&
-      opts.collapseEngineRoutingPairs &&
-      node.children.length === 1 &&
-      isEngineRoutingPair(node, node.children[0])
-    ) {
-      mergedRouting = true
-      descendants = node.children[0].children
-    }
-
-    if (!hidden) {
-      result.push({
-        ...node,
-        displayDepth: Math.max(0, node.depth - depthOffset),
-        mergedRouting,
-      })
-    }
-
-    const nextOffset = hidden ? depthOffset + 1 : depthOffset
-    const childrenVisible = hidden || opts.expandedIds.has(node.span_id)
-    if (childrenVisible) {
-      for (const child of descendants) {
-        traverse(child, nextOffset)
-      }
-    }
-  }
-
-  for (const node of nodes) {
-    traverse(node, 0)
-  }
-  return result
 }
 
 interface DisplayState {

--- a/console/packages/console-frontend/src/components/traces/WaterfallChart.tsx
+++ b/console/packages/console-frontend/src/components/traces/WaterfallChart.tsx
@@ -550,7 +550,8 @@ export function WaterfallChart({ data, onSpanClick, selectedSpanId }: WaterfallC
                   style={{
                     background:
                       'linear-gradient(90deg, transparent 0%, transparent 25%, var(--border-subtle) 25%, var(--border-subtle) 25.1%, transparent 25.1%, transparent 50%, var(--border-subtle) 50%, var(--border-subtle) 50.1%, transparent 50.1%, transparent 75%, var(--border-subtle) 75%, var(--border-subtle) 75.1%, transparent 75.1%)',
-                  }}>
+                  }}
+                >
                   <div
                     className={`
                       absolute h-4 top-1 rounded-[3px] min-w-[3px] transition-all duration-150

--- a/console/packages/console-frontend/src/components/traces/WorkflowChain.tsx
+++ b/console/packages/console-frontend/src/components/traces/WorkflowChain.tsx
@@ -76,7 +76,7 @@ export function WorkflowChain({ data, onSpanClick }: WorkflowChainProps) {
   if (chain.length < 2) return null
 
   return (
-    <div className="px-4 py-3 border-t border-[#1D1D1D]">
+    <div className="px-4 py-3 border-t border-border-subtle">
       <div className="text-[10px] text-gray-500 uppercase tracking-wider mb-2 flex items-center gap-1.5">
         <Zap className="w-3 h-3" />
         Workflow Chain

--- a/console/packages/console-frontend/src/hooks/useTraceData.ts
+++ b/console/packages/console-frontend/src/hooks/useTraceData.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useEffect, useRef, useState } from 'react'
 import { fetchTraces } from '@/api'
+import { useEngineSdk } from '@/api/engine-sdk-provider'
 import type { TracesFilterParams } from '@/api/observability/traces'
 import { toMs } from '@/lib/traceTransform'
 
@@ -43,6 +44,7 @@ export function useTraceData({
   debouncedSearch,
   isPaused,
 }: UseTraceDataOptions): UseTraceDataReturn {
+  const sdk = useEngineSdk()
   const [traceGroups, setTraceGroups] = useState<TraceGroup[]>([])
   const [hasOtelConfigured, setHasOtelConfigured] = useState(false)
   const [newTraceIds, setNewTraceIds] = useState<Set<string>>(new Set())
@@ -60,7 +62,7 @@ export function useTraceData({
   } = useQuery({
     queryKey: ['traces', filterParams, showSystem, debouncedSearch],
     queryFn: () =>
-      fetchTraces({
+      fetchTraces(sdk, {
         ...filterParams,
         ...(debouncedSearch && !filterParams.name
           ? { name: debouncedSearch, search_all_spans: true }

--- a/console/packages/console-frontend/src/hooks/useTraceData.ts
+++ b/console/packages/console-frontend/src/hooks/useTraceData.ts
@@ -7,7 +7,7 @@ import { toMs } from '@/lib/traceTransform'
 
 const DEFAULT_TRACE_LIMIT = 500
 
-export interface TraceGroup {
+export interface TraceListItem {
   traceId: string
   rootOperation: string
   functionId?: string
@@ -28,7 +28,7 @@ export interface UseTraceDataOptions {
 }
 
 export interface UseTraceDataReturn {
-  traceGroups: TraceGroup[]
+  traceGroups: TraceListItem[]
   newTraceIds: Set<string>
   setNewTraceIds: React.Dispatch<React.SetStateAction<Set<string>>>
   hasOtelConfigured: boolean
@@ -45,7 +45,7 @@ export function useTraceData({
   isPaused,
 }: UseTraceDataOptions): UseTraceDataReturn {
   const sdk = useEngineSdk()
-  const [traceGroups, setTraceGroups] = useState<TraceGroup[]>([])
+  const [traceGroups, setTraceListItems] = useState<TraceListItem[]>([])
   const [hasOtelConfigured, setHasOtelConfigured] = useState(false)
   const [newTraceIds, setNewTraceIds] = useState<Set<string>>(new Set())
 
@@ -53,7 +53,7 @@ export function useTraceData({
   const prevTraceIdsRef = useRef<Set<string>>(new Set())
 
   const isHoveredRef = useRef(false)
-  const pendingTracesRef = useRef<TraceGroup[] | null>(null)
+  const pendingTracesRef = useRef<TraceListItem[] | null>(null)
 
   const {
     data: tracesData,
@@ -79,7 +79,7 @@ export function useTraceData({
     if (!tracesData) return
 
     if (tracesData.spans && tracesData.spans.length > 0) {
-      const traces: TraceGroup[] = tracesData.spans.map((span) => {
+      const traces: TraceListItem[] = tracesData.spans.map((span) => {
         const startTime = toMs(span.start_time_unix_nano)
         const endTime = toMs(span.end_time_unix_nano)
         const duration = endTime - startTime
@@ -113,7 +113,11 @@ export function useTraceData({
 
       traces.sort((a, b) => b.startTime - a.startTime)
 
-      const fingerprint = `${traces.length}:${traces[0]?.traceId}:${traces[traces.length - 1]?.traceId}:${traces[traces.length - 1]?.startTime}`
+      // Identity fingerprint: count + every trace_id in order. Earlier
+      // versions sampled only first/last/count, which would have missed
+      // middle-only churn if the sort order ever flipped to ascending.
+      // 500-trace ceiling × 32-char IDs ≈ 16KB per compare — cheap.
+      const fingerprint = `${traces.length}:${traces.map((t) => t.traceId).join(',')}`
       if (fingerprint === fingerprintRef.current) return
       fingerprintRef.current = fingerprint
 
@@ -132,17 +136,17 @@ export function useTraceData({
         return
       }
 
-      setTraceGroups(traces)
+      setTraceListItems(traces)
       setHasOtelConfigured(true)
     } else {
-      setTraceGroups([])
+      setTraceListItems([])
       setHasOtelConfigured(false)
     }
   }, [tracesData])
 
   const flushPendingTraces = () => {
     if (pendingTracesRef.current) {
-      setTraceGroups(pendingTracesRef.current)
+      setTraceListItems(pendingTracesRef.current)
       setHasOtelConfigured(true)
       pendingTracesRef.current = null
     }

--- a/console/packages/console-frontend/src/hooks/useTraceData.ts
+++ b/console/packages/console-frontend/src/hooks/useTraceData.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import { fetchTraces } from '@/api'
 import { useEngineSdk } from '@/api/engine-sdk-provider'
 import type { TracesFilterParams } from '@/api/observability/traces'
-import { toMs } from '@/lib/traceTransform'
+import { fingerprintTraceList, mapSpanToListItem } from '@/lib/traceListItem'
 
 const DEFAULT_TRACE_LIMIT = 500
 
@@ -79,45 +79,11 @@ export function useTraceData({
     if (!tracesData) return
 
     if (tracesData.spans && tracesData.spans.length > 0) {
-      const traces: TraceListItem[] = tracesData.spans.map((span) => {
-        const startTime = toMs(span.start_time_unix_nano)
-        const endTime = toMs(span.end_time_unix_nano)
-        const duration = endTime - startTime
-
-        const attrs: Record<string, unknown> = {}
-        if (Array.isArray(span.attributes)) {
-          for (const item of span.attributes) {
-            if (Array.isArray(item) && item.length >= 2) {
-              attrs[String(item[0])] = item[1]
-            }
-          }
-        } else if (span.attributes) {
-          Object.assign(attrs, span.attributes)
-        }
-        const functionId = (attrs['faas.invoked_name'] || attrs.function_id) as string | undefined
-        const topic = attrs['messaging.destination.name'] as string | undefined
-
-        return {
-          traceId: span.trace_id,
-          rootOperation: span.name,
-          functionId,
-          topic,
-          status: span.status.toLowerCase() === 'error' ? 'error' : 'ok',
-          startTime,
-          endTime,
-          duration,
-          spanCount: 1,
-          services: [span.service_name || 'unknown'],
-        }
-      })
+      const traces: TraceListItem[] = tracesData.spans.map(mapSpanToListItem)
 
       traces.sort((a, b) => b.startTime - a.startTime)
 
-      // Identity fingerprint: count + every trace_id in order. Earlier
-      // versions sampled only first/last/count, which would have missed
-      // middle-only churn if the sort order ever flipped to ascending.
-      // 500-trace ceiling × 32-char IDs ≈ 16KB per compare — cheap.
-      const fingerprint = `${traces.length}:${traces.map((t) => t.traceId).join(',')}`
+      const fingerprint = fingerprintTraceList(traces)
       if (fingerprint === fingerprintRef.current) return
       fingerprintRef.current = fingerprint
 

--- a/console/packages/console-frontend/src/hooks/useTraceData.ts
+++ b/console/packages/console-frontend/src/hooks/useTraceData.ts
@@ -34,7 +34,7 @@ export interface UseTraceDataReturn {
   hasOtelConfigured: boolean
   isQueryLoading: boolean
   refetch: () => void
-  isHoveredRef: React.MutableRefObject<boolean>
+  isHoveredRef: React.RefObject<boolean>
   flushPendingTraces: () => void
 }
 

--- a/console/packages/console-frontend/src/hooks/useTraceFilters.ts
+++ b/console/packages/console-frontend/src/hooks/useTraceFilters.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { TracesFilterParams } from '@/api'
+import type { GroupByOption } from '@/lib/groupTraces'
 
 export interface TraceFilterState {
   serviceName?: string
@@ -14,6 +15,12 @@ export interface TraceFilterState {
   attributes?: [string, string][]
   sortBy?: 'start_time' | 'duration' | 'service_name'
   sortOrder?: 'asc' | 'desc'
+  /**
+   * Group spans by an attribute value. When set to anything other than
+   * 'none', `useTraceData` switches to `fetchTracesGroupBy` and the list
+   * view renders collapsible group rows. Default 'none'.
+   */
+  groupBy?: GroupByOption
   page: number
   pageSize: number
 }
@@ -29,6 +36,7 @@ const defaultFilters: TraceFilterState = {
   attributes: undefined,
   sortBy: 'start_time',
   sortOrder: 'desc',
+  groupBy: 'none',
   page: 1,
   pageSize: 50,
 }

--- a/console/packages/console-frontend/src/hooks/useTraceFilters.ts
+++ b/console/packages/console-frontend/src/hooks/useTraceFilters.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { TracesFilterParams } from '@/api'
 import type { GroupByOption } from '@/lib/groupTraces'

--- a/console/packages/console-frontend/src/hooks/useTraceFilters.ts
+++ b/console/packages/console-frontend/src/hooks/useTraceFilters.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { TracesFilterParams } from '@/api'
 import type { GroupByOption } from '@/lib/groupTraces'
+import { buildFilterParams, countActiveFilters } from '@/lib/traceFilters'
 
 export interface TraceFilterState {
   serviceName?: string
@@ -125,65 +126,13 @@ export function useTraceFilters() {
     if (operationNameTimerRef.current) clearTimeout(operationNameTimerRef.current)
   }, [])
 
-  const getActiveFilterCount = useCallback(() => {
-    let count = 0
-    if (filters.serviceName) count++
-    if (filters.operationName) count++
-    if (filters.status != null) count++
-    if (filters.minDurationMs !== null) count++
-    if (filters.maxDurationMs !== null) count++
-    if (filters.startTime !== null) count++
-    if (filters.endTime !== null) count++
-    if (filters.attributes && filters.attributes.length > 0) count++
-    if (filters.sortBy !== 'start_time') count++
-    if (filters.sortOrder !== 'desc') count++
-    return count
-  }, [filters])
+  const getActiveFilterCount = useCallback(() => countActiveFilters(filters), [filters])
 
-  // Filter-only params (excludes pagination) -- stable reference when only page changes
+  // Filter-only params (excludes pagination) -- stable reference when only page changes.
+  // Delegation to `buildFilterParams` keeps the swap-validation logic
+  // pure and testable (see lib/traceFilters.test.ts).
   const { filterOnlyParams, computedWarnings } = useMemo(() => {
-    const params: TracesFilterParams = {}
-    const warnings: { durationSwapped?: boolean; timeRangeSwapped?: boolean } = {}
-
-    if (filters.serviceName) params.service_name = filters.serviceName
-    if (filters.operationName) {
-      params.name = filters.operationName
-      params.search_all_spans = true
-    }
-    if (filters.status != null) params.status = filters.status
-
-    if (filters.minDurationMs != null && filters.maxDurationMs != null) {
-      if (filters.minDurationMs > filters.maxDurationMs) {
-        params.min_duration_ms = filters.maxDurationMs
-        params.max_duration_ms = filters.minDurationMs
-        warnings.durationSwapped = true
-      } else {
-        params.min_duration_ms = filters.minDurationMs
-        params.max_duration_ms = filters.maxDurationMs
-      }
-    } else {
-      if (filters.minDurationMs != null) params.min_duration_ms = filters.minDurationMs
-      if (filters.maxDurationMs != null) params.max_duration_ms = filters.maxDurationMs
-    }
-
-    if (filters.startTime != null && filters.endTime != null) {
-      if (filters.startTime > filters.endTime) {
-        params.start_time = filters.endTime
-        params.end_time = filters.startTime
-        warnings.timeRangeSwapped = true
-      } else {
-        params.start_time = filters.startTime
-        params.end_time = filters.endTime
-      }
-    } else {
-      if (filters.startTime != null) params.start_time = filters.startTime
-      if (filters.endTime != null) params.end_time = filters.endTime
-    }
-
-    if (filters.attributes && filters.attributes.length > 0) params.attributes = filters.attributes
-    if (filters.sortBy) params.sort_by = filters.sortBy
-    if (filters.sortOrder) params.sort_order = filters.sortOrder
-
+    const { params, warnings } = buildFilterParams(filters)
     return { filterOnlyParams: params, computedWarnings: warnings }
   }, [
     filters.serviceName,

--- a/console/packages/console-frontend/src/hooks/useTraceFilters.ts
+++ b/console/packages/console-frontend/src/hooks/useTraceFilters.ts
@@ -128,24 +128,17 @@ export function useTraceFilters() {
 
   const getActiveFilterCount = useCallback(() => countActiveFilters(filters), [filters])
 
-  // Filter-only params (excludes pagination) -- stable reference when only page changes.
-  // Delegation to `buildFilterParams` keeps the swap-validation logic
-  // pure and testable (see lib/traceFilters.test.ts).
+  // Filter-only params (excludes pagination). Recomputes on any
+  // `filters` identity change — including page/pageSize — but the
+  // result identity downstream isn't load-bearing: TanStack Query
+  // compares queryKeys structurally, so identical content (e.g. when
+  // only page changed) doesn't trigger a refetch. Delegation to
+  // `buildFilterParams` keeps the swap-validation logic pure and
+  // testable (see lib/traceFilters.test.ts).
   const { filterOnlyParams, computedWarnings } = useMemo(() => {
     const { params, warnings } = buildFilterParams(filters)
     return { filterOnlyParams: params, computedWarnings: warnings }
-  }, [
-    filters.serviceName,
-    filters.operationName,
-    filters.status,
-    filters.minDurationMs,
-    filters.maxDurationMs,
-    filters.startTime,
-    filters.endTime,
-    filters.attributes,
-    filters.sortBy,
-    filters.sortOrder,
-  ])
+  }, [filters])
 
   // Full params including pagination offset/limit
   const apiParams = useMemo(

--- a/console/packages/console-frontend/src/hooks/useTraceGroups.ts
+++ b/console/packages/console-frontend/src/hooks/useTraceGroups.ts
@@ -1,0 +1,71 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchTracesGroupBy } from '@/api'
+import { useEngineSdk } from '@/api/engine-sdk-provider'
+import type { TraceGroup, TracesGroupByResponse } from '@/api/observability/traces'
+import type { GroupByOption } from '@/lib/groupTraces'
+import { isGroupByUnavailable } from '@/lib/groupTraces'
+
+const DEFAULT_GROUP_LIMIT = 100
+
+export interface UseTraceGroupsOptions {
+  /** When 'none', the hook is disabled (no network calls). */
+  groupBy: GroupByOption
+  /** Include engine-internal spans. */
+  includeInternal: boolean
+  /** When true, suspend auto-refresh (matches the flat-list hook). */
+  isPaused: boolean
+}
+
+export interface UseTraceGroupsReturn {
+  groups: TraceGroup[]
+  isLoading: boolean
+  /**
+   * Set when the engine doesn't expose `engine::traces::group_by` (older
+   * deploy or `iii-observability` not running). UI should hide the group
+   * view and fall back to the flat list when this is true.
+   */
+  unavailable: boolean
+  refetch: () => void
+}
+
+/**
+ * React Query wrapper around `fetchTracesGroupBy`. Returns the
+ * server-aggregated group list and surfaces a soft-failure flag when
+ * the endpoint isn't available so callers can degrade gracefully
+ * rather than showing an error pill.
+ */
+export function useTraceGroups({
+  groupBy,
+  includeInternal,
+  isPaused,
+}: UseTraceGroupsOptions): UseTraceGroupsReturn {
+  const sdk = useEngineSdk()
+  const enabled = groupBy !== 'none'
+
+  const { data, isLoading, error, refetch } = useQuery<TracesGroupByResponse, Error>({
+    queryKey: ['traceGroups', groupBy, includeInternal],
+    enabled,
+    queryFn: () =>
+      fetchTracesGroupBy(sdk, {
+        attribute: groupBy,
+        limit: DEFAULT_GROUP_LIMIT,
+        include_internal: includeInternal,
+      }),
+    refetchInterval: isPaused ? false : 3000,
+    staleTime: 1000,
+    retry: (failureCount, err) => {
+      // Don't retry when the endpoint is missing — the UI hides the
+      // affordance in that case and waits for the user to switch back
+      // to flat-list mode.
+      if (isGroupByUnavailable(err)) return false
+      return failureCount < 2
+    },
+  })
+
+  return {
+    groups: data?.groups ?? [],
+    isLoading,
+    unavailable: !!error && isGroupByUnavailable(error),
+    refetch,
+  }
+}

--- a/console/packages/console-frontend/src/lib/formatPossibleJson.test.ts
+++ b/console/packages/console-frontend/src/lib/formatPossibleJson.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { formatPossibleJson } from './formatPossibleJson'
+
+describe('formatPossibleJson', () => {
+  describe('returns formatted JSON', () => {
+    it('pretty-prints a JSON object with 2-space indent', () => {
+      const result = formatPossibleJson('{"foo":"bar","n":1}')
+      expect(result).toBe('{\n  "foo": "bar",\n  "n": 1\n}')
+    })
+
+    it('pretty-prints a JSON array', () => {
+      const result = formatPossibleJson('[1,2,3]')
+      expect(result).toBe('[\n  1,\n  2,\n  3\n]')
+    })
+
+    it('handles nested objects with consistent indent', () => {
+      const result = formatPossibleJson('{"a":{"b":{"c":1}}}')
+      expect(result).toBe('{\n  "a": {\n    "b": {\n      "c": 1\n    }\n  }\n}')
+    })
+
+    it('handles a string with leading and trailing whitespace', () => {
+      const result = formatPossibleJson('  {"x":1}  ')
+      expect(result).toBe('{\n  "x": 1\n}')
+    })
+
+    it('handles a typical iii.payload.json payload shape', () => {
+      const result = formatPossibleJson(
+        '{"message_id":"m-1","data":{"k":"v"},"timestamp":1700000000000}',
+      )
+      expect(result).toContain('"message_id"')
+      expect(result).toContain('"data": {')
+      expect(result).toContain('"timestamp": 1700000000000')
+    })
+  })
+
+  describe('returns null', () => {
+    it('returns null for non-string input', () => {
+      expect(formatPossibleJson(42)).toBeNull()
+      expect(formatPossibleJson(true)).toBeNull()
+      expect(formatPossibleJson(null)).toBeNull()
+      expect(formatPossibleJson(undefined)).toBeNull()
+      expect(formatPossibleJson({ already: 'object' })).toBeNull()
+      expect(formatPossibleJson([1, 2, 3])).toBeNull()
+    })
+
+    it('returns null for an empty string', () => {
+      expect(formatPossibleJson('')).toBeNull()
+      expect(formatPossibleJson('   ')).toBeNull()
+    })
+
+    it('returns null for a string that does NOT start with { or [', () => {
+      expect(formatPossibleJson('hello')).toBeNull()
+      expect(formatPossibleJson('42')).toBeNull()
+      expect(formatPossibleJson('true')).toBeNull()
+      expect(formatPossibleJson('"a quoted string"')).toBeNull()
+    })
+
+    it('returns null for malformed JSON (looks like JSON but parse fails)', () => {
+      expect(formatPossibleJson('{not valid}')).toBeNull()
+      expect(formatPossibleJson('{"unterminated":')).toBeNull()
+      expect(formatPossibleJson('[1, 2,')).toBeNull()
+    })
+
+    it('returns null for trailing-comma JSON (strict parse)', () => {
+      // JSON.parse is strict; trailing commas fail. This is desired —
+      // we don't want to silently fix the data, we just want to know if
+      // it parses cleanly.
+      expect(formatPossibleJson('{"a":1,}')).toBeNull()
+    })
+  })
+})

--- a/console/packages/console-frontend/src/lib/formatPossibleJson.ts
+++ b/console/packages/console-frontend/src/lib/formatPossibleJson.ts
@@ -1,0 +1,34 @@
+/**
+ * Pretty-print a value as JSON if and only if it looks like a JSON
+ * object/array string.
+ *
+ * Returns the indented JSON string when the input is a string whose
+ * trimmed form starts with `{` or `[` AND parses successfully. Returns
+ * null otherwise (non-strings, empty strings, primitives wrapped as
+ * strings like `"42"` or `"true"`, malformed JSON).
+ *
+ * Used by `SpanLogsTab` to pretty-print `iii.payload.json` event
+ * attributes inside a <pre> block. Strings that are bare numbers,
+ * booleans, or plain text fall through to the single-line renderer.
+ *
+ * Indent is fixed at 2 spaces.
+ *
+ * Performance: only attempts `JSON.parse` for strings with the right
+ * leading character — bare quoted strings (`"hi"`) are valid JSON but
+ * pretty-printing a single string would just add surrounding quotes,
+ * which is noise. The leading-char filter avoids that and also short-
+ * circuits cheaply.
+ */
+export function formatPossibleJson(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return null
+  const first = trimmed[0]
+  if (first !== '{' && first !== '[') return null
+  try {
+    const parsed = JSON.parse(trimmed)
+    return JSON.stringify(parsed, null, 2)
+  } catch {
+    return null
+  }
+}

--- a/console/packages/console-frontend/src/lib/groupTraces.test.ts
+++ b/console/packages/console-frontend/src/lib/groupTraces.test.ts
@@ -1,0 +1,116 @@
+// Regression tests for the `isGroupByUnavailable` heuristic.
+//
+// The regex was tightened from `/function[_ ]not[_ ]found|group_by|404/`
+// (which would swallow legitimate errors like "failed to group_by: timeout")
+// to `/function[_ ]not[_ ]found/i`. These tests pin the new behavior and
+// guard against future loosening that re-introduces silent error swallowing.
+
+import { describe, expect, it } from 'vitest'
+import type { TraceGroup } from '../api/observability/traces'
+import {
+  groupByLabel,
+  groupHeading,
+  isGroupByUnavailable,
+  summarizeGroup,
+} from './groupTraces'
+
+function makeGroup(overrides: Partial<TraceGroup> = {}): TraceGroup {
+  return {
+    value: 'sess-1',
+    trace_ids: ['t-1', 't-2'],
+    span_count: 12,
+    first_seen_ms: 1_700_000_000_000,
+    last_seen_ms: 1_700_000_001_000,
+    duration_ms: 1_420,
+    error_count: 0,
+    ...overrides,
+  }
+}
+
+describe('groupByLabel', () => {
+  it('returns human-readable labels for each option', () => {
+    expect(groupByLabel('none')).toBe('No grouping')
+    expect(groupByLabel('iii.message.id')).toBe('Group by message')
+    expect(groupByLabel('iii.session.id')).toBe('Group by session')
+    expect(groupByLabel('iii.function.id')).toBe('Group by function')
+  })
+})
+
+describe('summarizeGroup', () => {
+  it('renders pluralization for the error count', () => {
+    expect(summarizeGroup(makeGroup({ error_count: 0 }))).toContain('0 errors')
+    expect(summarizeGroup(makeGroup({ error_count: 1 }))).toContain('1 error')
+    expect(summarizeGroup(makeGroup({ error_count: 5 }))).toContain('5 errors')
+  })
+
+  it('formats sub-second durations as ms, multi-second as s, long as m+s', () => {
+    expect(summarizeGroup(makeGroup({ duration_ms: 0.4 }))).toContain('<1ms')
+    expect(summarizeGroup(makeGroup({ duration_ms: 42 }))).toContain('42ms')
+    expect(summarizeGroup(makeGroup({ duration_ms: 1_420 }))).toContain('1.42s')
+    expect(summarizeGroup(makeGroup({ duration_ms: 62_000 }))).toContain('1m2s')
+  })
+
+  it('includes span_count in the summary', () => {
+    expect(summarizeGroup(makeGroup({ span_count: 12 }))).toContain('12 spans')
+  })
+})
+
+describe('groupHeading', () => {
+  it('returns the raw value for normal attributes', () => {
+    expect(groupHeading(makeGroup({ value: 'fn-foo' }), 'iii.function.id')).toBe('fn-foo')
+  })
+
+  it('rewrites the wildcard session sentinel to a friendlier label', () => {
+    // ui::subscribe/unsubscribe calls use `*` for the session id; the
+    // raw value would render as an asterisk which is meaningless to the
+    // user.
+    expect(groupHeading(makeGroup({ value: '*' }), 'iii.session.id')).toBe(
+      'all sessions (wildcard)',
+    )
+  })
+
+  it('does NOT rewrite the wildcard for non-session attributes', () => {
+    // A `*` message id should render as `*`, not the session label.
+    expect(groupHeading(makeGroup({ value: '*' }), 'iii.message.id')).toBe('*')
+  })
+})
+
+describe('isGroupByUnavailable', () => {
+  it('matches the engine error_code with underscore (function_not_found)', () => {
+    expect(isGroupByUnavailable(new Error('function_not_found: engine::traces::group_by'))).toBe(
+      true,
+    )
+  })
+
+  it('matches with a space (function not found)', () => {
+    expect(isGroupByUnavailable(new Error('function not found'))).toBe(true)
+  })
+
+  it('matches case-insensitively (FUNCTION_NOT_FOUND, Function_Not_Found)', () => {
+    expect(isGroupByUnavailable(new Error('FUNCTION_NOT_FOUND'))).toBe(true)
+    expect(isGroupByUnavailable(new Error('Function_Not_Found in registry'))).toBe(true)
+  })
+
+  it('accepts a plain string error', () => {
+    expect(isGroupByUnavailable('function_not_found')).toBe(true)
+  })
+
+  it('does NOT match a timeout that happens to mention group_by', () => {
+    // This is the regression: the old regex matched `/group_by/` and would
+    // have classified this as "unavailable", silently swallowing a real
+    // timeout error.
+    expect(isGroupByUnavailable(new Error('failed to group_by: request timeout'))).toBe(false)
+  })
+
+  it('does NOT match an HTTP 404 unrelated to function dispatch', () => {
+    // Old regex matched `/404/` anywhere. A network 404 from a CDN or
+    // proxy in front of the engine would silently degrade the UI.
+    expect(isGroupByUnavailable(new Error('Network error: 404 Not Found'))).toBe(false)
+  })
+
+  it('does NOT match a generic error', () => {
+    expect(isGroupByUnavailable(new Error('something went wrong'))).toBe(false)
+    expect(isGroupByUnavailable(null)).toBe(false)
+    expect(isGroupByUnavailable(undefined)).toBe(false)
+  })
+})

--- a/console/packages/console-frontend/src/lib/groupTraces.test.ts
+++ b/console/packages/console-frontend/src/lib/groupTraces.test.ts
@@ -7,12 +7,7 @@
 
 import { describe, expect, it } from 'vitest'
 import type { TraceGroup } from '../api/observability/traces'
-import {
-  groupByLabel,
-  groupHeading,
-  isGroupByUnavailable,
-  summarizeGroup,
-} from './groupTraces'
+import { groupByLabel, groupHeading, isGroupByUnavailable, summarizeGroup } from './groupTraces'
 
 function makeGroup(overrides: Partial<TraceGroup> = {}): TraceGroup {
   return {

--- a/console/packages/console-frontend/src/lib/groupTraces.ts
+++ b/console/packages/console-frontend/src/lib/groupTraces.ts
@@ -1,0 +1,89 @@
+// Pure helpers for the TRACES tab "Group by" affordance.
+//
+// The server-side aggregation (`engine::traces::group_by`) returns
+// `TraceGroup[]`; this module formats and classifies that data for the
+// UI without re-implementing any grouping logic. Extracted from the
+// route component so it's testable in isolation when the console grows
+// test infrastructure.
+
+import type { TraceGroup } from '../api/observability/traces'
+
+/**
+ * Span attributes the TRACES tab can group by. Aligned with the
+ * iii-sdk allowlist (`iii.session.id`, `iii.message.id`,
+ * `iii.function.id`). Keep in lock-step.
+ */
+export type GroupByAttribute = 'iii.message.id' | 'iii.session.id' | 'iii.function.id'
+
+export type GroupByOption = 'none' | GroupByAttribute
+
+/**
+ * Human-readable label for the dropdown.
+ */
+export function groupByLabel(option: GroupByOption): string {
+  switch (option) {
+    case 'none':
+      return 'No grouping'
+    case 'iii.message.id':
+      return 'Group by message'
+    case 'iii.session.id':
+      return 'Group by session'
+    case 'iii.function.id':
+      return 'Group by function'
+  }
+}
+
+/**
+ * Format the group's metadata into the inline summary string the row
+ * shows, e.g. "(12 spans, 1.42s, 1 error)".
+ *
+ * Handles the wildcard session sentinel `*` from `ui::subscribe` /
+ * `ui::unsubscribe` calls by emitting "all sessions (wildcard)" rather
+ * than the literal asterisk.
+ */
+export function summarizeGroup(group: TraceGroup): string {
+  const errors =
+    group.error_count === 0
+      ? '0 errors'
+      : group.error_count === 1
+        ? '1 error'
+        : `${group.error_count} errors`
+  return `${group.span_count} spans, ${formatDurationMs(group.duration_ms)}, ${errors}`
+}
+
+/**
+ * Display string for the group's heading. Hides the wildcard sentinel
+ * behind a friendlier label.
+ */
+export function groupHeading(group: TraceGroup, option: GroupByAttribute): string {
+  if (group.value === '*' && option === 'iii.session.id') {
+    return 'all sessions (wildcard)'
+  }
+  return group.value
+}
+
+function formatDurationMs(ms: number): string {
+  if (ms < 1) return '<1ms'
+  if (ms < 1_000) return `${Math.round(ms)}ms`
+  if (ms < 60_000) return `${(ms / 1_000).toFixed(2)}s`
+  const seconds = Math.round(ms / 1_000)
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return `${m}m${s}s`
+}
+
+/**
+ * Heuristic: tells the caller whether `engine::traces::group_by` is
+ * unavailable in this engine deploy (older version, or
+ * `iii-observability` not configured). Used so the dropdown can hide
+ * itself gracefully rather than surfacing an error.
+ *
+ * The engine returns `function_not_found` as the error_code; the fetch
+ * path surfaces it as a thrown Error whose message contains the string.
+ * String-match is intentionally generous — different runtimes wrap the
+ * error differently.
+ */
+export function isGroupByUnavailable(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err)
+  return /function[_ ]not[_ ]found|group_by|404/.test(message.toLowerCase())
+}

--- a/console/packages/console-frontend/src/lib/groupTraces.ts
+++ b/console/packages/console-frontend/src/lib/groupTraces.ts
@@ -78,12 +78,12 @@ function formatDurationMs(ms: number): string {
  * `iii-observability` not configured). Used so the dropdown can hide
  * itself gracefully rather than surfacing an error.
  *
- * The engine returns `function_not_found` as the error_code; the fetch
- * path surfaces it as a thrown Error whose message contains the string.
- * String-match is intentionally generous — different runtimes wrap the
- * error differently.
+ * Matches the engine's `function_not_found` error_code. Earlier versions
+ * of this helper also matched bare `group_by` and `404` substrings,
+ * which was too broad — a legitimate "failed to group_by: timeout"
+ * would have been silently swallowed.
  */
 export function isGroupByUnavailable(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err)
-  return /function[_ ]not[_ ]found|group_by|404/.test(message.toLowerCase())
+  return /function[_ ]not[_ ]found/i.test(message)
 }

--- a/console/packages/console-frontend/src/lib/spanLabel.test.ts
+++ b/console/packages/console-frontend/src/lib/spanLabel.test.ts
@@ -1,0 +1,171 @@
+// Coverage for the engine-routing heuristics that drive the
+// "Hide engine routing" and "Collapse routing pairs" toggles in
+// WaterfallChart. These functions encode iii-specific knowledge
+// (service name `iii`, verb prefixes `handle_invocation ` / `call `);
+// a port targeting a different trace producer should reuse the test
+// shape but feed in its own routing config.
+
+import { describe, expect, it } from 'vitest'
+import {
+  formatSpanLabel,
+  getSpanKindIndicator,
+  isEngineRoutingPair,
+  isEngineRoutingSpan,
+} from './spanLabel'
+
+describe('getSpanKindIndicator', () => {
+  it('maps each OTel span kind to a compact icon + label', () => {
+    expect(getSpanKindIndicator('server')).toEqual({
+      icon: '▶',
+      label: 'server (handles incoming)',
+    })
+    expect(getSpanKindIndicator('client')).toEqual({
+      icon: '↗',
+      label: 'client (outgoing call)',
+    })
+    expect(getSpanKindIndicator('producer')).toEqual({
+      icon: '↥',
+      label: 'producer (sends to queue)',
+    })
+    expect(getSpanKindIndicator('consumer')).toEqual({
+      icon: '↧',
+      label: 'consumer (reads from queue)',
+    })
+    expect(getSpanKindIndicator('internal')).toEqual({ icon: '•', label: 'internal' })
+  })
+
+  it('is case-insensitive on the kind string', () => {
+    expect(getSpanKindIndicator('SERVER')?.icon).toBe('▶')
+    expect(getSpanKindIndicator('Client')?.icon).toBe('↗')
+  })
+
+  it('returns null for an unrecognized kind', () => {
+    expect(getSpanKindIndicator('weird')).toBeNull()
+  })
+
+  it('returns null for missing kind', () => {
+    expect(getSpanKindIndicator(undefined)).toBeNull()
+  })
+})
+
+describe('formatSpanLabel', () => {
+  it('strips the `handle_invocation ` engine verb prefix', () => {
+    expect(formatSpanLabel({ name: 'handle_invocation fn-foo', service_name: 'iii' })).toBe(
+      'fn-foo',
+    )
+  })
+
+  it('strips the `call ` engine verb prefix', () => {
+    expect(formatSpanLabel({ name: 'call fn-foo', service_name: 'iii' })).toBe('fn-foo')
+  })
+
+  it('strips the service-name dot prefix when it appears AFTER the verb strip', () => {
+    // Real-world case: span name is `call billing.charge`, service is
+    // `billing`. We strip the `call ` first, then strip `billing.` to
+    // produce just `charge`. The verb strip must happen first because
+    // the service prefix doesn't appear at the start of the original
+    // name.
+    expect(formatSpanLabel({ name: 'call billing.charge', service_name: 'billing' })).toBe(
+      'charge',
+    )
+  })
+
+  it('does NOT strip a service-name prefix that is just a substring (only leading)', () => {
+    expect(formatSpanLabel({ name: 'fooBar', service_name: 'foo' })).toBe('fooBar')
+  })
+
+  it('returns the name unchanged when no prefix matches', () => {
+    expect(formatSpanLabel({ name: 'simple-name', service_name: 'svc' })).toBe('simple-name')
+  })
+
+  it('handles missing service_name', () => {
+    expect(formatSpanLabel({ name: 'call fn-foo', service_name: undefined })).toBe('fn-foo')
+  })
+
+  it('only strips the first matching verb prefix, not chained ones', () => {
+    // Defensive: a name like `call handle_invocation foo` is pathological
+    // but should still produce a sensible result (strip outermost only).
+    expect(
+      formatSpanLabel({ name: 'call handle_invocation foo', service_name: 'iii' }),
+    ).toBe('handle_invocation foo')
+  })
+})
+
+describe('isEngineRoutingSpan', () => {
+  it('matches `handle_invocation X` on service `iii`', () => {
+    expect(isEngineRoutingSpan({ name: 'handle_invocation fn-foo', service_name: 'iii' })).toBe(
+      true,
+    )
+  })
+
+  it('matches `call X` on service `iii`', () => {
+    expect(isEngineRoutingSpan({ name: 'call fn-foo', service_name: 'iii' })).toBe(true)
+  })
+
+  it('does NOT match the same name on a different service', () => {
+    expect(isEngineRoutingSpan({ name: 'handle_invocation fn-foo', service_name: 'other' })).toBe(
+      false,
+    )
+  })
+
+  it('does NOT match a non-routing name on service `iii`', () => {
+    expect(isEngineRoutingSpan({ name: 'process_event', service_name: 'iii' })).toBe(false)
+  })
+
+  it('does NOT match when service_name is missing', () => {
+    expect(isEngineRoutingSpan({ name: 'call fn-foo', service_name: undefined })).toBe(false)
+  })
+})
+
+describe('isEngineRoutingPair', () => {
+  it('matches when parent.handle_invocation and child.call name the same function', () => {
+    expect(
+      isEngineRoutingPair(
+        { name: 'handle_invocation fn-foo', service_name: 'iii' },
+        { name: 'call fn-foo', service_name: 'iii' },
+      ),
+    ).toBe(true)
+  })
+
+  it('does NOT match when the function names differ', () => {
+    expect(
+      isEngineRoutingPair(
+        { name: 'handle_invocation fn-foo', service_name: 'iii' },
+        { name: 'call fn-bar', service_name: 'iii' },
+      ),
+    ).toBe(false)
+  })
+
+  it('does NOT match when the parent is not a handle_invocation', () => {
+    expect(
+      isEngineRoutingPair(
+        { name: 'process_event', service_name: 'iii' },
+        { name: 'call fn-foo', service_name: 'iii' },
+      ),
+    ).toBe(false)
+  })
+
+  it('does NOT match when the child is not a call', () => {
+    expect(
+      isEngineRoutingPair(
+        { name: 'handle_invocation fn-foo', service_name: 'iii' },
+        { name: 'process fn-foo', service_name: 'iii' },
+      ),
+    ).toBe(false)
+  })
+
+  it('does NOT match if either side is on a non-engine service', () => {
+    expect(
+      isEngineRoutingPair(
+        { name: 'handle_invocation fn-foo', service_name: 'other' },
+        { name: 'call fn-foo', service_name: 'iii' },
+      ),
+    ).toBe(false)
+    expect(
+      isEngineRoutingPair(
+        { name: 'handle_invocation fn-foo', service_name: 'iii' },
+        { name: 'call fn-foo', service_name: 'other' },
+      ),
+    ).toBe(false)
+  })
+})

--- a/console/packages/console-frontend/src/lib/spanLabel.test.ts
+++ b/console/packages/console-frontend/src/lib/spanLabel.test.ts
@@ -65,9 +65,7 @@ describe('formatSpanLabel', () => {
     // produce just `charge`. The verb strip must happen first because
     // the service prefix doesn't appear at the start of the original
     // name.
-    expect(formatSpanLabel({ name: 'call billing.charge', service_name: 'billing' })).toBe(
-      'charge',
-    )
+    expect(formatSpanLabel({ name: 'call billing.charge', service_name: 'billing' })).toBe('charge')
   })
 
   it('does NOT strip a service-name prefix that is just a substring (only leading)', () => {
@@ -85,9 +83,9 @@ describe('formatSpanLabel', () => {
   it('only strips the first matching verb prefix, not chained ones', () => {
     // Defensive: a name like `call handle_invocation foo` is pathological
     // but should still produce a sensible result (strip outermost only).
-    expect(
-      formatSpanLabel({ name: 'call handle_invocation foo', service_name: 'iii' }),
-    ).toBe('handle_invocation foo')
+    expect(formatSpanLabel({ name: 'call handle_invocation foo', service_name: 'iii' })).toBe(
+      'handle_invocation foo',
+    )
   })
 })
 

--- a/console/packages/console-frontend/src/lib/spanLabel.ts
+++ b/console/packages/console-frontend/src/lib/spanLabel.ts
@@ -1,0 +1,63 @@
+import type { VisualizationSpan } from './traceTransform'
+
+const ENGINE_SERVICE_NAME = 'iii'
+const ENGINE_VERB_PREFIXES = ['handle_invocation ', 'call '] as const
+
+export interface SpanKindIndicator {
+  icon: string
+  label: string
+}
+
+export function getSpanKindIndicator(kind: string | undefined): SpanKindIndicator | null {
+  if (!kind) return null
+  const k = kind.toLowerCase()
+  switch (k) {
+    case 'server':
+      return { icon: '▶', label: 'server (handles incoming)' }
+    case 'client':
+      return { icon: '↗', label: 'client (outgoing call)' }
+    case 'producer':
+      return { icon: '↥', label: 'producer (sends to queue)' }
+    case 'consumer':
+      return { icon: '↧', label: 'consumer (reads from queue)' }
+    case 'internal':
+      return { icon: '•', label: 'internal' }
+    default:
+      return null
+  }
+}
+
+export function formatSpanLabel(span: Pick<VisualizationSpan, 'name' | 'service_name'>): string {
+  let label = span.name
+  for (const prefix of ENGINE_VERB_PREFIXES) {
+    if (label.startsWith(prefix)) {
+      label = label.slice(prefix.length)
+      break
+    }
+  }
+  if (span.service_name) {
+    const servicePrefix = `${span.service_name}.`
+    if (label.startsWith(servicePrefix)) {
+      label = label.slice(servicePrefix.length)
+    }
+  }
+  return label
+}
+
+export function isEngineRoutingSpan(
+  span: Pick<VisualizationSpan, 'name' | 'service_name'>,
+): boolean {
+  if (span.service_name !== ENGINE_SERVICE_NAME) return false
+  return ENGINE_VERB_PREFIXES.some((p) => span.name.startsWith(p))
+}
+
+export function isEngineRoutingPair(
+  parent: Pick<VisualizationSpan, 'name' | 'service_name'>,
+  child: Pick<VisualizationSpan, 'name' | 'service_name'>,
+): boolean {
+  if (parent.service_name !== ENGINE_SERVICE_NAME) return false
+  if (child.service_name !== ENGINE_SERVICE_NAME) return false
+  if (!parent.name.startsWith('handle_invocation ')) return false
+  if (!child.name.startsWith('call ')) return false
+  return parent.name.slice('handle_invocation '.length) === child.name.slice('call '.length)
+}

--- a/console/packages/console-frontend/src/lib/spanTree.test.ts
+++ b/console/packages/console-frontend/src/lib/spanTree.test.ts
@@ -1,0 +1,370 @@
+// Coverage for the waterfall's tree construction + flattening. These
+// are the trickiest pure functions in the feature: parent linking,
+// critical-path greedy DFS, depth-offset propagation when hiding
+// engine routing parents, and the handle_invocation+call pair merge.
+
+import { describe, expect, it } from 'vitest'
+import { buildSpanTree, flattenTree, type SpanNode } from './spanTree'
+import type { VisualizationSpan } from './traceTransform'
+
+function makeSpan(overrides: Partial<VisualizationSpan> = {}): VisualizationSpan {
+  return {
+    span_id: 's-1',
+    trace_id: 't-1',
+    name: 'span',
+    duration_ms: 10,
+    depth: 0,
+    start_percent: 0,
+    width_percent: 100,
+    status: 'ok',
+    attributes: {},
+    events: [],
+    links: [],
+    service_name: 'svc',
+    start_time_unix_nano: 0,
+    end_time_unix_nano: 0,
+    ...overrides,
+  } as VisualizationSpan
+}
+
+function expandAll(nodes: SpanNode[]): Set<string> {
+  const ids = new Set<string>()
+  function walk(n: SpanNode) {
+    ids.add(n.span_id)
+    n.children.forEach(walk)
+  }
+  nodes.forEach(walk)
+  return ids
+}
+
+describe('buildSpanTree — linking', () => {
+  it('returns an empty array when given no spans', () => {
+    expect(buildSpanTree([])).toEqual([])
+  })
+
+  it('treats every span with no parent as a root', () => {
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'a' }),
+      makeSpan({ span_id: 'b' }),
+      makeSpan({ span_id: 'c' }),
+    ])
+    expect(tree).toHaveLength(3)
+    expect(tree.every((n) => n.children.length === 0)).toBe(true)
+  })
+
+  it('links children to their parent via parent_span_id', () => {
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'a' }),
+      makeSpan({ span_id: 'b', parent_span_id: 'a' }),
+      makeSpan({ span_id: 'c', parent_span_id: 'a' }),
+    ])
+    expect(tree).toHaveLength(1)
+    expect(tree[0].span_id).toBe('a')
+    expect(tree[0].children.map((c) => c.span_id)).toEqual(['b', 'c'])
+  })
+
+  it('treats spans whose parent_span_id is missing from input as roots', () => {
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'a', parent_span_id: 'gone' }),
+      makeSpan({ span_id: 'b', parent_span_id: 'a' }),
+    ])
+    expect(tree.map((r) => r.span_id)).toEqual(['a'])
+    expect(tree[0].children.map((c) => c.span_id)).toEqual(['b'])
+  })
+
+  it('preserves children order based on input order', () => {
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'root' }),
+      makeSpan({ span_id: 'b', parent_span_id: 'root' }),
+      makeSpan({ span_id: 'a', parent_span_id: 'root' }),
+      makeSpan({ span_id: 'c', parent_span_id: 'root' }),
+    ])
+    expect(tree[0].children.map((c) => c.span_id)).toEqual(['b', 'a', 'c'])
+  })
+})
+
+describe('buildSpanTree — critical path', () => {
+  it('marks the lone path as critical when the tree is linear', () => {
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'a', duration_ms: 100 }),
+      makeSpan({ span_id: 'b', parent_span_id: 'a', duration_ms: 50 }),
+      makeSpan({ span_id: 'c', parent_span_id: 'b', duration_ms: 30 }),
+    ])
+    expect(tree[0].isCriticalPath).toBe(true)
+    expect(tree[0].children[0].isCriticalPath).toBe(true)
+    expect(tree[0].children[0].children[0].isCriticalPath).toBe(true)
+  })
+
+  it('picks the slower of two sibling subtrees as critical', () => {
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'root', duration_ms: 100 }),
+      makeSpan({ span_id: 'fast', parent_span_id: 'root', duration_ms: 5 }),
+      makeSpan({ span_id: 'slow', parent_span_id: 'root', duration_ms: 50 }),
+    ])
+    const [fast, slow] = tree[0].children
+    expect(slow.isCriticalPath).toBe(true)
+    expect(fast.isCriticalPath).toBe(false)
+  })
+
+  it('chooses based on cumulative path duration, not just immediate child duration', () => {
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'root', duration_ms: 100 }),
+      // Branch A: short immediate but long descendant chain.
+      makeSpan({ span_id: 'a', parent_span_id: 'root', duration_ms: 10 }),
+      makeSpan({ span_id: 'a-deep', parent_span_id: 'a', duration_ms: 200 }),
+      // Branch B: longer immediate but shorter total.
+      makeSpan({ span_id: 'b', parent_span_id: 'root', duration_ms: 50 }),
+    ])
+    const [a, b] = tree[0].children
+    // A's cumulative path is 10 + 200 = 210; B's is 50. A wins.
+    expect(a.isCriticalPath).toBe(true)
+    expect(a.children[0].isCriticalPath).toBe(true)
+    expect(b.isCriticalPath).toBe(false)
+  })
+
+  it('unmarks non-critical siblings recursively (their descendants too)', () => {
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'root', duration_ms: 100 }),
+      makeSpan({ span_id: 'slow', parent_span_id: 'root', duration_ms: 100 }),
+      makeSpan({ span_id: 'fast', parent_span_id: 'root', duration_ms: 5 }),
+      makeSpan({ span_id: 'fast-child', parent_span_id: 'fast', duration_ms: 1 }),
+    ])
+    const fast = tree[0].children.find((c) => c.span_id === 'fast') as SpanNode
+    expect(fast.isCriticalPath).toBe(false)
+    expect(fast.children[0].isCriticalPath).toBe(false)
+  })
+})
+
+describe('flattenTree — basic ordering', () => {
+  it('emits one row per node in DFS pre-order when all expanded', () => {
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'a', depth: 0 }),
+      makeSpan({ span_id: 'b', parent_span_id: 'a', depth: 1 }),
+      makeSpan({ span_id: 'c', parent_span_id: 'b', depth: 2 }),
+      makeSpan({ span_id: 'd', parent_span_id: 'a', depth: 1 }),
+    ])
+    const flat = flattenTree(tree, {
+      expandedIds: expandAll(tree),
+      hideEngineRouting: false,
+      collapseEngineRoutingPairs: false,
+    })
+    expect(flat.map((r) => r.span_id)).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('hides descendants of a collapsed node', () => {
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'a', depth: 0 }),
+      makeSpan({ span_id: 'b', parent_span_id: 'a', depth: 1 }),
+      makeSpan({ span_id: 'c', parent_span_id: 'b', depth: 2 }),
+    ])
+    const flat = flattenTree(tree, {
+      expandedIds: new Set(['a']),
+      hideEngineRouting: false,
+      collapseEngineRoutingPairs: false,
+    })
+    // 'a' is expanded, 'b' is not in expandedIds -> only 'a' and 'b'.
+    expect(flat.map((r) => r.span_id)).toEqual(['a', 'b'])
+  })
+
+  it('preserves displayDepth from node.depth when no hide is in effect', () => {
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'a', depth: 0 }),
+      makeSpan({ span_id: 'b', parent_span_id: 'a', depth: 1 }),
+      makeSpan({ span_id: 'c', parent_span_id: 'b', depth: 2 }),
+    ])
+    const flat = flattenTree(tree, {
+      expandedIds: expandAll(tree),
+      hideEngineRouting: false,
+      collapseEngineRoutingPairs: false,
+    })
+    expect(flat.map((r) => r.displayDepth)).toEqual([0, 1, 2])
+  })
+})
+
+describe('flattenTree — hideEngineRouting depth offset', () => {
+  it('skips engine routing spans and shifts descendants left by 1', () => {
+    // iii / handle_invocation X is a routing span; its children shift up.
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'root', service_name: 'iii', name: 'handle_invocation fn', depth: 0 }),
+      makeSpan({
+        span_id: 'user',
+        parent_span_id: 'root',
+        service_name: 'billing',
+        name: 'charge',
+        depth: 1,
+      }),
+    ])
+    const flat = flattenTree(tree, {
+      expandedIds: expandAll(tree),
+      hideEngineRouting: true,
+      collapseEngineRoutingPairs: false,
+    })
+    expect(flat.map((r) => r.span_id)).toEqual(['user'])
+    expect(flat[0].displayDepth).toBe(0) // 1 - 1 (one hidden ancestor)
+  })
+
+  it('stacks the offset for multiple hidden ancestors', () => {
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'r1', service_name: 'iii', name: 'handle_invocation a', depth: 0 }),
+      makeSpan({
+        span_id: 'r2',
+        parent_span_id: 'r1',
+        service_name: 'iii',
+        name: 'call a',
+        depth: 1,
+      }),
+      makeSpan({
+        span_id: 'user',
+        parent_span_id: 'r2',
+        service_name: 'billing',
+        name: 'charge',
+        depth: 2,
+      }),
+    ])
+    const flat = flattenTree(tree, {
+      expandedIds: expandAll(tree),
+      hideEngineRouting: true,
+      collapseEngineRoutingPairs: false,
+    })
+    expect(flat.map((r) => r.span_id)).toEqual(['user'])
+    expect(flat[0].displayDepth).toBe(0) // 2 - 2 (two hidden ancestors)
+  })
+
+  it('clamps displayDepth to 0 (never negative)', () => {
+    // Pathological: a non-routing span at depth 0 under a hidden parent.
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'r', service_name: 'iii', name: 'handle_invocation x', depth: 0 }),
+      makeSpan({
+        span_id: 'user',
+        parent_span_id: 'r',
+        service_name: 'billing',
+        name: 'charge',
+        depth: 0,
+      }),
+    ])
+    const flat = flattenTree(tree, {
+      expandedIds: expandAll(tree),
+      hideEngineRouting: true,
+      collapseEngineRoutingPairs: false,
+    })
+    expect(flat[0].displayDepth).toBe(0)
+  })
+
+  it('leaves non-engine spans unchanged when hideEngineRouting is on', () => {
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'r', service_name: 'billing', name: 'charge', depth: 0 }),
+      makeSpan({
+        span_id: 'c',
+        parent_span_id: 'r',
+        service_name: 'billing',
+        name: 'inner',
+        depth: 1,
+      }),
+    ])
+    const flat = flattenTree(tree, {
+      expandedIds: expandAll(tree),
+      hideEngineRouting: true,
+      collapseEngineRoutingPairs: false,
+    })
+    expect(flat.map((r) => r.span_id)).toEqual(['r', 'c'])
+    expect(flat.map((r) => r.displayDepth)).toEqual([0, 1])
+  })
+})
+
+describe('flattenTree — collapseEngineRoutingPairs', () => {
+  it('merges a handle_invocation X parent with its single call X child', () => {
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'h', service_name: 'iii', name: 'handle_invocation fn', depth: 0 }),
+      makeSpan({
+        span_id: 'c',
+        parent_span_id: 'h',
+        service_name: 'iii',
+        name: 'call fn',
+        depth: 1,
+      }),
+      makeSpan({
+        span_id: 'inner',
+        parent_span_id: 'c',
+        service_name: 'billing',
+        name: 'charge',
+        depth: 2,
+      }),
+    ])
+    const flat = flattenTree(tree, {
+      expandedIds: expandAll(tree),
+      hideEngineRouting: false,
+      collapseEngineRoutingPairs: true,
+    })
+    // 'c' is absorbed; 'h' renders with mergedRouting=true, and inner
+    // becomes h's effective grandchild rendered at its own depth.
+    expect(flat.map((r) => r.span_id)).toEqual(['h', 'inner'])
+    expect(flat[0].mergedRouting).toBe(true)
+    expect(flat[1].mergedRouting).toBe(false)
+  })
+
+  it('does NOT merge when the parent has multiple children', () => {
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'h', service_name: 'iii', name: 'handle_invocation fn', depth: 0 }),
+      makeSpan({
+        span_id: 'c1',
+        parent_span_id: 'h',
+        service_name: 'iii',
+        name: 'call fn',
+        depth: 1,
+      }),
+      makeSpan({
+        span_id: 'c2',
+        parent_span_id: 'h',
+        service_name: 'iii',
+        name: 'call fn',
+        depth: 1,
+      }),
+    ])
+    const flat = flattenTree(tree, {
+      expandedIds: expandAll(tree),
+      hideEngineRouting: false,
+      collapseEngineRoutingPairs: true,
+    })
+    expect(flat.map((r) => r.span_id)).toEqual(['h', 'c1', 'c2'])
+    expect(flat.every((r) => !r.mergedRouting)).toBe(true)
+  })
+
+  it('does NOT merge when the function names mismatch', () => {
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'h', service_name: 'iii', name: 'handle_invocation foo', depth: 0 }),
+      makeSpan({
+        span_id: 'c',
+        parent_span_id: 'h',
+        service_name: 'iii',
+        name: 'call bar',
+        depth: 1,
+      }),
+    ])
+    const flat = flattenTree(tree, {
+      expandedIds: expandAll(tree),
+      hideEngineRouting: false,
+      collapseEngineRoutingPairs: true,
+    })
+    expect(flat.map((r) => r.span_id)).toEqual(['h', 'c'])
+  })
+
+  it('hide takes precedence over merge — a hidden parent does not get mergedRouting', () => {
+    const tree = buildSpanTree([
+      makeSpan({ span_id: 'h', service_name: 'iii', name: 'handle_invocation fn', depth: 0 }),
+      makeSpan({
+        span_id: 'c',
+        parent_span_id: 'h',
+        service_name: 'iii',
+        name: 'call fn',
+        depth: 1,
+      }),
+    ])
+    const flat = flattenTree(tree, {
+      expandedIds: expandAll(tree),
+      hideEngineRouting: true,
+      collapseEngineRoutingPairs: true,
+    })
+    // Both routing spans hide; tree is empty.
+    expect(flat).toEqual([])
+  })
+})

--- a/console/packages/console-frontend/src/lib/spanTree.ts
+++ b/console/packages/console-frontend/src/lib/spanTree.ts
@@ -1,0 +1,173 @@
+// Pure tree construction + flattening for the waterfall view.
+//
+// Extracted from `WaterfallChart` so the critical-path marking and
+// the depth-offset / hide / collapse-pair logic are testable without
+// rendering the component. A porter that wants to wire the same
+// waterfall to a different render layer (canvas, native, SVG export)
+// can reuse these helpers directly.
+
+import { isEngineRoutingPair, isEngineRoutingSpan } from './spanLabel'
+import type { VisualizationSpan } from './traceTransform'
+
+export interface SpanNode extends VisualizationSpan {
+  children: SpanNode[]
+  isExpanded: boolean
+  isCriticalPath: boolean
+}
+
+export interface FlatSpanRow extends SpanNode {
+  /**
+   * Visible indentation depth after applying `hideEngineRouting`.
+   * Equals `node.depth` minus the count of ancestors that were hidden.
+   * Always >= 0.
+   */
+  displayDepth: number
+  /**
+   * True when this row absorbed an engine `call X` child that was
+   * collapsed into its `handle_invocation X` parent. Renderers should
+   * show a "+1" affordance to signal the merge.
+   */
+  mergedRouting: boolean
+}
+
+export interface FlattenOptions {
+  /** Span IDs the user has expanded. Collapsed nodes hide their subtree. */
+  expandedIds: Set<string>
+  /** When true, engine routing spans (`handle_invocation X`, `call X` on the
+   *  `iii` service) are skipped during render and their children render at
+   *  the parent's depth instead. */
+  hideEngineRouting: boolean
+  /** When true, a `handle_invocation X` parent with a single `call X` child
+   *  is rendered as ONE row, with the child's subtree promoted under the
+   *  parent. The row gets `mergedRouting: true`. */
+  collapseEngineRoutingPairs: boolean
+}
+
+/**
+ * Build a parent/child tree from a flat list of `VisualizationSpan`s,
+ * then mark the critical path.
+ *
+ * Parent linking: each span's `parent_span_id` is looked up in the
+ * input set; spans with no parent (or whose parent isn't in the set)
+ * become roots. Spans linked into the tree appear in the order they
+ * were added to the flat input — caller controls ordering.
+ *
+ * Critical-path marking: greedy DFS from each root. A node is on the
+ * critical path if its longest child path is the dominant subtree
+ * (the slowest leaf-to-root chain). Tied children: first wins.
+ * Non-critical siblings are recursively unmarked.
+ */
+export function buildSpanTree(spans: VisualizationSpan[]): SpanNode[] {
+  const spanMap = new Map<string, SpanNode>()
+  const roots: SpanNode[] = []
+
+  spans.forEach((span) => {
+    spanMap.set(span.span_id, {
+      ...span,
+      children: [],
+      isExpanded: true,
+      isCriticalPath: false,
+    })
+  })
+
+  spans.forEach((span) => {
+    const node = spanMap.get(span.span_id)
+    if (!node) return
+    if (span.parent_span_id && spanMap.has(span.parent_span_id)) {
+      spanMap.get(span.parent_span_id)?.children.push(node)
+    } else {
+      roots.push(node)
+    }
+  })
+
+  function markCriticalPath(node: SpanNode): number {
+    if (node.children.length === 0) {
+      node.isCriticalPath = true
+      return node.duration_ms
+    }
+
+    let maxDuration = 0
+    let criticalChild: SpanNode | null = null
+
+    node.children.forEach((child) => {
+      const duration = markCriticalPath(child)
+      if (duration > maxDuration) {
+        maxDuration = duration
+        criticalChild = child
+      }
+    })
+
+    node.isCriticalPath = true
+    node.children.forEach((child) => {
+      if (child !== criticalChild) {
+        unmarkCriticalPath(child)
+      }
+    })
+
+    return node.duration_ms + maxDuration
+  }
+
+  function unmarkCriticalPath(node: SpanNode) {
+    node.isCriticalPath = false
+    node.children.forEach(unmarkCriticalPath)
+  }
+
+  roots.forEach(markCriticalPath)
+
+  return roots
+}
+
+/**
+ * Flatten the tree into a render-ordered list of rows, respecting
+ * collapse state and the two engine-routing affordances.
+ *
+ * Depth-offset rule (for `hideEngineRouting`): when a parent is
+ * hidden, its visible descendants shift left by 1. Multiple stacked
+ * hidden ancestors stack the offset, so a deeply nested user span
+ * under three hidden routing parents renders at displayDepth = depth - 3.
+ * `Math.max(0, ...)` ensures the depth never goes negative.
+ *
+ * Children-visibility rule: a node's children are emitted if the
+ * node is in `expandedIds` OR if the node itself is hidden (in which
+ * case the children take its place at the shifted depth).
+ */
+export function flattenTree(nodes: SpanNode[], opts: FlattenOptions): FlatSpanRow[] {
+  const result: FlatSpanRow[] = []
+
+  function traverse(node: SpanNode, depthOffset: number) {
+    const hidden = opts.hideEngineRouting && isEngineRoutingSpan(node)
+
+    let mergedRouting = false
+    let descendants = node.children
+    if (
+      !hidden &&
+      opts.collapseEngineRoutingPairs &&
+      node.children.length === 1 &&
+      isEngineRoutingPair(node, node.children[0])
+    ) {
+      mergedRouting = true
+      descendants = node.children[0].children
+    }
+
+    if (!hidden) {
+      result.push({
+        ...node,
+        displayDepth: Math.max(0, node.depth - depthOffset),
+        mergedRouting,
+      })
+    }
+
+    const nextOffset = hidden ? depthOffset + 1 : depthOffset
+    const childrenVisible = hidden || opts.expandedIds.has(node.span_id)
+    if (childrenVisible) {
+      for (const child of descendants) {
+        traverse(child, nextOffset)
+      }
+    }
+  }
+
+  for (const node of nodes) {
+    traverse(node, 0)
+  }
+  return result
+}

--- a/console/packages/console-frontend/src/lib/traceFilters.test.ts
+++ b/console/packages/console-frontend/src/lib/traceFilters.test.ts
@@ -1,0 +1,213 @@
+// Tests for the pure filter-param building extracted from
+// `useTraceFilters`. Covers happy-path translation (camelCase ->
+// snake_case), single-bounded ranges, and the swap-validation paths
+// that auto-correct inverted ranges with a warning flag.
+
+import { describe, expect, it } from 'vitest'
+import type { TraceFilterState } from '../hooks/useTraceFilters'
+import { buildFilterParams, countActiveFilters } from './traceFilters'
+
+function makeFilters(overrides: Partial<TraceFilterState> = {}): TraceFilterState {
+  return {
+    serviceName: undefined,
+    operationName: undefined,
+    status: null,
+    minDurationMs: null,
+    maxDurationMs: null,
+    startTime: null,
+    endTime: null,
+    attributes: undefined,
+    sortBy: 'start_time',
+    sortOrder: 'desc',
+    groupBy: 'none',
+    page: 1,
+    pageSize: 50,
+    ...overrides,
+  }
+}
+
+describe('buildFilterParams — happy path', () => {
+  it('emits no fields when filters are at defaults', () => {
+    const { params, warnings } = buildFilterParams(makeFilters())
+    // sortBy + sortOrder always pass through (server uses them); other
+    // fields are absent.
+    expect(params).toEqual({ sort_by: 'start_time', sort_order: 'desc' })
+    expect(warnings).toEqual({})
+  })
+
+  it('translates serviceName -> service_name', () => {
+    const { params } = buildFilterParams(makeFilters({ serviceName: 'api-gateway' }))
+    expect(params.service_name).toBe('api-gateway')
+  })
+
+  it('translates operationName -> name + search_all_spans flag', () => {
+    const { params } = buildFilterParams(makeFilters({ operationName: 'POST /api/users' }))
+    expect(params.name).toBe('POST /api/users')
+    expect(params.search_all_spans).toBe(true)
+  })
+
+  it('translates status when non-null', () => {
+    expect(buildFilterParams(makeFilters({ status: 'error' })).params.status).toBe('error')
+    expect(buildFilterParams(makeFilters({ status: null })).params.status).toBeUndefined()
+  })
+
+  it('forwards attributes when non-empty', () => {
+    const attrs: [string, string][] = [
+      ['http.method', 'GET'],
+      ['http.status_code', '500'],
+    ]
+    expect(buildFilterParams(makeFilters({ attributes: attrs })).params.attributes).toEqual(attrs)
+  })
+
+  it('drops attributes when array is empty', () => {
+    expect(buildFilterParams(makeFilters({ attributes: [] })).params.attributes).toBeUndefined()
+  })
+})
+
+describe('buildFilterParams — duration range', () => {
+  it('passes min and max through unchanged when min <= max', () => {
+    const { params, warnings } = buildFilterParams(
+      makeFilters({ minDurationMs: 100, maxDurationMs: 500 }),
+    )
+    expect(params.min_duration_ms).toBe(100)
+    expect(params.max_duration_ms).toBe(500)
+    expect(warnings.durationSwapped).toBeUndefined()
+  })
+
+  it('swaps min/max and flags warning when inverted', () => {
+    const { params, warnings } = buildFilterParams(
+      makeFilters({ minDurationMs: 500, maxDurationMs: 100 }),
+    )
+    expect(params.min_duration_ms).toBe(100)
+    expect(params.max_duration_ms).toBe(500)
+    expect(warnings.durationSwapped).toBe(true)
+  })
+
+  it('handles single-bounded min only', () => {
+    const { params, warnings } = buildFilterParams(makeFilters({ minDurationMs: 100 }))
+    expect(params.min_duration_ms).toBe(100)
+    expect(params.max_duration_ms).toBeUndefined()
+    expect(warnings.durationSwapped).toBeUndefined()
+  })
+
+  it('handles single-bounded max only', () => {
+    const { params, warnings } = buildFilterParams(makeFilters({ maxDurationMs: 500 }))
+    expect(params.min_duration_ms).toBeUndefined()
+    expect(params.max_duration_ms).toBe(500)
+    expect(warnings.durationSwapped).toBeUndefined()
+  })
+
+  it('treats equal min/max as valid (no swap, no warning)', () => {
+    const { params, warnings } = buildFilterParams(
+      makeFilters({ minDurationMs: 250, maxDurationMs: 250 }),
+    )
+    expect(params.min_duration_ms).toBe(250)
+    expect(params.max_duration_ms).toBe(250)
+    expect(warnings.durationSwapped).toBeUndefined()
+  })
+})
+
+describe('buildFilterParams — time range', () => {
+  const t0 = 1_700_000_000_000
+  const t1 = 1_700_000_001_000
+
+  it('passes start/end through unchanged when start <= end', () => {
+    const { params, warnings } = buildFilterParams(
+      makeFilters({ startTime: t0, endTime: t1 }),
+    )
+    expect(params.start_time).toBe(t0)
+    expect(params.end_time).toBe(t1)
+    expect(warnings.timeRangeSwapped).toBeUndefined()
+  })
+
+  it('swaps start/end and flags warning when inverted', () => {
+    const { params, warnings } = buildFilterParams(
+      makeFilters({ startTime: t1, endTime: t0 }),
+    )
+    expect(params.start_time).toBe(t0)
+    expect(params.end_time).toBe(t1)
+    expect(warnings.timeRangeSwapped).toBe(true)
+  })
+
+  it('handles single-bounded startTime only', () => {
+    const { params } = buildFilterParams(makeFilters({ startTime: t0 }))
+    expect(params.start_time).toBe(t0)
+    expect(params.end_time).toBeUndefined()
+  })
+
+  it('handles single-bounded endTime only', () => {
+    const { params } = buildFilterParams(makeFilters({ endTime: t1 }))
+    expect(params.start_time).toBeUndefined()
+    expect(params.end_time).toBe(t1)
+  })
+
+  it('independently swaps duration and time-range', () => {
+    const { warnings } = buildFilterParams(
+      makeFilters({
+        minDurationMs: 500,
+        maxDurationMs: 100,
+        startTime: t1,
+        endTime: t0,
+      }),
+    )
+    expect(warnings.durationSwapped).toBe(true)
+    expect(warnings.timeRangeSwapped).toBe(true)
+  })
+})
+
+describe('buildFilterParams — sort', () => {
+  it('passes sortBy through', () => {
+    expect(buildFilterParams(makeFilters({ sortBy: 'duration' })).params.sort_by).toBe('duration')
+    expect(buildFilterParams(makeFilters({ sortBy: 'service_name' })).params.sort_by).toBe(
+      'service_name',
+    )
+  })
+
+  it('passes sortOrder through', () => {
+    expect(buildFilterParams(makeFilters({ sortOrder: 'asc' })).params.sort_order).toBe('asc')
+  })
+})
+
+describe('countActiveFilters', () => {
+  it('returns 0 for default filters', () => {
+    expect(countActiveFilters(makeFilters())).toBe(0)
+  })
+
+  it('counts each non-default field', () => {
+    expect(countActiveFilters(makeFilters({ serviceName: 'api' }))).toBe(1)
+    expect(countActiveFilters(makeFilters({ operationName: 'GET /x' }))).toBe(1)
+    expect(countActiveFilters(makeFilters({ status: 'error' }))).toBe(1)
+    expect(countActiveFilters(makeFilters({ minDurationMs: 100 }))).toBe(1)
+    expect(countActiveFilters(makeFilters({ maxDurationMs: 500 }))).toBe(1)
+    expect(countActiveFilters(makeFilters({ startTime: 1 }))).toBe(1)
+    expect(countActiveFilters(makeFilters({ endTime: 2 }))).toBe(1)
+    expect(countActiveFilters(makeFilters({ attributes: [['k', 'v']] }))).toBe(1)
+    expect(countActiveFilters(makeFilters({ sortBy: 'duration' }))).toBe(1)
+    expect(countActiveFilters(makeFilters({ sortOrder: 'asc' }))).toBe(1)
+  })
+
+  it('does NOT count empty attributes array', () => {
+    expect(countActiveFilters(makeFilters({ attributes: [] }))).toBe(0)
+  })
+
+  it('does NOT count sortBy === start_time (default)', () => {
+    expect(countActiveFilters(makeFilters({ sortBy: 'start_time' }))).toBe(0)
+  })
+
+  it('does NOT count sortOrder === desc (default)', () => {
+    expect(countActiveFilters(makeFilters({ sortOrder: 'desc' }))).toBe(0)
+  })
+
+  it('sums multiple active filters', () => {
+    expect(
+      countActiveFilters(
+        makeFilters({
+          serviceName: 'api',
+          status: 'error',
+          minDurationMs: 100,
+          sortBy: 'duration',
+        }),
+      ),
+    ).toBe(4)
+  })
+})

--- a/console/packages/console-frontend/src/lib/traceFilters.test.ts
+++ b/console/packages/console-frontend/src/lib/traceFilters.test.ts
@@ -112,18 +112,14 @@ describe('buildFilterParams — time range', () => {
   const t1 = 1_700_000_001_000
 
   it('passes start/end through unchanged when start <= end', () => {
-    const { params, warnings } = buildFilterParams(
-      makeFilters({ startTime: t0, endTime: t1 }),
-    )
+    const { params, warnings } = buildFilterParams(makeFilters({ startTime: t0, endTime: t1 }))
     expect(params.start_time).toBe(t0)
     expect(params.end_time).toBe(t1)
     expect(warnings.timeRangeSwapped).toBeUndefined()
   })
 
   it('swaps start/end and flags warning when inverted', () => {
-    const { params, warnings } = buildFilterParams(
-      makeFilters({ startTime: t1, endTime: t0 }),
-    )
+    const { params, warnings } = buildFilterParams(makeFilters({ startTime: t1, endTime: t0 }))
     expect(params.start_time).toBe(t0)
     expect(params.end_time).toBe(t1)
     expect(warnings.timeRangeSwapped).toBe(true)

--- a/console/packages/console-frontend/src/lib/traceFilters.ts
+++ b/console/packages/console-frontend/src/lib/traceFilters.ts
@@ -1,0 +1,109 @@
+// Pure filter-param building for the TRACES tab.
+//
+// Extracted from `useTraceFilters` so the range-swap validation logic
+// (auto-fix min > max and startTime > endTime) is testable without a
+// React render. The hook calls this and surfaces the warnings via a
+// state effect.
+
+import type { TracesFilterParams } from '@/api/observability/traces'
+import type { TraceFilterState } from '@/hooks/useTraceFilters'
+
+export interface FilterValidationWarnings {
+  durationSwapped?: boolean
+  timeRangeSwapped?: boolean
+}
+
+export interface BuiltFilterParams {
+  params: TracesFilterParams
+  warnings: FilterValidationWarnings
+}
+
+/**
+ * Convert the UI's `TraceFilterState` into the engine's
+ * `TracesFilterParams` shape (camelCase → snake_case).
+ *
+ * Range validation:
+ * - When both `minDurationMs` and `maxDurationMs` are set and min > max,
+ *   the values are swapped and `warnings.durationSwapped = true`.
+ * - When both `startTime` and `endTime` are set and start > end, the
+ *   values are swapped and `warnings.timeRangeSwapped = true`.
+ * - Single-bounded ranges (only min OR only max set) pass through
+ *   unchanged without warnings.
+ *
+ * Empty / null / undefined fields are not emitted on the output —
+ * downstream the engine treats missing fields as "no filter".
+ *
+ * Pagination is NOT included here; the hook adds offset/limit on top.
+ */
+export function buildFilterParams(filters: TraceFilterState): BuiltFilterParams {
+  const params: TracesFilterParams = {}
+  const warnings: FilterValidationWarnings = {}
+
+  if (filters.serviceName) params.service_name = filters.serviceName
+  if (filters.operationName) {
+    params.name = filters.operationName
+    params.search_all_spans = true
+  }
+  if (filters.status != null) params.status = filters.status
+
+  if (filters.minDurationMs != null && filters.maxDurationMs != null) {
+    if (filters.minDurationMs > filters.maxDurationMs) {
+      params.min_duration_ms = filters.maxDurationMs
+      params.max_duration_ms = filters.minDurationMs
+      warnings.durationSwapped = true
+    } else {
+      params.min_duration_ms = filters.minDurationMs
+      params.max_duration_ms = filters.maxDurationMs
+    }
+  } else {
+    if (filters.minDurationMs != null) params.min_duration_ms = filters.minDurationMs
+    if (filters.maxDurationMs != null) params.max_duration_ms = filters.maxDurationMs
+  }
+
+  if (filters.startTime != null && filters.endTime != null) {
+    if (filters.startTime > filters.endTime) {
+      params.start_time = filters.endTime
+      params.end_time = filters.startTime
+      warnings.timeRangeSwapped = true
+    } else {
+      params.start_time = filters.startTime
+      params.end_time = filters.endTime
+    }
+  } else {
+    if (filters.startTime != null) params.start_time = filters.startTime
+    if (filters.endTime != null) params.end_time = filters.endTime
+  }
+
+  if (filters.attributes && filters.attributes.length > 0) {
+    params.attributes = filters.attributes
+  }
+  if (filters.sortBy) params.sort_by = filters.sortBy
+  if (filters.sortOrder) params.sort_order = filters.sortOrder
+
+  return { params, warnings }
+}
+
+/**
+ * Count of "non-default" filters active on a state. Used by the UI
+ * to render a badge next to the filter button.
+ *
+ * Defaults considered:
+ * - sortBy === 'start_time' (no count)
+ * - sortOrder === 'desc' (no count)
+ * - status === null (no count)
+ * - other fields: count if present / non-empty
+ */
+export function countActiveFilters(filters: TraceFilterState): number {
+  let count = 0
+  if (filters.serviceName) count++
+  if (filters.operationName) count++
+  if (filters.status != null) count++
+  if (filters.minDurationMs !== null) count++
+  if (filters.maxDurationMs !== null) count++
+  if (filters.startTime !== null) count++
+  if (filters.endTime !== null) count++
+  if (filters.attributes && filters.attributes.length > 0) count++
+  if (filters.sortBy !== 'start_time') count++
+  if (filters.sortOrder !== 'desc') count++
+  return count
+}

--- a/console/packages/console-frontend/src/lib/traceListItem.test.ts
+++ b/console/packages/console-frontend/src/lib/traceListItem.test.ts
@@ -1,0 +1,209 @@
+// Tests for the pure span -> view-model mapper extracted from
+// `useTraceData`. Covers attribute-shape normalization (array vs
+// object), status normalization, OTel semantic attribute lookup, and
+// fingerprinting for fetch-result dedup.
+
+import { describe, expect, it } from 'vitest'
+import type { StoredSpan } from '../api/observability/traces'
+import type { TraceListItem } from '../hooks/useTraceData'
+import {
+  fingerprintTraceList,
+  mapSpanToListItem,
+  normalizeSpanAttributes,
+} from './traceListItem'
+
+const NS_PER_MS = 1_000_000
+
+function makeSpan(overrides: Partial<StoredSpan> = {}): StoredSpan {
+  return {
+    trace_id: 't-1',
+    span_id: 's-1',
+    name: 'GET /api/users',
+    start_time_unix_nano: 1_700_000_000_000 * NS_PER_MS,
+    end_time_unix_nano: (1_700_000_000_000 + 42) * NS_PER_MS,
+    status: 'OK',
+    attributes: [],
+    events: [],
+    links: [],
+    service_name: 'api-gateway',
+    ...overrides,
+  }
+}
+
+describe('normalizeSpanAttributes', () => {
+  it('normalizes the array-of-tuples shape into a flat object', () => {
+    const out = normalizeSpanAttributes([
+      ['http.method', 'GET'],
+      ['http.status_code', 200],
+      ['user.id', 'u-7'],
+    ])
+    expect(out).toEqual({ 'http.method': 'GET', 'http.status_code': 200, 'user.id': 'u-7' })
+  })
+
+  it('normalizes the plain-object shape', () => {
+    const out = normalizeSpanAttributes({ k1: 'v1', k2: 2 })
+    expect(out).toEqual({ k1: 'v1', k2: 2 })
+  })
+
+  it('returns an empty object for undefined / null / empty array', () => {
+    expect(normalizeSpanAttributes(undefined)).toEqual({})
+    expect(normalizeSpanAttributes(null as unknown as undefined)).toEqual({})
+    expect(normalizeSpanAttributes([])).toEqual({})
+  })
+
+  it('skips malformed tuples (length < 2)', () => {
+    const out = normalizeSpanAttributes([
+      ['ok', 'value'],
+      ['malformed'] as unknown as [string, unknown],
+    ])
+    expect(out).toEqual({ ok: 'value' })
+  })
+
+  it('coerces non-string keys to strings', () => {
+    const out = normalizeSpanAttributes([[42 as unknown as string, 'value']])
+    expect(out['42']).toBe('value')
+  })
+
+  it('returns a fresh object (does not mutate input)', () => {
+    const input = { k: 'v' }
+    const out = normalizeSpanAttributes(input)
+    out.k = 'mutated'
+    expect(input.k).toBe('v')
+  })
+})
+
+describe('mapSpanToListItem — basic shape', () => {
+  it('converts unix-nano times to ms and computes duration', () => {
+    // `toMs` auto-detects ns vs ms by magnitude — values below the
+    // ~year-2100-in-ms threshold pass through as-is. Use realistic
+    // 2024-era ns timestamps so the divide-by-1M branch fires.
+    const startMs = 1_700_000_000_000
+    const endMs = 1_700_000_000_500
+    const span = makeSpan({
+      start_time_unix_nano: startMs * NS_PER_MS,
+      end_time_unix_nano: endMs * NS_PER_MS,
+    })
+    const out = mapSpanToListItem(span)
+    expect(out.startTime).toBe(startMs)
+    expect(out.endTime).toBe(endMs)
+    expect(out.duration).toBe(500)
+  })
+
+  it('forwards trace_id, name, and service_name', () => {
+    const out = mapSpanToListItem(
+      makeSpan({ trace_id: 'abc', name: 'POST /x', service_name: 'svc-x' }),
+    )
+    expect(out.traceId).toBe('abc')
+    expect(out.rootOperation).toBe('POST /x')
+    expect(out.services).toEqual(['svc-x'])
+  })
+
+  it('falls back to "unknown" when service_name is missing', () => {
+    expect(mapSpanToListItem(makeSpan({ service_name: undefined })).services).toEqual(['unknown'])
+  })
+
+  it('always emits spanCount = 1', () => {
+    expect(mapSpanToListItem(makeSpan()).spanCount).toBe(1)
+  })
+})
+
+describe('mapSpanToListItem — status normalization', () => {
+  it.each(['error', 'Error', 'ERROR', 'errOr'])(
+    'maps case variant %s of "error" to status="error"',
+    (raw) => {
+      expect(mapSpanToListItem(makeSpan({ status: raw })).status).toBe('error')
+    },
+  )
+
+  it.each(['OK', 'ok', 'unset', 'UNSET', '', 'something_else'])(
+    'maps non-error status %s to status="ok"',
+    (raw) => {
+      expect(mapSpanToListItem(makeSpan({ status: raw })).status).toBe('ok')
+    },
+  )
+})
+
+describe('mapSpanToListItem — semantic attributes', () => {
+  it('reads functionId from OTel faas.invoked_name', () => {
+    const out = mapSpanToListItem(
+      makeSpan({ attributes: [['faas.invoked_name', 'fn-billing']] }),
+    )
+    expect(out.functionId).toBe('fn-billing')
+  })
+
+  it('falls back to legacy function_id when faas.invoked_name is absent', () => {
+    const out = mapSpanToListItem(makeSpan({ attributes: [['function_id', 'fn-legacy']] }))
+    expect(out.functionId).toBe('fn-legacy')
+  })
+
+  it('prefers faas.invoked_name over function_id when both are set', () => {
+    const out = mapSpanToListItem(
+      makeSpan({
+        attributes: [
+          ['faas.invoked_name', 'fn-new'],
+          ['function_id', 'fn-old'],
+        ],
+      }),
+    )
+    expect(out.functionId).toBe('fn-new')
+  })
+
+  it('reads topic from OTel messaging.destination.name', () => {
+    const out = mapSpanToListItem(
+      makeSpan({ attributes: [['messaging.destination.name', 'orders.created']] }),
+    )
+    expect(out.topic).toBe('orders.created')
+  })
+
+  it('leaves functionId/topic undefined when neither attribute is present', () => {
+    const out = mapSpanToListItem(makeSpan({ attributes: [] }))
+    expect(out.functionId).toBeUndefined()
+    expect(out.topic).toBeUndefined()
+  })
+
+  it('works with the plain-object attributes shape too', () => {
+    const out = mapSpanToListItem(
+      makeSpan({
+        attributes: { 'faas.invoked_name': 'fn-from-object' } as unknown as StoredSpan['attributes'],
+      }),
+    )
+    expect(out.functionId).toBe('fn-from-object')
+  })
+})
+
+describe('fingerprintTraceList', () => {
+  function item(traceId: string): TraceListItem {
+    return {
+      traceId,
+      rootOperation: '_',
+      status: 'ok',
+      startTime: 0,
+      spanCount: 1,
+      services: [],
+    }
+  }
+
+  it('returns the same fingerprint for identical lists', () => {
+    const a = [item('t-1'), item('t-2'), item('t-3')]
+    const b = [item('t-1'), item('t-2'), item('t-3')]
+    expect(fingerprintTraceList(a)).toBe(fingerprintTraceList(b))
+  })
+
+  it('differs when order changes (catches sort-direction flips)', () => {
+    const ascending = [item('t-1'), item('t-2'), item('t-3')]
+    const descending = [item('t-3'), item('t-2'), item('t-1')]
+    expect(fingerprintTraceList(ascending)).not.toBe(fingerprintTraceList(descending))
+  })
+
+  it('differs when middle item changes (was the latent bug in the old fingerprint)', () => {
+    const before = [item('t-1'), item('t-MIDDLE'), item('t-9')]
+    const after = [item('t-1'), item('t-OTHER'), item('t-9')]
+    // Old fingerprint sampled only first + last + count — would have
+    // returned the same value here. The all-IDs fingerprint catches it.
+    expect(fingerprintTraceList(before)).not.toBe(fingerprintTraceList(after))
+  })
+
+  it('returns a distinct fingerprint for an empty list', () => {
+    expect(fingerprintTraceList([])).toBe('0:')
+  })
+})

--- a/console/packages/console-frontend/src/lib/traceListItem.test.ts
+++ b/console/packages/console-frontend/src/lib/traceListItem.test.ts
@@ -6,11 +6,7 @@
 import { describe, expect, it } from 'vitest'
 import type { StoredSpan } from '../api/observability/traces'
 import type { TraceListItem } from '../hooks/useTraceData'
-import {
-  fingerprintTraceList,
-  mapSpanToListItem,
-  normalizeSpanAttributes,
-} from './traceListItem'
+import { fingerprintTraceList, mapSpanToListItem, normalizeSpanAttributes } from './traceListItem'
 
 const NS_PER_MS = 1_000_000
 
@@ -108,26 +104,30 @@ describe('mapSpanToListItem — basic shape', () => {
 })
 
 describe('mapSpanToListItem — status normalization', () => {
-  it.each(['error', 'Error', 'ERROR', 'errOr'])(
-    'maps case variant %s of "error" to status="error"',
-    (raw) => {
-      expect(mapSpanToListItem(makeSpan({ status: raw })).status).toBe('error')
-    },
-  )
+  it.each([
+    'error',
+    'Error',
+    'ERROR',
+    'errOr',
+  ])('maps case variant %s of "error" to status="error"', (raw) => {
+    expect(mapSpanToListItem(makeSpan({ status: raw })).status).toBe('error')
+  })
 
-  it.each(['OK', 'ok', 'unset', 'UNSET', '', 'something_else'])(
-    'maps non-error status %s to status="ok"',
-    (raw) => {
-      expect(mapSpanToListItem(makeSpan({ status: raw })).status).toBe('ok')
-    },
-  )
+  it.each([
+    'OK',
+    'ok',
+    'unset',
+    'UNSET',
+    '',
+    'something_else',
+  ])('maps non-error status %s to status="ok"', (raw) => {
+    expect(mapSpanToListItem(makeSpan({ status: raw })).status).toBe('ok')
+  })
 })
 
 describe('mapSpanToListItem — semantic attributes', () => {
   it('reads functionId from OTel faas.invoked_name', () => {
-    const out = mapSpanToListItem(
-      makeSpan({ attributes: [['faas.invoked_name', 'fn-billing']] }),
-    )
+    const out = mapSpanToListItem(makeSpan({ attributes: [['faas.invoked_name', 'fn-billing']] }))
     expect(out.functionId).toBe('fn-billing')
   })
 
@@ -164,7 +164,9 @@ describe('mapSpanToListItem — semantic attributes', () => {
   it('works with the plain-object attributes shape too', () => {
     const out = mapSpanToListItem(
       makeSpan({
-        attributes: { 'faas.invoked_name': 'fn-from-object' } as unknown as StoredSpan['attributes'],
+        attributes: {
+          'faas.invoked_name': 'fn-from-object',
+        } as unknown as StoredSpan['attributes'],
       }),
     )
     expect(out.functionId).toBe('fn-from-object')

--- a/console/packages/console-frontend/src/lib/traceListItem.ts
+++ b/console/packages/console-frontend/src/lib/traceListItem.ts
@@ -1,0 +1,92 @@
+// Pure mapping from an OTel `StoredSpan` (server shape) to a
+// `TraceListItem` (UI view-model used by the flat-list view in the
+// TRACES tab). Extracted from `useTraceData` so a porter can run the
+// same mapping in non-React contexts (e.g. tests, server-side render,
+// a different SDK transport that emits the same span shape).
+
+import type { StoredSpan } from '@/api/observability/traces'
+import type { TraceListItem } from '@/hooks/useTraceData'
+import { toMs } from './traceTransform'
+
+/**
+ * Normalize a span's attributes to a flat object.
+ *
+ * The engine emits attributes in two shapes depending on the encoder:
+ * - Array of `[key, value]` tuples (newer protobuf-derived shape)
+ * - Plain object (older JSON shape)
+ *
+ * Returns a fresh object so callers can mutate freely. Non-array,
+ * non-object inputs (null, undefined) return `{}` rather than throwing.
+ */
+export function normalizeSpanAttributes(
+  attrs: StoredSpan['attributes'] | Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  if (!attrs) return out
+  if (Array.isArray(attrs)) {
+    for (const item of attrs) {
+      if (Array.isArray(item) && item.length >= 2) {
+        out[String(item[0])] = item[1]
+      }
+    }
+    return out
+  }
+  if (typeof attrs === 'object') {
+    Object.assign(out, attrs)
+  }
+  return out
+}
+
+/**
+ * Map one stored span into the flat-list TRACES row view-model.
+ *
+ * Status normalization: any case variant of "error" maps to 'error';
+ * everything else (including 'OK', 'unset', 'UNSET') maps to 'ok'.
+ * The flat-list view treats 'unset' as 'ok' because it has no neutral
+ * indicator (the session-aggregate view has its own).
+ *
+ * Function-ID and topic come from OTel semantic attributes:
+ * - `faas.invoked_name` is the OTel-standard FaaS function attribute;
+ *   `function_id` is the iii-engine-specific fallback.
+ * - `messaging.destination.name` is the OTel-standard queue/topic
+ *   attribute (set when the span is an enqueue).
+ *
+ * `spanCount` is always 1 because the flat-list view treats each row
+ * as one trace; the engine's aggregate counts live in the
+ * group-by/`SessionDetailPanel` path.
+ */
+export function mapSpanToListItem(span: StoredSpan): TraceListItem {
+  const startTime = toMs(span.start_time_unix_nano)
+  const endTime = toMs(span.end_time_unix_nano)
+  const duration = endTime - startTime
+  const attrs = normalizeSpanAttributes(span.attributes)
+
+  const functionId = (attrs['faas.invoked_name'] || attrs.function_id) as string | undefined
+  const topic = attrs['messaging.destination.name'] as string | undefined
+
+  return {
+    traceId: span.trace_id,
+    rootOperation: span.name,
+    functionId,
+    topic,
+    status: span.status.toLowerCase() === 'error' ? 'error' : 'ok',
+    startTime,
+    endTime,
+    duration,
+    spanCount: 1,
+    services: [span.service_name || 'unknown'],
+  }
+}
+
+/**
+ * Stable identity fingerprint for a list of TraceListItems. Used by
+ * the hook to dedupe back-to-back fetches that return the same rows.
+ *
+ * Joins all trace IDs in order. Earlier versions sampled only first +
+ * last + count, which would have missed middle-only churn if the sort
+ * order ever flipped. At the 500-trace ceiling × 32-char IDs the
+ * fingerprint is ~16KB — cheap to compare.
+ */
+export function fingerprintTraceList(traces: ReadonlyArray<TraceListItem>): string {
+  return `${traces.length}:${traces.map((t) => t.traceId).join(',')}`
+}

--- a/console/packages/console-frontend/src/lib/traceTransform.test.ts
+++ b/console/packages/console-frontend/src/lib/traceTransform.test.ts
@@ -1,0 +1,79 @@
+// Tests for the pure timestamp helpers in `lib/traceTransform.ts`.
+// `toWaterfallData` and `treeToWaterfallData` are higher-level
+// transforms with many derived fields (depth, percent positioning);
+// they're indirectly exercised by the rest of the test suite and
+// would benefit from richer fixture coverage in a follow-up.
+
+import { describe, expect, it } from 'vitest'
+import { calculateDurationMs, toMs } from './traceTransform'
+
+const NS_PER_MS = 1_000_000
+// NANO_THRESHOLD in the module is Jan 1 2100 in ms (4102444800000).
+// Any number above that is treated as nanoseconds.
+const NANO_THRESHOLD = 4_102_444_800_000
+
+describe('toMs', () => {
+  it('passes ms-magnitude values through unchanged', () => {
+    expect(toMs(0)).toBe(0)
+    expect(toMs(1_700_000_000_000)).toBe(1_700_000_000_000)
+  })
+
+  it('divides ns-magnitude values by 1_000_000', () => {
+    // A 2024-era nanosecond timestamp is ~1.7e18; toMs should return ~1.7e12 (ms).
+    const ns = 1_700_000_000_000 * NS_PER_MS
+    expect(toMs(ns)).toBe(1_700_000_000_000)
+  })
+
+  it('uses the exact NANO_THRESHOLD boundary', () => {
+    // Values equal to the threshold are treated as ms (`>` not `>=`).
+    expect(toMs(NANO_THRESHOLD)).toBe(NANO_THRESHOLD)
+    // Just above is treated as ns and divided.
+    expect(toMs(NANO_THRESHOLD + 1)).toBe((NANO_THRESHOLD + 1) / NS_PER_MS)
+  })
+
+  it('returns 0 for non-finite inputs', () => {
+    expect(toMs(Number.NaN)).toBe(0)
+    expect(toMs(Number.POSITIVE_INFINITY)).toBe(0)
+    expect(toMs(Number.NEGATIVE_INFINITY)).toBe(0)
+  })
+})
+
+describe('calculateDurationMs', () => {
+  it('returns difference for ms-magnitude inputs', () => {
+    expect(calculateDurationMs(100, 250)).toBe(150)
+  })
+
+  it('returns difference for ns-magnitude inputs (within float64 precision)', () => {
+    // Float64 has ~15-16 decimal digits of precision; 1.7e18 + 2.5e8 ns
+    // loses the last few digits on the divide-by-1e6 path. Tolerate
+    // sub-millisecond error.
+    const t0 = 1_700_000_000_000 * NS_PER_MS
+    const t1 = t0 + 250 * NS_PER_MS
+    expect(calculateDurationMs(t0, t1)).toBeCloseTo(250, 1)
+  })
+
+  it('handles mixed-magnitude inputs (one ns, one ms)', () => {
+    // A bug magnet: if a tree stores start in ns and end in ms, the
+    // helper should still produce a sensible result via per-arg toMs.
+    const startNs = 1_700_000_000_000 * NS_PER_MS
+    const endMs = 1_700_000_000_500
+    expect(calculateDurationMs(startNs, endMs)).toBe(500)
+  })
+
+  it('returns 0 for negative duration (end before start)', () => {
+    expect(calculateDurationMs(500, 100)).toBe(0)
+  })
+
+  it('coerces non-finite inputs to 0 via toMs (does NOT short-circuit to 0)', () => {
+    // toMs(NaN) returns 0 and the function then computes the diff
+    // against the other arg, so the result is the other arg's ms value
+    // rather than 0. Pins this quirk: callers should validate input
+    // before calling rather than relying on a sentinel.
+    expect(calculateDurationMs(Number.NaN, 100)).toBe(100)
+    expect(calculateDurationMs(100, Number.NaN)).toBe(0) // end < start -> guard returns 0
+  })
+
+  it('returns 0 when start equals end', () => {
+    expect(calculateDurationMs(100, 100)).toBe(0)
+  })
+})

--- a/console/packages/console-frontend/src/lib/traceUtils.test.ts
+++ b/console/packages/console-frontend/src/lib/traceUtils.test.ts
@@ -1,0 +1,153 @@
+// Tests for the pure helpers in `lib/traceUtils.ts`. The
+// `useCopyToClipboard` hook is not covered here (needs RTL + jsdom);
+// `STATUS_CONFIG` is a const, exercised indirectly via SpanPanel.
+
+import { describe, expect, it } from 'vitest'
+import type { VisualizationSpan } from './traceTransform'
+import {
+  classifySpanType,
+  formatDuration,
+  formatRelative,
+  getServiceName,
+} from './traceUtils'
+
+function makeSpan(overrides: Partial<VisualizationSpan> = {}): VisualizationSpan {
+  return {
+    span_id: 's-1',
+    trace_id: 't-1',
+    name: 'GET /api/users',
+    kind: 'server',
+    start_time_unix_nano: 0,
+    end_time_unix_nano: 0,
+    duration_ms: 0,
+    depth: 0,
+    start_percent: 0,
+    width_percent: 100,
+    status: 'ok',
+    attributes: {},
+    events: [],
+    links: [],
+    service_name: 'api',
+    ...overrides,
+  } as VisualizationSpan
+}
+
+describe('formatDuration', () => {
+  it('emits 0μs for very small values', () => {
+    expect(formatDuration(0)).toBe('0μs')
+    expect(formatDuration(0.0005)).toBe('0μs')
+  })
+
+  it('emits μs for sub-millisecond values', () => {
+    expect(formatDuration(0.5)).toBe('500μs')
+    expect(formatDuration(0.123)).toBe('123μs')
+  })
+
+  it('emits ms with 2 decimals for sub-second values', () => {
+    expect(formatDuration(1.5)).toBe('1.50ms')
+    expect(formatDuration(42)).toBe('42.00ms')
+    expect(formatDuration(999.99)).toBe('999.99ms')
+  })
+
+  it('emits s with 2 decimals for >= 1000ms', () => {
+    expect(formatDuration(1000)).toBe('1.00s')
+    expect(formatDuration(1500)).toBe('1.50s')
+    expect(formatDuration(60_500)).toBe('60.50s')
+  })
+})
+
+describe('formatRelative', () => {
+  it('emits sub-millisecond values as +μs', () => {
+    expect(formatRelative(0.5)).toBe('+500μs')
+    expect(formatRelative(0.001)).toBe('+1μs')
+  })
+
+  it('emits sub-second values as +ms with 1 decimal', () => {
+    expect(formatRelative(1.5)).toBe('+1.5ms')
+    expect(formatRelative(42)).toBe('+42.0ms')
+    expect(formatRelative(999.9)).toBe('+999.9ms')
+  })
+
+  it('emits >= 1000ms as +s with 2 decimals', () => {
+    expect(formatRelative(1000)).toBe('+1.00s')
+    expect(formatRelative(2500)).toBe('+2.50s')
+  })
+
+  it('emits negative values with a leading - sign (recursive)', () => {
+    expect(formatRelative(-42)).toBe('-+42.0ms')
+    // Note: the implementation's recursive `-${formatRelative(-x)}` style
+    // produces `-+Xms` which is a known quirk. Test pins current behavior.
+  })
+
+  it('handles zero', () => {
+    expect(formatRelative(0)).toBe('+0μs')
+  })
+})
+
+describe('classifySpanType', () => {
+  it('classifies as enqueue when messaging.operation.type === publish', () => {
+    expect(
+      classifySpanType(
+        makeSpan({ attributes: { 'messaging.operation.type': 'publish' } }),
+      ),
+    ).toBe('enqueue')
+  })
+
+  it('classifies as enqueue when messaging.destination.name is set', () => {
+    expect(
+      classifySpanType(
+        makeSpan({ attributes: { 'messaging.destination.name': 'orders' } }),
+      ),
+    ).toBe('enqueue')
+  })
+
+  it('classifies as trigger when name starts with "trigger"', () => {
+    expect(classifySpanType(makeSpan({ name: 'trigger.api-call' }))).toBe('trigger')
+  })
+
+  it('classifies as trigger when iii.function.kind attribute is set', () => {
+    expect(
+      classifySpanType(makeSpan({ attributes: { 'iii.function.kind': 'api' } })),
+    ).toBe('trigger')
+  })
+
+  it('defaults to function for everything else', () => {
+    expect(classifySpanType(makeSpan({ name: 'GET /api', attributes: {} }))).toBe('function')
+  })
+
+  it('prefers enqueue over trigger when both signals are present', () => {
+    // enqueue check runs first in the implementation.
+    expect(
+      classifySpanType(
+        makeSpan({
+          name: 'trigger.x',
+          attributes: { 'messaging.destination.name': 'orders' },
+        }),
+      ),
+    ).toBe('enqueue')
+  })
+
+  it('treats missing attributes as no-signal (defaults to function)', () => {
+    expect(
+      classifySpanType(makeSpan({ name: 'do_thing', attributes: undefined as never })),
+    ).toBe('function')
+  })
+})
+
+describe('getServiceName', () => {
+  it('returns service_name when present', () => {
+    expect(getServiceName({ service_name: 'billing', name: 'charge' })).toBe('billing')
+  })
+
+  it('falls back to the first dot-separated segment of name when service_name is missing', () => {
+    expect(getServiceName({ service_name: undefined, name: 'billing.charge' })).toBe('billing')
+  })
+
+  it('returns the whole name when service_name is missing AND name has no dot', () => {
+    expect(getServiceName({ service_name: undefined, name: 'flat-name' })).toBe('flat-name')
+  })
+
+  it('returns the whole name when service_name is empty string (falsy)', () => {
+    expect(getServiceName({ service_name: '', name: 'billing.charge' })).toBe('billing')
+  })
+})

--- a/console/packages/console-frontend/src/lib/traceUtils.ts
+++ b/console/packages/console-frontend/src/lib/traceUtils.ts
@@ -57,27 +57,37 @@ export function getServiceName(span: { service_name?: string; name: string }): s
   return span.service_name || span.name.split('.')[0]
 }
 
+// Status pill colors flow from the design tokens (`--success`, `--error`,
+// `--muted`) so SpanPanel re-themes correctly under `[data-theme="light"]`
+// or in any host that overrides the CSS custom properties. Subtle bg/border
+// shades use `color-mix(in srgb, var(--token) 8%, transparent)` for an
+// 8%-opacity tint without baking in an rgba literal.
 export const STATUS_CONFIG: Record<
   string,
   { color: string; bg: string; border: string; label: string }
 > = {
-  ok: { color: '#22C55E', bg: 'rgba(34,197,94,0.08)', border: 'rgba(34,197,94,0.15)', label: 'OK' },
+  ok: {
+    color: 'var(--success)',
+    bg: 'color-mix(in srgb, var(--success) 8%, transparent)',
+    border: 'color-mix(in srgb, var(--success) 15%, transparent)',
+    label: 'OK',
+  },
   error: {
-    color: '#EF4444',
-    bg: 'rgba(239,68,68,0.08)',
-    border: 'rgba(239,68,68,0.15)',
+    color: 'var(--error)',
+    bg: 'color-mix(in srgb, var(--error) 8%, transparent)',
+    border: 'color-mix(in srgb, var(--error) 15%, transparent)',
     label: 'ERROR',
   },
   unset: {
-    color: '#6B7280',
-    bg: 'rgba(107,114,128,0.08)',
-    border: 'rgba(107,114,128,0.15)',
+    color: 'var(--muted)',
+    bg: 'color-mix(in srgb, var(--muted) 8%, transparent)',
+    border: 'color-mix(in srgb, var(--muted) 15%, transparent)',
     label: 'UNSET',
   },
   default: {
-    color: '#6B7280',
-    bg: 'rgba(107,114,128,0.08)',
-    border: 'rgba(107,114,128,0.15)',
+    color: 'var(--muted)',
+    bg: 'color-mix(in srgb, var(--muted) 8%, transparent)',
+    border: 'color-mix(in srgb, var(--muted) 15%, transparent)',
     label: 'UNKNOWN',
   },
 }

--- a/console/packages/console-frontend/src/main.tsx
+++ b/console/packages/console-frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { createRouter, RouterProvider } from '@tanstack/react-router'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ConfigProvider } from './api/config-provider'
+import { EngineSdkProvider } from './api/engine-sdk-provider'
 import { routeTree } from './routeTree.gen'
 import './styles/globals.css'
 
@@ -38,8 +39,10 @@ createRoot(rootElement).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <ConfigProvider>
-        <RouterProvider router={router} />
-        {showDevtools && <ReactQueryDevtools initialIsOpen={false} />}
+        <EngineSdkProvider>
+          <RouterProvider router={router} />
+          {showDevtools && <ReactQueryDevtools initialIsOpen={false} />}
+        </EngineSdkProvider>
       </ConfigProvider>
     </QueryClientProvider>
   </StrictMode>,

--- a/console/packages/console-frontend/src/routes/traces.tsx
+++ b/console/packages/console-frontend/src/routes/traces.tsx
@@ -15,11 +15,15 @@ import {
 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { fetchTraceTree } from '@/api'
+import { useEngineSdk } from '@/api/engine-sdk-provider'
+import type { TraceGroup as ApiTraceGroup } from '@/api/observability/traces'
 import { FlameGraph } from '@/components/traces/FlameGraph'
 import { FlowView } from '@/components/traces/FlowView'
 import { ServiceBreakdown } from '@/components/traces/ServiceBreakdown'
+import { SessionDetailPanel } from '@/components/traces/SessionDetailPanel'
 import { SpanPanel } from '@/components/traces/SpanPanel'
 import { TraceFilters } from '@/components/traces/TraceFilters'
+import { TraceGroupsView } from '@/components/traces/TraceGroupsView'
 import { TraceHeader } from '@/components/traces/TraceHeader'
 import { TraceMap } from '@/components/traces/TraceMap'
 import { ViewSwitcher, type ViewType } from '@/components/traces/ViewSwitcher'
@@ -72,6 +76,7 @@ function StatusIcon({ status }: { status: TraceGroup['status'] }) {
 }
 
 function TracesPage() {
+  const sdk = useEngineSdk()
   const [searchQuery, setSearchQuery] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -82,6 +87,11 @@ function TracesPage() {
   }, [])
   const [showSystem, setShowSystem] = useState(false)
   const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null)
+  // When `filterState.groupBy` is active, clicking a session row sets this.
+  // The detail panel switches to `SessionDetailPanel` which renders every
+  // trace in the group instead of just one. Cleared when groupBy goes back
+  // to 'none' or the user closes the panel.
+  const [selectedGroup, setSelectedGroup] = useState<ApiTraceGroup | null>(null)
 
   const [activeView, setActiveView] = useState<ViewType>('waterfall')
   const [selectedSpan, setSelectedSpan] = useState<VisualizationSpan | null>(null)
@@ -126,7 +136,7 @@ function TracesPage() {
     setWaterfallData(null)
 
     try {
-      const data = await fetchTraceTree(traceId)
+      const data = await fetchTraceTree(sdk, traceId)
 
       if (data.roots && data.roots.length > 0) {
         const wfData = treeToWaterfallData(data.roots)
@@ -147,7 +157,7 @@ function TracesPage() {
     } finally {
       setIsLoadingSpans(false)
     }
-  }, [])
+  }, [sdk])
 
   const selectTrace = useCallback(
     (traceId: string | null) => {
@@ -165,7 +175,24 @@ function TracesPage() {
     [loadTraceSpans],
   )
 
-  const selectedTrace = traceGroups.find((g) => g.traceId === selectedTraceId)
+  // In group-by mode the clicked trace_id comes from the engine's
+  // aggregated `TraceGroup` list, not from `traceGroups` (which is the
+  // flat-list `useTraceData` state and is empty when group-by is active).
+  // Synthesize a minimal stub so the existing detail-panel render guard
+  // (`{selectedTrace && (...)}`) still fires. Downstream code only reads
+  // `selectedTrace.traceId` — the other fields are placeholders.
+  const selectedTrace =
+    traceGroups.find((g) => g.traceId === selectedTraceId) ??
+    (selectedTraceId
+      ? ({
+          traceId: selectedTraceId,
+          rootOperation: 'trace',
+          status: 'ok' as const,
+          startTime: 0,
+          spanCount: 0,
+          services: [],
+        } satisfies TraceGroup)
+      : undefined)
 
   const filteredTraces = useMemo(() => {
     // When debouncedSearch is active, server already filtered by name across all spans
@@ -192,10 +219,23 @@ function TracesPage() {
   }, [filteredTraces, filterState.page, filterState.pageSize])
 
   useEffect(() => {
+    // In group-by mode `pagedTraces` is the flat-list view, which is empty
+    // (the view shows engine-aggregated groups instead). Don't auto-evict
+    // a selectedTraceId that came from clicking a group row.
+    if (filterState.groupBy && filterState.groupBy !== 'none') return
     if (selectedTraceId && !pagedTraces.some((g) => g.traceId === selectedTraceId)) {
       selectTrace(null)
     }
-  }, [pagedTraces, selectedTraceId, selectTrace])
+  }, [pagedTraces, selectedTraceId, selectTrace, filterState.groupBy])
+
+  // Clear any selected session group when group-by goes back to 'none',
+  // otherwise stale session state would briefly render alongside the
+  // flat-list view.
+  useEffect(() => {
+    if (!filterState.groupBy || filterState.groupBy === 'none') {
+      setSelectedGroup(null)
+    }
+  }, [filterState.groupBy])
 
   const stats = useMemo(
     () => ({
@@ -307,7 +347,16 @@ function TracesPage() {
               flushPendingTraces()
             }}
           >
-            {isQueryLoading && traceGroups.length === 0 ? (
+            {filterState.groupBy && filterState.groupBy !== 'none' ? (
+              <TraceGroupsView
+                attribute={filterState.groupBy}
+                showSystem={showSystem}
+                isPaused={isPaused}
+                selectedTraceId={selectedTraceId}
+                onSelectTrace={(traceId) => selectTrace(traceId)}
+                onSelectGroup={(group) => setSelectedGroup(group)}
+              />
+            ) : isQueryLoading && traceGroups.length === 0 ? (
               <div className="flex flex-col gap-0">
                 {(['tr-sk-0', 'tr-sk-1', 'tr-sk-2', 'tr-sk-3', 'tr-sk-4'] as const).map((sk) => (
                   <div key={sk} className="p-3 border-b border-border">
@@ -441,6 +490,22 @@ function TracesPage() {
               style={{ width: panelWidths.trace }}
               className={`bg-sidebar flex flex-col h-full overflow-hidden flex-shrink-0 animate-trace-panel-in ${isResizing ? 'pointer-events-none select-none' : ''}`}
             >
+              {selectedGroup ? (
+                // Session-level group: stacked vertical view of every
+                // trace in the group. Bypasses the single-trace
+                // isLoadingSpans/waterfallData path entirely — the
+                // session panel fetches each trace tree itself.
+                <SessionDetailPanel
+                  group={selectedGroup}
+                  onClose={() => {
+                    setSelectedGroup(null)
+                    selectTrace(null)
+                  }}
+                  onSpanClick={setSelectedSpan}
+                  selectedSpanId={selectedSpan?.span_id}
+                />
+              ) : (
+                <>
               {isLoadingSpans && (
                 <div className="flex-1 flex flex-col p-4 gap-3">
                   <div className="flex items-center gap-2">
@@ -529,6 +594,8 @@ function TracesPage() {
                   )}
                 </>
               )}
+                </>
+              )}
             </div>
           </>
         )}
@@ -554,7 +621,15 @@ function TracesPage() {
               className={`bg-sidebar flex-shrink-0 h-full overflow-hidden ${isResizing ? 'pointer-events-none select-none' : ''}`}
             >
               <SpanPanel
-                key={selectedSpan.span_id}
+                // Intentionally NO `key={span.span_id}`: a span-id keyed
+                // remount wipes the Tabs internal state, so switching
+                // between spans would snap the tab back to the
+                // `defaultValue` (errors or info). Keeping a single
+                // instance means the user's last-picked tab (e.g.
+                // Events, with `iii.invocation.input`/`output`)
+                // persists when they click through child spans —
+                // matching how every other devtool span inspector
+                // behaves.
                 span={selectedSpan}
                 traceData={waterfallData}
                 onClose={() => setSelectedSpan(null)}

--- a/console/packages/console-frontend/src/routes/traces.tsx
+++ b/console/packages/console-frontend/src/routes/traces.tsx
@@ -16,7 +16,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { fetchTraceTree } from '@/api'
 import { useEngineSdk } from '@/api/engine-sdk-provider'
-import type { TraceGroup as ApiTraceGroup } from '@/api/observability/traces'
+import type { TraceGroup } from '@/api/observability/traces'
 import { FlameGraph } from '@/components/traces/FlameGraph'
 import { FlowView } from '@/components/traces/FlowView'
 import { ServiceBreakdown } from '@/components/traces/ServiceBreakdown'
@@ -34,7 +34,7 @@ import { ErrorBoundary } from '@/components/ui/error-boundary'
 import { Pagination } from '@/components/ui/pagination'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useResizablePanels } from '@/hooks/useResizablePanels'
-import { type TraceGroup, useTraceData } from '@/hooks/useTraceData'
+import { type TraceListItem, useTraceData } from '@/hooks/useTraceData'
 import { useTraceFilters } from '@/hooks/useTraceFilters'
 import {
   treeToWaterfallData,
@@ -64,7 +64,7 @@ function formatTime(timestamp: number): string {
   })
 }
 
-function StatusIcon({ status }: { status: TraceGroup['status'] }) {
+function StatusIcon({ status }: { status: TraceListItem['status'] }) {
   switch (status) {
     case 'ok':
       return <CheckCircle2 className="w-3.5 h-3.5 text-success" />
@@ -91,7 +91,7 @@ function TracesPage() {
   // The detail panel switches to `SessionDetailPanel` which renders every
   // trace in the group instead of just one. Cleared when groupBy goes back
   // to 'none' or the user closes the panel.
-  const [selectedGroup, setSelectedGroup] = useState<ApiTraceGroup | null>(null)
+  const [selectedGroup, setSelectedGroup] = useState<TraceGroup | null>(null)
 
   const [activeView, setActiveView] = useState<ViewType>('waterfall')
   const [selectedSpan, setSelectedSpan] = useState<VisualizationSpan | null>(null)
@@ -144,15 +144,18 @@ function TracesPage() {
         if (wfData) {
           setWaterfallData(wfData)
         } else {
-          console.warn('[Traces] treeToWaterfallData returned null')
           setSpansError('Failed to process span data')
         }
       } else {
-        console.warn('[Traces] No roots found for trace:', traceId)
         setSpansError('No span data available for this trace')
       }
     } catch (error) {
-      console.error('[Traces] Failed to load trace tree:', error)
+      // Surface the stack to the devtools console only in dev — production
+      // users see the `spansError` UI state instead.
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.error('[Traces] Failed to load trace tree:', error)
+      }
       setSpansError(error instanceof Error ? error.message : 'Failed to load trace details')
     } finally {
       setIsLoadingSpans(false)
@@ -191,7 +194,7 @@ function TracesPage() {
           startTime: 0,
           spanCount: 0,
           services: [],
-        } satisfies TraceGroup)
+        } satisfies TraceListItem)
       : undefined)
 
   const filteredTraces = useMemo(() => {

--- a/console/packages/console-frontend/src/routes/traces.tsx
+++ b/console/packages/console-frontend/src/routes/traces.tsx
@@ -130,37 +130,40 @@ function TracesPage() {
     isPaused,
   })
 
-  const loadTraceSpans = useCallback(async (traceId: string) => {
-    setIsLoadingSpans(true)
-    setSpansError(null)
-    setWaterfallData(null)
+  const loadTraceSpans = useCallback(
+    async (traceId: string) => {
+      setIsLoadingSpans(true)
+      setSpansError(null)
+      setWaterfallData(null)
 
-    try {
-      const data = await fetchTraceTree(sdk, traceId)
+      try {
+        const data = await fetchTraceTree(sdk, traceId)
 
-      if (data.roots && data.roots.length > 0) {
-        const wfData = treeToWaterfallData(data.roots)
+        if (data.roots && data.roots.length > 0) {
+          const wfData = treeToWaterfallData(data.roots)
 
-        if (wfData) {
-          setWaterfallData(wfData)
+          if (wfData) {
+            setWaterfallData(wfData)
+          } else {
+            setSpansError('Failed to process span data')
+          }
         } else {
-          setSpansError('Failed to process span data')
+          setSpansError('No span data available for this trace')
         }
-      } else {
-        setSpansError('No span data available for this trace')
+      } catch (error) {
+        // Surface the stack to the devtools console only in dev — production
+        // users see the `spansError` UI state instead.
+        if (import.meta.env.DEV) {
+          // eslint-disable-next-line no-console
+          console.error('[Traces] Failed to load trace tree:', error)
+        }
+        setSpansError(error instanceof Error ? error.message : 'Failed to load trace details')
+      } finally {
+        setIsLoadingSpans(false)
       }
-    } catch (error) {
-      // Surface the stack to the devtools console only in dev — production
-      // users see the `spansError` UI state instead.
-      if (import.meta.env.DEV) {
-        // eslint-disable-next-line no-console
-        console.error('[Traces] Failed to load trace tree:', error)
-      }
-      setSpansError(error instanceof Error ? error.message : 'Failed to load trace details')
-    } finally {
-      setIsLoadingSpans(false)
-    }
-  }, [sdk])
+    },
+    [sdk],
+  )
 
   const selectTrace = useCallback(
     (traceId: string | null) => {
@@ -509,94 +512,96 @@ function TracesPage() {
                 />
               ) : (
                 <>
-              {isLoadingSpans && (
-                <div className="flex-1 flex flex-col p-4 gap-3">
-                  <div className="flex items-center gap-2">
-                    <Skeleton className="w-4 h-4 rounded-full" />
-                    <Skeleton className="h-4 w-32" />
-                    <Skeleton className="h-4 w-20 ml-auto" />
-                  </div>
-                  {(['tr-p-sk-0', 'tr-p-sk-1', 'tr-p-sk-2', 'tr-p-sk-3', 'tr-p-sk-4'] as const).map(
-                    (sk) => (
-                      <div key={sk} className="flex items-center gap-2">
-                        <Skeleton className="h-6 w-full" />
+                  {isLoadingSpans && (
+                    <div className="flex-1 flex flex-col p-4 gap-3">
+                      <div className="flex items-center gap-2">
+                        <Skeleton className="w-4 h-4 rounded-full" />
+                        <Skeleton className="h-4 w-32" />
+                        <Skeleton className="h-4 w-20 ml-auto" />
                       </div>
-                    ),
-                  )}
-                </div>
-              )}
-
-              {!isLoadingSpans && spansError && (
-                <div className="flex-1 flex flex-col items-center justify-center p-8">
-                  <div className="w-10 h-10 mb-3 rounded-lg bg-dark-gray border border-border flex items-center justify-center">
-                    <AlertCircle className="w-5 h-5 text-error" />
-                  </div>
-                  <div className="text-xs font-medium mb-1 text-error">Failed to load trace</div>
-                  <div className="text-[10px] text-muted text-center mb-3 max-w-xs">
-                    {spansError}
-                  </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => loadTraceSpans(selectedTrace.traceId)}
-                    className="text-[10px] h-6"
-                  >
-                    <RefreshCw className="w-3 h-3 mr-1" />
-                    Retry
-                  </Button>
-                </div>
-              )}
-
-              {!isLoadingSpans && !spansError && waterfallData && (
-                <>
-                  <TraceHeader
-                    data={waterfallData}
-                    traceId={selectedTrace.traceId}
-                    onClose={() => selectTrace(null)}
-                    onSpanClick={setSelectedSpan}
-                  />
-
-                  <div className="border-b border-border-subtle px-4 py-2.5">
-                    <ViewSwitcher currentView={activeView} onViewChange={setActiveView} />
-                  </div>
-
-                  <div className="flex-1 overflow-auto min-h-0">
-                    {activeView === 'waterfall' && (
-                      <WaterfallChart
-                        data={waterfallData}
-                        onSpanClick={setSelectedSpan}
-                        selectedSpanId={selectedSpan?.span_id}
-                      />
-                    )}
-
-                    {activeView === 'flamegraph' && (
-                      <FlameGraph
-                        data={waterfallData}
-                        onSpanClick={setSelectedSpan}
-                        selectedSpanId={selectedSpan?.span_id}
-                      />
-                    )}
-
-                    {activeView === 'map' && (
-                      <TraceMap data={waterfallData} onSpanClick={setSelectedSpan} />
-                    )}
-
-                    {activeView === 'flow' && (
-                      <FlowView
-                        data={waterfallData}
-                        onSpanClick={setSelectedSpan}
-                        selectedSpanId={selectedSpan?.span_id}
-                      />
-                    )}
-                  </div>
-
-                  {activeView !== 'flow' && (
-                    <div className="border-t border-border-subtle flex-shrink-0">
-                      <ServiceBreakdown data={waterfallData} />
+                      {(
+                        ['tr-p-sk-0', 'tr-p-sk-1', 'tr-p-sk-2', 'tr-p-sk-3', 'tr-p-sk-4'] as const
+                      ).map((sk) => (
+                        <div key={sk} className="flex items-center gap-2">
+                          <Skeleton className="h-6 w-full" />
+                        </div>
+                      ))}
                     </div>
                   )}
-                </>
-              )}
+
+                  {!isLoadingSpans && spansError && (
+                    <div className="flex-1 flex flex-col items-center justify-center p-8">
+                      <div className="w-10 h-10 mb-3 rounded-lg bg-dark-gray border border-border flex items-center justify-center">
+                        <AlertCircle className="w-5 h-5 text-error" />
+                      </div>
+                      <div className="text-xs font-medium mb-1 text-error">
+                        Failed to load trace
+                      </div>
+                      <div className="text-[10px] text-muted text-center mb-3 max-w-xs">
+                        {spansError}
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => loadTraceSpans(selectedTrace.traceId)}
+                        className="text-[10px] h-6"
+                      >
+                        <RefreshCw className="w-3 h-3 mr-1" />
+                        Retry
+                      </Button>
+                    </div>
+                  )}
+
+                  {!isLoadingSpans && !spansError && waterfallData && (
+                    <>
+                      <TraceHeader
+                        data={waterfallData}
+                        traceId={selectedTrace.traceId}
+                        onClose={() => selectTrace(null)}
+                        onSpanClick={setSelectedSpan}
+                      />
+
+                      <div className="border-b border-border-subtle px-4 py-2.5">
+                        <ViewSwitcher currentView={activeView} onViewChange={setActiveView} />
+                      </div>
+
+                      <div className="flex-1 overflow-auto min-h-0">
+                        {activeView === 'waterfall' && (
+                          <WaterfallChart
+                            data={waterfallData}
+                            onSpanClick={setSelectedSpan}
+                            selectedSpanId={selectedSpan?.span_id}
+                          />
+                        )}
+
+                        {activeView === 'flamegraph' && (
+                          <FlameGraph
+                            data={waterfallData}
+                            onSpanClick={setSelectedSpan}
+                            selectedSpanId={selectedSpan?.span_id}
+                          />
+                        )}
+
+                        {activeView === 'map' && (
+                          <TraceMap data={waterfallData} onSpanClick={setSelectedSpan} />
+                        )}
+
+                        {activeView === 'flow' && (
+                          <FlowView
+                            data={waterfallData}
+                            onSpanClick={setSelectedSpan}
+                            selectedSpanId={selectedSpan?.span_id}
+                          />
+                        )}
+                      </div>
+
+                      {activeView !== 'flow' && (
+                        <div className="border-t border-border-subtle flex-shrink-0">
+                          <ServiceBreakdown data={waterfallData} />
+                        </div>
+                      )}
+                    </>
+                  )}
                 </>
               )}
             </div>

--- a/console/packages/console-frontend/vitest.config.ts
+++ b/console/packages/console-frontend/vitest.config.ts
@@ -1,0 +1,15 @@
+import path from 'node:path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'node',
+    globals: false,
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  },
+})

--- a/console/packages/console-rust/src/main.rs
+++ b/console/packages/console-rust/src/main.rs
@@ -134,6 +134,7 @@ async fn main() -> Result<()> {
         engine_host: args.engine_host,
         engine_port: args.engine_port,
         ws_port: args.ws_port,
+        bridge_port: args.bridge_port,
         enable_flow: args.enable_flow,
     };
 

--- a/console/packages/console-rust/src/server.rs
+++ b/console/packages/console-rust/src/server.rs
@@ -28,6 +28,7 @@ pub struct ServerConfig {
     pub engine_host: String,
     pub engine_port: u16,
     pub ws_port: u16,
+    pub bridge_port: u16,
     pub enable_flow: bool,
 }
 
@@ -44,6 +45,7 @@ fn get_index_html(config: &ServerConfig) -> String {
         "engineHost": config.engine_host,
         "enginePort": config.engine_port,
         "wsPort": config.ws_port,
+        "bridgePort": config.bridge_port,
         "enableFlow": config.enable_flow,
     });
 
@@ -85,6 +87,7 @@ async fn serve_config(
         "engineHost": config.engine_host,
         "enginePort": config.engine_port,
         "wsPort": config.ws_port,
+        "bridgePort": config.bridge_port,
         "consolePort": config.port,
         "version": env!("CARGO_PKG_VERSION"),
         "enableFlow": config.enable_flow,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       dagre:
         specifier: ^0.8.5
         version: 0.8.5
+      iii-browser-sdk:
+        specifier: workspace:*
+        version: link:../../../sdk/packages/node/iii-browser
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.4)
@@ -154,6 +157,9 @@ importers:
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@25.3.3)(happy-dom@17.6.3)(lightningcss@1.31.1)
 
   docs:
     devDependencies:


### PR DESCRIPTION
## Summary

Migrates the console TRACES page off the HTTP transport and onto the `iii-browser-sdk` WebSocket bridge (engine `bridge_port`), then takes the feature through a portability + code-quality pass. Result: 164 unit tests where there were 0, every Tailwind hex literal in the feature converted to design tokens, hooks broken down into pure-logic libs, and an injectable `EngineSdkProvider` so the feature can be embedded outside this console.

## Why

The traces page was the only console feature still on the HTTP transport. Migrating it brings the whole console onto one transport surface (the SDK) and removes a parallel codepath. Once on the SDK, the natural follow-up was "could a different React app reuse this feature?" — this PR answers yes and lays the test/seam groundwork.

## What's in here

**Transport**
- `console-rust`: surface `bridge_port` on `ServerConfig` and emit it as `bridgePort` in the runtime config payload.
- `iii-browser-sdk` dep added to `console-frontend`; `EngineSdkProvider` wraps the app.
- `api/observability/traces.ts` rewritten on top of `ISdk.trigger` with per-function timeouts, generic `stripUndefined<T>`, and a memory-exporter-not-enabled fallback for list/tree (clear still rethrows by design).
- Engine contract exported as `TRACES_RPC_FUNCTIONS` with versioning JSDoc.

**Recovered features (from stash)**
- Group-by view: `lib/groupTraces.ts`, `hooks/useTraceGroups.ts`, `components/traces/TraceGroupsView.tsx`, `components/traces/SessionDetailPanel.tsx`, group-by popover in `TraceFilters`.
- Waterfall toolbar: \"Collapse routing pairs\" and \"Hide engine routing\" checkboxes + `lib/spanLabel.ts` engine-routing heuristics.
- `SpanLogsTab`: JSON pretty-printer for `iii.payload.json` attributes.

**Portability + theming**
- ~185 Tailwind-class hex literals across 15 component files swept to semantic tokens (`bg-sidebar`, `border-border-subtle`, `text-accent`, ...) so the feature re-themes under `[data-theme=\"light\"]` and in any host that overrides the CSS custom properties.
- `STATUS_CONFIG` (`lib/traceUtils.ts`) uses `var(--success/error/muted)` + `color-mix()` for subtle tints.
- Accent-yellow box-shadows in `WaterfallChart` + `FlowView` use `color-mix(in srgb, var(--accent) NN%, transparent)`.
- `EngineSdkProvider` accepts `sdk?: ISdk` (consumer-owned lifecycle) and `bridgeUrl?: string` (override the `ConfigProvider` chain). Default behavior unchanged.
- ASCII data-flow diagrams in `WaterfallChart`, `api/observability/traces.ts`, `SessionDetailPanel`, `FlameGraph`, `TraceMap`.
- Local `TraceGroup` (per-trace view-model) renamed to `TraceListItem` to deconflict with the server-side aggregate.

**Pure-logic extractions (all from hooks/components → testable libs)**
- `lib/groupTraces.ts` — group-by labels, summarize, wildcard sentinel rewrite
- `lib/spanLabel.ts` — engine routing detection, label formatting
- `lib/formatPossibleJson.ts` — JSON pretty-print detection
- `lib/traceFilters.ts` — camelCase→snake_case translation + range-swap validation
- `lib/traceListItem.ts` — span→view-model mapper + identity fingerprint
- `lib/spanTree.ts` — parent linking, critical-path greedy DFS, depth-offset hide, routing-pair merge

**Behavior fixes**
- `SessionDetailPanel` now lazy-fetches per card (was firing N parallel `useQueries` on mount — a 100-trace session opened 100 simultaneous WebSocket calls).
- `useTraceData` fingerprint hashes all trace IDs (was first/last/count — would have missed middle-only churn if sort order ever flipped).
- `isGroupByUnavailable` regex tightened from `/function_not_found|group_by|404/` to `/function_not_found/i`. The old version silently swallowed legitimate errors that happened to contain \"group_by\" or \"404\" in the message.
- `console.warn`/`console.error` in `routes/traces.tsx` cleaned up; surviving `console.error` gated behind `import.meta.env.DEV`.
- `'use client'` no-ops dropped (3 files — Vite project, copy-paste from a Next.js reference).
- React 19 `MutableRefObject` → `RefObject` deprecation cleared.

**Tests added**
| File | Tests |
|------|------:|
| `api/observability/traces.test.ts` | 15 |
| `lib/groupTraces.test.ts` | 14 |
| `lib/spanLabel.test.ts` | 21 |
| `lib/formatPossibleJson.test.ts` | 10 |
| `lib/traceFilters.test.ts` | 24 |
| `lib/traceListItem.test.ts` | 30 |
| `lib/traceUtils.test.ts` | 20 |
| `lib/traceTransform.test.ts` | 10 |
| `lib/spanTree.test.ts` | 20 |
| **Total** | **164** |

## Out of scope (deferred)

- Component / route DOM tests — needs `@testing-library/react` + jsdom infra.
- E2E suite (Playwright) — net-new tooling setup.
- Canvas theming for `FlameGraph` + `TraceMap` — documented refactor pattern in both file headers (`getComputedStyle` + theme-change observer).
- `WaterfallChart` virtualization — `@tanstack/react-virtual` integration.
- `api/queries.ts` per-feature split — affects every console feature, not just traces.

## Test plan

- [ ] `pnpm exec tsc --noEmit` clean
- [ ] `pnpm test` 164/164 green
- [ ] `biome check` clean on touched files
- [ ] Manual smoke: open `iii dev`, navigate to /traces, verify list, click a trace, see waterfall, toggle the new \"Hide engine routing\" + \"Collapse routing pairs\" checkboxes
- [ ] Manual smoke: switch \"Group by\" to session/message/function — verify groups render and clicking opens the SessionDetailPanel (one card per trace_id, first auto-open, others lazy-fetch on click)
- [ ] Manual smoke: span detail panel → Events tab on a span with `iii.payload.json` — verify the JSON renders as a pretty-printed `<pre>` block
- [ ] Manual smoke: clear traces button works (clearTraces does NOT swallow memory-exporter-not-enabled errors)
- [ ] Visual check: theme tokens render correctly in dark mode (default); spot-check that no obvious color regressed

## Commit stack

```
3bdc84793 refactor: extract WaterfallChart span tree logic + 20 tests
7f11d2221 test: cover traceUtils + traceTransform pure helpers
8af2e8320 chore: biome auto-fix + drop deprecated MutableRefObject
da6f6533e refactor: extract span->ListItem mapper + 30 tests
a0a0f9e23 refactor: extract pure filter-param builder + 24 tests
bc9b10394 refactor: sweep remaining traces hex literals to design tokens
c897592ba refactor: lazy-fetch session details + extract JSON helper + STATUS_CONFIG tokens
4ae493e8b refactor: portability + code-quality pass on the traces page
68fc707fb feat: migrate traces page to iii-browser-sdk + restore group-by, engine-routing, JSON log controls
```