### PR TITLE
fix(engine): pass -y when stopping external workers

### DIFF
--- a/engine/src/workers/registry_worker.rs
+++ b/engine/src/workers/registry_worker.rs
@@ -303,7 +303,7 @@ impl ExternalWorkerProcess {
         // actual worker process.
         if let Some(binary) = resolve_iii_worker_binary() {
             let result = tokio::process::Command::new(&binary)
-                .args(["stop", &self.name])
+                .args(["stop", "-y", &self.name])
                 .output()
                 .await;
             match result {


### PR DESCRIPTION
## Summary
- Engine spawns `iii-worker stop <name>` as a subprocess on shutdown. Without `-y`, the CLI's consent guard fails non-interactively and exits 1 with `stop is destructive; pass -y/--yes for non-interactive use`.
- Symptom: pressing Ctrl-C on the engine surfaces the error message and leaves workers running.
- Fix: pass `-y` in the subprocess invocation at `engine/src/workers/registry_worker.rs:306`.

## Test plan
- [ ] Start engine with an external worker, press Ctrl-C, confirm no `stop is destructive` message and worker process exits.
- [ ] `cargo check -p iii --lib` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced external worker shutdown process with automatic confirmation, reducing manual steps required when stopping workers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->