### PR TITLE
fix(worker): clarify KVM sandbox requirements

### DIFF
--- a/crates/iii-worker/src/cli/vm_boot.rs
+++ b/crates/iii-worker/src/cli/vm_boot.rs
@@ -211,15 +211,21 @@ fn check_kvm_available() -> Result<(), String> {
 #[cfg(target_os = "linux")]
 fn check_kvm_at_path(kvm: &std::path::Path) -> Result<(), String> {
     if !kvm.exists() {
-        return Err("KVM not available -- /dev/kvm does not exist. \
-             Ensure KVM is enabled in your kernel and loaded (modprobe kvm_intel or kvm_amd)."
+        return Err("KVM sandbox unavailable -- /dev/kvm does not exist.\n\n\
+         iii workers require hardware virtualization for the Linux VM sandbox.\n\
+         This commonly happens in WSL2, shared cloud VMs, AWS free-tier instances,\n\
+         or any environment where nested virtualization is unavailable.\n\n\
+         To run sandbox workers, use native Linux with KVM enabled, a machine/VM\n\
+         that exposes /dev/kvm, or another supported host environment.\n\n\
+         See the sandbox worker documentation for Windows/WSL2 and cloud VM limitations."
             .to_string());
     }
     match std::fs::File::options().read(true).write(true).open(kvm) {
         Ok(_) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => Err(
-            "KVM not accessible -- /dev/kvm exists but current user lacks permission. \
-             Add your user to the 'kvm' group: sudo usermod -aG kvm $USER"
+            "KVM sandbox unavailable -- /dev/kvm exists but the current user cannot access it.\n\n\
+             Add your user to the 'kvm' group, then log out and back in:\n\
+             sudo usermod -aG kvm $USER"
                 .to_string(),
         ),
         Err(e) => Err(format!("KVM check failed: {}", e)),

--- a/docs/0-11-0/how-to/developing-sandbox-workers.mdx
+++ b/docs/0-11-0/how-to/developing-sandbox-workers.mdx
@@ -231,6 +231,17 @@ Each sandbox is cached at `~/.iii/managed/<worker-name>/`. The caching lifecycle
 ls -l /dev/kvm
 ```
 
+> **Windows/WSL2 and shared cloud VM limitation**
+>
+> On Linux, sandbox workers require KVM through `/dev/kvm`. This is often not
+> available inside WSL2, shared cloud VMs, AWS free-tier instances, or other
+> environments where nested virtualization is disabled or not exposed to the
+> guest operating system.
+>
+> If `/dev/kvm` does not exist, sandbox workers cannot start in that environment.
+> Use native Linux with KVM enabled, a machine or VM that exposes `/dev/kvm`, or
+> another supported host environment.
+
 ## Result
 
 Your worker runs inside an isolated microVM connected to the engine. The sandbox has its own filesystem, network stack, and process tree. The worker is registered in `config.yaml` and managed through the standard `iii worker` lifecycle commands — `start`, `stop`, `list`, and `remove`. To rebuild the sandbox after changing dependencies, re-add the worker with `iii worker add ./my-project --force`.


### PR DESCRIPTION
## Summary

Improves the developer experience when sandbox workers fail to start due to missing KVM support.

This PR:

* improves `/dev/kvm` error messaging
* explains common unsupported environments (WSL2, shared cloud VMs, AWS free-tier instances)
* clarifies permission-related KVM failures
* documents Windows/WSL2 virtualization limitations in the sandbox worker guide

## Problem

Previously, sandbox worker startup failures only returned:

```txt
KVM not available -- /dev/kvm does not exist
```

This did not clearly explain:

* why the failure occurs
* which environments are commonly affected
* that nested virtualization limitations are the root cause in WSL2/shared VMs
* how users can resolve or work around the issue

As a result, workers could appear stuck in a confusing state for developers unfamiliar with KVM requirements.

## Changes

### Improved KVM unavailable error messaging

Updated the `/dev/kvm` existence check to provide:

* clearer explanation of hardware virtualization requirements
* guidance around WSL2 and cloud VM limitations
* actionable next steps for supported environments

### Improved permission error messaging

Updated the permission-denied path to clarify:

* the user can access `/dev/kvm`
* how to join the `kvm` group
* that a logout/login cycle may be required

### Documentation updates

Added a new note in:

* `docs/0-11-0/how-to/developing-sandbox-workers.mdx`

The new documentation explains:

* WSL2 limitations
* nested virtualization constraints
* unsupported shared/cloud VM scenarios
* `/dev/kvm` requirements for Linux sandbox workers

## Validation

- `cargo fmt` completed successfully
- `cargo test -p iii-worker` was attempted on native Windows, but did not complete because `iii-worker` pulls in Linux/macOS virtualization-specific dependencies such as KVM/eventfd/Unix file descriptor APIs

## Related

Addresses part of #1684


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when KVM sandbox is unavailable, providing clearer guidance for WSL2, cloud VMs, shared hosting, and other environment-specific scenarios.

* **Documentation**
  * Added documentation explaining Linux sandbox worker KVM requirements and their limitations in WSL2, shared cloud environments, and setups without native KVM support, with native Linux guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->