### PR TITLE
feat(iii-worker): expand ${VAR} in worker config: at start time

### DIFF
--- a/crates/iii-worker/examples/dump_worker_env.rs
+++ b/crates/iii-worker/examples/dump_worker_env.rs
@@ -1,0 +1,24 @@
+//! Quick demo: dumps the env hashmap that `iii worker start <name>`
+//! would inject into the sandbox VM for a given worker, after
+//! `${VAR}` / `${VAR:default}` expansion. Run from a directory
+//! containing `config.yaml`:
+//!
+//!     ANTHROPIC_API_KEY=sk-real \
+//!       cargo run -p iii-worker --example dump_worker_env -- ai-worker
+
+fn main() {
+    let name = std::env::args().nth(1).unwrap_or_else(|| {
+        eprintln!("usage: dump_worker_env <worker-name>");
+        std::process::exit(2);
+    });
+    let env = iii_worker::cli::config_file::get_worker_config_as_env(&name);
+    if env.is_empty() {
+        eprintln!("(empty — worker not found, or expansion failed; see stderr above)");
+        std::process::exit(1);
+    }
+    let mut keys: Vec<_> = env.keys().collect();
+    keys.sort();
+    for k in keys {
+        println!("{}={}", k, env[k]);
+    }
+}

--- a/crates/iii-worker/src/cli/config_file.rs
+++ b/crates/iii-worker/src/cli/config_file.rs
@@ -7,7 +7,9 @@
 //! Helpers to read/append/remove worker entries from `config.yaml` while
 //! preserving existing formatting and comments.
 
+use regex::Regex;
 use std::path::Path;
+use std::sync::LazyLock;
 
 pub(crate) const CONFIG_FILE: &str = "config.yaml";
 
@@ -707,10 +709,95 @@ fn check_binary_fallback(name: &str) -> ResolvedWorkerType {
     check_install_fallback(name)
 }
 
+/// Expand `${VAR}` and `${VAR:default}` references against the host
+/// environment. Mirrors `engine::workers::config::EngineConfig::expand_env_vars`
+/// (see `engine/src/workers/config.rs`) so the same syntax that works
+/// in the engine's `config.yaml` reader also works when iii-worker
+/// reads the per-worker `config:` block to build the worker's env
+/// injection set.
+///
+/// Why not a shared crate: the regex + env-lookup helper is 30 lines
+/// of pure logic with one dependency (`regex`) we already have. A
+/// dedicated `iii-config-utils` crate would add a workspace member for
+/// one function. If a third reader appears, consolidate then.
+///
+/// On a missing variable with no default: returns `Err` with the list
+/// of unset vars and leaves the literal `${VAR}` in place at the match
+/// site so partial output is still valid YAML. The single caller
+/// (`get_worker_config_as_env`) surfaces the error via stderr and
+/// returns an empty hashmap — better than silently injecting a literal
+/// `${VAR}` into the guest env, which would surface much later as an
+/// opaque "API key is invalid" inside the worker.
+///
+/// Does NOT support the engine-specific `__III_ENGINE_VERSION__`
+/// placeholder. iii-worker is not the version source of truth.
+fn expand_env_vars(yaml_content: &str) -> Result<String, String> {
+    static RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\$\{([^}:]+)(?::([^}]*))?\}").unwrap());
+
+    let mut missing: Vec<String> = Vec::new();
+    let expanded = RE.replace_all(yaml_content, |caps: &regex::Captures| {
+        let var_name = &caps[1];
+        let default_value = caps.get(2).map(|m| m.as_str());
+
+        match std::env::var(var_name) {
+            Ok(value) => value,
+            Err(_) => match default_value {
+                Some(default) => default.to_string(),
+                None => {
+                    missing.push(var_name.to_string());
+                    // Keep literal so downstream YAML parse still succeeds;
+                    // caller decides whether to surface or drop.
+                    caps[0].to_string()
+                }
+            },
+        }
+    });
+
+    if !missing.is_empty() {
+        return Err(format!(
+            "env var(s) not set and no default provided: {}",
+            missing.join(", ")
+        ));
+    }
+    Ok(expanded.to_string())
+}
+
 /// Returns the `config:` block for a named worker as a flat `HashMap<String, String>`.
 ///
 /// Suitable for injecting as environment variables into OCI workers.
 /// Nested keys are flattened with `_` separator and uppercased.
+///
+/// `${VAR}` and `${VAR:default}` references in values are expanded
+/// against the host environment at read time. This mirrors the engine's
+/// `EngineConfig::config_file` behavior (see
+/// `engine/src/workers/config.rs::expand_env_vars`) so the same syntax
+/// works in both readers of `config.yaml`.
+///
+/// Expansion happens at start time, not when `iii worker add` copies
+/// `iii.worker.yaml`'s `config:` into `config.yaml`. That keeps the
+/// literal `${VAR}` on disk (so secrets don't get baked into a file
+/// users sometimes check into git) and lets the host env be the source
+/// of truth on every worker start.
+///
+/// On missing variables with no default, surfaces the error via stderr
+/// AND `tracing::error!` (so subprocess-captured logs see it too — the
+/// CLI is often spawned by `iii engine` which redirects stderr to the
+/// managed-dir log), then drops the **entire** worker config: block
+/// (not just the offending key) by returning an empty hashmap. The
+/// worker then boots with no config-derived env vars — its own startup
+/// code will surface a more specific error when it tries to read the
+/// missing variable, which is more actionable than a literal `${VAR}`
+/// reaching the guest. If granular per-key resilience is needed later,
+/// move expansion into `flatten_value_to_env` so only the bad leaf is
+/// dropped.
+///
+/// Scoping vs engine: engine's `EngineConfig::config_file` expands
+/// across the WHOLE `config.yaml` and panics on missing vars. This
+/// function expands only the extracted worker's `config:` block and
+/// fails soft. In practice the engine boots first; if it would panic
+/// on a top-level `${X}`, iii-worker is never invoked — so the
+/// scoping divergence is invisible.
 pub fn get_worker_config_as_env(name: &str) -> std::collections::HashMap<String, String> {
     let path = Path::new(CONFIG_FILE);
     let content = match std::fs::read_to_string(path) {
@@ -721,6 +808,21 @@ pub fn get_worker_config_as_env(name: &str) -> std::collections::HashMap<String,
     let config_str = match extract_worker_config(&content, name) {
         Some(c) => c,
         None => return std::collections::HashMap::new(),
+    };
+
+    let config_str = match expand_env_vars(&config_str) {
+        Ok(s) => s,
+        Err(e) => {
+            let msg = format!(
+                "failed to expand env vars in config.yaml `workers[name={name}].config:`: {e}"
+            );
+            // Belt-and-suspenders: tracing for subprocess log capture,
+            // eprintln for interactive CLI invocations where tracing
+            // may not be initialized yet.
+            tracing::error!("{}", msg);
+            eprintln!("error: {msg}");
+            return std::collections::HashMap::new();
+        }
     };
 
     let value: serde_json::Value = match serde_yaml::from_str(&config_str) {
@@ -1413,5 +1515,230 @@ workers:
             manager_port_from("not: valid: yaml: :"),
             super::super::app::DEFAULT_PORT
         );
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // expand_env_vars — must match `engine::workers::config::expand_env_vars`
+    // semantics so `${VAR}` / `${VAR:default}` behaves the same whether
+    // the engine reads config.yaml at boot OR iii-worker's CLI reads it
+    // to build worker env. Tests below mirror engine's set; if engine
+    // semantics change, update both sides.
+    // ──────────────────────────────────────────────────────────────────
+
+    /// Serialize env-var manipulating tests. `std::env::set_var` mutates
+    /// global process state and is unsafe to run in parallel with other
+    /// tests that read the same vars.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Scoped env-var setter that restores the prior value on drop so a
+    /// failing test can't leak state into siblings.
+    struct EnvGuard {
+        key: String,
+        prior: Option<String>,
+    }
+    impl EnvGuard {
+        fn set(key: &str, value: &str) -> Self {
+            let prior = std::env::var(key).ok();
+            // SAFETY: tests holding ENV_LOCK serialize all env mutation.
+            unsafe { std::env::set_var(key, value) };
+            Self {
+                key: key.to_string(),
+                prior,
+            }
+        }
+        fn unset(key: &str) -> Self {
+            let prior = std::env::var(key).ok();
+            unsafe { std::env::remove_var(key) };
+            Self {
+                key: key.to_string(),
+                prior,
+            }
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(v) => unsafe { std::env::set_var(&self.key, v) },
+                None => unsafe { std::env::remove_var(&self.key) },
+            }
+        }
+    }
+
+    #[test]
+    fn expand_env_vars_substitutes_known_var() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::set("TEST_EXPAND_FOO", "bar");
+        let out = expand_env_vars("k: ${TEST_EXPAND_FOO}\n").unwrap();
+        assert_eq!(out, "k: bar\n");
+    }
+
+    #[test]
+    fn expand_env_vars_uses_default_when_missing() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::unset("TEST_EXPAND_UNSET");
+        let out = expand_env_vars("k: ${TEST_EXPAND_UNSET:fallback}\n").unwrap();
+        assert_eq!(out, "k: fallback\n");
+    }
+
+    #[test]
+    fn expand_env_vars_default_ignored_when_var_present() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::set("TEST_EXPAND_HAS", "real");
+        let out = expand_env_vars("k: ${TEST_EXPAND_HAS:fallback}\n").unwrap();
+        assert_eq!(out, "k: real\n");
+    }
+
+    #[test]
+    fn expand_env_vars_passes_through_when_no_refs() {
+        let yaml = "auto_install: true\nport: 3000\n";
+        assert_eq!(expand_env_vars(yaml).unwrap(), yaml);
+    }
+
+    #[test]
+    fn expand_env_vars_errors_on_missing_var_with_no_default() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::unset("TEST_EXPAND_REQUIRED");
+        let err = expand_env_vars("k: ${TEST_EXPAND_REQUIRED}\n").unwrap_err();
+        assert!(err.contains("TEST_EXPAND_REQUIRED"), "got: {err}");
+        assert!(err.contains("not set"), "got: {err}");
+    }
+
+    #[test]
+    fn expand_env_vars_lists_all_missing_vars() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g1 = EnvGuard::unset("TEST_EXPAND_MISSING_A");
+        let _g2 = EnvGuard::unset("TEST_EXPAND_MISSING_B");
+        let err = expand_env_vars("a: ${TEST_EXPAND_MISSING_A}\nb: ${TEST_EXPAND_MISSING_B}\n")
+            .unwrap_err();
+        assert!(err.contains("TEST_EXPAND_MISSING_A"), "got: {err}");
+        assert!(err.contains("TEST_EXPAND_MISSING_B"), "got: {err}");
+    }
+
+    #[test]
+    fn expand_env_vars_handles_multiple_same_var() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::set("TEST_EXPAND_REPEAT", "x");
+        let out = expand_env_vars("a: ${TEST_EXPAND_REPEAT}\nb: ${TEST_EXPAND_REPEAT}\n").unwrap();
+        assert_eq!(out, "a: x\nb: x\n");
+    }
+
+    #[test]
+    fn expand_env_vars_empty_default_allowed() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::unset("TEST_EXPAND_EMPTY_DEF");
+        let out = expand_env_vars("k: ${TEST_EXPAND_EMPTY_DEF:}\n").unwrap();
+        assert_eq!(out, "k: \n");
+    }
+
+    // Parity tests: mirror engine/src/workers/config.rs to confirm the
+    // contract is byte-for-byte the same.
+
+    #[test]
+    fn expand_env_vars_default_with_special_chars() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::unset("TEST_EXPAND_SPECIAL");
+        let out = expand_env_vars("k: ${TEST_EXPAND_SPECIAL:hello world}\n").unwrap();
+        assert_eq!(out, "k: hello world\n");
+    }
+
+    #[test]
+    fn expand_env_vars_adjacent_variables() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g1 = EnvGuard::set("TEST_EXPAND_SCHEME", "https");
+        let _g2 = EnvGuard::set("TEST_EXPAND_HOST", "example.com");
+        let _g3 = EnvGuard::set("TEST_EXPAND_PORT", "443");
+        let out = expand_env_vars(
+            "url: ${TEST_EXPAND_SCHEME}://${TEST_EXPAND_HOST}:${TEST_EXPAND_PORT}\n",
+        )
+        .unwrap();
+        assert_eq!(out, "url: https://example.com:443\n");
+    }
+
+    #[test]
+    fn expand_env_vars_var_with_underscore_and_numbers() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::set("TEST_EXPAND_MY_VAR_123", "ok");
+        let out = expand_env_vars("k: ${TEST_EXPAND_MY_VAR_123}\n").unwrap();
+        assert_eq!(out, "k: ok\n");
+    }
+
+    #[test]
+    fn expand_env_vars_surrounding_text_preserved() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::set("TEST_EXPAND_MIDDLE", "VAL");
+        let out = expand_env_vars("k: prefix-${TEST_EXPAND_MIDDLE}-suffix\n").unwrap();
+        assert_eq!(out, "k: prefix-VAL-suffix\n");
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // get_worker_config_as_env — verify expansion is wired up end-to-end.
+    // These tests cd into a tempdir because CONFIG_FILE is the relative
+    // path "config.yaml".
+    // ──────────────────────────────────────────────────────────────────
+
+    /// Process-wide guard for tests that touch `config.yaml` in cwd.
+    /// `set_current_dir` is global, so these can't overlap with other
+    /// tests in this crate that read/write `config.yaml`.
+    static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_temp_config<R>(yaml: &str, f: impl FnOnce() -> R) -> R {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("config.yaml"), yaml).expect("write config.yaml");
+        let prior = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(dir.path()).expect("set_current_dir");
+        let result = f();
+        std::env::set_current_dir(&prior).expect("restore cwd");
+        result
+    }
+
+    #[test]
+    fn get_worker_config_as_env_expands_known_var() {
+        let _cwd = CWD_LOCK.lock().unwrap();
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::set("TEST_WORKER_KEY", "sk-real-value");
+        let yaml =
+            "workers:\n  - name: my-worker\n    config:\n      api_key: ${TEST_WORKER_KEY}\n";
+        let env = with_temp_config(yaml, || get_worker_config_as_env("my-worker"));
+        assert_eq!(
+            env.get("API_KEY").map(String::as_str),
+            Some("sk-real-value")
+        );
+    }
+
+    #[test]
+    fn get_worker_config_as_env_uses_default_when_var_missing() {
+        let _cwd = CWD_LOCK.lock().unwrap();
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::unset("TEST_WORKER_UNSET");
+        let yaml =
+            "workers:\n  - name: w\n    config:\n      host: ${TEST_WORKER_UNSET:localhost}\n";
+        let env = with_temp_config(yaml, || get_worker_config_as_env("w"));
+        assert_eq!(env.get("HOST").map(String::as_str), Some("localhost"));
+    }
+
+    #[test]
+    fn get_worker_config_as_env_returns_empty_on_missing_required_var() {
+        let _cwd = CWD_LOCK.lock().unwrap();
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::unset("TEST_WORKER_REQUIRED");
+        let yaml = "workers:\n  - name: w\n    config:\n      api_key: ${TEST_WORKER_REQUIRED}\n";
+        let env = with_temp_config(yaml, || get_worker_config_as_env("w"));
+        // Fail-soft: empty hashmap rather than panic. The worker boots
+        // without API_KEY and its own startup will surface a clear error.
+        assert!(env.is_empty(), "expected empty, got: {env:?}");
+    }
+
+    #[test]
+    fn get_worker_config_as_env_expands_inside_nested_block() {
+        let _cwd = CWD_LOCK.lock().unwrap();
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::set("TEST_WORKER_DB_HOST", "db.prod.internal");
+        let yaml = "workers:\n  - name: w\n    config:\n      database:\n        host: ${TEST_WORKER_DB_HOST}\n        port: 5432\n";
+        let env = with_temp_config(yaml, || get_worker_config_as_env("w"));
+        assert_eq!(
+            env.get("DATABASE_HOST").map(String::as_str),
+            Some("db.prod.internal")
+        );
+        assert_eq!(env.get("DATABASE_PORT").map(String::as_str), Some("5432"));
     }
 }


### PR DESCRIPTION
## Summary

- iii-worker's `get_worker_config_as_env` now expands `${VAR}` / `${VAR:default}` references in the per-worker `config:` block at start time, mirroring the engine's `EngineConfig::config_file` behavior.
- Before: `ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}` in `iii.worker.yaml`'s `config:` arrived inside the sandbox VM as the literal string `${ANTHROPIC_API_KEY}`. After: the host env value flows through `--env KEY=VALUE` → libkrun → `init.krun` → iii-init.
- Expansion happens at worker start, never at `iii worker add` time — secrets stay only in the host env and never get baked into `config.yaml` on disk.
- Adds `crates/iii-worker/examples/dump_worker_env.rs` so the fix can be exercised against any `config.yaml` without booting a VM.

## Why

Two readers of `config.yaml` had diverged:

| Path | File | Expansion? |
|---|---|---|
| Engine boot | `engine/src/workers/config.rs:99` | ✅ via `expand_env_vars` |
| iii-worker → guest env | `crates/iii-worker/src/cli/config_file.rs:709` (`get_worker_config_as_env`) | ❌ |

The iii-worker side feeds the env-var flags to `__vm-boot`, so users couldn't reference host env vars from `iii.worker.yaml`'s `config:` block — they had to hardcode raw secret values in a file that's sometimes checked into git.

## Failure semantics

On a missing `${VAR}` with no default, the worker config: block is dropped (returns empty hashmap) and the error is surfaced via:
- `tracing::error!` — caught by subprocess log capture when the engine spawns iii-worker as a child.
- `eprintln!` — visible on interactive CLI invocations even before tracing is initialized.

This is documented as intentional fail-soft so the worker boots and its own startup code can surface the specific missing-var error, rather than the guest receiving a literal `${VAR}` and failing much later with an opaque "invalid API key" message.

## Tests

16 new tests in `crates/iii-worker/src/cli/config_file.rs`:
- 12 `expand_env_vars` unit tests: basic substitution, defaults, missing-var error, multiple/adjacent/nested refs, special chars in defaults, var names with underscores/numbers, surrounding text preserved.
- 4 `get_worker_config_as_env` wiring tests: end-to-end against a temp `config.yaml`, including the fail-soft empty-hashmap path and nested-key flattening.

Mirrors the engine's parallel test set for behavioral parity.

## Test plan

- [x] `cargo test -p iii-worker --lib` — 740 passed (was 736), 0 failed, 1 ignored
- [x] `cargo test -p iii-worker --test config_crud_integration` — 22 passed
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p iii-worker --lib --no-deps` — no new lints
- [x] End-to-end verified with `examples/dump_worker_env`:
  ```
  ANTHROPIC_API_KEY=sk-ant-PROOF-OF-FIX ANTHROPIC_MODEL=claude-opus \
    cargo run -p iii-worker --example dump_worker_env -- ai-worker
  ```
  Output: `ANTHROPIC_API_KEY=sk-ant-PROOF-OF-FIX`, `MODEL_NAME=claude-opus`, `MODEL_PROVIDER=anthropic`, `REQUEST_TIMEOUT_MS=30000`.
- [ ] Manual full-VM verification: scaffold a worker with `${ANTHROPIC_API_KEY}` in `iii.worker.yaml`, `iii worker add`, `iii engine`, confirm env reaches the guest process.

## Files changed

- `crates/iii-worker/src/cli/config_file.rs` — `expand_env_vars` helper + wiring + 16 tests
- `crates/iii-worker/examples/dump_worker_env.rs` — verification driver

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment variable expansion in worker configuration files, supporting `${VAR}` and `${VAR:default}` syntax
  * Added example tool to display resolved worker environment configuration

* **Tests**
  * Extended test coverage for configuration expansion scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->