### PR TITLE
docs(observability): add agent skills bundle for iii-observability worker

### DIFF
--- a/engine/src/workers/observability/skills/index.md
+++ b/engine/src/workers/observability/skills/index.md
@@ -1,0 +1,45 @@
+---
+type: index
+title: iii-observability
+---
+
+# iii-observability
+
+OpenTelemetry-backed observability for the iii engine: distributed tracing, structured logs, metrics with rollups, alert rules, sampling configuration, and baggage propagation. Every surface is a callable engine function under `engine::*`, plus a single `log` reactive trigger that fires on every ingested log entry. The worker exposes 19 functions across 9 sub-namespaces — emit, listen, query stored telemetry, manage configuration, propagate context.
+
+The worker is on by default (`config.enabled: true`). When disabled, the emit and read functions still register but become no-ops; the trigger never fires. Core config keys: `service_name` / `service_version` / `service_namespace` (OTel resource attributes), `exporter` (`memory` | `otlp` | `both`), `endpoint` (OTLP collector URL, default `http://localhost:4317`), `sampling_ratio` (`0.0`–`1.0`, default `1.0`), `memory_max_spans` (default `1000`), and per-pillar toggles (`metrics_enabled`, `logs_enabled`) plus retention/limit knobs (`metrics_retention_seconds`, `metrics_max_count`, `logs_max_count`, `logs_retention_seconds`, `logs_console_output`, `logs_sampling_ratio`). Most fields can be overridden via env vars (`OTEL_*`). Alert rules and the advanced sampling block are documented inline alongside the relevant skills.
+
+- **Emit and listen** (`engine::log::*`, `log` trigger) — five severity-level emit functions and a reactive trigger that fires on every ingested log.
+- **Query stored telemetry** (`engine::logs::*`, `engine::traces::*`, `engine::metrics::*`, `engine::rollups::*`) — list/tree/clear for the in-memory log + span store, list metrics with optional time bucketing, list metric rollup aggregations.
+- **Inspect configuration** (`engine::sampling::*`, `engine::health::*`, `engine::alerts::*`) — view the active sampling rules, check engine health, list and re-evaluate alert rules.
+- **Propagate context** (`engine::baggage::*`) — read and write OpenTelemetry baggage keys for cross-call context (note: writes don't propagate back to the caller — see the file).
+
+## How-tos
+
+### `engine::log::*` — emit log entries
+
+- [`engine::log::info`, `warn`, `error`, `debug`, `trace`](iii://iii-observability/engine/log/log) — five emit functions sharing the same input shape (`message`, optional `data`/`trace_id`/`span_id`/`service_name`); only the severity differs.
+
+### `log` triggers
+
+- [React to ingested log entries](iii://iii-observability/engine/log/reactive-triggers) — register a handler bound to the `log` trigger type to fire on every (or filtered-by-level) log emitted via `engine::log::*` or stored via the OTel log pipeline.
+
+### `engine::logs::*` and `engine::traces::*` — query stored telemetry
+
+- [`engine::logs::list`, `engine::logs::clear`](iii://iii-observability/engine/logs/logs) — read or wipe the in-memory log store; filter by time range, trace correlation, or severity.
+- [`engine::traces::list`, `engine::traces::tree`, `engine::traces::clear`](iii://iii-observability/engine/traces/traces) — list spans, walk a single trace as a parent/child tree, or wipe stored spans.
+
+### `engine::metrics::*` and `engine::rollups::*` — metrics inspection
+
+- [`engine::metrics::list`](iii://iii-observability/engine/metrics/list) — list metrics with aggregated stats; surfaces engine counters, SDK metrics, and optional time-bucketed values.
+- [`engine::rollups::list`](iii://iii-observability/engine/rollups/list) — list metric rollup aggregations across 1-minute, 5-minute, and 1-hour windows.
+
+### `engine::baggage::*` — context propagation
+
+- [`engine::baggage::get`, `engine::baggage::set`, `engine::baggage::get_all`](iii://iii-observability/engine/baggage/baggage) — read and (locally) set OpenTelemetry baggage keys. **Note**: `baggage::set` does not propagate back to the caller — propagation must be done at the SDK/invocation level via baggage headers.
+
+### `engine::sampling::*`, `engine::health::*`, `engine::alerts::*` — operational inspection
+
+- [`engine::sampling::rules`](iii://iii-observability/engine/sampling/rules) — list the active sampling rules (default rate, parent-based flag, per-operation rules, rate limits).
+- [`engine::health::check`](iii://iii-observability/engine/health/check) — return engine health (`status`, per-component breakdown, `timestamp`, `version`).
+- [`engine::alerts::list`, `engine::alerts::evaluate`](iii://iii-observability/engine/alerts/alerts) — inspect configured alert rules and their current state, or manually trigger an evaluation pass.

--- a/engine/src/workers/observability/skills/skills/engine/alerts/alerts.md
+++ b/engine/src/workers/observability/skills/skills/engine/alerts/alerts.md
@@ -1,0 +1,74 @@
+---
+type: how-to
+functions: [engine::alerts::list, engine::alerts::evaluate]
+title: List configured alert rules and trigger an evaluation pass
+---
+
+# When to use
+
+The two functions cover the two operations on configured alert rules:
+
+| Question                                                              | Use this                    |
+|-----------------------------------------------------------------------|-----------------------------|
+| Which alerts are configured, and which are firing right now?          | `engine::alerts::list`      |
+| Force an evaluation pass against current metric values (no waiting)   | `engine::alerts::evaluate`  |
+
+Reach for `list` when:
+
+- An on-call dashboard needs the current state of every configured alert.
+- An operator wants to verify a new alert rule from `iii-config.yaml` registered correctly.
+- An incident-response tool needs to know which thresholds the engine has breached.
+
+Reach for `evaluate` when:
+
+- You're testing an alert rule end-to-end and don't want to wait for the next periodic evaluation.
+- You're forcing a re-evaluation after manually clearing or backfilling metrics.
+
+Alert rule definitions live in `iii-config.yaml` (`alerts:` array). Each rule has: `name` (required, unique), `metric` (required, e.g. `iii.invocations.error`), `threshold` (required, number), `operator` (`>` | `>=` | `<` | `<=` | `==` | `!=`; default `>`), `window_seconds` (default `60`), `cooldown_seconds` (default `60`), `enabled` (default `true`), and `action` — one of `{ "type": "log" }`, `{ "type": "webhook", "url": "..." }`, or `{ "type": "function", "path": "..." }`. Neither function modifies rules — they're config-driven.
+
+# `engine::alerts::list`
+
+## Inputs
+
+```json
+{}
+```
+
+`list` takes no fields.
+
+## Outputs
+
+The response is an array of configured alert rules with their current state — typical fields per rule include `name`, the configured `metric` / `threshold` / `operator` / `window_seconds`, the `enabled` flag, the last evaluation timestamp, and a current `state` (e.g. `firing` / `ok`) plus the last value seen against the threshold. Use the `name` field as the join key against alert action artifacts (logs, webhook deliveries).
+
+# `engine::alerts::evaluate`
+
+## Inputs
+
+```json
+{}
+```
+
+`evaluate` takes no fields. The function evaluates **every** configured rule against current metric values; per-rule evaluation cannot be requested.
+
+## Outputs
+
+The response summarizes the evaluation pass: how many rules were evaluated, how many transitioned state (firing→ok or ok→firing), and a per-rule breakdown matching the shape of `alerts::list` rows. Action side effects (`log`, `webhook`, `function` per the rule's `action` field) fire as part of the evaluation; the response itself is informational.
+
+# Worked example
+
+Both functions take no input — invoke either with an empty payload:
+
+```json
+{}
+```
+
+The typical pattern is `list` for periodic dashboard reads, `evaluate` for end-to-end verification. After editing `iii-config.yaml` and restarting, call `list` to confirm the new rule is registered, then call `evaluate` and re-`list` to confirm the rule fires when the threshold is breached. For runtime alerting, the engine evaluates rules automatically on a periodic schedule — `evaluate` is for forcing the schedule, not for routine operation.
+
+For runnable scaffolds, see the observability worker source and SDK examples in [the iii main repo](https://github.com/iii-hq/iii).
+
+# Related
+
+- `iii-observability` worker config — the `alerts:` block in `iii-config.yaml` is the source of truth for rule definitions; see the schema in **When to use** above.
+- [`engine::metrics::list`](iii://iii-observability/engine/metrics/list) — alert rules evaluate against the metric values returned here.
+- [`engine::rollups::list`](iii://iii-observability/engine/rollups/list) — when an alert's `window_seconds` matches a rollup window (60 / 300 / 3600), the rollup is the cheapest source for the same value.
+- [`engine::health::check`](iii://iii-observability/engine/health/check) — quick "is anything firing right now?" alternative.

--- a/engine/src/workers/observability/skills/skills/engine/baggage/baggage.md
+++ b/engine/src/workers/observability/skills/skills/engine/baggage/baggage.md
@@ -1,0 +1,104 @@
+---
+type: how-to
+functions: [engine::baggage::get, engine::baggage::set, engine::baggage::get_all]
+title: Read and locally set OpenTelemetry baggage
+---
+
+# When to use
+
+The three functions inspect the OpenTelemetry **baggage** attached to the current trace context — string-keyed values that propagate alongside spans for cross-cutting concerns (tenant id, request id, A/B variant, feature flags). All three are read-side or local-only: there is no engine function that writes baggage so the next inbound request sees it.
+
+| Question                                                          | Use this                          |
+|-------------------------------------------------------------------|-----------------------------------|
+| Read one baggage key                                              | `engine::baggage::get`            |
+| Read every baggage key                                            | `engine::baggage::get_all`        |
+| Set a value for the current call's downstream code                | `engine::baggage::set` (see warning below) |
+
+> **Warning — `baggage::set` does not propagate.** OpenTelemetry baggage is immutable; the engine constructs a new context with the value but cannot push it back to the caller's invocation. The function exists for verification and debugging. Real baggage propagation must happen at the **SDK / invocation level** by attaching baggage headers to the next outbound call. The function returns a `note` field reminding the caller of this.
+
+Reach for `get` / `get_all` when:
+
+- A handler needs the tenant/user/request id the upstream caller stamped onto baggage.
+- You're debugging trace correlation and want to verify baggage is flowing.
+
+Use a function-input field instead of `baggage::set` when you actually need to pass a value to a downstream call — baggage is for opaque cross-cutting context, not for inter-function arguments.
+
+# `engine::baggage::get`
+
+## Inputs
+
+```json
+{
+  "key": "tenant_id"     // required. The baggage key to read.
+}
+```
+
+## Outputs
+
+```json
+{
+  "value": "tenant-7"    // The string value, or null when the key isn't present in the current baggage.
+}
+```
+
+# `engine::baggage::get_all`
+
+## Inputs
+
+```json
+{}
+```
+
+`get_all` takes no fields.
+
+## Outputs
+
+```json
+{
+  "baggage": {
+    "tenant_id":  "tenant-7",
+    "request_id": "req-abc-123"
+  }
+}
+```
+
+The response is an object map of every baggage key/value in the current context. Empty baggage returns `{ "baggage": {} }`.
+
+# `engine::baggage::set`
+
+## Inputs
+
+```json
+{
+  "key":   "feature_variant",   // required. Baggage key.
+  "value": "experiment-A"       // required. String value to set.
+}
+```
+
+## Outputs
+
+```json
+{
+  "success": true,
+  "note":    "Baggage set in new context. For propagation, use SDK-level baggage headers."
+}
+```
+
+The `note` field is the engine's reminder that **this set is local-only**. The new context exists for the duration of the call but is not handed back to the caller's tracing pipeline. Verify, debug, or test with this function — do not rely on it for runtime context propagation.
+
+# Worked example
+
+Read the `tenant_id` baggage key the upstream caller stamped onto the trace context:
+
+```json
+{ "key": "tenant_id" }
+```
+
+The typical pattern is `get`/`get_all` for inspection. A handler reads `tenant_id` from baggage, branches on it, and proceeds; for tracing visibility this means the value was stamped by an upstream caller (HTTP middleware, SDK auto-instrumentation, etc.). `set` is only useful in tests or when verifying the OTel pipeline is wired up correctly.
+
+For runnable scaffolds and the SDK-level pattern for actually propagating baggage, see the observability worker source and SDK examples in [the iii main repo](https://github.com/iii-hq/iii).
+
+# Related
+
+- `iii-observability` worker config — sampling and trace-context configuration governs whether baggage flows through to your handler. The relevant knobs are `sampling_ratio` (global trace ratio) and the advanced `sampling:` block (`default`, `parent_based`, `rules: [{operation, rate}]`, `rate_limit: { max_traces_per_second }`); set per `iii-config.yaml`.
+- [`engine::traces::tree`](iii://iii-observability/engine/traces/traces) — when investigating a trace, `attributes` on each span often duplicate baggage values, useful as a cross-check.

--- a/engine/src/workers/observability/skills/skills/engine/health/check.md
+++ b/engine/src/workers/observability/skills/skills/engine/health/check.md
@@ -1,0 +1,62 @@
+---
+type: how-to
+function_id: engine::health::check
+title: Check engine health status
+---
+
+# When to use
+
+Call `engine::health::check` to get a structured snapshot of the engine's health: an overall status, per-component detail, the engine version, and a server-side timestamp. It's the canonical "is the engine OK right now?" call — use it for liveness/readiness probes, on-call dashboards, deploy-time canaries, and operator CLIs.
+
+Reach for it when:
+
+- A platform-level component (load balancer, orchestrator, deploy script) needs a yes/no signal before routing traffic to this engine.
+- An on-call dashboard needs a per-component breakdown to point at the failing subsystem.
+- A canary script needs a deterministic success/failure check after a rolling deploy.
+
+Use [`engine::metrics::list`](iii://iii-observability/engine/metrics/list) instead when you need quantitative load/error data rather than a status; use [`engine::alerts::list`](iii://iii-observability/engine/alerts/alerts) when you want to know whether any configured alert is currently firing.
+
+# Inputs
+
+```json
+{}
+```
+
+`check` takes no fields.
+
+# Outputs
+
+```json
+{
+  "status":    "ok",                              // "ok" | "degraded" | "unhealthy" — the rolled-up overall status.
+  "version":   "0.12.0",                          // engine version string.
+  "timestamp": "2026-05-20T17:00:00.123Z",        // server-side time of the check, RFC 3339.
+  "components": {                                 // per-component breakdown; keys are component names, values carry status + diagnostic detail.
+    "engine":      { "status": "ok",       "details": null },
+    "scheduler":   { "status": "ok",       "details": null },
+    "telemetry":   { "status": "ok",       "details": null },
+    "adapters":    { "status": "degraded", "details": "redis: connection refused" }
+  }
+}
+```
+
+- `status` is rolled up from the worst component status: any `unhealthy` makes the overall `unhealthy`; any `degraded` (with no `unhealthy`) makes the overall `degraded`; everything `ok` makes the overall `ok`.
+- `components` keys depend on what's configured (adapter set, optional features). Treat unknown keys as additive — a parser should iterate rather than hard-code an enum.
+- `details` is human-readable diagnostic text; expect it to be `null` on healthy components.
+
+# Worked example
+
+`check` takes no input — invoke with an empty payload:
+
+```json
+{}
+```
+
+The typical pattern is to read `status` for the binary signal and walk `components` only when `status !== "ok"`. For liveness probes, treat `unhealthy` as failure; for readiness, treat both `unhealthy` and `degraded` as failure (the engine should not receive traffic if any component is degraded).
+
+For runnable scaffolds, see the observability worker source and SDK examples in [the iii main repo](https://github.com/iii-hq/iii).
+
+# Related
+
+- [`engine::alerts::list`](iii://iii-observability/engine/alerts/alerts) — `health::check` reports current state; `alerts::list` reports rule-based threshold breaches over a time window. Read both during incident triage.
+- [`engine::metrics::list`](iii://iii-observability/engine/metrics/list) — quantitative drill-down when health is degraded.

--- a/engine/src/workers/observability/skills/skills/engine/log/log.md
+++ b/engine/src/workers/observability/skills/skills/engine/log/log.md
@@ -1,0 +1,71 @@
+---
+type: how-to
+functions: [engine::log::info, engine::log::warn, engine::log::error, engine::log::debug, engine::log::trace]
+title: Emit a log entry through the engine's OpenTelemetry pipeline
+---
+
+# When to use
+
+The five emit functions all do the same thing — record a structured log entry in the engine's OTel log pipeline — and differ only in **severity**. Pick by how a downstream consumer (alerting, log routing, the `log` reactive trigger) should treat the message.
+
+| Function                | Severity | OTel severity_number | Typical use                                                |
+|-------------------------|----------|----------------------|------------------------------------------------------------|
+| `engine::log::trace`    | TRACE    | 1                    | Per-step diagnostic noise; almost always sampled out.      |
+| `engine::log::debug`    | DEBUG    | 5                    | Developer-facing detail useful during incidents.            |
+| `engine::log::info`     | INFO     | 9                    | Normal operational events; the default for most callers.    |
+| `engine::log::warn`     | WARN     | 13                   | Recoverable problems worth surfacing in dashboards.         |
+| `engine::log::error`    | ERROR    | 17                   | Failures that warrant alerting or operator attention.       |
+
+Reach for these when:
+
+- A handler should record progress, decisions, or failure detail in a way that survives in the engine's log store and propagates to OTLP exporters when configured.
+- You want a `log` reactive trigger (see [React to ingested log entries](iii://iii-observability/engine/log/reactive-triggers)) to fire on the message — every emit goes through the same pipeline that feeds the trigger.
+- You want trace correlation: pass `trace_id`/`span_id` so the entry shows up under the right span in `engine::traces::tree`.
+
+Use `engine::traces::*` (`iii://iii-observability/engine/traces/traces`) instead when the goal is to record timing/structure of an operation — spans are richer than logs for that.
+
+# Inputs
+
+All five functions accept the same `OtelLogInput`:
+
+```json
+{
+  "message":      "request handled",         // required. The log body.
+  "data":         { "user_id": "u_1" },      // optional. Structured attributes attached to the log entry.
+  "trace_id":     "0123456789abcdef0123456789abcdef",  // optional. Correlation to a specific trace; leave unset to inherit the current OTel context.
+  "span_id":      "0123456789abcdef",        // optional. Correlation to a specific span within the trace.
+  "service_name": "billing"                  // optional. Override the service name attribute on this entry; defaults to the worker's configured `service_name`.
+}
+```
+
+`message` is required. All other fields are optional.
+
+# Outputs
+
+The functions return no value (`FunctionResult::NoResult`); on the wire the response is `null`. The observable effects happen on the side: the entry is stored in memory (subject to `logs_max_count` and `logs_retention_seconds`), the `log` reactive trigger fires, and — when `logs_console_output` is on — the entry is printed to stderr.
+
+When the worker is disabled (`config.enabled: false`) or `logs_enabled: false`, the call is silently a no-op: no storage, no trigger fan-out, no console print, no export.
+
+# Worked example
+
+Emit an `error` entry with a structured payload and trace correlation:
+
+```json
+{
+  "message":      "payment authorization failed",
+  "data":         { "user_id": "u_1", "amount_cents": 4200, "code": "card_declined" },
+  "trace_id":     "0123456789abcdef0123456789abcdef",
+  "span_id":      "0123456789abcdef",
+  "service_name": "billing"
+}
+```
+
+The typical pattern is one call per significant operational event: an `info` on success, a `warn` on a recoverable problem, an `error` on a failure that should alert. Pass `data` for structured fields the log query and trigger handler can branch on (`level`, `user_id`, `request_id`, etc.) — those land in the entry's `attributes` map and are queryable via `engine::logs::list`.
+
+For runnable scaffolds (TypeScript, Python, Rust) plus the standard `Logger` wrapper that batches these calls, see the observability worker source and SDK examples in [the iii main repo](https://github.com/iii-hq/iii).
+
+# Related
+
+- [React to ingested log entries](iii://iii-observability/engine/log/reactive-triggers) — register a `log` trigger to run a function every time `engine::log::*` is called.
+- [`engine::logs::list`](iii://iii-observability/engine/logs/logs) — query the stored entries this function produces.
+- [`engine::traces::*`](iii://iii-observability/engine/traces/traces) — for span-shaped telemetry; pair with logs by passing the same `trace_id`.

--- a/engine/src/workers/observability/skills/skills/engine/log/reactive-triggers.md
+++ b/engine/src/workers/observability/skills/skills/engine/log/reactive-triggers.md
@@ -1,0 +1,93 @@
+---
+type: how-to
+trigger_type: log
+title: React to ingested log entries
+---
+
+# When to use
+
+Register a `log` trigger when a function should run automatically every time a log entry lands in the engine's OTel log pipeline — emitted via `engine::log::*`, ingested via the OTLP collector, or recorded by any worker that uses the engine's structured logging. Each subscription receives the same OTel-shaped log record, so consumers can route by severity, attribute, or trace correlation.
+
+Reach for it when:
+
+- A specific severity (typically `error`) should page a human, send a Slack message, or open a ticket — register the handler with `level: "error"` and the trigger only fires on matching entries.
+- You want a real-time fan-out of all log entries to a downstream sink (S3 archive, log analytics, custom transformer) without polling `engine::logs::list`.
+- You want auditing: any log emitted anywhere in the engine should be recorded somewhere durable.
+
+Use [`engine::logs::list`](iii://iii-observability/engine/logs/logs) instead when you need to **query** stored entries on demand rather than react to each as it arrives.
+
+# Inputs
+
+Registration is the standard two-step pattern: define the handler, then bind it to the `log` trigger.
+
+## Handler function
+
+Register any function id. The handler receives the OTel log record documented in **Outputs**.
+
+```json
+// iii.registerFunction — handler id only; no engine payload.
+{ "id": "monitoring::on-error" }
+```
+
+## Trigger registration
+
+```json
+{
+  "type":        "log",                        // required. Must be exactly "log".
+  "function_id": "monitoring::on-error",       // required. Handler invoked when a log entry matches.
+  "config": {
+    "level": "error"                           // optional. One of "trace" | "debug" | "info" | "warn" | "error". Omit to fire on every level.
+  }
+}
+```
+
+`type` and `function_id` are required. `config.level`, when set, restricts firing to entries at that severity; when omitted, the trigger fires on every entry.
+
+# Outputs
+
+The handler receives the OTel-shaped log record:
+
+```json
+{
+  "timestamp_unix_nano":          1716220800000000000,         // when the log was emitted (nanos since epoch)
+  "observed_timestamp_unix_nano": 1716220800001000000,         // when the engine ingested it (nanos since epoch)
+  "severity_number":              17,                          // OTel severity number (TRACE=1, DEBUG=5, INFO=9, WARN=13, ERROR=17)
+  "severity_text":                "ERROR",                     // "TRACE" | "DEBUG" | "INFO" | "WARN" | "ERROR"
+  "body":                         "request failed",            // The log message (whatever was passed as `message` to engine::log::*).
+  "attributes":                   { "user_id": "u_1", "code": 500 },  // The structured `data` from the emit call, plus any pipeline-added attributes.
+  "trace_id":                     "0123456789abcdef0123456789abcdef",  // null when no trace context was present.
+  "span_id":                      "0123456789abcdef",          // null when no span context was present.
+  "resource":                     { "service.name": "billing" }, // OTel resource attributes from the emitting service.
+  "service_name":                 "billing",                   // Convenience field; same as resource["service.name"].
+  "instrumentation_scope_name":   "iii-engine",
+  "instrumentation_scope_version": "0.12.0"
+}
+```
+
+- `timestamp_unix_nano` is in **nanoseconds** since the Unix epoch — divide by `1_000_000` for milliseconds.
+- `severity_text` and `severity_number` always agree; use whichever is convenient.
+- `trace_id`/`span_id` are `null` when the emit happened outside any active OTel context.
+
+The handler's return value is **ignored**. Trigger invocations are spawned asynchronously after each log entry is stored — handler errors do not roll back the log entry or block the next firing.
+
+# Worked example
+
+Subscribe a handler that fires only on `error`-level entries:
+
+```json
+{
+  "type":        "log",
+  "function_id": "monitoring::on-error",
+  "config":      { "level": "error" }
+}
+```
+
+The typical pattern is one trigger per concern: a `level: "error"` trigger that pages on failures, a `level: "warn"` trigger that records to a metrics store, an unfiltered trigger (omit `level`) that archives every log to long-term storage. Branch inside the handler on `severity_text`, `service_name`, or specific keys in `attributes` to dispatch.
+
+For runnable scaffolds covering these patterns, see the observability worker source and SDK examples in [the iii main repo](https://github.com/iii-hq/iii).
+
+# Related
+
+- [`engine::log::*`](iii://iii-observability/engine/log/log) — the emit functions whose calls fire this trigger.
+- [`engine::logs::list`](iii://iii-observability/engine/logs/logs) — query stored entries on demand, complementing the reactive path.
+- `iii-observability` worker config — when `logs_enabled: false` (default `false`; must be turned on in `iii-config.yaml`), the log pipeline is dormant and no trigger fires. The `level` config key (`trace` | `debug` | `info` | `warn` | `error`; default `info`) sets the **minimum** severity ingested; entries below it are dropped before reaching this trigger.

--- a/engine/src/workers/observability/skills/skills/engine/logs/logs.md
+++ b/engine/src/workers/observability/skills/skills/engine/logs/logs.md
@@ -1,0 +1,88 @@
+---
+type: how-to
+functions: [engine::logs::list, engine::logs::clear]
+title: Query and clear stored log entries
+---
+
+# When to use
+
+The two functions read and reset the in-memory OTel log store. Pick by intent:
+
+| Question                                                    | Use this              |
+|-------------------------------------------------------------|-----------------------|
+| Show me logs matching a filter (time range, trace, severity)| `engine::logs::list`  |
+| Wipe the in-memory log store (test setup, manual cleanup)   | `engine::logs::clear` |
+| React to each new log as it arrives                          | The `log` reactive trigger — see [React to ingested log entries](iii://iii-observability/engine/log/reactive-triggers) |
+
+Reach for `list` when:
+
+- You're rendering an in-engine dashboard or debug UI and need recent entries.
+- You're correlating spans + logs for a specific `trace_id`.
+- You're inspecting why an alert fired and want the surrounding log context.
+
+Reach for `clear` only when:
+
+- You're running an integration test that needs a clean log store before assertions.
+- An operator wants to flush memory without restarting the engine (rare).
+
+Note: when the store fills up, the engine automatically evicts the oldest entries based on `logs_max_count` and `logs_retention_seconds` — `clear` is not needed for routine memory management.
+
+# `engine::logs::list`
+
+## Inputs
+
+```json
+{
+  "start_time":    "2026-05-20T17:00:00Z",   // optional. RFC 3339; only entries at or after this time are returned.
+  "end_time":      "2026-05-20T18:00:00Z",   // optional. RFC 3339; only entries at or before this time are returned.
+  "trace_id":      "0123456789abcdef0123456789abcdef",  // optional. Restrict to a single trace.
+  "span_id":       "0123456789abcdef",       // optional. Restrict to a single span; usually paired with trace_id.
+  "severity_min":  9,                        // optional. OTel severity number (TRACE=1, DEBUG=5, INFO=9, WARN=13, ERROR=17). Inclusive lower bound.
+  "severity_text": "ERROR",                  // optional. Exact match on the severity label; mutually useful with severity_min.
+  "offset":        0,                        // optional. Pagination offset; defaults to 0.
+  "limit":         100                       // optional. Max entries returned. Defaults to the worker's configured page size.
+}
+```
+
+All fields are optional. With no filters, the call returns the most recent page of entries.
+
+## Outputs
+
+The response is a paginated list of OTel log records — same shape the `log` trigger handler receives, plus paging metadata. Each entry carries `timestamp_unix_nano`, `severity_number`, `severity_text`, `body`, `attributes`, `trace_id`, `span_id`, `resource`, `service_name`, and instrumentation scope info. See [React to ingested log entries](iii://iii-observability/engine/log/reactive-triggers) for the full record shape.
+
+# `engine::logs::clear`
+
+## Inputs
+
+```json
+{}
+```
+
+`clear` takes no fields.
+
+## Outputs
+
+The response acknowledges the wipe and reports how many entries were removed; the exact shape is implementation-defined and intended for human inspection rather than programmatic branching. The next `engine::logs::list` will return an empty list until new entries arrive.
+
+# Worked example
+
+Pull the most recent 100 ERROR-level entries from the last hour:
+
+```json
+{
+  "start_time":    "2026-05-20T17:00:00Z",
+  "end_time":      "2026-05-20T18:00:00Z",
+  "severity_text": "ERROR",
+  "limit":         100
+}
+```
+
+The typical pattern is to scope a `list` call by the field that's most selective — `trace_id` if you're investigating one request, `severity_text: "ERROR"` for a recent-errors view, or `start_time`/`end_time` for time-bound dashboards. Pair with `engine::traces::tree` (passing the same `trace_id`) to get spans + logs for the same operation. Use `clear` only in tests or one-off operator workflows.
+
+For runnable scaffolds, see the observability worker source and SDK examples in [the iii main repo](https://github.com/iii-hq/iii).
+
+# Related
+
+- [`engine::log::*`](iii://iii-observability/engine/log/log) — the emit side; entries returned by `list` are the entries `log::info`/`warn`/`error`/`debug`/`trace` produced.
+- [React to ingested log entries](iii://iii-observability/engine/log/reactive-triggers) — the reactive counterpart to polling `list`.
+- [`engine::traces::tree`](iii://iii-observability/engine/traces/traces) — pair with `list` filtered by `trace_id` to view both logs and spans for one trace.

--- a/engine/src/workers/observability/skills/skills/engine/metrics/list.md
+++ b/engine/src/workers/observability/skills/skills/engine/metrics/list.md
@@ -1,0 +1,57 @@
+---
+type: how-to
+function_id: engine::metrics::list
+title: List engine and SDK metrics with aggregated statistics
+---
+
+# When to use
+
+Call `engine::metrics::list` to inspect counter, gauge, and histogram values the engine and SDK have recorded. The function aggregates raw measurements into named metrics and returns each one's current value plus optional time-bucketed series. It's the right call for an at-a-glance health view, a CLI snapshot, or building a custom dashboard against the engine's in-memory metric store.
+
+Reach for it when:
+
+- You want the current invocation count, error count, latency stats, queue depths, etc. without hooking up an OTLP backend.
+- You need to compare two points in time without a separate metrics database — pass a time range and the response is bucketed.
+- You're verifying that custom SDK metrics emitted by your worker actually reached the engine.
+
+Use [`engine::rollups::list`](iii://iii-observability/engine/rollups/list) instead when you want pre-computed window aggregates (1-minute, 5-minute, 1-hour) rather than ad-hoc bucketing.
+
+# Inputs
+
+```json
+{
+  "names":         ["iii.invocations.total", "iii.invocations.error"],  // optional. Restrict to these metric names; omit to return all.
+  "start_time":    "2026-05-20T17:00:00Z",       // optional. RFC 3339; only data points at or after this time.
+  "end_time":      "2026-05-20T18:00:00Z",       // optional. RFC 3339; only data points at or before this time.
+  "bucket_seconds": 60                            // optional. When set, return time-bucketed values at this resolution; when omitted, only summary stats are returned.
+}
+```
+
+All fields are optional. With no filters, the call returns every known metric with cumulative stats over the configured retention window (`metrics_retention_seconds`).
+
+# Outputs
+
+The response carries per-metric entries; each entry includes the metric name, type (`counter`/`gauge`/`histogram`), current value, summary stats (count/sum/min/max/avg, plus percentiles for histograms), and — when `bucket_seconds` was set — a `series` array of timestamped values at that resolution. Engine-emitted metric names are stable (`iii.invocations.total`, `iii.invocations.error`, `iii.workers.connected`, etc.); SDK and user metric names follow whatever the worker published.
+
+# Worked example
+
+Bucket the invocation total + error count for the last hour at one-minute resolution:
+
+```json
+{
+  "names":          ["iii.invocations.total", "iii.invocations.error"],
+  "start_time":     "2026-05-20T17:00:00Z",
+  "end_time":       "2026-05-20T18:00:00Z",
+  "bucket_seconds": 60
+}
+```
+
+The typical pattern is to filter by `names` (so the response stays small) and pass `bucket_seconds` only when you need time series. For a dashboard tile, request the specific metric and a one-minute bucket; for a one-shot snapshot, omit `bucket_seconds` and read the summary fields. Engine metric names are documented in the iii main repo source — searching for the metric name in `engine/src/workers/observability/` shows where it's emitted.
+
+For runnable scaffolds, see the observability worker source and SDK examples in [the iii main repo](https://github.com/iii-hq/iii).
+
+# Related
+
+- [`engine::rollups::list`](iii://iii-observability/engine/rollups/list) — pre-computed window aggregates; cheaper than calling `metrics::list` with `bucket_seconds`.
+- [`engine::traces::list`](iii://iii-observability/engine/traces/traces) — drill from an aggregate metric into the individual spans contributing to it.
+- [`engine::alerts::list`](iii://iii-observability/engine/alerts/alerts) — alert rules are evaluated against these same metrics.

--- a/engine/src/workers/observability/skills/skills/engine/rollups/list.md
+++ b/engine/src/workers/observability/skills/skills/engine/rollups/list.md
@@ -1,0 +1,58 @@
+---
+type: how-to
+function_id: engine::rollups::list
+title: List metric rollup aggregations
+---
+
+# When to use
+
+Call `engine::rollups::list` for pre-computed time-window aggregates of engine metrics. The engine maintains 1-minute, 5-minute, and 1-hour rollup windows so dashboards and alerting can read aggregated values without re-bucketing raw measurements on every call.
+
+Reach for it when:
+
+- You want a "last hour by minute" or "last day by hour" view without paying for ad-hoc `metrics::list` bucketing.
+- An alert rule references a per-window aggregate; the same numbers feeding `engine::alerts::evaluate` are available here.
+- You're building a long-window trend that would be too coarse with raw `metrics::list` bucketing.
+
+Use [`engine::metrics::list`](iii://iii-observability/engine/metrics/list) instead when you want the raw current value or non-standard bucket sizes.
+
+# Inputs
+
+```json
+{
+  "names":  ["iii.invocations.total"],   // optional. Restrict to these metric names; omit to return rollups for every known metric.
+  "window": "1m"                         // optional. One of "1m" | "5m" | "1h". When omitted, returns rollups for all three windows.
+}
+```
+
+All fields are optional. With no filters, the call returns every metric's rollup entries across all three windows.
+
+# Outputs
+
+The response is keyed by metric name, with per-window arrays of bucketed aggregates. Each bucket carries a window-start timestamp, the aggregate value (sum, average, count, min/max — varies by metric type), and the bucket duration. Use the returned bucket boundaries when rendering — they're aligned to the engine's clock, not the request time.
+
+# Worked example
+
+Read 1-minute rollups for the invocation total — useful for a live dashboard tile:
+
+```json
+{
+  "names":  ["iii.invocations.total"],
+  "window": "1m"
+}
+```
+
+The typical pattern is to read rollups for a specific metric at the window most useful to the consumer:
+
+- 1-minute window for live dashboards (how busy is the engine right now?).
+- 5-minute window for medium-range trends (is the error rate climbing this hour?).
+- 1-hour window for capacity planning and slow-moving SLOs.
+
+Pair with `engine::alerts::list` to see which rule operates on which rollup; the rule's `metric` and `window_seconds` map to the rollup window.
+
+For runnable scaffolds, see the observability worker source and SDK examples in [the iii main repo](https://github.com/iii-hq/iii).
+
+# Related
+
+- [`engine::metrics::list`](iii://iii-observability/engine/metrics/list) — the underlying metric values that feed into these rollups.
+- [`engine::alerts::list`](iii://iii-observability/engine/alerts/alerts) — alerts evaluate against rollup windows; the rule's `window_seconds` maps to one of the windows here.

--- a/engine/src/workers/observability/skills/skills/engine/sampling/rules.md
+++ b/engine/src/workers/observability/skills/skills/engine/sampling/rules.md
@@ -1,0 +1,67 @@
+---
+type: how-to
+function_id: engine::sampling::rules
+title: List the active OpenTelemetry sampling rules
+---
+
+# When to use
+
+Call `engine::sampling::rules` to inspect the sampling configuration currently in effect — the global default rate, the parent-based flag, per-operation rules, and any rate-limit cap. It's a read-only snapshot of the sampling policy the engine is using to decide which traces are kept.
+
+Reach for it when:
+
+- An operator needs to verify a recent config change actually took effect.
+- A trace you expect to see is missing from `engine::traces::list` and you want to confirm whether sampling dropped it.
+- You're auditing how aggressively the engine is sampling each operation type before raising or lowering the rate.
+
+There is **no runtime sampling-mutation function**. Changing the sampling configuration is a `iii-config.yaml` edit + engine restart. The relevant fields under the worker's `sampling:` block are `default` (default ratio, `0.0`–`1.0`), `parent_based` (boolean — when true, child spans inherit the parent's decision), `rules: [{operation, rate}]` (per-operation overrides; first match wins), and `rate_limit: { max_traces_per_second }` (hard cap regardless of per-operation rate).
+
+# Inputs
+
+```json
+{}
+```
+
+`rules` takes no fields.
+
+# Outputs
+
+The response describes the active sampling policy:
+
+```json
+{
+  "default":            1.0,                                // the default sampling ratio (0.0 - 1.0)
+  "parent_based":       true,                                // when true, child spans inherit the parent's sampling decision
+  "rules": [                                                // optional per-operation overrides
+    { "operation": "api.*",   "rate": 0.1 },
+    { "operation": "health.*", "rate": 0.0 }
+  ],
+  "rate_limit": {                                            // optional global cap
+    "max_traces_per_second": 100
+  }
+}
+```
+
+- `default` is the global ratio used when no rule matches.
+- `parent_based` controls whether child spans inherit their parent span's sampling decision.
+- `rules` is the per-operation override list — the first matching rule wins.
+- `rate_limit` enforces a hard cap regardless of the per-operation rate.
+
+Empty `rules` and unset `rate_limit` indicate no overrides — the `default` ratio applies to every trace.
+
+# Worked example
+
+`rules` takes no input — invoke with an empty payload to read the current sampling policy:
+
+```json
+{}
+```
+
+The typical pattern is a quick verification step inside an admin console or a debug handler: "given the engine's current sampling, would I see this trace?" Read the rules, find the rule whose `operation` pattern matches the operation you're investigating, and use that `rate`; if none match, use `default`.
+
+For changing the policy, edit `iii-config.yaml` (`sampling:` block) and restart the engine. The schema is `default` (number, `0.0`–`1.0`), `parent_based` (boolean), `rules: [{operation, rate}]` (operation-pattern matched in order), and `rate_limit: { max_traces_per_second }` (a global cap that applies on top of per-rule rates).
+
+# Related
+
+- `iii-observability` worker config — the source of truth this function exposes at runtime; the `sampling:` block schema is documented inline above.
+- [`engine::traces::list`](iii://iii-observability/engine/traces/traces) — the data the sampling policy gates; missing traces here often correlate with low sampling rates here.

--- a/engine/src/workers/observability/skills/skills/engine/traces/traces.md
+++ b/engine/src/workers/observability/skills/skills/engine/traces/traces.md
@@ -1,0 +1,107 @@
+---
+type: how-to
+functions: [engine::traces::list, engine::traces::tree, engine::traces::clear]
+title: Query and clear stored OpenTelemetry spans
+---
+
+# When to use
+
+The three functions cover the three ways an agent inspects stored span data:
+
+| Question                                                          | Use this                  |
+|-------------------------------------------------------------------|---------------------------|
+| Find spans matching filters (service, name, duration, time range) | `engine::traces::list`    |
+| Show all spans for one `trace_id` as a parent/child tree           | `engine::traces::tree`    |
+| Wipe the in-memory span store                                     | `engine::traces::clear`   |
+
+Reach for `list` for ad-hoc search over many traces; reach for `tree` once you have a `trace_id` and want the full request waterfall; reach for `clear` only in tests or operator one-offs.
+
+Use [`engine::logs::list`](iii://iii-observability/engine/logs/logs) instead when you want unstructured-message telemetry rather than span-shaped timing data. Pair with `traces::tree` (passing the same `trace_id`) to render logs alongside spans.
+
+# `engine::traces::list`
+
+## Inputs
+
+```json
+{
+  "trace_id":          "0123456789abcdef0123456789abcdef",  // optional. Restrict to spans in this trace.
+  "service_name":      "billing",                // optional. Restrict to one service (the resource attribute service.name).
+  "name":              "process_payment",        // optional. Span name; partial-match support is implementation-defined.
+  "status":            "error",                  // optional. "ok" | "error" | "unset".
+  "min_duration_ms":   100,                      // optional. Inclusive lower bound on span duration.
+  "max_duration_ms":   10000,                    // optional. Inclusive upper bound on span duration.
+  "start_time":        "2026-05-20T17:00:00Z",   // optional. RFC 3339; only spans starting at or after this time.
+  "end_time":          "2026-05-20T18:00:00Z",   // optional. RFC 3339; only spans starting at or before this time.
+  "sort_by":           "start_time",             // optional. "start_time" | "duration_ms" | "name".
+  "sort_order":        "desc",                   // optional. "asc" | "desc". Defaults to "desc".
+  "attributes":        { "http.status_code": "500" },  // optional. Map of attribute keys to required values; spans must match every key.
+  "include_internal":  false,                    // optional. When false (default), excludes spans with kind "INTERNAL" (engine plumbing).
+  "offset":            0,                        // optional. Pagination offset.
+  "limit":             100                       // optional. Max spans returned per page.
+}
+```
+
+All fields are optional. With no filters, the call returns the most recent page of spans (excluding INTERNAL spans by default — set `include_internal: true` to see engine plumbing).
+
+## Outputs
+
+A paginated list of spans; each span carries `trace_id`, `span_id`, `parent_span_id` (or null for root), `name`, `kind`, `service_name`, `start_time`, `end_time`, `duration_ms`, `status`, `attributes`, and event/link arrays. The exact field set tracks the OTel span schema.
+
+# `engine::traces::tree`
+
+## Inputs
+
+```json
+{
+  "trace_id": "0123456789abcdef0123456789abcdef"   // required. The trace id to assemble.
+}
+```
+
+`trace_id` is required.
+
+## Outputs
+
+A single tree-shaped object: the root span at the top, each `children` array containing direct child spans (each with their own `children`), recursively. Each node has the same fields as a `traces::list` row. Empty `children: []` arrays mark leaves.
+
+# `engine::traces::clear`
+
+## Inputs
+
+```json
+{}
+```
+
+`clear` takes no fields.
+
+## Outputs
+
+The response acknowledges the wipe; the next `traces::list` returns an empty list until new spans arrive.
+
+# Worked example
+
+Find recent error traces in the billing service:
+
+```json
+{
+  "service_name": "billing",
+  "status":       "error",
+  "start_time":   "2026-05-20T17:00:00Z",
+  "limit":        50
+}
+```
+
+Then pick a `trace_id` from the response and walk it as a parent/child tree via `engine::traces::tree`:
+
+```json
+{ "trace_id": "0123456789abcdef0123456789abcdef" }
+```
+
+The typical pattern is "find a trace, then walk it" — `list` to narrow, `tree` to drill in. Optionally call `engine::logs::list` with the same `trace_id` to interleave logs with spans. `clear` is for test setup only — production span retention is governed by `memory_max_spans`.
+
+For runnable scaffolds, see the observability worker source and SDK examples in [the iii main repo](https://github.com/iii-hq/iii).
+
+# Related
+
+- [`engine::logs::list`](iii://iii-observability/engine/logs/logs) — the matching log query; pair with `traces::tree` filtered by `trace_id`.
+- [`engine::log::*`](iii://iii-observability/engine/log/log) — when emitting logs from inside a span, pass `trace_id`/`span_id` so the entries link up here.
+- [`engine::metrics::list`](iii://iii-observability/engine/metrics/list) — for aggregated views over many traces.


### PR DESCRIPTION
## Summary

Adds the agent skills bundle for the **`iii-observability`** built-in engine worker. Follows the canonical convention established by [#1667](https://github.com/iii-hq/iii/pull/1667). One of the N-PR plan paired with #1665 (`iii-stream`), #1666 (`iii-cron`), #1668 (`iii-http`), #1669 (`iii-bridge`).

This worker has the broadest surface so far — 18 callable functions across 9 sub-namespaces plus 1 trigger type. The bundle uses multi-function variants where functions share shape (5 log levels, log list+clear, traces list+tree+clear, baggage get+set+get_all, alerts list+evaluate) so 18 functions land in 7 how-to files.

### What's added

```
engine/src/workers/observability/skills/
├── index.md                                       # type: index — worker overview
└── skills/
    └── engine/
        ├── log/
        │   ├── log.md                              # multi-function: 5 emit functions (info/warn/error/debug/trace)
        │   └── reactive-triggers.md                # the `log` trigger type
        ├── logs/
        │   └── logs.md                             # multi-function: list + clear
        ├── traces/
        │   └── traces.md                           # multi-function: list + tree + clear
        ├── metrics/
        │   └── list.md                             # single function
        ├── rollups/
        │   └── list.md                             # single function
        ├── baggage/
        │   └── baggage.md                          # multi-function: get + set + get_all
        ├── sampling/
        │   └── rules.md                            # single function
        ├── health/
        │   └── check.md                            # single function
        └── alerts/
            └── alerts.md                           # multi-function: list + evaluate
```

### Faithful to the source

Function ids and input/output shapes come straight from `engine/src/workers/observability/mod.rs`:

- 5 emit functions at `mod.rs:362-405` (`engine::log::{info,warn,error,debug,trace}`) — all share `OtelLogInput` (`mod.rs:275`).
- 3 baggage functions at `mod.rs:411-468`. The `set` function's "doesn't propagate to the caller" caveat is documented because the source explicitly notes it (`mod.rs:438-441`) and the function itself returns a `note` field warning callers.
- Traces functions at `mod.rs:629-855`, metrics at `mod.rs:974`, logs at `mod.rs:1152-1203`, sampling/health/alerts at `mod.rs:1224-1419`, rollups at `mod.rs:1418`.
- The `log` trigger type registered at `mod.rs:1650-1657` (`LOG_TRIGGER_TYPE = "log"` per `mod.rs:252`). Trigger payload shape (OTel log record with `timestamp_unix_nano`, `severity_number`, `severity_text`, `body`, `attributes`, `trace_id`, `span_id`, `resource`, `service_name`, `instrumentation_scope_*`) matches the `log` storage subscribe surface and the README's documented payload (`README.md:158`).

### Adherence to canonical convention

- **Path layout**: `engine/src/workers/observability/skills/skills/engine/<sub-ns>/<file>.md` matches the doubled-`skills/` shape `build_skills_payload.py` produces.
- **URI scheme**: `iii://iii-observability/engine/<sub-ns>/<file>` — worker-name-prefixed, matching `iii://iii-state/state/...` and `iii://iii-stream/stream/...`.
- **Multi-function frontmatter** on the 5 collapsed how-tos (`functions: [...]` array, no `function_id`) per section 5 of `DOCUMENTATION_GUIDELINES.md`.
- **No example code in `# Worked example`** — prose-only with a pointer to [the iii main repo](https://github.com/iii-hq/iii) for runnable scaffolds, matching the pattern from previous PRs.
- **Section order**: `# When to use` → `# Inputs` → `# Outputs` → `# Worked example` → `# Related` (multi-function variant uses per-function H1s with H2 Inputs/Outputs subsections per the spec).

### Validated through canonical pipeline

`python3 .github/scripts/build_skills_payload.py --worker-dir engine/src/workers/observability` produces 11 skill keys, all regex-passing:

```
index.md
skills/skills/engine/alerts/alerts.md
skills/skills/engine/baggage/baggage.md
skills/skills/engine/health/check.md
skills/skills/engine/log/log.md
skills/skills/engine/log/reactive-triggers.md
skills/skills/engine/logs/logs.md
skills/skills/engine/metrics/list.md
skills/skills/engine/rollups/list.md
skills/skills/engine/sampling/rules.md
skills/skills/engine/traces/traces.md
```

## Out of scope

- No code changes. Markdown-only addition under `engine/src/workers/observability/skills/`.
- The exact field schemas of `metrics::list`, `rollups::list`, `traces::list`, and `alerts::list` responses are documented at the level of "what fields they carry and what they're for"; precise JSON shapes vary as the engine adds new metric types and span attributes. The skills point at the README + iii main repo for the authoritative response schemas.
- Advanced sampling configuration (the `sampling:` block schema) lives in the README — `engine::sampling::rules` is read-only and points there.

## Test plan

- [ ] Bundle structure validates against `DOCUMENTATION_GUIDELINES.md` — frontmatter, required sections in order, multi-function variant shape, valid `iii://` link form, no emoji.
- [ ] Function ids in frontmatter match the registered ids in source (`mod.rs:362-1419`).
- [ ] Trigger config (`level: "trace"|"debug"|"info"|"warn"|"error"|null`) and payload (OTel log record shape) match `mod.rs:1650-1657` and the storage subscribe surface.
- [ ] CI green — markdown-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive observability guides covering alerts (listing and forced evaluation workflows), baggage inspection and local set semantics, health-check contract and component rollups, structured log emission (severity mapping, retention, console output), real-time log triggers, querying and clearing logs, metrics and pre-computed rollups, runtime sampling inspection, and trace querying with tree-style visualization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->