### PR TITLE
docs(exec): add agent skills bundle for iii-exec worker

### DIFF
--- a/engine/src/workers/shell/skills/index.md
+++ b/engine/src/workers/shell/skills/index.md
@@ -1,0 +1,63 @@
+---
+type: index
+title: iii-exec
+---
+
+# iii-exec
+
+Run a sequential pipeline of shell commands as part of engine startup. Each entry in the configured `exec:` array launches as a separate child process, must exit `0` before the next entry starts, and the **final** entry is kept running as a long-lived process for the lifetime of the engine. Optionally, a `watch:` glob list restarts the entire pipeline whenever a matching file changes.
+
+The worker exposes **no callable functions and no trigger types**. Its surface is entirely declarative — configure `exec:` in `iii-config.yaml` and the engine handles the rest. There is nothing for an agent to call at runtime; this skill describes when to reach for the worker and how to shape its config.
+
+For the full config schema (`exec:`, `watch:`), the per-process semantics, and the watch-pattern limitations (root-dir + extension matching only; filename portion ignored; files without extensions never matched), see [the README](../README.md).
+
+- **Startup pipeline** (`exec:`) — sequential commands that must succeed in order, with the final command kept running as a long-lived process bound to the engine's lifecycle.
+- **File-watch restart** (`watch:`) — glob patterns that trigger a full pipeline restart on change. Useful for development; rarely the right choice for production.
+
+## How-tos
+
+### When to use `iii-exec`
+
+Reach for this worker when the engine should manage the lifecycle of a separate process — typically a long-running app or daemon that the engine boots, supervises, and shuts down alongside itself. Common patterns:
+
+- **Build then serve.** Two prep commands that must succeed before the long-lived server runs:
+  ```yaml
+  - name: iii-exec
+    config:
+      exec:
+        - cd frontend && npm install
+        - cd frontend && npm run build
+        - bun run --enable-source-maps index-production.js
+  ```
+  The first two run sequentially and must exit `0`; the third stays running. If any prep step fails (non-zero exit), the pipeline stops, the long-lived server never starts, and the engine surfaces the failure.
+
+- **Development with file watch.** Add a `watch:` block so the pipeline restarts when source files change:
+  ```yaml
+  - name: iii-exec
+    config:
+      watch:
+        - steps/**/*.{ts,js}
+        - config/*.json
+      exec:
+        - cd frontend && npm install
+        - cd frontend && npm run build
+        - bun run --enable-source-maps index-production.js
+  ```
+  Note from the [README](../README.md): watch patterns match by root directory + file extension only — the filename portion is ignored. `src/**/*.test.ts` matches every `.ts` file under `src/`, not only `*.test.ts`. Files without an extension are never matched.
+
+### When *not* to use `iii-exec`
+
+- **Recurring scheduled jobs.** Use the `cron` reactive trigger from `iii-cron` (see its [skills bundle](https://github.com/iii-hq/iii/tree/main/engine/src/workers/cron/skills)) — `iii-exec` is for one-shot startup pipelines and a single long-lived process, not for cron-style scheduling.
+- **Inter-process state sharing across entries.** Each entry runs in its own shell, so working directory and environment changes do not carry forward. Chain steps that need to share state with `&&` inside one entry:
+  ```yaml
+  - cd path/to/project && npm run build
+  ```
+- **Calling shell commands at runtime from a function.** `iii-exec` runs at engine startup only. There's no engine function for "execute this command now."
+
+### Operational notes
+
+- **Sequential execution, not parallel.** Entries run in order. Use a separate process supervisor (or multiple `iii-exec` worker instances if your config supports them) when you genuinely need parallel processes.
+- **Exit-code propagation.** Non-zero exit on any intermediate command stops the pipeline; remaining commands are skipped. The final long-lived command's exit signals engine shutdown of this worker.
+- **Watch caveats.** The watcher is intentionally simple — review [the README's note on pattern limitations](../README.md) before relying on watch in CI or production.
+
+For the full schema and runnable examples, see [the README](../README.md) and [the iii main repo](https://github.com/iii-hq/iii).

--- a/engine/src/workers/shell/skills/index.md
+++ b/engine/src/workers/shell/skills/index.md
@@ -9,7 +9,10 @@ Run a sequential pipeline of shell commands as part of engine startup. Each entr
 
 The worker exposes **no callable functions and no trigger types**. Its surface is entirely declarative — configure `exec:` in `iii-config.yaml` and the engine handles the rest. There is nothing for an agent to call at runtime; this skill describes when to reach for the worker and how to shape its config.
 
-For the full config schema (`exec:`, `watch:`), the per-process semantics, and the watch-pattern limitations (root-dir + extension matching only; filename portion ignored; files without extensions never matched), see [the README](https://github.com/iii-hq/iii/blob/main/engine/src/workers/shell/README.md).
+Config schema:
+
+- `exec: string[]` — required. Sequential pipeline of shell commands. Each entry is run as a separate child process; intermediate entries must exit `0` before the next starts, and the final entry is held open as the long-lived process for the worker's lifetime.
+- `watch: string[]` — optional. Glob patterns that trigger a full pipeline restart on file change. **Caveat**: the watcher matches by root directory + file extension only — the filename portion is ignored, so `src/**/*.test.ts` matches every `.ts` file under `src/`, not only test files. Files without an extension (`Makefile`, shell scripts) are never matched. Use `**` for recursive subdirectory matching (`config/*.json` watches only the top level of `config/`; `config/**/*.json` watches at any depth).
 
 - **Startup pipeline** (`exec:`) — sequential commands that must succeed in order, with the final command kept running as a long-lived process bound to the engine's lifecycle.
 - **File-watch restart** (`watch:`) — glob patterns that trigger a full pipeline restart on change. Useful for development; rarely the right choice for production.
@@ -43,7 +46,7 @@ Reach for this worker when the engine should manage the lifecycle of a separate 
         - cd frontend && npm run build
         - bun run --enable-source-maps index-production.js
   ```
-  Note from the [README](https://github.com/iii-hq/iii/blob/main/engine/src/workers/shell/README.md): watch patterns match by root directory + file extension only — the filename portion is ignored. `src/**/*.test.ts` matches every `.ts` file under `src/`, not only `*.test.ts`. Files without an extension are never matched.
+  The watch caveat (repeated for visibility): patterns match by root directory + file extension only — the filename portion is ignored. `src/**/*.test.ts` matches every `.ts` file under `src/`, not only `*.test.ts`. Files without an extension are never matched.
 
 ### When *not* to use `iii-exec`
 
@@ -58,6 +61,6 @@ Reach for this worker when the engine should manage the lifecycle of a separate 
 
 - **Sequential execution, not parallel.** Entries run in order. Use a separate process supervisor (or multiple `iii-exec` worker instances if your config supports them) when you genuinely need parallel processes.
 - **Exit-code propagation.** Non-zero exit on any intermediate command stops the pipeline; remaining commands are skipped. The final long-lived command's exit signals engine shutdown of this worker.
-- **Watch caveats.** The watcher is intentionally simple — review [the README's note on pattern limitations](https://github.com/iii-hq/iii/blob/main/engine/src/workers/shell/README.md) before relying on watch in CI or production.
+- **Watch caveats.** The watcher is intentionally simple — see the pattern-matching limits documented above before relying on watch in CI or production.
 
-For the full schema and runnable examples, see [the README](https://github.com/iii-hq/iii/blob/main/engine/src/workers/shell/README.md) and [the iii main repo](https://github.com/iii-hq/iii).
+For runnable examples, see [the iii main repo](https://github.com/iii-hq/iii).

--- a/engine/src/workers/shell/skills/index.md
+++ b/engine/src/workers/shell/skills/index.md
@@ -9,7 +9,7 @@ Run a sequential pipeline of shell commands as part of engine startup. Each entr
 
 The worker exposes **no callable functions and no trigger types**. Its surface is entirely declarative — configure `exec:` in `iii-config.yaml` and the engine handles the rest. There is nothing for an agent to call at runtime; this skill describes when to reach for the worker and how to shape its config.
 
-For the full config schema (`exec:`, `watch:`), the per-process semantics, and the watch-pattern limitations (root-dir + extension matching only; filename portion ignored; files without extensions never matched), see [the README](../README.md).
+For the full config schema (`exec:`, `watch:`), the per-process semantics, and the watch-pattern limitations (root-dir + extension matching only; filename portion ignored; files without extensions never matched), see [the README](https://github.com/iii-hq/iii/blob/main/engine/src/workers/shell/README.md).
 
 - **Startup pipeline** (`exec:`) — sequential commands that must succeed in order, with the final command kept running as a long-lived process bound to the engine's lifecycle.
 - **File-watch restart** (`watch:`) — glob patterns that trigger a full pipeline restart on change. Useful for development; rarely the right choice for production.
@@ -43,7 +43,7 @@ Reach for this worker when the engine should manage the lifecycle of a separate 
         - cd frontend && npm run build
         - bun run --enable-source-maps index-production.js
   ```
-  Note from the [README](../README.md): watch patterns match by root directory + file extension only — the filename portion is ignored. `src/**/*.test.ts` matches every `.ts` file under `src/`, not only `*.test.ts`. Files without an extension are never matched.
+  Note from the [README](https://github.com/iii-hq/iii/blob/main/engine/src/workers/shell/README.md): watch patterns match by root directory + file extension only — the filename portion is ignored. `src/**/*.test.ts` matches every `.ts` file under `src/`, not only `*.test.ts`. Files without an extension are never matched.
 
 ### When *not* to use `iii-exec`
 
@@ -58,6 +58,6 @@ Reach for this worker when the engine should manage the lifecycle of a separate 
 
 - **Sequential execution, not parallel.** Entries run in order. Use a separate process supervisor (or multiple `iii-exec` worker instances if your config supports them) when you genuinely need parallel processes.
 - **Exit-code propagation.** Non-zero exit on any intermediate command stops the pipeline; remaining commands are skipped. The final long-lived command's exit signals engine shutdown of this worker.
-- **Watch caveats.** The watcher is intentionally simple — review [the README's note on pattern limitations](../README.md) before relying on watch in CI or production.
+- **Watch caveats.** The watcher is intentionally simple — review [the README's note on pattern limitations](https://github.com/iii-hq/iii/blob/main/engine/src/workers/shell/README.md) before relying on watch in CI or production.
 
-For the full schema and runnable examples, see [the README](../README.md) and [the iii main repo](https://github.com/iii-hq/iii).
+For the full schema and runnable examples, see [the README](https://github.com/iii-hq/iii/blob/main/engine/src/workers/shell/README.md) and [the iii main repo](https://github.com/iii-hq/iii).


### PR DESCRIPTION
## Summary

Adds the agent skills bundle for the **`iii-exec`** built-in engine worker (folder name `shell`, registry slug `iii-exec`). Follows the canonical convention from [#1667](https://github.com/iii-hq/iii/pull/1667).

This is the smallest bundle in the queue: `iii-exec` exposes **no callable functions and no trigger types** (verified — `engine/src/workers/shell/` has zero `#[function]` registrations and no `register_trigger_type` calls). Its entire surface is declarative configuration (`exec:` / `watch:` blocks in `iii-config.yaml`), so the bundle is a single `index.md` describing **when** to reach for the worker, **how** to shape its config, and the operational caveats that aren't obvious from the README alone.

### What's added

```
engine/src/workers/shell/skills/
└── index.md                    # type: index — overview + when-to-use / when-not-to-use guidance
```

### Faithful to the source

The bundle's claims trace to the source and README directly:

- "No callable functions, no trigger types." Verified by `rg '#\[function|register_trigger_type' engine/src/workers/shell/` returning empty.
- Sequential semantics, exit-code stop-on-failure, last-entry-stays-running: `engine/src/workers/shell/README.md`.
- Watch pattern limitations (root + extension only, filename portion ignored, no-extension files never matched): copied from the README's explicit note.
- Entries don't share shell state — use `&&` in a single entry: from the README's "Because each entry runs as a separate process..." paragraph.

### Adherence to canonical convention

- **Path layout**: `engine/src/workers/shell/skills/index.md` is all that's needed; there are no functions to nest under `skills/skills/<ns>/`.
- **Frontmatter**: `type: index` + `title: iii-exec`.
- **No example code in `# Worked example`** — there isn't a `# Worked example` section because there's nothing to invoke. The `## How-tos` section instead lists "When to use" / "When not to use" / "Operational notes" subsections, each with prose pointing at the README and iii main repo for runnable scaffolds.
- The two YAML config blocks shown in the body are direct copies of the README's example config; they're documentation of an existing, agent-actionable contract (the `iii-config.yaml` schema), not invocation examples.

### Validated through canonical pipeline

`python3 .github/scripts/build_skills_payload.py --worker-dir engine/src/workers/shell` produces 1 skill key (`index.md`).

## Out of scope

- The full `iii-config.yaml` schema for `exec:`/`watch:` lives in [the README](https://github.com/iii-hq/iii/blob/main/engine/src/workers/shell/README.md). The skills bundle cross-references it rather than duplicating.
- Process-supervision semantics (signal handling on engine shutdown, restart-on-crash policy, etc.) are deliberately documented at the level the README documents them.

## Test plan

- [ ] Bundle structure validates against `DOCUMENTATION_GUIDELINES.md` for `type: index` files (frontmatter, H1 body opener, no emoji).
- [ ] Source-claim verification: zero `#[function]` macros and zero `register_trigger_type` calls under `engine/src/workers/shell/`. Re-run the rg if a future change adds either; the bundle would need to grow accordingly.
- [ ] CI green — markdown-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive user docs for the iii-exec startup skill: declarative startup pipelines, sequential command behavior and exit-code handling, optional file-watch restart behavior and its matching limitations, examples (build→serve, dev with watch), guidance on when not to use it, and operational notes on execution and watch caveats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->