### PR TITLE
feat(iii-worker): make sandbox::* handlers agent-friendly

### DIFF
--- a/crates/iii-worker/src/sandbox_daemon/create.rs
+++ b/crates/iii-worker/src/sandbox_daemon/create.rs
@@ -7,29 +7,45 @@ use crate::sandbox_daemon::{
     overlay::OverlayLayout,
     registry::{SandboxRegistry, SandboxState},
 };
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::time::Instant;
 use uuid::Uuid;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct CreateRequest {
+    /// Catalog name of the image to boot. Bundled presets are
+    /// `"python"` and `"node"`; pass either string verbatim. The only
+    /// other accepted values are the literal keys of
+    /// `sandbox.custom_images` in `iii.config.yaml` — set by the
+    /// operator. Do NOT pass an OCI ref like
+    /// `"ghcr.io/iii-hq/node:latest"` or `"docker.io/library/node:20"`
+    /// unless that exact string is the catalog key. Unknown values
+    /// return S100 with the allowed set in the error message.
     pub image: String,
+    /// vCPU count; daemon/image default applies when omitted.
     #[serde(default)]
     pub cpus: Option<u32>,
+    /// Memory cap in MiB; daemon/image default applies when omitted.
     #[serde(default)]
     pub memory_mb: Option<u32>,
+    /// Human label surfaced by `sandbox::list`; not an identifier.
     #[serde(default)]
     pub name: Option<String>,
+    /// Whether the VM gets outbound networking; daemon default when omitted.
     #[serde(default)]
     pub network: Option<bool>,
+    /// Auto-stop the VM after this many seconds of inactivity; daemon
+    /// default applies when omitted.
     #[serde(default)]
     pub idle_timeout_secs: Option<u64>,
+    /// `"K=V"` entries injected into the VM's environment.
     #[serde(default)]
     pub env: Vec<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, JsonSchema)]
 pub struct CreateResponse {
     pub sandbox_id: String,
     pub image: String,

--- a/crates/iii-worker/src/sandbox_daemon/errors.rs
+++ b/crates/iii-worker/src/sandbox_daemon/errors.rs
@@ -256,6 +256,52 @@ impl SandboxError {
     }
 }
 
+/// Display-as-JSON wire adapter for `RegisterFunction::new_async`.
+///
+/// The new async-handler builder collapses errors via `Display`, but the
+/// `sandbox::*` wire contract — preserved across the
+/// `register_function_with` → `register_function` migration — is the
+/// structured payload produced by [`SandboxError::to_payload`]
+/// (`code`/`type`/`message`/`docs_url`/`retryable`). Wrapping the error
+/// in `SandboxErrorWire` and `map_err`-ing into it makes `Display` emit
+/// that JSON, so callers (CLI, agents, engine clients) see the exact
+/// same body they did when handlers wrote
+/// `IIIError::Handler(serde_json::to_string(&e.to_payload())…)` by hand.
+///
+/// SDK contract dependency: this wrapper is load-bearing only as long as
+/// `iii_sdk::IntoAsyncHandler` collapses `E` via `e.to_string()` (i.e.
+/// the `Display` impl). If the SDK ever switches to a structured error
+/// trait or to `Debug`, the wire format will drift silently — the
+/// `sandbox_error_wire_display_matches_to_payload_json` test pins the
+/// local invariant but cannot catch SDK-side regressions. Re-audit this
+/// adapter whenever `iii-sdk`'s handler-error path changes.
+pub struct SandboxErrorWire(pub SandboxError);
+
+impl From<SandboxError> for SandboxErrorWire {
+    fn from(err: SandboxError) -> Self {
+        SandboxErrorWire(err)
+    }
+}
+
+impl std::fmt::Display for SandboxErrorWire {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Falls back to the inner `thiserror` Display only if the JSON
+        // payload itself cannot be serialized — matching the
+        // `unwrap_or_else(|_| e.to_string())` branch of the legacy
+        // hand-written handlers.
+        match serde_json::to_string(&self.0.to_payload()) {
+            Ok(json) => f.write_str(&json),
+            Err(_) => std::fmt::Display::fmt(&self.0, f),
+        }
+    }
+}
+
+impl std::fmt::Debug for SandboxErrorWire {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.0, f)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -369,6 +415,31 @@ mod tests {
                 *expected,
                 "variant {err:?} expected to serialize with code {expected}"
             );
+        }
+    }
+
+    /// Pins the wire format `RegisterFunction::new_async` callers see for
+    /// `sandbox::*` errors. Before the migration, handlers wrote
+    /// `IIIError::Handler(serde_json::to_string(&e.to_payload())…)`
+    /// directly; after, they `map_err` into `SandboxErrorWire` and the
+    /// SDK's async-handler glue calls `Display`. This test asserts both
+    /// paths produce the same JSON bytes, so callers branching on
+    /// `code` / `type` / `retryable` keep working.
+    #[test]
+    fn sandbox_error_wire_display_matches_to_payload_json() {
+        let cases: &[SandboxError] = &[
+            SandboxError::InvalidRequest("cmd must be a single binary".into()),
+            SandboxError::NotFound("11111111-1111-1111-1111-111111111111".into()),
+            SandboxError::ExecTimedOut { timeout_ms: 1500 },
+            SandboxError::FsUnsupported,
+        ];
+        for err in cases {
+            let expected = serde_json::to_string(&err.to_payload()).unwrap();
+            let actual = SandboxErrorWire(err.clone()).to_string();
+            assert_eq!(actual, expected, "wire format drift for {err:?}");
+            // And the embedded code stays parseable by clients.
+            let parsed: serde_json::Value = serde_json::from_str(&actual).unwrap();
+            assert_eq!(parsed["code"], err.code().as_str());
         }
     }
 }

--- a/crates/iii-worker/src/sandbox_daemon/exec.rs
+++ b/crates/iii-worker/src/sandbox_daemon/exec.rs
@@ -2,26 +2,39 @@
 //! time. `SandboxRegistry::begin_exec` / `end_exec` holds that guard.
 
 use crate::sandbox_daemon::{errors::SandboxError, registry::SandboxRegistry};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct ExecRequest {
+    /// UUID returned by `sandbox::create`.
     pub sandbox_id: String,
+    /// The binary to execute as a single string — NOT a shell line.
+    /// `"node"` is correct; `"node -v"` is not (put `-v` in `args`).
+    /// `handle_exec` rejects values containing whitespace with S001.
+    /// Shell metacharacters (`;`, `|`, `&&`, `>`, etc.) in `cmd` are not
+    /// interpreted — the runner spawns `cmd` literally. Use a wrapper
+    /// script inside the VM if you need shell behavior.
     pub cmd: String,
+    /// Argv tail passed to `cmd` (each entry is one argv slot).
     #[serde(default)]
     pub args: Vec<String>,
+    /// Base64-encoded bytes piped to the child's stdin.
     #[serde(default)]
-    pub stdin: Option<String>, // base64-encoded stdin bytes
+    pub stdin: Option<String>,
+    /// `"K=V"` entries (NOT a map) added to the child's environment.
     #[serde(default)]
-    pub env: Vec<String>, // "K=V" entries
+    pub env: Vec<String>,
+    /// Kill-after window in ms; daemon default applies when omitted.
     #[serde(default)]
     pub timeout_ms: Option<u64>,
+    /// Working directory inside the sandbox; image default when omitted.
     #[serde(default)]
     pub workdir: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, JsonSchema)]
 pub struct ExecResponse {
     pub stdout: String,
     pub stderr: String,
@@ -51,6 +64,25 @@ pub async fn handle_exec<R: ShellRunner>(
             req.sandbox_id
         ))
     })?;
+    // Reject `cmd` containing whitespace. The runner spawns `cmd` as a
+    // single binary (no shell expansion), so `cmd: "node -v"` looks for a
+    // binary literally named `node -v` and fails inside the VM. In
+    // practice the failure mode observed downstream is a shell-relay
+    // disconnect (S300 "vm disconnected mid-run") rather than a clean
+    // not-found error, leaving agents stuck retrying a doomed call.
+    // Catching it here converts that into a recoverable S001 with a
+    // hint, so the caller learns the right shape on the first miss.
+    if req.cmd.chars().any(|c| c.is_whitespace()) {
+        return Err(SandboxError::InvalidRequest(format!(
+            "cmd must be a single binary, not a shell line: got {:?}. Put arguments in `args` (Vec<String>) instead — e.g. {{ cmd: \"node\", args: [\"-v\"] }}.",
+            req.cmd
+        )));
+    }
+    if req.cmd.is_empty() {
+        return Err(SandboxError::InvalidRequest(
+            "cmd is required and must be non-empty".to_string(),
+        ));
+    }
     let state = registry.begin_exec(id).await?;
 
     // Always clear exec flag on exit (success OR error).
@@ -167,5 +199,87 @@ mod tests {
         };
         let err = handle_exec(req, &reg, &runner).await.unwrap_err();
         assert_eq!(err.code().as_str(), "S002");
+    }
+
+    #[tokio::test]
+    async fn cmd_with_whitespace_returns_s001_with_hint() {
+        // Regression: kimi-k2.6 (and other LLMs) frequently pass
+        // `cmd: "node -v"` instead of `cmd: "node", args: ["-v"]`. Before
+        // the guard this reached the shell relay and surfaced as
+        // S300 "vm disconnected mid-run" — opaque, retried in a loop,
+        // and left the operator's QA report blocked.
+        let reg = SandboxRegistry::new();
+        let id = Uuid::new_v4();
+        reg.insert(state_for(id)).await;
+        let runner = FakeRunner {
+            stdout: "".into(),
+            exit: 0,
+        };
+        let req = ExecRequest {
+            sandbox_id: id.to_string(),
+            cmd: "node -v".into(),
+            args: vec![],
+            stdin: None,
+            env: vec![],
+            timeout_ms: None,
+            workdir: None,
+        };
+        let err = handle_exec(req, &reg, &runner).await.unwrap_err();
+        assert_eq!(err.code().as_str(), "S001");
+        let payload = err.to_payload();
+        // Message must steer the caller to the correct shape.
+        let msg = payload["message"].as_str().unwrap();
+        assert!(msg.contains("single binary"), "msg={msg}");
+        assert!(msg.contains("args"), "msg={msg}");
+        // begin_exec must NOT have flipped — a doomed call should not
+        // hold the per-sandbox exec lock.
+        let state = reg.get(id).await.unwrap();
+        assert!(!state.exec_in_progress);
+    }
+
+    #[tokio::test]
+    async fn cmd_with_tab_or_newline_also_rejected() {
+        for bad in ["node\t-v", "node\n-v"] {
+            let reg = SandboxRegistry::new();
+            let id = Uuid::new_v4();
+            reg.insert(state_for(id)).await;
+            let runner = FakeRunner {
+                stdout: "".into(),
+                exit: 0,
+            };
+            let req = ExecRequest {
+                sandbox_id: id.to_string(),
+                cmd: bad.into(),
+                args: vec![],
+                stdin: None,
+                env: vec![],
+                timeout_ms: None,
+                workdir: None,
+            };
+            let err = handle_exec(req, &reg, &runner).await.unwrap_err();
+            assert_eq!(err.code().as_str(), "S001", "input={bad:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_cmd_returns_s001() {
+        let reg = SandboxRegistry::new();
+        let id = Uuid::new_v4();
+        reg.insert(state_for(id)).await;
+        let runner = FakeRunner {
+            stdout: "".into(),
+            exit: 0,
+        };
+        let req = ExecRequest {
+            sandbox_id: id.to_string(),
+            cmd: "".into(),
+            args: vec![],
+            stdin: None,
+            env: vec![],
+            timeout_ms: None,
+            workdir: None,
+        };
+        let err = handle_exec(req, &reg, &runner).await.unwrap_err();
+        assert_eq!(err.code().as_str(), "S001");
     }
 }

--- a/crates/iii-worker/src/sandbox_daemon/fs/write.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/write.rs
@@ -121,6 +121,31 @@ impl tokio::io::AsyncRead for ChannelReaderAdapter {
 // Request / response types
 // ---------------------------------------------------------------------------
 
+/// File body for `sandbox::fs::write`. Untagged so the JSON shape
+/// decides which variant runs:
+///
+/// - A bare JSON string (`"console.log('hi')"`) → [`WriteContent::Utf8`].
+///   This is what LLM agents naturally pass and the recommended form
+///   for source files / configs / small text.
+/// - An object that matches [`StreamChannelRef`] → [`WriteContent::Stream`].
+///   The existing channel-streaming path for large or binary payloads
+///   coming from a programmatic caller that can construct a channel.
+///
+/// Serde tries variants in declaration order; `Utf8` matches first
+/// because every JSON string deserialises into `String`, and
+/// `StreamChannelRef` requires an object. Binary inline data uses the
+/// separate `content_b64` field on [`WriteRequest`] (not a variant
+/// here, so a caller can't accidentally pass base64 expecting it to be
+/// decoded — they have to opt in by name).
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum WriteContent {
+    /// Inline UTF-8 string. Written to the file verbatim.
+    Utf8(String),
+    /// Streaming channel for large / binary uploads.
+    Stream(StreamChannelRef),
+}
+
 #[derive(Debug, Deserialize)]
 pub struct WriteRequest {
     pub sandbox_id: String,
@@ -129,7 +154,15 @@ pub struct WriteRequest {
     pub mode: String,
     #[serde(default)]
     pub parents: bool,
-    pub content: StreamChannelRef,
+    /// File body — pass a UTF-8 string for source/text, or a
+    /// `StreamChannelRef` object for streaming. Mutually exclusive
+    /// with `content_b64`; exactly one of the two must be set.
+    #[serde(default)]
+    pub content: Option<WriteContent>,
+    /// Base64-encoded inline body for small binary payloads.
+    /// Mutually exclusive with `content`.
+    #[serde(default)]
+    pub content_b64: Option<String>,
 }
 
 fn default_mode() -> String {
@@ -184,22 +217,64 @@ pub async fn handle_write_with_reader<R: FsRunner + ?Sized>(
     }
 }
 
-/// Public trigger handler. Constructs a `ChannelReader` from the caller's
-/// `StreamChannelRef` and delegates to `handle_write_with_reader`.
+/// Public trigger handler. Dispatches on the body shape and delegates
+/// to [`handle_write_with_reader`].
+///
+/// Accepts three input shapes (exactly one must be present):
+///
+/// - `content: "<utf-8 string>"` — inline UTF-8 body, wrapped in a
+///   `Cursor` and written verbatim. The path LLM agents naturally take
+///   when they pass `content` as a string. No channel setup required.
+/// - `content_b64: "<base64>"` — inline binary body. Decoded, then
+///   wrapped in a `Cursor` like the UTF-8 form. Use for files with
+///   bytes the JSON layer would mangle (NUL, invalid UTF-8, etc.).
+/// - `content: { reader_ref: …, … }` — a `StreamChannelRef`. The
+///   original streaming path, for large uploads from programmatic
+///   callers that can construct a channel.
 pub async fn handle_write<R: FsRunner + ?Sized>(
     req: WriteRequest,
     registry: &SandboxRegistry,
     runner: &R,
     engine_address: &str,
 ) -> Result<WriteResponse, SandboxError> {
-    let ch_reader = ChannelReader::new(engine_address, &req.content);
-    let adapter = ChannelReaderAdapter::new(ch_reader);
+    use base64::Engine as _;
+    use std::io::Cursor;
+
+    let reader: Box<dyn tokio::io::AsyncRead + Unpin + Send> = match (req.content, req.content_b64)
+    {
+        (Some(WriteContent::Utf8(s)), None) => Box::new(Cursor::new(s.into_bytes())),
+        (Some(WriteContent::Stream(ref_)), None) => {
+            let ch_reader = ChannelReader::new(engine_address, &ref_);
+            Box::new(ChannelReaderAdapter::new(ch_reader))
+        }
+        (None, Some(b64)) => {
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(b64.as_bytes())
+                .map_err(|e| {
+                    SandboxError::InvalidRequest(format!("content_b64 is not valid base64: {e}"))
+                })?;
+            Box::new(Cursor::new(bytes))
+        }
+        (Some(_), Some(_)) => {
+            return Err(SandboxError::InvalidRequest(
+                "set either `content` (string or StreamChannelRef) or `content_b64`, not both"
+                    .into(),
+            ));
+        }
+        (None, None) => {
+            return Err(SandboxError::InvalidRequest(
+                "missing file body: set `content` (string or StreamChannelRef) or `content_b64`"
+                    .into(),
+            ));
+        }
+    };
+
     handle_write_with_reader(
         req.sandbox_id,
         req.path,
         req.mode,
         req.parents,
-        Box::new(adapter),
+        reader,
         registry,
         runner,
     )
@@ -377,5 +452,141 @@ mod tests {
         .await
         .unwrap_err();
         assert_eq!(err.code().as_str(), "S002");
+    }
+
+    // ── public handle_write — body-shape dispatch (option A) ────────────
+
+    /// `content: "<utf-8 string>"` is the path agents naturally take.
+    /// It must just work — no channel setup, no base64, write the bytes.
+    #[tokio::test]
+    async fn handle_write_accepts_inline_utf8_content() {
+        let reg = SandboxRegistry::new();
+        let id = Uuid::new_v4();
+        reg.insert(make_state(id)).await;
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let runner = FakeRunner {
+            captured: captured.clone(),
+        };
+        let req = WriteRequest {
+            sandbox_id: id.to_string(),
+            path: "/workspace/app.js".into(),
+            mode: "0644".into(),
+            parents: false,
+            content: Some(WriteContent::Utf8("console.log('hi')\n".into())),
+            content_b64: None,
+        };
+        let resp = handle_write(req, &reg, &runner, "irrelevant")
+            .await
+            .unwrap();
+        assert_eq!(resp.bytes_written, "console.log('hi')\n".len() as u64);
+        assert_eq!(*captured.lock().await, b"console.log('hi')\n");
+    }
+
+    /// `content_b64` is the inline path for binary or shell-fragile bytes.
+    #[tokio::test]
+    async fn handle_write_accepts_inline_content_b64() {
+        use base64::Engine as _;
+        let reg = SandboxRegistry::new();
+        let id = Uuid::new_v4();
+        reg.insert(make_state(id)).await;
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let runner = FakeRunner {
+            captured: captured.clone(),
+        };
+        let payload = b"\x00\x01\x02binary\xffbytes";
+        let b64 = base64::engine::general_purpose::STANDARD.encode(payload);
+        let req = WriteRequest {
+            sandbox_id: id.to_string(),
+            path: "/workspace/blob.bin".into(),
+            mode: "0644".into(),
+            parents: false,
+            content: None,
+            content_b64: Some(b64),
+        };
+        let resp = handle_write(req, &reg, &runner, "irrelevant")
+            .await
+            .unwrap();
+        assert_eq!(resp.bytes_written, payload.len() as u64);
+        assert_eq!(&*captured.lock().await, payload);
+    }
+
+    #[tokio::test]
+    async fn handle_write_rejects_invalid_base64() {
+        let reg = SandboxRegistry::new();
+        let id = Uuid::new_v4();
+        reg.insert(make_state(id)).await;
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let runner = FakeRunner { captured };
+        let req = WriteRequest {
+            sandbox_id: id.to_string(),
+            path: "/x".into(),
+            mode: "0644".into(),
+            parents: false,
+            content: None,
+            content_b64: Some("not!valid!base64!".into()),
+        };
+        let err = handle_write(req, &reg, &runner, "irrelevant")
+            .await
+            .unwrap_err();
+        assert_eq!(err.code().as_str(), "S001");
+        assert!(err.to_string().contains("not valid base64"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn handle_write_rejects_both_content_and_content_b64() {
+        let reg = SandboxRegistry::new();
+        let id = Uuid::new_v4();
+        reg.insert(make_state(id)).await;
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let runner = FakeRunner { captured };
+        let req = WriteRequest {
+            sandbox_id: id.to_string(),
+            path: "/x".into(),
+            mode: "0644".into(),
+            parents: false,
+            content: Some(WriteContent::Utf8("a".into())),
+            content_b64: Some("YQ==".into()),
+        };
+        let err = handle_write(req, &reg, &runner, "irrelevant")
+            .await
+            .unwrap_err();
+        assert_eq!(err.code().as_str(), "S001");
+        assert!(err.to_string().contains("not both"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn handle_write_rejects_neither_content_nor_content_b64() {
+        let reg = SandboxRegistry::new();
+        let id = Uuid::new_v4();
+        reg.insert(make_state(id)).await;
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let runner = FakeRunner { captured };
+        let req = WriteRequest {
+            sandbox_id: id.to_string(),
+            path: "/x".into(),
+            mode: "0644".into(),
+            parents: false,
+            content: None,
+            content_b64: None,
+        };
+        let err = handle_write(req, &reg, &runner, "irrelevant")
+            .await
+            .unwrap_err();
+        assert_eq!(err.code().as_str(), "S001");
+        assert!(err.to_string().contains("missing file body"), "got: {err}");
+    }
+
+    /// Serde dispatch: a bare JSON string lands as `Utf8`; an object
+    /// matching `StreamChannelRef` lands as `Stream`. We don't test the
+    /// `Stream` path end-to-end here (it requires a live engine for
+    /// `ChannelReader`); the unit test covers the JSON → enum shape.
+    #[tokio::test]
+    async fn write_content_deserialises_string_as_utf8_variant() {
+        let v: WriteContent = serde_json::from_value(serde_json::json!("hello"))
+            .expect("string must deserialise as Utf8");
+        match v {
+            WriteContent::Utf8(s) => assert_eq!(s, "hello"),
+            other => panic!("expected Utf8, got {other:?}"),
+        }
     }
 }

--- a/crates/iii-worker/src/sandbox_daemon/list.rs
+++ b/crates/iii-worker/src/sandbox_daemon/list.rs
@@ -4,12 +4,13 @@
 //! wire-compat break.
 
 use crate::sandbox_daemon::registry::SandboxRegistry;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct ListRequest {}
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, JsonSchema)]
 pub struct SandboxSummary {
     pub sandbox_id: String,
     pub name: Option<String>,
@@ -19,7 +20,7 @@ pub struct SandboxSummary {
     pub stopped: bool,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, JsonSchema)]
 pub struct ListResponse {
     pub sandboxes: Vec<SandboxSummary>,
 }

--- a/crates/iii-worker/src/sandbox_daemon/mod.rs
+++ b/crates/iii-worker/src/sandbox_daemon/mod.rs
@@ -19,16 +19,12 @@ pub mod stop;
 pub use errors::SandboxError;
 pub use registry::SandboxRegistry;
 
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
 
-use iii_sdk::{
-    IIIError, InitOptions, OtelConfig, RegisterFunctionMessage, WorkerMetadata, register_worker,
-};
-use serde_json::Value;
+use iii_sdk::{InitOptions, OtelConfig, RegisterFunction, WorkerMetadata, register_worker};
 
 use crate::sandbox_daemon::config::SandboxConfig;
+use crate::sandbox_daemon::errors::SandboxErrorWire;
 
 pub async fn run(config: SandboxConfig, engine_url: &str) -> anyhow::Result<()> {
     tracing::info!(url = %engine_url, "connecting to III engine");
@@ -96,42 +92,29 @@ fn register_sandbox_create(
     cfg: Arc<crate::sandbox_daemon::config::SandboxConfig>,
     launcher: Arc<crate::sandbox_daemon::adapters::IiiWorkerLauncher>,
 ) {
-    let handler = move |payload: Value| {
-        let registry = registry.clone();
-        let cfg = cfg.clone();
-        let launcher = launcher.clone();
-        Box::pin(async move {
-            let req: crate::sandbox_daemon::create::CreateRequest = serde_json::from_value(payload)
-                .map_err(|e| IIIError::Handler(format!("bad request: {e}")))?;
-            match crate::sandbox_daemon::create::handle_create(
-                req,
-                &cfg,
-                &registry,
-                &*launcher,
-                |e| {
-                    tracing::info!(event = ?e, "sandbox create event");
-                },
-            )
-            .await
-            {
-                Ok(resp) => serde_json::to_value(resp)
-                    .map_err(|e| IIIError::Handler(format!("serialize: {e}"))),
-                Err(e) => Err(IIIError::Handler(
-                    serde_json::to_string(&e.to_payload()).unwrap_or_else(|_| e.to_string()),
-                )),
-            }
-        }) as Pin<Box<dyn Future<Output = Result<Value, IIIError>> + Send>>
-    };
-    let _ = iii.register_function_with(
-        RegisterFunctionMessage {
-            id: "sandbox::create".to_string(),
-            description: Some("Create an ephemeral sandbox VM from a preset image".to_string()),
-            request_format: None,
-            response_format: None,
-            metadata: None,
-            invocation: None,
-        },
-        handler,
+    let _ = iii.register_function(
+        RegisterFunction::new_async(
+            "sandbox::create",
+            move |req: crate::sandbox_daemon::create::CreateRequest| {
+                let registry = registry.clone();
+                let cfg = cfg.clone();
+                let launcher = launcher.clone();
+                async move {
+                    crate::sandbox_daemon::create::handle_create(
+                        req,
+                        &cfg,
+                        &registry,
+                        &*launcher,
+                        |e| {
+                            tracing::info!(event = ?e, "sandbox create event");
+                        },
+                    )
+                    .await
+                    .map_err(SandboxErrorWire)
+                }
+            },
+        )
+        .description("Create an ephemeral sandbox VM from a preset image"),
     );
 }
 
@@ -140,31 +123,20 @@ fn register_sandbox_exec(
     registry: Arc<crate::sandbox_daemon::SandboxRegistry>,
     runner: Arc<crate::sandbox_daemon::adapters::ShellProtoRunner>,
 ) {
-    let handler = move |payload: Value| {
-        let registry = registry.clone();
-        let runner = runner.clone();
-        Box::pin(async move {
-            let req: crate::sandbox_daemon::exec::ExecRequest = serde_json::from_value(payload)
-                .map_err(|e| IIIError::Handler(format!("bad request: {e}")))?;
-            match crate::sandbox_daemon::exec::handle_exec(req, &registry, &*runner).await {
-                Ok(resp) => serde_json::to_value(resp)
-                    .map_err(|e| IIIError::Handler(format!("serialize: {e}"))),
-                Err(e) => Err(IIIError::Handler(
-                    serde_json::to_string(&e.to_payload()).unwrap_or_else(|_| e.to_string()),
-                )),
-            }
-        }) as Pin<Box<dyn Future<Output = Result<Value, IIIError>> + Send>>
-    };
-    let _ = iii.register_function_with(
-        RegisterFunctionMessage {
-            id: "sandbox::exec".to_string(),
-            description: Some("Execute a command inside a live sandbox".to_string()),
-            request_format: None,
-            response_format: None,
-            metadata: None,
-            invocation: None,
-        },
-        handler,
+    let _ = iii.register_function(
+        RegisterFunction::new_async(
+            "sandbox::exec",
+            move |req: crate::sandbox_daemon::exec::ExecRequest| {
+                let registry = registry.clone();
+                let runner = runner.clone();
+                async move {
+                    crate::sandbox_daemon::exec::handle_exec(req, &registry, &*runner)
+                        .await
+                        .map_err(SandboxErrorWire)
+                }
+            },
+        )
+        .description("Execute a command inside a live sandbox"),
     );
 }
 
@@ -173,31 +145,20 @@ fn register_sandbox_stop(
     registry: Arc<crate::sandbox_daemon::SandboxRegistry>,
     stopper: Arc<crate::sandbox_daemon::adapters::SignalStopper>,
 ) {
-    let handler = move |payload: Value| {
-        let registry = registry.clone();
-        let stopper = stopper.clone();
-        Box::pin(async move {
-            let req: crate::sandbox_daemon::stop::StopRequest = serde_json::from_value(payload)
-                .map_err(|e| IIIError::Handler(format!("bad request: {e}")))?;
-            match crate::sandbox_daemon::stop::handle_stop(req, &registry, &*stopper).await {
-                Ok(resp) => serde_json::to_value(resp)
-                    .map_err(|e| IIIError::Handler(format!("serialize: {e}"))),
-                Err(e) => Err(IIIError::Handler(
-                    serde_json::to_string(&e.to_payload()).unwrap_or_else(|_| e.to_string()),
-                )),
-            }
-        }) as Pin<Box<dyn Future<Output = Result<Value, IIIError>> + Send>>
-    };
-    let _ = iii.register_function_with(
-        RegisterFunctionMessage {
-            id: "sandbox::stop".to_string(),
-            description: Some("Stop and remove a running sandbox".to_string()),
-            request_format: None,
-            response_format: None,
-            metadata: None,
-            invocation: None,
-        },
-        handler,
+    let _ = iii.register_function(
+        RegisterFunction::new_async(
+            "sandbox::stop",
+            move |req: crate::sandbox_daemon::stop::StopRequest| {
+                let registry = registry.clone();
+                let stopper = stopper.clone();
+                async move {
+                    crate::sandbox_daemon::stop::handle_stop(req, &registry, &*stopper)
+                        .await
+                        .map_err(SandboxErrorWire)
+                }
+            },
+        )
+        .description("Stop and remove a running sandbox"),
     );
 }
 
@@ -205,24 +166,29 @@ fn register_sandbox_list(
     iii: &iii_sdk::III,
     registry: Arc<crate::sandbox_daemon::SandboxRegistry>,
 ) {
-    let handler = move |payload: Value| {
-        let registry = registry.clone();
-        Box::pin(async move {
-            let req: crate::sandbox_daemon::list::ListRequest =
-                serde_json::from_value(payload).unwrap_or_default();
-            let resp = crate::sandbox_daemon::list::handle_list(req, &registry).await;
-            serde_json::to_value(resp).map_err(|e| IIIError::Handler(format!("serialize: {e}")))
-        }) as Pin<Box<dyn Future<Output = Result<Value, IIIError>> + Send>>
-    };
-    let _ = iii.register_function_with(
-        RegisterFunctionMessage {
-            id: "sandbox::list".to_string(),
-            description: Some("List active sandboxes".to_string()),
-            request_format: None,
-            response_format: None,
-            metadata: None,
-            invocation: None,
-        },
-        handler,
+    // Note: pre-migration this handler used
+    // `serde_json::from_value(payload).unwrap_or_default()`, silently
+    // coercing `null`/non-object payloads into an empty `ListRequest`.
+    // `new_async` is strict, so a literal `null` payload now returns an
+    // S001-style handler error instead of an empty list. The only
+    // production caller (`cli::sandbox::handle_list`, which sends
+    // `json!({})`) is unaffected; an empty object still deserializes to
+    // the unit `ListRequest`.
+    let _ = iii.register_function(
+        RegisterFunction::new_async(
+            "sandbox::list",
+            move |req: crate::sandbox_daemon::list::ListRequest| {
+                let registry = registry.clone();
+                async move {
+                    // handle_list is infallible — Result wrapping is just
+                    // so the closure satisfies IntoAsyncHandler's
+                    // `Result<R, E>` shape. The Err arm is unreachable.
+                    Ok::<_, SandboxErrorWire>(
+                        crate::sandbox_daemon::list::handle_list(req, &registry).await,
+                    )
+                }
+            },
+        )
+        .description("List active sandboxes"),
     );
 }

--- a/crates/iii-worker/src/sandbox_daemon/stop.rs
+++ b/crates/iii-worker/src/sandbox_daemon/stop.rs
@@ -1,17 +1,19 @@
 use crate::sandbox_daemon::{
     errors::SandboxError, overlay::OverlayLayout, registry::SandboxRegistry,
 };
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct StopRequest {
     pub sandbox_id: String,
+    /// Block until the VM is fully reaped before returning.
     #[serde(default)]
     pub wait: bool,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, JsonSchema)]
 pub struct StopResponse {
     pub sandbox_id: String,
     pub stopped: bool,


### PR DESCRIPTION
## Summary
- Migrate `sandbox::create/exec/stop/list` off `register_function_with`'s hand-rolled `Value` handlers and onto `RegisterFunction::new_async` with typed request/response. A new `SandboxErrorWire` `Display` adapter wraps `SandboxError` so `map_err` produces the same JSON bytes (`code`/`type`/`message`/`docs_url`/`retryable`) the legacy handlers wrote by hand — wire format is pinned with `sandbox_error_wire_display_matches_to_payload_json`.
- `sandbox::fs::write` now accepts an inline UTF-8 string (`content: "…"`) or `content_b64` in addition to the existing `StreamChannelRef`. Exactly one body form must be set; mismatches return `S001` with a hint. Channels remain the path for large/programmatic uploads.
- `sandbox::exec` rejects `cmd` containing whitespace or empty `cmd` with `S001` and a hint pointing at `args`. Previously `cmd: "node -v"` reached the shell relay and surfaced as opaque `S300 "vm disconnected mid-run"`, which agents retried in a loop.
- `CreateRequest` / `ExecRequest` / `StopRequest` / `ListRequest` / `SandboxSummary` derive `JsonSchema` with field-level docs, so the schemas surfaced by the new builder steer callers toward the right shapes (e.g. `image` must be a catalog key, `env` is `"K=V"` entries).

## Behavioral notes / compatibility
- `sandbox::list`'s old `unwrap_or_default()` swallowed `null` payloads; `new_async` is strict, so a literal `null` now returns an S001-style error. The only production caller (`cli::sandbox::handle_list`) sends `json!({})`, which still deserializes to the unit request. Documented inline in `mod.rs`.
- `SandboxErrorWire` depends on `iii_sdk::IntoAsyncHandler` collapsing `E` via `Display`. If the SDK switches to a structured-error trait or `Debug`, the wire format drifts silently — the in-crate test catches local regressions but cannot catch SDK-side changes. Doc comment flags this for future audits.

## Test plan
- [ ] `cargo test -p iii-worker sandbox_daemon::errors` — wire-format invariant test passes
- [ ] `cargo test -p iii-worker sandbox_daemon::exec` — whitespace/empty `cmd` guards + existing exec tests
- [ ] `cargo test -p iii-worker sandbox_daemon::fs::write` — inline UTF-8 / `content_b64` / both-set / neither-set / invalid-base64 paths
- [ ] `cargo build -p iii-worker` — typed handler migration compiles cleanly
- [ ] Smoke: `sandbox::list` with `json!({})` still returns the active set; `sandbox::create` with a bare preset name (`"node"`) still boots

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File write operations now accept multiple content formats: inline UTF-8 strings, base64-encoded binary data, or stream channels.

* **Bug Fixes**
  * Command execution now validates input to reject commands containing whitespace; pass arguments via the `args` parameter instead.
  * Enhanced error responses with detailed JSON payloads containing error codes, messages, and retry information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->