### PR TITLE
fix(iii-worker): inject default PATH for guests with no OCI env

### DIFF
--- a/crates/iii-worker/src/cli/vm_boot.rs
+++ b/crates/iii-worker/src/cli/vm_boot.rs
@@ -268,6 +268,35 @@ pub fn rewrite_localhost(s: &str, gateway_ip: &str) -> String {
         .replace("://127.0.0.1:", &format!("://{}:", gateway_ip))
 }
 
+/// Default PATH for the guest VM when neither the caller nor the OCI
+/// image config provides one. Mirrors the value every standard
+/// Debian/Ubuntu image (and most other distros) ships in
+/// `/etc/profile`.
+///
+/// Why this matters: libkrun starts iii-init (PID 1) with whatever
+/// env we pass to `set_env`, and only that. When `args.env` doesn't
+/// carry `PATH`, PID 1 has none — and neither does any process it
+/// spawns (the worker boot script, the shell dispatcher, `iii worker
+/// exec` children). dash's compile-time default fills `$PATH`
+/// internally so `node` typed at a shell prompt still works, but
+/// **dash does not mark that internal default as exported**. So a
+/// `#!/usr/bin/env <prog>` shebang re-execs through `/usr/bin/env`,
+/// which inherits the empty env, falls back to libc's
+/// `_PATH_DEFPATH` (`/usr/bin:/bin`), and can't find anything in
+/// `/usr/local/bin` — breaking npm/npx/yarn/pip/etc.
+///
+/// The caller-supplied env wins: if `args.env` already carries
+/// `PATH`, this constant is not used.
+pub const DEFAULT_GUEST_PATH: &str =
+    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
+/// True when any `KEY=VALUE` entry in `env` has the literal key `PATH`.
+/// Case-sensitive: env var names are case-sensitive on Unix.
+pub fn env_has_path(env: &[String]) -> bool {
+    env.iter()
+        .any(|kv| matches!(kv.split_once('='), Some(("PATH", _))))
+}
+
 /// Conditionally rewrite localhost/loopback URLs.
 ///
 /// `None` means networking is disabled — no virtio-net device is attached,
@@ -820,6 +849,16 @@ fn boot_vm(args: &VmBootArgs) -> Result<std::convert::Infallible, String> {
                 e = e.env(key, &rewritten_value);
             }
         }
+        // Fallback PATH for rootfs caches that pre-date the
+        // `.oci-config.json` write step (`oci.rs:604`) — `read_oci_env`
+        // returns [] on those, so PATH never makes it into `args.env`,
+        // and shebang scripts like `#!/usr/bin/env node` then fail to
+        // resolve binaries that live in /usr/local/bin. The check runs
+        // after the caller loop so an explicit `--env PATH=...` (or an
+        // OCI image that does ship PATH) always wins.
+        if !env_has_path(&args.env) {
+            e = e.env("PATH", DEFAULT_GUEST_PATH);
+        }
         e
     });
 
@@ -1093,5 +1132,70 @@ mod tests {
     fn test_shell_quote_with_embedded_single_quotes() {
         let result = shell_quote("it's a test");
         assert_eq!(result, "'it'\\''s a test'");
+    }
+
+
+    // --- 6.3: env_has_path / DEFAULT_GUEST_PATH (guards the npm
+    // shebang fallback added when a rootfs cache lacks
+    // `.oci-config.json`). See the `DEFAULT_GUEST_PATH` docstring for
+    // the full rationale.
+    #[test]
+    fn env_has_path_detects_present() {
+        let env = vec![
+            "FOO=bar".to_string(),
+            "PATH=/usr/bin".to_string(),
+            "QUX=quux".to_string(),
+        ];
+        assert!(env_has_path(&env));
+    }
+
+    #[test]
+    fn env_has_path_returns_false_when_missing() {
+        let env = vec!["FOO=bar".to_string(), "QUX=quux".to_string()];
+        assert!(!env_has_path(&env));
+    }
+
+    #[test]
+    fn env_has_path_empty_is_false() {
+        let env: Vec<String> = vec![];
+        assert!(!env_has_path(&env));
+    }
+
+    #[test]
+    fn env_has_path_is_case_sensitive() {
+        // Unix env names are case-sensitive; `Path` and `path` must not
+        // mask the missing `PATH` and suppress the fallback.
+        let env = vec!["Path=/usr/bin".to_string(), "path=/bin".to_string()];
+        assert!(!env_has_path(&env));
+    }
+
+    #[test]
+    fn env_has_path_ignores_path_prefix_keys() {
+        // `PATHFOO=...` and `MY_PATH=...` must not be confused with the
+        // literal `PATH` key — split_once('=') anchors the comparison.
+        let env = vec!["PATHFOO=/x".to_string(), "MY_PATH=/y".to_string()];
+        assert!(!env_has_path(&env));
+    }
+
+    #[test]
+    fn env_has_path_handles_empty_value() {
+        // `PATH=` (empty value) is technically a set PATH — exporting
+        // an empty PATH is a real user choice (e.g. forcing absolute
+        // paths). Don't override it.
+        let env = vec!["PATH=".to_string()];
+        assert!(env_has_path(&env));
+    }
+
+    #[test]
+    fn default_guest_path_matches_debian_default() {
+        // Smoke test: keep the constant aligned with `/etc/profile` on
+        // the Debian-family base images the worker rootfs ships from.
+        // If you change this, also bump the constant docstring and the
+        // related test that asserts the fallback fix for shebang
+        // scripts in /usr/local/bin.
+        assert_eq!(
+            DEFAULT_GUEST_PATH,
+            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        );
     }
 }

--- a/crates/iii-worker/src/cli/vm_boot.rs
+++ b/crates/iii-worker/src/cli/vm_boot.rs
@@ -287,8 +287,7 @@ pub fn rewrite_localhost(s: &str, gateway_ip: &str) -> String {
 ///
 /// The caller-supplied env wins: if `args.env` already carries
 /// `PATH`, this constant is not used.
-pub const DEFAULT_GUEST_PATH: &str =
-    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+pub const DEFAULT_GUEST_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 
 /// True when any `KEY=VALUE` entry in `env` has the literal key `PATH`.
 /// Case-sensitive: env var names are case-sensitive on Unix.
@@ -1133,7 +1132,6 @@ mod tests {
         let result = shell_quote("it's a test");
         assert_eq!(result, "'it'\\''s a test'");
     }
-
 
     // --- 6.3: env_has_path / DEFAULT_GUEST_PATH (guards the npm
     // shebang fallback added when a rootfs cache lacks


### PR DESCRIPTION
## Summary

- `iii worker exec <name> -- /bin/sh` left npm/npx/yarn/pip and any `#!/usr/bin/env <prog>` shebang broken with `/usr/bin/env: '<prog>': No such file or directory`, even though typing `<prog>` at the dash prompt worked. Root cause is that PATH wasn't exported into the spawned shell's env.
- The trigger is `read_oci_env` returning `[]` for rootfs caches that pre-date the `.oci-config.json` write step ([`oci.rs:604`](crates/iii-worker/src/cli/worker_manager/oci.rs#L604)). On those caches no `--env PATH=…` flag reaches `__vm-boot`, so libkrun starts iii-init (PID 1) with no PATH, dash backfills `$PATH` from its compile-time default for **its own** command lookup but does NOT mark it exported, and child `execve`s (the shebang `env`) fall back to libc's `/usr/bin:/bin` — which doesn't include `/usr/local/bin` where `node` lives.
- Fix: inject the standard Debian PATH (`/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`) in `vm_boot.rs` only when neither the caller nor the OCI image config supplied one. Explicit `--env PATH=…` and image-provided PATH still win.

## Reproduction & verification

Stale `iiidev/node` cache (extracted Apr 24, before `.oci-config.json` writing) → ai-worker exec:

```
# before
$ iii worker exec ai-worker -- /usr/local/bin/npm -v
/usr/bin/env: 'node': No such file or directory

# after
$ iii worker exec ai-worker -- /usr/local/bin/npm -v
11.11.0
$ iii worker exec ai-worker -- /bin/sh -c 'env | grep ^PATH='
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

## Test plan

- [x] `cargo test -p iii-worker --lib cli::vm_boot::tests::env_has_path` — 6 new tests pass (presence, absence, empty list, case sensitivity, `PATHFOO`/`MY_PATH` prefix safety, `PATH=` empty-value treated as set)
- [x] `cargo test -p iii-worker --lib cli::vm_boot::tests::default_guest_path_matches_debian_default` — constant smoke test
- [x] `cargo check -p iii-worker` — clean build, no new warnings
- [x] Live end-to-end: stop ai-worker, rebuild `iii-worker` for `aarch64-apple-darwin`, restart, `iii worker exec ai-worker -- /usr/local/bin/npm -v` returns `11.11.0`; `env | grep ^PATH=` now shows the exported PATH
- [x] Caller-supplied `--env PATH=…` still wins (asserted by "loop runs first, fallback emits only when missing" structure)
- [ ] Reviewer: confirm wording/positioning of `DEFAULT_GUEST_PATH` docstring matches your taste (it's the load-bearing comment for "why does this exist")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VM boot now injects a sensible default PATH into the guest when no explicit PATH is provided, ensuring consistent guest environment behavior.

* **Tests**
  * Expanded test coverage for PATH detection and related environment scenarios, including presence/absence, empty values, and case-sensitive matching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->