### PR TITLE
docs(http): add agent skills bundle for iii-http worker

### DIFF
--- a/engine/src/workers/rest_api/skills/index.md
+++ b/engine/src/workers/rest_api/skills/index.md
@@ -1,0 +1,22 @@
+---
+type: index
+title: iii-http
+---
+
+# iii-http
+
+The `iii-http` worker exposes registered functions as HTTP endpoints. It runs an axum server on the configured `port`/`host`, routes incoming requests against `http` triggers (the only trigger type it provides), and invokes the bound function with an `HttpRequest` payload. The function returns an `HttpResponse` envelope (`status_code`/`headers`/`body`) which the worker serializes back to the wire — choosing JSON, plain text, or bytes based on the `Content-Type` header the handler sets.
+
+The worker has **no callable functions**. Its entire surface is one trigger type (`http`) plus a middleware system that runs before each handler. Routes are registered through `iii.registerTrigger({ type: 'http', ... })`. Middleware is plain registered functions whose ids are listed in either the global config (`iii-config.yaml` → `middleware:`) or the per-trigger `middleware_function_ids` array; the worker invokes them in order before each request reaches its handler.
+
+For the full server config block (`port`, `host`, `default_timeout`, `concurrency_request_limit`, `cors`, `body_limit`, `trust_proxy`, `request_id_header`, `ignore_trailing_slash`, `not_found_function`) see [the README](../README.md).
+
+- **`http` trigger** — bind a registered function to an `(api_path, http_method)` pair. Optional `condition_function_id` gates the firing; optional `middleware_function_ids` runs per-route preHandlers.
+- **Middleware functions** — preHandler hooks for cross-cutting concerns (auth, rate limiting, request logging). Each middleware returns either `{ action: "continue" }` to proceed or `{ action: "respond", response }` to short-circuit with an immediate response.
+
+## How-tos
+
+### `http` triggers
+
+- [Expose a function as an HTTP endpoint](iii://iii-http/http/reactive-triggers) — register a handler and an `http` trigger to route an `(api_path, http_method)` pair to that handler, including the `HttpRequest` payload shape, the `HttpResponse` return contract, and the per-route condition/middleware hooks.
+- [Add request preHandler middleware](iii://iii-http/http/middleware) — register middleware functions globally (via `iii-config.yaml`) or per-route (via `middleware_function_ids`) to run authentication, rate limiting, logging, or any other cross-cutting concern before the handler.

--- a/engine/src/workers/rest_api/skills/skills/http/middleware.md
+++ b/engine/src/workers/rest_api/skills/skills/http/middleware.md
@@ -1,0 +1,125 @@
+---
+type: how-to
+trigger_type: http
+title: Add request preHandler middleware
+---
+
+# When to use
+
+Register a middleware function when the same logic must run before **multiple** route handlers — authentication, rate limiting, request logging, header normalization, IP allow-listing. Middleware sits between the worker's body parser and the handler; it inspects the request and either lets it proceed (with optional `context` enrichment) or short-circuits with an immediate response.
+
+| Question                                                                              | Use this                                                            |
+|---------------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| Should this run on **every** matched HTTP route?                                      | Global middleware (configured in `iii-config.yaml` → `middleware:`) |
+| Should this run only on a specific subset of routes?                                  | Per-route middleware (`middleware_function_ids` on the trigger)     |
+| Is the function the route's actual response logic, not a precondition?                | The handler itself — see [Expose a function as an HTTP endpoint](iii://iii-http/http/reactive-triggers) |
+| Should it gate firing without supplying its own response?                             | The trigger's `condition_function_id` (returns truthy/falsy only)  |
+
+Reach for it when:
+
+- You need to enforce auth across many endpoints — register one auth middleware globally and have it short-circuit on missing/invalid bearer tokens.
+- You want to attach a per-request value (verified user, tenant id, request id) to `context` so handlers receive it without re-parsing the request.
+- You need rate-limiting or request-size accounting that runs uniformly without each handler having to call into a shared library.
+
+# Inputs
+
+A middleware is just a regular registered function whose function id is referenced by config. Two registration paths target it at routes:
+
+## Global middleware
+
+Configure on the worker in `iii-config.yaml`. Runs on **every** matching HTTP route, sorted by `priority` ascending (lower priority runs first).
+
+```yaml
+- name: iii-http
+  config:
+    middleware:
+      - function_id: "global::rate-limiter"          # required. Function id of the middleware to invoke.
+        phase: preHandler                            # optional. Currently only "preHandler" is supported. Defaults to "preHandler".
+        priority: 5                                  # optional. Execution order, lower runs first. Defaults to 0.
+      - function_id: "global::auth"
+        phase: preHandler
+        priority: 10
+```
+
+## Per-route middleware
+
+Set `middleware_function_ids` on the `http` trigger config. Runs **after** the global chain, in array order.
+
+```json
+{
+  "type":        "http",
+  "function_id": "api::get-admin-data",
+  "config": {
+    "api_path":                "/admin/data",
+    "http_method":             "GET",
+    "middleware_function_ids": ["auth::require-admin", "audit::log-access"]   // invoked in order; either may short-circuit before the handler runs
+  }
+}
+```
+
+The full preHandler chain executes in this order on every request:
+
+1. Route match (against `api_path` + `http_method`).
+2. Global middleware (sorted by `priority` ascending).
+3. Route condition (the trigger's optional `condition_function_id`).
+4. Per-route middleware (in `middleware_function_ids` array order).
+5. Body parsing.
+6. Handler function.
+
+Any middleware can stop the chain by returning `{ action: "respond", ... }`; subsequent middleware and the handler are skipped.
+
+# Outputs
+
+The middleware function receives a **subset** of the `HttpRequest` — body is omitted because middleware runs before body parsing:
+
+```json
+{
+  "path":         "/users/123",                       // request path
+  "method":       "GET",                              // HTTP method
+  "path_params":  { "id": "123" },                    // path variables from :name segments
+  "query_params": { "fields": "name,email" },         // query string
+  "headers":      { "authorization": "Bearer ...", "content-type": "application/json" }  // request headers (lowercased keys)
+}
+```
+
+The middleware must return one of two shapes:
+
+```json
+// Continue: pass control to the next middleware (or the handler when this is the last one).
+{
+  "action":  "continue",
+  "context": { "user_id": "u_123", "scopes": ["read", "write"] }   // optional. Merged into HttpRequest.context for downstream middleware and the handler.
+}
+```
+
+```json
+// Respond: short-circuit with an immediate HTTP response. Subsequent middleware and the handler do not run.
+{
+  "action":   "respond",
+  "response": {                                       // The same shape an HTTP handler returns — see "Outputs" in the http trigger how-to for full rules.
+    "status_code": 401,
+    "headers":     { "Content-Type": "application/json" },
+    "body":        { "error": "missing_or_invalid_bearer" }
+  }
+}
+```
+
+- `action` is required and must be exactly `"continue"` or `"respond"`. Any other value (including a missing `action` field) is treated as an error and short-circuits the request with a 500.
+- On `"continue"`, the optional `context` field is shallow-merged into `HttpRequest.context`; later middleware can read or extend it; the handler sees the final accumulated object.
+- On `"respond"`, the `response` object follows the same `HttpResponse` rules as a regular handler — `status_code` defaults to 200 if omitted, headers can be object or array form, and Content-Type drives body serialization.
+
+# Worked example
+
+The typical pattern is one middleware function per cross-cutting concern, wired up either globally or per-route:
+
+- **Global auth.** Register an auth middleware whose function id is in the global `middleware:` list with `phase: preHandler`. It inspects `headers.authorization`, returns `{ action: "respond", response: { status_code: 401, ... } }` on missing/invalid tokens, or `{ action: "continue", context: { user_id, scopes } }` on success — every handler then receives `HttpRequest.context.user_id` without parsing the header itself.
+- **Per-route admin gate.** On routes that need elevated privilege, set `middleware_function_ids: ["auth::require-admin"]`. The route condition (`condition_function_id`) is the right place for cheap boolean checks; middleware is the right place when you need to enrich `context` or return a structured error response.
+- **Logging + rate-limit chain.** Stack multiple middleware globally with explicit priorities (`priority: 5` for rate-limit before `priority: 10` for auth), so the cheaper check runs first and rejects 429s before authentication work happens.
+
+For runnable scaffolds in TypeScript, Python, and Rust, see the http worker source and the SDK usage examples in [the iii main repo](https://github.com/iii-hq/iii).
+
+# Related
+
+- [Expose a function as an HTTP endpoint](iii://iii-http/http/reactive-triggers) — the route how-to; `middleware_function_ids` is documented there as part of the trigger config.
+- `iii-http` worker config (see [the README](../../../README.md)) — full `middleware:` block schema with all defaults.
+- `condition_function_id` (on the http trigger) — the lighter-weight gate when you only need a boolean check and don't need to attach context or shape the error response.

--- a/engine/src/workers/rest_api/skills/skills/http/reactive-triggers.md
+++ b/engine/src/workers/rest_api/skills/skills/http/reactive-triggers.md
@@ -1,0 +1,115 @@
+---
+type: how-to
+trigger_type: http
+title: Expose a function as an HTTP endpoint
+---
+
+# When to use
+
+Register an `http` trigger when a registered function should be invoked by an inbound HTTP request matching an `(api_path, http_method)` pair. The worker handles routing, parsing, body limits, CORS, and timeouts; the bound function receives a structured `HttpRequest` and returns an `HttpResponse` envelope.
+
+Reach for it when:
+
+- You want to expose a function as a REST endpoint without standing up a separate HTTP server.
+- You need URL path parameters (`/users/:id`) or query strings parsed and surfaced to the handler.
+- You want condition-gated routes (the trigger's `condition_function_id` is invoked with the request and the handler is skipped on falsy/error) or per-route preHandler middleware (see [Add request preHandler middleware](iii://iii-http/http/middleware)).
+- You want a single not-found handler for unmatched routes (configure `not_found_function` on the worker — see [the README](../../../README.md)).
+
+Use [middleware](iii://iii-http/http/middleware) instead when the work is cross-cutting and should run before *every* matching request rather than be the route handler itself.
+
+Prerequisite: the `iii-http` worker must be enabled in `config.yaml`. Handlers and triggers are registered from a connected worker via `iii.registerFunction` and `iii.registerTrigger` — the worker has no `http::*` engine functions.
+
+# Inputs
+
+Registration is a two-step pattern: define the handler function, then bind it to the `http` trigger type.
+
+## Handler function
+
+Register any function id. The handler receives the `HttpRequest` payload documented below in **Outputs** and must return an `HttpResponse` envelope.
+
+```json
+// iii.registerFunction — handler id only; no engine payload.
+{ "id": "api::get-user" }
+```
+
+## Trigger registration
+
+```json
+{
+  "type":        "http",                              // required. Must be exactly "http".
+  "function_id": "api::get-user",                     // required. Handler invoked when the route matches.
+  "config": {
+    "api_path":                "/users/:id",         // required. URL path. ":name" segments become path_params on the request.
+    "http_method":             "GET",                // required. HTTP method (case-insensitive: "GET", "POST", "PUT", "DELETE", "PATCH", etc.).
+    "condition_function_id":   "auth::is-public",    // optional. Engine invokes this with the request; handler runs only on truthy.
+    "middleware_function_ids": ["auth::require-bearer", "log::request"]  // optional. Per-route preHandler chain, invoked in array order before the handler.
+  }
+}
+```
+
+`type`, `function_id`, `config.api_path`, and `config.http_method` are required. The path syntax recognizes `:name` segments as path parameters; everything else is matched literally. Two routes registered against the same `(api_path, http_method)` pair conflict — the worker's hot router resolves to the most recently registered.
+
+`condition_function_id` is optional. When set, the engine calls it with the same `HttpRequest` the handler would receive and runs the handler only when it returns truthy. A condition that errors is logged and the handler is skipped — the request gets the worker's not-found response (or `404` if `not_found_function` is unset).
+
+`middleware_function_ids` is optional. Each id is invoked in array order **after** any global middleware configured on the worker; see [Add request preHandler middleware](iii://iii-http/http/middleware) for the contract.
+
+# Outputs
+
+When a route matches, the engine invokes `function_id` with the `HttpRequest` payload:
+
+```json
+{
+  "path":         "/users/123",                       // The full request path as received.
+  "method":       "GET",                              // The HTTP method.
+  "path_params":  { "id": "123" },                    // Variables extracted from `:name` segments in api_path.
+  "query_params": { "fields": "name,email" },         // URL query string parameters.
+  "headers":      { "content-type": "application/json", "authorization": "Bearer ..." },  // Request headers (lowercased keys).
+  "body":         { "any": "json" },                  // Parsed request body. JSON object/array/scalar; `null` when the request had no body.
+  "trigger":      { "type": "http", "path": "/users/:id", "method": "GET" },  // Optional. Trigger metadata so handlers bound to multiple routes can dispatch on the original `api_path`.
+  "context":      { "user_id": "u_123" }              // Populated by middleware via { action: "continue" }; merged across all middleware in chain order.
+}
+```
+
+- `path_params` keys come from `:name` segments in the configured `api_path`. A request to `/users/123` against `/users/:id` produces `{"id":"123"}`. Path params are always strings; coerce numerically inside the handler if needed.
+- `query_params` flattens the URL's query string. Repeated keys keep only the **last** value (this worker uses a `HashMap<String, String>`, not a multimap); if you need multi-valued params, pre-encode them as a comma-joined value or split into distinct keys.
+- `headers` keys are lowercase. Match case-insensitively in the handler.
+- `body` is the parsed JSON body. Empty bodies arrive as `null`. The worker rejects bodies larger than `body_limit` (default 1 MB) before the handler runs.
+- `trigger` is populated when this request was routed via an `http` trigger; downstream workers that share handlers across trigger types (`http`, `cron`, `state`, ...) branch on `trigger.type`.
+- `context` accumulates fields each middleware adds when it returns `{ action: "continue", context: { ... } }`. Auth middleware typically attaches the verified user; rate-limit middleware attaches counter info.
+
+The handler must return an `HttpResponse` envelope:
+
+```json
+{
+  "status_code": 200,                                  // HTTP status code. Defaults to 200 when omitted.
+  "headers":     { "Content-Type": "application/json", "X-Custom": "value" },  // Response headers. Either an object (preferred) or an array of "Name: value" strings.
+  "body":        { "user": { "id": "123", "name": "Alice" } }                  // Response payload. JSON object/array/scalar/string; serialization is chosen by Content-Type (see below).
+}
+```
+
+- `status_code` defaults to 200 when omitted or non-numeric.
+- `headers` accepts both shapes:
+  - Object form (`{ "Name": "value" }`) — preferred.
+  - Array form (`["Name: value", "Other: value"]`) — entries without a colon or with non-string values are silently dropped.
+- `body` serialization follows the `Content-Type`:
+  - When `Content-Type` is unset, the worker defaults to `application/json` and serializes `body` as JSON.
+  - When `Content-Type` is set and the body is a JSON string, the string's bytes are written verbatim (use this for HTML, XML, plain text).
+  - When `Content-Type` is set, not `application/json`, and the body is an object/array, it's stringified before writing.
+- The default `Content-Type: application/json` is added only when the handler doesn't set its own.
+
+# Worked example
+
+The typical pattern is a one-step registration:
+
+- Register a function with `iii.registerFunction` to receive the `HttpRequest` payload above.
+- Bind it via `iii.registerTrigger({ type: 'http', function_id, config: { api_path, http_method } })`.
+
+For path parameters, use `:name` segments in `api_path`; the matching value arrives in `path_params[name]`. For per-route preHandlers (auth checks, rate limits), set `middleware_function_ids` on the trigger config — the chain runs after any global middleware configured in `iii-config.yaml`.
+
+For runnable scaffolds in TypeScript, Python, and Rust, see the http worker source and the SDK usage examples in [the iii main repo](https://github.com/iii-hq/iii).
+
+# Related
+
+- [Add request preHandler middleware](iii://iii-http/http/middleware) — the matching how-to for cross-cutting concerns; `middleware_function_ids` on a trigger references middleware ids documented there.
+- `iii-http` worker config (see [the README](../../../README.md)) — `port`, `host`, `default_timeout`, `concurrency_request_limit`, `cors`, `body_limit`, `trust_proxy`, `request_id_header`, `ignore_trailing_slash`, `not_found_function`.
+- `state`/`stream`/`cron` reactive triggers — pair with `http` when an inbound request should kick off a state mutation that fans out via reactive triggers.


### PR DESCRIPTION
## Summary

Adds the agent skills bundle for the **`iii-http`** built-in engine worker (folder name `rest_api`, registry slug `iii-http`). Follows the canonical convention established by [#1667](https://github.com/iii-hq/iii/pull/1667) (state worker + publishing pipeline).

This is one of an N-PR plan to add skills bundles to each engine built-in worker — paired with #1665 (`iii-stream`) and #1666 (`iii-cron`).

### What's added

```
engine/src/workers/rest_api/skills/
├── index.md                                    # type: index — worker overview
└── skills/
    └── http/
        ├── reactive-triggers.md                # the `http` trigger type (route handlers)
        └── middleware.md                       # request preHandler middleware (separate concept)
```

The two how-tos under `skills/skills/http/` reflect the worker's two distinct registration concepts: the `http` trigger that binds a function to an `(api_path, http_method)` pair, and the middleware system that runs before the handler. Both can be deep-linked: `iii://iii-http/http/reactive-triggers` and `iii://iii-http/http/middleware`.

### Faithful to the source

Inputs/outputs come straight from the Rust types in `engine/src/workers/rest_api/`:

- Trigger config (`api_path`, `http_method`, `condition_function_id`, `middleware_function_ids`) — `engine/src/workers/rest_api/types.rs` + `README.md` "Trigger Type: `http`".
- `HttpRequest` shape (`path`, `method`, `path_params`, `query_params`, `headers`, `body`, `trigger`, `context`) — `types.rs:30-42`.
- `HttpResponse` shape and serialization rules (object-vs-array headers, Content-Type-driven body serialization, default `application/json`) — `types.rs:44-132` and the test cases in `types.rs:200-378`.
- Middleware contract (`{ action: "continue", context }` vs `{ action: "respond", response }`) — `README.md` "Middleware Function Contract".
- Global vs per-route middleware execution order — `README.md` "Execution Order".
- Global middleware config schema (`function_id`, `phase: preHandler`, `priority`) — `engine/src/workers/rest_api/config.rs:60-71`.

### Adherence to the canonical convention

- **Path layout**: `engine/src/workers/rest_api/skills/skills/http/<file>.md` matches the doubled-`skills/` shape that `build_skills_payload.py` (`build_skills_payload.py:61`) produces for registry keys.
- **URI scheme**: `iii://<iii.worker.yaml-name>/<rest>` — uses `iii-http` as the worker prefix, matching `iii://iii-state/state/...` from [#1667](https://github.com/iii-hq/iii/pull/1667).
- **Frontmatter**: `type: how-to` + `trigger_type: http` for both how-tos (this worker has no callable functions, so `function_id:` doesn't apply).
- **Section order**: `# When to use` → `# Inputs` → `# Outputs` → `# Worked example` → `# Related` (the spec's required order, no optional sections).
- **No example code**: `# Worked example` sections are prose-only with a pointer to [the iii main repo](https://github.com/iii-hq/iii) for runnable scaffolds, matching the pattern established in #1665 / #1666.
- **No emoji, no narrative filler.**

### Validated through the canonical pipeline

`python3 .github/scripts/build_skills_payload.py --worker-dir engine/src/workers/rest_api` produces 3 skill keys, all matching the registry's `^[a-z0-9][a-z0-9._/\-]*\.md$` regex:

```
index.md
skills/skills/http/middleware.md
skills/skills/http/reactive-triggers.md
```

## Out of scope

- No code changes. Markdown-only addition under `engine/src/workers/rest_api/skills/`.
- The existing `engine/src/workers/rest_api/README.md` is unchanged. The skills bundle cross-references it via `../../../README.md` for the full server config block.
- HTTP trigger payload includes `request_body` and `response` `StreamChannelRef` fields (per `types.rs:40-41`) for streaming use cases. Those aren't documented in this PR — they're an advanced surface and warrant a separate skill if/when streaming becomes a first-class agent-facing pattern.

## Test plan

- [ ] Bundle structure validates against `DOCUMENTATION_GUIDELINES.md` (frontmatter, required sections in order, valid `iii://` link shape, no emoji). Confirmed locally.
- [ ] Frontmatter `trigger_type: http` matches the trigger type registered in source.
- [ ] JSON examples use real keys + plausible values + inline `// ...` comments per the guidelines.
- [ ] `build_skills_payload.py` produces a valid payload (3 skill keys, all regex-passing).
- [ ] CI green (markdown-only change, no Rust touched).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for configuring HTTP workers, implementing middleware, and exposing functions as HTTP endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1668?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->