### PR TITLE
fix(ci): sync iii-observability with iii on release bump

### DIFF
--- a/.github/scripts/bump_manifests.py
+++ b/.github/scripts/bump_manifests.py
@@ -20,3 +20,20 @@ def bump_cargo_package_version(text: str, new_version: str) -> str:
         raise ValueError("no top-level version line in Cargo manifest")
     start, end = m.span()
     return f'{text[:start]}version = "{new_version}"{text[end:]}'
+
+
+def bump_cargo_workspace_dep_version(text: str, dep_name: str, new_version: str) -> str:
+    """Replace the ``version = "..."`` value inside a ``dep_name = { ... }`` line.
+
+    Matches a single workspace-dependency entry whose key is exactly
+    ``dep_name`` and rewrites the embedded ``version`` field. Other fields
+    on the line (``path``, ``features``, ...) are preserved.
+    """
+    line_re = re.compile(
+        rf'^(?P<lead>{re.escape(dep_name)}\s*=\s*\{{[^}}\n]*?version\s*=\s*")[^"]*(?P<tail>"[^}}\n]*\}})',
+        re.MULTILINE,
+    )
+    m = line_re.search(text)
+    if m is None:
+        raise ValueError(f"no workspace dependency entry for {dep_name!r}")
+    return f'{text[:m.start()]}{m.group("lead")}{new_version}{m.group("tail")}{text[m.end():]}'

--- a/.github/scripts/bump_manifests.py
+++ b/.github/scripts/bump_manifests.py
@@ -55,3 +55,16 @@ def bump_json_top_level_version(text: str, new_version: str) -> str:
     indent, sp1, sp2 = m.group(1), m.group(2), m.group(3)
     replacement = f'{indent}"version"{sp1}:{sp2}"{new_version}"'
     return f'{text[:m.start()]}{replacement}{text[m.end():]}'
+
+
+def bump_pep440_dep_pin(text: str, dep_name: str, new_pep440: str) -> str:
+    """Replace ``"<dep_name>==<old>"`` with ``"<dep_name>==<new_pep440>"``.
+
+    Used for the ``iii-observability`` pin inside the python iii
+    ``pyproject.toml`` ``dependencies = [...]`` array.
+    """
+    line_re = re.compile(rf'"{re.escape(dep_name)}==[^"]*"')
+    m = line_re.search(text)
+    if m is None:
+        raise ValueError(f"no pinned dependency entry for {dep_name!r}")
+    return f'{text[:m.start()]}"{dep_name}=={new_pep440}"{text[m.end():]}'

--- a/.github/scripts/bump_manifests.py
+++ b/.github/scripts/bump_manifests.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Rewrite every release-bumped manifest in lockstep.
+
+Pure functions live at module top so they can be unit-tested. The CLI at
+the bottom drives the rewrites the create-tag workflow used to perform
+inline with sed/jq.
+"""
+from __future__ import annotations
+
+import re
+
+
+_CARGO_PACKAGE_VERSION_RE = re.compile(r'^version = "[^"]*"', re.MULTILINE)
+
+
+def bump_cargo_package_version(text: str, new_version: str) -> str:
+    """Replace the first top-level ``version = "..."`` line in a Cargo manifest."""
+    m = _CARGO_PACKAGE_VERSION_RE.search(text)
+    if m is None:
+        raise ValueError("no top-level version line in Cargo manifest")
+    start, end = m.span()
+    return f'{text[:start]}version = "{new_version}"{text[end:]}'

--- a/.github/scripts/bump_manifests.py
+++ b/.github/scripts/bump_manifests.py
@@ -114,3 +114,23 @@ def rewrite_all(root: Path, new_version: str, new_py_version: str) -> None:
     # Python observability: top-level version only
     py_obs = root / "sdk/packages/python/observability/pyproject.toml"
     py_obs.write_text(bump_cargo_package_version(py_obs.read_text(), new_py_version))
+
+
+import argparse
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--python-version", required=True)
+    args = parser.parse_args(argv)
+
+    rewrite_all(root=args.root, new_version=args.version, new_py_version=args.python_version)
+    print(f"Bumped manifests to {args.version} (python: {args.python_version})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/bump_manifests.py
+++ b/.github/scripts/bump_manifests.py
@@ -37,3 +37,21 @@ def bump_cargo_workspace_dep_version(text: str, dep_name: str, new_version: str)
     if m is None:
         raise ValueError(f"no workspace dependency entry for {dep_name!r}")
     return f'{text[:m.start()]}{m.group("lead")}{new_version}{m.group("tail")}{text[m.end():]}'
+
+
+_JSON_TOP_VERSION_RE = re.compile(r'^(\s*)"version"(\s*):(\s*)"[^"]*"', re.MULTILINE)
+
+
+def bump_json_top_level_version(text: str, new_version: str) -> str:
+    """Replace the first top-level ``"version": "..."`` line in a JSON file.
+
+    Operates textually to preserve formatting. The npm/iii workflow uses
+    ``jq`` today; we replace it with this so the workflow has a single
+    invocation point and the behaviour is unit-tested.
+    """
+    m = _JSON_TOP_VERSION_RE.search(text)
+    if m is None:
+        raise ValueError("no top-level version key in JSON manifest")
+    indent, sp1, sp2 = m.group(1), m.group(2), m.group(3)
+    replacement = f'{indent}"version"{sp1}:{sp2}"{new_version}"'
+    return f'{text[:m.start()]}{replacement}{text[m.end():]}'

--- a/.github/scripts/bump_manifests.py
+++ b/.github/scripts/bump_manifests.py
@@ -68,3 +68,49 @@ def bump_pep440_dep_pin(text: str, dep_name: str, new_pep440: str) -> str:
     if m is None:
         raise ValueError(f"no pinned dependency entry for {dep_name!r}")
     return f'{text[:m.start()]}"{dep_name}=={new_pep440}"{text[m.end():]}'
+
+
+from pathlib import Path
+
+
+_CARGO_PACKAGE_FILES = (
+    "engine/Cargo.toml",
+    "sdk/packages/rust/iii/Cargo.toml",
+    "sdk/packages/rust/observability/Cargo.toml",
+    "console/packages/console-rust/Cargo.toml",
+)
+_JSON_PACKAGE_FILES = (
+    "sdk/packages/node/iii/package.json",
+    "sdk/packages/node/iii-browser/package.json",
+    "sdk/packages/node/observability/package.json",
+)
+
+
+def rewrite_all(root: Path, new_version: str, new_py_version: str) -> None:
+    """Rewrite every release manifest under ``root`` in lockstep."""
+    # Cargo package versions
+    for rel in _CARGO_PACKAGE_FILES:
+        path = root / rel
+        path.write_text(bump_cargo_package_version(path.read_text(), new_version))
+
+    # Workspace root: bump both the workspace.package version and the
+    # iii-observability workspace-dep version pin.
+    workspace_path = root / "Cargo.toml"
+    body = bump_cargo_package_version(workspace_path.read_text(), new_version)
+    body = bump_cargo_workspace_dep_version(body, "iii-observability", new_version)
+    workspace_path.write_text(body)
+
+    # JSON package versions
+    for rel in _JSON_PACKAGE_FILES:
+        path = root / rel
+        path.write_text(bump_json_top_level_version(path.read_text(), new_version))
+
+    # Python iii: top-level version + iii-observability pin
+    py_iii = root / "sdk/packages/python/iii/pyproject.toml"
+    body = bump_cargo_package_version(py_iii.read_text(), new_py_version)
+    body = bump_pep440_dep_pin(body, "iii-observability", new_py_version)
+    py_iii.write_text(body)
+
+    # Python observability: top-level version only
+    py_obs = root / "sdk/packages/python/observability/pyproject.toml"
+    py_obs.write_text(bump_cargo_package_version(py_obs.read_text(), new_py_version))

--- a/.github/scripts/test_bump_manifests.py
+++ b/.github/scripts/test_bump_manifests.py
@@ -1,0 +1,37 @@
+"""Unit tests for bump_manifests.py.
+
+Run with: python -m pytest .github/scripts/test_bump_manifests.py -v
+"""
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from bump_manifests import bump_cargo_package_version
+
+
+class TestBumpCargoPackageVersion:
+    def test_replaces_first_version_only(self):
+        src = textwrap.dedent(
+            """\
+            [package]
+            name = "iii-observability"
+            version = "0.13.0-next.1"
+            edition = "2024"
+
+            [dependencies]
+            other = { version = "1.2.3" }
+            """
+        )
+        out = bump_cargo_package_version(src, "0.16.0-next.2")
+        assert 'version = "0.16.0-next.2"' in out
+        assert 'other = { version = "1.2.3" }' in out
+        # First match anchored on line start only — no other top-level
+        # version line should change.
+        assert out.count('version = "0.16.0-next.2"') == 1
+
+    def test_raises_when_no_version(self):
+        src = '[package]\nname = "foo"\n'
+        with pytest.raises(ValueError, match="no top-level version"):
+            bump_cargo_package_version(src, "0.16.0-next.2")

--- a/.github/scripts/test_bump_manifests.py
+++ b/.github/scripts/test_bump_manifests.py
@@ -9,6 +9,7 @@ import textwrap
 import pytest
 
 from bump_manifests import bump_cargo_package_version
+from bump_manifests import bump_cargo_workspace_dep_version
 
 
 class TestBumpCargoPackageVersion:
@@ -35,3 +36,23 @@ class TestBumpCargoPackageVersion:
         src = '[package]\nname = "foo"\n'
         with pytest.raises(ValueError, match="no top-level version"):
             bump_cargo_package_version(src, "0.16.0-next.2")
+
+
+class TestBumpCargoWorkspaceDepVersion:
+    def test_replaces_version_pin(self):
+        src = (
+            "[workspace.dependencies]\n"
+            'iii-observability = { path = "sdk/packages/rust/observability", version = "0.13.0-next.1" }\n'
+            'tokio = { version = "1", features = ["macros"] }\n'
+        )
+        out = bump_cargo_workspace_dep_version(src, "iii-observability", "0.16.0-next.2")
+        assert (
+            'iii-observability = { path = "sdk/packages/rust/observability", version = "0.16.0-next.2" }'
+            in out
+        )
+        assert 'tokio = { version = "1", features = ["macros"] }' in out
+
+    def test_raises_when_dep_missing(self):
+        src = '[workspace.dependencies]\ntokio = { version = "1" }\n'
+        with pytest.raises(ValueError, match="iii-observability"):
+            bump_cargo_workspace_dep_version(src, "iii-observability", "0.16.0-next.2")

--- a/.github/scripts/test_bump_manifests.py
+++ b/.github/scripts/test_bump_manifests.py
@@ -11,6 +11,7 @@ import pytest
 from bump_manifests import bump_cargo_package_version
 from bump_manifests import bump_cargo_workspace_dep_version
 from bump_manifests import bump_json_top_level_version
+from bump_manifests import bump_pep440_dep_pin
 
 
 class TestBumpCargoPackageVersion:
@@ -78,3 +79,21 @@ class TestBumpJsonTopLevelVersion:
         src = '{ "name": "x" }\n'
         with pytest.raises(ValueError, match="no top-level version"):
             bump_json_top_level_version(src, "1.0.0")
+
+
+class TestBumpPep440DepPin:
+    def test_replaces_pin(self):
+        src = (
+            'dependencies = [\n'
+            '    "websockets>=12.0",\n'
+            '    "iii-observability==0.13.0.dev1",\n'
+            ']\n'
+        )
+        out = bump_pep440_dep_pin(src, "iii-observability", "0.16.0.dev2")
+        assert '"iii-observability==0.16.0.dev2"' in out
+        assert '"websockets>=12.0"' in out
+
+    def test_raises_when_dep_missing(self):
+        src = 'dependencies = [\n    "websockets>=12.0",\n]\n'
+        with pytest.raises(ValueError, match="iii-observability"):
+            bump_pep440_dep_pin(src, "iii-observability", "0.16.0.dev2")

--- a/.github/scripts/test_bump_manifests.py
+++ b/.github/scripts/test_bump_manifests.py
@@ -4,6 +4,8 @@ Run with: python -m pytest .github/scripts/test_bump_manifests.py -v
 """
 from __future__ import annotations
 
+import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
@@ -143,3 +145,36 @@ def test_rewrite_all_updates_every_target_file(tmp_path: Path):
     assert '"iii-observability==0.16.0.dev2"' in py_iii
     assert 'version = "0.16.0.dev2"' in (root / "sdk/packages/python/observability/pyproject.toml").read_text()
     assert 'version = "0.16.0-next.2"' in (root / "console/packages/console-rust/Cargo.toml").read_text()
+
+
+def test_cli_invokes_rewrite_all(tmp_path: Path):
+    root = tmp_path
+    _write(root / "Cargo.toml", (
+        '[workspace.package]\n'
+        'version = "0.15.0-next.1"\n\n'
+        '[workspace.dependencies]\n'
+        'iii-observability = { path = "sdk/packages/rust/observability", version = "0.13.0-next.1" }\n'
+    ))
+    _write(root / "engine" / "Cargo.toml", 'version = "0.15.0-next.1"\n')
+    _write(root / "sdk/packages/rust/iii/Cargo.toml", 'version = "0.15.0-next.1"\n')
+    _write(root / "sdk/packages/rust/observability/Cargo.toml", 'version = "0.13.0-next.1"\n')
+    _write(root / "sdk/packages/node/iii/package.json", '{\n  "version": "0.15.0-next.1"\n}\n')
+    _write(root / "sdk/packages/node/iii-browser/package.json", '{\n  "version": "0.15.0-next.1"\n}\n')
+    _write(root / "sdk/packages/node/observability/package.json", '{\n  "version": "0.13.0-next.1"\n}\n')
+    _write(root / "sdk/packages/python/iii/pyproject.toml", (
+        'version = "0.15.0.dev1"\n'
+        'dependencies = [\n    "iii-observability==0.13.0.dev1",\n]\n'
+    ))
+    _write(root / "sdk/packages/python/observability/pyproject.toml", 'version = "0.13.0.dev1"\n')
+    _write(root / "console/packages/console-rust/Cargo.toml", 'version = "0.15.0-next.1"\n')
+
+    script = Path(__file__).parent / "bump_manifests.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--root", str(root),
+         "--version", "0.16.0-next.2", "--python-version", "0.16.0.dev2"],
+        check=True, capture_output=True, text=True,
+    )
+    assert "0.16.0-next.2" in result.stdout
+
+    assert 'version = "0.16.0-next.2"' in (root / "Cargo.toml").read_text()
+    assert 'iii-observability==0.16.0.dev2' in (root / "sdk/packages/python/iii/pyproject.toml").read_text()

--- a/.github/scripts/test_bump_manifests.py
+++ b/.github/scripts/test_bump_manifests.py
@@ -5,6 +5,7 @@ Run with: python -m pytest .github/scripts/test_bump_manifests.py -v
 from __future__ import annotations
 
 import textwrap
+from pathlib import Path
 
 import pytest
 
@@ -12,6 +13,7 @@ from bump_manifests import bump_cargo_package_version
 from bump_manifests import bump_cargo_workspace_dep_version
 from bump_manifests import bump_json_top_level_version
 from bump_manifests import bump_pep440_dep_pin
+from bump_manifests import rewrite_all
 
 
 class TestBumpCargoPackageVersion:
@@ -97,3 +99,47 @@ class TestBumpPep440DepPin:
         src = 'dependencies = [\n    "websockets>=12.0",\n]\n'
         with pytest.raises(ValueError, match="iii-observability"):
             bump_pep440_dep_pin(src, "iii-observability", "0.16.0.dev2")
+
+
+def _write(p: Path, body: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body)
+
+
+def test_rewrite_all_updates_every_target_file(tmp_path: Path):
+    root = tmp_path
+
+    _write(root / "Cargo.toml", (
+        '[workspace.package]\n'
+        'version = "0.15.0-next.1"\n\n'
+        '[workspace.dependencies]\n'
+        'iii-observability = { path = "sdk/packages/rust/observability", version = "0.13.0-next.1" }\n'
+    ))
+    _write(root / "engine" / "Cargo.toml", '[package]\nname = "iii"\nversion = "0.15.0-next.1"\n')
+    _write(root / "sdk/packages/rust/iii/Cargo.toml", '[package]\nname = "iii-sdk"\nversion = "0.15.0-next.1"\n')
+    _write(root / "sdk/packages/rust/observability/Cargo.toml", '[package]\nname = "iii-observability"\nversion = "0.13.0-next.1"\n')
+    _write(root / "sdk/packages/node/iii/package.json", '{\n  "name": "iii-sdk",\n  "version": "0.15.0-next.1"\n}\n')
+    _write(root / "sdk/packages/node/iii-browser/package.json", '{\n  "name": "iii-browser",\n  "version": "0.15.0-next.1"\n}\n')
+    _write(root / "sdk/packages/node/observability/package.json", '{\n  "name": "@iii-dev/observability",\n  "version": "0.13.0-next.1"\n}\n')
+    _write(root / "sdk/packages/python/iii/pyproject.toml", (
+        '[project]\nname = "iii-sdk"\nversion = "0.15.0.dev1"\n'
+        'dependencies = [\n    "iii-observability==0.13.0.dev1",\n]\n'
+    ))
+    _write(root / "sdk/packages/python/observability/pyproject.toml", '[project]\nname = "iii-observability"\nversion = "0.13.0.dev1"\n')
+    _write(root / "console/packages/console-rust/Cargo.toml", '[package]\nname = "console-rust"\nversion = "0.15.0-next.1"\n')
+
+    rewrite_all(root=root, new_version="0.16.0-next.2", new_py_version="0.16.0.dev2")
+
+    assert 'version = "0.16.0-next.2"' in (root / "Cargo.toml").read_text()
+    assert 'iii-observability = { path = "sdk/packages/rust/observability", version = "0.16.0-next.2" }' in (root / "Cargo.toml").read_text()
+    assert 'version = "0.16.0-next.2"' in (root / "engine" / "Cargo.toml").read_text()
+    assert 'version = "0.16.0-next.2"' in (root / "sdk/packages/rust/iii/Cargo.toml").read_text()
+    assert 'version = "0.16.0-next.2"' in (root / "sdk/packages/rust/observability/Cargo.toml").read_text()
+    assert '"version": "0.16.0-next.2"' in (root / "sdk/packages/node/iii/package.json").read_text()
+    assert '"version": "0.16.0-next.2"' in (root / "sdk/packages/node/iii-browser/package.json").read_text()
+    assert '"version": "0.16.0-next.2"' in (root / "sdk/packages/node/observability/package.json").read_text()
+    py_iii = (root / "sdk/packages/python/iii/pyproject.toml").read_text()
+    assert 'version = "0.16.0.dev2"' in py_iii
+    assert '"iii-observability==0.16.0.dev2"' in py_iii
+    assert 'version = "0.16.0.dev2"' in (root / "sdk/packages/python/observability/pyproject.toml").read_text()
+    assert 'version = "0.16.0-next.2"' in (root / "console/packages/console-rust/Cargo.toml").read_text()

--- a/.github/scripts/test_bump_manifests.py
+++ b/.github/scripts/test_bump_manifests.py
@@ -10,6 +10,7 @@ import pytest
 
 from bump_manifests import bump_cargo_package_version
 from bump_manifests import bump_cargo_workspace_dep_version
+from bump_manifests import bump_json_top_level_version
 
 
 class TestBumpCargoPackageVersion:
@@ -56,3 +57,24 @@ class TestBumpCargoWorkspaceDepVersion:
         src = '[workspace.dependencies]\ntokio = { version = "1" }\n'
         with pytest.raises(ValueError, match="iii-observability"):
             bump_cargo_workspace_dep_version(src, "iii-observability", "0.16.0-next.2")
+
+
+class TestBumpJsonTopLevelVersion:
+    def test_replaces_first_version(self):
+        src = (
+            '{\n'
+            '  "name": "iii-sdk",\n'
+            '  "version": "0.13.0-next.1",\n'
+            '  "dependencies": {\n'
+            '    "@iii-dev/observability": "workspace:*"\n'
+            '  }\n'
+            '}\n'
+        )
+        out = bump_json_top_level_version(src, "0.16.0-next.2")
+        assert '"version": "0.16.0-next.2"' in out
+        assert '"@iii-dev/observability": "workspace:*"' in out
+
+    def test_raises_when_no_top_level_version(self):
+        src = '{ "name": "x" }\n'
+        with pytest.raises(ValueError, match="no top-level version"):
+            bump_json_top_level_version(src, "1.0.0")

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -112,32 +112,10 @@ jobs:
           NEW_VERSION: ${{ steps.versions.outputs.version }}
           PY_VERSION: ${{ steps.versions.outputs.python_version }}
         run: |
-          sed -i "0,/^version = \".*\"/{s/^version = \".*\"/version = \"${NEW_VERSION}\"/}" engine/Cargo.toml
-          echo "Updated engine/Cargo.toml to $NEW_VERSION"
-
-          sed -i "0,/^version = \".*\"/{s/^version = \".*\"/version = \"${NEW_VERSION}\"/}" sdk/packages/rust/iii/Cargo.toml
-          echo "Updated sdk/packages/rust/iii/Cargo.toml to $NEW_VERSION"
-
-          sed -i "0,/^version = \".*\"/{s/^version = \".*\"/version = \"${NEW_VERSION}\"/}" sdk/packages/rust/observability/Cargo.toml
-          echo "Updated sdk/packages/rust/observability/Cargo.toml to $NEW_VERSION"
-
-          jq --arg v "$NEW_VERSION" '.version = $v' sdk/packages/node/iii/package.json > tmp.json && mv tmp.json sdk/packages/node/iii/package.json
-          echo "Updated sdk/packages/node/iii/package.json to $NEW_VERSION"
-
-          jq --arg v "$NEW_VERSION" '.version = $v' sdk/packages/node/iii-browser/package.json > tmp.json && mv tmp.json sdk/packages/node/iii-browser/package.json
-          echo "Updated sdk/packages/node/iii-browser/package.json to $NEW_VERSION"
-
-          jq --arg v "$NEW_VERSION" '.version = $v' sdk/packages/node/observability/package.json > tmp.json && mv tmp.json sdk/packages/node/observability/package.json
-          echo "Updated sdk/packages/node/observability/package.json to $NEW_VERSION"
-
-          sed -i "0,/^version = \".*\"/{s/^version = \".*\"/version = \"${PY_VERSION}\"/}" sdk/packages/python/iii/pyproject.toml
-          echo "Updated sdk/packages/python/iii/pyproject.toml to $PY_VERSION"
-
-          sed -i "0,/^version = \".*\"/{s/^version = \".*\"/version = \"${NEW_VERSION}\"/}" console/packages/console-rust/Cargo.toml
-          echo "Updated console/packages/console-rust/Cargo.toml to $NEW_VERSION"
-
-          sed -i "0,/^version = \".*\"/{s/^version = \".*\"/version = \"${NEW_VERSION}\"/}" Cargo.toml
-          echo "Updated Cargo.toml workspace version to $NEW_VERSION"
+          python3 .github/scripts/bump_manifests.py \
+            --root . \
+            --version "${NEW_VERSION}" \
+            --python-version "${PY_VERSION}"
 
       - name: Sync Cargo.lock
         if: inputs.target == 'iii' && inputs.dry_run != true

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -150,6 +150,26 @@ jobs:
             echo "  $1 -> $actual"
           }
 
+          check_workspace_dep() {
+            local actual
+            actual=$(grep -E "^iii-observability\s*=" "$1" | sed -E 's/.*version\s*=\s*"([^"]+)".*/\1/')
+            if [[ "$actual" != "$2" ]]; then
+              echo "::error::$1 iii-observability dep version mismatch: expected $2, got $actual"
+              exit 1
+            fi
+            echo "  $1 iii-observability -> $actual"
+          }
+
+          check_pep440_pin() {
+            local actual
+            actual=$(grep -oE '"iii-observability==[^"]+"' "$1" | head -n1 | sed -E 's/.*==([^"]+)".*/\1/')
+            if [[ "$actual" != "$2" ]]; then
+              echo "::error::$1 iii-observability pin mismatch: expected $2, got $actual"
+              exit 1
+            fi
+            echo "  $1 iii-observability -> $actual"
+          }
+
           echo "Validating version updates..."
 
           if [[ "$TARGET" == "iii" ]]; then
@@ -160,8 +180,11 @@ jobs:
             check_json "sdk/packages/node/iii-browser/package.json" "$VERSION"
             check_json "sdk/packages/node/observability/package.json" "$VERSION"
             check_cargo "sdk/packages/python/iii/pyproject.toml" "$PY_VERSION"
+            check_cargo "sdk/packages/python/observability/pyproject.toml" "$PY_VERSION"
             check_cargo "console/packages/console-rust/Cargo.toml" "$VERSION"
             check_cargo "Cargo.toml" "$VERSION"
+            check_workspace_dep "Cargo.toml" "$VERSION"
+            check_pep440_pin "sdk/packages/python/iii/pyproject.toml" "$PY_VERSION"
           fi
 
           echo "All versions validated."

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -70,13 +70,15 @@ jobs:
           fi
 
           if [[ "$TARGET" == "iii" ]]; then
-            for f in engine/Cargo.toml \
+            for f in Cargo.toml \
+                     engine/Cargo.toml \
                      sdk/packages/rust/iii/Cargo.toml \
                      sdk/packages/rust/observability/Cargo.toml \
                      sdk/packages/node/iii/package.json \
                      sdk/packages/node/iii-browser/package.json \
                      sdk/packages/node/observability/package.json \
                      sdk/packages/python/iii/pyproject.toml \
+                     sdk/packages/python/observability/pyproject.toml \
                      console/packages/console-rust/Cargo.toml \
                      crates/scaffolder-core/Cargo.toml \
                      crates/motia-tools/Cargo.toml; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "iii-observability"
-version = "0.13.0-next.1"
+version = "0.16.0-next.1"
 dependencies = [
  "async-trait",
  "ctor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://iii.dev"
 
 [workspace.dependencies]
 iii-sdk = { path = "sdk/packages/rust/iii" }
-iii-observability = { path = "sdk/packages/rust/observability", version = "0.13.0-next.1" }
+iii-observability = { path = "sdk/packages/rust/observability", version = "0.16.0-next.1" }
 scaffolder-core = { path = "crates/scaffolder-core" }
 
 # Shared dependencies used by tooling crates

--- a/sdk/packages/node/observability/package.json
+++ b/sdk/packages/node/observability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iii-dev/observability",
-  "version": "0.13.0-next.1",
+  "version": "0.16.0-next.1",
   "private": false,
   "publishConfig": { "access": "public" },
   "type": "module",

--- a/sdk/packages/python/iii/pyproject.toml
+++ b/sdk/packages/python/iii/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "websockets>=12.0",
     "pydantic>=2.0",
     "opentelemetry-api>=1.25",
-    "iii-observability==0.13.0.dev1",
+    "iii-observability==0.16.0.dev1",
 ]
 
 [project.urls]

--- a/sdk/packages/python/observability/pyproject.toml
+++ b/sdk/packages/python/observability/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "iii-observability"
-version = "0.13.0.dev1"
+version = "0.16.0.dev1"
 description = "OpenTelemetry and logging primitives shared across iii SDKs."
 authors = [{ name = "III" }]
 license = { text = "Apache-2.0" }

--- a/sdk/packages/rust/observability/Cargo.toml
+++ b/sdk/packages/rust/observability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iii-observability"
-version = "0.13.0-next.1"
+version = "0.16.0-next.1"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

CI `Create Tag` workflow failed with `failed to select a version for the requirement iii-observability = "^0.13.0-next.1"` because three observability version references never got bumped along with `iii`.

- Move release manifest rewriting from inline `sed`/`jq` into a tested `.github/scripts/bump_manifests.py` (10 pytest cases — pure helpers + `rewrite_all` orchestrator + CLI).
- Cover the three previously-missed pins: workspace dep `version` in root `Cargo.toml`, `sdk/packages/python/observability/pyproject.toml`, and the `iii-observability==X` PEP 440 pin in `sdk/packages/python/iii/pyproject.toml`.
- Catch-up commit syncs all stale `0.13.0-next.1` / `0.13.0.dev1` observability manifests to the current `0.16.0-next.1` train.
- Extend `Pre-flight checks` (12 files) and `Validate version updates` (12 calls, two new helpers `check_workspace_dep` + `check_pep440_pin`) to match the orchestrator's surface area.

## Test plan

- [x] `python -m pytest .github/scripts/` — 125 passed (10 new + 115 existing)
- [x] `cargo check --workspace` — clean
- [x] `grep -rn "0.13.0-next\|0.13.0.dev" Cargo.toml sdk/packages .github/workflows | grep -v .venv | grep -v uv.lock | grep -v src/lib.rs` — empty
- [ ] After merge, dispatch `Create Tag` workflow (workflow_dispatch, dry_run=true) on main — `Sync Cargo.lock` and `Validate version updates` must succeed end-to-end

## Out of scope (separate follow-ups)

- `sdk/packages/rust/observability/src/lib.rs:2` ships a hardcoded `pub const VERSION = "0.13.0-next.1"` — pre-existing drift; likely wants `env!("CARGO_PKG_VERSION")`.
- `sdk/packages/python/*/uv.lock` still mention `0.13` — regenerate on next `uv lock`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated observability package versions from 0.13.0 to 0.16.0 across Rust, Node, and Python implementations.
  * Enhanced automated release tooling to streamline multi-language manifest version updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1695?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->