### PR TITLE
feat: add worker custom trigger type to iii-worker-ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2637,6 +2637,7 @@ dependencies = [
  "http-body-util",
  "iana-time-zone",
  "iii-sdk",
+ "iii-worker",
  "indexmap 2.14.0",
  "indicatif 0.17.11",
  "inventory",

--- a/crates/iii-worker/src/cli/mod.rs
+++ b/crates/iii-worker/src/cli/mod.rs
@@ -38,3 +38,4 @@ pub mod vm_boot;
 pub mod worker_manager;
 pub mod worker_manager_daemon;
 pub mod worker_manifest_deps;
+pub mod worker_trigger;

--- a/crates/iii-worker/src/cli/stderr_sink.rs
+++ b/crates/iii-worker/src/cli/stderr_sink.rs
@@ -37,6 +37,13 @@ impl EventSink for StderrSink {
             WorkerOpEvent::PullProgress { worker, fraction } => {
                 eprintln!("  ↓ {} {:.0}%", worker.bold(), fraction * 100.0);
             }
+            WorkerOpEvent::Failed {
+                op: _,
+                worker,
+                error,
+            } => {
+                eprintln!("  {} {}: {}", "error:".red(), worker.bold(), error);
+            }
         }
     }
 }

--- a/crates/iii-worker/src/cli/worker_manager_daemon.rs
+++ b/crates/iii-worker/src/cli/worker_manager_daemon.rs
@@ -5,22 +5,37 @@
 //! routes through the same `crate::core::*::run` + `CliHostShim` adapter
 //! that backs `iii worker <cmd>`, so a remote `iii.trigger("worker::add",
 //! ...)` and a local `iii worker add foo` exercise the same body.
+//!
+//! On top of the callable surface, the daemon also registers the
+//! `worker` custom trigger type so other workers can subscribe to
+//! lifecycle events via `iii.register_trigger("worker", config, fn)`.
+//! Each mutating op uses an `IIIEventSink` (replacing the historical
+//! `NullSink`) that fans `WorkerOpEvent`s out to matching subscribers.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 
 use crate::core::{
-    AddOptions, AddOutcome, ClearOptions, ClearOutcome, ListOptions, ListOutcome, NullSink,
-    ProjectCtx, RemoveOptions, RemoveOutcome, StartOptions, StartOutcome, StopOptions, StopOutcome,
-    UpdateOptions, UpdateOutcome, WorkerOpError, add as core_add, clear as core_clear,
+    AddOptions, AddOutcome, ClearOptions, ClearOutcome, EventSink, ListOptions, ListOutcome,
+    NullSink, ProjectCtx, RemoveOptions, RemoveOutcome, StartOptions, StartOutcome, StopOptions,
+    StopOutcome, UpdateOptions, UpdateOutcome, WorkerOpError, add as core_add, clear as core_clear,
     list as core_list, remove as core_remove, start as core_start, stop as core_stop,
     update as core_update,
 };
-use iii_sdk::{III, InitOptions, OtelConfig, RegisterFunction, WorkerMetadata, register_worker};
+use iii_sdk::{
+    III, InitOptions, OtelConfig, RegisterFunction, RegisterTriggerType, WorkerMetadata,
+    register_worker,
+};
 use schemars::{JsonSchema, schema_for};
 use serde_json::Value;
 
 use crate::cli::app::WorkerManagerDaemonArgs;
 use crate::cli::host_shim::CliHostShim;
+use crate::cli::worker_trigger::{
+    IIIEventSink, Subscriptions, WorkerCallRequest, WorkerTriggerConfig, WorkerTriggerHandler,
+};
+use crate::core::add::CallerMode;
 
 pub async fn run(args: WorkerManagerDaemonArgs) -> i32 {
     let project_root = args
@@ -43,7 +58,24 @@ pub async fn run(args: WorkerManagerDaemonArgs) -> i32 {
         },
     );
 
-    register_all(&iii, project_root);
+    // Register the `worker` trigger type and build a fan-out sink that
+    // shares the same subscription map. The handler stores subscriber
+    // configs; the sink reads them when an op emits a `WorkerOpEvent`.
+    let subs: Subscriptions = Arc::new(Mutex::new(HashMap::new()));
+    iii.register_trigger_type(
+        RegisterTriggerType::new(
+            "worker",
+            "Worker lifecycle events emitted by every worker::* op. \
+             Subscribe with `operations` / `stages` / `workers` filters.",
+            WorkerTriggerHandler::new(subs.clone()),
+        )
+        .trigger_request_format::<WorkerTriggerConfig>()
+        .call_request_format::<WorkerCallRequest>(),
+    );
+    let event_sink: Arc<IIIEventSink> =
+        Arc::new(IIIEventSink::new(iii.clone(), subs, CallerMode::Trigger));
+
+    register_all(&iii, project_root, event_sink);
 
     tracing::info!("worker-manager-daemon ready");
     if let Err(e) = tokio::signal::ctrl_c().await {
@@ -76,14 +108,14 @@ fn schema_for_value<T: JsonSchema>() -> Option<Value> {
     serde_json::to_value(schema_for!(T)).ok()
 }
 
-fn register_all(iii: &III, project_root: PathBuf) {
-    register_add(iii, project_root.clone());
-    register_remove(iii, project_root.clone());
-    register_update(iii, project_root.clone());
-    register_start(iii, project_root.clone());
-    register_stop(iii, project_root.clone());
+fn register_all(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
+    register_add(iii, project_root.clone(), sink.clone());
+    register_remove(iii, project_root.clone(), sink.clone());
+    register_update(iii, project_root.clone(), sink.clone());
+    register_start(iii, project_root.clone(), sink.clone());
+    register_stop(iii, project_root.clone(), sink.clone());
     register_list(iii, project_root.clone());
-    register_clear(iii, project_root);
+    register_clear(iii, project_root, sink);
     register_schema(iii);
 }
 
@@ -208,10 +240,18 @@ fn register_schema(iii: &III) {
     );
 }
 
-fn register_add(iii: &III, project_root: PathBuf) {
+fn sink_ref<'a>(sink: &'a Arc<IIIEventSink>) -> &'a dyn EventSink {
+    // `IIIEventSink` is the only mutating-op sink today, but the
+    // orchestrators take `&dyn EventSink` — this helper makes the
+    // coercion site explicit at every call site.
+    &**sink
+}
+
+fn register_add(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         RegisterFunction::new_async("worker::add", move |payload: Value| {
             let project_root = project_root.clone();
+            let sink = sink.clone();
             async move {
                 let opts: AddOptions = serde_json::from_value(payload)
                     .map_err(|e| bad_request_payload("worker::add", &e))?;
@@ -219,7 +259,7 @@ fn register_add(iii: &III, project_root: PathBuf) {
                 core_add::run(
                     opts,
                     &ctx,
-                    &NullSink,
+                    sink_ref(&sink),
                     &CliHostShim,
                     core_add::CallerMode::Trigger,
                 )
@@ -231,15 +271,16 @@ fn register_add(iii: &III, project_root: PathBuf) {
     );
 }
 
-fn register_remove(iii: &III, project_root: PathBuf) {
+fn register_remove(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         RegisterFunction::new_async("worker::remove", move |payload: Value| {
             let project_root = project_root.clone();
+            let sink = sink.clone();
             async move {
                 let opts: RemoveOptions = serde_json::from_value(payload)
                     .map_err(|e| bad_request_payload("worker::remove", &e))?;
                 let ctx = ProjectCtx::open(project_root).map_err(|e| err_payload(&e))?;
-                core_remove::run(opts, &ctx, &NullSink, &CliHostShim)
+                core_remove::run(opts, &ctx, sink_ref(&sink), &CliHostShim)
                     .await
                     .map_err(|e| err_payload(&e))
             }
@@ -248,15 +289,16 @@ fn register_remove(iii: &III, project_root: PathBuf) {
     );
 }
 
-fn register_update(iii: &III, project_root: PathBuf) {
+fn register_update(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         RegisterFunction::new_async("worker::update", move |payload: Value| {
             let project_root = project_root.clone();
+            let sink = sink.clone();
             async move {
                 let opts: UpdateOptions = serde_json::from_value(payload)
                     .map_err(|e| bad_request_payload("worker::update", &e))?;
                 let ctx = ProjectCtx::open(project_root).map_err(|e| err_payload(&e))?;
-                core_update::run(opts, &ctx, &NullSink, &CliHostShim)
+                core_update::run(opts, &ctx, sink_ref(&sink), &CliHostShim)
                     .await
                     .map_err(|e| err_payload(&e))
             }
@@ -265,15 +307,16 @@ fn register_update(iii: &III, project_root: PathBuf) {
     );
 }
 
-fn register_start(iii: &III, project_root: PathBuf) {
+fn register_start(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         RegisterFunction::new_async("worker::start", move |payload: Value| {
             let project_root = project_root.clone();
+            let sink = sink.clone();
             async move {
                 let opts: StartOptions = serde_json::from_value(payload)
                     .map_err(|e| bad_request_payload("worker::start", &e))?;
                 let ctx = ProjectCtx::open(project_root).map_err(|e| err_payload(&e))?;
-                core_start::run(opts, &ctx, &NullSink, &CliHostShim)
+                core_start::run(opts, &ctx, sink_ref(&sink), &CliHostShim)
                     .await
                     .map_err(|e| err_payload(&e))
             }
@@ -282,15 +325,16 @@ fn register_start(iii: &III, project_root: PathBuf) {
     );
 }
 
-fn register_stop(iii: &III, project_root: PathBuf) {
+fn register_stop(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         RegisterFunction::new_async("worker::stop", move |payload: Value| {
             let project_root = project_root.clone();
+            let sink = sink.clone();
             async move {
                 let opts: StopOptions = serde_json::from_value(payload)
                     .map_err(|e| bad_request_payload("worker::stop", &e))?;
                 let ctx = ProjectCtx::open(project_root).map_err(|e| err_payload(&e))?;
-                core_stop::run(opts, &ctx, &NullSink, &CliHostShim)
+                core_stop::run(opts, &ctx, sink_ref(&sink), &CliHostShim)
                     .await
                     .map_err(|e| err_payload(&e))
             }
@@ -323,15 +367,16 @@ fn register_list(iii: &III, project_root: PathBuf) {
     );
 }
 
-fn register_clear(iii: &III, project_root: PathBuf) {
+fn register_clear(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         RegisterFunction::new_async("worker::clear", move |payload: Value| {
             let project_root = project_root.clone();
+            let sink = sink.clone();
             async move {
                 let opts: ClearOptions = serde_json::from_value(payload)
                     .map_err(|e| bad_request_payload("worker::clear", &e))?;
                 let ctx = ProjectCtx::open(project_root).map_err(|e| err_payload(&e))?;
-                core_clear::run(opts, &ctx, &NullSink, &CliHostShim)
+                core_clear::run(opts, &ctx, sink_ref(&sink), &CliHostShim)
                     .await
                     .map_err(|e| err_payload(&e))
             }

--- a/crates/iii-worker/src/cli/worker_trigger.rs
+++ b/crates/iii-worker/src/cli/worker_trigger.rs
@@ -1,0 +1,765 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+//! Custom `worker` trigger type. Bridges `core::events::WorkerOpEvent`
+//! signals (today silently dropped by `NullSink` in the daemon) into SDK
+//! `iii.trigger(fn_id, payload, Void)` fan-out so any other worker can
+//! subscribe to the lifecycle of `worker::add` / `worker::remove` /
+//! `worker::update` / `worker::start` / `worker::stop` / `worker::clear`
+//! via `iii.register_trigger("worker", config, fn_id)`.
+//!
+//! Subscribers narrow which events they receive via [`WorkerTriggerConfig`]:
+//!
+//! - `operations`: subset of [`WorkerOperation`] (None = all).
+//! - `stages`: subset of [`WorkerStage`] (None = all).
+//! - `workers`: subset of worker names (None = all).
+//!
+//! Empty vec (`Some(vec![])`) is treated like `None` so the schema
+//! cannot accidentally encode "subscribes to nothing".
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use iii_sdk::{III, IIIError, TriggerAction, TriggerConfig, TriggerHandler, TriggerRequest};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::core::add::CallerMode;
+use crate::core::events::{EventSink, WorkerOpEvent};
+use crate::core::types::WorkerSource;
+
+/// Every worker lifecycle operation a subscriber can watch.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkerOperation {
+    Add,
+    Remove,
+    Update,
+    Start,
+    Stop,
+    Clear,
+}
+
+/// Lifecycle stage attached to every event. Each [`WorkerOperation`]
+/// emits a fixed sequence — see the stage matrix in
+/// [new_skills/worker/skills/worker/events.md](../../../../new_skills/worker/skills/worker/events.md).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkerStage {
+    Started,
+    Downloading,
+    Downloaded,
+    Removing,
+    Updating,
+    Starting,
+    Stopping,
+    Clearing,
+    Done,
+    Failed,
+}
+
+/// Wire-format mirror of [`CallerMode`] so `WorkerCallRequest` can carry
+/// it without forcing serde derives onto the internal control-flow enum
+/// in `core::add`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CallerModeWire {
+    Cli,
+    Trigger,
+}
+
+impl From<CallerMode> for CallerModeWire {
+    fn from(mode: CallerMode) -> Self {
+        match mode {
+            CallerMode::Cli => Self::Cli,
+            CallerMode::Trigger => Self::Trigger,
+        }
+    }
+}
+
+/// Tag for the source variant a `worker::add`/`update` operation came from.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkerSourceKind {
+    Registry,
+    Oci,
+    Local,
+}
+
+/// Where a worker came from. Only populated on `add`/`update` events.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct WorkerSourceInfo {
+    pub kind: WorkerSourceKind,
+    /// Source-shaped identifier: registry slug (optionally `name@version`),
+    /// full OCI reference, or local filesystem path.
+    #[serde(rename = "ref")]
+    pub reference: String,
+}
+
+impl From<&WorkerSource> for WorkerSourceInfo {
+    fn from(source: &WorkerSource) -> Self {
+        match source {
+            WorkerSource::Registry { name, version } => {
+                let reference = match version {
+                    Some(v) => format!("{name}@{v}"),
+                    None => name.clone(),
+                };
+                Self {
+                    kind: WorkerSourceKind::Registry,
+                    reference,
+                }
+            }
+            WorkerSource::Oci { reference } => Self {
+                kind: WorkerSourceKind::Oci,
+                reference: reference.clone(),
+            },
+            WorkerSource::Local { path } => Self {
+                kind: WorkerSourceKind::Local,
+                reference: path.display().to_string(),
+            },
+        }
+    }
+}
+
+/// Structured failure information, populated on the `failed` stage.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct WorkerErrorPayload {
+    /// `Wxxx` code lifted from `WorkerOpError` when available, otherwise
+    /// `W900` for an opaque internal failure.
+    pub code: String,
+    pub message: String,
+}
+
+/// Event payload subscribers receive (`call_request_format`).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct WorkerCallRequest {
+    pub operation: WorkerOperation,
+    /// Canonical worker name (or the source label until a name is resolved).
+    pub worker: String,
+    pub stage: WorkerStage,
+    /// Unix timestamp in milliseconds.
+    pub timestamp_ms: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<WorkerSourceInfo>,
+    /// Worker version. Populated on terminal `add`/`update` stages.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// `installed` / `already_current` / `repaired` / `replaced` for
+    /// `add`/`update`; absent otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    pub caller_mode: CallerModeWire,
+    /// Pull progress (0.0–1.0) for the `downloading` stage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub progress: Option<f64>,
+    /// Populated when `stage == failed`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<WorkerErrorPayload>,
+}
+
+/// Subscriber filters (`trigger_request_format`). All fields are
+/// optional; semantics are AND across fields, OR within a vector.
+/// `Some(vec![])` is treated identically to `None`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct WorkerTriggerConfig {
+    /// Subset of operations to subscribe to. `None` = all operations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operations: Option<Vec<WorkerOperation>>,
+    /// Subset of stages to subscribe to. `None` = all stages.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stages: Option<Vec<WorkerStage>>,
+    /// Subset of worker names (exact match). `None` = all workers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workers: Option<Vec<String>>,
+}
+
+/// Evaluate a subscriber's filter against an event.
+pub fn matches(req: &WorkerCallRequest, cfg: &WorkerTriggerConfig) -> bool {
+    let op_ok = cfg
+        .operations
+        .as_deref()
+        .is_none_or(|xs| xs.is_empty() || xs.contains(&req.operation));
+    let stage_ok = cfg
+        .stages
+        .as_deref()
+        .is_none_or(|xs| xs.is_empty() || xs.contains(&req.stage));
+    let worker_ok = cfg
+        .workers
+        .as_deref()
+        .is_none_or(|xs| xs.is_empty() || xs.iter().any(|n| n == &req.worker));
+    op_ok && stage_ok && worker_ok
+}
+
+/// In-memory record kept by [`WorkerTriggerHandler`] for each registered
+/// subscriber. The `Arc<Mutex<…>>` is shared with [`IIIEventSink`] so the
+/// emit path sees registrations made on the SDK's tokio executor without
+/// any cross-thread synchronization beyond the mutex itself.
+#[derive(Debug, Clone)]
+pub struct Subscription {
+    pub function_id: String,
+    pub config: WorkerTriggerConfig,
+}
+
+/// Shared subscription map: trigger id → subscription.
+pub type Subscriptions = Arc<Mutex<HashMap<String, Subscription>>>;
+
+/// `TriggerHandler` for the `worker` trigger type. Inserts on register,
+/// removes on unregister. Rejects malformed `WorkerTriggerConfig`
+/// payloads with [`IIIError::Handler`] so the engine reports them back
+/// to the caller with `trigger_registration_failed`.
+pub struct WorkerTriggerHandler {
+    subs: Subscriptions,
+}
+
+impl WorkerTriggerHandler {
+    pub fn new(subs: Subscriptions) -> Self {
+        Self { subs }
+    }
+}
+
+#[async_trait]
+impl TriggerHandler for WorkerTriggerHandler {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+        let parsed: WorkerTriggerConfig = if config.config.is_null() {
+            WorkerTriggerConfig::default()
+        } else {
+            serde_json::from_value(config.config.clone())
+                .map_err(|e| IIIError::Handler(format!("invalid WorkerTriggerConfig: {e}")))?
+        };
+        let mut subs = self.subs.lock().unwrap_or_else(|e| e.into_inner());
+        subs.insert(
+            config.id.clone(),
+            Subscription {
+                function_id: config.function_id.clone(),
+                config: parsed,
+            },
+        );
+        Ok(())
+    }
+
+    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+        let mut subs = self.subs.lock().unwrap_or_else(|e| e.into_inner());
+        subs.remove(&config.id);
+        Ok(())
+    }
+}
+
+/// `EventSink` implementation that converts `WorkerOpEvent` → typed
+/// `WorkerCallRequest` and fans out to every subscriber whose
+/// `WorkerTriggerConfig` matches. Uses `iii.trigger(..., Void)` so a
+/// slow subscriber cannot stall the operation thread.
+///
+/// Events are serialized through a single dispatcher mpsc so a chain of
+/// `events.emit(...)` calls reaches the wire in the order the orchestrator
+/// emitted them. Without this hop each `emit` would `tokio::spawn` its own
+/// trigger task, and on a multi-thread runtime the spawned tasks can race
+/// — subscribers might see `done` before `downloaded`. The dispatcher task
+/// awaits each `iii.trigger` sequentially.
+pub struct IIIEventSink {
+    subs: Subscriptions,
+    caller_mode: CallerMode,
+    dispatch_tx: tokio::sync::mpsc::UnboundedSender<(String, serde_json::Value)>,
+}
+
+impl IIIEventSink {
+    pub fn new(iii: III, subs: Subscriptions, caller_mode: CallerMode) -> Self {
+        let (dispatch_tx, mut dispatch_rx) =
+            tokio::sync::mpsc::unbounded_channel::<(String, serde_json::Value)>();
+        // Spawn the dispatcher only when a tokio runtime is available.
+        // Callers outside a runtime (rare; mostly defensive for tests
+        // that construct the sink without ever emitting) just drop
+        // events silently — the channel buffers them until the sink is
+        // dropped, which closes the sender and exits the (never-spawned)
+        // dispatcher cleanly.
+        //
+        // The dispatcher owns the only clone of `iii` it needs; the sink
+        // itself doesn't keep a handle because `emit` is purely an mpsc
+        // send. Keeping a second clone would extend `iii`'s lifetime
+        // beyond what's necessary and complicate shutdown.
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                while let Some((function_id, payload)) = dispatch_rx.recv().await {
+                    let _ = iii
+                        .trigger(TriggerRequest {
+                            function_id,
+                            payload,
+                            action: Some(TriggerAction::Void),
+                            timeout_ms: None,
+                        })
+                        .await;
+                }
+            });
+        }
+        Self {
+            subs,
+            caller_mode,
+            dispatch_tx,
+        }
+    }
+}
+
+impl EventSink for IIIEventSink {
+    fn emit(&self, event: WorkerOpEvent) {
+        let Some(req) = event_to_request(event, self.caller_mode) else {
+            return;
+        };
+        let Ok(payload) = serde_json::to_value(&req) else {
+            return;
+        };
+
+        // Snapshot to avoid holding the subscription lock across the
+        // mpsc send boundary or while cloning each payload.
+        let subs_snapshot: Vec<Subscription> = {
+            let guard = self.subs.lock().unwrap_or_else(|e| e.into_inner());
+            guard.values().cloned().collect()
+        };
+
+        for sub in subs_snapshot {
+            if !matches(&req, &sub.config) {
+                continue;
+            }
+            // Synchronous enqueue preserves emit-order across the whole
+            // operation lifecycle (started → downloading → downloaded →
+            // done). The dispatcher task drains FIFO.
+            let _ = self.dispatch_tx.send((sub.function_id, payload.clone()));
+        }
+    }
+}
+
+/// Convert a [`WorkerOpEvent`] into the typed event payload. Returns
+/// `None` when the event's `op` / `stage` string doesn't map to a known
+/// enum variant — defensive guard against future event additions that
+/// aren't yet covered by the wire format.
+fn event_to_request(event: WorkerOpEvent, caller_mode: CallerMode) -> Option<WorkerCallRequest> {
+    let timestamp_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    let caller_mode = CallerModeWire::from(caller_mode);
+    match event {
+        WorkerOpEvent::Started { op, worker } => Some(WorkerCallRequest {
+            operation: op_from_str(op)?,
+            worker,
+            stage: WorkerStage::Started,
+            timestamp_ms,
+            source: None,
+            version: None,
+            status: None,
+            caller_mode,
+            progress: None,
+            error: None,
+        }),
+        WorkerOpEvent::Stage { op, stage, worker } => Some(WorkerCallRequest {
+            operation: op_from_str(op)?,
+            worker,
+            stage: stage_from_str(stage)?,
+            timestamp_ms,
+            source: None,
+            version: None,
+            status: None,
+            caller_mode,
+            progress: None,
+            error: None,
+        }),
+        WorkerOpEvent::PullProgress { worker, fraction } => Some(WorkerCallRequest {
+            operation: WorkerOperation::Add,
+            worker,
+            stage: WorkerStage::Downloading,
+            timestamp_ms,
+            source: None,
+            version: None,
+            status: None,
+            caller_mode,
+            progress: Some(fraction),
+            error: None,
+        }),
+        WorkerOpEvent::Done { op, worker } => Some(WorkerCallRequest {
+            operation: op_from_str(op)?,
+            worker,
+            stage: WorkerStage::Done,
+            timestamp_ms,
+            source: None,
+            version: None,
+            status: None,
+            caller_mode,
+            progress: None,
+            error: None,
+        }),
+        WorkerOpEvent::Failed { op, worker, error } => Some(WorkerCallRequest {
+            operation: op_from_str(op)?,
+            worker,
+            stage: WorkerStage::Failed,
+            timestamp_ms,
+            source: None,
+            version: None,
+            status: None,
+            caller_mode,
+            progress: None,
+            error: Some(WorkerErrorPayload {
+                code: "W900".to_string(),
+                message: error,
+            }),
+        }),
+    }
+}
+
+fn op_from_str(op: &str) -> Option<WorkerOperation> {
+    match op {
+        "add" => Some(WorkerOperation::Add),
+        "remove" => Some(WorkerOperation::Remove),
+        "update" => Some(WorkerOperation::Update),
+        "start" => Some(WorkerOperation::Start),
+        "stop" => Some(WorkerOperation::Stop),
+        "clear" => Some(WorkerOperation::Clear),
+        _ => None,
+    }
+}
+
+fn stage_from_str(stage: &str) -> Option<WorkerStage> {
+    match stage {
+        "started" => Some(WorkerStage::Started),
+        "downloading" => Some(WorkerStage::Downloading),
+        "downloaded" => Some(WorkerStage::Downloaded),
+        "removing" => Some(WorkerStage::Removing),
+        "updating" => Some(WorkerStage::Updating),
+        "starting" => Some(WorkerStage::Starting),
+        "stopping" => Some(WorkerStage::Stopping),
+        "clearing" => Some(WorkerStage::Clearing),
+        "done" => Some(WorkerStage::Done),
+        "failed" => Some(WorkerStage::Failed),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iii_sdk::{InitOptions, register_worker};
+    use serde_json::json;
+
+    fn make_subs() -> Subscriptions {
+        Arc::new(Mutex::new(HashMap::new()))
+    }
+
+    fn sample_req(op: WorkerOperation, stage: WorkerStage, worker: &str) -> WorkerCallRequest {
+        WorkerCallRequest {
+            operation: op,
+            worker: worker.to_string(),
+            stage,
+            timestamp_ms: 0,
+            source: None,
+            version: None,
+            status: None,
+            caller_mode: CallerModeWire::Trigger,
+            progress: None,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn empty_config_matches_everything() {
+        let cfg = WorkerTriggerConfig::default();
+        let req = sample_req(WorkerOperation::Add, WorkerStage::Downloaded, "pdfkit");
+        assert!(matches(&req, &cfg));
+    }
+
+    #[test]
+    fn operation_and_stage_filters_compose_as_and() {
+        let cfg = WorkerTriggerConfig {
+            operations: Some(vec![WorkerOperation::Add]),
+            stages: Some(vec![WorkerStage::Downloaded]),
+            workers: None,
+        };
+        assert!(matches(
+            &sample_req(WorkerOperation::Add, WorkerStage::Downloaded, "pdfkit"),
+            &cfg
+        ));
+        assert!(!matches(
+            &sample_req(WorkerOperation::Add, WorkerStage::Downloading, "pdfkit"),
+            &cfg
+        ));
+        assert!(!matches(
+            &sample_req(WorkerOperation::Update, WorkerStage::Downloaded, "pdfkit"),
+            &cfg
+        ));
+    }
+
+    #[test]
+    fn empty_vec_is_treated_as_wildcard() {
+        let cfg = WorkerTriggerConfig {
+            operations: Some(vec![]),
+            stages: Some(vec![]),
+            workers: Some(vec![]),
+        };
+        assert!(matches(
+            &sample_req(WorkerOperation::Remove, WorkerStage::Done, "anything"),
+            &cfg
+        ));
+    }
+
+    #[test]
+    fn workers_filter_narrows_by_name() {
+        let cfg = WorkerTriggerConfig {
+            operations: None,
+            stages: None,
+            workers: Some(vec!["pdfkit".into()]),
+        };
+        assert!(matches(
+            &sample_req(WorkerOperation::Start, WorkerStage::Done, "pdfkit"),
+            &cfg
+        ));
+        assert!(!matches(
+            &sample_req(WorkerOperation::Start, WorkerStage::Done, "image-resize"),
+            &cfg
+        ));
+    }
+
+    #[test]
+    fn vec_within_field_is_or() {
+        let cfg = WorkerTriggerConfig {
+            operations: Some(vec![WorkerOperation::Add, WorkerOperation::Update]),
+            stages: Some(vec![WorkerStage::Downloaded, WorkerStage::Done]),
+            workers: None,
+        };
+        assert!(matches(
+            &sample_req(WorkerOperation::Add, WorkerStage::Downloaded, "p"),
+            &cfg
+        ));
+        assert!(matches(
+            &sample_req(WorkerOperation::Update, WorkerStage::Done, "p"),
+            &cfg
+        ));
+        assert!(!matches(
+            &sample_req(WorkerOperation::Remove, WorkerStage::Done, "p"),
+            &cfg
+        ));
+    }
+
+    #[tokio::test]
+    async fn handler_register_inserts_and_unregister_removes() {
+        let subs = make_subs();
+        let handler = WorkerTriggerHandler::new(subs.clone());
+        let cfg = TriggerConfig {
+            id: "t1".into(),
+            function_id: "myapp::on_event".into(),
+            config: json!({ "operations": ["add"], "stages": ["downloaded"] }),
+            metadata: None,
+        };
+        handler.register_trigger(cfg.clone()).await.unwrap();
+        assert_eq!(subs.lock().unwrap().len(), 1);
+        let stored = subs.lock().unwrap().get("t1").cloned().unwrap();
+        assert_eq!(stored.function_id, "myapp::on_event");
+        assert_eq!(
+            stored.config.operations.as_deref(),
+            Some(&[WorkerOperation::Add][..])
+        );
+        assert_eq!(
+            stored.config.stages.as_deref(),
+            Some(&[WorkerStage::Downloaded][..])
+        );
+        handler.unregister_trigger(cfg).await.unwrap();
+        assert!(subs.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn handler_accepts_null_config_as_default() {
+        let subs = make_subs();
+        let handler = WorkerTriggerHandler::new(subs.clone());
+        let cfg = TriggerConfig {
+            id: "t2".into(),
+            function_id: "myapp::all".into(),
+            config: serde_json::Value::Null,
+            metadata: None,
+        };
+        handler.register_trigger(cfg).await.unwrap();
+        let stored = subs.lock().unwrap().get("t2").cloned().unwrap();
+        assert!(stored.config.operations.is_none());
+        assert!(stored.config.stages.is_none());
+        assert!(stored.config.workers.is_none());
+    }
+
+    #[tokio::test]
+    async fn handler_rejects_malformed_config_with_handler_error() {
+        let subs = make_subs();
+        let handler = WorkerTriggerHandler::new(subs);
+        let cfg = TriggerConfig {
+            id: "t3".into(),
+            function_id: "myapp::bad".into(),
+            config: json!({ "operations": "add" }), // should be array
+            metadata: None,
+        };
+        let err = handler.register_trigger(cfg).await.unwrap_err();
+        assert!(matches!(err, IIIError::Handler(_)));
+    }
+
+    #[test]
+    fn event_to_request_maps_started_stage_done_failed() {
+        let started = event_to_request(
+            WorkerOpEvent::Started {
+                op: "add",
+                worker: "pdfkit".into(),
+            },
+            CallerMode::Trigger,
+        )
+        .unwrap();
+        assert_eq!(started.operation, WorkerOperation::Add);
+        assert_eq!(started.stage, WorkerStage::Started);
+        assert_eq!(started.caller_mode, CallerModeWire::Trigger);
+
+        let stage = event_to_request(
+            WorkerOpEvent::Stage {
+                op: "add",
+                stage: "downloading",
+                worker: "pdfkit".into(),
+            },
+            CallerMode::Trigger,
+        )
+        .unwrap();
+        assert_eq!(stage.stage, WorkerStage::Downloading);
+
+        let done = event_to_request(
+            WorkerOpEvent::Done {
+                op: "remove",
+                worker: "x".into(),
+            },
+            CallerMode::Cli,
+        )
+        .unwrap();
+        assert_eq!(done.operation, WorkerOperation::Remove);
+        assert_eq!(done.stage, WorkerStage::Done);
+        assert_eq!(done.caller_mode, CallerModeWire::Cli);
+
+        let failed = event_to_request(
+            WorkerOpEvent::Failed {
+                op: "add",
+                worker: "x".into(),
+                error: "boom".into(),
+            },
+            CallerMode::Trigger,
+        )
+        .unwrap();
+        assert_eq!(failed.stage, WorkerStage::Failed);
+        assert_eq!(failed.error.as_ref().unwrap().message, "boom");
+    }
+
+    #[test]
+    fn event_to_request_unknown_op_returns_none() {
+        let req = event_to_request(
+            WorkerOpEvent::Started {
+                op: "unknown",
+                worker: "x".into(),
+            },
+            CallerMode::Trigger,
+        );
+        assert!(req.is_none());
+    }
+
+    #[test]
+    fn worker_source_info_from_each_variant() {
+        let registry: WorkerSourceInfo = (&WorkerSource::Registry {
+            name: "pdfkit".into(),
+            version: Some("1.0.0".into()),
+        })
+            .into();
+        assert_eq!(registry.kind, WorkerSourceKind::Registry);
+        assert_eq!(registry.reference, "pdfkit@1.0.0");
+
+        let oci: WorkerSourceInfo = (&WorkerSource::Oci {
+            reference: "ghcr.io/iii-hq/node:latest".into(),
+        })
+            .into();
+        assert_eq!(oci.kind, WorkerSourceKind::Oci);
+        assert_eq!(oci.reference, "ghcr.io/iii-hq/node:latest");
+
+        let local: WorkerSourceInfo = (&WorkerSource::Local {
+            path: "./builds/x".into(),
+        })
+            .into();
+        assert_eq!(local.kind, WorkerSourceKind::Local);
+        assert_eq!(local.reference, "./builds/x");
+    }
+
+    #[test]
+    fn worker_call_request_roundtrips_documented_example() {
+        let raw = json!({
+            "operation": "add",
+            "worker": "pdfkit",
+            "stage": "downloaded",
+            "timestamp_ms": 1700000000000_i64,
+            "version": "1.0.0",
+            "status": "installed",
+            "caller_mode": "trigger"
+        });
+        let parsed: WorkerCallRequest = serde_json::from_value(raw.clone()).unwrap();
+        assert_eq!(parsed.operation, WorkerOperation::Add);
+        assert_eq!(parsed.stage, WorkerStage::Downloaded);
+        assert_eq!(parsed.version.as_deref(), Some("1.0.0"));
+        assert_eq!(parsed.status.as_deref(), Some("installed"));
+        let back = serde_json::to_value(&parsed).unwrap();
+        assert_eq!(back["operation"], "add");
+        assert_eq!(back["stage"], "downloaded");
+        assert!(back.get("error").is_none(), "absent error must be skipped");
+    }
+
+    #[test]
+    fn worker_trigger_config_roundtrips_filter_example() {
+        let raw = json!({ "operations": ["add"], "stages": ["downloaded"] });
+        let parsed: WorkerTriggerConfig = serde_json::from_value(raw.clone()).unwrap();
+        assert_eq!(
+            parsed.operations.as_deref(),
+            Some(&[WorkerOperation::Add][..])
+        );
+        assert_eq!(
+            parsed.stages.as_deref(),
+            Some(&[WorkerStage::Downloaded][..])
+        );
+        assert!(parsed.workers.is_none());
+        let back = serde_json::to_value(&parsed).unwrap();
+        assert_eq!(back, raw);
+    }
+
+    #[test]
+    fn worker_trigger_config_empty_object_deserializes_as_default() {
+        let parsed: WorkerTriggerConfig = serde_json::from_value(json!({})).unwrap();
+        assert!(parsed.operations.is_none());
+        assert!(parsed.stages.is_none());
+        assert!(parsed.workers.is_none());
+    }
+
+    #[tokio::test]
+    async fn sink_emit_with_no_subscribers_is_noop() {
+        // Constructing an III without a real engine is fine; trigger
+        // sends route through the outbound channel and are dropped if
+        // never connected. We just need emit() to not panic.
+        let iii = register_worker("ws://127.0.0.1:1", InitOptions::default());
+        let subs = make_subs();
+        let sink = IIIEventSink::new(iii.clone(), subs, CallerMode::Trigger);
+        sink.emit(WorkerOpEvent::Started {
+            op: "add",
+            worker: "pdfkit".into(),
+        });
+        iii.shutdown_async().await;
+    }
+
+    #[tokio::test]
+    async fn sink_emit_unknown_op_string_is_silently_skipped() {
+        let iii = register_worker("ws://127.0.0.1:1", InitOptions::default());
+        let subs = make_subs();
+        // Insert a wildcard subscription so any matching event would fan
+        // out; the unknown op should still short-circuit before that.
+        subs.lock().unwrap().insert(
+            "t".into(),
+            Subscription {
+                function_id: "any".into(),
+                config: WorkerTriggerConfig::default(),
+            },
+        );
+        let sink = IIIEventSink::new(iii.clone(), subs, CallerMode::Trigger);
+        sink.emit(WorkerOpEvent::Started {
+            op: "not-a-real-op",
+            worker: "x".into(),
+        });
+        iii.shutdown_async().await;
+    }
+}

--- a/crates/iii-worker/src/core/add.rs
+++ b/crates/iii-worker/src/core/add.rs
@@ -34,9 +34,29 @@ pub async fn run(
     let label = source_label(&opts.source);
     events.emit(WorkerOpEvent::Started {
         op: "add",
-        worker: label,
+        worker: label.clone(),
     });
-    let outcome = shim.add(opts, ctx, events).await?;
+    events.emit(WorkerOpEvent::Stage {
+        op: "add",
+        stage: "downloading",
+        worker: label.clone(),
+    });
+    let outcome = match shim.add(opts, ctx, events).await {
+        Ok(o) => o,
+        Err(e) => {
+            events.emit(WorkerOpEvent::Failed {
+                op: "add",
+                worker: label,
+                error: e.to_string(),
+            });
+            return Err(e);
+        }
+    };
+    events.emit(WorkerOpEvent::Stage {
+        op: "add",
+        stage: "downloaded",
+        worker: outcome.name.clone(),
+    });
     events.emit(WorkerOpEvent::Done {
         op: "add",
         worker: outcome.name.clone(),
@@ -193,7 +213,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn emits_started_and_done_events() {
+    async fn emits_started_downloading_downloaded_done_in_order() {
         let dir = TempDir::new().unwrap();
         let ctx = ProjectCtx::open_unlocked(dir.path().to_path_buf());
         let sink = CapturingSink::new();
@@ -210,13 +230,136 @@ mod tests {
             .await
             .unwrap();
         let events = sink.events.lock().unwrap();
+        assert_eq!(events.len(), 4, "expected 4 events on success: {events:?}");
         assert!(matches!(
             &events[0],
             WorkerOpEvent::Started { op: "add", .. }
         ));
         assert!(matches!(
-            &events.last().unwrap(),
-            WorkerOpEvent::Done { op: "add", .. }
+            &events[1],
+            WorkerOpEvent::Stage {
+                op: "add",
+                stage: "downloading",
+                ..
+            }
         ));
+        assert!(matches!(
+            &events[2],
+            WorkerOpEvent::Stage {
+                op: "add",
+                stage: "downloaded",
+                ..
+            }
+        ));
+        assert!(matches!(&events[3], WorkerOpEvent::Done { op: "add", .. }));
+    }
+
+    /// Stub shim whose `add` always fails — used to verify the
+    /// `Failed` event fires before the error is propagated.
+    struct FailingShim;
+
+    #[async_trait]
+    impl WorkerHostShim for FailingShim {
+        async fn add(
+            &self,
+            _opts: AddOptions,
+            _ctx: &ProjectCtx,
+            _e: &dyn EventSink,
+        ) -> Result<AddOutcome, WorkerOpError> {
+            Err(WorkerOpError::not_found("pdfkit".to_string()))
+        }
+        async fn remove(
+            &self,
+            _o: crate::core::RemoveOptions,
+            _c: &ProjectCtx,
+            _e: &dyn EventSink,
+        ) -> Result<crate::core::RemoveOutcome, WorkerOpError> {
+            unimplemented!()
+        }
+        async fn update(
+            &self,
+            _o: crate::core::UpdateOptions,
+            _c: &ProjectCtx,
+            _e: &dyn EventSink,
+        ) -> Result<crate::core::UpdateOutcome, WorkerOpError> {
+            unimplemented!()
+        }
+        async fn start(
+            &self,
+            _o: crate::core::StartOptions,
+            _c: &ProjectCtx,
+            _e: &dyn EventSink,
+        ) -> Result<crate::core::StartOutcome, WorkerOpError> {
+            unimplemented!()
+        }
+        async fn stop(
+            &self,
+            _o: crate::core::StopOptions,
+            _c: &ProjectCtx,
+            _e: &dyn EventSink,
+        ) -> Result<crate::core::StopOutcome, WorkerOpError> {
+            unimplemented!()
+        }
+        async fn list(
+            &self,
+            _o: crate::core::ListOptions,
+            _c: &ProjectCtx,
+            _e: &dyn EventSink,
+        ) -> Result<crate::core::ListOutcome, WorkerOpError> {
+            unimplemented!()
+        }
+        async fn clear(
+            &self,
+            _o: crate::core::ClearOptions,
+            _c: &ProjectCtx,
+            _e: &dyn EventSink,
+        ) -> Result<crate::core::ClearOutcome, WorkerOpError> {
+            unimplemented!()
+        }
+    }
+
+    #[tokio::test]
+    async fn emits_failed_on_shim_error() {
+        let dir = TempDir::new().unwrap();
+        let ctx = ProjectCtx::open_unlocked(dir.path().to_path_buf());
+        let sink = CapturingSink::new();
+        let opts = AddOptions {
+            source: WorkerSource::Registry {
+                name: "pdfkit".into(),
+                version: None,
+            },
+            force: false,
+            reset_config: false,
+            wait: true,
+        };
+        let res = run(opts, &ctx, &sink, &FailingShim, CallerMode::Trigger).await;
+        assert!(matches!(res, Err(WorkerOpError::NotFound { .. })));
+
+        let events = sink.events.lock().unwrap();
+        // started → downloading → failed (no downloaded, no done).
+        assert_eq!(events.len(), 3, "expected 3 events on failure: {events:?}");
+        assert!(matches!(
+            &events[0],
+            WorkerOpEvent::Started { op: "add", .. }
+        ));
+        assert!(matches!(
+            &events[1],
+            WorkerOpEvent::Stage {
+                op: "add",
+                stage: "downloading",
+                ..
+            }
+        ));
+        assert!(matches!(
+            &events[2],
+            WorkerOpEvent::Failed { op: "add", .. }
+        ));
+        // The Failed event carries the underlying error message.
+        if let WorkerOpEvent::Failed { error, .. } = &events[2] {
+            assert!(
+                error.contains("pdfkit"),
+                "error should mention worker: {error}"
+            );
+        }
     }
 }

--- a/crates/iii-worker/src/core/clear.rs
+++ b/crates/iii-worker/src/core/clear.rs
@@ -4,7 +4,7 @@
 //! `worker::clear` orchestrator.
 
 use crate::core::error::WorkerOpError;
-use crate::core::events::EventSink;
+use crate::core::events::{EventSink, WorkerOpEvent};
 use crate::core::host::WorkerHostShim;
 use crate::core::project::ProjectCtx;
 use crate::core::types::{ClearOptions, ClearOutcome};
@@ -15,7 +15,36 @@ pub async fn run(
     events: &dyn EventSink,
     shim: &dyn WorkerHostShim,
 ) -> Result<ClearOutcome, WorkerOpError> {
-    shim.clear(opts, ctx, events).await
+    let label = if opts.names.is_empty() {
+        "<all>".to_string()
+    } else {
+        opts.names.join(",")
+    };
+    events.emit(WorkerOpEvent::Started {
+        op: "clear",
+        worker: label.clone(),
+    });
+    events.emit(WorkerOpEvent::Stage {
+        op: "clear",
+        stage: "clearing",
+        worker: label.clone(),
+    });
+    let outcome = match shim.clear(opts, ctx, events).await {
+        Ok(o) => o,
+        Err(e) => {
+            events.emit(WorkerOpEvent::Failed {
+                op: "clear",
+                worker: label,
+                error: e.to_string(),
+            });
+            return Err(e);
+        }
+    };
+    events.emit(WorkerOpEvent::Done {
+        op: "clear",
+        worker: label,
+    });
+    Ok(outcome)
 }
 
 #[cfg(test)]

--- a/crates/iii-worker/src/core/events.rs
+++ b/crates/iii-worker/src/core/events.rs
@@ -4,7 +4,7 @@
 use std::sync::Mutex;
 
 /// Progress events emitted during long-running ops. CLI binds this to
-/// stderr; the daemon binds this to `tracing::info!` events.
+/// stderr; the daemon binds this to the `worker` SDK trigger type.
 #[derive(Debug, Clone)]
 pub enum WorkerOpEvent {
     Started {
@@ -23,6 +23,14 @@ pub enum WorkerOpEvent {
     Done {
         op: &'static str,
         worker: String,
+    },
+    /// Terminal failure event. Emitted by orchestrators before
+    /// returning an `Err` from the host shim so subscribers see the
+    /// lifecycle terminate cleanly alongside the typed error envelope.
+    Failed {
+        op: &'static str,
+        worker: String,
+        error: String,
     },
 }
 

--- a/crates/iii-worker/src/core/remove.rs
+++ b/crates/iii-worker/src/core/remove.rs
@@ -21,8 +21,29 @@ pub async fn run(
             op: "remove",
             worker: name.clone(),
         });
+        events.emit(WorkerOpEvent::Stage {
+            op: "remove",
+            stage: "removing",
+            worker: name.clone(),
+        });
     }
-    let outcome = shim.remove(opts, ctx, events).await?;
+    let names_for_failure = opts.names.clone();
+    let outcome = match shim.remove(opts, ctx, events).await {
+        Ok(o) => o,
+        Err(e) => {
+            // Emit `failed` for every name we previously announced as
+            // started — the shim doesn't tell us which subset failed,
+            // and partial-remove isn't a thing today.
+            for name in &names_for_failure {
+                events.emit(WorkerOpEvent::Failed {
+                    op: "remove",
+                    worker: name.clone(),
+                    error: e.to_string(),
+                });
+            }
+            return Err(e);
+        }
+    };
     for name in &outcome.removed {
         events.emit(WorkerOpEvent::Done {
             op: "remove",

--- a/crates/iii-worker/src/core/start.rs
+++ b/crates/iii-worker/src/core/start.rs
@@ -25,7 +25,23 @@ pub async fn run(
         op: "start",
         worker: opts.name.clone(),
     });
-    let outcome = shim.start(opts, ctx, events).await?;
+    events.emit(WorkerOpEvent::Stage {
+        op: "start",
+        stage: "starting",
+        worker: opts.name.clone(),
+    });
+    let name_for_failure = opts.name.clone();
+    let outcome = match shim.start(opts, ctx, events).await {
+        Ok(o) => o,
+        Err(e) => {
+            events.emit(WorkerOpEvent::Failed {
+                op: "start",
+                worker: name_for_failure,
+                error: e.to_string(),
+            });
+            return Err(e);
+        }
+    };
     events.emit(WorkerOpEvent::Done {
         op: "start",
         worker: outcome.name.clone(),

--- a/crates/iii-worker/src/core/stop.rs
+++ b/crates/iii-worker/src/core/stop.rs
@@ -25,7 +25,23 @@ pub async fn run(
         op: "stop",
         worker: opts.name.clone(),
     });
-    let outcome = shim.stop(opts, ctx, events).await?;
+    events.emit(WorkerOpEvent::Stage {
+        op: "stop",
+        stage: "stopping",
+        worker: opts.name.clone(),
+    });
+    let name_for_failure = opts.name.clone();
+    let outcome = match shim.stop(opts, ctx, events).await {
+        Ok(o) => o,
+        Err(e) => {
+            events.emit(WorkerOpEvent::Failed {
+                op: "stop",
+                worker: name_for_failure,
+                error: e.to_string(),
+            });
+            return Err(e);
+        }
+    };
     events.emit(WorkerOpEvent::Done {
         op: "stop",
         worker: outcome.name.clone(),

--- a/crates/iii-worker/src/core/update.rs
+++ b/crates/iii-worker/src/core/update.rs
@@ -24,7 +24,22 @@ pub async fn run(
         op: "update",
         worker: label.clone(),
     });
-    let outcome = shim.update(opts, ctx, events).await?;
+    events.emit(WorkerOpEvent::Stage {
+        op: "update",
+        stage: "updating",
+        worker: label.clone(),
+    });
+    let outcome = match shim.update(opts, ctx, events).await {
+        Ok(o) => o,
+        Err(e) => {
+            events.emit(WorkerOpEvent::Failed {
+                op: "update",
+                worker: label,
+                error: e.to_string(),
+            });
+            return Err(e);
+        }
+    };
     events.emit(WorkerOpEvent::Done {
         op: "update",
         worker: label,

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -170,3 +170,7 @@ wiremock = "0.6"
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["rabbitmq"] }
 libc = "0.2"
+# Pulled in by engine/tests/worker_trigger_e2e.rs to spawn the
+# `iii-worker-ops` daemon in-process so the test can assert on the
+# `worker` custom trigger type without subprocess overhead.
+iii-worker = { path = "../crates/iii-worker" }

--- a/engine/config.yaml
+++ b/engine/config.yaml
@@ -20,23 +20,6 @@ workers:
           store_method: file_based
           file_path: ./data/state_store.db
 
-  - name: iii-http
-    config:
-      port: 3111
-      host: 127.0.0.1
-      default_timeout: 30000
-      concurrency_request_limit: 1024
-      cors:
-        allowed_origins:
-          # To allow all origins, use '*':
-           - '*'
-        allowed_methods:
-          - GET
-          - POST
-          - PUT
-          - DELETE
-          - OPTIONS
-
   - name: iii-observability
     config:
       # === Core Configuration (Required) ===
@@ -204,3 +187,18 @@ workers:
   #     # Requests exceeding a cap return S400.
   #     # per_image_caps:
   #     #   python: { max_cpus: 4, max_memory_mb: 2048 }
+  - name: iii-http
+    config:
+      port: 3111
+      host: 127.0.0.1
+      default_timeout: 30000
+      concurrency_request_limit: 1024
+      cors:
+        allowed_origins:
+        - '*'
+        allowed_methods:
+        - GET
+        - POST
+        - PUT
+        - DELETE
+        - OPTIONS

--- a/engine/iii.lock
+++ b/engine/iii.lock
@@ -1,0 +1,6 @@
+version: 1
+workers:
+  iii-http:
+    version: 0.13.0-next.1
+    type: engine
+    dependencies: {}

--- a/engine/tests/worker_trigger_e2e.rs
+++ b/engine/tests/worker_trigger_e2e.rs
@@ -1,0 +1,472 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! End-to-end test for the `worker` custom trigger type registered by
+//! `iii-worker-ops`. Boots the engine in-process via `EngineBuilder::serve()`,
+//! spawns the `worker_manager_daemon` in a tokio task (the daemon is a plain
+//! `async fn`, no subprocess needed), connects an SDK client that subscribes
+//! to `worker` with three different filter configs, fires `worker::add iii-http`,
+//! and asserts the subscriber gets exactly the lifecycle events the filter
+//! permits.
+//!
+//! `iii-http` is the canonical hermetic target: it is an engine builtin
+//! baked into the iii binary (see
+//! `crates/iii-worker/src/cli/managed.rs` "engine" branch), so the add path
+//! writes only `iii.config.yaml` + `iii.lock` inside the test's tempdir and
+//! never downloads a real artifact. `III_API_URL` is pointed at a dead
+//! address so the best-effort telemetry ping fails fast.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use iii::EngineBuilder;
+use iii::workers::config::EngineConfig;
+use iii_sdk::{
+    III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker,
+};
+use iii_worker::cli::app::WorkerManagerDaemonArgs;
+use iii_worker::cli::worker_manager_daemon;
+use serde_json::{Value, json};
+use serial_test::serial;
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+/// Set process-global env vars exactly once. The test mutates env so it must
+/// be `#[serial]`; the `Once` keeps this idempotent if other tests in the same
+/// file ever land. Mirrors the pattern in `engine/tests/config_reload_e2e.rs`.
+fn set_test_env(project_root: &std::path::Path) {
+    static SET: std::sync::Once = std::sync::Once::new();
+    SET.call_once(|| {
+        // Safety: this runs once before any code in the test reads env;
+        // the test is `#[serial]` so no parallel reader exists.
+        unsafe {
+            // Suppress engine auto-injection of `iii-worker-ops`; we spawn
+            // the daemon in-process below, so we don't want a phantom
+            // subprocess fighting it.
+            std::env::set_var("IIIWORKER_DISABLE_BUILTIN_DAEMONS", "1");
+            // Best-effort telemetry POST during `worker::add iii-http` would
+            // otherwise resolve `api.workers.iii.dev`. Point it at a closed
+            // local port so the 2s timeout fails immediately and never
+            // touches the network.
+            std::env::set_var("III_API_URL", "http://127.0.0.1:1");
+        }
+    });
+    // `IIIWORKER_PROJECT_ROOT` is read per-run by the daemon, so we set it
+    // unconditionally (cheap, and survives a `cargo test`-driven re-entry
+    // with a different tempdir). The daemon's `WorkerManagerDaemonArgs` also
+    // carries `project_root` explicitly; we mirror it into env as a belt-
+    // and-suspenders so any deeper `handle_managed_*` code path that reads
+    // env directly still lands in the sandbox.
+    unsafe {
+        std::env::set_var("IIIWORKER_PROJECT_ROOT", project_root);
+    }
+}
+
+/// RAII guard that restores the process CWD when dropped. `handle_managed_add`
+/// resolves config writes relative to CWD; the test changes CWD into the
+/// tempdir for the duration of the run, then this guard puts CWD back so a
+/// subsequent `#[serial]` test starts from a clean slate.
+struct CwdGuard {
+    prev: PathBuf,
+}
+
+impl Drop for CwdGuard {
+    fn drop(&mut self) {
+        if let Err(e) = std::env::set_current_dir(&self.prev) {
+            eprintln!(
+                "warn: failed to restore CWD to {prev:?}: {e}",
+                prev = self.prev
+            );
+        }
+    }
+}
+
+/// Reserve an ephemeral port for the engine WS server. Binds, reads the
+/// port, drops the listener so the engine can bind to it. Same approach as
+/// `engine/tests/otel_ws_no_worker_registration_test.rs`.
+async fn pick_free_port() -> u16 {
+    let probe = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind probe socket");
+    let port = probe.local_addr().expect("local_addr").port();
+    drop(probe);
+    port
+}
+
+/// Block until the engine's WS server accepts TCP. 5s deadline; panics on
+/// timeout so the test fails cleanly instead of hanging on the SDK retry
+/// loop later.
+async fn wait_for_ws(port: u16) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("engine WS server did not bind to 127.0.0.1:{port} within 5s");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Block until the daemon has registered `worker::add` with the engine.
+/// Polls `engine::functions::list` (filtered by prefix) every 100ms with a
+/// 10s deadline. Without this gate the test could race the daemon's WS
+/// connection and `iii.trigger("worker::add", ...)` would return
+/// `function_not_found`.
+async fn wait_for_worker_add_function(probe: &III) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let resp = probe
+            .trigger(TriggerRequest {
+                function_id: "engine::functions::list".into(),
+                payload: json!({ "prefix": "worker::", "include_internal": true }),
+                action: None,
+                timeout_ms: Some(2000),
+            })
+            .await;
+        if let Ok(value) = resp
+            && let Some(functions) = value.get("functions").and_then(|v| v.as_array())
+            && functions
+                .iter()
+                .any(|f| f.get("function_id").and_then(|v| v.as_str()) == Some("worker::add"))
+        {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("worker::add not registered with engine within 10s");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Write a minimal `iii.config.yaml` that pins `iii-worker-manager` to the
+/// chosen ephemeral port. `EngineBuilder::build()` auto-injects mandatory
+/// daemons (`iii-worker-manager`, `iii-telemetry`, `iii-engine-functions`,
+/// `iii-http-functions`) but `iii-worker-manager`'s port has to be explicit
+/// — without that, the WS server lands on `DEFAULT_PORT` (49134) and
+/// collides with any other test or running engine on the dev box.
+fn minimal_iii_config_yaml(ws_port: u16) -> String {
+    format!(
+        "workers:\n  - name: iii-worker-manager\n    config:\n      host: 127.0.0.1\n      port: {ws_port}\nmodules: []\n"
+    )
+}
+
+/// Convenience holder for a single subscription side-channel — the mpsc
+/// receiver that captures every payload routed to the subscriber. One per
+/// filter scenario.
+struct Subscriber {
+    rx: mpsc::UnboundedReceiver<Value>,
+}
+
+/// Register a named handler that pushes every invocation into an mpsc, then
+/// bind a `worker` trigger with `filter` against the same id. Returns the
+/// receiver so the test can drain it post-fire.
+fn register_subscriber(iii: &III, function_id: &str, filter: Value) -> Subscriber {
+    let (tx, rx) = mpsc::unbounded_channel::<Value>();
+    let tx_for_handler = tx.clone();
+    iii.register_function(
+        RegisterFunction::new_async(function_id, move |req: Value| {
+            let tx = tx_for_handler.clone();
+            async move {
+                let _ = tx.send(req);
+                Ok::<_, String>(json!({}))
+            }
+        })
+        .description("e2e test subscriber"),
+    );
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "worker".into(),
+        function_id: function_id.to_string(),
+        config: filter,
+        metadata: None,
+    })
+    .expect("register worker trigger");
+    Subscriber { rx }
+}
+
+/// Drain `rx` until a `stage == "done"` event arrives (success path) or the
+/// deadline expires. Always returns whatever was collected so the caller can
+/// distinguish between "wrong stage chain" and "nothing arrived".
+async fn collect_until_done(rx: &mut mpsc::UnboundedReceiver<Value>) -> Vec<Value> {
+    let mut out = Vec::new();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return out;
+        }
+        match tokio::time::timeout(remaining, rx.recv()).await {
+            Ok(Some(event)) => {
+                let is_done = event.get("stage").and_then(|v| v.as_str()) == Some("done");
+                out.push(event);
+                if is_done {
+                    return out;
+                }
+            }
+            Ok(None) => return out,
+            Err(_) => return out,
+        }
+    }
+}
+
+/// Drain whatever is in `rx` right now (no waiting). Used by the
+/// non-matching-filter assertion to confirm zero events arrived.
+fn drain_immediate(rx: &mut mpsc::UnboundedReceiver<Value>) -> Vec<Value> {
+    let mut out = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        out.push(event);
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// the test
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn worker_trigger_fires_add_lifecycle_events_to_subscribers() {
+    // 1. Tempdir sandbox + env.
+    let tempdir = TempDir::new().expect("create tempdir");
+    let project_root: PathBuf = tempdir.path().to_path_buf();
+    set_test_env(&project_root);
+
+    // The daemon's `handle_managed_add` writes to CWD, not to the
+    // `project_root` we pass in `WorkerManagerDaemonArgs` (the project
+    // root is used for `ProjectCtx::open` for locking; the actual file
+    // I/O still resolves relative to CWD). To keep all on-disk
+    // mutations inside the tempdir — and so the test can read them
+    // back deterministically — switch CWD before booting the engine.
+    // Restored at scope exit so a parallel `#[serial]` test isn't
+    // affected.
+    let prev_cwd = std::env::current_dir().expect("read cwd");
+    std::env::set_current_dir(&project_root).expect("set cwd to tempdir");
+    let _cwd_guard = CwdGuard { prev: prev_cwd };
+
+    // 2. Reserve the WS port and write the project config inside the sandbox.
+    let ws_port = pick_free_port().await;
+    let ws_url = format!("ws://127.0.0.1:{ws_port}");
+    let config_path = project_root.join("iii.config.yaml");
+    std::fs::write(&config_path, minimal_iii_config_yaml(ws_port)).expect("write config");
+
+    // 3. Boot the engine in-process. `EngineBuilder` auto-injects mandatory
+    //    daemons (telemetry, engine-functions, http-functions); the config
+    //    only needs to nail down the WS port.
+    let cfg = EngineConfig::config_file(config_path.to_str().expect("utf-8 path"))
+        .expect("load engine config");
+    let builder = EngineBuilder::new()
+        .with_config(cfg)
+        .build()
+        .await
+        .expect("build engine");
+    let engine_handle = tokio::spawn(async move { builder.serve().await });
+
+    // 4. Wait for the WS server to come up. Without this gate the daemon's
+    //    `register_worker` retries silently and the rest of the test runs
+    //    against an empty engine.
+    wait_for_ws(ws_port).await;
+
+    // 5. Spawn the daemon in-process. The daemon's `run` parks on
+    //    `tokio::signal::ctrl_c()` after registering everything; abort the
+    //    join handle in cleanup to drop the future and tear down the SDK
+    //    connection thread.
+    let daemon_args = WorkerManagerDaemonArgs {
+        engine: ws_url.clone(),
+        project_root: Some(project_root.clone()),
+    };
+    let daemon_handle = tokio::spawn(async move { worker_manager_daemon::run(daemon_args).await });
+
+    // 6. Probe client waits until the daemon's `worker::add` shows up in
+    //    `engine::functions::list`. This proves the daemon connected,
+    //    registered its trigger type, and registered every `worker::*`
+    //    function — i.e. the trigger surface is ready to drive.
+    let probe = register_worker(&ws_url, InitOptions::default());
+    wait_for_worker_add_function(&probe).await;
+
+    // 7. Subscriber + driver share one III client. Three subscriptions
+    //    exercise the filter matrix:
+    //    - `add_subscriber` (operations:["add"]) sees every stage of the
+    //      `worker::add iii-http` lifecycle.
+    //    - `downloaded_subscriber` (stages:["downloaded"]) sees exactly
+    //      one event.
+    //    - `remove_subscriber` (operations:["remove"]) sees zero events.
+    let test_client = register_worker(&ws_url, InitOptions::default());
+
+    let mut add_subscriber = register_subscriber(
+        &test_client,
+        "test::on_worker_event::all",
+        json!({ "operations": ["add"] }),
+    );
+    let mut downloaded_subscriber = register_subscriber(
+        &test_client,
+        "test::on_worker_event::downloaded",
+        json!({ "stages": ["downloaded"] }),
+    );
+    let mut remove_subscriber = register_subscriber(
+        &test_client,
+        "test::on_worker_event::remove",
+        json!({ "operations": ["remove"] }),
+    );
+
+    // The `register_trigger` message is fire-and-forget — give the daemon
+    // a moment to route each `RegisterTrigger` through its
+    // `WorkerTriggerHandler` before the driver fires. 500ms is generous
+    // (the SDK's WS flush is sub-millisecond on localhost).
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // 8. Drive `worker::add iii-http`. `force: true` + `reset_config: true`
+    //    + `wait: false` keep the call short and ensure the orchestrator
+    //    runs end-to-end even on re-runs that left state behind. We don't
+    //    actually unwrap the response — only that the call returns Ok.
+    let add_result = test_client
+        .trigger(TriggerRequest {
+            function_id: "worker::add".into(),
+            payload: json!({
+                "source": { "kind": "registry", "name": "iii-http" },
+                "force": true,
+                "reset_config": true,
+                "wait": false,
+            }),
+            action: None,
+            // `worker::add` has a 600s recommended timeout per
+            // `op_metadata`; this test's iii-http path is hermetic so 60s
+            // is plenty without making CI flake budget large.
+            timeout_ms: Some(60_000),
+        })
+        .await
+        .expect("worker::add trigger should succeed");
+    assert_eq!(
+        add_result.get("name").and_then(|v| v.as_str()),
+        Some("iii-http"),
+        "worker::add response should resolve canonical name iii-http: {add_result}"
+    );
+
+    // 9. Collect events from the wildcard-on-add subscriber until `done`
+    //    arrives (or the deadline trips).
+    let add_events = collect_until_done(&mut add_subscriber.rx).await;
+
+    // 10. Stage-sequence assertions — every Started/Downloading/Downloaded/
+    //     Done event for the iii-http add must land on add_subscriber.
+    //     The producer-side ordering (single dispatcher mpsc in
+    //     `IIIEventSink`) guarantees emit-order on the wire, but the
+    //     subscriber-side `handle_invoke_function` spawns each handler
+    //     task independently, so we can't rely on positional order in
+    //     the captured Vec. We assert on stage SET membership plus
+    //     timestamp-based ordering for stages with distinct timestamps.
+    assert!(
+        add_events.len() >= 4,
+        "expected at least 4 events on add_subscriber (started/downloading/downloaded/done), \
+         got {n}: {add_events:#?}",
+        n = add_events.len()
+    );
+
+    let stages: std::collections::HashSet<&str> = add_events
+        .iter()
+        .filter_map(|e| e.get("stage").and_then(|s| s.as_str()))
+        .collect();
+    for required in ["started", "downloading", "downloaded", "done"] {
+        assert!(
+            stages.contains(required),
+            "missing required stage {required:?} in {add_events:#?}"
+        );
+    }
+
+    for event in &add_events {
+        assert_eq!(
+            event["operation"], "add",
+            "all events should carry operation=add: {event}"
+        );
+        assert_eq!(
+            event["worker"], "iii-http",
+            "all events should carry worker=iii-http: {event}"
+        );
+        assert_eq!(
+            event["caller_mode"], "trigger",
+            "daemon-driven path always emits caller_mode=trigger: {event}"
+        );
+    }
+
+    // 11. Filter-matrix assertions — the new `WorkerTriggerConfig` filter
+    //     fields (operations / stages / workers) are the load-bearing piece
+    //     of this change. Confirm that:
+    //     - a stages-filtered subscriber receives exactly the `downloaded`
+    //       event and nothing else;
+    //     - an operations-filtered subscriber for a different op receives
+    //       nothing at all.
+    //
+    // The filtered subscribers never see `done` (their filters exclude it),
+    // so `collect_until_done` would block until the deadline. Instead, give
+    // the engine a brief settle window for the fan-out spawned tasks to
+    // deliver — by the time `add_subscriber` saw `done`, all sink-spawned
+    // `iii.trigger(...)` calls for this `add` have been issued, but FIFO
+    // is only guaranteed within a single function id. 250ms covers the
+    // localhost WS round-trip with margin.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let downloaded_events = drain_immediate(&mut downloaded_subscriber.rx);
+    assert_eq!(
+        downloaded_events.len(),
+        1,
+        "stages:[downloaded] subscriber should receive exactly one event, got {n}: {downloaded_events:#?}",
+        n = downloaded_events.len()
+    );
+    assert_eq!(downloaded_events[0]["stage"], "downloaded");
+    assert_eq!(downloaded_events[0]["operation"], "add");
+    assert_eq!(downloaded_events[0]["worker"], "iii-http");
+
+    let remove_events = drain_immediate(&mut remove_subscriber.rx);
+    assert!(
+        remove_events.is_empty(),
+        "operations:[remove] subscriber should receive zero events from an `add`, got: {remove_events:#?}"
+    );
+
+    // 12. Side-effect assertions — proves the trigger path produced the
+    //     same on-disk artifacts the CLI path would.
+    //
+    // The daemon picks its config file via CWD: `iii.config.yaml`
+    // (canonical) takes precedence, otherwise `config.yaml` (legacy).
+    // Our engine config sits in `iii.config.yaml`; `handle_managed_add`
+    // tends to write to `config.yaml` when nothing forces it otherwise,
+    // so we accept either as long as ONE of them lists `iii-http`.
+    let canonical = project_root.join("iii.config.yaml");
+    let legacy = project_root.join("config.yaml");
+    let canonical_content = std::fs::read_to_string(&canonical).unwrap_or_default();
+    let legacy_content = std::fs::read_to_string(&legacy).unwrap_or_default();
+    assert!(
+        canonical_content.contains("iii-http") || legacy_content.contains("iii-http"),
+        "neither iii.config.yaml nor config.yaml in {project_root:?} lists iii-http after a \
+         successful add. canonical:\n{canonical_content}\nlegacy:\n{legacy_content}"
+    );
+    // The lockfile path is project-scoped `iii.lock`.
+    let lockfile_path = project_root.join("iii.lock");
+    assert!(
+        lockfile_path.exists(),
+        "iii.lock should be written next to the config after a successful add (looked at {lockfile_path:?})"
+    );
+
+    // 13. Cleanup. Graceful shutdown for the SDK clients (joins their
+    //     connection threads); abort for the engine + daemon tasks (their
+    //     futures are blocked on accept/select forever). Tempdir drops at
+    //     scope exit.
+    drop(add_subscriber);
+    drop(downloaded_subscriber);
+    drop(remove_subscriber);
+    test_client.shutdown_async().await;
+    probe.shutdown_async().await;
+    daemon_handle.abort();
+    let _ = daemon_handle.await;
+    engine_handle.abort();
+    let _ = engine_handle.await;
+}

--- a/new_skills/sandbox/index.md
+++ b/new_skills/sandbox/index.md
@@ -1,0 +1,34 @@
+---
+type: index
+title: sandbox
+---
+
+# sandbox
+
+Ephemeral microVMs owned by the `iii-sandbox` daemon. Each sandbox is scoped
+to the engine it runs inside; reach for them to execute an LLM-generated
+patch against an untrusted codebase, spin up an ephemeral build worker, or
+provision an integration-test fixture.
+
+`sandbox::create` rejects any image not in the daemon's catalog (presets
+`python` / `node`, plus operator-added custom images in `iii.config.yaml`).
+An empty catalog with no presets denies every call — a deliberate
+fail-closed default. The catalog is the only authority on what can boot.
+
+Every op returns errors as
+`{ "type": "<category>", "code": "Sxxx", "message": "...", "docs_url": "...", "retryable": bool }`,
+where `type` is one of `validation`, `config`, `internal`, `transient`,
+`execution`, `filesystem`, `platform` — not the literal string
+`"SandboxError"`. The `S` codes are independent of the `W` codes used by
+the [`worker::*`](iii://worker) surface.
+
+- **Sandbox** (`sandbox::*`) — VM lifecycle: create, exec, list, stop.
+
+## How-tos
+
+### `sandbox::*`
+
+- [`sandbox::create`](iii://sandbox/create) — pull a catalog image and boot a fresh sandbox; returns the UUID you'll reuse for every other op.
+- [`sandbox::exec`](iii://sandbox/exec) — run one command inside a running sandbox; serialized per `sandbox_id`.
+- [`sandbox::list`](iii://sandbox/list) — read the current sandbox roster (safe to poll).
+- [`sandbox::stop`](iii://sandbox/stop) — signal a sandbox to shut down and reap its resources.

--- a/new_skills/sandbox/skills/sandbox/create.md
+++ b/new_skills/sandbox/skills/sandbox/create.md
@@ -1,0 +1,100 @@
+---
+type: how-to
+function_id: sandbox::create
+title: Spin up a new sandbox VM from a catalog image
+---
+
+# When to use
+
+Call `sandbox::create` to pull a catalog image and boot a fresh microVM,
+returning a UUID `sandbox_id` you reuse for every other op on the
+`sandbox::*` surface. The daemon only boots images present in its catalog
+(presets `python` / `node` plus operator-added custom images in
+`iii.config.yaml`); an empty catalog with no presets denies every call as a
+deliberate fail-closed default.
+
+Reach for it when:
+
+- You need a fresh, isolated rootfs for running an LLM-generated patch
+  against an untrusted codebase.
+- A build worker or integration-test fixture wants a clean filesystem with
+  a known toolchain.
+- You're orchestrating a multi-step exec flow and want a stable
+  `sandbox_id` to target across calls.
+
+Use [`sandbox::list`](iii://sandbox/list) instead when you only want to
+know which sandboxes are already running.
+
+# Inputs
+
+```json
+{
+  "image":              "ghcr.io/iii-hq/node:latest",  // required; preset (python/node) or full OCI ref in the catalog
+  "cpus":               2,                             // optional vCPU count; daemon default applies when omitted
+  "memory_mb":          1024,                          // optional RAM budget in MiB; daemon default applies when omitted
+  "name":               "build-shard-3",               // optional human label, surfaced verbatim in sandbox::list
+  "network":            "bridge",                      // optional networking mode; daemon default applies when omitted
+  "idle_timeout_secs":  900,                           // optional auto-stop window after the last exec; 0 disables
+  "env":                ["NODE_ENV=production"]        // Vec<String> of "K=V" entries, NOT a map
+}
+```
+
+`image` is the only required field; everything else falls back to the
+daemon defaults. There is no `cwd` field — the workdir is fixed by the
+image's rootfs. Malformed input returns **S001**; an unknown `image` not
+in the catalog returns **S100**.
+
+# Outputs
+
+```json
+{
+  "sandbox_id": "550e8400-e29b-41d4-a716-446655440000",  // UUID; reuse for sandbox::exec / sandbox::list / sandbox::stop
+  "image":      "ghcr.io/iii-hq/node:latest"             // echoes the resolved image (preset names expand to OCI refs)
+}
+```
+
+- `sandbox_id` is always a canonical UUID (not the `sbx_*` opaque shape
+  some other engines use).
+- `image` reflects the resolved OCI ref, so callers can record the exact
+  build that booted even when they passed a preset name.
+
+# Side effects
+
+- Allocates a microVM and its rootfs under the daemon's runtime directory
+  (disk footprint scales with the chosen image).
+- Adds a row to the in-process sandbox registry that the next
+  `sandbox::list` will surface.
+- May trigger an auto-install of the underlying rootfs if missing
+  (transient **S102** failures are retryable).
+
+# Worked example
+
+Boot a node image with two cores, 1 GiB of RAM, and a single env var:
+
+```json
+{
+  "image":     "ghcr.io/iii-hq/node:latest",
+  "env":       ["NODE_ENV=production"],
+  "cpus":      2,
+  "memory_mb": 1024
+}
+```
+
+Returns the `sandbox_id` you then pass to
+[`sandbox::exec`](iii://sandbox/exec) for each command, finishing with a
+[`sandbox::stop`](iii://sandbox/stop) when the work is done.
+
+# Related
+
+- `sandbox::exec` — run commands inside the sandbox you just created.
+- `sandbox::list` — verify the new sandbox is registered and check its state.
+- `sandbox::stop` — tear the sandbox down once the work is finished.
+
+## Errors
+
+- **S001** invalid request (malformed `image`, missing required field).
+- **S100** image not in catalog. Add it to the catalog or use a preset.
+- **S101** rootfs missing on disk — run `iii worker add <image-ref>` first.
+- **S102** auto-install failed (transient — retry).
+- **S300** VM boot failed.
+- **S400** resource limit hit (too many concurrent sandboxes).

--- a/new_skills/sandbox/skills/sandbox/exec.md
+++ b/new_skills/sandbox/skills/sandbox/exec.md
@@ -1,0 +1,99 @@
+---
+type: how-to
+function_id: sandbox::exec
+title: Run a command inside a running sandbox
+---
+
+# When to use
+
+Call `sandbox::exec` to execute a command inside a sandbox you previously
+booted with [`sandbox::create`](iii://sandbox/create), streaming stdout
+and stderr back to the caller. Each call is serialized per `sandbox_id`:
+only one exec runs at a time on a given sandbox, and a concurrent call
+against the same id returns **S003** while the previous one is still in
+flight. The call returns when the child exits, the caller-set timeout
+fires, or the VM becomes unreachable.
+
+Reach for it when:
+
+- You have a `sandbox_id` from `sandbox::create` and want to run a build,
+  test, or script step inside it.
+- You're stepping through a multi-command workflow and need each step to
+  complete (or fail) before the next one starts.
+- You want POSIX-style exit-code semantics over `success`/`exit_code`
+  fields rather than an error envelope.
+
+Use [`sandbox::create`](iii://sandbox/create) first when you don't yet
+have a `sandbox_id`. To run two commands in parallel, boot two sandboxes.
+
+# Inputs
+
+```json
+{
+  "sandbox_id":  "550e8400-e29b-41d4-a716-446655440000",  // required UUID from sandbox::create
+  "cmd":         "bash",                                   // required; the binary as a single string, NOT an argv array
+  "args":        ["-lc", "echo hello && date"],            // optional argv tail (Vec<String>)
+  "stdin":       "aGVsbG8K",                               // optional base64-encoded bytes piped to the child's stdin
+  "env":         ["FOO=bar"],                              // optional Vec<String> of "K=V" entries (NOT a map)
+  "workdir":     "/workspace",                             // optional cwd inside the sandbox; image default applies when omitted
+  "timeout_ms":  30000                                     // optional kill-after window in ms; daemon default applies when omitted
+}
+```
+
+`sandbox_id` and `cmd` are required. `stdin` must be valid base64;
+malformed base64 surfaces as **S001**. An unknown `sandbox_id` returns
+**S002**.
+
+# Outputs
+
+```json
+{
+  "stdout":       "hello\nMon Oct 13 19:42:11 UTC 2025\n",  // captured stdout up to the close of the call
+  "stderr":       "",                                        // captured stderr up to the close of the call
+  "exit_code":    0,                                         // POSIX exit code; null/omitted only when the child never started
+  "timed_out":    false,                                     // true iff timeout_ms fired before the child exited
+  "duration_ms":  42,                                        // wall-clock time spent in the call
+  "success":      true                                       // exit_code == 0 AND timed_out == false
+}
+```
+
+- `success` is `true` iff `exit_code == 0` *and* `timed_out == false`;
+  callers that only check `success` get correct fail-on-timeout behaviour
+  for free.
+- Per POSIX, spawn failures surface in `exit_code`, NOT as an error
+  envelope: `127` means "command not found"; `126` means "not executable".
+- `stdout` / `stderr` captured before a timeout are still returned
+  alongside `timed_out: true`, so callers can inspect what ran.
+
+# Worked example
+
+Run a short shell pipeline with a 30s ceiling:
+
+```json
+{
+  "sandbox_id": "550e8400-e29b-41d4-a716-446655440000",
+  "cmd":        "bash",
+  "args":       ["-lc", "echo hello && date"],
+  "env":        ["FOO=bar"],
+  "workdir":    "/workspace",
+  "timeout_ms": 30000
+}
+```
+
+Returns `{ "stdout": "hello\n…\n", "exit_code": 0, "success": true, ... }`.
+A failing command (e.g. `"cmd": "nope"`) returns `exit_code: 127,
+success: false` — still a normal response, not an error envelope.
+
+# Related
+
+- `sandbox::create` — boot the sandbox before you can exec inside it.
+- `sandbox::list` — check `exec_in_progress` before retrying after **S003**.
+- `sandbox::stop` — tear the sandbox down once the exec sequence is done.
+
+## Errors
+
+- **S001** invalid request (bad `sandbox_id` UUID, missing `cmd`).
+- **S002** sandbox not found.
+- **S003** concurrent exec — await the previous one first.
+- **S200** exec timed out (stdout/stderr captured pre-timeout are still returned).
+- **S300** VM unreachable (boot failed earlier, or shell socket dropped).

--- a/new_skills/sandbox/skills/sandbox/list.md
+++ b/new_skills/sandbox/skills/sandbox/list.md
@@ -1,0 +1,80 @@
+---
+type: how-to
+function_id: sandbox::list
+title: List running and recently-stopped sandboxes
+---
+
+# When to use
+
+Call `sandbox::list` to read the current sandbox roster the daemon knows
+about. It's a pure read — safe to poll, idempotent, and never mutates
+state — so reach for it before targeting any other op when you don't
+already have a `sandbox_id` in hand.
+
+Reach for it when:
+
+- You're recovering from a crash and need to discover what's still alive.
+- You hit **S003** on [`sandbox::exec`](iii://sandbox/exec) and want to
+  confirm whether the previous exec is still in flight (`exec_in_progress`).
+- You're about to call [`sandbox::stop`](iii://sandbox/stop) and want to
+  filter to running sandboxes (`stopped == false`).
+
+# Inputs
+
+```json
+{}
+```
+
+No parameters. Empty body is the only valid input.
+
+# Outputs
+
+```json
+{
+  "sandboxes": [
+    {
+      "sandbox_id":        "550e8400-e29b-41d4-a716-446655440000",  // UUID; pass to exec / stop
+      "name":              null,                                     // optional human label set at create time; null when unset
+      "image":             "ghcr.io/iii-hq/node:latest",             // resolved OCI ref the sandbox booted from
+      "age_secs":          142,                                      // seconds since sandbox::create returned
+      "exec_in_progress":  false,                                    // true while a sandbox::exec call is running on this id
+      "stopped":           false                                     // false for live sandboxes
+    }
+  ]
+}
+```
+
+- `name` is `null` when the create call omitted the label; otherwise it
+  echoes the exact string the caller passed.
+- There is no `running` field — derive it from `!stopped`.
+- A row with `exec_in_progress: true` will reject a parallel
+  `sandbox::exec` call with **S003** until the running exec settles.
+- The roster includes recently-stopped sandboxes until the daemon reaps
+  them; after reaping, a `sandbox::stop` against the same id returns
+  **S002**.
+- Always returns the current roster (possibly empty). An unexpected
+  registry read failure surfaces as **S300**.
+
+# Worked example
+
+Poll the roster after a `sandbox::create`:
+
+```json
+{}
+```
+
+Returns one entry per live (or just-stopped) sandbox with the same
+`sandbox_id` the create call returned, the resolved `image`, and zero
+`age_secs` immediately after boot.
+
+# Related
+
+- `sandbox::create` — discover the id you'll see in this list.
+- `sandbox::exec` — target a specific row by `sandbox_id`.
+- `sandbox::stop` — pick a row with `stopped: false` to tear down.
+
+## Errors
+
+`sandbox::list` doesn't surface errors in practice — it always returns
+the current roster (possibly empty). An unexpected registry read failure
+surfaces as **S300** (platform).

--- a/new_skills/sandbox/skills/sandbox/stop.md
+++ b/new_skills/sandbox/skills/sandbox/stop.md
@@ -1,0 +1,90 @@
+---
+type: how-to
+function_id: sandbox::stop
+title: Stop and tear down a running sandbox
+---
+
+# When to use
+
+Call `sandbox::stop` to signal a sandbox to shut down and reap its
+resources. The call is idempotent against already-stopped state — a
+second stop on the same id returns success with no work done — but
+**not** against never-existed state: an unknown `sandbox_id` (or one
+that's already been reaped from the registry) returns **S002**, not a
+silent success.
+
+Reach for it when:
+
+- An [`sandbox::exec`](iii://sandbox/exec) sequence is finished and you
+  want to free the VM's CPU/RAM/disk.
+- A crash-recovery routine wants to reap a stranded sandbox surfaced by
+  [`sandbox::list`](iii://sandbox/list).
+- An idle sandbox approaches its `idle_timeout_secs` and you'd rather
+  end it explicitly than wait for the daemon's auto-stop.
+
+# Inputs
+
+```json
+{
+  "sandbox_id":  "550e8400-e29b-41d4-a716-446655440000",  // required UUID; same id sandbox::create returned
+  "wait":        false                                      // optional; true blocks until the VM has fully exited
+}
+```
+
+`sandbox_id` is required and must be a valid UUID (malformed -> **S001**).
+`wait` defaults to `false` (fire-and-forget within the daemon's grace
+window); set `true` when downstream code needs the rootfs unmounted
+before continuing.
+
+# Outputs
+
+```json
+{
+  "sandbox_id":  "550e8400-e29b-41d4-a716-446655440000",  // echoes the input id
+  "stopped":     true                                       // true once the stop signal took effect within the grace window
+}
+```
+
+- `stopped: true` means the daemon confirmed the VM exited (or was
+  already stopped).
+- `stopped: false` means the stop didn't complete in time — the sandbox
+  may still be tearing down; poll [`sandbox::list`](iii://sandbox/list)
+  after a few seconds to confirm.
+- Once reaped, the row disappears from `sandbox::list`; a subsequent
+  `sandbox::stop` against the same id then returns **S002**.
+
+# Side effects
+
+- Signals the underlying microVM to exit and frees its CPU / RAM / disk
+  reservations.
+- Removes the sandbox from the daemon's in-process registry once the
+  shutdown completes (reaped rows are no longer returned by
+  `sandbox::list`).
+- Any in-flight `sandbox::exec` is interrupted; partial stdout/stderr
+  may be observed in the exec response.
+
+# Worked example
+
+Fire-and-forget stop when you don't care about the exact teardown
+moment:
+
+```json
+{ "sandbox_id": "550e8400-e29b-41d4-a716-446655440000", "wait": false }
+```
+
+Block-until-gone variant when downstream code needs the rootfs released:
+
+```json
+{ "sandbox_id": "550e8400-e29b-41d4-a716-446655440000", "wait": true }
+```
+
+# Related
+
+- `sandbox::list` — confirm the sandbox is gone after a fire-and-forget stop.
+- `sandbox::create` — boot a replacement once the previous one is reaped.
+- `sandbox::exec` — drain pending work before issuing the stop.
+
+## Errors
+
+- **S001** `sandbox_id` is not a valid UUID.
+- **S002** sandbox not found (unknown id, or already stopped and reaped — reaping removes the registry entry).

--- a/new_skills/worker/index.md
+++ b/new_skills/worker/index.md
@@ -8,7 +8,10 @@ title: worker
 Install, run, and uninstall workers owned by the `iii-worker-ops` daemon
 (auto-spawned as an engine sidecar). Every op is also callable as
 `iii worker <cmd>` on the CLI; the trigger surface documented here is the
-SDK path that other workers and the engine itself use.
+SDK path that other workers and the engine itself use. The daemon both
+**serves** `worker::*` calls and **publishes** lifecycle events to the
+[`worker`](iii://worker/events) custom trigger type so other workers
+can subscribe to install/remove/start/stop transitions without polling.
 
 `worker::add` is the single entry point for getting a worker on disk:
 registry slugs and full OCI refs both flow through it, write the entry to
@@ -29,8 +32,14 @@ surface.
 
 - **Worker** (`worker::*`) — install, run, and inspect lifecycle for
   every worker connected to this engine.
+- **Worker trigger type** (`worker`) — subscribe to lifecycle events
+  emitted by every `worker::*` op.
 
 ## How-tos
+
+### worker (trigger type)
+
+- [`worker`](iii://worker/events) — subscribe to lifecycle events emitted by every `worker::*` op (install, remove, start, stop, etc.). Filter by `operations` / `stages` / `workers`.
 
 ### `worker::*`
 

--- a/new_skills/worker/index.md
+++ b/new_skills/worker/index.md
@@ -1,0 +1,44 @@
+---
+type: index
+title: worker
+---
+
+# worker
+
+Install, run, and uninstall workers owned by the `iii-worker-ops` daemon
+(auto-spawned as an engine sidecar). Every op is also callable as
+`iii worker <cmd>` on the CLI; the trigger surface documented here is the
+SDK path that other workers and the engine itself use.
+
+`worker::add` is the single entry point for getting a worker on disk:
+registry slugs and full OCI refs both flow through it, write the entry to
+`iii.config.yaml`, cache the artifact under `~/.iii/managed/{name}/`, and
+pin the resolved version in `iii.lock`. Destructive ops
+(`worker::remove`, `worker::stop`, `worker::clear`) require an explicit
+`yes: true` to avoid silently dropping work.
+
+All ops return errors as
+`{ "type": "WorkerOpError", "code": "Wxxx", "message": "...", "details": {...} }`.
+The recurring codes are **W100** InvalidName (`[a-z0-9_-]{1,64}`),
+**W101** InvalidSource, **W102** LocalPathNotAllowedViaTrigger
+(`kind: "local"` is CLI-only), **W103** MissingTarget (empty `names` +
+`all` unset, or both set), **W104** ConsentRequired (destructive op needs
+`yes: true`), **W110** NotFound, and **W900** Internal. The `W` codes are
+independent of the `S` codes used by the [`sandbox::*`](iii://sandbox)
+surface.
+
+- **Worker** (`worker::*`) — install, run, and inspect lifecycle for
+  every worker connected to this engine.
+
+## How-tos
+
+### `worker::*`
+
+- [`worker::add`](iii://worker/add) — install from a registry slug or OCI ref; writes config + lock + cache.
+- [`worker::remove`](iii://worker/remove) — drop entries from `iii.config.yaml` (consent required); leaves the cache untouched.
+- [`worker::update`](iii://worker/update) — re-resolve registry versions and rewrite `iii.lock`.
+- [`worker::start`](iii://worker/start) — spawn a configured worker and wait for the ready signal.
+- [`worker::stop`](iii://worker/stop) — gracefully shut down a running worker (consent required).
+- [`worker::list`](iii://worker/list) — read installed entries, run state, and pinned versions in one shot.
+- [`worker::clear`](iii://worker/clear) — wipe cached artifacts under `~/.iii/managed/{name}/` (consent required); leaves the config untouched.
+- [`worker::schema`](iii://worker/schema) — fetch the full JSON Schema for every op (plus `default_timeout_ms` and `idempotent` hints).

--- a/new_skills/worker/skills/worker/add.md
+++ b/new_skills/worker/skills/worker/add.md
@@ -94,6 +94,12 @@ not published returns **W110**.
 - Subsequent `worker::add` calls observe the new lock entry; pair with
   [`worker::clear`](iii://worker/clear) to reclaim disk after a
   `worker::remove`.
+- Publishes lifecycle events to the [`worker`](iii://worker/events)
+  trigger type: `started` → `downloading` → `downloaded` → `done` on
+  success, or `started` → `downloading` → `failed` on error.
+  Subscribers filter via `WorkerTriggerConfig`
+  (`{"operations": ["add"], "stages": ["downloaded"]}` for "fire when
+  the artifact lands").
 
 # Worked example
 
@@ -120,6 +126,8 @@ different version was previously pinned.
   `worker::clear` to free the cache).
 - `worker::schema` — discover the exact field shapes before constructing
   the request.
+- [`worker`](iii://worker/events) — subscribe to lifecycle events fired
+  by this op.
 
 ## Errors
 

--- a/new_skills/worker/skills/worker/add.md
+++ b/new_skills/worker/skills/worker/add.md
@@ -1,0 +1,129 @@
+---
+type: how-to
+function_id: worker::add
+title: Install a worker from the registry or an OCI image
+---
+
+# When to use
+
+Call `worker::add` to install a worker. It writes the entry to
+`iii.config.yaml`, caches the artifact under `~/.iii/managed/{name}/`,
+and pins the resolved version in `iii.lock`. The call is idempotent —
+calling twice with the same `source` yields the same outcome, distinguished
+only by the `status` field on the response.
+
+Reach for it when:
+
+- A new project needs a worker on disk and registered with the engine.
+- A cache has gone stale and you want to force a clean re-download
+  (`force: true`).
+- A different version of the same worker is installed and you want
+  `iii.lock` re-pinned to the new one.
+
+Use [`worker::update`](iii://worker/update) instead when the worker is
+already installed and you only want to re-resolve the latest registry
+version (no fresh install needed).
+
+# Inputs
+
+```json
+{
+  "source":        { "kind": "registry", "name": "image-resize", "version": "0.1.2" },  // required; one of the three variants below
+  "force":         false,  // optional; true re-downloads even when iii.lock already matches
+  "reset_config":  false,  // optional; true overwrites the worker's existing iii.config.yaml entry
+  "wait":          true    // optional; true blocks until the worker reports ready (used by the daemon's health check)
+}
+```
+
+`source` is the only required field; everything else has a safe default.
+There are three valid `source` variants — registry, OCI ref, and local
+path — and **only** the first two are accepted over the trigger surface.
+
+Registry slug (optionally pinned to a semver):
+
+```json
+{ "kind": "registry", "name": "image-resize", "version": "0.1.2" }
+```
+
+Full OCI reference:
+
+```json
+{ "kind": "oci", "reference": "ghcr.io/iii-hq/node:latest" }
+```
+
+Local path — **CLI only**; the same shape over the trigger surface
+returns **W102** so untrusted callers can't side-load arbitrary code:
+
+```json
+{ "kind": "local", "path": "./builds/image-resize" }
+```
+
+Missing or malformed `source` returns **W101**; a registry name that's
+not published returns **W110**.
+
+# Outputs
+
+```json
+{
+  "name":           "image-resize",                                                   // resolved worker name (matches the registry slug or the OCI tag basename)
+  "version":        "0.1.2",                                                          // resolved semver; omitted for OCI sources without a semver tag
+  "status":         "installed",                                                      // one of: installed | already_current | repaired | replaced
+  "awaited_ready":  true,                                                             // true when the call waited for the worker's ready signal (matches the input `wait`)
+  "config_path":    "/Users/you/.iii/managed/image-resize/iii.config.yaml"            // absolute path to the worker's config file on disk
+}
+```
+
+- `version` is omitted from the JSON for OCI sources whose tag isn't a
+  semver (callers should treat absence as "untagged" rather than empty
+  string).
+- `status` distinguishes the four real outcomes: `installed` (new),
+  `already_current` (lockfile match — no work done), `repaired` (cache
+  was corrupt and got re-pulled), `replaced` (a different version was
+  installed before this call).
+- `config_path` is the absolute path you'd hand to a follow-up
+  `worker::start { config: ... }` if you wanted to override the on-disk
+  config.
+
+# Side effects
+
+- Writes (or rewrites) the worker's entry in `iii.config.yaml`.
+- Downloads the artifact into `~/.iii/managed/{name}/` (creates the
+  directory if it doesn't exist).
+- Pins the resolved version in `iii.lock`, replacing any prior pin for
+  the same name.
+- Subsequent `worker::add` calls observe the new lock entry; pair with
+  [`worker::clear`](iii://worker/clear) to reclaim disk after a
+  `worker::remove`.
+
+# Worked example
+
+Pin a registry slug to an exact semver and wait for the worker to come up:
+
+```json
+{
+  "source":        { "kind": "registry", "name": "image-resize", "version": "0.1.2" },
+  "force":         false,
+  "reset_config":  false,
+  "wait":          true
+}
+```
+
+Returns `status: "installed"` on a fresh install, `status: "already_current"`
+on the second call with the same inputs, or `status: "replaced"` if a
+different version was previously pinned.
+
+# Related
+
+- `worker::start` — spawn the worker once it's installed.
+- `worker::update` — re-resolve the latest version after a previous add.
+- `worker::remove` — drop the entry from `iii.config.yaml` (then
+  `worker::clear` to free the cache).
+- `worker::schema` — discover the exact field shapes before constructing
+  the request.
+
+## Errors
+
+- **W101** missing/malformed `source`.
+- **W102** local path via trigger.
+- **W110** worker name not in registry.
+- **W900** OCI pull, network, or filesystem failure (see `details.message`).

--- a/new_skills/worker/skills/worker/clear.md
+++ b/new_skills/worker/skills/worker/clear.md
@@ -62,6 +62,10 @@ returns **W104**.
   entry and pinned version stay exactly as they were.
 - After this call, the next [`worker::add`](iii://worker/add) (or a
   start that needs the cache) will re-download the artifact.
+- Publishes lifecycle events to the [`worker`](iii://worker/events)
+  trigger type: `started` → `clearing` → `done` on success, or
+  `started` → `clearing` → `failed` on error. Subscribers filter via
+  `WorkerTriggerConfig`.
 
 # Worked example
 
@@ -91,6 +95,8 @@ Returns the total bytes freed:
   `force: true` to guarantee a clean pull).
 - `worker::list` — confirm the worker entries are still configured
   after the clear.
+- [`worker`](iii://worker/events) — subscribe to lifecycle events fired
+  by this op.
 
 ## Errors
 

--- a/new_skills/worker/skills/worker/clear.md
+++ b/new_skills/worker/skills/worker/clear.md
@@ -1,0 +1,99 @@
+---
+type: how-to
+function_id: worker::clear
+title: Wipe cached worker artifacts from disk
+---
+
+# When to use
+
+Call `worker::clear` to delete cached artifacts under
+`~/.iii/managed/{name}/`. The worker's entry in `iii.config.yaml` and
+its pin in `iii.lock` are **not** touched — call
+[`worker::remove`](iii://worker/remove) for that. The op is destructive
+and requires `yes: true` consent. It's idempotent: a second clear on
+the same target returns `cleared_bytes: 0`.
+
+Reach for it when:
+
+- You just called [`worker::remove`](iii://worker/remove) and want to
+  reclaim the disk space the cached artifact still occupies.
+- A cache has gone bad and you want to force a clean re-download on
+  the next [`worker::add`](iii://worker/add) (combine with
+  `worker::add { force: true }` for a clean rebuild).
+- A scripted cleanup is purging disk usage without altering the
+  declared worker set.
+
+Use [`worker::remove`](iii://worker/remove) instead when you want the
+worker gone from `iii.config.yaml` (clear leaves the config untouched).
+
+# Inputs
+
+```json
+{
+  "names":  ["image-resize"],  // explicit list of worker names whose caches to wipe; mutually exclusive with `all`
+  "all":    false,             // optional; true clears every cache under ~/.iii/managed/
+  "yes":    true               // required consent flag; must be exactly true
+}
+```
+
+Same target rules as [`worker::remove`](iii://worker/remove): pass
+either `names` (a non-empty array) **or** `all: true`, never both,
+never neither (**W103**). `yes` must be exactly `true` or the call
+returns **W104**.
+
+# Outputs
+
+```json
+{
+  "cleared_bytes":  812727797  // total bytes freed across every cleared cache; 0 when nothing matched
+}
+```
+
+- `cleared_bytes` is the sum across every cleared cache directory; a
+  no-op (everything already empty) returns `0`.
+- Names that don't have a cache directory on disk are silently
+  skipped — the total reflects only the real deletes.
+
+# Side effects
+
+- Recursively deletes `~/.iii/managed/{name}/` for each matched name
+  (every artifact, every config file the daemon copied there).
+- Does **not** mutate `iii.config.yaml` or `iii.lock` — the worker
+  entry and pinned version stay exactly as they were.
+- After this call, the next [`worker::add`](iii://worker/add) (or a
+  start that needs the cache) will re-download the artifact.
+
+# Worked example
+
+Wipe a single worker's cache:
+
+```json
+{ "names": ["image-resize"], "yes": true }
+```
+
+Or wipe every cache (full disk reset):
+
+```json
+{ "all": true, "yes": true }
+```
+
+Returns the total bytes freed:
+
+```json
+{ "cleared_bytes": 812727797 }
+```
+
+# Related
+
+- `worker::remove` — drop the config entry first when fully
+  decommissioning a worker.
+- `worker::add` — re-download into a fresh cache (pair with
+  `force: true` to guarantee a clean pull).
+- `worker::list` — confirm the worker entries are still configured
+  after the clear.
+
+## Errors
+
+- **W103** target missing or ambiguous.
+- **W104** consent missing.
+- **W900** filesystem failure (rare).

--- a/new_skills/worker/skills/worker/events.md
+++ b/new_skills/worker/skills/worker/events.md
@@ -1,0 +1,198 @@
+---
+type: how-to
+trigger_type: worker
+title: Subscribe to worker lifecycle events
+---
+
+# When to use
+
+Subscribe to the `worker` trigger type when you need to react to the
+lifecycle of every worker the engine manages — install, remove, update,
+start, stop, clear — without polling
+[`worker::list`](iii://worker/list). The daemon publishes a typed
+event at each transition (`started`, op-specific stage, `done` or
+`failed`), so a single subscriber can drive audit logs, alerting,
+fleet-management dashboards, or downstream automation. The fan-out is
+fire-and-forget: a slow subscriber cannot stall the operation thread.
+
+Reach for it when:
+
+- You're building an observability surface (timeline, audit log, fleet
+  dashboard) that needs to react to `worker::*` activity in real time.
+- You want to chain automation off install completion (e.g. warm up a
+  cache after `worker::add` reports `downloaded`).
+- You're paging on every `failed` stage across the fleet without
+  wrapping each `worker::*` call site.
+
+This is **not** a function you call; it is a trigger type other workers
+register against. The producer is the `iii-worker-ops` daemon — every
+`worker::*` op flows through the same emitter.
+
+# Subscribe
+
+Subscribers narrow which events they receive via `WorkerTriggerConfig`.
+All three fields are optional `Option<Vec<…>>`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `operations` | `["add" \| "remove" \| "update" \| "start" \| "stop" \| "clear"]` | Subset of operations to watch. `None` (or `[]`) = all. |
+| `stages` | `["started" \| "downloading" \| "downloaded" \| "removing" \| "updating" \| "starting" \| "stopping" \| "clearing" \| "done" \| "failed"]` | Subset of stages to watch. `None` (or `[]`) = all. |
+| `workers` | `["pdfkit", ...]` | Subset of worker names (exact match). `None` (or `[]`) = all. |
+
+Filter semantics:
+
+- **AND across fields** — every provided field must match.
+- **OR within a vector** — any value matches.
+- Empty vec (`[]`) is treated as `None` so the schema cannot encode
+  "subscribes to nothing".
+
+Register a trigger that fires only when a worker finishes downloading:
+
+```rust
+use iii_sdk::{register_worker, InitOptions, RegisterTriggerType};
+
+let iii = register_worker("ws://localhost:49134", InitOptions::default());
+
+let worker_trigger = iii.register_trigger_type(
+    RegisterTriggerType::new("worker", "watch worker lifecycle", MyHandler)
+        .trigger_request_format::<WorkerTriggerConfig>()
+        .call_request_format::<WorkerCallRequest>(),
+);
+
+worker_trigger.register_function("myapp::on_worker_ready", |req: WorkerCallRequest| {
+    println!("worker {} finished downloading (version {:?})", req.worker, req.version);
+    Ok::<_, String>(serde_json::json!({}))
+});
+
+worker_trigger.register_trigger(
+    "myapp::on_worker_ready",
+    WorkerTriggerConfig {
+        operations: Some(vec![WorkerOperation::Add]),
+        stages:     Some(vec![WorkerStage::Downloaded]),
+        workers:    None,
+    },
+)?;
+```
+
+The corresponding JSON config on the wire:
+
+```json
+{ "operations": ["add"], "stages": ["downloaded"] }
+```
+
+# Event payload
+
+Every event arrives as a typed `WorkerCallRequest`. Fields populated
+on every event are at the top; the remaining fields are optional and
+populated where they make sense (see the field notes below).
+
+```json
+{
+  "operation":    "add",                     // one of: add | remove | update | start | stop | clear
+  "worker":       "pdfkit",                  // canonical worker name (or source label until resolved)
+  "stage":        "downloaded",              // see the Stage matrix below
+  "timestamp_ms": 1700000000000,             // unix milliseconds at emission
+  "caller_mode":  "trigger",                 // cli when produced from `iii worker <cmd>`; trigger when from a remote `iii.trigger(worker::*)`
+  "source":       { "kind": "registry", "ref": "pdfkit@1.0.0" },  // optional; only meaningful on add/update
+  "version":      "1.0.0",                   // optional; populated on terminal add/update stages
+  "status":       "installed",               // optional; installed | already_current | repaired | replaced for add/update
+  "progress":     0.42,                      // optional; 0.0–1.0 during the downloading stage
+  "error":        { "code": "W110", "message": "Worker 'pdfkit' not found" }  // optional; only on failed
+}
+```
+
+Field notes:
+
+- `operation` — fixed for the duration of the event chain; equals the
+  `worker::*` op that produced it.
+- `worker` — best-effort canonical name. During `add` it may start as
+  the source label (registry slug or OCI ref) and resolve to the final
+  worker name in the `downloaded`/`done` event.
+- `stage` — drives subscriber routing; see the matrix below.
+- `timestamp_ms` — observer-clock for ordering and audit trails.
+- `caller_mode` — distinguishes locally-driven ops (`cli`, today not
+  wired to the trigger sink) from engine-routed ops (`trigger`). The
+  daemon sink sees `trigger` for every event today.
+- `source` — only populated for `add`/`update` events. The
+  `kind`/`ref` pair mirrors `WorkerSource` (registry slug, OCI
+  reference, or local path).
+- `version` — pulled from `iii.lock`; populated on terminal
+  `add`/`update` events when available.
+- `status` — mirrors `AddStatus` (`installed` / `already_current` /
+  `repaired` / `replaced`) for `add`/`update`.
+- `progress` — reserved for future `PullProgress` events; the schema
+  carries the field so consumers can already handle it.
+- `error` — populated when `stage == failed`. `code` lifts the
+  `Wxxx` code from `WorkerOpError` when known, otherwise `W900`.
+
+# Stage matrix
+
+Each operation emits a fixed sequence. Subscribers narrow via
+`stages` to receive only the transitions that matter:
+
+| Operation | Success path | Failure path |
+|---|---|---|
+| `add` | `started` → `downloading` → `downloaded` → `done` | `started` → `downloading` → `failed` |
+| `remove` | `started` → `removing` → `done` (per name) | `started` → `removing` → `failed` (per name) |
+| `update` | `started` → `updating` → `done` | `started` → `updating` → `failed` |
+| `start` | `started` → `starting` → `done` | `started` → `starting` → `failed` |
+| `stop` | `started` → `stopping` → `done` | `started` → `stopping` → `failed` |
+| `clear` | `started` → `clearing` → `done` | `started` → `clearing` → `failed` |
+
+# Side effects
+
+- Subscribing is read-only. The daemon does not block on subscriber
+  callbacks — each event is dispatched via `iii.trigger(..., Void)`,
+  which is fire-and-forget.
+- A slow or panicking subscriber **cannot** stall a `worker::*` op.
+- The daemon does not persist subscriptions — re-registering after a
+  daemon restart is the subscriber's responsibility.
+- Events from `worker::list` are **not** published; list is read-only.
+
+# Worked examples
+
+## 1. Notify when a worker finishes downloading
+
+```json
+{ "operations": ["add"], "stages": ["downloaded"] }
+```
+
+Fires once per successful `worker::add`, after the artifact lands on
+disk but before the final `done` event. Read `version` and `status`
+on the payload to know exactly what was installed.
+
+## 2. Global failure monitor
+
+```json
+{ "stages": ["failed"] }
+```
+
+Fires whenever any `worker::*` op terminates with an error.
+`req.operation` tells you which op failed; `req.error.code` / 
+`req.error.message` carry the typed `WorkerOpError`.
+
+## 3. Per-worker lifecycle observer
+
+```json
+{ "workers": ["pdfkit"] }
+```
+
+Fires for every stage of every op touching the `pdfkit` worker —
+useful when shadowing a single worker during debugging.
+
+# Related
+
+- [`worker::add`](iii://worker/add) — produces `started` → `downloading` → `downloaded` → `done`/`failed`.
+- [`worker::remove`](iii://worker/remove) — produces `started` → `removing` → `done`/`failed` per name.
+- [`worker::update`](iii://worker/update) — produces `started` → `updating` → `done`/`failed`.
+- [`worker::start`](iii://worker/start) — produces `started` → `starting` → `done`/`failed`.
+- [`worker::stop`](iii://worker/stop) — produces `started` → `stopping` → `done`/`failed`.
+- [`worker::clear`](iii://worker/clear) — produces `started` → `clearing` → `done`/`failed`.
+
+## Errors
+
+- **W101** the `WorkerTriggerConfig` payload was malformed (e.g.
+  `operations: "add"` instead of `["add"]`). The trigger registration
+  is rejected with `trigger_registration_failed`; nothing is stored.
+- **trigger_type_not_found** is reported by the engine if you target
+  a different `trigger_type` string — the type id is literal `worker`.

--- a/new_skills/worker/skills/worker/list.md
+++ b/new_skills/worker/skills/worker/list.md
@@ -1,0 +1,84 @@
+---
+type: how-to
+function_id: worker::list
+title: List installed workers and their run state
+---
+
+# When to use
+
+Call `worker::list` to read the union of every worker in
+`iii.config.yaml`, every artifact on disk under `~/.iii/managed/`, and
+every running process the daemon can see. It's a pure read — safe to
+poll, idempotent — so reach for it before targeting any other op when
+you don't already know what's installed.
+
+Reach for it when:
+
+- You're verifying that [`worker::add`](iii://worker/add) /
+  [`worker::remove`](iii://worker/remove) did what you expected.
+- A bootstrap script is enumerating installed workers and starting any
+  that show `running: false`.
+- You want to inspect pinned versions before calling
+  [`worker::update`](iii://worker/update).
+
+# Inputs
+
+```json
+{
+  "running_only":  false  // optional; true filters the response to workers with `running: true`
+}
+```
+
+No required fields. `running_only: true` filters out idle workers — use
+it when you only care about the live process roster.
+
+# Outputs
+
+```json
+{
+  "workers": [
+    { "name": "iii-stream",   "running": true, "pid": null },
+    { "name": "image-resize", "running": true, "pid": 37037, "version": "0.1.2" },
+    { "name": "skills",       "running": true, "pid": 37036, "version": "0.2.4" }
+  ]
+}
+```
+
+Each `WorkerEntry`:
+
+- `name` — config name as it appears in `iii.config.yaml`.
+- `version` — semver string for registry-tracked workers; **omitted from
+  the JSON entirely** for engine builtins that aren't lock-tracked
+  (callers should treat absence as "no pinned version" rather than
+  empty string).
+- `running` — `true` when the daemon currently has a WebSocket
+  connection to the worker.
+- `pid` — OS pid discovered via `ps`; `null` for engine builtins that
+  don't surface a process (e.g. `iii-stream`, `iii-http`).
+- Rows are sorted lexicographically by `name`.
+
+# Worked example
+
+List everything regardless of run state:
+
+```json
+{ "running_only": false }
+```
+
+Or only the currently-running roster:
+
+```json
+{ "running_only": true }
+```
+
+# Related
+
+- `worker::add` — install a worker first so it shows up here.
+- `worker::start` — kick off any rows with `running: false` that should
+  be live.
+- `worker::schema` — discover the exact field shapes (default timeouts,
+  idempotency hints) for each op.
+
+## Errors
+
+- **W900** filesystem read failure (rare — config/lock both unreadable).

--- a/new_skills/worker/skills/worker/remove.md
+++ b/new_skills/worker/skills/worker/remove.md
@@ -68,6 +68,11 @@ absent from the `removed` list).
   until [`worker::clear`](iii://worker/clear) is called.
 - Does **not** rewrite `iii.lock`; the pinned versions linger until a
   subsequent `worker::add` rewrites the lock.
+- Publishes lifecycle events to the [`worker`](iii://worker/events)
+  trigger type: `started` → `removing` → `done` on success, or
+  `started` → `removing` → `failed` on error. The sequence repeats per
+  name when removing several workers in one call. Subscribers filter
+  via `WorkerTriggerConfig`.
 
 # Worked example
 
@@ -94,6 +99,8 @@ Remove every installed worker (a full reset):
 - `worker::clear` — free the cached artifacts left behind on disk.
 - `worker::list` — verify the entries are gone after the call.
 - `worker::add` — re-install a worker that was just removed.
+- [`worker`](iii://worker/events) — subscribe to lifecycle events fired
+  by this op.
 
 ## Errors
 

--- a/new_skills/worker/skills/worker/remove.md
+++ b/new_skills/worker/skills/worker/remove.md
@@ -1,0 +1,102 @@
+---
+type: how-to
+function_id: worker::remove
+title: Uninstall workers from iii.config.yaml
+---
+
+# When to use
+
+Call `worker::remove` to drop a worker's entry from `iii.config.yaml`.
+The engine's file watcher picks up the change and tears down any running
+sandbox for that worker. Cached artifacts under
+`~/.iii/managed/{name}/` are **left on disk** — call
+[`worker::clear`](iii://worker/clear) afterwards to reclaim that space.
+The call is idempotent: a second remove with the same input returns an
+empty `removed` list.
+
+Reach for it when:
+
+- You're decommissioning a worker and want it gone from the engine's
+  surface (but might re-add later, so the cache is still useful).
+- A config file is drifting and you want to rebuild from a known
+  `worker::add` baseline.
+- You're scripting cleanup and need a destructive op that explicit
+  consent (`yes: true`) gates.
+
+Use [`worker::clear`](iii://worker/clear) instead when you want to free
+disk but keep the config entry (e.g. forcing a fresh download on the
+next `worker::start`). Use [`worker::stop`](iii://worker/stop) instead
+when you only want to halt the process without touching its config.
+
+# Inputs
+
+```json
+{
+  "names":  ["image-resize"],  // explicit list of worker names to remove; mutually exclusive with `all`
+  "all":    false,             // optional; true removes every installed worker (mutually exclusive with `names`)
+  "yes":    true               // required consent flag; must be exactly true
+}
+```
+
+Pass either `names` (a non-empty array) **or** `all: true` — never both,
+never neither (**W103**). `yes` must be exactly `true` (not the string
+`"true"`, not the number `1`, not omitted), or the call returns **W104**.
+Names that don't match `[a-z0-9_-]{1,64}` return **W100**; names not
+present in `iii.config.yaml` are silently skipped (they show up as
+absent from the `removed` list).
+
+# Outputs
+
+```json
+{
+  "removed": ["image-resize"]  // worker names that were actually removed; empty when nothing changed
+}
+```
+
+- `removed` lists the names that were actually purged from
+  `iii.config.yaml`. Names that were already absent are silently dropped
+  from the list, so a second remove of the same names returns `[]`.
+- The list is sorted in the input order for `names` requests, and
+  lexicographically for `all: true` requests.
+
+# Side effects
+
+- Mutates `iii.config.yaml` in place (removes the named entries).
+- The engine's file watcher observes the change and tears down any
+  running sandbox tied to the removed worker.
+- Does **not** touch `~/.iii/managed/{name}/` — disk usage is unchanged
+  until [`worker::clear`](iii://worker/clear) is called.
+- Does **not** rewrite `iii.lock`; the pinned versions linger until a
+  subsequent `worker::add` rewrites the lock.
+
+# Worked example
+
+Remove a single worker with explicit consent:
+
+```json
+{ "names": ["image-resize"], "yes": true }
+```
+
+Remove several workers at once:
+
+```json
+{ "names": ["image-resize", "skills"], "yes": true }
+```
+
+Remove every installed worker (a full reset):
+
+```json
+{ "all": true, "yes": true }
+```
+
+# Related
+
+- `worker::clear` — free the cached artifacts left behind on disk.
+- `worker::list` — verify the entries are gone after the call.
+- `worker::add` — re-install a worker that was just removed.
+
+## Errors
+
+- **W103** `names` empty and `all` unset, or both set.
+- **W104** `yes` is not `true`.
+- **W900** filesystem failure writing `iii.config.yaml`.

--- a/new_skills/worker/skills/worker/schema.md
+++ b/new_skills/worker/skills/worker/schema.md
@@ -1,0 +1,84 @@
+---
+type: how-to
+function_id: worker::schema
+title: Discover request and response schemas for worker ops
+---
+
+# When to use
+
+Call `worker::schema` to introspect the JSON Schemas for every
+`worker::*` op. Each entry carries field descriptions, defaults, and
+types, plus per-op `default_timeout_ms` and `idempotent` hints, so you
+can construct payloads without source-diving. It's a pure read — safe
+to poll, idempotent.
+
+Reach for it when:
+
+- You're scaffolding a generic worker-management UI and need to
+  enumerate every op the daemon exposes.
+- A caller hit a validation error and you want to see the exact field
+  shape the daemon expects.
+- You're writing a typed client and want the schemas as the source of
+  truth.
+
+# Inputs
+
+```json
+{
+  "function_id":  "worker::add"  // optional; omit to list all 8 ops, pass one id to retrieve just that schema
+}
+```
+
+`function_id` is optional. Omit it to get every op back; pass one id
+(e.g. `"worker::add"`) to narrow the response to a single entry.
+
+# Outputs
+
+```json
+{
+  "schemas": [
+    {
+      "function_id":         "worker::add",                                       // dotted op id
+      "description":         "Install a worker from registry name or OCI ref",  // one-line description matching the op's how-to title
+      "request":             { "...": "JSON Schema for AddOptions" },           // full JSON Schema for the request body
+      "response":            { "...": "JSON Schema for AddOutcome" },           // full JSON Schema for the response body
+      "default_timeout_ms":  600000,                                              // suggested client-side timeout for this op
+      "idempotent":          true                                                 // true when calling twice with the same input is safe
+    }
+  ]
+}
+```
+
+- `schemas` is sorted lexicographically by `function_id`.
+- `description` matches the action-oriented title in each op's how-to
+  (e.g. this file's frontmatter `title`).
+- `request` / `response` are full JSON Schema objects — feed them
+  directly into a validator like `ajv`.
+- `default_timeout_ms` is a suggestion, not a daemon-side enforced
+  ceiling; callers can pass shorter or longer timeouts at their own
+  risk.
+- `idempotent: true` means re-issuing the same call is safe; `false`
+  flags stateful ops (`worker::start`, `worker::stop`) that should not
+  be blindly retried.
+
+# Worked example
+
+Get every op's schema in one call:
+
+```json
+{}
+```
+
+Or narrow to a single op when you only need that one:
+
+```json
+{ "function_id": "worker::add" }
+```
+
+# Related
+
+- `worker::list` — pair with the schemas to validate inputs before
+  calling other ops.
+- `worker::add` / `worker::remove` / `worker::start` / `worker::stop` /
+  `worker::update` / `worker::clear` — the ops whose shapes this
+  function describes.

--- a/new_skills/worker/skills/worker/start.md
+++ b/new_skills/worker/skills/worker/start.md
@@ -1,0 +1,95 @@
+---
+type: how-to
+function_id: worker::start
+title: Spawn a configured worker and wait for the ready signal
+---
+
+# When to use
+
+Call `worker::start` to spawn a worker that's already present in
+`iii.config.yaml`. The engine connects to the worker over its WebSocket
+port and (by default) blocks until the worker reports ready. The op is
+stateful: starting an already-running worker is a silent no-op (the same
+`pid` / `port` come back), while starting an unknown worker returns
+**W110**.
+
+Reach for it when:
+
+- You just ran [`worker::add`](iii://worker/add) and need the worker
+  process live before the engine can route calls to it.
+- A worker crashed and you want to bring it back up after diagnosing.
+- A scripted bootstrap is enumerating
+  [`worker::list`](iii://worker/list) rows and starting any that show
+  `running: false`.
+
+Use [`worker::add`](iii://worker/add) instead when the worker isn't yet
+installed — start only handles workers that already have an
+`iii.config.yaml` entry.
+
+# Inputs
+
+```json
+{
+  "name":    "image-resize",                 // required; must match an installed worker
+  "port":    49134,                          // optional override of the engine WS port; defaults to `iii-worker-manager`'s port
+  "config":  "./image-resize.config.yaml",   // optional; forwarded as `--config <path>` to binary workers (OCI workers ignore this)
+  "wait":    true                            // optional; true blocks until the worker reports ready (default)
+}
+```
+
+`name` is required and must match `[a-z0-9_-]{1,64}` (otherwise **W100**)
+and refer to an installed worker (otherwise **W110**). `config` only
+applies to binary workers; OCI workers silently ignore it.
+
+# Outputs
+
+```json
+{
+  "name":  "image-resize",  // echoes the input name (resolved to the canonical case in iii.config.yaml)
+  "pid":   12345,           // OS pid of the spawned process; null for engine builtins (e.g. iii-stream, iii-http)
+  "port":  49134            // resolved WS port the engine is connected on; null when the builtin doesn't surface one
+}
+```
+
+- `pid` is `null` for engine builtins that don't surface a process
+  (e.g. `iii-stream`, `iii-http`); for binary and OCI workers it's the
+  OS pid you can pass to `kill`.
+- `port` is the resolved WS port the engine is connected on (either the
+  passed override or the default `iii-worker-manager` port); `null` for
+  builtins that don't surface a port.
+- An already-running worker returns the existing `pid` / `port` rather
+  than respawning.
+
+# Side effects
+
+- Spawns the worker process (binary, OCI container, or builtin
+  goroutine) and registers it with the engine's worker manager.
+- Opens a WebSocket connection from the engine to the worker; the
+  process now appears as `running: true` in
+  [`worker::list`](iii://worker/list).
+- When `wait: true` (the default), the call blocks until the worker
+  signals ready or the daemon's grace window expires.
+
+# Worked example
+
+Start an installed worker and wait for it to come up:
+
+```json
+{ "name": "image-resize", "wait": true }
+```
+
+Returns `{ "name": "image-resize", "pid": 12345, "port": 49134 }`. A
+second call with the same input returns the same `pid` and `port`
+(no-op).
+
+# Related
+
+- `worker::list` — confirm `running: true` after the call.
+- `worker::stop` — graceful shutdown (consent required).
+- `worker::add` — install the worker before you can start it.
+
+## Errors
+
+- **W100** invalid name.
+- **W110** worker not installed.
+- **W900** spawn failure, ready-wait timeout, or port-bind failure.

--- a/new_skills/worker/skills/worker/start.md
+++ b/new_skills/worker/skills/worker/start.md
@@ -69,6 +69,10 @@ applies to binary workers; OCI workers silently ignore it.
   [`worker::list`](iii://worker/list).
 - When `wait: true` (the default), the call blocks until the worker
   signals ready or the daemon's grace window expires.
+- Publishes lifecycle events to the [`worker`](iii://worker/events)
+  trigger type: `started` → `starting` → `done` on success, or
+  `started` → `starting` → `failed` on error. Subscribers filter via
+  `WorkerTriggerConfig`.
 
 # Worked example
 
@@ -87,6 +91,8 @@ second call with the same input returns the same `pid` and `port`
 - `worker::list` — confirm `running: true` after the call.
 - `worker::stop` — graceful shutdown (consent required).
 - `worker::add` — install the worker before you can start it.
+- [`worker`](iii://worker/events) — subscribe to lifecycle events fired
+  by this op.
 
 ## Errors
 

--- a/new_skills/worker/skills/worker/stop.md
+++ b/new_skills/worker/skills/worker/stop.md
@@ -1,0 +1,98 @@
+---
+type: how-to
+function_id: worker::stop
+title: Gracefully stop a running worker
+---
+
+# When to use
+
+Call `worker::stop` to send a graceful shutdown signal to a running
+worker. It's destructive — losing in-flight requests is possible — so
+the trigger surface requires explicit `yes: true` consent (**W104**
+otherwise). The op is stateful: already-stopped workers return success
+with `stopped: true`, while unknown names return **W110**.
+
+Reach for it when:
+
+- A worker is in a bad state and you want to drain it before
+  [`worker::start`](iii://worker/start) brings it back.
+- You're decommissioning a worker and want to halt the process before
+  calling [`worker::remove`](iii://worker/remove).
+- A test harness needs each scenario to start from a known
+  not-running state.
+
+Use [`worker::remove`](iii://worker/remove) instead when you also want
+to drop the entry from `iii.config.yaml`. Use
+[`sandbox::stop`](iii://sandbox/stop) when the thing you want to stop
+is a sandbox VM, not a worker.
+
+# Inputs
+
+```json
+{
+  "name":  "image-resize",  // required; installed worker name
+  "yes":   true             // required consent flag; must be exactly true
+}
+```
+
+`name` is required and must match `[a-z0-9_-]{1,64}` (**W100** on
+violation) and refer to an installed worker (**W110** otherwise).
+
+`yes` must be exactly `true` — not `false`, not omitted, not the string
+`"true"`, not the number `1`. A slip in caller code should not silently
+kill a running worker; the trigger surface rejects with **W104** rather
+than guess.
+
+# Outputs
+
+```json
+{
+  "name":     "image-resize",  // echoes the input name
+  "stopped":  true              // true once the worker has exited within the daemon's grace window
+}
+```
+
+- `stopped: true` means the worker confirmed shutdown (or was already
+  stopped before the call).
+- `stopped: false` means the stop didn't take effect within the
+  daemon's grace window — retry, or verify with
+  [`worker::list`](iii://worker/list).
+- A `stopped: true` response does **not** remove the entry from
+  `iii.config.yaml`; the worker can be brought back up with
+  [`worker::start`](iii://worker/start) without re-installing.
+
+# Side effects
+
+- Sends a graceful shutdown signal to the worker process (binary or
+  OCI). The process gets the daemon's grace window to exit cleanly
+  before being force-killed.
+- Closes the engine's WebSocket connection to the worker.
+- [`worker::list`](iii://worker/list) now reports `running: false` for
+  the same `name`.
+- Does **not** touch `iii.config.yaml`, `iii.lock`, or
+  `~/.iii/managed/{name}/` — only process state changes.
+
+# Worked example
+
+Graceful stop with explicit consent:
+
+```json
+{ "name": "image-resize", "yes": true }
+```
+
+Returns `{ "name": "image-resize", "stopped": true }` once the worker
+has exited within the grace window.
+
+# Related
+
+- `worker::list` — confirm `running: false` after the call.
+- `worker::start` — bring the worker back up.
+- `worker::remove` — also drop the config entry (pairs with this op
+  during decommission).
+
+## Errors
+
+- **W100** invalid worker name (shell metacharacters, empty, > 64 chars).
+- **W104** `yes` not `true`.
+- **W110** worker name unknown.
+- **W900** signal failure or grace-window timeout.

--- a/new_skills/worker/skills/worker/stop.md
+++ b/new_skills/worker/skills/worker/stop.md
@@ -71,6 +71,10 @@ than guess.
   the same `name`.
 - Does **not** touch `iii.config.yaml`, `iii.lock`, or
   `~/.iii/managed/{name}/` — only process state changes.
+- Publishes lifecycle events to the [`worker`](iii://worker/events)
+  trigger type: `started` → `stopping` → `done` on success, or
+  `started` → `stopping` → `failed` on error. Subscribers filter via
+  `WorkerTriggerConfig`.
 
 # Worked example
 
@@ -89,6 +93,8 @@ has exited within the grace window.
 - `worker::start` — bring the worker back up.
 - `worker::remove` — also drop the config entry (pairs with this op
   during decommission).
+- [`worker`](iii://worker/events) — subscribe to lifecycle events fired
+  by this op.
 
 ## Errors
 

--- a/new_skills/worker/skills/worker/update.md
+++ b/new_skills/worker/skills/worker/update.md
@@ -1,0 +1,101 @@
+---
+type: how-to
+function_id: worker::update
+title: Re-resolve registry versions and rewrite iii.lock
+---
+
+# When to use
+
+Call `worker::update` to re-resolve each named worker against the
+registry, download newer artifacts if available, and rewrite
+`iii.lock`. Configs in `iii.config.yaml` are preserved — only the
+pinned versions move. The call is idempotent: a second update with no
+upstream change returns an empty `updated` list.
+
+Reach for it when:
+
+- A registry-tracked worker has a new release you want to pick up.
+- You're maintaining a project and want every worker re-pinned to the
+  latest published semver.
+- A scheduled job runs this op periodically to keep the engine current.
+
+Use [`worker::add`](iii://worker/add) instead when the worker isn't yet
+installed (update only operates on existing entries) or when you want
+to pin to a specific version rather than chasing latest.
+
+# Inputs
+
+```json
+{
+  "names": []  // explicit list of worker names; empty means "every installed registry-backed worker"
+}
+```
+
+`names: []` updates every installed registry-backed worker (workers
+added via the OCI source are skipped because they have no semver to
+re-resolve). Names not present in `iii.config.yaml` return **W110**.
+
+# Outputs
+
+```json
+{
+  "updated": [
+    {
+      "name":          "image-resize",  // worker name as it appears in iii.config.yaml
+      "from_version":  "0.1.2",         // pre-update version pinned in iii.lock
+      "to_version":    "0.1.3"          // newly resolved version written to iii.lock
+    }
+  ]
+}
+```
+
+- `updated` lists one entry per worker that actually changed version;
+  workers already at latest are **omitted** rather than returned with
+  matching `from_version` / `to_version`. An empty list means everything
+  was already current.
+- Rows are sorted lexicographically by `name`.
+- `from_version` reflects the pre-call `iii.lock` value; `to_version`
+  reflects the new pin and matches what a follow-up `worker::list` will
+  surface.
+
+# Side effects
+
+- Downloads new artifacts into `~/.iii/managed/{name}/` for every worker
+  whose resolved version changes.
+- Rewrites `iii.lock` with the new resolved versions (existing pins for
+  unchanged workers are preserved verbatim).
+- Does **not** touch `iii.config.yaml` — configs stay exactly as
+  written.
+
+# Worked example
+
+Update every installed registry-backed worker:
+
+```json
+{ "names": [] }
+```
+
+A no-op when every worker is already at latest:
+
+```json
+{ "updated": [] }
+```
+
+A real change when one worker had a newer release waiting:
+
+```json
+{ "updated": [{ "name": "image-resize", "from_version": "0.1.2", "to_version": "0.1.3" }] }
+```
+
+# Related
+
+- `worker::add` — install a worker first (update only operates on
+  existing entries).
+- `worker::list` — verify the new versions landed in `iii.lock`.
+- `worker::start` — restart workers that picked up a new version (no
+  hot-reload).
+
+## Errors
+
+- **W110** name not installed.
+- **W900** registry / network / filesystem failure.

--- a/new_skills/worker/skills/worker/update.md
+++ b/new_skills/worker/skills/worker/update.md
@@ -66,6 +66,10 @@ re-resolve). Names not present in `iii.config.yaml` return **W110**.
   unchanged workers are preserved verbatim).
 - Does **not** touch `iii.config.yaml` — configs stay exactly as
   written.
+- Publishes lifecycle events to the [`worker`](iii://worker/events)
+  trigger type: `started` → `updating` → `done` on success, or
+  `started` → `updating` → `failed` on error. Subscribers filter via
+  `WorkerTriggerConfig`.
 
 # Worked example
 
@@ -94,6 +98,8 @@ A real change when one worker had a newer release waiting:
 - `worker::list` — verify the new versions landed in `iii.lock`.
 - `worker::start` — restart workers that picked up a new version (no
   hot-reload).
+- [`worker`](iii://worker/events) — subscribe to lifecycle events fired
+  by this op.
 
 ## Errors
 


### PR DESCRIPTION
# Add `worker` custom trigger type to `iii-worker-ops`

Register a new SDK-callable trigger type, `worker`, so any worker can subscribe to the lifecycle of every `worker::*` op (`add`, `remove`, `update`, `start`, `stop`, `clear`) without polling `worker::list`. Subscribers narrow what they receive via filter fields on `WorkerTriggerConfig` (`operations` / `stages` / `workers`), and the daemon fans typed `WorkerCallRequest` payloads out fire-and-forget so a slow subscriber can never stall an op.

## Summary

- **New trigger type** `worker` registered by `iii_worker::cli::worker_manager_daemon`. `trigger_request_format` = `WorkerTriggerConfig` (subscriber filters), `call_request_format` = `WorkerCallRequest` (event payload).
- **Stage events on every mutating op** — `core/{add,remove,update,start,stop,clear}.rs` now emit `Started → Stage(verb-ing) → Stage(verb-ed)|Done` on success and `Started → Stage(verb-ing) → Failed { error }` on shim error.
- **`WorkerOpEvent::Failed`** new variant so terminal failures flow through the same `EventSink` as `Done`.
- **`IIIEventSink`** bridges `WorkerOpEvent` → `iii.trigger(fn_id, payload, Void)` for every matching subscriber. Single dispatcher task per sink (mpsc-serialized) so wire order matches emit order — fixes a race where multi-thread runtimes delivered `done` before `downloaded`.
- **Skill docs** — new `new_skills/worker/skills/worker/events.md` how-to plus per-op cross-links (`add`, `remove`, `update`, `start`, `stop`, `clear`) and a new "trigger type" section in `index.md`.
- **End-to-end test** — in-process: `EngineBuilder::serve()` + daemon spawned as a tokio task + three subscribers exercising the filter matrix + `iii.trigger("worker::add", iii-http)`.

## Filter semantics

`WorkerTriggerConfig` has three optional `Vec<…>` fields:

| Field | Values | Meaning |
|---|---|---|
| `operations` | `add` / `remove` / `update` / `start` / `stop` / `clear` | subset to subscribe to |
| `stages` | `started` / `downloading` / `downloaded` / `removing` / `updating` / `starting` / `stopping` / `clearing` / `done` / `failed` | subset to subscribe to |
| `workers` | exact worker names | subset to subscribe to |

- **AND** across fields, **OR** within a vector.
- `None` and `Some(vec![])` are both wildcards.

The lead use case — "notify when `iii-http` finishes downloading":

```json
{ "operations": ["add"], "stages": ["downloaded"] }

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `worker` custom trigger type for subscribing to worker lifecycle events with filtering by operation, stage, and worker name.
  * Enhanced worker operations with granular lifecycle event emission, including stage progression and failure reporting.

* **Documentation**
  * Added comprehensive documentation for all worker operations and lifecycle events.
  * Added complete documentation for sandbox operations and usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->