### PR TITLE
feat: configuration worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +546,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +687,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +720,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -1731,6 +1772,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +1870,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +1931,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,6 +1977,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -2642,6 +2724,7 @@ dependencies = [
  "indexmap 2.14.0",
  "indicatif 0.17.11",
  "inventory",
+ "jsonschema",
  "lapin",
  "libc",
  "machineid-rs",
@@ -3166,6 +3249,32 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b46a0365a611fbf1d2143104dcf910aada96fafd295bab16c60b802bf6fa1d"
+dependencies = [
+ "ahash",
+ "base64",
+ "bytecount",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "once_cell",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "uuid-simd",
 ]
 
 [[package]]
@@ -3893,6 +4002,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4190,6 +4305,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p12-keystore"
@@ -4904,6 +5025,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "referencing"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8eff4fa778b5c2a57e85c5f2fe3a709c52f0e60d23146e2151cbef5893f420e"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -6739,6 +6874,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6797,6 +6943,12 @@ dependencies = [
  "bitflags 1.3.2",
  "libc",
 ]
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -132,6 +132,7 @@ clap-help = "1"
 regex = "1"
 hex = "0.4"
 notify = "8.2.0"
+jsonschema = { version = "0.30", default-features = false }
 inventory = "0.3"
 rand = "0.8"
 rkyv = "0.8.12"

--- a/engine/config.yaml
+++ b/engine/config.yaml
@@ -145,6 +145,16 @@ workers:
       adapter:
         name: kv
 
+  - name: configuration
+    config:
+      adapter:
+        name: fs
+        config:
+          directory: ./data/configuration
+      # 0 disables TTL cleanup. Set >0 (in seconds) to delete a configuration
+      # entry whose last subscriber trigger has been unregistered for that long.
+      ttl_seconds: 0
+
   # - name: iii-bridge
   #   config:
   #     url: ${REMOTE_III_URL:ws://192.168.1.200:49134}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -22,6 +22,7 @@ pub mod worker_connections;
 pub mod workers {
     pub mod bridge_client;
     pub mod config;
+    pub mod configuration;
     pub mod cron;
     pub mod engine_fn;
     pub mod external;

--- a/engine/src/trigger.rs
+++ b/engine/src/trigger.rs
@@ -23,6 +23,7 @@ pub const BUILTIN_TRIGGER_TYPES: &[(&str, &str)] = &[
     ("stream:join", "iii-stream"),
     ("stream:leave", "iii-stream"),
     ("log", "iii-observability"),
+    ("configuration", "configuration"),
 ];
 
 /// Maps a trigger-type id to the in-process worker that owns it. In-process
@@ -111,6 +112,7 @@ impl TriggerType {
             "stream:join" | "stream:leave" => Self::schema_for::<StreamJoinLeaveTriggerConfig>(),
             "stream" => Self::schema_for::<StreamTriggerConfig>(),
             "log" => Self::schema_for::<LogTriggerConfig>(),
+            "configuration" => Self::schema_for::<ConfigurationTriggerConfig>(),
             _ => None,
         }
     }
@@ -125,6 +127,7 @@ impl TriggerType {
             "stream:join" | "stream:leave" => Self::schema_for::<StreamJoinLeaveCallRequest>(),
             "stream" => Self::schema_for::<StreamCallRequest>(),
             "log" => Self::schema_for::<LogCallRequest>(),
+            "configuration" => Self::schema_for::<ConfigurationCallRequest>(),
             _ => None,
         }
     }

--- a/engine/src/trigger_formats.rs
+++ b/engine/src/trigger_formats.rs
@@ -209,7 +209,7 @@ pub struct ConfigurationTriggerConfig {
     /// Configuration id to watch (exact match filter). When omitted, every id matches.
     pub configuration_id: Option<String>,
     /// Event types to filter on (e.g. ["configuration:updated"]). When omitted, every event matches.
-    pub event_types: Option<Vec<String>>,
+    pub event_types: Option<Vec<ConfigurationEventType>>,
     /// Optional function id to evaluate before invoking the handler
     pub condition_function_id: Option<String>,
 }

--- a/engine/src/trigger_formats.rs
+++ b/engine/src/trigger_formats.rs
@@ -202,6 +202,51 @@ pub struct StreamCallRequest {
     pub event: Value,
 }
 
+// ── Configuration ───────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ConfigurationTriggerConfig {
+    /// Configuration id to watch (exact match filter). When omitted, every id matches.
+    pub configuration_id: Option<String>,
+    /// Event types to filter on (e.g. ["configuration:updated"]). When omitted, every event matches.
+    pub event_types: Option<Vec<String>>,
+    /// Optional function id to evaluate before invoking the handler
+    pub condition_function_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub enum ConfigurationEventType {
+    #[serde(rename = "configuration:registered")]
+    Registered,
+    #[serde(rename = "configuration:updated")]
+    Updated,
+    #[serde(rename = "configuration:deleted")]
+    Deleted,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ConfigurationCallRequest {
+    /// Always "configuration"
+    #[serde(rename = "type")]
+    pub message_type: String,
+    /// Type of configuration change
+    pub event_type: ConfigurationEventType,
+    /// Configuration id (e.g. `iii-stream`)
+    pub id: String,
+    /// Human-readable name
+    pub name: String,
+    /// Description
+    pub description: String,
+    /// JSON Schema describing the value shape
+    pub schema: Value,
+    /// Previous value (null on registered/deleted-without-prior-state events)
+    pub old_value: Option<Value>,
+    /// New value with `${VAR:default}` placeholders expanded; null on deletion
+    pub new_value: Option<Value>,
+    /// Optional caller-supplied metadata stored alongside the entry
+    pub metadata: Option<Value>,
+}
+
 // ── Log (observability) ─────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/engine/src/workers/config.rs
+++ b/engine/src/workers/config.rs
@@ -44,7 +44,7 @@ impl EngineConfig {
         }
     }
 
-    pub(crate) fn expand_env_vars(yaml_content: &str) -> String {
+    pub fn expand_env_vars(yaml_content: &str) -> String {
         static RE: LazyLock<Regex> =
             LazyLock::new(|| Regex::new(r"\$\{([^}:]+)(?::([^}]*))?\}").unwrap());
         let re = &*RE;

--- a/engine/src/workers/configuration/README.md
+++ b/engine/src/workers/configuration/README.md
@@ -1,0 +1,210 @@
+# configuration
+
+Schema-validated, reactive registry of named configuration entries. Workers register their configuration ids with a JSON Schema, publish values that are validated against it, and emit `configuration` triggers on every change so other workers react without polling.
+
+The default `fs` adapter stores one YAML file per id under a configurable directory and watches it for external edits — manual edits surface as `configuration:updated` events the same way SDK calls do. The `bridge` adapter delegates to a remote III Engine and re-broadcasts its events into the local fan-out. Reads expand `${VAR:default}` placeholders against the live process env on every call, so env changes propagate without a worker restart.
+
+## Sample Configuration
+
+```yaml
+- name: configuration
+  config:
+    adapter:
+      name: fs
+      config:
+        directory: ./data/configuration
+    ttl_seconds: 0
+```
+
+## Configuration
+
+| Field | Type | Description |
+|---|---|---|
+| `adapter` | Adapter | Adapter for configuration persistence. Defaults to `fs`. |
+| `ttl_seconds` | integer | Per-id cleanup countdown in seconds. When `>0`, an entry whose last subscriber trigger has been unregistered for this long is deleted. Defaults to `0` (no cleanup). |
+
+## Adapters
+
+### fs
+
+File-system adapter that stores one YAML file per configuration id and watches the directory for external edits.
+
+```yaml
+name: fs
+config:
+  directory: ./data/configuration
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `directory` | string | Directory holding `<id>.yaml` files. Created on boot. Defaults to `./data/configuration`. |
+
+External writes / edits / removals to the watched directory are debounced (500 ms) and replayed as `configuration:registered`, `configuration:updated`, or `configuration:deleted` events through the same trigger fan-out used by SDK calls.
+
+### bridge
+
+Forwards every `configuration::*` call to a remote III Engine via the iii-sdk and registers a remote `configuration` trigger so changes on the source engine are mirrored into the local trigger fan-out.
+
+```yaml
+name: bridge
+config:
+  bridge_url: ${REMOTE_III_URL:ws://localhost:49134}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `bridge_url` | string | WebSocket URL of the remote III Engine. Defaults to `ws://localhost:49134`. |
+
+The `bridge` adapter cannot delete configurations on the remote engine; cleanup happens via the remote's TTL or by operating on the remote engine directly.
+
+## Functions
+
+### `configuration::register`
+
+Declare a configuration id with a JSON Schema, name, description, and optional initial value. Idempotent — re-registering replaces the schema, name, description, and metadata; the stored value is kept unless `initial_value` is supplied. Validates `initial_value` against `schema` before persisting. Fires `configuration:registered` on first registration or `configuration:updated` on subsequent calls.
+
+Parameters: `id` (string), `name` (string), `description` (string), `schema` (object — JSON Schema), `initial_value` (any, optional), `metadata` (any, optional)
+
+Returns: the stored entry `{ id, name, description, schema, value, metadata }`. Templates inside `value` are stored verbatim; expansion happens on read.
+
+### `configuration::set`
+
+Replace the stored value for a registered id. Validates `value` against the registered schema. Fires `configuration:updated`.
+
+Parameters: `id` (string), `value` (any)
+
+Returns: `old_value` (any, or `null` if the entry had no prior value), `new_value` (any)
+
+### `configuration::get`
+
+Read one configuration by id.
+
+Parameters: `id` (string), `raw` (boolean, optional — defaults to `false`)
+
+Returns: `id` (string), `value` (any). When `raw` is `false`, `${VAR:default}` placeholders inside string fields are expanded against the live process env. When `raw` is `true`, the stored value is returned verbatim.
+
+### `configuration::list`
+
+Enumerate every registered configuration. Never returns the stored value — pair with `configuration::get` once you have the id you want.
+
+Returns: `configurations` (array of `{ id, name, description, schema, metadata }`), sorted lexicographically by `id`.
+
+### `configuration::schema`
+
+Read the schema, name, description, and metadata for one id without exposing the value.
+
+Parameters: `id` (string)
+
+Returns: `id` (string), `name` (string), `description` (string), `schema` (object), `metadata` (any, optional)
+
+### Error Codes
+
+| Code | Meaning |
+|---|---|
+| `NOT_REGISTERED` | `set` was called against an id that has not been passed to `register` yet. |
+| `INVALID_ID` | The id does not match `[a-z0-9_-]{1,64}` — the constraint applied so ids are safe filenames for the `fs` adapter. |
+| `SCHEMA_INVALID` | The supplied value does not satisfy the registered JSON Schema. The error message lists each violation. |
+| `NOT_FOUND` | `get` or `schema` was called against an id that is not registered. |
+| `ADAPTER_ERROR` | The adapter failed to persist the change (disk error, bridge unreachable, etc.). |
+
+## Trigger Type: `configuration`
+
+Fires when a configuration entry is registered, updated, or deleted — including external `fs` file edits and bridge-forwarded events from a remote engine.
+
+| Config Field | Type | Description |
+|---|---|---|
+| `configuration_id` | string | Only fire for changes to this id. When omitted, fires for every id. |
+| `event_types` | string[] | Subset of `configuration:registered`, `configuration:updated`, `configuration:deleted`. When omitted, fires for every event type. |
+| `condition_function_id` | string | Function ID for conditional execution. If it returns `false`, the handler is skipped. |
+
+### Configuration Event Payload
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | string | Always `"configuration"`. |
+| `event_type` | string | `"configuration:registered"`, `"configuration:updated"`, or `"configuration:deleted"`. |
+| `id` | string | The configuration id that changed. |
+| `name` | string | The registered name at the time of the event. |
+| `description` | string | The registered description. |
+| `schema` | object | The registered JSON Schema. |
+| `old_value` | any | Previous value with `${VAR:default}` placeholders expanded. `null` on `configuration:registered`. |
+| `new_value` | any | New value with `${VAR:default}` placeholders expanded. `null` on `configuration:deleted`. |
+| `metadata` | any | Echoes the registered metadata; omitted when none was supplied. |
+
+### Sample Code
+
+```typescript
+const fn = iii.registerFunction(
+  { id: 'stream::onConfigChange' },
+  async (event) => {
+    console.log('Configuration changed:', event.event_type, event.id)
+    console.log('New value:', event.new_value)
+    return {}
+  },
+)
+
+iii.registerTrigger({
+  type: 'configuration',
+  function_id: fn.id,
+  config: {
+    configuration_id: 'iii-stream',
+    event_types: ['configuration:updated'],
+  },
+})
+```
+
+Mutations that fire triggers: `configuration::register` (`:registered` on first call, `:updated` on re-registration), `configuration::set` (`:updated`), TTL-driven cleanup (`:deleted`), and external `fs` create / edit / delete events. Reads (`configuration::get`, `configuration::list`, `configuration::schema`) do **not** fire triggers.
+
+## TTL Cleanup
+
+The worker tracks the number of triggers currently bound to each configuration id. When `ttl_seconds > 0` is configured AND the **last** trigger for an id is unregistered, a countdown deletes the entry after the TTL elapses. A new trigger registration before the countdown fires aborts the cleanup; while at least one trigger is bound to an id, that entry never expires.
+
+`ttl_seconds = 0` (the default) disables expiry entirely — entries persist until they are explicitly deleted via the adapter or, for the `fs` adapter, by removing the underlying file.
+
+This is the cleanup story for ephemeral workers that come and go (sandboxes, short-lived consumers) and should not leave stale configuration behind when no one is left subscribing.
+
+## Usage Example: Migrating a Worker Off `config.yaml`
+
+```typescript
+import { registerWorker } from 'iii-sdk'
+
+const iii = registerWorker('ws://localhost:49134')
+
+// 1. Declare the schema once at startup.
+await iii.trigger({
+  function_id: 'configuration::register',
+  payload: {
+    id: 'iii-stream',
+    name: 'Stream worker',
+    description: 'Connection settings for the stream worker.',
+    schema: {
+      type: 'object',
+      required: ['port'],
+      properties: {
+        port: { type: 'integer', minimum: 1, maximum: 65535 },
+        host: { type: 'string' },
+      },
+    },
+    initial_value: { port: 3112, host: '127.0.0.1' },
+  },
+})
+
+// 2. Read the live value (placeholders expanded) anywhere you need it.
+const { value } = await iii.trigger({
+  function_id: 'configuration::get',
+  payload: { id: 'iii-stream' },
+})
+
+// 3. Subscribe to changes elsewhere — set/external-edit/bridge events all
+//    arrive on the same trigger.
+const onChange = iii.registerFunction('stream::onConfigChange', async (event) => {
+  console.log('Stream config now:', event.new_value)
+  return {}
+})
+
+iii.registerTrigger({
+  type: 'configuration',
+  function_id: onChange.id,
+  config: { configuration_id: 'iii-stream' },
+})
+```

--- a/engine/src/workers/configuration/adapters/bridge.rs
+++ b/engine/src/workers/configuration/adapters/bridge.rs
@@ -1,0 +1,292 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Bridge adapter — delegates `configuration::*` to a remote III instance
+//! and rebroadcasts that instance's `configuration` trigger events into the
+//! local fan-out so subscribers see remote-originated changes too.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use iii_sdk::{
+    III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker,
+};
+use serde::Serialize;
+use serde_json::Value;
+use tokio::sync::OnceCell;
+
+use crate::engine::Engine;
+use crate::workers::configuration::adapters::{
+    ConfigurationAdapter, ExternalChange, ExternalChangeSender, RegisterKind, RegisterOutcome,
+    SetOutcome,
+};
+use crate::workers::configuration::registry::{
+    ConfigurationAdapterFuture, ConfigurationAdapterRegistration,
+};
+use crate::workers::configuration::structs::{
+    ConfigurationEntry, ConfigurationEventData, ConfigurationEventType, ConfigurationGetInput,
+    ConfigurationListInput, ConfigurationListResult, ConfigurationRegisterInput,
+    ConfigurationSetInput,
+};
+
+const DEFAULT_BRIDGE_URL: &str = "ws://localhost:49134";
+const RELAY_FUNCTION_ID: &str = "configuration::__bridge_relay";
+
+pub struct BridgeAdapter {
+    bridge: Arc<III>,
+    /// Holds onto the relay [`iii_sdk::Trigger`] handle so the SDK keeps
+    /// the remote subscription alive for the worker's lifetime.
+    relay_trigger: Mutex<Option<iii_sdk::Trigger>>,
+    /// Set lazily by `watch` — used by the relay function below.
+    sender: OnceCell<ExternalChangeSender>,
+}
+
+impl BridgeAdapter {
+    pub async fn new(bridge_url: String) -> anyhow::Result<Self> {
+        tracing::info!(
+            bridge_url = %bridge_url,
+            "Connecting configuration bridge to remote engine"
+        );
+        let bridge = Arc::new(register_worker(&bridge_url, InitOptions::default()));
+        Ok(Self {
+            bridge,
+            relay_trigger: Mutex::new(None),
+            sender: OnceCell::new(),
+        })
+    }
+
+    async fn call<I: Serialize>(&self, function_id: &str, input: I) -> anyhow::Result<Value> {
+        let payload =
+            serde_json::to_value(input).map_err(|e| anyhow::anyhow!("encode payload: {}", e))?;
+        self.bridge
+            .trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("remote {} failed: {}", function_id, e))
+    }
+}
+
+#[async_trait]
+impl ConfigurationAdapter for BridgeAdapter {
+    async fn register(&self, entry: ConfigurationEntry) -> anyhow::Result<RegisterOutcome> {
+        let raw = self
+            .call(
+                "configuration::register",
+                ConfigurationRegisterInput {
+                    id: entry.id.clone(),
+                    name: entry.name.clone(),
+                    description: entry.description.clone(),
+                    schema: entry.schema.clone(),
+                    initial_value: Some(entry.value.clone()),
+                    metadata: entry.metadata.clone(),
+                },
+            )
+            .await?;
+        let returned: ConfigurationEntry = serde_json::from_value(raw)
+            .map_err(|e| anyhow::anyhow!("decode register response: {}", e))?;
+        Ok(RegisterOutcome {
+            kind: RegisterKind::Replaced,
+            entry: returned,
+            old_value: None,
+        })
+    }
+
+    async fn set(&self, id: &str, value: Value) -> anyhow::Result<SetOutcome> {
+        let raw = self
+            .call(
+                "configuration::set",
+                ConfigurationSetInput {
+                    id: id.to_string(),
+                    value,
+                },
+            )
+            .await?;
+        let old_value = raw.get("old_value").cloned();
+        let new_value = raw
+            .get("new_value")
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("remote set response missing 'new_value'"))?;
+
+        let mut entry = self
+            .get(id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("remote set succeeded but get returned None"))?;
+        entry.value = new_value;
+        Ok(SetOutcome { entry, old_value })
+    }
+
+    async fn get(&self, id: &str) -> anyhow::Result<Option<ConfigurationEntry>> {
+        let value_resp = match self
+            .call(
+                "configuration::get",
+                ConfigurationGetInput {
+                    id: id.to_string(),
+                    raw: true,
+                },
+            )
+            .await
+        {
+            Ok(v) => v,
+            Err(_) => return Ok(None),
+        };
+        let value = value_resp.get("value").cloned().unwrap_or(Value::Null);
+
+        let schema_resp = match self
+            .call("configuration::schema", serde_json::json!({ "id": id }))
+            .await
+        {
+            Ok(v) => v,
+            Err(_) => return Ok(None),
+        };
+        Ok(Some(ConfigurationEntry {
+            id: id.to_string(),
+            name: schema_resp
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            description: schema_resp
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            schema: schema_resp.get("schema").cloned().unwrap_or(Value::Null),
+            value,
+            metadata: schema_resp.get("metadata").cloned(),
+        }))
+    }
+
+    async fn delete(&self, _id: &str) -> anyhow::Result<Option<ConfigurationEntry>> {
+        // The remote `configuration::*` surface does not expose `delete`
+        // — cleanup happens through TTL on the remote engine. Surface a
+        // clear error so callers know to operate on the remote engine
+        // directly when they want a hard removal.
+        Err(anyhow::anyhow!(
+            "bridge adapter cannot delete configurations on the remote engine; \
+             rely on TTL or operate on the remote engine directly"
+        ))
+    }
+
+    async fn list(&self) -> anyhow::Result<Vec<ConfigurationEntry>> {
+        let raw = self
+            .call("configuration::list", ConfigurationListInput {})
+            .await?;
+        let listed: ConfigurationListResult =
+            serde_json::from_value(raw).map_err(|e| anyhow::anyhow!("decode list: {}", e))?;
+        let mut out = Vec::with_capacity(listed.configurations.len());
+        for view in listed.configurations {
+            let value = self
+                .call(
+                    "configuration::get",
+                    ConfigurationGetInput {
+                        id: view.id.clone(),
+                        raw: true,
+                    },
+                )
+                .await
+                .ok()
+                .and_then(|raw| raw.get("value").cloned())
+                .unwrap_or(Value::Null);
+            out.push(ConfigurationEntry {
+                id: view.id,
+                name: view.name,
+                description: view.description,
+                schema: view.schema,
+                value,
+                metadata: view.metadata,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn watch(&self, sender: ExternalChangeSender) -> anyhow::Result<()> {
+        // Stash the sender so the relay function below (which is called by
+        // the remote engine via this WebSocket) can forward events.
+        self.sender
+            .set(sender)
+            .map_err(|_| anyhow::anyhow!("watch already started"))?;
+        let sender_lookup = self.sender.clone();
+
+        // Register the relay handler on this bridge worker — when the
+        // remote engine fires the `configuration` trigger we registered
+        // below, it'll route the call to this function.
+        self.bridge.register_function(
+            RELAY_FUNCTION_ID,
+            RegisterFunction::new_async(move |payload: Value| {
+                let sender_lookup = sender_lookup.clone();
+                async move {
+                    let event: ConfigurationEventData = serde_json::from_value(payload)
+                        .map_err(|e| iii_sdk::IIIError::Handler(e.to_string()))?;
+                    if let Some(tx) = sender_lookup.get() {
+                        let entry = ConfigurationEntry {
+                            id: event.id.clone(),
+                            name: event.name.clone(),
+                            description: event.description.clone(),
+                            schema: event.schema.clone(),
+                            value: event.new_value.clone().unwrap_or(Value::Null),
+                            metadata: event.metadata.clone(),
+                        };
+                        let change = match event.event_type {
+                            ConfigurationEventType::Registered => ExternalChange::Registered(entry),
+                            ConfigurationEventType::Updated => ExternalChange::Updated {
+                                entry,
+                                old_value: event.old_value.clone(),
+                            },
+                            ConfigurationEventType::Deleted => ExternalChange::Deleted { entry },
+                        };
+                        let _ = tx.send(change);
+                    }
+                    Ok::<Value, iii_sdk::IIIError>(Value::Null)
+                }
+            }),
+        );
+
+        let trigger = self
+            .bridge
+            .register_trigger(RegisterTriggerInput {
+                trigger_type: "configuration".to_string(),
+                function_id: RELAY_FUNCTION_ID.to_string(),
+                config: serde_json::json!({}),
+                metadata: None,
+            })
+            .map_err(|e| {
+                anyhow::anyhow!("failed to subscribe to remote configuration trigger: {}", e)
+            })?;
+        *self.relay_trigger.lock().expect("relay trigger lock") = Some(trigger);
+        Ok(())
+    }
+
+    async fn destroy(&self) -> anyhow::Result<()> {
+        if let Some(trigger) = self
+            .relay_trigger
+            .lock()
+            .expect("relay trigger lock")
+            .take()
+        {
+            trigger.unregister();
+        }
+        self.bridge.shutdown_async().await;
+        Ok(())
+    }
+}
+
+fn make_adapter(_engine: Arc<Engine>, config: Option<Value>) -> ConfigurationAdapterFuture {
+    Box::pin(async move {
+        let bridge_url = config
+            .as_ref()
+            .and_then(|c| c.get("bridge_url"))
+            .and_then(|v| v.as_str())
+            .unwrap_or(DEFAULT_BRIDGE_URL)
+            .to_string();
+        Ok(Arc::new(BridgeAdapter::new(bridge_url).await?) as Arc<dyn ConfigurationAdapter>)
+    })
+}
+
+crate::register_adapter!(<ConfigurationAdapterRegistration> name: "bridge", make_adapter);

--- a/engine/src/workers/configuration/adapters/bridge.rs
+++ b/engine/src/workers/configuration/adapters/bridge.rs
@@ -34,6 +34,11 @@ use crate::workers::configuration::structs::{
 
 const DEFAULT_BRIDGE_URL: &str = "ws://localhost:49134";
 const RELAY_FUNCTION_ID: &str = "configuration::__bridge_relay";
+/// Bounded timeout for every remote `configuration::*` call so an
+/// unresponsive remote engine can't hang the local worker indefinitely.
+/// 30 s is generous for a control-plane call and matches the order of magnitude
+/// of other engine-to-engine timeouts.
+const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 
 pub struct BridgeAdapter {
     bridge: Arc<III>,
@@ -66,7 +71,7 @@ impl BridgeAdapter {
                 function_id: function_id.to_string(),
                 payload,
                 action: None,
-                timeout_ms: None,
+                timeout_ms: Some(DEFAULT_TIMEOUT_MS),
             })
             .await
             .map_err(|e| anyhow::anyhow!("remote {} failed: {}", function_id, e))
@@ -123,6 +128,11 @@ impl ConfigurationAdapter for BridgeAdapter {
     }
 
     async fn get(&self, id: &str) -> anyhow::Result<Option<ConfigurationEntry>> {
+        // We treat any remote error as "absent" here because the SDK's
+        // `IIIError` is already string-wrapped by `call` above, so we can't
+        // cleanly distinguish a NOT_FOUND from a network/timeout failure
+        // without a wider refactor. Log the underlying error so transient
+        // remote failures aren't completely silent.
         let value_resp = match self
             .call(
                 "configuration::get",
@@ -134,7 +144,14 @@ impl ConfigurationAdapter for BridgeAdapter {
             .await
         {
             Ok(v) => v,
-            Err(_) => return Ok(None),
+            Err(err) => {
+                tracing::warn!(
+                    configuration_id = %id,
+                    error = %err,
+                    "Bridge configuration::get failed; treating as absent"
+                );
+                return Ok(None);
+            }
         };
         let value = value_resp.get("value").cloned().unwrap_or(Value::Null);
 
@@ -143,7 +160,14 @@ impl ConfigurationAdapter for BridgeAdapter {
             .await
         {
             Ok(v) => v,
-            Err(_) => return Ok(None),
+            Err(err) => {
+                tracing::warn!(
+                    configuration_id = %id,
+                    error = %err,
+                    "Bridge configuration::schema failed; treating as absent"
+                );
+                return Ok(None);
+            }
         };
         Ok(Some(ConfigurationEntry {
             id: id.to_string(),

--- a/engine/src/workers/configuration/adapters/fs.rs
+++ b/engine/src/workers/configuration/adapters/fs.rs
@@ -1,0 +1,485 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! File-system adapter — one YAML file per configuration id.
+//!
+//! Layout: `<directory>/<id>.yaml` where each file is a serialised
+//! [`ConfigurationEntry`]. The adapter watches the directory with `notify`
+//! and surfaces external edits through the `ExternalChange` channel so the
+//! worker can fire `configuration` triggers without depending on the source
+//! of the change.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use serde_json::Value;
+use tokio::sync::{Mutex as TokioMutex, RwLock};
+
+use crate::engine::Engine;
+use crate::workers::configuration::adapters::{
+    ConfigurationAdapter, ExternalChange, ExternalChangeSender, RegisterKind, RegisterOutcome,
+    SetOutcome,
+};
+use crate::workers::configuration::registry::{
+    ConfigurationAdapterFuture, ConfigurationAdapterRegistration,
+};
+use crate::workers::configuration::structs::ConfigurationEntry;
+
+const DEFAULT_DIRECTORY: &str = "./data/configuration";
+const FILE_EXTENSION: &str = "yaml";
+
+pub struct FsAdapter {
+    directory: PathBuf,
+    /// In-adapter cache, used by the watcher loop to diff disk state.
+    /// The store holds its own cache too — they are intentionally redundant
+    /// so the watcher can detect "what changed" without locking the worker.
+    cache: Arc<RwLock<HashMap<String, ConfigurationEntry>>>,
+    watcher: TokioMutex<Option<RecommendedWatcher>>,
+}
+
+impl FsAdapter {
+    pub async fn new(config: Option<Value>) -> anyhow::Result<Self> {
+        let directory = config
+            .as_ref()
+            .and_then(|c| c.get("directory"))
+            .and_then(|v| v.as_str())
+            .unwrap_or(DEFAULT_DIRECTORY)
+            .to_string();
+        let directory = PathBuf::from(directory);
+        tokio::fs::create_dir_all(&directory).await.map_err(|e| {
+            anyhow::anyhow!(
+                "failed to create configuration directory '{}': {}",
+                directory.display(),
+                e
+            )
+        })?;
+
+        let cache = Self::load_directory(&directory).await?;
+        tracing::info!(
+            directory = %directory.display(),
+            entries = cache.len(),
+            "FsAdapter initialised"
+        );
+
+        Ok(Self {
+            directory,
+            cache: Arc::new(RwLock::new(cache)),
+            watcher: TokioMutex::new(None),
+        })
+    }
+
+    fn entry_path(&self, id: &str) -> PathBuf {
+        self.directory.join(format!("{}.{}", id, FILE_EXTENSION))
+    }
+
+    async fn load_directory(dir: &Path) -> anyhow::Result<HashMap<String, ConfigurationEntry>> {
+        let mut entries = HashMap::new();
+        let mut read_dir = tokio::fs::read_dir(dir).await?;
+        while let Some(dir_entry) = read_dir.next_entry().await? {
+            let path = dir_entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            if path.extension().and_then(|e| e.to_str()) != Some(FILE_EXTENSION) {
+                continue;
+            }
+            match Self::read_entry(&path).await {
+                Ok(entry) => {
+                    entries.insert(entry.id.clone(), entry);
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %err,
+                        "Skipping configuration file with invalid YAML"
+                    );
+                }
+            }
+        }
+        Ok(entries)
+    }
+
+    async fn read_entry(path: &Path) -> anyhow::Result<ConfigurationEntry> {
+        let bytes = tokio::fs::read(path).await?;
+        let entry: ConfigurationEntry = serde_yaml::from_slice(&bytes)
+            .map_err(|e| anyhow::anyhow!("failed to parse {}: {}", path.display(), e))?;
+        Ok(entry)
+    }
+
+    async fn write_entry(&self, entry: &ConfigurationEntry) -> anyhow::Result<()> {
+        let path = self.entry_path(&entry.id);
+        let yaml = serde_yaml::to_string(entry)
+            .map_err(|e| anyhow::anyhow!("failed to serialise entry: {}", e))?;
+        let tmp = path.with_extension(format!("{}.tmp", FILE_EXTENSION));
+        tokio::fs::write(&tmp, yaml.as_bytes()).await?;
+        tokio::fs::rename(&tmp, &path).await?;
+        Ok(())
+    }
+
+    /// Test helper — extract the configuration id from a file path with the
+    /// adapter's `.yaml` extension. Returns `None` for paths that don't match
+    /// the expected layout.
+    #[cfg(test)]
+    fn id_from_path(path: &Path) -> Option<String> {
+        let file = path.file_name()?.to_str()?;
+        let stripped = file.strip_suffix(&format!(".{}", FILE_EXTENSION))?;
+        if stripped.is_empty() {
+            return None;
+        }
+        Some(stripped.to_string())
+    }
+}
+
+#[async_trait]
+impl ConfigurationAdapter for FsAdapter {
+    async fn register(&self, entry: ConfigurationEntry) -> anyhow::Result<RegisterOutcome> {
+        let mut cache = self.cache.write().await;
+        let prior = cache.get(&entry.id).cloned();
+        let kind = if prior.is_some() {
+            RegisterKind::Replaced
+        } else {
+            RegisterKind::Created
+        };
+        cache.insert(entry.id.clone(), entry.clone());
+        drop(cache);
+
+        self.write_entry(&entry).await?;
+        Ok(RegisterOutcome {
+            kind,
+            entry,
+            old_value: prior.map(|p| p.value),
+        })
+    }
+
+    async fn set(&self, id: &str, value: Value) -> anyhow::Result<SetOutcome> {
+        let mut cache = self.cache.write().await;
+        let mut entry = cache
+            .get(id)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("configuration '{}' not registered", id))?;
+        let old_value = Some(entry.value.clone());
+        entry.value = value;
+        cache.insert(id.to_string(), entry.clone());
+        drop(cache);
+
+        self.write_entry(&entry).await?;
+        Ok(SetOutcome { entry, old_value })
+    }
+
+    async fn get(&self, id: &str) -> anyhow::Result<Option<ConfigurationEntry>> {
+        Ok(self.cache.read().await.get(id).cloned())
+    }
+
+    async fn delete(&self, id: &str) -> anyhow::Result<Option<ConfigurationEntry>> {
+        let removed = self.cache.write().await.remove(id);
+        if removed.is_some() {
+            let path = self.entry_path(id);
+            match tokio::fs::remove_file(&path).await {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => {
+                    return Err(anyhow::anyhow!(
+                        "failed to delete configuration file '{}': {}",
+                        path.display(),
+                        err
+                    ));
+                }
+            }
+        }
+        Ok(removed)
+    }
+
+    async fn list(&self) -> anyhow::Result<Vec<ConfigurationEntry>> {
+        Ok(self.cache.read().await.values().cloned().collect())
+    }
+
+    async fn watch(&self, sender: ExternalChangeSender) -> anyhow::Result<()> {
+        let directory = self.directory.clone();
+        let cache = self.cache.clone();
+
+        // Channel used to bridge the synchronous notify callback into our
+        // async debounce loop.
+        let (raw_tx, mut raw_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+
+        let mut watcher = notify::recommended_watcher(move |res: notify::Result<Event>| {
+            if let Ok(event) = res {
+                match event.kind {
+                    EventKind::Modify(_) | EventKind::Create(_) | EventKind::Remove(_) => {
+                        let _ = raw_tx.send(());
+                    }
+                    _ => {}
+                }
+            }
+        })
+        .map_err(|e| anyhow::anyhow!("failed to create configuration watcher: {}", e))?;
+        watcher
+            .watch(&directory, RecursiveMode::NonRecursive)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to watch configuration directory '{}': {}",
+                    directory.display(),
+                    e
+                )
+            })?;
+        *self.watcher.lock().await = Some(watcher);
+
+        // Debounce loop: drains every queued raw event in a 500ms window
+        // and then diffs the directory snapshot against the cache, emitting
+        // one ExternalChange per id that actually changed.
+        tokio::spawn(async move {
+            while let Some(()) = raw_rx.recv().await {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                while raw_rx.try_recv().is_ok() {}
+
+                let snapshot = match Self::load_directory(&directory).await {
+                    Ok(s) => s,
+                    Err(err) => {
+                        tracing::warn!(
+                            directory = %directory.display(),
+                            error = %err,
+                            "Failed to read configuration directory during watch"
+                        );
+                        continue;
+                    }
+                };
+
+                // Diff under the cache write lock so concurrent register/set
+                // calls don't race the watcher.
+                let mut cache_guard = cache.write().await;
+                let mut events: Vec<ExternalChange> = Vec::new();
+
+                for (id, fresh) in snapshot.iter() {
+                    match cache_guard.get(id) {
+                        None => {
+                            events.push(ExternalChange::Registered(fresh.clone()));
+                        }
+                        Some(existing)
+                            if existing.value != fresh.value
+                                || existing.schema != fresh.schema
+                                || existing.name != fresh.name
+                                || existing.description != fresh.description =>
+                        {
+                            let old_value = Some(existing.value.clone());
+                            events.push(ExternalChange::Updated {
+                                entry: fresh.clone(),
+                                old_value,
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+                let removed_ids: Vec<String> = cache_guard
+                    .keys()
+                    .filter(|id| !snapshot.contains_key(*id))
+                    .cloned()
+                    .collect();
+                for id in removed_ids {
+                    if let Some(prior) = cache_guard.remove(&id) {
+                        events.push(ExternalChange::Deleted { entry: prior });
+                    }
+                }
+                for event in &events {
+                    match event {
+                        ExternalChange::Registered(e)
+                        | ExternalChange::Updated { entry: e, .. } => {
+                            cache_guard.insert(e.id.clone(), e.clone());
+                        }
+                        ExternalChange::Deleted { .. } => {}
+                    }
+                }
+                drop(cache_guard);
+
+                for event in events {
+                    if sender.send(event).is_err() {
+                        // Receiver dropped — stop the watcher loop.
+                        return;
+                    }
+                }
+            }
+        });
+        Ok(())
+    }
+
+    async fn destroy(&self) -> anyhow::Result<()> {
+        // Drop the watcher so its background thread exits.
+        *self.watcher.lock().await = None;
+        Ok(())
+    }
+}
+
+fn make_adapter(_engine: Arc<Engine>, config: Option<Value>) -> ConfigurationAdapterFuture {
+    Box::pin(
+        async move { Ok(Arc::new(FsAdapter::new(config).await?) as Arc<dyn ConfigurationAdapter>) },
+    )
+}
+
+crate::register_adapter!(<ConfigurationAdapterRegistration> name: "fs", make_adapter);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn temp_dir() -> tempfile::TempDir {
+        tempfile::tempdir().expect("create tempdir")
+    }
+
+    fn sample_entry(id: &str) -> ConfigurationEntry {
+        ConfigurationEntry {
+            id: id.into(),
+            name: format!("{} display", id),
+            description: "test".into(),
+            schema: json!({ "type": "object" }),
+            value: json!({ "port": 3112 }),
+            metadata: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn register_and_get_round_trip() {
+        let dir = temp_dir();
+        let adapter = FsAdapter::new(Some(json!({ "directory": dir.path().to_str().unwrap() })))
+            .await
+            .unwrap();
+
+        let entry = sample_entry("iii-stream");
+        let outcome = adapter.register(entry.clone()).await.unwrap();
+        assert_eq!(outcome.kind, RegisterKind::Created);
+        let read = adapter.get("iii-stream").await.unwrap().unwrap();
+        assert_eq!(read.value, entry.value);
+
+        let path = dir.path().join("iii-stream.yaml");
+        assert!(path.exists(), "yaml file should be created on disk");
+    }
+
+    #[tokio::test]
+    async fn second_register_replaces_and_returns_old_value() {
+        let dir = temp_dir();
+        let adapter = FsAdapter::new(Some(json!({ "directory": dir.path().to_str().unwrap() })))
+            .await
+            .unwrap();
+
+        adapter.register(sample_entry("iii-stream")).await.unwrap();
+        let mut updated = sample_entry("iii-stream");
+        updated.value = json!({ "port": 9999 });
+        let outcome = adapter.register(updated.clone()).await.unwrap();
+        assert_eq!(outcome.kind, RegisterKind::Replaced);
+        assert_eq!(outcome.old_value, Some(json!({ "port": 3112 })));
+    }
+
+    #[tokio::test]
+    async fn set_updates_value_and_returns_old() {
+        let dir = temp_dir();
+        let adapter = FsAdapter::new(Some(json!({ "directory": dir.path().to_str().unwrap() })))
+            .await
+            .unwrap();
+        adapter.register(sample_entry("iii-stream")).await.unwrap();
+
+        let outcome = adapter
+            .set("iii-stream", json!({ "port": 4242 }))
+            .await
+            .unwrap();
+        assert_eq!(outcome.old_value, Some(json!({ "port": 3112 })));
+        assert_eq!(outcome.entry.value, json!({ "port": 4242 }));
+    }
+
+    #[tokio::test]
+    async fn set_unknown_id_returns_error() {
+        let dir = temp_dir();
+        let adapter = FsAdapter::new(Some(json!({ "directory": dir.path().to_str().unwrap() })))
+            .await
+            .unwrap();
+        let err = adapter.set("missing", json!({})).await.unwrap_err();
+        assert!(err.to_string().contains("not registered"));
+    }
+
+    #[tokio::test]
+    async fn delete_removes_file_and_cache() {
+        let dir = temp_dir();
+        let adapter = FsAdapter::new(Some(json!({ "directory": dir.path().to_str().unwrap() })))
+            .await
+            .unwrap();
+        adapter.register(sample_entry("iii-stream")).await.unwrap();
+        let removed = adapter.delete("iii-stream").await.unwrap();
+        assert!(removed.is_some());
+        assert!(adapter.get("iii-stream").await.unwrap().is_none());
+        assert!(!dir.path().join("iii-stream.yaml").exists());
+    }
+
+    #[tokio::test]
+    async fn list_returns_every_registered_entry() {
+        let dir = temp_dir();
+        let adapter = FsAdapter::new(Some(json!({ "directory": dir.path().to_str().unwrap() })))
+            .await
+            .unwrap();
+        adapter.register(sample_entry("a")).await.unwrap();
+        adapter.register(sample_entry("b")).await.unwrap();
+        let mut listed: Vec<String> = adapter
+            .list()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|e| e.id)
+            .collect();
+        listed.sort();
+        assert_eq!(listed, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn loading_existing_directory_picks_up_yaml_files() {
+        let dir = temp_dir();
+        let entry = sample_entry("preexisting");
+        let yaml = serde_yaml::to_string(&entry).unwrap();
+        tokio::fs::write(dir.path().join("preexisting.yaml"), yaml)
+            .await
+            .unwrap();
+
+        let adapter = FsAdapter::new(Some(json!({ "directory": dir.path().to_str().unwrap() })))
+            .await
+            .unwrap();
+        let read = adapter.get("preexisting").await.unwrap().unwrap();
+        assert_eq!(read.value, entry.value);
+    }
+
+    #[tokio::test]
+    async fn watcher_emits_registered_event_on_external_create() {
+        let dir = temp_dir();
+        let adapter = FsAdapter::new(Some(json!({ "directory": dir.path().to_str().unwrap() })))
+            .await
+            .unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        adapter.watch(tx).await.unwrap();
+
+        let entry = sample_entry("external");
+        let yaml = serde_yaml::to_string(&entry).unwrap();
+        tokio::fs::write(dir.path().join("external.yaml"), yaml)
+            .await
+            .unwrap();
+
+        let evt = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("watcher should report an event")
+            .expect("channel closed");
+        match evt {
+            ExternalChange::Registered(e) => assert_eq!(e.id, "external"),
+            other => panic!("unexpected change: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn id_from_path_extracts_stem() {
+        assert_eq!(
+            FsAdapter::id_from_path(Path::new("/tmp/iii-stream.yaml")),
+            Some("iii-stream".to_string())
+        );
+        assert_eq!(FsAdapter::id_from_path(Path::new("/tmp/no_ext")), None);
+        assert_eq!(FsAdapter::id_from_path(Path::new("/tmp/.yaml")), None);
+    }
+}

--- a/engine/src/workers/configuration/adapters/fs.rs
+++ b/engine/src/workers/configuration/adapters/fs.rs
@@ -140,6 +140,10 @@ impl FsAdapter {
 #[async_trait]
 impl ConfigurationAdapter for FsAdapter {
     async fn register(&self, entry: ConfigurationEntry) -> anyhow::Result<RegisterOutcome> {
+        // Hold the write lock across the disk write so a `write_entry`
+        // failure leaves the in-memory cache untouched. Without this, a
+        // failed I/O would leave readers observing a value that disappears
+        // on restart.
         let mut cache = self.cache.write().await;
         let prior = cache.get(&entry.id).cloned();
         let kind = if prior.is_some() {
@@ -147,10 +151,8 @@ impl ConfigurationAdapter for FsAdapter {
         } else {
             RegisterKind::Created
         };
-        cache.insert(entry.id.clone(), entry.clone());
-        drop(cache);
-
         self.write_entry(&entry).await?;
+        cache.insert(entry.id.clone(), entry.clone());
         Ok(RegisterOutcome {
             kind,
             entry,
@@ -159,6 +161,9 @@ impl ConfigurationAdapter for FsAdapter {
     }
 
     async fn set(&self, id: &str, value: Value) -> anyhow::Result<SetOutcome> {
+        // Same ordering as `register` — disk first, cache second, both under
+        // the same write lock. Read traffic blocks on this lock while the
+        // I/O is in flight, which is acceptable for a configuration store.
         let mut cache = self.cache.write().await;
         let mut entry = cache
             .get(id)
@@ -166,10 +171,8 @@ impl ConfigurationAdapter for FsAdapter {
             .ok_or_else(|| anyhow::anyhow!("configuration '{}' not registered", id))?;
         let old_value = Some(entry.value.clone());
         entry.value = value;
-        cache.insert(id.to_string(), entry.clone());
-        drop(cache);
-
         self.write_entry(&entry).await?;
+        cache.insert(id.to_string(), entry.clone());
         Ok(SetOutcome { entry, old_value })
     }
 

--- a/engine/src/workers/configuration/adapters/mod.rs
+++ b/engine/src/workers/configuration/adapters/mod.rs
@@ -1,0 +1,86 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+pub mod bridge;
+pub mod fs;
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::workers::configuration::structs::ConfigurationEntry;
+
+/// Persistent change report returned by `register`.
+///
+/// `Created` means the id had no prior entry; `Replaced` means the worker
+/// updated metadata/schema (and possibly value, when `initial_value` was
+/// provided) of an existing id.
+#[derive(Debug, Clone)]
+pub struct RegisterOutcome {
+    pub kind: RegisterKind,
+    pub entry: ConfigurationEntry,
+    pub old_value: Option<Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegisterKind {
+    Created,
+    Replaced,
+}
+
+#[derive(Debug, Clone)]
+pub struct SetOutcome {
+    pub entry: ConfigurationEntry,
+    pub old_value: Option<Value>,
+}
+
+/// External-edit report surfaced by adapters that watch their backing
+/// store (e.g. the `fs` adapter's `notify` watcher). Drives the worker's
+/// trigger fan-out for changes that did not originate from a local
+/// `configuration::*` call.
+#[derive(Debug, Clone)]
+pub enum ExternalChange {
+    Registered(ConfigurationEntry),
+    Updated {
+        entry: ConfigurationEntry,
+        old_value: Option<Value>,
+    },
+    Deleted {
+        entry: ConfigurationEntry,
+    },
+}
+
+/// Channel sender the worker hands to adapters that surface external changes.
+pub type ExternalChangeSender = tokio::sync::mpsc::UnboundedSender<ExternalChange>;
+
+#[async_trait]
+pub trait ConfigurationAdapter: Send + Sync {
+    /// Insert or replace an entry. `initial_value` already fills `entry.value`
+    /// when supplied — adapters should NOT inspect it separately.
+    async fn register(&self, entry: ConfigurationEntry) -> anyhow::Result<RegisterOutcome>;
+
+    /// Replace the value of an existing entry. Returns `None` from `get`
+    /// if the id is unknown — `set` itself does not implicitly create.
+    async fn set(&self, id: &str, value: Value) -> anyhow::Result<SetOutcome>;
+
+    /// Return a single entry, or `None` if absent.
+    async fn get(&self, id: &str) -> anyhow::Result<Option<ConfigurationEntry>>;
+
+    /// Remove an entry. Returns the removed entry when one was present.
+    async fn delete(&self, id: &str) -> anyhow::Result<Option<ConfigurationEntry>>;
+
+    /// Return every stored entry, deterministic order is the adapter's
+    /// responsibility (the worker re-sorts by id before returning to callers).
+    async fn list(&self) -> anyhow::Result<Vec<ConfigurationEntry>>;
+
+    /// Wire a sender that receives change events the adapter detects on its
+    /// own (file edits, remote bridge events, etc.). Default no-op for adapters
+    /// that have no out-of-band edit path.
+    async fn watch(&self, _sender: ExternalChangeSender) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn destroy(&self) -> anyhow::Result<()>;
+}

--- a/engine/src/workers/configuration/config.rs
+++ b/engine/src/workers/configuration/config.rs
@@ -1,0 +1,55 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+use serde::{Deserialize, Serialize};
+
+use crate::workers::traits::AdapterEntry;
+
+/// Worker-level configuration parsed from `engine/config.yaml`'s
+/// `- name: configuration` block.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ConfigurationModuleConfig {
+    /// Adapter entry. `fs` is the default; `bridge` delegates to a remote engine.
+    #[serde(default)]
+    pub adapter: Option<AdapterEntry>,
+
+    /// Per-id TTL in seconds. When set to a non-zero value, an entry whose
+    /// last trigger has been unregistered is deleted after this many seconds
+    /// of inactivity. `0` (the default) disables the cleanup.
+    #[serde(default)]
+    pub ttl_seconds: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn default_config_has_no_adapter_and_zero_ttl() {
+        let config = ConfigurationModuleConfig::default();
+        assert!(config.adapter.is_none());
+        assert_eq!(config.ttl_seconds, 0);
+    }
+
+    #[test]
+    fn deserialize_with_ttl_and_adapter() {
+        let json = json!({
+            "adapter": { "name": "fs", "config": { "directory": "/tmp/cfg" } },
+            "ttl_seconds": 3600,
+        });
+        let cfg: ConfigurationModuleConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(cfg.ttl_seconds, 3600);
+        assert_eq!(cfg.adapter.unwrap().name, "fs");
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        let json = json!({ "frobnicate": true });
+        assert!(serde_json::from_value::<ConfigurationModuleConfig>(json).is_err());
+    }
+}

--- a/engine/src/workers/configuration/configuration.rs
+++ b/engine/src/workers/configuration/configuration.rs
@@ -1,0 +1,710 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock as SyncRwLock},
+};
+
+use function_macros::{function, service};
+use once_cell::sync::Lazy;
+use serde_json::Value;
+use tokio::sync::Mutex as TokioMutex;
+use tracing::Instrument;
+
+use crate::{
+    condition::check_condition,
+    engine::{Engine, EngineTrait, Handler, RegisterFunctionRequest},
+    function::FunctionResult,
+    protocol::ErrorBody,
+    trigger::TriggerType,
+    workers::{
+        configuration::{
+            adapters::{ConfigurationAdapter, ExternalChange, RegisterKind},
+            config::ConfigurationModuleConfig,
+            store::{ConfigurationStore, StoreError, expand_value},
+            structs::{
+                ConfigurationEntry, ConfigurationEventData, ConfigurationEventType,
+                ConfigurationGetInput, ConfigurationGetResult, ConfigurationListInput,
+                ConfigurationListResult, ConfigurationRegisterInput, ConfigurationSchemaInput,
+                ConfigurationSchemaView, ConfigurationSetInput, ConfigurationSetResult,
+            },
+            trigger::{ConfigurationTriggers, TRIGGER_TYPE},
+        },
+        traits::{AdapterFactory, ConfigurableWorker, Worker},
+    },
+};
+
+#[derive(Clone)]
+pub struct ConfigurationWorker {
+    pub(crate) store: Arc<ConfigurationStore>,
+    pub(crate) engine: Arc<Engine>,
+    pub(crate) triggers: Arc<ConfigurationTriggers>,
+    pub(crate) ttl_seconds: u64,
+    /// Holds the watcher loop handle so destroy() can stop external-edit
+    /// fan-out before the adapter is torn down.
+    watch_task: Arc<TokioMutex<Option<tokio::task::JoinHandle<()>>>>,
+}
+
+#[async_trait::async_trait]
+impl Worker for ConfigurationWorker {
+    fn name(&self) -> &'static str {
+        "ConfigurationWorker"
+    }
+
+    async fn create(engine: Arc<Engine>, config: Option<Value>) -> anyhow::Result<Box<dyn Worker>> {
+        Self::create_with_adapters(engine, config).await
+    }
+
+    fn register_functions(&self, engine: Arc<Engine>) {
+        self.register_functions(engine);
+    }
+
+    async fn initialize(&self) -> anyhow::Result<()> {
+        tracing::info!("Initializing ConfigurationWorker");
+
+        // Pull existing entries off the adapter into the in-memory cache so
+        // `list` / `get` work without an extra round-trip per call.
+        if let Err(err) = self.store.prime_from_adapter().await {
+            tracing::warn!(
+                error = %err,
+                "Failed to prime configuration cache from adapter; starting empty"
+            );
+        }
+
+        let _ = self
+            .engine
+            .register_trigger_type(TriggerType::new(
+                TRIGGER_TYPE,
+                "Configuration trigger — fires on register/update/delete events",
+                Box::new(self.clone()),
+                None,
+            ))
+            .await;
+
+        // Start the adapter's external-change watcher (no-op for adapters
+        // without an out-of-band edit path).
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ExternalChange>();
+        if let Err(err) = self.store.adapter().watch(tx).await {
+            tracing::warn!(
+                error = %err,
+                "Adapter watch failed; external edits will not fire triggers"
+            );
+        } else {
+            let worker = self.clone();
+            let handle = tokio::spawn(async move {
+                while let Some(change) = rx.recv().await {
+                    worker.handle_external_change(change).await;
+                }
+            });
+            *self.watch_task.lock().await = Some(handle);
+        }
+
+        Ok(())
+    }
+
+    async fn destroy(&self) -> anyhow::Result<()> {
+        tracing::info!("Destroying ConfigurationWorker");
+        self.triggers.abort_all_expiries().await;
+        if let Some(handle) = self.watch_task.lock().await.take() {
+            handle.abort();
+        }
+        self.store.adapter().destroy().await?;
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ConfigurableWorker for ConfigurationWorker {
+    type Config = ConfigurationModuleConfig;
+    type Adapter = dyn ConfigurationAdapter;
+    type AdapterRegistration = super::registry::ConfigurationAdapterRegistration;
+    const DEFAULT_ADAPTER_NAME: &'static str = "fs";
+
+    async fn registry() -> &'static SyncRwLock<HashMap<String, AdapterFactory<Self::Adapter>>> {
+        static REGISTRY: Lazy<
+            SyncRwLock<HashMap<String, AdapterFactory<dyn ConfigurationAdapter>>>,
+        > = Lazy::new(|| SyncRwLock::new(ConfigurationWorker::build_registry()));
+        &REGISTRY
+    }
+
+    fn build(engine: Arc<Engine>, config: Self::Config, adapter: Arc<Self::Adapter>) -> Self {
+        Self {
+            store: Arc::new(ConfigurationStore::new(adapter)),
+            engine,
+            triggers: Arc::new(ConfigurationTriggers::new()),
+            ttl_seconds: config.ttl_seconds,
+            watch_task: Arc::new(TokioMutex::new(None)),
+        }
+    }
+
+    fn adapter_name_from_config(config: &Self::Config) -> Option<String> {
+        config.adapter.as_ref().map(|a| a.name.clone())
+    }
+
+    fn adapter_config_from_config(config: &Self::Config) -> Option<Value> {
+        config.adapter.as_ref().and_then(|a| a.config.clone())
+    }
+}
+
+impl ConfigurationWorker {
+    /// Construct a worker with explicit pieces — used by tests so they don't
+    /// have to round-trip through `create_with_adapters`. Exposed publicly
+    /// (with `#[doc(hidden)]`) so integration tests in `engine/tests/` can
+    /// drive the worker without booting the full engine.
+    #[doc(hidden)]
+    pub fn for_test(
+        engine: Arc<Engine>,
+        adapter: Arc<dyn ConfigurationAdapter>,
+        ttl_seconds: u64,
+    ) -> Self {
+        Self {
+            store: Arc::new(ConfigurationStore::new(adapter)),
+            engine,
+            triggers: Arc::new(ConfigurationTriggers::new()),
+            ttl_seconds,
+            watch_task: Arc::new(TokioMutex::new(None)),
+        }
+    }
+
+    /// Trigger fan-out for an event already produced by the worker
+    /// (register/set) or surfaced by the adapter watcher (file edit).
+    pub(crate) async fn fan_out(&self, event: ConfigurationEventData) {
+        let triggers = self.triggers.matching(&event.id).await;
+        if triggers.is_empty() {
+            return;
+        }
+
+        let event_value = match serde_json::to_value(&event) {
+            Ok(v) => v,
+            Err(err) => {
+                tracing::error!(error = %err, "Failed to serialise configuration event");
+                return;
+            }
+        };
+        let engine = self.engine.clone();
+        let event_type_wire = match event.event_type {
+            ConfigurationEventType::Registered => "configuration:registered",
+            ConfigurationEventType::Updated => "configuration:updated",
+            ConfigurationEventType::Deleted => "configuration:deleted",
+        };
+        let id = event.id.clone();
+        let current_span = tracing::Span::current();
+
+        tokio::spawn(
+            async move {
+                for trigger in triggers {
+                    if let Some(filter) = trigger.config.event_types.as_ref()
+                        && !filter.iter().any(|t| t == event_type_wire)
+                    {
+                        continue;
+                    }
+
+                    if let Some(condition_id) = trigger.config.condition_function_id.as_ref() {
+                        match check_condition(engine.as_ref(), condition_id, event_value.clone())
+                            .await
+                        {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                tracing::debug!(
+                                    function_id = %trigger.trigger.function_id,
+                                    "Condition returned false, skipping handler"
+                                );
+                                continue;
+                            }
+                            Err(err) => {
+                                tracing::error!(
+                                    condition_function_id = %condition_id,
+                                    error = ?err,
+                                    "Condition function errored, skipping handler"
+                                );
+                                continue;
+                            }
+                        }
+                    }
+
+                    if let Err(err) = engine
+                        .call(&trigger.trigger.function_id, event_value.clone())
+                        .await
+                    {
+                        tracing::error!(
+                            function_id = %trigger.trigger.function_id,
+                            id = %id,
+                            error = ?err,
+                            "Configuration trigger handler failed"
+                        );
+                    }
+                }
+            }
+            .instrument(tracing::info_span!(parent: current_span, "configuration_triggers")),
+        );
+    }
+
+    /// Apply a watcher-surfaced change into the cache and broadcast.
+    pub(crate) async fn handle_external_change(&self, change: ExternalChange) {
+        self.store.apply_external(&change).await;
+        let event = match change {
+            ExternalChange::Registered(entry) => entry_to_event(
+                &entry,
+                ConfigurationEventType::Registered,
+                None,
+                Some(entry.value.clone()),
+            ),
+            ExternalChange::Updated { entry, old_value } => entry_to_event(
+                &entry,
+                ConfigurationEventType::Updated,
+                old_value,
+                Some(entry.value.clone()),
+            ),
+            ExternalChange::Deleted { entry } => entry_to_event(
+                &entry,
+                ConfigurationEventType::Deleted,
+                Some(entry.value.clone()),
+                None,
+            ),
+        };
+        self.fan_out(event).await;
+    }
+
+    /// TTL-driven cleanup. Called from the trigger module when the
+    /// last-trigger countdown elapses.
+    pub(crate) async fn expire_configuration(&self, id: &str) -> anyhow::Result<()> {
+        match self.store.delete(id).await {
+            Ok(Some(entry)) => {
+                let event = entry_to_event(
+                    &entry,
+                    ConfigurationEventType::Deleted,
+                    Some(entry.value.clone()),
+                    None,
+                );
+                self.fan_out(event).await;
+                Ok(())
+            }
+            Ok(None) => Ok(()),
+            Err(err) => Err(err.into()),
+        }
+    }
+}
+
+/// Build a `ConfigurationEventData` from an entry + event semantics.
+/// `new_value` is expanded for the wire (subscribers should see resolved
+/// `${VAR:default}` values); the caller chooses the `old_value`.
+fn entry_to_event(
+    entry: &ConfigurationEntry,
+    event_type: ConfigurationEventType,
+    old_value: Option<Value>,
+    new_value_raw: Option<Value>,
+) -> ConfigurationEventData {
+    ConfigurationEventData {
+        message_type: "configuration".to_string(),
+        event_type,
+        id: entry.id.clone(),
+        name: entry.name.clone(),
+        description: entry.description.clone(),
+        schema: entry.schema.clone(),
+        old_value: old_value.map(|v| expand_value(&v)),
+        new_value: new_value_raw.map(|v| expand_value(&v)),
+        metadata: entry.metadata.clone(),
+    }
+}
+
+fn store_error_to_failure(err: StoreError) -> ErrorBody {
+    let code = match &err {
+        StoreError::NotRegistered(_) => "NOT_REGISTERED",
+        StoreError::InvalidId(_) => "INVALID_ID",
+        StoreError::SchemaInvalid(_) => "SCHEMA_INVALID",
+        StoreError::Adapter(_) => "ADAPTER_ERROR",
+    };
+    ErrorBody {
+        message: err.to_string(),
+        code: code.to_string(),
+        stacktrace: None,
+    }
+}
+
+#[service(name = "configuration")]
+impl ConfigurationWorker {
+    #[function(
+        id = "configuration::register",
+        description = "Register a configuration id with a name, description, and JSON Schema. Idempotent — re-registering replaces metadata and (when initial_value is provided) the value. Validates initial_value against the schema."
+    )]
+    pub async fn register_fn(
+        &self,
+        input: ConfigurationRegisterInput,
+    ) -> FunctionResult<ConfigurationEntry, ErrorBody> {
+        let outcome = match self
+            .store
+            .register(
+                input.id,
+                input.name,
+                input.description,
+                input.schema,
+                input.initial_value,
+                input.metadata,
+            )
+            .await
+        {
+            Ok(o) => o,
+            Err(err) => return FunctionResult::Failure(store_error_to_failure(err)),
+        };
+
+        let event_type = match outcome.kind {
+            RegisterKind::Created => ConfigurationEventType::Registered,
+            RegisterKind::Replaced => ConfigurationEventType::Updated,
+        };
+        let event = entry_to_event(
+            &outcome.entry,
+            event_type,
+            outcome.old_value.clone(),
+            Some(outcome.entry.value.clone()),
+        );
+        self.fan_out(event).await;
+
+        FunctionResult::Success(outcome.entry)
+    }
+
+    #[function(
+        id = "configuration::set",
+        description = "Replace the value of an already-registered configuration. Validates the value against the registered JSON Schema and emits a configuration:updated event."
+    )]
+    pub async fn set_fn(
+        &self,
+        input: ConfigurationSetInput,
+    ) -> FunctionResult<ConfigurationSetResult, ErrorBody> {
+        let outcome = match self.store.set(&input.id, input.value).await {
+            Ok(o) => o,
+            Err(err) => return FunctionResult::Failure(store_error_to_failure(err)),
+        };
+
+        let event = entry_to_event(
+            &outcome.entry,
+            ConfigurationEventType::Updated,
+            outcome.old_value.clone(),
+            Some(outcome.entry.value.clone()),
+        );
+        self.fan_out(event).await;
+
+        FunctionResult::Success(ConfigurationSetResult {
+            old_value: outcome.old_value,
+            new_value: outcome.entry.value,
+        })
+    }
+
+    #[function(
+        id = "configuration::get",
+        description = "Read a configuration by id. Expands ${VAR:default} placeholders against the live process env unless raw=true is passed."
+    )]
+    pub async fn get_fn(
+        &self,
+        input: ConfigurationGetInput,
+    ) -> FunctionResult<ConfigurationGetResult, ErrorBody> {
+        match self.store.get(&input.id).await {
+            Some(entry) => {
+                let value = if input.raw {
+                    entry.value
+                } else {
+                    expand_value(&entry.value)
+                };
+                FunctionResult::Success(ConfigurationGetResult {
+                    id: entry.id,
+                    value,
+                })
+            }
+            None => FunctionResult::Failure(ErrorBody {
+                message: format!("configuration '{}' not found", input.id),
+                code: "NOT_FOUND".to_string(),
+                stacktrace: None,
+            }),
+        }
+    }
+
+    #[function(
+        id = "configuration::list",
+        description = "List every registered configuration with id, name, description, and schema. Sorted by id; never returns the stored value."
+    )]
+    pub async fn list_fn(
+        &self,
+        _input: ConfigurationListInput,
+    ) -> FunctionResult<ConfigurationListResult, ErrorBody> {
+        let configurations = self.store.list().await;
+        FunctionResult::Success(ConfigurationListResult { configurations })
+    }
+
+    #[function(
+        id = "configuration::schema",
+        description = "Retrieve the schema, name, and description for a configuration id. Mirrors a single entry from configuration::list."
+    )]
+    pub async fn schema_fn(
+        &self,
+        input: ConfigurationSchemaInput,
+    ) -> FunctionResult<ConfigurationSchemaView, ErrorBody> {
+        match self.store.schema_view(&input.id).await {
+            Some(view) => FunctionResult::Success(view),
+            None => FunctionResult::Failure(ErrorBody {
+                message: format!("configuration '{}' not found", input.id),
+                code: "NOT_FOUND".to_string(),
+                stacktrace: None,
+            }),
+        }
+    }
+}
+
+crate::register_worker!("configuration", ConfigurationWorker, mandatory);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workers::configuration::adapters::fs::FsAdapter;
+    use serde_json::json;
+
+    async fn setup() -> (Arc<Engine>, ConfigurationWorker, tempfile::TempDir) {
+        crate::workers::observability::metrics::ensure_default_meter();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let adapter = Arc::new(
+            FsAdapter::new(Some(json!({ "directory": dir.path().to_str().unwrap() })))
+                .await
+                .expect("fs adapter"),
+        ) as Arc<dyn ConfigurationAdapter>;
+        let engine = Arc::new(Engine::new());
+        let worker = ConfigurationWorker::for_test(engine.clone(), adapter, 0);
+        (engine, worker, dir)
+    }
+
+    fn schema_object_required_port() -> Value {
+        json!({
+            "type": "object",
+            "required": ["port"],
+            "properties": { "port": { "type": "integer" } },
+        })
+    }
+
+    fn register_input(id: &str, initial: Option<Value>) -> ConfigurationRegisterInput {
+        ConfigurationRegisterInput {
+            id: id.into(),
+            name: format!("{} display", id),
+            description: "test".into(),
+            schema: schema_object_required_port(),
+            initial_value: initial,
+            metadata: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn register_creates_entry_and_returns_it() {
+        let (_engine, worker, _dir) = setup().await;
+        let result = worker
+            .register_fn(register_input("iii-stream", Some(json!({ "port": 3112 }))))
+            .await;
+        match result {
+            FunctionResult::Success(entry) => {
+                assert_eq!(entry.id, "iii-stream");
+                assert_eq!(entry.value, json!({ "port": 3112 }));
+            }
+            _ => panic!("expected register success"),
+        }
+    }
+
+    #[tokio::test]
+    async fn register_without_initial_value_seeds_null() {
+        let (_engine, worker, _dir) = setup().await;
+        let result = worker.register_fn(register_input("iii-stream", None)).await;
+        match result {
+            FunctionResult::Success(entry) => assert!(entry.value.is_null()),
+            _ => panic!("expected register success without initial_value"),
+        }
+    }
+
+    #[tokio::test]
+    async fn register_rejects_initial_value_violating_schema() {
+        let (_engine, worker, _dir) = setup().await;
+        let result = worker
+            .register_fn(register_input(
+                "iii-stream",
+                Some(json!({ "port": "not-an-integer" })),
+            ))
+            .await;
+        match result {
+            FunctionResult::Failure(err) => assert_eq!(err.code, "SCHEMA_INVALID"),
+            _ => panic!("expected schema validation failure"),
+        }
+    }
+
+    #[tokio::test]
+    async fn set_validates_against_registered_schema() {
+        let (_engine, worker, _dir) = setup().await;
+        worker
+            .register_fn(register_input("iii-stream", Some(json!({ "port": 3112 }))))
+            .await;
+
+        let bad = worker
+            .set_fn(ConfigurationSetInput {
+                id: "iii-stream".into(),
+                value: json!({ "port": "wrong" }),
+            })
+            .await;
+        match bad {
+            FunctionResult::Failure(err) => assert_eq!(err.code, "SCHEMA_INVALID"),
+            _ => panic!("expected schema validation failure on set"),
+        }
+
+        let good = worker
+            .set_fn(ConfigurationSetInput {
+                id: "iii-stream".into(),
+                value: json!({ "port": 4242 }),
+            })
+            .await;
+        match good {
+            FunctionResult::Success(s) => {
+                assert_eq!(s.old_value, Some(json!({ "port": 3112 })));
+                assert_eq!(s.new_value, json!({ "port": 4242 }));
+            }
+            _ => panic!("expected set success"),
+        }
+    }
+
+    #[tokio::test]
+    async fn set_on_unregistered_id_returns_not_registered() {
+        let (_engine, worker, _dir) = setup().await;
+        let result = worker
+            .set_fn(ConfigurationSetInput {
+                id: "missing".into(),
+                value: json!({}),
+            })
+            .await;
+        match result {
+            FunctionResult::Failure(err) => assert_eq!(err.code, "NOT_REGISTERED"),
+            _ => panic!("expected NOT_REGISTERED"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_expands_env_var_placeholders_by_default() {
+        let (_engine, worker, _dir) = setup().await;
+        unsafe {
+            std::env::set_var("CFG_GET_HOST", "db.local");
+        }
+
+        // Schema accepts strings under host so the placeholder set passes validation.
+        let mut input = register_input("svc", None);
+        input.schema = json!({
+            "type": "object",
+            "properties": { "host": { "type": "string" } },
+        });
+        input.initial_value = Some(json!({ "host": "${CFG_GET_HOST:fallback}" }));
+        worker.register_fn(input).await;
+
+        let expanded = worker
+            .get_fn(ConfigurationGetInput {
+                id: "svc".into(),
+                raw: false,
+            })
+            .await;
+        match expanded {
+            FunctionResult::Success(out) => assert_eq!(out.value["host"], "db.local"),
+            _ => panic!("expected get success"),
+        }
+
+        let raw = worker
+            .get_fn(ConfigurationGetInput {
+                id: "svc".into(),
+                raw: true,
+            })
+            .await;
+        match raw {
+            FunctionResult::Success(out) => {
+                assert_eq!(out.value["host"], "${CFG_GET_HOST:fallback}")
+            }
+            _ => panic!("expected raw get success"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_unknown_id_returns_not_found() {
+        let (_engine, worker, _dir) = setup().await;
+        let result = worker
+            .get_fn(ConfigurationGetInput {
+                id: "missing".into(),
+                raw: false,
+            })
+            .await;
+        match result {
+            FunctionResult::Failure(err) => assert_eq!(err.code, "NOT_FOUND"),
+            _ => panic!("expected NOT_FOUND"),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_returns_registered_entries_sorted_without_value() {
+        let (_engine, worker, _dir) = setup().await;
+        worker
+            .register_fn(register_input("zebra", Some(json!({ "port": 1 }))))
+            .await;
+        worker
+            .register_fn(register_input("alpha", Some(json!({ "port": 2 }))))
+            .await;
+
+        let result = worker.list_fn(ConfigurationListInput {}).await;
+        match result {
+            FunctionResult::Success(out) => {
+                let ids: Vec<String> = out.configurations.iter().map(|c| c.id.clone()).collect();
+                assert_eq!(ids, vec!["alpha".to_string(), "zebra".to_string()]);
+                let serialised = serde_json::to_value(&out.configurations[0]).unwrap();
+                assert!(
+                    serialised.get("value").is_none(),
+                    "list must not leak the stored value"
+                );
+            }
+            _ => panic!("expected list success"),
+        }
+    }
+
+    #[tokio::test]
+    async fn schema_returns_registered_schema() {
+        let (_engine, worker, _dir) = setup().await;
+        worker
+            .register_fn(register_input("iii-stream", Some(json!({ "port": 3112 }))))
+            .await;
+
+        let result = worker
+            .schema_fn(ConfigurationSchemaInput {
+                id: "iii-stream".into(),
+            })
+            .await;
+        match result {
+            FunctionResult::Success(view) => {
+                assert_eq!(view.id, "iii-stream");
+                assert_eq!(view.schema, schema_object_required_port());
+            }
+            _ => panic!("expected schema success"),
+        }
+
+        let missing = worker
+            .schema_fn(ConfigurationSchemaInput {
+                id: "missing".into(),
+            })
+            .await;
+        match missing {
+            FunctionResult::Failure(err) => assert_eq!(err.code, "NOT_FOUND"),
+            _ => panic!("expected NOT_FOUND"),
+        }
+    }
+
+    #[tokio::test]
+    async fn re_register_replaces_metadata_keeps_value_when_initial_omitted() {
+        let (_engine, worker, _dir) = setup().await;
+        worker
+            .register_fn(register_input("iii-stream", Some(json!({ "port": 3112 }))))
+            .await;
+
+        let mut update = register_input("iii-stream", None);
+        update.description = "updated".into();
+        worker.register_fn(update).await;
+
+        let entry = worker.store.get("iii-stream").await.expect("entry");
+        assert_eq!(entry.description, "updated");
+        assert_eq!(entry.value, json!({ "port": 3112 }));
+    }
+}

--- a/engine/src/workers/configuration/mod.rs
+++ b/engine/src/workers/configuration/mod.rs
@@ -1,0 +1,18 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+pub mod adapters;
+mod config;
+
+#[allow(clippy::module_inception)]
+mod configuration;
+
+pub mod registry;
+mod store;
+pub mod structs;
+mod trigger;
+
+pub use self::configuration::ConfigurationWorker;

--- a/engine/src/workers/configuration/registry.rs
+++ b/engine/src/workers/configuration/registry.rs
@@ -1,0 +1,15 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+use crate::workers::{
+    configuration::adapters::ConfigurationAdapter,
+    registry::{AdapterFuture, AdapterRegistration},
+};
+
+pub type ConfigurationAdapterFuture = AdapterFuture<dyn ConfigurationAdapter>;
+pub type ConfigurationAdapterRegistration = AdapterRegistration<dyn ConfigurationAdapter>;
+
+inventory::collect!(ConfigurationAdapterRegistration);

--- a/engine/src/workers/configuration/skills/SKILL.md
+++ b/engine/src/workers/configuration/skills/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: configuration
+description: >-
+  Schema-validated, reactive registry for named configuration entries — the
+  migration target for per-worker config blocks currently in engine/config.yaml.
+---
+
+# configuration
+
+The `configuration` worker is a server-side registry of named entries. Every entry has an id (e.g. `iii-stream`, `billing-service`), a human-readable name and description, a JSON Schema describing the value shape, and a JSON value validated against that schema. Workers call `configuration::register` once at startup to declare their schema and `configuration::set` to publish values; consumers call `configuration::get` / `configuration::list` to read and bind a `configuration` trigger to react to changes without polling.
+
+The default `fs` adapter persists one YAML file per id under `./data/configuration` and watches the directory for external edits, so manual edits to those files surface as `configuration:updated` events the same way SDK calls do. The `bridge` adapter delegates to a remote engine and re-broadcasts its events into the local fan-out — the function surface is identical across adapters. The worker is enabled by default in `engine/config.yaml`.
+
+A per-id TTL (off by default) cleans up entries whose last subscriber trigger has unregistered, scoped to the lifecycle of ephemeral workers that come and go without an explicit teardown step.
+
+## When to Use
+
+- A worker is migrating its block out of `engine/config.yaml` and needs a typed, observable surface other workers can read and validate against.
+- Two workers need to agree on the same configuration values without one polling the other or hardcoding a path on disk.
+- An operator should be able to edit a single YAML file (or the remote control plane) and have the change propagate to every subscriber without a worker restart.
+- A worker comes and goes (sandboxes, ephemeral consumers) and its configuration should be cleaned up automatically when no one is left subscribing.
+
+## Boundaries
+
+- Not a general-purpose key/value store — every entry must have a registered JSON Schema. Use `iii-state` for free-form values.
+- No partial-update surface; `set` always replaces the whole value. Build the new value client-side and ship it in one call.
+- The `bridge` adapter cannot delete entries on the remote engine; cleanup over the bridge happens via TTL or directly on the source engine.
+- Schemas are not version-checked across re-registrations — re-registering with an incompatible schema simply replaces it. Coordinate schema migrations out-of-band.
+
+## Functions
+
+- `configuration::register` — declare an id with name, description, JSON Schema, and an optional `initial_value`; idempotent re-registration replaces the schema and metadata.
+- `configuration::set` — replace the value for a registered id; validates against the registered schema and emits `configuration:updated`.
+- `configuration::get` — read one entry by id; expands `${VAR:default}` against live env unless `raw: true`.
+- `configuration::list` — enumerate every registered id with name, description, and schema; never returns the value.
+- `configuration::schema` — read schema/name/description for one id without exposing the value.
+
+`register` and `set` are the only mutators; the read-side functions are cache-backed and cheap. Reads expand `${VAR:default}` placeholders against the live process env on every call, so env changes propagate without restarts — pass `raw: true` to `configuration::get` when you need the stored template form.
+
+## Reactive triggers
+
+Bind a `configuration` trigger when a function should run automatically on every register / set / delete — including external `fs` file edits and bridge-forwarded events from a remote engine. The engine invokes matching handlers asynchronously after each successful mutation and after TTL-driven cleanup, so a worker stays in sync with its configuration without polling.
+
+Reach for it when:
+
+- A worker needs to reload in-memory state when its configuration is rewritten by another component or by an operator editing the YAML directly.
+- The same handler should run regardless of who edited the configuration (local SDK call, remote engine via the bridge adapter, or a file edit).
+
+If you only need the new value inside the same function that wrote it, `configuration::set` already returns `old_value` / `new_value` — register a trigger only when a *different* worker should react.
+
+### How to bind
+
+1. Register a handler: `iii.registerFunction('stream::on-config-change', handler)`.
+2. Register the trigger:
+
+```typescript
+iii.registerTrigger({
+  type: 'configuration',
+  function_id: 'stream::on-config-change',
+  config: {
+    configuration_id: 'iii-stream',          // optional. Omit to receive every id.
+    event_types: ['configuration:updated'],  // optional. Subset of registered/updated/deleted.
+    // condition_function_id is also supported — see get function info.
+  },
+})
+```
+
+Mutations that fire triggers: `configuration::register` (`:registered` on first call, `:updated` on re-registration), `configuration::set` (`:updated`), TTL cleanup (`:deleted`), and external `fs` create/edit/delete events. Reads do **not** fire triggers.
+
+The worker also respects per-id TTL: when `ttl_seconds > 0` is configured and the **last** trigger bound to a `configuration_id` is unregistered, the entry is deleted after the TTL elapses. A new trigger registration before the countdown fires aborts the cleanup.
+
+For the event payload shape, call `iii get function info` on the trigger type or handler function id.

--- a/engine/src/workers/configuration/skills/SKILL.md
+++ b/engine/src/workers/configuration/skills/SKILL.md
@@ -59,7 +59,7 @@ iii.registerTrigger({
   function_id: 'stream::on-config-change',
   config: {
     configuration_id: 'iii-stream',          // optional. Omit to receive every id.
-    event_types: ['configuration:updated'],  // optional. Subset of registered/updated/deleted.
+    event_types: ['configuration:updated'],  // optional. Subset of configuration:registered|configuration:updated|configuration:deleted.
     // condition_function_id is also supported — see get function info.
   },
 })

--- a/engine/src/workers/configuration/store.rs
+++ b/engine/src/workers/configuration/store.rs
@@ -1,0 +1,304 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! In-memory cache + schema validation layer that sits between the
+//! `configuration::*` engine functions and the on-disk / remote adapter.
+//!
+//! Loading is lazy: the cache stays empty until either `register` or
+//! `prime_from_adapter` populates it. Reads check the cache first and fall
+//! back to the adapter; writes update both atomically.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use jsonschema::Validator;
+use serde_json::{Map, Value};
+use tokio::sync::RwLock;
+
+use crate::workers::config::EngineConfig;
+use crate::workers::configuration::adapters::{
+    ConfigurationAdapter, ExternalChange, RegisterOutcome, SetOutcome,
+};
+use crate::workers::configuration::structs::{ConfigurationEntry, ConfigurationSchemaView};
+
+/// Walk a JSON value and replace every string leaf with the env-var-expanded
+/// form (`${VAR:default}` → process env or default). Maps and arrays are
+/// walked recursively; non-string scalars pass through unchanged.
+pub fn expand_value(v: &Value) -> Value {
+    match v {
+        Value::String(s) => Value::String(EngineConfig::expand_env_vars(s)),
+        Value::Array(items) => Value::Array(items.iter().map(expand_value).collect()),
+        Value::Object(map) => {
+            let mut out: Map<String, Value> = Map::with_capacity(map.len());
+            for (k, val) in map {
+                out.insert(k.clone(), expand_value(val));
+            }
+            Value::Object(out)
+        }
+        other => other.clone(),
+    }
+}
+
+/// Validate `value` against `schema`. Returns a list of human-readable
+/// error strings; an empty list means the value is valid.
+pub fn validate_against_schema(value: &Value, schema: &Value) -> Result<(), Vec<String>> {
+    let validator = match Validator::new(schema) {
+        Ok(v) => v,
+        Err(err) => {
+            return Err(vec![format!("invalid JSON Schema: {}", err)]);
+        }
+    };
+    let errors: Vec<String> = validator
+        .iter_errors(value)
+        .map(|e| e.to_string())
+        .collect();
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+    #[error("configuration '{0}' is not registered; call configuration::register first")]
+    NotRegistered(String),
+    #[error("invalid configuration id '{0}': must match [a-z0-9_-]{{1,64}}")]
+    InvalidId(String),
+    #[error("schema validation failed: {0}")]
+    SchemaInvalid(String),
+    #[error(transparent)]
+    Adapter(#[from] anyhow::Error),
+}
+
+pub struct ConfigurationStore {
+    adapter: Arc<dyn ConfigurationAdapter>,
+    /// Authoritative in-memory cache. Source of truth for `get`/`list`/`schema`.
+    /// Populated lazily from the adapter and kept in sync on every mutation.
+    entries: Arc<RwLock<HashMap<String, ConfigurationEntry>>>,
+}
+
+impl ConfigurationStore {
+    pub fn new(adapter: Arc<dyn ConfigurationAdapter>) -> Self {
+        Self {
+            adapter,
+            entries: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub fn adapter(&self) -> &Arc<dyn ConfigurationAdapter> {
+        &self.adapter
+    }
+
+    /// Pull every entry the adapter knows about into the cache. Called once
+    /// during worker `initialize()`.
+    pub async fn prime_from_adapter(&self) -> anyhow::Result<()> {
+        let entries = self.adapter.list().await?;
+        let mut cache = self.entries.write().await;
+        cache.clear();
+        for entry in entries {
+            cache.insert(entry.id.clone(), entry);
+        }
+        Ok(())
+    }
+
+    pub async fn register(
+        &self,
+        id: String,
+        name: String,
+        description: String,
+        schema: Value,
+        initial_value: Option<Value>,
+        metadata: Option<Value>,
+    ) -> Result<RegisterOutcome, StoreError> {
+        Self::validate_id(&id)?;
+
+        // Determine the value being installed. Existing entries keep their
+        // value unless `initial_value` is supplied. New entries default to
+        // `Value::Null`.
+        let prior = self.entries.read().await.get(&id).cloned();
+        let value = match (initial_value, prior.as_ref()) {
+            (Some(v), _) => v,
+            (None, Some(existing)) => existing.value.clone(),
+            (None, None) => Value::Null,
+        };
+
+        // Skip schema validation when the seeded value is the implicit
+        // `Null` placeholder for a brand-new entry — the schema may legitimately
+        // disallow null, and the entry has no caller-supplied value yet.
+        if !(prior.is_none() && value.is_null())
+            && let Err(errs) = validate_against_schema(&value, &schema)
+        {
+            return Err(StoreError::SchemaInvalid(errs.join("; ")));
+        }
+
+        let entry = ConfigurationEntry {
+            id: id.clone(),
+            name,
+            description,
+            schema,
+            value,
+            metadata,
+        };
+        let outcome = self.adapter.register(entry.clone()).await?;
+        self.entries.write().await.insert(id, outcome.entry.clone());
+        Ok(outcome)
+    }
+
+    pub async fn set(&self, id: &str, value: Value) -> Result<SetOutcome, StoreError> {
+        Self::validate_id(id)?;
+
+        let entry = self.entries.read().await.get(id).cloned();
+        let entry = match entry {
+            Some(e) => e,
+            None => return Err(StoreError::NotRegistered(id.to_string())),
+        };
+
+        if let Err(errs) = validate_against_schema(&value, &entry.schema) {
+            return Err(StoreError::SchemaInvalid(errs.join("; ")));
+        }
+
+        let outcome = self.adapter.set(id, value).await?;
+        self.entries
+            .write()
+            .await
+            .insert(id.to_string(), outcome.entry.clone());
+        Ok(outcome)
+    }
+
+    pub async fn get(&self, id: &str) -> Option<ConfigurationEntry> {
+        self.entries.read().await.get(id).cloned()
+    }
+
+    pub async fn delete(&self, id: &str) -> Result<Option<ConfigurationEntry>, StoreError> {
+        let removed = self.adapter.delete(id).await?;
+        if removed.is_some() {
+            self.entries.write().await.remove(id);
+        }
+        Ok(removed)
+    }
+
+    pub async fn list(&self) -> Vec<ConfigurationSchemaView> {
+        let cache = self.entries.read().await;
+        let mut views: Vec<ConfigurationSchemaView> =
+            cache.values().map(ConfigurationSchemaView::from).collect();
+        views.sort_by(|a, b| a.id.cmp(&b.id));
+        views
+    }
+
+    pub async fn schema_view(&self, id: &str) -> Option<ConfigurationSchemaView> {
+        self.entries
+            .read()
+            .await
+            .get(id)
+            .map(ConfigurationSchemaView::from)
+    }
+
+    /// Apply an external change (file edit, remote bridge event) into the
+    /// cache without round-tripping through the adapter again.
+    pub async fn apply_external(&self, change: &ExternalChange) {
+        let mut cache = self.entries.write().await;
+        match change {
+            ExternalChange::Registered(entry) | ExternalChange::Updated { entry, .. } => {
+                cache.insert(entry.id.clone(), entry.clone());
+            }
+            ExternalChange::Deleted { entry } => {
+                cache.remove(&entry.id);
+            }
+        }
+    }
+
+    fn validate_id(id: &str) -> Result<(), StoreError> {
+        if id.is_empty() || id.len() > 64 {
+            return Err(StoreError::InvalidId(id.to_string()));
+        }
+        if !id
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-' || b == b'_')
+        {
+            return Err(StoreError::InvalidId(id.to_string()));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn expand_value_replaces_env_var_in_string() {
+        unsafe {
+            std::env::set_var("CFG_TEST_HOST", "db.local");
+        }
+        let input = json!({ "host": "${CFG_TEST_HOST:fallback}", "port": 5432 });
+        let expanded = expand_value(&input);
+        assert_eq!(expanded["host"], "db.local");
+        assert_eq!(expanded["port"], 5432);
+    }
+
+    #[test]
+    fn expand_value_uses_default_when_var_missing() {
+        unsafe {
+            std::env::remove_var("CFG_TEST_MISSING");
+        }
+        let input = json!({ "url": "${CFG_TEST_MISSING:http://default}" });
+        assert_eq!(expand_value(&input)["url"], "http://default");
+    }
+
+    #[test]
+    fn expand_value_walks_arrays_and_nested_objects() {
+        unsafe {
+            std::env::set_var("CFG_TEST_NAME", "alice");
+        }
+        let input = json!({
+            "users": [
+                { "name": "${CFG_TEST_NAME:?}" },
+                { "name": "static" }
+            ]
+        });
+        let out = expand_value(&input);
+        assert_eq!(out["users"][0]["name"], "alice");
+        assert_eq!(out["users"][1]["name"], "static");
+    }
+
+    #[test]
+    fn expand_value_passes_non_string_scalars_through() {
+        let input = json!({ "n": 42, "b": true, "nil": null });
+        let out = expand_value(&input);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn validate_against_schema_passes_valid_value() {
+        let schema = json!({ "type": "object", "required": ["port"], "properties": { "port": { "type": "integer" } } });
+        assert!(validate_against_schema(&json!({ "port": 3112 }), &schema).is_ok());
+    }
+
+    #[test]
+    fn validate_against_schema_rejects_invalid_value() {
+        let schema = json!({ "type": "object", "required": ["port"], "properties": { "port": { "type": "integer" } } });
+        let err = validate_against_schema(&json!({ "port": "nope" }), &schema)
+            .expect_err("string is not integer");
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn validate_id_rejects_uppercase_and_long_ids() {
+        assert!(matches!(
+            ConfigurationStore::validate_id("UPPER"),
+            Err(StoreError::InvalidId(_))
+        ));
+        let long = "a".repeat(65);
+        assert!(matches!(
+            ConfigurationStore::validate_id(&long),
+            Err(StoreError::InvalidId(_))
+        ));
+        assert!(ConfigurationStore::validate_id("iii-stream").is_ok());
+        assert!(ConfigurationStore::validate_id("a_b-c-1").is_ok());
+    }
+}

--- a/engine/src/workers/configuration/structs.rs
+++ b/engine/src/workers/configuration/structs.rs
@@ -1,0 +1,190 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// A single configuration entry tracked by the worker.
+///
+/// `value` is stored verbatim — including any `${VAR:default}` template
+/// strings. Expansion happens on read (`configuration::get`) and during
+/// trigger fan-out so env-var changes propagate without a worker restart.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ConfigurationEntry {
+    /// Stable identifier (e.g. `iii-stream`, `iii-observability`).
+    pub id: String,
+    /// Human-readable display name.
+    pub name: String,
+    /// One-line description of what this configuration controls.
+    pub description: String,
+    /// JSON Schema describing the shape of `value`.
+    pub schema: Value,
+    /// Stored configuration body. May contain `${VAR:default}` placeholders.
+    #[serde(default)]
+    pub value: Value,
+    /// Optional caller-supplied metadata (owner team, change ticket, etc.).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+/// Subset of a [`ConfigurationEntry`] returned from `list` / `schema` —
+/// the schema-only view that never leaks the stored value.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ConfigurationSchemaView {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub schema: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+impl From<&ConfigurationEntry> for ConfigurationSchemaView {
+    fn from(entry: &ConfigurationEntry) -> Self {
+        Self {
+            id: entry.id.clone(),
+            name: entry.name.clone(),
+            description: entry.description.clone(),
+            schema: entry.schema.clone(),
+            metadata: entry.metadata.clone(),
+        }
+    }
+}
+
+// ── function inputs / outputs ───────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ConfigurationRegisterInput {
+    /// Configuration id. Must match `[a-z0-9_-]{1,64}` so it is safe as a
+    /// filename in the `fs` adapter.
+    pub id: String,
+    /// Human-readable name shown in `configuration::list`.
+    pub name: String,
+    /// Description shown in `configuration::list`.
+    pub description: String,
+    /// JSON Schema describing the value shape. `set` validates against this.
+    pub schema: Value,
+    /// Optional initial value to install. Validated against `schema`.
+    pub initial_value: Option<Value>,
+    /// Optional opaque metadata stored alongside the entry.
+    pub metadata: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ConfigurationSetInput {
+    pub id: String,
+    /// New configuration value. Validated against the registered schema.
+    pub value: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ConfigurationGetInput {
+    pub id: String,
+    /// When `true`, return the stored value verbatim (including `${VAR}` placeholders).
+    /// When `false` (default), expand `${VAR:default}` against the live process env.
+    #[serde(default)]
+    pub raw: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ConfigurationListInput {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ConfigurationSchemaInput {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ConfigurationGetResult {
+    pub id: String,
+    pub value: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ConfigurationSetResult {
+    /// Previous stored value, or `null` when the entry had no value yet.
+    pub old_value: Option<Value>,
+    /// Current stored value (templates not expanded).
+    pub new_value: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ConfigurationListResult {
+    pub configurations: Vec<ConfigurationSchemaView>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub enum ConfigurationEventType {
+    #[serde(rename = "configuration:registered")]
+    Registered,
+    #[serde(rename = "configuration:updated")]
+    Updated,
+    #[serde(rename = "configuration:deleted")]
+    Deleted,
+}
+
+/// Trigger event payload. Mirrors [`crate::trigger_formats::ConfigurationCallRequest`]
+/// but lives next to the worker so the in-process invoker doesn't depend on
+/// the schema-only struct.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConfigurationEventData {
+    #[serde(rename = "type")]
+    pub message_type: String,
+    pub event_type: ConfigurationEventType,
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub schema: Value,
+    pub old_value: Option<Value>,
+    pub new_value: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn schema_view_drops_value_field() {
+        let entry = ConfigurationEntry {
+            id: "iii-stream".into(),
+            name: "Stream worker".into(),
+            description: "...".into(),
+            schema: json!({ "type": "object" }),
+            value: json!({ "port": 3112 }),
+            metadata: None,
+        };
+        let view = ConfigurationSchemaView::from(&entry);
+        let serialized = serde_json::to_value(view).unwrap();
+        assert!(serialized.get("value").is_none());
+        assert_eq!(serialized["id"], "iii-stream");
+    }
+
+    #[test]
+    fn event_type_serde_roundtrip() {
+        for (variant, wire) in [
+            (
+                ConfigurationEventType::Registered,
+                "configuration:registered",
+            ),
+            (ConfigurationEventType::Updated, "configuration:updated"),
+            (ConfigurationEventType::Deleted, "configuration:deleted"),
+        ] {
+            let v = serde_json::to_value(&variant).unwrap();
+            assert_eq!(v.as_str().unwrap(), wire);
+        }
+    }
+
+    #[test]
+    fn get_input_defaults_raw_to_false() {
+        let input: ConfigurationGetInput =
+            serde_json::from_value(json!({ "id": "iii-stream" })).unwrap();
+        assert!(!input.raw);
+    }
+}

--- a/engine/src/workers/configuration/trigger.rs
+++ b/engine/src/workers/configuration/trigger.rs
@@ -1,0 +1,497 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! `configuration` trigger type.
+//!
+//! Subscribers bind a function to changes on a specific configuration id by
+//! registering a trigger of type `configuration`. The worker walks every
+//! matching trigger after each create / update / delete and invokes the
+//! handler asynchronously via `engine.call(...)`.
+//!
+//! ## TTL
+//!
+//! Each id maintains a ref-count of currently registered triggers. When the
+//! ref-count drops to zero AND the worker config has `ttl_seconds > 0`, a
+//! `tokio::spawn`-based countdown is scheduled. The countdown deletes the
+//! configuration entry (and emits `configuration:deleted`) when it elapses
+//! without being interrupted. A new trigger registration before expiry
+//! aborts the pending task; `destroy()` aborts every live countdown.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::time::Duration;
+
+use futures::Future;
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
+
+use crate::trigger::{Trigger, TriggerRegistrator};
+use crate::workers::configuration::ConfigurationWorker;
+
+pub const TRIGGER_TYPE: &str = "configuration";
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct ConfigurationTriggerConfig {
+    /// Configuration id to watch (exact match). Omit to match every id.
+    #[serde(default)]
+    pub configuration_id: Option<String>,
+    /// Event type filter (e.g. `["configuration:updated"]`). Omit to match all.
+    #[serde(default)]
+    pub event_types: Option<Vec<String>>,
+    /// Optional condition function evaluated on the event before the handler runs.
+    #[serde(default)]
+    pub condition_function_id: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct ConfigurationTrigger {
+    pub config: ConfigurationTriggerConfig,
+    pub trigger: Trigger,
+}
+
+/// Per-configuration-id trigger ref-count + pending TTL handle.
+struct TriggerSlot {
+    triggers: HashMap<String, ConfigurationTrigger>,
+    expiry: Option<JoinHandle<()>>,
+}
+
+impl TriggerSlot {
+    fn new() -> Self {
+        Self {
+            triggers: HashMap::new(),
+            expiry: None,
+        }
+    }
+}
+
+pub struct ConfigurationTriggers {
+    /// Triggers without a configuration_id filter — fan out to every event
+    /// regardless of id. Stored separately so they don't keep arbitrary
+    /// id-specific slots alive.
+    global: RwLock<HashMap<String, ConfigurationTrigger>>,
+    /// Triggers scoped to a specific configuration_id. The slot also holds
+    /// the TTL countdown JoinHandle for that id.
+    per_id: RwLock<HashMap<String, TriggerSlot>>,
+}
+
+impl Default for ConfigurationTriggers {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ConfigurationTriggers {
+    pub fn new() -> Self {
+        Self {
+            global: RwLock::new(HashMap::new()),
+            per_id: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Snapshot every trigger that should be evaluated for a given id +
+    /// event type. Filtering by event type happens in the worker; this
+    /// method collapses the global + per-id buckets so the caller doesn't
+    /// have to know about the split.
+    pub async fn matching(&self, id: &str) -> Vec<ConfigurationTrigger> {
+        let mut out = Vec::new();
+        for trigger in self.global.read().await.values() {
+            out.push(trigger.clone());
+        }
+        if let Some(slot) = self.per_id.read().await.get(id) {
+            for trigger in slot.triggers.values() {
+                out.push(trigger.clone());
+            }
+        }
+        out
+    }
+
+    /// Abort every pending TTL countdown. Called by the worker on shutdown.
+    pub async fn abort_all_expiries(&self) {
+        let mut per_id = self.per_id.write().await;
+        for slot in per_id.values_mut() {
+            if let Some(handle) = slot.expiry.take() {
+                handle.abort();
+            }
+        }
+    }
+
+    /// Test-only — does the per-id slot currently have a pending expiry task?
+    #[cfg(test)]
+    pub async fn has_pending_expiry(&self, id: &str) -> bool {
+        self.per_id
+            .read()
+            .await
+            .get(id)
+            .map(|slot| slot.expiry.is_some())
+            .unwrap_or(false)
+    }
+
+    /// Test-only — total triggers registered for a given id (global triggers
+    /// excluded since they're not bound to any specific id).
+    #[cfg(test)]
+    pub async fn id_trigger_count(&self, id: &str) -> usize {
+        self.per_id
+            .read()
+            .await
+            .get(id)
+            .map(|slot| slot.triggers.len())
+            .unwrap_or(0)
+    }
+}
+
+#[async_trait::async_trait]
+impl TriggerRegistrator for ConfigurationWorker {
+    fn register_trigger(
+        &self,
+        trigger: Trigger,
+    ) -> Pin<Box<dyn Future<Output = Result<(), anyhow::Error>> + Send + '_>> {
+        Box::pin(async move {
+            let config: ConfigurationTriggerConfig = serde_json::from_value(trigger.config.clone())
+                .map_err(|e| {
+                    anyhow::anyhow!("Failed to parse configuration trigger config: {}", e)
+                })?;
+
+            let trigger_id = trigger.id.clone();
+            let stored = ConfigurationTrigger {
+                config: config.clone(),
+                trigger,
+            };
+
+            tracing::info!(
+                trigger_id = %trigger_id,
+                configuration_id = ?config.configuration_id,
+                event_types = ?config.event_types,
+                "Registering configuration trigger"
+            );
+
+            match config.configuration_id.as_ref() {
+                None => {
+                    self.triggers
+                        .global
+                        .write()
+                        .await
+                        .insert(trigger_id, stored);
+                }
+                Some(cfg_id) => {
+                    let mut per_id = self.triggers.per_id.write().await;
+                    let slot = per_id
+                        .entry(cfg_id.clone())
+                        .or_insert_with(TriggerSlot::new);
+                    if let Some(handle) = slot.expiry.take() {
+                        handle.abort();
+                        tracing::debug!(
+                            configuration_id = %cfg_id,
+                            "Cancelled pending TTL expiry due to new trigger registration"
+                        );
+                    }
+                    slot.triggers.insert(trigger_id, stored);
+                }
+            }
+            Ok(())
+        })
+    }
+
+    fn unregister_trigger(
+        &self,
+        trigger: Trigger,
+    ) -> Pin<Box<dyn Future<Output = Result<(), anyhow::Error>> + Send + '_>> {
+        Box::pin(async move {
+            let trigger_id = trigger.id.clone();
+            let parsed: ConfigurationTriggerConfig =
+                serde_json::from_value(trigger.config.clone()).unwrap_or_default();
+
+            match parsed.configuration_id.as_ref() {
+                None => {
+                    self.triggers.global.write().await.remove(&trigger_id);
+                }
+                Some(cfg_id) => {
+                    let cfg_id = cfg_id.clone();
+                    let now_empty = {
+                        let mut per_id = self.triggers.per_id.write().await;
+                        if let Some(slot) = per_id.get_mut(&cfg_id) {
+                            slot.triggers.remove(&trigger_id);
+                            slot.triggers.is_empty()
+                        } else {
+                            false
+                        }
+                    };
+
+                    if now_empty && self.ttl_seconds > 0 {
+                        self.schedule_ttl_expiry(cfg_id).await;
+                    }
+                }
+            }
+            Ok(())
+        })
+    }
+}
+
+impl ConfigurationWorker {
+    /// Spawn a TTL countdown for `cfg_id`. Stores the JoinHandle on the
+    /// per-id slot so a subsequent registration (or `destroy()`) can abort it.
+    async fn schedule_ttl_expiry(&self, cfg_id: String) {
+        let ttl = Duration::from_secs(self.ttl_seconds);
+        let worker = self.clone();
+        let cfg_id_for_task = cfg_id.clone();
+
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(ttl).await;
+            tracing::info!(
+                configuration_id = %cfg_id_for_task,
+                ttl_seconds = worker.ttl_seconds,
+                "TTL expired with no triggers — cleaning up configuration"
+            );
+            if let Err(e) = worker.expire_configuration(&cfg_id_for_task).await {
+                tracing::error!(
+                    configuration_id = %cfg_id_for_task,
+                    error = %e,
+                    "Failed to expire configuration"
+                );
+            }
+        });
+
+        let mut per_id = self.triggers.per_id.write().await;
+        let slot = per_id.entry(cfg_id).or_insert_with(TriggerSlot::new);
+        // Replace any leftover handle (race between rapid unregister-register
+        // cycles) — the previous handle was already aborted by register.
+        if let Some(prev) = slot.expiry.replace(handle) {
+            prev.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::Arc;
+
+    #[test]
+    fn config_defaults_match_optional_filters() {
+        let cfg: ConfigurationTriggerConfig = serde_json::from_value(json!({})).unwrap();
+        assert!(cfg.configuration_id.is_none());
+        assert!(cfg.event_types.is_none());
+        assert!(cfg.condition_function_id.is_none());
+    }
+
+    #[test]
+    fn config_with_explicit_filters() {
+        let cfg: ConfigurationTriggerConfig = serde_json::from_value(json!({
+            "configuration_id": "iii-stream",
+            "event_types": ["configuration:updated"],
+        }))
+        .unwrap();
+        assert_eq!(cfg.configuration_id.as_deref(), Some("iii-stream"));
+        assert_eq!(
+            cfg.event_types.as_deref(),
+            Some(&["configuration:updated".to_string()][..])
+        );
+    }
+
+    #[tokio::test]
+    async fn register_then_unregister_drains_per_id_slot() {
+        use crate::workers::configuration::{
+            ConfigurationWorker, adapters::ConfigurationAdapter, adapters::fs::FsAdapter,
+        };
+        crate::workers::observability::metrics::ensure_default_meter();
+
+        let dir = tempfile::tempdir().unwrap();
+        let adapter = Arc::new(
+            FsAdapter::new(Some(json!({ "directory": dir.path().to_str().unwrap() })))
+                .await
+                .unwrap(),
+        ) as Arc<dyn ConfigurationAdapter>;
+        let engine = Arc::new(crate::engine::Engine::new());
+        let worker = ConfigurationWorker::for_test(engine, adapter, 0);
+
+        let trigger = Trigger {
+            id: "t-1".into(),
+            trigger_type: TRIGGER_TYPE.into(),
+            function_id: "h::handler".into(),
+            config: json!({ "configuration_id": "iii-stream" }),
+            worker_id: None,
+            metadata: None,
+        };
+        worker.register_trigger(trigger.clone()).await.unwrap();
+        assert_eq!(worker.triggers.id_trigger_count("iii-stream").await, 1);
+
+        worker.unregister_trigger(trigger).await.unwrap();
+        assert_eq!(worker.triggers.id_trigger_count("iii-stream").await, 0);
+        // ttl_seconds=0 means no countdown is scheduled.
+        assert!(!worker.triggers.has_pending_expiry("iii-stream").await);
+    }
+
+    #[tokio::test]
+    async fn ttl_countdown_fires_when_last_trigger_unregistered() {
+        use crate::workers::configuration::{
+            ConfigurationWorker, adapters::ConfigurationAdapter, adapters::fs::FsAdapter,
+            structs::ConfigurationRegisterInput,
+        };
+        crate::workers::observability::metrics::ensure_default_meter();
+
+        let dir = tempfile::tempdir().unwrap();
+        let adapter = Arc::new(
+            FsAdapter::new(Some(json!({ "directory": dir.path().to_str().unwrap() })))
+                .await
+                .unwrap(),
+        ) as Arc<dyn ConfigurationAdapter>;
+        let engine = Arc::new(crate::engine::Engine::new());
+        // 1-second TTL keeps the test fast but still exercises the real
+        // tokio::time::sleep path the production code uses.
+        let worker = ConfigurationWorker::for_test(engine, adapter, 1);
+
+        worker
+            .register_fn(ConfigurationRegisterInput {
+                id: "iii-stream".into(),
+                name: "Stream".into(),
+                description: "...".into(),
+                schema: json!({ "type": "object" }),
+                initial_value: Some(json!({})),
+                metadata: None,
+            })
+            .await;
+        assert!(worker.store.get("iii-stream").await.is_some());
+
+        let trigger = Trigger {
+            id: "t-ttl".into(),
+            trigger_type: TRIGGER_TYPE.into(),
+            function_id: "h::handler".into(),
+            config: json!({ "configuration_id": "iii-stream" }),
+            worker_id: None,
+            metadata: None,
+        };
+        worker.register_trigger(trigger.clone()).await.unwrap();
+        worker.unregister_trigger(trigger).await.unwrap();
+
+        // Pending expiry handle exists immediately after the unregister.
+        assert!(worker.triggers.has_pending_expiry("iii-stream").await);
+
+        // Wait long enough for the real-time TTL to elapse and the cleanup
+        // task to run. Loop with a short interval so we don't oversleep.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if worker.store.get("iii-stream").await.is_none() {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!("configuration should be cleaned up after TTL elapses");
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn ttl_countdown_aborts_on_re_register() {
+        use crate::workers::configuration::{
+            ConfigurationWorker, adapters::ConfigurationAdapter, adapters::fs::FsAdapter,
+            structs::ConfigurationRegisterInput,
+        };
+        crate::workers::observability::metrics::ensure_default_meter();
+
+        let dir = tempfile::tempdir().unwrap();
+        let adapter = Arc::new(
+            FsAdapter::new(Some(json!({ "directory": dir.path().to_str().unwrap() })))
+                .await
+                .unwrap(),
+        ) as Arc<dyn ConfigurationAdapter>;
+        let engine = Arc::new(crate::engine::Engine::new());
+        let worker = ConfigurationWorker::for_test(engine, adapter, 1);
+
+        worker
+            .register_fn(ConfigurationRegisterInput {
+                id: "iii-stream".into(),
+                name: "Stream".into(),
+                description: "...".into(),
+                schema: json!({ "type": "object" }),
+                initial_value: Some(json!({})),
+                metadata: None,
+            })
+            .await;
+
+        let trigger_a = Trigger {
+            id: "t-a".into(),
+            trigger_type: TRIGGER_TYPE.into(),
+            function_id: "h::a".into(),
+            config: json!({ "configuration_id": "iii-stream" }),
+            worker_id: None,
+            metadata: None,
+        };
+        worker.register_trigger(trigger_a.clone()).await.unwrap();
+        worker.unregister_trigger(trigger_a).await.unwrap();
+        assert!(worker.triggers.has_pending_expiry("iii-stream").await);
+
+        // New trigger arrives BEFORE TTL elapses — countdown should abort.
+        let trigger_b = Trigger {
+            id: "t-b".into(),
+            trigger_type: TRIGGER_TYPE.into(),
+            function_id: "h::b".into(),
+            config: json!({ "configuration_id": "iii-stream" }),
+            worker_id: None,
+            metadata: None,
+        };
+        worker.register_trigger(trigger_b).await.unwrap();
+        assert!(!worker.triggers.has_pending_expiry("iii-stream").await);
+
+        // Wait > TTL of real time so any leftover countdown would have fired.
+        tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+
+        assert!(
+            worker.store.get("iii-stream").await.is_some(),
+            "configuration should survive when a new trigger lands before TTL elapses"
+        );
+    }
+
+    #[tokio::test]
+    async fn matching_collapses_global_and_per_id_buckets() {
+        let triggers = ConfigurationTriggers::new();
+        triggers.global.write().await.insert(
+            "g-1".into(),
+            ConfigurationTrigger {
+                config: ConfigurationTriggerConfig::default(),
+                trigger: Trigger {
+                    id: "g-1".into(),
+                    trigger_type: TRIGGER_TYPE.into(),
+                    function_id: "f::a".into(),
+                    config: json!({}),
+                    worker_id: None,
+                    metadata: None,
+                },
+            },
+        );
+
+        let mut slot = TriggerSlot::new();
+        slot.triggers.insert(
+            "p-1".into(),
+            ConfigurationTrigger {
+                config: ConfigurationTriggerConfig {
+                    configuration_id: Some("iii-stream".into()),
+                    ..Default::default()
+                },
+                trigger: Trigger {
+                    id: "p-1".into(),
+                    trigger_type: TRIGGER_TYPE.into(),
+                    function_id: "f::b".into(),
+                    config: json!({ "configuration_id": "iii-stream" }),
+                    worker_id: None,
+                    metadata: None,
+                },
+            },
+        );
+        triggers
+            .per_id
+            .write()
+            .await
+            .insert("iii-stream".into(), slot);
+
+        let matched = triggers.matching("iii-stream").await;
+        assert_eq!(matched.len(), 2);
+
+        let unmatched = triggers.matching("other").await;
+        assert_eq!(unmatched.len(), 1);
+        assert_eq!(unmatched[0].trigger.id, "g-1");
+    }
+}

--- a/engine/src/workers/configuration/trigger.rs
+++ b/engine/src/workers/configuration/trigger.rs
@@ -233,10 +233,26 @@ impl TriggerRegistrator for ConfigurationWorker {
 impl ConfigurationWorker {
     /// Spawn a TTL countdown for `cfg_id`. Stores the JoinHandle on the
     /// per-id slot so a subsequent registration (or `destroy()`) can abort it.
+    ///
+    /// Re-checks the slot's trigger count under the write lock before
+    /// installing the handle: `unregister_trigger` releases its lock between
+    /// "slot is empty" and this call, so a concurrent `register_trigger` may
+    /// have repopulated the slot in that window. Bail out in that case so the
+    /// TTL countdown isn't scheduled against a slot that is no longer empty.
     async fn schedule_ttl_expiry(&self, cfg_id: String) {
         let ttl = Duration::from_secs(self.ttl_seconds);
         let worker = self.clone();
         let cfg_id_for_task = cfg_id.clone();
+
+        let mut per_id = self.triggers.per_id.write().await;
+        let slot = per_id.entry(cfg_id).or_insert_with(TriggerSlot::new);
+        if !slot.triggers.is_empty() {
+            tracing::debug!(
+                configuration_id = %cfg_id_for_task,
+                "Skipping TTL countdown — a concurrent registration repopulated the slot"
+            );
+            return;
+        }
 
         let handle = tokio::spawn(async move {
             tokio::time::sleep(ttl).await;
@@ -254,8 +270,6 @@ impl ConfigurationWorker {
             }
         });
 
-        let mut per_id = self.triggers.per_id.write().await;
-        let slot = per_id.entry(cfg_id).or_insert_with(TriggerSlot::new);
         // Replace any leftover handle (race between rapid unregister-register
         // cycles) — the previous handle was already aborted by register.
         if let Some(prev) = slot.expiry.replace(handle) {

--- a/engine/src/workers/telemetry/mod.rs
+++ b/engine/src/workers/telemetry/mod.rs
@@ -203,6 +203,7 @@ pub fn is_iii_builtin_function_id(id: &str) -> bool {
     id.starts_with("engine::")
         || id.starts_with("state::")
         || id.starts_with("stream::")
+        || id.starts_with("configuration::")
         || id.starts_with("iii::")
         || id.starts_with("bridge.")
         || id.starts_with("motia::")
@@ -2137,6 +2138,7 @@ mod tests {
         assert!(is_iii_builtin_function_id("engine::x"));
         assert!(is_iii_builtin_function_id("state::get"));
         assert!(is_iii_builtin_function_id("stream::list"));
+        assert!(is_iii_builtin_function_id("configuration::get"));
         assert!(is_iii_builtin_function_id("iii::durable::publish"));
         assert!(is_iii_builtin_function_id("publish"));
         assert!(is_iii_builtin_function_id("bridge.invoke"));

--- a/engine/tests/configuration_e2e.rs
+++ b/engine/tests/configuration_e2e.rs
@@ -1,0 +1,307 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! End-to-end test for the `configuration` worker exercising the
+//! register / set / get / list / schema surface, the `configuration`
+//! trigger fan-out (with `${VAR:default}` expansion), and the file-watcher
+//! surfacing external edits as `configuration:updated` events.
+//!
+//! Modeled on `engine/tests/state_stream_update_e2e.rs` — drives the
+//! worker through its public function surface against a real `FsAdapter`
+//! pointed at a `tempfile::tempdir()`. No engine boot, no WebSocket, no
+//! subprocess. Anything that needs the real engine routing is covered
+//! by the unit tests inside `configuration.rs` and `trigger.rs`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tokio::sync::mpsc;
+
+use iii::engine::{Engine, EngineTrait, Handler, RegisterFunctionRequest};
+use iii::function::FunctionResult;
+use iii::trigger::{Trigger, TriggerRegistrator};
+use iii::workers::configuration::ConfigurationWorker;
+use iii::workers::configuration::adapters::ConfigurationAdapter;
+use iii::workers::configuration::adapters::fs::FsAdapter;
+use iii::workers::configuration::structs::{
+    ConfigurationGetInput, ConfigurationListInput, ConfigurationRegisterInput,
+    ConfigurationSetInput,
+};
+use iii::workers::traits::Worker;
+
+async fn build_worker(
+    dir: &std::path::Path,
+    ttl_seconds: u64,
+) -> (Arc<Engine>, ConfigurationWorker) {
+    iii::workers::observability::metrics::ensure_default_meter();
+    let adapter = Arc::new(
+        FsAdapter::new(Some(json!({ "directory": dir.to_str().unwrap() })))
+            .await
+            .expect("fs adapter"),
+    ) as Arc<dyn ConfigurationAdapter>;
+    let engine = Arc::new(Engine::new());
+    let worker = ConfigurationWorker::for_test(engine.clone(), adapter, ttl_seconds);
+    (engine, worker)
+}
+
+/// Subscribe a fresh handler that forwards every received event payload
+/// through an mpsc channel. Returns the receiver and the function id.
+fn install_event_capture(
+    engine: &Arc<Engine>,
+    function_id: &'static str,
+) -> mpsc::UnboundedReceiver<Value> {
+    let (tx, rx) = mpsc::unbounded_channel::<Value>();
+    engine.register_function_handler(
+        RegisterFunctionRequest {
+            function_id: function_id.to_string(),
+            description: None,
+            request_format: None,
+            response_format: None,
+            metadata: None,
+        },
+        Handler::new(move |input: Value| {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(input);
+                FunctionResult::Success(None)
+            }
+        }),
+    );
+    rx
+}
+
+#[tokio::test]
+async fn register_set_get_round_trip_with_env_var_expansion() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_engine, worker) = build_worker(dir.path(), 0).await;
+
+    unsafe {
+        std::env::set_var("CFG_E2E_HOST", "expanded.local");
+    }
+
+    let registered = worker
+        .register_fn(ConfigurationRegisterInput {
+            id: "iii-stream".into(),
+            name: "Stream".into(),
+            description: "Connection settings".into(),
+            schema: json!({
+                "type": "object",
+                "properties": {
+                    "host": { "type": "string" },
+                    "port": { "type": "integer" }
+                },
+                "required": ["host"]
+            }),
+            initial_value: Some(json!({
+                "host": "${CFG_E2E_HOST:fallback}",
+                "port": 3112
+            })),
+            metadata: None,
+        })
+        .await;
+    match registered {
+        FunctionResult::Success(entry) => {
+            assert_eq!(entry.value["host"], "${CFG_E2E_HOST:fallback}");
+        }
+        _ => panic!("expected register success"),
+    }
+
+    let read = worker
+        .get_fn(ConfigurationGetInput {
+            id: "iii-stream".into(),
+            raw: false,
+        })
+        .await;
+    match read {
+        FunctionResult::Success(out) => {
+            assert_eq!(out.value["host"], "expanded.local");
+            assert_eq!(out.value["port"], 3112);
+        }
+        _ => panic!("expected get success"),
+    }
+
+    let set = worker
+        .set_fn(ConfigurationSetInput {
+            id: "iii-stream".into(),
+            value: json!({ "host": "${CFG_E2E_HOST:fallback}", "port": 4242 }),
+        })
+        .await;
+    assert!(matches!(set, FunctionResult::Success(_)));
+
+    let listed = worker.list_fn(ConfigurationListInput {}).await;
+    match listed {
+        FunctionResult::Success(out) => {
+            assert_eq!(out.configurations.len(), 1);
+            assert_eq!(out.configurations[0].id, "iii-stream");
+        }
+        _ => panic!("expected list success"),
+    }
+}
+
+#[tokio::test]
+async fn trigger_fan_out_delivers_expanded_event_payload() {
+    let dir = tempfile::tempdir().unwrap();
+    let (engine, worker) = build_worker(dir.path(), 0).await;
+
+    unsafe {
+        std::env::set_var("CFG_E2E_TRIGGER_HOST", "trigger.local");
+    }
+
+    let mut events = install_event_capture(&engine, "test::on_configuration_change");
+
+    let trigger = Trigger {
+        id: "trig-1".into(),
+        trigger_type: "configuration".into(),
+        function_id: "test::on_configuration_change".into(),
+        config: json!({ "configuration_id": "iii-stream" }),
+        worker_id: None,
+        metadata: None,
+    };
+    worker
+        .register_trigger(trigger.clone())
+        .await
+        .expect("register configuration trigger");
+
+    worker
+        .register_fn(ConfigurationRegisterInput {
+            id: "iii-stream".into(),
+            name: "Stream".into(),
+            description: "...".into(),
+            schema: json!({
+                "type": "object",
+                "properties": { "host": { "type": "string" } }
+            }),
+            initial_value: Some(json!({ "host": "${CFG_E2E_TRIGGER_HOST:fallback}" })),
+            metadata: None,
+        })
+        .await;
+
+    let payload = tokio::time::timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("trigger should fire")
+        .expect("channel open");
+    assert_eq!(payload["type"], "configuration");
+    assert_eq!(payload["event_type"], "configuration:registered");
+    assert_eq!(payload["id"], "iii-stream");
+    assert_eq!(payload["new_value"]["host"], "trigger.local");
+    assert!(payload["old_value"].is_null());
+
+    worker
+        .set_fn(ConfigurationSetInput {
+            id: "iii-stream".into(),
+            value: json!({ "host": "set.local" }),
+        })
+        .await;
+    let payload = tokio::time::timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("set should fire trigger")
+        .expect("channel open");
+    assert_eq!(payload["event_type"], "configuration:updated");
+    assert_eq!(payload["new_value"]["host"], "set.local");
+}
+
+#[tokio::test]
+async fn fs_watcher_surfaces_external_file_edits_as_updates() {
+    let dir = tempfile::tempdir().unwrap();
+    let (engine, worker) = build_worker(dir.path(), 0).await;
+
+    let mut events = install_event_capture(&engine, "test::on_external_change");
+    worker
+        .register_trigger(Trigger {
+            id: "trig-watch".into(),
+            trigger_type: "configuration".into(),
+            function_id: "test::on_external_change".into(),
+            config: json!({ "configuration_id": "iii-bridge" }),
+            worker_id: None,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    // Boot the worker watcher so external file edits are picked up.
+    worker.initialize().await.unwrap();
+
+    let entry = iii::workers::configuration::structs::ConfigurationEntry {
+        id: "iii-bridge".into(),
+        name: "Bridge".into(),
+        description: "Test fixture".into(),
+        schema: json!({ "type": "object" }),
+        value: json!({ "url": "ws://primary" }),
+        metadata: None,
+    };
+    let yaml = serde_yaml::to_string(&entry).unwrap();
+    tokio::fs::write(dir.path().join("iii-bridge.yaml"), yaml)
+        .await
+        .unwrap();
+
+    let payload = tokio::time::timeout(Duration::from_secs(5), events.recv())
+        .await
+        .expect("file watcher should fire trigger")
+        .expect("channel open");
+    assert_eq!(payload["event_type"], "configuration:registered");
+    assert_eq!(payload["id"], "iii-bridge");
+    assert_eq!(payload["new_value"]["url"], "ws://primary");
+
+    worker.destroy().await.expect("destroy");
+}
+
+#[tokio::test]
+async fn ttl_cleanup_removes_configuration_after_last_trigger_unregistered() {
+    let dir = tempfile::tempdir().unwrap();
+    // 1-second TTL keeps the test fast while exercising the real
+    // tokio::time::sleep cleanup path.
+    let (engine, worker) = build_worker(dir.path(), 1).await;
+
+    let mut events = install_event_capture(&engine, "test::on_ttl_change");
+
+    let trigger = Trigger {
+        id: "trig-ttl".into(),
+        trigger_type: "configuration".into(),
+        function_id: "test::on_ttl_change".into(),
+        config: json!({ "configuration_id": "ephemeral" }),
+        worker_id: None,
+        metadata: None,
+    };
+    worker.register_trigger(trigger.clone()).await.unwrap();
+
+    worker
+        .register_fn(ConfigurationRegisterInput {
+            id: "ephemeral".into(),
+            name: "Ephemeral".into(),
+            description: "Used by a worker that comes and goes.".into(),
+            schema: json!({ "type": "object" }),
+            initial_value: Some(json!({})),
+            metadata: None,
+        })
+        .await;
+    let _registered_evt = tokio::time::timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("register fires trigger")
+        .expect("channel open");
+
+    worker.unregister_trigger(trigger).await.unwrap();
+
+    // Poll the public function surface until the entry vanishes or the
+    // deadline elapses. The cleanup task runs on tokio's real-time timer
+    // because the worker spawns it via `tokio::spawn`.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let after = worker
+            .get_fn(ConfigurationGetInput {
+                id: "ephemeral".into(),
+                raw: false,
+            })
+            .await;
+        if matches!(after, FunctionResult::Failure(_)) {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("ephemeral configuration should have been TTL-deleted");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new mandatory built-in worker, `configuration`, that provides a schema-validated, reactive registry for named configuration entries. This is the foundation for migrating per-worker config blocks out of the monolithic `engine/config.yaml` into typed, observable entries that other workers can read and subscribe to.

### What ships

- **Five public functions**
  - `configuration::register` — declare an id with name, description, JSON Schema, and optional `initial_value` (idempotent re-registration replaces metadata/schema)
  - `configuration::set` — replace the full value for a registered id; validates against schema and emits `configuration:updated`
  - `configuration::get` — read one entry by id; expands `${VAR:default}` against live env unless `raw: true`
  - `configuration::list` — enumerate all registered ids with name, description, and schema (never returns values)
  - `configuration::schema` — schema-only view for a single id

- **New `configuration` trigger type** — workers bind a handler to react to `configuration:registered`, `configuration:updated`, and `configuration:deleted` events. Filters support `configuration_id`, `event_types`, and optional `condition_function_id`. Trigger payloads include expanded `${VAR:default}` values so subscribers see the effective config without polling.

- **Two storage adapters** (mirroring the `iii-state` adapter pattern)
  - **`fs`** (default) — one YAML file per id under `./data/configuration`; watches the directory so manual file edits surface as trigger events
  - **`bridge`** — delegates all CRUD to a remote III instance and re-broadcasts remote trigger events into the local fan-out

- **TTL cleanup** — when `ttl_seconds > 0` and the last trigger bound to a `configuration_id` is unregistered, the entry is deleted after the TTL elapses (abortable if a new trigger registers first). Supports ephemeral workers that register config and leave without explicit teardown.

- **Env-var expansion** — `${VAR:default}` placeholders stored verbatim; expanded on every `get` and in trigger fan-out so env changes propagate without restarts.

- **Worker enabled by default** in `engine/config.yaml` with the `fs` adapter and `ttl_seconds: 0`.

- **Skill docs** — `engine/src/workers/configuration/skills/SKILL.md` covering functions, triggers, adapters, TTL, and boundaries.

- **Typed trigger formats** — `ConfigurationTriggerConfig` and `ConfigurationCallRequest` added to `engine/src/trigger_formats.rs`.

### Architecture notes

- In-memory cache (`store.rs`) primed from the adapter at startup; mutations go through adapter + cache + trigger fan-out.
- JSON Schema validation on `register` (`initial_value`) and `set` (`value`).
- Configuration ids must match `[a-z0-9_-]{1,64}` so they are safe as filenames in the `fs` adapter.
- `set` always replaces the whole value — no partial-update surface.
- Bridge adapter cannot delete entries on the remote engine; cleanup over the bridge happens via TTL or directly on the source engine.

## Test plan

- [x] Unit tests across `configuration.rs`, `store.rs`, `trigger.rs`, `structs.rs`, `config.rs`, and `adapters/fs.rs` (~38 tests)
- [x] E2e test suite `engine/tests/configuration_e2e.rs`:
  - [x] `register_set_get_round_trip_with_env_var_expansion` — CRUD surface + `${VAR:default}` expansion
  - [x] `trigger_fan_out_delivers_expanded_event_payload` — reactive trigger on register/set
  - [x] `fs_watcher_surfaces_external_file_edits_as_updates` — external YAML edits fire triggers
  - [x] `ttl_cleanup_removes_configuration_after_last_trigger_unregistered` — TTL deletion after last subscriber unregisters
- [ ] Run locally:

```bash
cargo test -p iii --test configuration_e2e -- --nocapture
cargo test -p iii configuration::
cargo fmt --all --check
cargo clippy -p iii -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration management system (register, get, set, list, delete) with schema validation and environment-variable expansion.
  * Reactive configuration triggers for register/update/delete, with per-id filtering and optional TTL-based cleanup.
  * Two adapters: filesystem persistence with file-watching and a remote bridge adapter for mirroring remote configurations.
* **Documentation**
  * Comprehensive README and usage docs for the configuration worker and trigger behavior.
* **Tests**
  * End-to-end and unit tests covering persistence, watching, validation, triggers, and TTL behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1700?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->