### PR TITLE
build: consume iii-observability from registries instead of workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -162,7 +162,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -976,7 +976,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1686,7 +1686,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1817,7 +1817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2718,7 +2718,7 @@ dependencies = [
  "hostname",
  "http-body-util",
  "iana-time-zone",
- "iii-observability",
+ "iii-observability 0.18.0-next.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iii-sdk",
  "iii-worker",
  "indexmap 2.14.0",
@@ -2781,7 +2781,7 @@ dependencies = [
  "axum",
  "clap",
  "futures-util",
- "iii-observability",
+ "iii-observability 0.18.0-next.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iii-sdk",
  "mime_guess",
  "reqwest 0.12.28",
@@ -2800,7 +2800,7 @@ name = "iii-example"
 version = "0.0.0"
 dependencies = [
  "async-trait",
- "iii-observability",
+ "iii-observability 0.18.0-next.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iii-sdk",
  "reqwest 0.12.28",
  "schemars 0.8.22",
@@ -2877,6 +2877,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-observability"
+version = "0.18.0-next.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e0c3fd5d08458c549177a07c6b870fe230b037fee7cc8f4b1b28d17a92a47c"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sysinfo 0.38.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite 0.28.0",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "iii-sdk"
 version = "0.18.0-next.1"
 dependencies = [
@@ -2884,7 +2908,7 @@ dependencies = [
  "ctor",
  "futures-util",
  "hostname",
- "iii-observability",
+ "iii-observability 0.18.0-next.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "opentelemetry",
  "opentelemetry_sdk",
  "reqwest 0.12.28",
@@ -2962,7 +2986,7 @@ dependencies = [
  "humantime",
  "iii-filesystem",
  "iii-network",
- "iii-observability",
+ "iii-observability 0.18.0-next.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iii-sdk",
  "iii-shell-client",
  "iii-shell-proto",
@@ -3140,7 +3164,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3977,7 +4001,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5284,7 +5308,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5367,7 +5391,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5904,7 +5928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6112,7 +6136,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7206,7 +7230,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://iii.dev"
 
 [workspace.dependencies]
 iii-sdk = { path = "sdk/packages/rust/iii" }
-iii-observability = { path = "sdk/packages/rust/observability", version = "0.18.0-next.1" }
+iii-observability = { version = "0.18.0-next.1" }
 scaffolder-core = { path = "crates/scaffolder-core" }
 
 # Shared dependencies used by tooling crates

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,8 +167,8 @@ importers:
   sdk/packages/node/iii:
     dependencies:
       '@iii-dev/observability':
-        specifier: workspace:*
-        version: link:../observability
+        specifier: 0.18.0-next.1
+        version: 0.18.0-next.1
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
@@ -904,6 +904,9 @@ packages:
 
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
+
+  '@iii-dev/observability@0.18.0-next.1':
+    resolution: {integrity: sha512-Tx7eNcIZyvw9v2GMY8lE43IEt2SInpsrWvbYffvFjZuIaFmi0WwwsefgJYvEKl3+YSOgnSKJFEgPViJ0MbknCQ==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -5387,6 +5390,25 @@ snapshots:
       '@shikijs/themes': 3.23.0
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
+
+  '@iii-dev/observability@0.18.0-next.1':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@img/colour@1.1.0': {}
 

--- a/sdk/packages/node/iii/package.json
+++ b/sdk/packages/node/iii/package.json
@@ -44,7 +44,7 @@
     }
   },
   "dependencies": {
-    "@iii-dev/observability": "workspace:*",
+    "@iii-dev/observability": "0.18.0-next.1",
     "@opentelemetry/api": "^1.9.0",
     "ws": "^8.18.3"
   },

--- a/sdk/packages/python/iii-example/pyproject.toml
+++ b/sdk/packages/python/iii-example/pyproject.toml
@@ -10,14 +10,13 @@ authors = [{ name = "III" }]
 requires-python = ">=3.10"
 dependencies = [
     "iii-sdk",
-    "iii-observability",
+    "iii-observability==0.18.0.dev1",
     "opentelemetry-api",
     "opentelemetry-sdk",
 ]
 
 [tool.uv.sources]
 iii-sdk = { path = "../iii", editable = true }
-iii-observability = { path = "../observability", editable = true }
 
 [project.scripts]
 iii-example = "src.main:main"

--- a/sdk/packages/python/iii-example/uv.lock
+++ b/sdk/packages/python/iii-example/uv.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "iii-observability", editable = "../observability" },
+    { name = "iii-observability", specifier = "==0.18.0.dev1" },
     { name = "iii-sdk", editable = "../iii" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
@@ -113,33 +113,22 @@ requires-dist = [
 
 [[package]]
 name = "iii-observability"
-version = "0.13.0.dev1"
-source = { editable = "../observability" }
+version = "0.18.0.dev1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
     { name = "websockets" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "httpx", specifier = ">=0.27" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
-    { name = "opentelemetry-api", specifier = ">=1.25" },
-    { name = "opentelemetry-sdk", specifier = ">=1.25" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
-    { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.30" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2" },
-    { name = "websockets", specifier = ">=12.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/f3/35/1360ef7f788536e40c5f2ee826389f20a9fe966dbec7598278ef8358012d/iii_observability-0.18.0.dev1.tar.gz", hash = "sha256:912bfade4592a64fcbcef58a525b1cf577308a807cf0c8dd62d59fe36c44aeab", size = 61799, upload-time = "2026-06-01T20:42:45.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/72/bf5ae59ffaac269ecb686665371599ff7dc94f04621a27bf793c0b9e1c0a/iii_observability-0.18.0.dev1-py3-none-any.whl", hash = "sha256:ae5e801d9be62edc174fd4ba47f218774072f86f776551d76e3e72762bb73211", size = 19780, upload-time = "2026-06-01T20:42:44.531Z" },
 ]
-provides-extras = ["dev"]
 
 [[package]]
 name = "iii-sdk"
-version = "0.13.0.dev1"
+version = "0.18.0.dev1"
 source = { editable = "../iii" }
 dependencies = [
     { name = "iii-observability" },
@@ -153,7 +142,7 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'dev'", specifier = ">=3.9" },
     { name = "anyio", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "griffe", marker = "extra == 'dev'", specifier = ">=1.0" },
-    { name = "iii-observability", editable = "../observability" },
+    { name = "iii-observability", specifier = "==0.18.0.dev1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "opentelemetry-api", specifier = ">=1.25" },
     { name = "pydantic", specifier = ">=2.0" },

--- a/sdk/packages/python/iii/pyproject.toml
+++ b/sdk/packages/python/iii/pyproject.toml
@@ -30,9 +30,6 @@ dependencies = [
 Homepage = "https://github.com/iii-hq/iii"
 Repository = "https://github.com/iii-hq/iii"
 
-[tool.uv.sources]
-iii-observability = { path = "../observability", editable = true }
-
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",

--- a/sdk/packages/python/iii/uv.lock
+++ b/sdk/packages/python/iii/uv.lock
@@ -546,33 +546,22 @@ wheels = [
 
 [[package]]
 name = "iii-observability"
-version = "0.16.0.dev3"
-source = { editable = "../observability" }
+version = "0.18.0.dev1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
     { name = "websockets" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "httpx", specifier = ">=0.27" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
-    { name = "opentelemetry-api", specifier = ">=1.25" },
-    { name = "opentelemetry-sdk", specifier = ">=1.25" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
-    { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.30" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2" },
-    { name = "websockets", specifier = ">=12.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/f3/35/1360ef7f788536e40c5f2ee826389f20a9fe966dbec7598278ef8358012d/iii_observability-0.18.0.dev1.tar.gz", hash = "sha256:912bfade4592a64fcbcef58a525b1cf577308a807cf0c8dd62d59fe36c44aeab", size = 61799, upload-time = "2026-06-01T20:42:45.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/72/bf5ae59ffaac269ecb686665371599ff7dc94f04621a27bf793c0b9e1c0a/iii_observability-0.18.0.dev1-py3-none-any.whl", hash = "sha256:ae5e801d9be62edc174fd4ba47f218774072f86f776551d76e3e72762bb73211", size = 19780, upload-time = "2026-06-01T20:42:44.531Z" },
 ]
-provides-extras = ["dev"]
 
 [[package]]
 name = "iii-sdk"
-version = "0.16.0.dev3"
+version = "0.18.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "iii-observability" },
@@ -598,7 +587,7 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'dev'", specifier = ">=3.9" },
     { name = "anyio", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "griffe", marker = "extra == 'dev'", specifier = ">=1.0" },
-    { name = "iii-observability", editable = "../observability" },
+    { name = "iii-observability", specifier = "==0.18.0.dev1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "opentelemetry-api", specifier = ">=1.25" },
     { name = "pydantic", specifier = ">=2.0" },


### PR DESCRIPTION
## Summary

Switches `iii-observability` from in-repo workspace links to the published registry versions for all consumers, now that the package has been published from PR #1678.

- **Rust:** `Cargo.toml` workspace dep drops `path = ...`, now consumes `iii-observability 0.13.0-next.1` from crates.io
- **Python (`iii-sdk`):** `[tool.uv.sources]` override removed; resolves `iii-observability==0.13.0.dev1` from PyPI
- **Python (`iii-example`):** `[tool.uv.sources]` override removed for `iii-observability` (keeps `iii-sdk` editable); pinned to `==0.13.0.dev1`
- **Node:** `@iii-dev/observability` changes from `workspace:*` to `0.13.0-next.1` (npm registry)

The local `sdk/packages/{rust,python,node}/observability` source packages remain as workspace members so they continue to build/test standalone in CI.

## Test Plan

- [ ] `cargo check --workspace` passes
- [ ] `cargo build --workspace` passes
- [ ] `pnpm --filter iii-sdk build` passes
- [ ] `pnpm --filter @iii-dev/observability build` passes
- [ ] `readlink -f sdk/packages/node/iii/node_modules/@iii-dev/observability` resolves into `node_modules/.pnpm/...`, NOT into the workspace member
- [ ] `Cargo.lock` shows registry-resolved `iii-observability` for all five consumers
- [ ] Both `sdk/packages/python/{iii,iii-example}/uv.lock` show `iii-observability` from `https://pypi.org/simple`
- [ ] CI green across Rust + Node + Python suites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned observability dependencies to prerelease versions across Node, Python, and Rust packages.
  * Removed local path-based references in favor of published package references to unify dependency sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->