### PR TITLE
fix(telemetry): dedupe PostHog payloads and add website session replay

### DIFF
--- a/engine/src/workers/telemetry/amplitude.rs
+++ b/engine/src/workers/telemetry/amplitude.rs
@@ -156,6 +156,30 @@ fn posthog_timestamp_millis(ms: i64) -> String {
         .to_rfc3339()
 }
 
+fn should_skip_posthog_user_property(
+    key: &str,
+    properties: &serde_json::Map<String, serde_json::Value>,
+) -> bool {
+    match key {
+        // app_version is the canonical PostHog field; iii_version is the Amplitude user prop alias.
+        "iii_version" => properties.contains_key("app_version"),
+        _ => false,
+    }
+}
+
+fn should_skip_posthog_event_property(
+    key: &str,
+    properties: &serde_json::Map<String, serde_json::Value>,
+) -> bool {
+    match key {
+        "version" => {
+            properties.contains_key("app_version") || properties.contains_key("iii_version")
+        }
+        "function_names" => true, // deprecated alias of `functions`
+        _ => false,
+    }
+}
+
 fn build_posthog_event(mut event: AmplitudeEvent) -> PostHogEvent {
     sanitize_event_properties(&mut event.event_properties);
     if let Some(props) = event.user_properties.as_mut() {
@@ -177,11 +201,17 @@ fn build_posthog_event(mut event: AmplitudeEvent) -> PostHogEvent {
     }
     if let Some(serde_json::Value::Object(user_props)) = event.user_properties {
         for (key, value) in user_props {
+            if should_skip_posthog_user_property(&key, &properties) {
+                continue;
+            }
             properties.insert(key, value);
         }
     }
     if let serde_json::Value::Object(event_props) = event.event_properties {
         for (key, value) in event_props {
+            if should_skip_posthog_event_property(&key, &properties) {
+                continue;
+            }
             properties.insert(key, value);
         }
     }
@@ -513,6 +543,46 @@ mod tests {
         assert_eq!(event["properties"]["user_mode"], "building");
         assert_eq!(event["properties"]["key"], "value");
         assert_eq!(event["properties"]["plan"], "free");
+    }
+
+    #[test]
+    fn test_posthog_payload_dedupes_version_and_function_fields() {
+        let event = AmplitudeEvent {
+            device_id: "device-1".to_string(),
+            user_id: None,
+            event_type: "heartbeat".to_string(),
+            event_properties: serde_json::json!({
+                "version": "0.13.0-next.1",
+                "function_names": ["orders::charge", "agent::memory"],
+                "functions": ["orders::charge", "agent::memory"],
+                "project_name": "agentmemory",
+            }),
+            user_properties: Some(serde_json::json!({
+                "iii_version": "0.13.0-next.1",
+                "project_name": "agentmemory",
+            })),
+            platform: "iii-engine".to_string(),
+            os_name: "linux".to_string(),
+            app_version: "0.13.0-next.1".to_string(),
+            time: 1700000000000,
+            insert_id: Some("ins-2".to_string()),
+            country: None,
+            language: None,
+            ip: None,
+        };
+
+        let props = build_posthog_event(event).properties;
+        let props = props.as_object().expect("properties object");
+
+        assert_eq!(props.get("app_version").unwrap(), "0.13.0-next.1");
+        assert!(!props.contains_key("iii_version"));
+        assert!(!props.contains_key("version"));
+        assert!(!props.contains_key("function_names"));
+        assert_eq!(
+            props.get("functions").unwrap(),
+            &serde_json::json!(["orders::charge", "agent::memory"])
+        );
+        assert_eq!(props.get("project_name").unwrap(), "agentmemory");
     }
 
     // =========================================================================

--- a/engine/src/workers/telemetry/mod.rs
+++ b/engine/src/workers/telemetry/mod.rs
@@ -288,10 +288,6 @@ fn build_base_properties(snap: &EngineSnapshot) -> serde_json::Map<String, serde
     );
     m.insert("functions".into(), serde_json::json!(snap.ft.functions));
     m.insert(
-        "function_names".into(),
-        serde_json::json!(snap.ft.functions),
-    );
-    m.insert(
         "trigger_types".into(),
         serde_json::json!(snap.ft.trigger_types),
     );
@@ -2028,8 +2024,12 @@ mod tests {
         let props = build_base_properties(&snap);
         assert_eq!(props["project_name"], serde_json::json!("checkout"));
         assert_eq!(
-            props["function_names"],
+            props["functions"],
             serde_json::json!(["orders::charge", "agent::memory"])
+        );
+        assert!(
+            !props.contains_key("function_names"),
+            "function_names duplicates functions and should not be sent"
         );
         assert_eq!(
             props["worker_names"],

--- a/website/index.html
+++ b/website/index.html
@@ -54,6 +54,7 @@
   } catch (_) {}
 })();
 </script>
+<script src="/posthog-consent.js"></script>
 
 <!-- Favicon -->
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -4339,6 +4340,7 @@
       } catch (_) {}
       banner.remove();
       if (window.iiiLoadCommonRoomSignals) window.iiiLoadCommonRoomSignals();
+      if (window.iiiLoadPostHog) window.iiiLoadPostHog();
     });
   }
   if (reject) {

--- a/website/manifesto.html
+++ b/website/manifesto.html
@@ -55,6 +55,7 @@
         } catch (_) {}
       })();
     </script>
+    <script src="/posthog-consent.js"></script>
 
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -571,6 +572,7 @@
             } catch (_) {}
             banner.remove();
             if (window.iiiLoadCommonRoomSignals) window.iiiLoadCommonRoomSignals();
+            if (window.iiiLoadPostHog) window.iiiLoadPostHog();
           });
         }
         if (reject) {

--- a/website/posthog-consent.js
+++ b/website/posthog-consent.js
@@ -1,0 +1,67 @@
+(function () {
+  var STORAGE_KEY = 'iii_cookie_consent';
+  var POSTHOG_KEY = 'phc_mmRHNXK6hkykVuxVp3JPn7R7sbo3ckSpEZLUKjofCWn6';
+  var POSTHOG_HOST = 'https://us.i.posthog.com';
+
+  window.iiiLoadPostHog = function () {
+    if (window.__iiiPostHogLoaded) return;
+    window.__iiiPostHogLoaded = true;
+
+    !(function (t, e) {
+      var o, n, p, r;
+      e.__SV ||
+        ((window.posthog = e),
+        (e._i = []),
+        (e.init = function (i, s, a) {
+          function g(t, e) {
+            var o = e.split('.');
+            2 == o.length && ((t = t[o[0]]), (e = o[1]));
+            t[e] = function () {
+              t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
+            };
+          }
+          ((p = t.createElement('script')).type = 'text/javascript'),
+            (p.crossOrigin = 'anonymous'),
+            (p.async = !0),
+            (p.src =
+              s.api_host
+                .replace('.i.posthog.com', '-assets.i.posthog.com')
+                .replace(/\/$/, '') + '/static/array.js'),
+            (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r);
+          var u = e;
+          for (
+            void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
+              u.people = u.people || [],
+              u.toString = function (t) {
+                var e = 'posthog';
+                return 'posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e;
+              },
+              u.people.toString = function () {
+                return u.toString(1) + '.people (stub)';
+              },
+              o =
+                'init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug'.split(
+                  ' ',
+                ),
+              n = 0;
+            n < o.length;
+            n++
+          )
+            g(u, o[n]);
+          e._i.push([i, s, a]);
+        }),
+        (e.__SV = 1));
+    })(document, window.posthog || []);
+
+    posthog.init(POSTHOG_KEY, {
+      api_host: POSTHOG_HOST,
+      person_profiles: 'identified_only',
+      capture_pageview: true,
+      capture_pageleave: true,
+    });
+  };
+
+  try {
+    if (localStorage.getItem(STORAGE_KEY) === 'accepted') window.iiiLoadPostHog();
+  } catch (_) {}
+})();


### PR DESCRIPTION
## Summary

Two related PostHog improvements for project 429867:

### 1. Engine telemetry dedup (PostHog export)

Heartbeats were sending duplicate fields that inflated payload size and cluttered HogQL dashboards:

- **`function_names`** — identical copy of **`functions`** (removed at source; biggest win on large registries)
- **`version` / `app_version` / `iii_version`** — same engine version under three keys (PostHog export now keeps `app_version` only)

Amplitude payloads are unchanged; dedup applies at PostHog export time in `amplitude.rs`.

### 2. Website session replay (iii.dev)

PostHog session replay was enabled in project settings but nothing was sending browser events — only server-side engine heartbeats.

Adds consent-gated `posthog-js` on the homepage and manifesto:

- Loads only after cookie banner **Accept** (same gate as Common Room)
- Auto-loads on return visits when consent was already given
- Uses the same project key as engine telemetry (`phc_mmRH...` → `us.i.posthog.com`)
- `person_profiles: 'identified_only'` for anonymous visitors

## Files changed

| Area | Files |
|------|-------|
| Engine | `engine/src/workers/telemetry/mod.rs`, `amplitude.rs` |
| Website | `website/posthog-consent.js`, `index.html`, `manifesto.html` |

## Test plan

- [ ] `cargo test -p iii dedupes_version`
- [ ] `cargo test -p iii short_term_names`
- [ ] Deploy website to production
- [ ] Visit https://iii.dev, accept cookies, browse 1–2 pages
- [ ] Confirm `$pageview` / `$snapshot` events in PostHog (project 429867)
- [ ] Confirm a session recording appears in [Session replay](https://us.posthog.com/project/429867/replay/home)

## Notes

- Docs site (`docs.iii.dev`) still uses GTM only — not in scope for this PR
- Declining cookies does not load PostHog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Add consent-gated analytics loader so PostHog starts only after cookie consent is accepted.

* **Chores**
  * Remove redundant telemetry properties during event translation to reduce payloads.
  * Consolidate function identifier tracking under a single field and replace deprecated telemetry keys.
  * Add tests and validation to ensure telemetry property deduplication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->