### PR TITLE
chore: bump versions for release -- iii(iii/v0.12.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "iii"
-version = "0.14.0-next.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "iii-console"
-version = "0.14.0-next.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.14.0-next.1"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "ctor",
@@ -2822,7 +2822,7 @@ dependencies = [
 
 [[package]]
 name = "iii-worker"
-version = "0.14.0-next.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "motia-tools"
-version = "0.14.0-next.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "scaffolder-core"
-version = "0.14.0-next.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.0-next.1"
+version = "0.12.0"
 edition = "2024"
 authors = ["Motia LLC"]
 repository = "https://github.com/iii-hq/iii"

--- a/console/packages/console-rust/Cargo.toml
+++ b/console/packages/console-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iii-console"
-version = "0.14.0-next.1"
+version = "0.12.0"
 edition = "2021"
 description = "Developer console for the iii engine"
 license = "Apache-2.0"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iii"
-version = "0.14.0-next.1"
+version = "0.12.0"
 edition = "2024"
 license = "Elastic-2.0"
 

--- a/sdk/packages/node/iii-browser/package.json
+++ b/sdk/packages/node/iii-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iii-browser-sdk",
-  "version": "0.14.0-next.1",
+  "version": "0.12.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/sdk/packages/node/iii/package.json
+++ b/sdk/packages/node/iii/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iii-sdk",
-  "version": "0.14.0-next.1",
+  "version": "0.12.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/sdk/packages/python/iii/pyproject.toml
+++ b/sdk/packages/python/iii/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "iii-sdk"
-version = "0.14.0.dev1"
+version = "0.12.0"
 description = "III SDK for Python"
 authors = [{ name = "III" }]
 license = { text = "Apache-2.0" }

--- a/sdk/packages/rust/iii/Cargo.toml
+++ b/sdk/packages/rust/iii/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iii-sdk"
-version = "0.14.0-next.1"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Rewrite all 7 iii manifest files from `0.14.0-next.1` to `0.12.0` (Python PEP 440 form: `0.12.0`).
- Sync `Cargo.lock` so all 6 workspace crates resolve to `0.12.0`.

After merging this, tag `iii/v0.12.0` on the merge commit to trigger the release pipeline.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, push `iii/v0.12.0` tag and confirm `release-iii.yml` publishes to crates.io, npm (latest), PyPI, Docker, and Homebrew

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions across the SDK, engine, and console packages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->