### PR TITLE
feat(worker-init): per-language package_manager in scaffolded manifest

### DIFF
--- a/crates/iii-worker/src/cli/init.rs
+++ b/crates/iii-worker/src/cli/init.rs
@@ -69,6 +69,19 @@ impl WorkerLanguage {
             WorkerLanguage::Rust => "./src/main.rs",
         }
     }
+
+    /// Default package manager for the language. Substituted into the
+    /// scaffolded `iii.worker.yaml` via the `{{worker_package_manager}}`
+    /// placeholder. The engine only consumes this for ts/js (npm vs
+    /// yarn/pnpm/bun); for py/rust it's informational so the manifest
+    /// stays self-describing.
+    pub fn package_manager(&self) -> &'static str {
+        match self {
+            WorkerLanguage::Ts | WorkerLanguage::Js => "npm",
+            WorkerLanguage::Py => "pip",
+            WorkerLanguage::Rust => "cargo",
+        }
+    }
 }
 
 #[derive(Args, Debug, Clone)]
@@ -395,8 +408,9 @@ fn restore_snapshots(
     Ok(())
 }
 
-/// Substitute `{{worker_name}}`, `{{worker_language}}`, `{{worker_entry}}`
-/// into `iii.worker.yaml`. No-op if the file is absent (test fixture
+/// Substitute `{{worker_name}}`, `{{worker_language}}`,
+/// `{{worker_package_manager}}`, `{{worker_entry}}` into
+/// `iii.worker.yaml`. No-op if the file is absent (test fixture
 /// short-circuit) or the placeholders are gone (idempotent re-run).
 fn substitute_yaml_placeholders(
     root: &Path,
@@ -414,6 +428,7 @@ fn substitute_yaml_placeholders(
     let replaced = contents
         .replace("{{worker_name}}", worker_name)
         .replace("{{worker_language}}", lang.manifest_key())
+        .replace("{{worker_package_manager}}", lang.package_manager())
         .replace("{{worker_entry}}", lang.default_entry());
     std::fs::write(&path, replaced)
 }


### PR DESCRIPTION
## Summary
- Add `WorkerLanguage::package_manager()` returning `npm` (ts/js), `pip` (python), `cargo` (rust).
- Substitute `{{worker_package_manager}}` in `iii.worker.yaml` during `iii worker init`.
- Updates doc comment on `substitute_yaml_placeholders` to list the new placeholder.

## Why
The engine only consumes `package_manager` for ts/js (npm vs yarn/pnpm/bun); for python and rust it's discarded. The bare worker template was emitting a literal `package_manager: npm` even for Python/Rust scaffolds, which forced authors to fix the field by hand and made the manifest self-contradictory.

## Pairs with
- `iii-hq/templates#fix/package_manager` — the worker-bare template swaps the hardcoded `npm` for `{{worker_package_manager}}`. Old templates (with hardcoded `npm`) continue to work because `.replace()` is a no-op when the placeholder is absent.

## Test plan
- [x] `cargo check -p iii-worker` — clean
- [x] `cargo test -p iii-worker --lib` — 763 pass, 1 unrelated rootfs-cache failure
- [x] `cargo test -p iii-worker --test worker_init_e2e` — 10/10 pass (covers `init_python_creates_pyproject_with_sdk` and `init_rust_creates_cargo_with_sdk`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worker initialization now auto-configures the appropriate package manager based on the selected language.
  * Project templates now substitute a package-manager placeholder in worker configuration files so generated projects include the correct package manager.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->