### PR TITLE
docs(bridge): add agent skills bundle for iii-bridge worker

### DIFF
--- a/engine/src/workers/bridge_client/skills/index.md
+++ b/engine/src/workers/bridge_client/skills/index.md
@@ -1,0 +1,28 @@
+---
+type: index
+title: iii-bridge
+---
+
+# iii-bridge
+
+Connect this iii engine instance to another iii instance over `iii-sdk` so functions on either side can call across the boundary. The worker opens a single outbound WebSocket connection to the configured `url`, registers itself with the remote engine using `service_id`, and stays open for the engine's lifetime — bridging is request/response over that long-lived connection. There are no trigger types.
+
+The worker is **configuration-driven**. The primary surface is two list-shaped config fields (`forward:` and `expose:`) that wire stable function ids on both sides; once configured, callers reach across the bridge by invoking those stable ids with the standard `iii.trigger({ function_id, payload })` — no bridge-specific call shape required. Two engine functions (`bridge.invoke`, `bridge.invoke_async`) are also registered as ad-hoc escape hatches for the rare case where the remote function id is dynamic at runtime; they are not the recommended path.
+
+Connection config: `url` (WebSocket URL of the remote iii instance; defaults to `${III_URL:ws://0.0.0.0:49134}`), `service_id` (service identifier registered with the remote), `service_name` (human-readable; defaults to `service_id`).
+
+Two list-shaped fields wire the bridge:
+
+- `expose: [{ local_function, remote_function? }]` — functions registered on **this** engine that the remote should be able to call. `remote_function` is the path the remote will invoke; defaults to `local_function`. The worker registers each entry with the remote at initialize time; remote callers then `iii.trigger({ function_id: remote_function, payload })` and the call lands on this engine.
+- `forward: [{ local_function, remote_function, timeout_ms? }]` — local aliases that proxy outbound to a remote function. The worker dynamically registers `local_function` on this engine so any caller can `iii.trigger({ function_id: local_function, payload })` and the call reaches the remote's `remote_function`. `timeout_ms` overrides the per-call deadline (default `30000`).
+
+Forward aliases and exposed functions don't have stable ids across deployments — they're whatever the operator wires in `iii-config.yaml`. This skill bundle covers the worker's purpose and the ad-hoc escape hatch only; the configured aliases are documented per-deployment alongside the worker's config.
+
+- **Configuration-driven** (`forward:` / `expose:`) — the recommended way to bridge. Configure once, call the local alias by its normal id; the bridge is invisible at the call site.
+- **Ad-hoc escape hatch** (`bridge.invoke` / `bridge.invoke_async`) — for one-off calls where the remote function id is dynamic at runtime, or for testing the connection. Reach for these only when a forward alias would be wrong.
+
+## How-tos
+
+### `bridge.*`
+
+- [`bridge.invoke` and `bridge.invoke_async`](iii://iii-bridge/bridge/invoke) — ad-hoc remote calls when a `forward:` alias isn't appropriate. Wait for the response with `bridge.invoke` or fire-and-forget with `bridge.invoke_async`. One file because they share the same input shape and only differ in whether the response round-trips.

--- a/engine/src/workers/bridge_client/skills/skills/bridge/invoke.md
+++ b/engine/src/workers/bridge_client/skills/skills/bridge/invoke.md
@@ -1,0 +1,101 @@
+---
+type: how-to
+functions: [bridge.invoke, bridge.invoke_async]
+title: Ad-hoc invoke a function on the remote iii engine
+---
+
+# When to use
+
+**First, check whether you can use a `forward:` alias instead.** The recommended way to call across the bridge is to configure a `forward:` entry on the `iii-bridge` worker (`{ local_function: "my::feature::do-thing", remote_function: "actual::remote::id", timeout_ms? }`) and then call `local_function` like any other engine function. The worker dynamically registers `local_function`, so the bridge is invisible at the call site and the function id is stable across the codebase. **`bridge.invoke` and `bridge.invoke_async` are ad-hoc escape hatches** for the cases where a forward alias is wrong or impossible — they should not be the default reach.
+
+Reach for these escape hatches only when:
+
+- The remote `function_id` is **dynamic at runtime** (looked up from a registry, computed from user input, etc.) — a `forward:` alias requires a static `remote_function` in config.
+- You're **prototyping** or running a one-off operator script and don't want to edit `iii-config.yaml` for a single call.
+- You need to **probe** the remote engine to verify connectivity or list available functions before deciding whether to wire a `forward:` alias.
+
+Once the choice to use the escape hatch is made, the two functions differ only in whether the call round-trips:
+
+| Question                                                              | Use this              |
+|-----------------------------------------------------------------------|-----------------------|
+| Need the remote function's return value to continue?                  | `bridge.invoke`       |
+| Want to forward telemetry, logs, or events without blocking?          | `bridge.invoke_async` |
+| Need timeout protection (slow remote should not hold up the caller)?  | `bridge.invoke` with `timeout_ms` set |
+| Will you call the same `(local, remote)` pair many times?             | **Don't use either** — configure a `forward:` alias and call `local_function` directly |
+
+# `bridge.invoke`
+
+## Inputs
+
+```json
+{
+  "function_id": "engine::log::info",                  // required. Remote function id to invoke. Must match a function the remote engine has registered.
+  "data":        { "message": "hello from local" },    // optional. JSON payload forwarded to the remote function. Defaults to null when omitted.
+  "timeout_ms":  5000                                  // optional. Per-call timeout in milliseconds. Defaults to 30000 (30 seconds).
+}
+```
+
+`function_id` is required. Empty `function_id` or any payload that fails to deserialize as `{function_id, data?, timeout_ms?}` returns a `deserialization_error`.
+
+`timeout_ms` overrides the default 30s deadline for this call only — pair small timeouts with a remote that's known-fast, or larger timeouts with a remote that does heavy work.
+
+## Outputs
+
+`bridge.invoke` returns the remote function's response value **directly** — no envelope wraps it. Whatever the remote function returned (object, array, scalar, `null`) is what the caller sees.
+
+```json
+// Example: when the remote function returned `{ "user": { "id": "u_1" } }`
+{ "user": { "id": "u_1" } }
+```
+
+When the bridge fails (timeout, connection drop, remote rejection, deserialization error), the call returns a `FunctionResult::Failure` with a stable `code` field:
+
+| `code`                  | When                                                                      |
+|-------------------------|---------------------------------------------------------------------------|
+| `"deserialization_error"` | The input payload didn't match `{function_id, data?, timeout_ms?}`.     |
+| `"bridge_error"`        | The remote rejected the call, the WebSocket disconnected mid-call, or the deadline elapsed. The `message` field carries the underlying error from the remote / transport. |
+
+# `bridge.invoke_async`
+
+## Inputs
+
+Same shape as `bridge.invoke`, except `timeout_ms` is **not honored** — the call returns as soon as the worker has handed the message off to the WebSocket send queue:
+
+```json
+{
+  "function_id": "engine::log::info",                  // required. Remote function id.
+  "data":        { "message": "hello from local" }     // optional. Payload forwarded to the remote function.
+}
+```
+
+If `timeout_ms` is supplied it is ignored — fire-and-forget has no deadline by design.
+
+## Outputs
+
+`bridge.invoke_async` returns no value (`FunctionResult::NoResult`). On the wire the response is `null`. Callers that `await` it should treat success as "the message was queued for delivery" — **not** "the remote handler ran" or "the remote handler succeeded." If the remote later rejects the call, errors are logged on the bridge worker but never surfaced to the caller.
+
+A failure return only happens when the local hand-off itself fails. Use the same `code` table as `bridge.invoke`: `deserialization_error` when the input payload doesn't match `{function_id, data?}`, and `bridge_error` when transport hand-off fails (broken WebSocket, queue full, or any other adapter-level rejection before the message reaches the wire). Once the message reaches the wire, `bridge.invoke_async` is fire-and-forget.
+
+# Worked example
+
+Synchronous remote call (waits for the remote function's response, bounded by `timeout_ms`):
+
+```json
+{
+  "function_id": "engine::log::info",
+  "data":        { "message": "hello from local" },
+  "timeout_ms":  5000
+}
+```
+
+Two patterns reach for these functions:
+
+- **Synchronous remote call.** `bridge.invoke` with the payload above returns the remote function's value directly. Use `timeout_ms` to bound the call when the remote may be slow; the default 30 s is rarely the right deadline for a UI-fronted handler.
+- **Fire-and-forget remote dispatch.** `bridge.invoke_async` with the same payload (minus `timeout_ms`, which is ignored) hands the message to the WebSocket and returns. Use it for telemetry, audit logs, mirrored writes — anywhere the caller doesn't need the remote response and shouldn't block on it.
+
+For runnable scaffolds (TypeScript, Python, Rust) plus the `forward:` / `expose:` config patterns that wrap these calls in stable local function ids, see the bridge worker source and the SDK usage examples in [the iii main repo](https://github.com/iii-hq/iii).
+
+# Related
+
+- `iii-bridge` worker config — `url` (remote WebSocket URL), `service_id` / `service_name` (registered with the remote), `expose:` (functions this engine exposes outward), `forward:` (local-alias entries that proxy to remote functions). Use `forward:` when the same `(local, remote)` pair is called many times so the local alias becomes a stable id.
+- The remote engine's own functions — `bridge.invoke` is a generic transport; the actual contract per call is the remote function's input/output shape, not anything this worker defines.


### PR DESCRIPTION
## Summary

Adds the agent skills bundle for the **`iii-bridge`** built-in engine worker (folder name `bridge_client`, registry slug `iii-bridge`). Follows the canonical convention established by [#1667](https://github.com/iii-hq/iii/pull/1667).

This is one of an N-PR plan to add skills bundles to each engine built-in worker — paired with #1665 (`iii-stream`), #1666 (`iii-cron`), and #1668 (`iii-http`).

### What's added

```
engine/src/workers/bridge_client/skills/
├── index.md                             # type: index — worker overview
└── skills/
    └── bridge/
        └── invoke.md                    # multi-function how-to: bridge.invoke + bridge.invoke_async
```

The two callable functions (`bridge.invoke`, `bridge.invoke_async`) share the same input shape and only differ in whether the response round-trips, so they're collapsed into one multi-function file per section 5 of `DOCUMENTATION_GUIDELINES.md` — same pattern Sergio used for state's `list-and-groups.md`. Note: function ids use a `.` separator, not `::` — that comes from the source (`engine/src/workers/bridge_client/mod.rs:100,152`).

### Faithful to the source

- Function registrations + input shape (`function_id`, `data`, `timeout_ms`): `engine/src/workers/bridge_client/mod.rs:95-193`.
- `timeout_ms` default of 30 000 ms: `mod.rs:124`.
- `bridge.invoke_async` ignoring `timeout_ms` and returning `NoResult`: `mod.rs:178,190`.
- Error codes (`deserialization_error`, `bridge_error`): `mod.rs:114,139,184`.
- Forward/expose config flow: `engine/src/workers/bridge_client/README.md` (referenced via `../../../README.md` in the bundle, not duplicated).

### Adherence to canonical convention

- **Path layout**: `engine/src/workers/bridge_client/skills/skills/bridge/<file>.md` matches the doubled-`skills/` shape that `build_skills_payload.py` produces for registry keys.
- **URI scheme**: `iii://iii-bridge/bridge/invoke` — worker-name-prefixed, matching `iii://iii-state/state/...`.
- **Multi-function frontmatter**: `functions: [bridge.invoke, bridge.invoke_async]` (not `function_id:`), with one `# <function-id>` H1 per function inside the body containing `## Inputs` / `## Outputs` H2 subsections — exactly what the multi-function variant prescribes.
- **No example code**: `# Worked example` is prose-only with a pointer to [the iii main repo](https://github.com/iii-hq/iii).

### Out of scope

- The `forward:` config dynamically registers user-defined local-alias functions (e.g. `remote::state::get`). These have no stable function id across deployments, so they're documented per-deployment in the README rather than in this skills bundle.
- `expose:` config (functions registered on the remote, callable from this side) is similarly per-deployment and points at [the README](https://github.com/iii-hq/iii/blob/main/engine/src/workers/bridge_client/README.md).

### Validated through canonical pipeline

`python3 .github/scripts/build_skills_payload.py --worker-dir engine/src/workers/bridge_client` produces 2 skill keys, both regex-passing:

```
index.md
skills/skills/bridge/invoke.md
```

## Test plan

- [ ] Bundle structure validates against `DOCUMENTATION_GUIDELINES.md` (frontmatter, required sections in order, multi-function variant shape, valid `iii://` link, no emoji). Confirmed locally.
- [ ] Frontmatter `functions: [bridge.invoke, bridge.invoke_async]` matches the function ids registered in source (`mod.rs:100,152`).
- [ ] CI green — markdown-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added user-facing docs for the iii-bridge worker describing connection/registration behavior, configuration fields, and how local “expose” and remote “forward” mappings bridge functions.
  * Added a comprehensive guide for invoking remote engine functions (sync vs async), input/output expectations, timeout semantics, and standardized success/failure representations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1669?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->