### PR TITLE
fix(engine): attribute trigger types to in-process workers in workers::info

### DIFF
--- a/engine/src/trigger.rs
+++ b/engine/src/trigger.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-const BUILTIN_TRIGGER_TYPES: &[(&str, &str)] = &[
+pub const BUILTIN_TRIGGER_TYPES: &[(&str, &str)] = &[
     ("http", "iii-http"),
     ("cron", "iii-cron"),
     ("subscribe", "iii-pubsub"),
@@ -25,7 +25,14 @@ const BUILTIN_TRIGGER_TYPES: &[(&str, &str)] = &[
     ("log", "iii-observability"),
 ];
 
-fn worker_name_for_trigger_type(trigger_type_id: &str) -> Option<&'static str> {
+/// Maps a trigger-type id to the in-process worker that owns it. In-process
+/// workers register their `TriggerType` with `worker_id: None`, so the
+/// `worker_registry` Uuid lookup used for WebSocket workers cannot attribute
+/// them. The static table is the source of truth for both error reporting
+/// (`RegisterTriggerError::UnknownBuiltin`) and discovery (`engine_fn`
+/// rolls trigger types up into the owning runtime worker's `workers::info`
+/// envelope).
+pub fn builtin_trigger_type_owner(trigger_type_id: &str) -> Option<&'static str> {
     BUILTIN_TRIGGER_TYPES
         .iter()
         .find(|(id, _)| *id == trigger_type_id)
@@ -251,7 +258,7 @@ impl TriggerRegistry {
     pub async fn register_trigger(&self, trigger: Trigger) -> Result<(), RegisterTriggerError> {
         let trigger_type_id = trigger.trigger_type.clone();
         let Some(trigger_type) = self.trigger_types.get(&trigger_type_id) else {
-            if let Some(worker_name) = worker_name_for_trigger_type(&trigger_type_id) {
+            if let Some(worker_name) = builtin_trigger_type_owner(&trigger_type_id) {
                 tracing::error!(
                     "Trigger type {} requires the {} worker, which is not active in your project.\n\n  To fix this, run:\n\n    {}\n",
                     trigger_type_id.purple().bold(),

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     engine::{Engine, EngineTrait, Handler, RegisterFunctionRequest, SessionHandler},
     function::FunctionResult,
     protocol::{ErrorBody, StreamChannelRef, WorkerMetrics},
-    trigger::{Trigger, TriggerRegistrator, TriggerType},
+    trigger::{Trigger, TriggerRegistrator, TriggerType, builtin_trigger_type_owner},
     worker_connections::{RuntimeWorkerInfo, WorkerConnection, WorkerConnectionTelemetryMeta},
     workers::traits::Worker,
     workers::worker::rbac_session::Session,
@@ -409,8 +409,11 @@ impl EngineFunctionsWorker {
         Self::first_segment(function_id)
     }
 
-    /// Resolves the worker name that owns a trigger type. Falls back to the
-    /// first `::` segment of the trigger-type id.
+    /// Resolves the worker name that owns a trigger type. Tries, in order:
+    /// the `worker_id` Uuid on the `TriggerType` (populated only by
+    /// WebSocket-connected workers), the static `BUILTIN_TRIGGER_TYPES` map
+    /// (used for in-process workers, which always register with
+    /// `worker_id: None`), and finally the first `::` segment of the id.
     fn worker_name_for_trigger_type(&self, tt_id: &str) -> String {
         if let Some(tt) = self.engine.trigger_registry.trigger_types.get(tt_id)
             && let Some(worker_id) = tt.worker_id
@@ -418,6 +421,9 @@ impl EngineFunctionsWorker {
             && let Some(name) = worker.name
         {
             return name;
+        }
+        if let Some(name) = builtin_trigger_type_owner(tt_id) {
+            return name.to_string();
         }
         Self::first_segment(tt_id)
     }
@@ -717,6 +723,7 @@ impl EngineFunctionsWorker {
         }
 
         let worker_id = envelope.id.clone();
+        let worker_name = envelope.name.clone();
         let index = self.function_owner_index().await;
         let mut functions: Vec<FunctionSummary> = function_ids
             .into_iter()
@@ -737,13 +744,25 @@ impl EngineFunctionsWorker {
             .trigger_types
             .iter()
             .filter(|entry| {
-                entry
-                    .value()
-                    .worker_id
-                    .and_then(|wid| self.engine.worker_registry.get_worker(&wid))
-                    .map(|w| w.id.to_string())
+                let tt = entry.value();
+                // WebSocket workers attribute via `worker_id` Uuid.
+                if let Some(wid) = tt.worker_id {
+                    return self
+                        .engine
+                        .worker_registry
+                        .get_worker(&wid)
+                        .map(|w| w.id.to_string())
+                        .as_deref()
+                        == Some(&worker_id);
+                }
+                // In-process workers register trigger types with
+                // `worker_id: None`, so fall back to the static
+                // BUILTIN_TRIGGER_TYPES map keyed by trigger-type id.
+                worker_name
                     .as_deref()
-                    == Some(&worker_id)
+                    .zip(builtin_trigger_type_owner(&tt.id))
+                    .map(|(name, owner)| name == owner)
+                    .unwrap_or(false)
             })
             .map(|entry| {
                 let tt = entry.value();

--- a/engine/tests/builtin_functions_e2e.rs
+++ b/engine/tests/builtin_functions_e2e.rs
@@ -250,3 +250,47 @@ async fn workers_info_returns_full_surface_for_runtime_worker() {
         .expect("functions array");
     assert!(!functions.is_empty(), "iii-state should expose functions");
 }
+
+/// In-process workers register `TriggerType` with `worker_id: None`, so the
+/// `worker_registry` Uuid lookup used for WebSocket workers cannot attribute
+/// them. `engine::workers::info` must still roll trigger types up into the
+/// owning runtime worker via the static `BUILTIN_TRIGGER_TYPES` map —
+/// otherwise the publish workflow ships an empty `triggers: []` array to the
+/// registry for iii-http, iii-cron, iii-state, etc.
+#[tokio::test]
+async fn workers_info_attributes_trigger_types_to_in_process_worker() {
+    let builder = boot_bare_engine().await;
+    let engine = builder.engine();
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let result = engine
+        .call("engine::workers::info", json!({ "name": "iii-http" }))
+        .await
+        .expect("engine::workers::info should succeed")
+        .expect("response should not be None");
+
+    let trigger_types = result
+        .get("trigger_types")
+        .and_then(|v| v.as_array())
+        .expect("trigger_types array");
+
+    let ids: Vec<&str> = trigger_types
+        .iter()
+        .filter_map(|tt| tt.get("id").and_then(|v| v.as_str()))
+        .collect();
+    assert!(
+        ids.contains(&"http"),
+        "iii-http workers::info should include the `http` trigger type, got {:?}",
+        ids
+    );
+
+    for tt in trigger_types {
+        assert_eq!(
+            tt.get("worker_name").and_then(|v| v.as_str()),
+            Some("iii-http"),
+            "trigger_type {:?} should be attributed to iii-http",
+            tt.get("id")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `engine::workers::info` was returning `trigger_types: []` for every in-process worker (`iii-http`, `iii-cron`, `iii-state`, `iii-telemetry`, ...). The filter introduced in #1675 only resolves ownership via `TriggerType.worker_id` (an `Option<Uuid>` populated by WebSocket-connected workers); in-process workers register with `worker_id: None`, so the `worker_registry` Uuid lookup never matched.
- As a result, the `_publish-engine-workers.yml` CI shipped empty `functions: []` and `triggers: []` arrays to the workers registry for every builtin engine worker. Visible in run [26465141644](https://github.com/iii-hq/iii/actions/runs/26465141644/job/77930482514) — the `iii-http` payload ends up as `{ ..., "functions": [], "triggers": [] }` despite the worker registering the `http` trigger type at init.
- Fix by promoting the existing `BUILTIN_TRIGGER_TYPES` static map (already the source of truth for `RegisterTriggerError::UnknownBuiltin`) and consulting it for runtime-worker attribution in both `build_worker_detail`'s trigger-type filter and `worker_name_for_trigger_type`'s fallback.

## Test plan

- [x] `cargo test -p iii --test builtin_functions_e2e` — 6 passed (incl. new regression test `workers_info_attributes_trigger_types_to_in_process_worker` which asserts `workers::info` for `iii-http` exposes the `http` trigger type attributed to `iii-http`).
- [x] `cargo test -p iii --lib trigger` — 123 passed.
- [x] `cargo fmt -p iii --check`.
- [ ] Re-run `_publish-engine-workers.yml` against this branch and confirm the registry payload for `iii-http` carries the `http` trigger type (and analogous payloads for `iii-cron`, `iii-state`, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attribution of built-in trigger types to their owning worker instances so worker info queries report trigger types consistently for in-process and external workers.

* **Tests**
  * Added an end-to-end test that boots the engine and validates trigger type attribution for an in-process worker, ensuring trigger types include the expected worker name.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->