### PR TITLE
feat(cli,engine): real-time visibility and reliable restart for iii worker add

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2947,6 +2947,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64",
+ "bytes",
  "clap",
  "cliclack",
  "colored",

--- a/crates/iii-worker/Cargo.toml
+++ b/crates/iii-worker/Cargo.toml
@@ -64,6 +64,10 @@ fslock = "0.2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 futures = "0.3"
+# Needed to construct `oci_client::client::ImageLayer` / `Config` when we
+# replace the monolithic `client.pull` with a streaming per-layer pull
+# for byte-level progress.
+bytes = "1"
 indicatif = "0.17"
 notify = "8.2.0"
 # `iii worker exec` stdout/stderr/stdin frames encode binary payloads

--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -113,13 +113,16 @@ pub enum Commands {
         config: Option<PathBuf>,
     },
 
-    /// Stop a managed worker container
+    /// Stop a managed worker container. Stop is treated as a routine,
+    /// reversible action — running `iii worker start <name>` brings it
+    /// back from the same config entry, so the CLI no longer prompts
+    /// for confirmation.
     Stop {
         /// Worker name to stop
         #[arg(value_name = "WORKER")]
         worker_name: String,
-        /// Skip the confirmation prompt. Required when stdin is non-interactive
-        /// (scripts, CI, agents); without `-y` the call needs a tty.
+        /// Backward-compat no-op. Stop never prompts; the flag is kept
+        /// so scripts that already pass `-y` keep working.
         #[arg(short = 'y', long = "yes")]
         yes: bool,
     },

--- a/crates/iii-worker/src/cli/host_shim.rs
+++ b/crates/iii-worker/src/cli/host_shim.rs
@@ -51,6 +51,29 @@ fn source_label_name(s: &crate::core::WorkerSource) -> String {
 
 static STDERR_CAPTURE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
+/// Returns `true` when fd 2 is a regular file. Used to distinguish the
+/// engine-spawned subprocess case (stderr → on-disk log file) from the
+/// daemon trigger case (stderr → pipe). On the file path we want stderr
+/// to flow through live so the wait UI's `tail:` row sees progress in
+/// real time; on the pipe path we still want to capture for clean
+/// trigger-response error reporting.
+fn stderr_is_regular_file() -> bool {
+    use std::os::unix::io::FromRawFd;
+    // dup fd 2 so the temporary `File` wrapper's Drop only closes the
+    // dup, not the real stderr.
+    let dup = unsafe { libc::dup(2) };
+    if dup < 0 {
+        return false;
+    }
+    let file = unsafe { std::fs::File::from_raw_fd(dup) };
+    let is_regular = file
+        .metadata()
+        .map(|m| m.file_type().is_file())
+        .unwrap_or(false);
+    drop(file); // closes `dup`
+    is_regular
+}
+
 async fn run_capturing_stderr<F, Fut>(f: F) -> (i32, String)
 where
     F: FnOnce() -> Fut,
@@ -62,6 +85,23 @@ where
     // CLI path — stderr is live for the user (interactive prompts, colored
     // progress). Skip capture entirely; let stderr flow through.
     if std::io::stderr().is_terminal() {
+        return (f().await, String::new());
+    }
+
+    // Engine-spawned subprocess: when the engine reload spawns
+    // `iii-worker start <name>` via `ExternalWorkerProcess::spawn`, it
+    // redirects the subprocess's stderr to a REGULAR FILE
+    // (`~/.iii/logs/<name>/stderr.log`) that the wait UI tails. The
+    // original `is_terminal()` check assumed non-tty == daemon-pipe and
+    // captured-then-mirrored stderr; that buffered every progress line
+    // from `prepare_rootfs` / OCI pull / "Preparing sandbox..." into a
+    // tempfile until the handler completed, dumping it all at once at
+    // the end and leaving the wait UI's `tail:` row stuck on the first
+    // line ("• starting <name>") for minutes. Detect "stderr is a
+    // regular file" and let it flow through live too. The SDK trigger
+    // path (daemon → engine pipe → stderr=FIFO) still captures, so
+    // clean error responses to trigger callers are preserved.
+    if stderr_is_regular_file() {
         return (f().await, String::new());
     }
 
@@ -727,6 +767,106 @@ fn dir_size(path: &std::path::Path) -> u64 {
 mod tests {
     use super::*;
     use crate::core::error::WorkerOpErrorKind;
+
+    /// Shared across every test that swaps fd 2 — fd 2 is process-
+    /// global, so a per-test local `static` Mutex (one per function)
+    /// is THREE separate locks, not one, which lets cargo test's
+    /// default parallel execution race the three swappers. CI on
+    /// Linux reliably trips the race (each test reads the OTHER
+    /// test's swap and asserts on it); macOS happens to win the race
+    /// most of the time. One module-level lock fixes it for both.
+    static FD_SWAP_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Regression: when fd 2 has been redirected to a regular file
+    /// (the engine-spawned subprocess case), `stderr_is_regular_file`
+    /// must return true so `run_capturing_stderr` passes stderr
+    /// through live instead of buffering it. The whole wait UI
+    /// `tail:` row depends on this.
+    #[test]
+    fn stderr_is_regular_file_detects_redirected_log() {
+        use std::os::unix::io::AsRawFd;
+        // Serialize fd 2 swaps; concurrent tests would see each
+        // other's redirects.
+        let _guard = FD_SWAP_LOCK.lock().unwrap();
+
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        let tmp_fd = tmp.as_file().as_raw_fd();
+
+        // SAFETY: fd 2 is process-global; the mutex above serializes;
+        // we restore on every path.
+        let orig = unsafe { libc::dup(2) };
+        assert!(orig >= 0, "dup(2) failed");
+        assert!(unsafe { libc::dup2(tmp_fd, 2) } >= 0, "dup2 failed");
+
+        let result = stderr_is_regular_file();
+
+        // Restore before asserting so a panic doesn't leave fd 2
+        // pointing at the temp file for the next test.
+        assert!(unsafe { libc::dup2(orig, 2) } >= 0, "restore dup2 failed");
+        unsafe { libc::close(orig) };
+
+        assert!(
+            result,
+            "stderr_is_regular_file must return true when fd 2 points at a regular file"
+        );
+    }
+
+    /// Regression: when fd 2 is a character device (/dev/null), the
+    /// helper must return false so the daemon-pipe capture path stays
+    /// in effect.
+    #[test]
+    fn stderr_is_regular_file_rejects_chardev() {
+        use std::os::unix::io::AsRawFd;
+        let _guard = FD_SWAP_LOCK.lock().unwrap();
+
+        let devnull = std::fs::OpenOptions::new()
+            .write(true)
+            .open("/dev/null")
+            .expect("open /dev/null");
+        let dn_fd = devnull.as_raw_fd();
+
+        let orig = unsafe { libc::dup(2) };
+        unsafe { libc::dup2(dn_fd, 2) };
+
+        let result = stderr_is_regular_file();
+
+        unsafe { libc::dup2(orig, 2) };
+        unsafe { libc::close(orig) };
+
+        assert!(
+            !result,
+            "stderr_is_regular_file must return false for /dev/null"
+        );
+    }
+
+    /// Regression: when fd 2 is a pipe (the daemon-trigger case the
+    /// capture path was designed for), the helper must return false.
+    /// If this ever flips, trigger callers stop seeing clean error
+    /// messages in their responses.
+    #[test]
+    fn stderr_is_regular_file_rejects_pipe() {
+        let _guard = FD_SWAP_LOCK.lock().unwrap();
+
+        let mut pipe_fds: [libc::c_int; 2] = [0; 2];
+        let rc = unsafe { libc::pipe(pipe_fds.as_mut_ptr()) };
+        assert_eq!(rc, 0, "pipe() failed");
+        let (read_end, write_end) = (pipe_fds[0], pipe_fds[1]);
+
+        let orig = unsafe { libc::dup(2) };
+        unsafe { libc::dup2(write_end, 2) };
+
+        let result = stderr_is_regular_file();
+
+        unsafe { libc::dup2(orig, 2) };
+        unsafe { libc::close(orig) };
+        unsafe { libc::close(read_end) };
+        unsafe { libc::close(write_end) };
+
+        assert!(
+            !result,
+            "stderr_is_regular_file must return false for pipes (daemon-trigger path)"
+        );
+    }
 
     #[test]
     fn classify_handler_error_maps_not_found_to_w110() {

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -126,20 +126,34 @@ pub async fn handle_binary_add(
         }
     };
 
-    if !brief {
-        eprintln!("  Downloading {}...", worker_name.bold());
-    }
-    let install_path =
-        match binary_download::download_and_install_binary(worker_name, binary_info).await {
-            Ok(path) => path,
+    // Wrap the silent download phase in a steady-tick spinner so the
+    // terminal doesn't look hung on slow connections. binary_download
+    // streams bytes without surfacing its own progress, so this is the
+    // only feedback the user sees until the request completes.
+    let install_path = {
+        let spinner = (!brief).then(|| {
+            super::spinner::Spinner::start(format!("Downloading binary {worker_name}..."))
+        });
+        let result = binary_download::download_and_install_binary(worker_name, binary_info).await;
+        match result {
+            Ok(path) => {
+                if let Some(s) = spinner {
+                    s.finish_ok(format!("Downloaded binary {worker_name}"));
+                }
+                path
+            }
             Err(e) => {
-                eprintln!("{} {}", "error:".red(), e);
+                if let Some(s) = spinner {
+                    s.finish_err(format!("Download failed: {e}"));
+                } else {
+                    eprintln!("{} {}", "error:".red(), e);
+                }
                 return 1;
             }
-        };
+        }
+    };
 
     if !brief {
-        eprintln!("  {} Downloaded successfully", "✓".green());
         eprintln!("  {}: {}", "Name".bold(), worker_name);
         eprintln!("  {}: {}", "Version".bold(), response.version);
         eprintln!("  {}: {}", "Platform".bold(), target);
@@ -217,31 +231,55 @@ pub async fn handle_bundle_add(
     let staging_dir = guard.staging_dir().to_path_buf();
 
     // 2. Stream-download + sha256 verify into staging/.archive.tar.gz.
-    if !brief {
-        eprintln!("  Downloading archive...");
-    }
-    let archive_path = match super::bundle_download::download_archive(
-        &response.archive_url,
-        &response.sha256,
-        &staging_dir,
-    )
-    .await
-    {
-        Ok(p) => p,
-        Err(e) => {
-            eprintln!("{} {}", "error:".red(), e);
-            return 1;
+    //    download_archive does seconds of work with no internal progress
+    //    surface, so wrap it in a spinner — without it the terminal
+    //    looks frozen on slow links.
+    let archive_path = {
+        let spinner = (!brief).then(|| {
+            super::spinner::Spinner::start(format!("Downloading bundle {worker_name}..."))
+        });
+        let result = super::bundle_download::download_archive(
+            &response.archive_url,
+            &response.sha256,
+            &staging_dir,
+        )
+        .await;
+        match result {
+            Ok(p) => {
+                if let Some(s) = spinner {
+                    s.finish_ok(format!("Downloaded bundle {worker_name}"));
+                }
+                p
+            }
+            Err(e) => {
+                if let Some(s) = spinner {
+                    s.finish_err(format!("Download failed: {e}"));
+                } else {
+                    eprintln!("{} {}", "error:".red(), e);
+                }
+                return 1;
+            }
         }
     };
 
     // 3. Extract with bundle-tight limits + entry_type filter.
-    if !brief {
-        eprintln!("  Extracting...");
-    }
-    if let Err(e) = super::bundle_download::extract_bundle_safely(&archive_path, &staging_dir).await
     {
-        eprintln!("{} {}", "error:".red(), e);
-        return 1;
+        let spinner = (!brief).then(|| super::spinner::Spinner::start("Extracting bundle..."));
+        match super::bundle_download::extract_bundle_safely(&archive_path, &staging_dir).await {
+            Ok(()) => {
+                if let Some(s) = spinner {
+                    s.finish_ok("Extracted bundle");
+                }
+            }
+            Err(e) => {
+                if let Some(s) = spinner {
+                    s.finish_err(format!("Extract failed: {e}"));
+                } else {
+                    eprintln!("{} {}", "error:".red(), e);
+                }
+                return 1;
+            }
+        }
     }
     // Archive blob is no longer needed; drop it so the staging->final
     // rename doesn't carry it into the install dir. We MUST fail-hard
@@ -340,7 +378,7 @@ pub async fn handle_bundle_add(
 
     if !brief {
         eprintln!(
-            "\n  {} Worker {} added as bundle (v{}) at {}",
+            "  {} Worker {} added as bundle (v{}) at {}",
             "✓".green(),
             worker_name.bold(),
             response.version,
@@ -1872,14 +1910,32 @@ async fn finish_add(worker_name: &str, rc: i32, wait: bool, brief: bool) -> i32 
 async fn handle_oci_pull_and_add(name: &str, image_ref: &str, brief: bool) -> i32 {
     let adapter = super::worker_manager::create_adapter("libkrun");
 
-    if !brief {
-        eprintln!("  Pulling {}...", image_ref.bold());
-    }
-    let pull_info = match adapter.pull(image_ref).await {
-        Ok(info) => info,
-        Err(e) => {
-            eprintln!("{} Pull failed: {}", "error:".red(), e);
-            return 1;
+    // Wrap the OCI pull in a steady-tick spinner. The adapter prints
+    // a per-layer progress bar of its own only when the registry
+    // returns enough metadata; on the slow-cache path or first-pull
+    // it can sit for tens of seconds without a glyph moving.
+    let pull_info = {
+        let spinner =
+            (!brief).then(|| super::spinner::Spinner::start(format!("Pulling {image_ref}...")));
+        let result = adapter.pull(image_ref).await;
+        match result {
+            Ok(info) => {
+                if let Some(s) = spinner {
+                    // Suppress the spinner's footer when the adapter is
+                    // about to print its own multi-line success block
+                    // below — otherwise we get two "pulled" lines.
+                    s.finish_silent();
+                }
+                info
+            }
+            Err(e) => {
+                if let Some(s) = spinner {
+                    s.finish_err(format!("Pull failed: {e}"));
+                } else {
+                    eprintln!("{} Pull failed: {}", "error:".red(), e);
+                }
+                return 1;
+            }
         }
     };
 
@@ -3310,17 +3366,23 @@ async fn start_binary_worker(
         return 1;
     }
 
-    let stdout_file = match std::fs::File::create(logs_dir.join("stdout.log")) {
+    // APPEND, not truncate — the parent `iii-worker start` and engine
+    // already wrote progress lines to these files; truncating wipes
+    // everything the wait UI tails for visibility. Same rationale as
+    // the libkrun path.
+    let mut open_opts = std::fs::OpenOptions::new();
+    open_opts.create(true).append(true);
+    let stdout_file = match open_opts.open(logs_dir.join("stdout.log")) {
         Ok(f) => f,
         Err(e) => {
-            eprintln!("{} Failed to create stdout log: {}", "error:".red(), e);
+            eprintln!("{} Failed to open stdout log: {}", "error:".red(), e);
             return 1;
         }
     };
-    let stderr_file = match std::fs::File::create(logs_dir.join("stderr.log")) {
+    let stderr_file = match open_opts.open(logs_dir.join("stderr.log")) {
         Ok(f) => f,
         Err(e) => {
-            eprintln!("{} Failed to create stderr log: {}", "error:".red(), e);
+            eprintln!("{} Failed to open stderr log: {}", "error:".red(), e);
             return 1;
         }
     };

--- a/crates/iii-worker/src/cli/mod.rs
+++ b/crates/iii-worker/src/cli/mod.rs
@@ -28,6 +28,7 @@ pub mod sandbox_daemon;
 pub mod shell_client;
 pub mod shell_relay;
 pub mod source_watcher;
+pub mod spinner;
 pub mod status;
 pub mod stderr_sink;
 pub mod supervisor_ctl;

--- a/crates/iii-worker/src/cli/spinner.rs
+++ b/crates/iii-worker/src/cli/spinner.rs
@@ -1,0 +1,156 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//! Steady-tick spinner for silent CLI phases.
+//!
+//! Several `iii worker` flows do tens of seconds of synchronous work
+//! between status prints (image pull, archive download, extract, VM
+//! boot). Without a tick the user sees a frozen terminal and assumes
+//! the command is hung. This wraps `indicatif::ProgressBar` with the
+//! one-line spinner aesthetic the rest of the CLI uses (`  ⠋ ...`),
+//! collapses to a no-op when stderr is not a tty (so daemon/test
+//! output stays log-friendly), and prints a single final-status line
+//! with elapsed time so the user can see each phase succeeded.
+
+use colored::Colorize;
+use indicatif::{ProgressBar, ProgressStyle};
+use std::io::IsTerminal;
+use std::time::{Duration, Instant};
+
+/// Steady-tick spinner. Construct with [`Spinner::start`], optionally
+/// update the visible label with [`Spinner::set_message`], then call
+/// [`Spinner::finish_ok`] / [`Spinner::finish_err`] when the wrapped
+/// work resolves. `Drop` is a safety net only — finish explicitly so
+/// the elapsed-time footer is printed.
+pub struct Spinner {
+    pb: Option<ProgressBar>,
+    started: Instant,
+}
+
+impl Spinner {
+    /// Begin a spinner labeled `message`. Hidden (`Drop`-only) when
+    /// stderr is not a tty so non-interactive callers (daemons, CI
+    /// logs, captured stderr) don't see ANSI noise.
+    pub fn start(message: impl Into<String>) -> Self {
+        let message = message.into();
+        let active = std::io::stderr().is_terminal();
+        let pb = if active {
+            let pb = ProgressBar::new_spinner();
+            // Match the rest of the CLI: two-space gutter + cyan glyph.
+            pb.set_style(
+                ProgressStyle::with_template("  {spinner:.cyan} {msg}")
+                    .expect("static template")
+                    .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
+            );
+            pb.set_message(message);
+            pb.enable_steady_tick(Duration::from_millis(100));
+            Some(pb)
+        } else {
+            None
+        };
+        Self {
+            pb,
+            started: Instant::now(),
+        }
+    }
+
+    /// Update the visible label without resetting the timer.
+    pub fn set_message(&self, message: impl Into<String>) {
+        if let Some(pb) = &self.pb {
+            pb.set_message(message.into());
+        }
+    }
+
+    /// Stop the spinner and print a single line with a green check,
+    /// the final message, and elapsed seconds.
+    pub fn finish_ok(mut self, final_message: impl AsRef<str>) {
+        if let Some(pb) = self.pb.take() {
+            pb.finish_and_clear();
+        }
+        let elapsed = self.started.elapsed();
+        eprintln!(
+            "  {} {} {}",
+            "✓".green(),
+            final_message.as_ref(),
+            format!("({:.1}s)", elapsed.as_secs_f64()).dimmed(),
+        );
+    }
+
+    /// Stop the spinner and print a single red-cross line. Use when
+    /// the wrapped operation returned an error so the spinner doesn't
+    /// stay on screen above the error message.
+    pub fn finish_err(mut self, final_message: impl AsRef<str>) {
+        if let Some(pb) = self.pb.take() {
+            pb.finish_and_clear();
+        }
+        eprintln!("  {} {}", "✗".red(), final_message.as_ref());
+    }
+
+    /// Stop the spinner without printing anything. Use when the caller
+    /// has its own follow-up output (e.g., a detailed multi-line
+    /// success block) and the spinner would just add noise.
+    pub fn finish_silent(mut self) {
+        if let Some(pb) = self.pb.take() {
+            pb.finish_and_clear();
+        }
+    }
+}
+
+impl Drop for Spinner {
+    fn drop(&mut self) {
+        // Safety net: if the caller forgot to finish explicitly, at
+        // least clear the spinner so it doesn't keep ticking after the
+        // owning future is dropped.
+        if let Some(pb) = self.pb.take() {
+            pb.finish_and_clear();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// In test mode the test runner captures stderr (or pipes it), so
+    /// `is_terminal()` returns false and `Spinner::start` takes the
+    /// hidden path with `pb: None`. The finish_* methods must not
+    /// panic on the None branch — they all unconditionally call
+    /// `take()`, which is safe (returns `None`), but the eprintln
+    /// fallback still has to be writeable.
+    #[test]
+    fn finish_ok_on_hidden_spinner_does_not_panic() {
+        let s = Spinner::start("test op");
+        s.finish_ok("done");
+    }
+
+    #[test]
+    fn finish_err_on_hidden_spinner_does_not_panic() {
+        let s = Spinner::start("test op");
+        s.finish_err("failed");
+    }
+
+    #[test]
+    fn finish_silent_on_hidden_spinner_does_not_panic() {
+        let s = Spinner::start("test op");
+        s.finish_silent();
+    }
+
+    /// Regression: dropping the Spinner without calling any finish_*
+    /// method must run the safety net without panic. Catches a future
+    /// refactor that accidentally double-takes the ProgressBar.
+    #[test]
+    fn drop_without_finish_does_not_panic() {
+        let _s = Spinner::start("orphan op");
+        // _s goes out of scope here, triggering Drop.
+    }
+
+    /// `set_message` on the hidden (non-tty) path must be a no-op
+    /// rather than a panic — callers don't condition on tty state.
+    #[test]
+    fn set_message_on_hidden_spinner_does_not_panic() {
+        let s = Spinner::start("test op");
+        s.set_message("updated");
+        s.finish_silent();
+    }
+}

--- a/crates/iii-worker/src/cli/status.rs
+++ b/crates/iii-worker/src/cli/status.rs
@@ -18,6 +18,24 @@ use std::time::{Duration, Instant, SystemTime};
 use super::config_file::{ResolvedWorkerType, resolve_worker_type, worker_exists};
 use super::managed::{is_engine_running_on, is_worker_running};
 
+/// Live-progress overlay for `render_with_progress` / `headline_with_progress`.
+/// Bumped from `watch_until_ready` so each redraw visibly changes even when
+/// the underlying worker state is static — a static block looks identical to
+/// "frozen" to the user, which is the bug the spinner is fighting.
+#[derive(Debug, Clone, Copy)]
+pub struct WatchProgress {
+    /// Monotonically increasing tick counter (used to pick a spinner glyph).
+    pub tick: usize,
+    /// Wall-clock time since the wait started.
+    pub elapsed: Duration,
+}
+
+const SPINNER_GLYPHS: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+fn spinner_glyph(tick: usize) -> &'static str {
+    SPINNER_GLYPHS[tick % SPINNER_GLYPHS.len()]
+}
+
 /// Terminal phase for waiters — once we reach `Ready` or `Failed` we stop
 /// polling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -307,6 +325,186 @@ impl WorkerStatus {
         )
     }
 
+    /// Same as [`Self::headline`] but appends a live spinner glyph and an
+    /// elapsed-seconds counter. The plain `headline` is used for one-shot
+    /// snapshots; this variant is what live `--watch` and `--wait` print so
+    /// every redraw is visibly different even when the underlying state is
+    /// unchanged (which is what the user sees as "frozen").
+    pub fn headline_with_progress(&self, p: WatchProgress) -> String {
+        let base = self.headline();
+        if matches!(
+            self.phase,
+            Phase::Ready | Phase::Failed | Phase::NotInConfig
+        ) {
+            return base;
+        }
+        let glyph = spinner_glyph(p.tick);
+        // Use `as_secs()` (u64 truncation) rather than
+        // `as_secs_f64()` with `{:.0}` (banker's rounding). Rust's
+        // `{:.0}` round-half-to-even turns 0.5→0, 1.5→2, 2.5→2,
+        // 3.5→4, so any per-iteration latency drift that lands sample
+        // times near n.5 boundaries makes the displayed counter skip
+        // odd numbers and appear to jump by 2. Truncation advances
+        // monotonically by exactly 1 each whole second and matches the
+        // mental model "Xs means at least X seconds elapsed".
+        //
+        // Yellow on the elapsed + spinner suffix for the same reason
+        // the tail row is yellow during non-terminal phases: this is
+        // the ticking "still working" pulse, and at default dim grey
+        // it visually disappeared into the headline. Yellow keeps the
+        // suffix scannable at a glance.
+        format!(
+            "{} {}",
+            base,
+            format!("({}s {})", p.elapsed.as_secs(), glyph).yellow()
+        )
+    }
+
+    /// Render a detailed multi-line snapshot with a live progress overlay.
+    /// The first non-blank line gets a spinner + elapsed counter, and during
+    /// non-terminal phases past a few seconds we surface the last line of
+    /// the worker's stderr log so the user can see what the engine
+    /// subprocess is actually doing without leaving the wait UI.
+    pub fn render_with_progress(&self, p: WatchProgress) -> Vec<String> {
+        let mut out = self.render();
+        // Splice the spinner-decorated headline in place of the plain one
+        // produced by `render()`. `render()` lays out:
+        //   [0] ""
+        //   [1] "  <headline>"
+        //   [2] ""
+        // so the headline lives at index 1, preserved by the leading two
+        // spaces from `format!("  {}", self.headline())`.
+        if out.len() > 1 {
+            out[1] = format!("  {}", self.headline_with_progress(p));
+        }
+        // After ~3s in a non-terminal phase, peek the last meaningful line
+        // of stderr.log and append it. The block grows by 0 or 1 line; the
+        // caller in `watch_until_ready` tracks prev_line_count so the ANSI
+        // rewind stays correct across renders of varying length.
+        if !matches!(
+            self.phase,
+            Phase::Ready | Phase::NotInConfig | Phase::Failed
+        ) && p.elapsed >= Duration::from_secs(3)
+            && let Some(line) = self.last_stderr_line()
+        {
+            // Insert above the trailing blank line so the layout stays:
+            //   ... logs:
+            //   ⤷ <tail>
+            //   <blank>
+            let insert_at = out.len().saturating_sub(1);
+            let truncated = truncate_to(&line, 120);
+            // Yellow on the tail content while the worker is still
+            // preparing. The status block is otherwise mostly muted
+            // (dimmed labels + green/red glyphs for done/error states),
+            // so the live progress messages — OCI pull byte counters,
+            // per-layer extract lines, rootfs/boot transitions — were
+            // visually indistinguishable from the static log-path hint
+            // above. Yellow makes "thing in flight" pop without
+            // per-message coloring at every emit site. Label stays
+            // dimmed for a clean left gutter.
+            out.insert(
+                insert_at,
+                format!("{:>12}  {}", "tail:".dimmed(), truncated.yellow()),
+            );
+        }
+        // Past 30s in Queued WITHOUT recent log activity, the engine
+        // probably failed to spawn the worker subprocess (or the
+        // subprocess crashed early). Surface a "stuck?" hint so the
+        // user doesn't sit and wait for the 120s timeout in silence.
+        //
+        // If the log file IS being actively written (e.g., OCI pull
+        // heartbeats every 3s during a multi-minute base-image
+        // download), suppress the hint — the worker is plainly making
+        // progress and a "may have failed" warning would directly
+        // contradict the `tail:` row right above it.
+        if matches!(self.phase, Phase::Queued)
+            && p.elapsed >= Duration::from_secs(30)
+            && !self.log_recently_updated(Duration::from_secs(10))
+        {
+            let insert_at = out.len().saturating_sub(1);
+            out.insert(
+                insert_at,
+                format!(
+                    "{:>12}  {}",
+                    "hint:".yellow(),
+                    "still queued, no log activity — check `iii worker logs {name} -f` (engine may have failed to spawn it)"
+                        .replace("{name}", &self.name)
+                        .dimmed()
+                ),
+            );
+        }
+        out
+    }
+
+    /// Returns `true` when `~/.iii/logs/<name>/stderr.log` was last
+    /// modified within `window` of now. Used to gate the "may have
+    /// failed" hint: when progress lines are flowing (OCI heartbeat,
+    /// VM boot, etc.) the file's mtime ticks every few seconds, which
+    /// is honest evidence the worker isn't stuck — so a "stuck?" hint
+    /// would mislead the user.
+    fn log_recently_updated(&self, window: Duration) -> bool {
+        let Some(dir) = self.logs_dir.as_ref() else {
+            return false;
+        };
+        let path = dir.join("stderr.log");
+        let Ok(meta) = std::fs::metadata(&path) else {
+            return false;
+        };
+        let Ok(modified) = meta.modified() else {
+            return false;
+        };
+        let Ok(elapsed) = modified.elapsed() else {
+            // Modified in the future (clock skew). Treat as recent —
+            // safer than spuriously showing the failure hint.
+            return true;
+        };
+        elapsed <= window
+    }
+
+    /// Read the last non-empty line of the worker's stderr.log. Cheap:
+    /// reads at most 4 KiB from the tail. Returns `None` when there's no
+    /// log file yet or it's empty.
+    fn last_stderr_line(&self) -> Option<String> {
+        use std::io::{Read, Seek, SeekFrom};
+        let dir = self.logs_dir.as_ref()?;
+        let path = dir.join("stderr.log");
+        let mut f = std::fs::File::open(&path).ok()?;
+        let len = f.metadata().ok()?.len();
+        let read_from = len.saturating_sub(4096);
+        f.seek(SeekFrom::Start(read_from)).ok()?;
+        let mut buf = Vec::with_capacity(4096);
+        // HARD-CAP the read at 4 KiB via `Read::take`. A bare
+        // `read_to_end` reads until `read()` returns 0, and on a file
+        // that's being appended to by a concurrent writer (the engine's
+        // `iii-worker start` heartbeat, OCI pull progress, layer
+        // extraction) EOF keeps moving forward as new bytes arrive. Per
+        // the second-pass adversarial review (jump-2s investigation),
+        // during a multi-MiB/s OCI pull this turned the intended 4-KiB
+        // tail read into a multi-second firehose drain, pushing
+        // `watch_until_ready` per-iteration latency to ~2s and making
+        // the headline elapsed counter visibly jump by 2 every redraw.
+        // `take` bounds the read at the seek point + 4 KiB regardless
+        // of how fast the writer is growing the file.
+        f.take(4096).read_to_end(&mut buf).ok()?;
+        // Only return lines that are TERMINATED by a newline. Without
+        // this, a mid-flush write from a concurrent producer (the
+        // engine's `iii-worker start` heartbeat, the extract loop, an
+        // OCI pull tick) returns the partial line, sometimes with a
+        // U+FFFD from a split UTF-8 codepoint. At 200ms redraw cadence
+        // the user sees `tail: Pulling docker.io/library/alpi` then
+        // the full line on the next render. Skipping unterminated
+        // tails costs at most one redraw of "no signal" while a write
+        // is mid-flight, which is fine.
+        let s = String::from_utf8_lossy(&buf);
+        let last_newline = s.rfind('\n')?;
+        let body = &s[..last_newline];
+        body.lines()
+            .rev()
+            .map(|line| line.trim())
+            .find(|line| !line.is_empty())
+            .map(|line| line.to_string())
+    }
+
     /// Render a detailed multi-line snapshot. Returns the number of lines
     /// written so `--watch` knows how much to rewind.
     pub fn render(&self) -> Vec<String> {
@@ -536,19 +734,48 @@ pub async fn watch_until_ready(
     port: u16,
 ) -> WorkerStatus {
     let started = Instant::now();
-    let mut first = true;
+    let mut tick: usize = 0;
+    // `prev_line_count` is the number of lines printed on the previous
+    // iteration. Use it (not the *current* line count) for the ANSI rewind
+    // so renders of varying length (the optional stderr-tail line, the
+    // "still queued" hint past 30s) clear correctly. The previous code used
+    // `lines.len()`, which only worked because `render()`'s output is
+    // shape-stable at 9 lines.
+    let mut prev_line_count: usize = 0;
+    // Tick at 200ms instead of the old 500ms. The spinner needs to move
+    // visibly often enough that the user can't mistake the wait UI for a
+    // hang — 5 fps is the floor for that. Probe cost is cheap (a few
+    // stat() calls + a TCP probe of the engine port), so faster polling
+    // also tightens reaction time on phase transitions.
+    let poll_interval = Duration::from_millis(200);
     loop {
         let status = WorkerStatus::probe_on(worker_name, port);
-        let lines = status.render();
+        let progress = WatchProgress {
+            tick,
+            elapsed: started.elapsed(),
+        };
+        let lines = status.render_with_progress(progress);
 
-        if !first {
+        // Clamp each rendered line to the current terminal width so the
+        // terminal doesn't soft-wrap them onto a second visual row. The
+        // ANSI rewind below moves the cursor up by LOGICAL line count
+        // (one per `\n`), so if a long line (long file path in
+        // `config:`, long image ref in `tail:`, etc.) wraps to two
+        // visual rows the rewind walks too few rows and leaves cruft
+        // above the redraw. Truncating to width-1 keeps one logical
+        // line == one visual row.
+        let width = terminal_width().saturating_sub(1).max(40);
+        let lines: Vec<String> = lines
+            .iter()
+            .map(|line| truncate_visible(line, width))
+            .collect();
+
+        if prev_line_count > 0 {
             // `\x1b[{n}F` = move cursor up n lines to start of line,
-            // `\x1b[J` = clear from cursor to end of screen. This keeps the
-            // snapshot pinned in place even as line counts shrink.
-            let n = lines.len();
-            eprint!("\x1b[{}F\x1b[J", n);
+            // `\x1b[J` = clear from cursor to end of screen.
+            eprint!("\x1b[{}F\x1b[J", prev_line_count);
         }
-        first = false;
+        prev_line_count = lines.len();
 
         for line in &lines {
             eprintln!("{}", line);
@@ -563,8 +790,93 @@ pub async fn watch_until_ready(
             return status;
         }
 
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        tick = tick.wrapping_add(1);
+        tokio::time::sleep(poll_interval).await;
     }
+}
+
+/// Truncate a single line to `max` characters, suffixing `…` if cut.
+/// Counts bytes for safety against multi-byte content; this is a UI
+/// helper, not a parser.
+fn truncate_to(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let mut end = max.saturating_sub(1);
+    while !s.is_char_boundary(end) && end > 0 {
+        end -= 1;
+    }
+    format!("{}…", &s[..end])
+}
+
+/// Stderr terminal width via TIOCGWINSZ. Falls back to 80 when fd 2
+/// is not a tty, or the ioctl fails. Used by `watch_until_ready` to
+/// clamp every rendered line to one visual row — otherwise long
+/// `config:`/`tail:` lines wrap and confuse the ANSI rewind math.
+fn terminal_width() -> usize {
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+        let fd = std::io::stderr().as_raw_fd();
+        let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
+        let result = unsafe { libc::ioctl(fd, libc::TIOCGWINSZ as _, &mut ws) };
+        if result == 0 && ws.ws_col > 0 {
+            return ws.ws_col as usize;
+        }
+    }
+    80
+}
+
+/// Truncate `s` to at most `max` VISIBLE columns, preserving ANSI
+/// escape sequences (which take zero visible columns). Appends `…`
+/// when the string was cut. Used to keep wait-UI lines from
+/// soft-wrapping on narrow terminals.
+fn truncate_visible(s: &str, max: usize) -> String {
+    let mut visible: usize = 0;
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    let mut truncated = false;
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            // ANSI CSI sequence: `ESC [ ... <final>` where final is in
+            // the range @-~. Copy through without counting visible
+            // width. Bail on the next non-`[` if the sequence shape is
+            // unfamiliar — colored output we generate is always CSI.
+            out.push(c);
+            if let Some(&next) = chars.peek()
+                && next == '['
+            {
+                out.push(chars.next().unwrap());
+                for nc in chars.by_ref() {
+                    out.push(nc);
+                    if ('@'..='~').contains(&nc) {
+                        break;
+                    }
+                }
+            }
+            continue;
+        }
+        if visible >= max {
+            truncated = true;
+            break;
+        }
+        out.push(c);
+        visible += 1;
+    }
+    if truncated {
+        // Reserve a column for the ellipsis — pop one visible char
+        // back off so the final width still fits inside `max`.
+        while out.chars().last().is_some_and(|c| c == '\x1b') {
+            out.pop();
+        }
+        if let Some(last) = out.chars().last()
+            && last != '\x1b'
+        {
+            out.pop();
+        }
+        out.push('…');
+    }
+    out
 }
 
 #[cfg(test)]
@@ -609,6 +921,161 @@ mod tests {
 
         not_in.phase = Phase::Failed;
         assert!(not_in.is_terminal_for_wait());
+    }
+
+    /// Regression: `truncate_visible` must count VISIBLE columns and
+    /// pass through ANSI escapes untouched. Long lines in `tail:` /
+    /// `config:` were getting cut mid-escape (or not truncated at all
+    /// because byte-count and visible-count disagreed), which both
+    /// broke colors and let the terminal soft-wrap the line — and the
+    /// ANSI rewind in `watch_until_ready` then walked too few rows.
+    #[test]
+    fn truncate_visible_preserves_ansi_and_counts_chars() {
+        // Plain text: simple truncation.
+        assert_eq!(truncate_visible("abcdefgh", 4), "abc…");
+        assert_eq!(truncate_visible("abc", 10), "abc");
+
+        // ANSI color codes don't count toward the visible budget.
+        let colored = "\x1b[32mhello\x1b[0m world";
+        // 11 visible columns; truncate to 8 should keep all 5 colored
+        // chars + space + 1 of "world" + ellipsis = "\x1b[32mhello\x1b[0m w…"
+        let out = truncate_visible(colored, 8);
+        // Must still contain the green-start escape so colors render.
+        assert!(out.starts_with("\x1b[32m"), "out: {:?}", out);
+        // Must end with the ellipsis sentinel.
+        assert!(out.ends_with('…'), "out: {:?}", out);
+
+        // 8 visible char budget on a 12-visible-char line → cut.
+        assert!(out.chars().filter(|c| *c == '…').count() == 1);
+    }
+
+    /// Regression: `last_stderr_line` must NOT drain a file that's
+    /// being concurrently appended to. The prior `read_to_end` after
+    /// `seek(len - 4096)` was effectively unbounded because EOF moves
+    /// forward as the writer appends — during a heavy OCI pull
+    /// (subprocess writing at MB/s) each call took ~2s, pushing the
+    /// `watch_until_ready` per-iteration latency to ~2s and making
+    /// the headline elapsed counter visibly skip seconds. The fix
+    /// wraps the file in `Read::take(4096)` so the read is hard-
+    /// capped regardless of file growth.
+    ///
+    /// This test simulates the scenario with a 5 MiB existing log
+    /// and asserts the call returns in well under one redraw budget.
+    #[test]
+    fn last_stderr_line_is_bounded_on_large_log() {
+        use std::io::Write;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let logs_dir = tmp.path().to_path_buf();
+        let log_path = logs_dir.join("stderr.log");
+
+        // Write ~5 MiB. Most of it is large fill lines; the trailing
+        // line is the "real" tail the function should return.
+        let mut f = std::fs::File::create(&log_path).expect("create");
+        let big_line = format!("{}\n", "X".repeat(4096));
+        for _ in 0..1200 {
+            f.write_all(big_line.as_bytes()).expect("fill");
+        }
+        f.write_all(b"  Pulling docker.io/iiidev/python: 99% done\n")
+            .expect("tail");
+        drop(f);
+
+        let status = WorkerStatus {
+            name: "demo".into(),
+            phase: Phase::Queued,
+            engine_running: true,
+            worker_type: Some("local"),
+            worker_path: Some("/path".into()),
+            managed_dir_exists: false,
+            prepared: false,
+            pid: None,
+            alive: false,
+            logs_dir: Some(logs_dir),
+            logs_last_modified: Some(SystemTime::now()),
+        };
+
+        let started = Instant::now();
+        let line = status.last_stderr_line().expect("tail line");
+        let elapsed = started.elapsed();
+
+        assert!(
+            line.contains("99% done"),
+            "tail line must surface the last real entry: {:?}",
+            line
+        );
+        // 50ms is generous — the bounded read should take sub-
+        // millisecond on any modern filesystem. Anything close to
+        // 1s would mean the read drained the whole file again.
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "last_stderr_line took {:?} on a 5 MiB file — must be \
+             bounded by the 4 KiB cap, not the file size",
+            elapsed
+        );
+    }
+
+    /// Regression: the headline elapsed counter must advance by
+    /// exactly 1 each whole second, regardless of when the sample
+    /// is taken. Using `{:.0}` on `as_secs_f64()` previously applied
+    /// round-half-to-even, producing 0→2→2→4→4 displays at exact
+    /// half-second boundaries. `as_secs()` truncates monotonically.
+    #[test]
+    fn headline_elapsed_counter_truncates_and_advances_by_one() {
+        let status = WorkerStatus {
+            name: "demo".into(),
+            phase: Phase::Queued,
+            engine_running: true,
+            worker_type: Some("local"),
+            worker_path: None,
+            managed_dir_exists: false,
+            prepared: false,
+            pid: None,
+            alive: false,
+            logs_dir: None,
+            logs_last_modified: None,
+        };
+        let mk = |secs: u64, nanos: u32| WatchProgress {
+            tick: 0,
+            elapsed: Duration::new(secs, nanos),
+        };
+        // Strip ANSI for easy substring assertions.
+        let strip = |s: String| {
+            let mut out = String::new();
+            let mut chars = s.chars().peekable();
+            while let Some(c) = chars.next() {
+                if c == '\x1b' {
+                    while let Some(&next) = chars.peek() {
+                        chars.next();
+                        if ('@'..='~').contains(&next) {
+                            break;
+                        }
+                    }
+                } else {
+                    out.push(c);
+                }
+            }
+            out
+        };
+
+        // Sub-second elapsed displays as 0s.
+        assert!(strip(status.headline_with_progress(mk(0, 500_000_000))).contains("(0s"));
+        // Just under 1s still 0s.
+        assert!(strip(status.headline_with_progress(mk(0, 999_999_999))).contains("(0s"));
+        // 1.0s exactly displays as 1s — not 0s, not 2s.
+        assert!(strip(status.headline_with_progress(mk(1, 0))).contains("(1s"));
+        // Banker's-rounding death zones: 0.5, 1.5, 2.5, 3.5, 4.5.
+        // Old code displayed 0,2,2,4,4 — the new code MUST display
+        // 0,1,2,3,4 with strict truncation.
+        for s in 0..=4 {
+            let half = mk(s, 500_000_000);
+            let out = strip(status.headline_with_progress(half));
+            assert!(
+                out.contains(&format!("({}s", s)),
+                "elapsed {}.5s must display ({}s, got: {:?}",
+                s,
+                s,
+                out
+            );
+        }
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/worker_manager/libkrun.rs
+++ b/crates/iii-worker/src/cli/worker_manager/libkrun.rs
@@ -176,17 +176,29 @@ pub async fn run_dev(
             eprintln!("{} Failed to create logs dir: {}", "error:".red(), e);
             return 1;
         }
-        let stdout_file = match std::fs::File::create(logs_dir.join("stdout.log")) {
+        // APPEND, do not truncate. The parent `iii-worker start` writes
+        // progress to these same log files for the full prepare_rootfs /
+        // OCI pull / layer extract / "Preparing sandbox..." phase before
+        // it reaches this point. `File::create` would truncate that
+        // history, leaving the wait UI's `tail:` row showing whatever
+        // libkrun emits next — which is usually nothing until the VM
+        // serial console wakes up. The user then sees ~0 progress signal
+        // during a multi-minute startup. Open in append mode so the
+        // earlier progress lines stay around and the VM serial console
+        // output is added below them.
+        let mut open_opts = std::fs::OpenOptions::new();
+        open_opts.create(true).append(true);
+        let stdout_file = match open_opts.open(logs_dir.join("stdout.log")) {
             Ok(f) => f,
             Err(e) => {
-                eprintln!("{} Failed to create stdout log: {}", "error:".red(), e);
+                eprintln!("{} Failed to open stdout log: {}", "error:".red(), e);
                 return 1;
             }
         };
-        let stderr_file = match std::fs::File::create(logs_dir.join("stderr.log")) {
+        let stderr_file = match open_opts.open(logs_dir.join("stderr.log")) {
             Ok(f) => f,
             Err(e) => {
-                eprintln!("{} Failed to create stderr log: {}", "error:".red(), e);
+                eprintln!("{} Failed to open stderr log: {}", "error:".red(), e);
                 return 1;
             }
         };
@@ -612,10 +624,18 @@ This image likely does not publish arm64. Rebuild/push a multi-arch image (linux
         std::fs::create_dir_all(&logs_dir)
             .with_context(|| format!("failed to create logs dir: {}", logs_dir.display()))?;
 
-        let stdout_file = std::fs::File::create(Self::stdout_log(&spec.name))
-            .with_context(|| "failed to create stdout.log")?;
-        let stderr_file = std::fs::File::create(Self::stderr_log(&spec.name))
-            .with_context(|| "failed to create stderr.log")?;
+        // APPEND, not truncate — see the rationale in `run_dev` above.
+        // The parent `iii-worker start` (and engine) wrote progress to
+        // these same files; truncating loses everything the wait UI
+        // could surface via `tail:`.
+        let mut open_opts = std::fs::OpenOptions::new();
+        open_opts.create(true).append(true);
+        let stdout_file = open_opts
+            .open(Self::stdout_log(&spec.name))
+            .with_context(|| "failed to open stdout.log")?;
+        let stderr_file = open_opts
+            .open(Self::stderr_log(&spec.name))
+            .with_context(|| "failed to open stderr.log")?;
 
         let (exec_path, mut exec_args) =
             read_oci_entrypoint(&worker_rootfs).unwrap_or_else(|| ("/bin/sh".to_string(), vec![]));

--- a/crates/iii-worker/src/cli/worker_manager/oci.rs
+++ b/crates/iii-worker/src/cli/worker_manager/oci.rs
@@ -471,12 +471,34 @@ pub async fn pull_and_extract_rootfs(image: &str, dest: &std::path::Path) -> Res
     };
     let client = Client::new(config);
 
-    eprintln!("  Pulling image layers...");
-    let media_types: Vec<&str> = vec![
-        oci_client::manifest::IMAGE_LAYER_GZIP_MEDIA_TYPE,
-        oci_client::manifest::IMAGE_DOCKER_LAYER_GZIP_MEDIA_TYPE,
-        oci_client::manifest::IMAGE_LAYER_MEDIA_TYPE,
-    ];
+    // Pre-fetch the manifest so we can tell the user UP FRONT what they're
+    // about to wait for (layer count + total compressed bytes). The
+    // `client.pull(...)` call below is one blocking network operation
+    // with no per-byte progress hook, so without this summary the only
+    // signal the wait UI has is the 3s heartbeat (elapsed time only).
+    // Knowing "1247 MiB across 5 layers" lets the user gauge how long
+    // the pull will realistically take. Best-effort: if the registry
+    // returns an Image Index (multi-platform manifest) we skip the
+    // summary rather than do the full platform resolution dance — the
+    // pull below handles that path natively.
+    let manifest_summary: String = match client
+        .pull_manifest(&reference, &RegistryAuth::Anonymous)
+        .await
+    {
+        Ok((oci_client::manifest::OciManifest::Image(m), _)) => {
+            let bytes: i64 = m.layers.iter().map(|l| l.size).sum();
+            format!(
+                " ({} layer{}, {:.1} MiB)",
+                m.layers.len(),
+                if m.layers.len() == 1 { "" } else { "s" },
+                bytes as f64 / (1024.0 * 1024.0),
+            )
+        }
+        _ => String::new(),
+    };
+
+    eprintln!("  Pulling {}{}...", image, manifest_summary);
+    let _ = manifest_summary; // consumed inside pull_with_progress now
 
     const MAX_PULL_ATTEMPTS: u32 = 3;
     let mut image_data = None;
@@ -494,10 +516,16 @@ pub async fn pull_and_extract_rootfs(image: &str, dest: &std::path::Path) -> Res
             tokio::time::sleep(delay).await;
         }
 
-        match client
-            .pull(&reference, &RegistryAuth::Anonymous, media_types.clone())
-            .await
-        {
+        // Streaming pull: fetch manifest, then pull each layer via
+        // `pull_blob_stream`, counting bytes into an Arc<AtomicU64>.
+        // A background task reads the counter every 2s and emits a
+        // real progress line:
+        //   "Pulling <image>: 412.6/1247.3 MiB (33%, 41.2 MiB/s, 10s)"
+        // The wait UI's `tail:` row picks up the latest one and shows
+        // genuine download progress instead of just elapsed time.
+        let pull_result = pull_with_progress(&client, &reference, image, host_arch).await;
+
+        match pull_result {
             Ok(data) => {
                 image_data = Some(data);
                 break;
@@ -593,10 +621,27 @@ pub async fn pull_and_extract_rootfs(image: &str, dest: &std::path::Path) -> Res
     };
 
     let mut total_size: u64 = 0;
+    use std::io::IsTerminal;
+    let mirror_layer_lines = !std::io::stderr().is_terminal();
     let extract_result: Result<()> = (|| {
         for (i, layer) in image_data.layers.iter().enumerate() {
             extract_layer_with_limits(&layer.data, &extract_root, i, layer_count, &mut total_size)?;
             pb.inc(1);
+            // On TTY, indicatif's progress bar handles the live row.
+            // On non-TTY (engine-captured log file), the bar produces
+            // nothing — so we mirror each completed layer as a plain
+            // eprintln to keep the `tail:` row in `iii worker add
+            // --wait` refreshing with concrete progress. The TTY
+            // branch SKIPS this print so it doesn't scroll the bar's
+            // row off as the bar is also being redrawn.
+            if mirror_layer_lines {
+                eprintln!(
+                    "  Extracted layer {}/{} ({:.1} MiB total)",
+                    i + 1,
+                    layer_count,
+                    total_size as f64 / (1024.0 * 1024.0),
+                );
+            }
         }
         pb.finish();
 
@@ -741,9 +786,373 @@ pub fn read_oci_env(rootfs: &std::path::Path) -> Vec<(String, String)> {
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Streaming pull with byte-level progress
+//
+// `oci_client::Client::pull` is one blocking call with no per-byte hook,
+// which forced our wait UI to fall back on an elapsed-time-only heart-
+// beat. Re-implement the pull at the layer level: fetch the manifest
+// (resolving multi-platform), pull the config blob, then stream each
+// layer via `pull_blob_stream`, counting bytes into a shared
+// `AtomicU64`. A background task reads the counter every 2s and emits
+// a real progress line that the wait UI's `tail:` row surfaces.
+// ─────────────────────────────────────────────────────────────────────────────
+
+async fn pull_with_progress(
+    client: &oci_client::Client,
+    reference: &oci_client::Reference,
+    image: &str,
+    host_arch: &str,
+) -> Result<oci_client::client::ImageData> {
+    use futures::StreamExt;
+    use oci_client::client::{Config, ImageData, ImageLayer};
+    use sha2::Digest;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    // 1. Manifest (resolving multi-platform if the registry returned an
+    //    ImageIndex). Tracks the resolved manifest digest so we can
+    //    return it to the caller alongside the data.
+    let (image_manifest, manifest_digest) =
+        pull_image_manifest_resolved(client, reference, host_arch).await?;
+
+    let total_bytes: u64 = image_manifest
+        .layers
+        .iter()
+        .map(|l| l.size.max(0) as u64)
+        .sum();
+    let downloaded = Arc::new(AtomicU64::new(0));
+
+    // 2. Heartbeat task using the byte counter. 2-second cadence
+    //    rather than 3 so the percentage feels live without burning
+    //    the file with chatter.
+    let downloaded_for_heartbeat = Arc::clone(&downloaded);
+    let total_for_heartbeat = total_bytes;
+    let image_for_heartbeat = image.to_string();
+    let attempt_started = std::time::Instant::now();
+    // Skip the per-second heartbeat eprintlns when stderr is a TTY: the
+    // caller (`handle_oci_pull_and_add`) wraps this whole call in a
+    // `Spinner` whose 100ms tick redraws the same row. Heartbeat
+    // eprintlns from here would scroll the spinner row off and produce
+    // visual chaos. The non-TTY path (engine-spawned subprocess →
+    // `~/.iii/logs/<name>/stderr.log`) NEEDS these lines because the
+    // wait UI tails that file for the `tail:` row, and there's no
+    // spinner there.
+    use std::io::IsTerminal;
+    let emit_heartbeat = !std::io::stderr().is_terminal();
+    // Scope guard: aborts the heartbeat task on Drop. Without this, every
+    // `?` operator between here and the explicit `drop(heartbeat)` at the
+    // end of this function (config-blob fetch, every layer's
+    // `pull_blob_stream`, every chunk read) would early-return and leak
+    // the task — it would keep `eprintln!`-ing progress lines for the
+    // rest of the process lifetime, racing against the retry loop's
+    // next attempt's fresh heartbeat. With this guard the abort fires
+    // unconditionally on any return path.
+    struct AbortOnDrop(tokio::task::JoinHandle<()>);
+    impl Drop for AbortOnDrop {
+        fn drop(&mut self) {
+            self.0.abort();
+        }
+    }
+    let heartbeat = AbortOnDrop(tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(2));
+        // Default `Burst` would replay missed ticks back-to-back if
+        // the runtime worker thread was held off (e.g., a blocking
+        // syscall elsewhere). The wait UI would suddenly see N
+        // identical "Pulling X.X/Y.Y MiB" lines in milliseconds, which
+        // looks like a glitch rather than honest progress.
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        interval.tick().await; // first tick is instant; consume it
+        loop {
+            interval.tick().await;
+            let dl = downloaded_for_heartbeat.load(Ordering::Relaxed);
+            let elapsed = attempt_started.elapsed().as_secs().max(1);
+            let mb = dl as f64 / (1024.0 * 1024.0);
+            if total_for_heartbeat > 0 {
+                let total_mb = total_for_heartbeat as f64 / (1024.0 * 1024.0);
+                let pct = (dl as u128 * 100 / total_for_heartbeat.max(1) as u128).min(100) as u64;
+                let rate = mb / elapsed as f64;
+                if emit_heartbeat {
+                    eprintln!(
+                        "  Pulling {}: {:.1}/{:.1} MiB ({}%, {:.1} MiB/s, {}s)",
+                        image_for_heartbeat, mb, total_mb, pct, rate, elapsed
+                    );
+                }
+            } else if emit_heartbeat {
+                // Registry didn't report layer sizes — show what we've
+                // got so the user at least sees activity.
+                eprintln!(
+                    "  Pulling {}: {:.1} MiB ({}s)",
+                    image_for_heartbeat, mb, elapsed
+                );
+            }
+        }
+    }));
+
+    // 3. Pull the config blob. Small (typically <10 KiB), doesn't
+    //    contribute to the layer-progress denominator. Verify the
+    //    descriptor's SHA256 digest while streaming so a corrupted CDN
+    //    response or MITM doesn't slip through — the upstream
+    //    `client.pull(...)` we replaced did this internally; the
+    //    streaming path needs to do it explicitly.
+    let mut config_bytes: Vec<u8> = Vec::with_capacity(image_manifest.config.size.max(0) as usize);
+    let mut config_hasher = sha2::Sha256::new();
+    let mut config_stream = client
+        .pull_blob_stream(reference, &image_manifest.config)
+        .await
+        .context("failed to pull image config blob")?;
+    while let Some(chunk) = config_stream.next().await {
+        let chunk = chunk.context("config blob stream chunk failed")?;
+        config_hasher.update(&chunk);
+        config_bytes.extend_from_slice(&chunk);
+    }
+    verify_sha256_digest(&image_manifest.config.digest, config_hasher, "image config")?;
+    let config = Config {
+        data: bytes::Bytes::from(config_bytes),
+        media_type: image_manifest.config.media_type.clone(),
+        annotations: None,
+    };
+
+    // 4. Pull each layer with byte-progress counter updates. Sequential
+    //    rather than concurrent: registries throttle per-connection, so
+    //    parallel pulls rarely speed things up and they make the
+    //    progress display incoherent ("layer 1 at 80%, layer 3 at 40%").
+    //    Each layer's bytes are hashed as they stream and verified
+    //    against the manifest descriptor's digest before the layer is
+    //    accepted into `layers` — content integrity match before the
+    //    extract step touches the rootfs.
+    let mut layers: Vec<ImageLayer> = Vec::with_capacity(image_manifest.layers.len());
+    for (idx, layer_desc) in image_manifest.layers.iter().enumerate() {
+        let mut layer_bytes: Vec<u8> = Vec::with_capacity(layer_desc.size.max(0) as usize);
+        let mut layer_hasher = sha2::Sha256::new();
+        let mut stream = client
+            .pull_blob_stream(reference, layer_desc)
+            .await
+            .with_context(|| format!("failed to pull layer {} blob", idx + 1))?;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.with_context(|| format!("layer {} stream chunk failed", idx + 1))?;
+            layer_hasher.update(&chunk);
+            downloaded.fetch_add(chunk.len() as u64, Ordering::Relaxed);
+            layer_bytes.extend_from_slice(&chunk);
+        }
+        verify_sha256_digest(
+            &layer_desc.digest,
+            layer_hasher,
+            &format!("layer {}", idx + 1),
+        )?;
+        layers.push(ImageLayer {
+            data: bytes::Bytes::from(layer_bytes),
+            media_type: layer_desc.media_type.clone(),
+            annotations: None,
+        });
+    }
+
+    drop(heartbeat); // explicit: AbortOnDrop fires here
+
+    // Final 100% line so the user sees the pull cleanly conclude
+    // before the extract eprintlns start. Gated on non-TTY for the same
+    // reason as the heartbeat: on TTY the outer Spinner provides the
+    // signal; here this line would just collide with it.
+    let final_mb = downloaded.load(Ordering::Relaxed) as f64 / (1024.0 * 1024.0);
+    let total_mb = total_bytes as f64 / (1024.0 * 1024.0);
+    let final_elapsed = attempt_started.elapsed().as_secs().max(1);
+    if emit_heartbeat {
+        eprintln!(
+            "  Pulling {}: {:.1}/{:.1} MiB (100%, {:.1}s total)",
+            image, final_mb, total_mb, final_elapsed as f64
+        );
+    }
+
+    Ok(ImageData {
+        layers,
+        digest: manifest_digest,
+        config,
+        manifest: Some(image_manifest),
+    })
+}
+
+/// Compare the SHA256 digest a streaming hasher produced against the OCI
+/// descriptor's expected digest string ("sha256:<hex>"). Returns Err on
+/// mismatch, unsupported algorithm, or malformed digest string — caller
+/// propagates so the corrupted blob never reaches the extract step or
+/// the rootfs.
+///
+/// This is the only content-integrity check on the streaming pull path.
+/// The original `oci_client::Client::pull(...)` did this internally; we
+/// have to do it explicitly now that we walk blobs ourselves for
+/// byte-level progress reporting.
+fn verify_sha256_digest(expected: &str, hasher: sha2::Sha256, label: &str) -> Result<()> {
+    use sha2::Digest;
+    // Match the algorithm prefix case-insensitively. The OCI spec
+    // mandates lowercase `sha256:` but defensively accepting `Sha256:`
+    // / `SHA256:` keeps a registry-side typo from surfacing as the
+    // wrong error ("unsupported algorithm" when the algorithm is fine
+    // and only the case is wrong).
+    let Some(expected_hex) = expected
+        .split_once(':')
+        .filter(|(alg, _)| alg.eq_ignore_ascii_case("sha256"))
+        .map(|(_, hex)| hex)
+    else {
+        // OCI distribution spec allows other algorithms, but in practice
+        // every registry we target uses SHA256. Fail loudly on anything
+        // else so a future spec drift doesn't silently degrade to
+        // "verified" when nothing was checked.
+        anyhow::bail!(
+            "{} digest uses unsupported algorithm: {} (expected sha256:...)",
+            label,
+            expected
+        );
+    };
+    let computed = hasher.finalize();
+    let computed_hex = computed
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect::<String>();
+    if !computed_hex.eq_ignore_ascii_case(expected_hex) {
+        anyhow::bail!(
+            "{} digest mismatch: expected sha256:{}, got sha256:{}",
+            label,
+            expected_hex,
+            computed_hex
+        );
+    }
+    Ok(())
+}
+
+/// Fetch the image manifest, resolving multi-platform `ImageIndex` to
+/// the appropriate `linux/<host_arch>` `Image` manifest. Returns the
+/// resolved Image manifest and its digest.
+async fn pull_image_manifest_resolved(
+    client: &oci_client::Client,
+    reference: &oci_client::Reference,
+    host_arch: &str,
+) -> Result<(oci_client::manifest::OciImageManifest, Option<String>)> {
+    use oci_client::secrets::RegistryAuth;
+
+    let target_arch = match host_arch {
+        "arm64" => oci_spec::image::Arch::ARM64,
+        _ => oci_spec::image::Arch::Amd64,
+    };
+
+    let (manifest, digest) = client
+        .pull_manifest(reference, &RegistryAuth::Anonymous)
+        .await
+        .context("failed to pull image manifest")?;
+
+    match manifest {
+        oci_client::manifest::OciManifest::Image(m) => Ok((m, Some(digest))),
+        oci_client::manifest::OciManifest::ImageIndex(idx) => {
+            let chosen = idx.manifests.iter().find(|m| {
+                m.platform.as_ref().is_some_and(|p| {
+                    p.os == oci_spec::image::Os::Linux && p.architecture == target_arch
+                })
+            });
+            let chosen_digest = chosen
+                .ok_or_else(|| {
+                    let available: Vec<String> = idx
+                        .manifests
+                        .iter()
+                        .filter_map(|m| {
+                            m.platform
+                                .as_ref()
+                                .map(|p| format!("{}/{}", p.os, p.architecture))
+                        })
+                        .collect();
+                    anyhow::anyhow!(
+                        "no linux/{} manifest in image index. Available platforms: {}",
+                        host_arch,
+                        available.join(", ")
+                    )
+                })?
+                .digest
+                .clone();
+            let resolved_ref = reference.clone_with_digest(chosen_digest.clone());
+            let (m, d) = client
+                .pull_manifest(&resolved_ref, &RegistryAuth::Anonymous)
+                .await
+                .context("failed to pull resolved platform manifest")?;
+            match m {
+                oci_client::manifest::OciManifest::Image(im) => Ok((im, Some(d))),
+                oci_client::manifest::OciManifest::ImageIndex(_) => {
+                    Err(anyhow::anyhow!("nested ImageIndex not supported"))
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression: the streaming pull's `verify_sha256_digest` must
+    /// accept a hasher whose finalize matches the descriptor's hex
+    /// suffix (case-insensitively).
+    #[test]
+    fn verify_sha256_digest_accepts_matching_hash() {
+        use sha2::Digest;
+        let mut h = sha2::Sha256::new();
+        h.update(b"hello world");
+        // sha256("hello world") = b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+        let expected = "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+        verify_sha256_digest(expected, h, "test blob").expect("digest must match");
+    }
+
+    /// Regression: a one-byte difference in streamed content must fail
+    /// loudly. Without this check, a MITM-corrupted CDN response would
+    /// silently land in the rootfs.
+    #[test]
+    fn verify_sha256_digest_rejects_mismatched_hash() {
+        use sha2::Digest;
+        let mut h = sha2::Sha256::new();
+        h.update(b"goodbye world");
+        let expected = "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+        let err = verify_sha256_digest(expected, h, "tampered blob")
+            .expect_err("mismatched digest must fail");
+        assert!(err.to_string().contains("tampered blob"));
+        assert!(err.to_string().contains("digest mismatch"));
+    }
+
+    /// Future spec drift safeguard: an unsupported digest algorithm
+    /// (e.g. "sha512:...") must error instead of silently passing.
+    #[test]
+    fn verify_sha256_digest_rejects_non_sha256_algorithm() {
+        use sha2::Digest;
+        let h = sha2::Sha256::new();
+        let err = verify_sha256_digest("sha512:deadbeef", h, "future blob")
+            .expect_err("non-sha256 algorithm must fail");
+        assert!(err.to_string().contains("unsupported algorithm"));
+    }
+
+    /// `verify_sha256_digest` accepts uppercase hex in the descriptor
+    /// (registries vary). Same content, same digest, just letter case.
+    #[test]
+    fn verify_sha256_digest_is_case_insensitive() {
+        use sha2::Digest;
+        let mut h = sha2::Sha256::new();
+        h.update(b"hello world");
+        let expected = "sha256:B94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9";
+        verify_sha256_digest(expected, h, "uppercase").expect("uppercase hex must match");
+    }
+
+    /// Regression: an out-of-spec `Sha256:` / `SHA256:` prefix from a
+    /// buggy registry must still be recognized as the supported
+    /// algorithm — without this, the operator chases an "unsupported
+    /// algorithm" error when the algorithm is fine and only the case
+    /// is off.
+    #[test]
+    fn verify_sha256_digest_accepts_uppercase_algorithm_prefix() {
+        use sha2::Digest;
+        let mut h = sha2::Sha256::new();
+        h.update(b"hello world");
+        let expected = "Sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+        verify_sha256_digest(expected, h, "Sha256-prefix").expect("uppercase prefix must match");
+
+        let mut h2 = sha2::Sha256::new();
+        h2.update(b"hello world");
+        let expected2 = "SHA256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+        verify_sha256_digest(expected2, h2, "SHA256-prefix").expect("ALL-CAPS prefix must match");
+    }
 
     #[test]
     fn test_rootfs_search_paths_includes_home() {

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -80,7 +80,13 @@ async fn main() -> anyhow::Result<()> {
                     }
                 };
                 let ctx = ProjectCtx::open_unlocked(cwd);
-                let sink = StderrSink::new(brief);
+                // The inner `handle_managed_add` already prints rich
+                // colored progress (Resolving → spinner → ✓ added).
+                // Running the sink in non-brief mode here just duplicates
+                // each Stage as a "• downloading <name>" line, which the
+                // user sees as extra noise that scrolls real progress
+                // off-screen. Keep the sink quiet on the CLI path.
+                let sink = StderrSink::new(true);
                 let result =
                     core_add::run(opts, &ctx, &sink, &CliHostShim, core_add::CallerMode::Cli).await;
 
@@ -163,7 +169,10 @@ async fn main() -> anyhow::Result<()> {
                     }
                 };
                 let ctx = ProjectCtx::open_unlocked(cwd);
-                let sink = StderrSink::new(false);
+                // Reinstall is `add --force`; keep the same brief-mode
+                // policy so we don't duplicate Stage events on top of
+                // the inner handler's progress output.
+                let sink = StderrSink::new(true);
                 if let Err(e) =
                     core_add::run(opts, &ctx, &sink, &CliHostShim, core_add::CallerMode::Cli).await
                 {
@@ -283,32 +292,20 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
         }
-        Commands::Stop { worker_name, yes } => {
+        Commands::Stop {
+            worker_name,
+            yes: _,
+        } => {
             use iii_worker::cli::host_shim::CliHostShim;
             use iii_worker::cli::stderr_sink::StderrSink;
             use iii_worker::core::{ProjectCtx, StopOptions, stop as core_stop};
-            use std::io::IsTerminal;
 
-            // Consent: -y / --yes always proceeds. Without -y, prompt
-            // when stderr is a tty; refuse non-interactively so scripts
-            // don't silently stop workers without confirmation.
-            if !yes {
-                if std::io::stderr().is_terminal() {
-                    use std::io::{BufRead, Write};
-                    eprint!("Stop worker '{}'? [y/N] ", worker_name);
-                    let _ = std::io::stderr().flush();
-                    let mut buf = String::new();
-                    let _ = std::io::stdin().lock().read_line(&mut buf);
-                    let trimmed = buf.trim().to_lowercase();
-                    if trimmed != "y" && trimmed != "yes" {
-                        eprintln!("Aborted.");
-                        std::process::exit(1);
-                    }
-                } else {
-                    eprintln!("error: stop is destructive; pass -y/--yes for non-interactive use");
-                    std::process::exit(1);
-                }
-            }
+            // `stop` is routine and reversible: `iii worker start <name>`
+            // brings the worker back from the same config entry, no data
+            // loss. Prompting "Stop worker '$name'? [y/N]" on every call
+            // was friction that hid the actual progress output, so the
+            // CLI now stops on intent. `-y/--yes` is still parsed for
+            // backward-compat with scripts that pass it.
             let opts = StopOptions {
                 name: worker_name,
                 yes: true,

--- a/engine/src/workers/registry_worker.rs
+++ b/engine/src/workers/registry_worker.rs
@@ -11,7 +11,10 @@
 use std::{
     collections::HashMap,
     path::PathBuf,
-    sync::{Arc, OnceLock},
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use serde_json::Value;
@@ -171,6 +174,23 @@ pub struct ExternalWorkerProcess {
     /// this instant to cover the gap between `iii-worker start` exiting and
     /// the detached VM writing its pidfile.
     pub spawned_at: std::time::Instant,
+    /// One-way latch: set to `true` the first time `is_alive` observes a
+    /// responsive pidfile. Once latched, a subsequent missing pidfile means
+    /// the worker is definitively dead, NOT "still booting". Without this
+    /// latch, the `SPAWN_GRACE` fallback turned `iii worker add --force`
+    /// (which deletes the pidfile out from under us) into a no-op whenever
+    /// it ran inside the grace window: `is_alive` returned true, the
+    /// reload's `promote_dead_unchanged` kept the entry as unchanged, and
+    /// no restart fired. With the latch, dead-after-alive is honest.
+    pub was_ever_alive: Arc<AtomicBool>,
+    /// `JoinHandle` for the post-spawn polling task that latches
+    /// `was_ever_alive` when the worker's pidfile first becomes
+    /// responsive. The poller has no time deadline — it runs until
+    /// either it observes the worker alive (and exits naturally) or
+    /// `Drop` aborts it. `None` only in unit-test fixtures that build
+    /// the struct outside a tokio runtime; the production `spawn`
+    /// path always sets `Some`.
+    pub poller_handle: Option<tokio::task::JoinHandle<()>>,
     /// Tracked so `stop` (and `Drop`, on panic) can unlink the temp config
     /// written by `spawn`. `std::sync::Mutex` rather than `tokio::sync::Mutex`
     /// because the lock is held for nanoseconds and `Drop` is not async.
@@ -186,6 +206,35 @@ pub struct ExternalWorkerProcess {
 /// seconds. 30s is conservative enough to avoid false-negative "dead" reads
 /// during boot without masking a genuine crash for long.
 const SPAWN_GRACE: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Returns `true` when one of `worker_name`'s candidate pidfiles points at
+/// a process responding to signal 0. Used by both `ExternalWorkerProcess::
+/// is_alive` (called from reload-time death detection) and the post-spawn
+/// background poller that latches `was_ever_alive` so external kills get
+/// honored even when no reload happens during the worker's lifetime.
+fn probe_pidfile_alive(worker_name: &str) -> bool {
+    let Some(home) = iii_home() else {
+        return false;
+    };
+    for pidfile in pid_file_candidates(&home, worker_name) {
+        if let Some(pid) = read_pid_hardened(&pidfile) {
+            #[cfg(unix)]
+            {
+                use nix::sys::signal::kill;
+                use nix::unistd::Pid;
+                if kill(Pid::from_raw(pid as i32), None).is_ok() {
+                    return true;
+                }
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = pid;
+                return true;
+            }
+        }
+    }
+    false
+}
 
 impl ExternalWorkerProcess {
     /// Spawns `iii-worker start <name> --port <port>` as a detached child.
@@ -210,10 +259,39 @@ impl ExternalWorkerProcess {
         std::fs::create_dir_all(&logs_dir)
             .map_err(|e| format!("Failed to create logs dir: {}", e))?;
 
-        let stdout_file = std::fs::File::create(logs_dir.join("stdout.log"))
-            .map_err(|e| format!("Failed to create stdout log: {}", e))?;
-        let stderr_file = std::fs::File::create(logs_dir.join("stderr.log"))
-            .map_err(|e| format!("Failed to create stderr log: {}", e))?;
+        // Truncate-and-open in a single call to clear stale lines from
+        // a prior spawn AND get an APPEND-mode fd for the subprocess.
+        // The subprocess's `iii-worker start` will itself spawn an
+        // `__vm-boot` child that re-opens this same log in append mode
+        // (see `worker_manager/libkrun.rs::run_dev`). With both FDs in
+        // append mode the kernel guarantees writes go atomically to
+        // EOF, so iii-worker progress lines and VM serial-console
+        // output interleave correctly instead of overwriting each
+        // other at stale tracked offsets.
+        //
+        // Sequence: (1) truncate via `File::create`, (2) reopen in
+        // append mode. We CANNOT combine `truncate(true).append(true)`
+        // in one OpenOptions call — Rust's stdlib rejects that flag
+        // combination with InvalidInput ("creating or truncating a
+        // file requires write or append access"), so the engine fails
+        // to start any external worker. The small disk-full /
+        // unlinked-between window between the two calls is acceptable;
+        // recovering history on partial failure is a P3 nicety
+        // compared to "engine boots at all".
+        let stdout_path = logs_dir.join("stdout.log");
+        let stderr_path = logs_dir.join("stderr.log");
+        let _ = std::fs::File::create(&stdout_path)
+            .map_err(|e| format!("Failed to truncate stdout log: {}", e))?;
+        let _ = std::fs::File::create(&stderr_path)
+            .map_err(|e| format!("Failed to truncate stderr log: {}", e))?;
+        let stdout_file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&stdout_path)
+            .map_err(|e| format!("Failed to reopen stdout log for append: {}", e))?;
+        let stderr_file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&stderr_path)
+            .map_err(|e| format!("Failed to reopen stderr log for append: {}", e))?;
 
         let config_path = match config {
             Some(cfg) => Some(secure_temp::write_engine_config_temp(name, cfg)?),
@@ -236,10 +314,63 @@ impl ExternalWorkerProcess {
             "Worker starting via iii-worker (logs: `iii worker logs {}`)", name
         );
 
+        let was_ever_alive = Arc::new(AtomicBool::new(false));
+
+        // Proactively poll for the worker's pidfile so the `was_ever_alive`
+        // latch gets set even when no config reload fires during the
+        // worker's lifetime. Without this, the latch only flips on the
+        // first reload-driven `is_alive` call — which means `iii worker
+        // add --force` run inside the spawn-grace window of a still-young
+        // worker still hits the grace fallback and looks alive, so
+        // `promote_dead_unchanged` keeps the entry unchanged and no
+        // restart fires.
+        //
+        // The poll runs until either: (a) it observes the pidfile alive
+        // and latches `was_ever_alive`, then exits naturally; or (b)
+        // `ExternalWorkerProcess::Drop` aborts it. Crucially, there's
+        // NO time-bounded deadline — a cold-cache OCI pull can run
+        // tens of minutes, and a deadline that expires before the
+        // worker boots would leave `was_ever_alive=false` permanently.
+        // From there, the moment the grace window passes, `is_alive`
+        // reports dead, and the next config reload restarts the still-
+        // healthy slow-booting worker mid-pull. Cheap to keep ticking
+        // (one stat() syscall per 500ms); Drop cancels cleanly.
+        //
+        // KNOWN RACE (follow-up):
+        // The 500ms interval still leaves a sub-second window. If a
+        // worker boots in <1s AND the user runs `iii worker add
+        // --force` within that window, the poller's next wakeup sees
+        // no pidfile and doesn't latch. The next engine reload then
+        // sees was_ever_alive=false within the grace window and skips
+        // the restart, hitting the exact bug the latch was supposed
+        // to fix. Realistic for scripts/agent loops that re-issue add
+        // immediately on observed Ready. Two fixes worth considering
+        // in a follow-up PR: (a) latch on pidfile EXISTENCE without
+        // the kill(pid, 0) responsiveness check — pidfile creation is
+        // honest evidence the worker was at least born; (b) tighter
+        // poll interval (50ms). (a) closes the window; (b) shrinks
+        // it.
+        let poller_handle = {
+            let was_ever_alive = Arc::clone(&was_ever_alive);
+            let name = name.to_string();
+            tokio::spawn(async move {
+                let interval = std::time::Duration::from_millis(500);
+                loop {
+                    if probe_pidfile_alive(&name) {
+                        was_ever_alive.store(true, Ordering::SeqCst);
+                        return;
+                    }
+                    tokio::time::sleep(interval).await;
+                }
+            })
+        };
+
         Ok(Self {
             name: name.to_string(),
             child: Arc::new(Mutex::new(Some(child))),
             spawned_at: std::time::Instant::now(),
+            was_ever_alive,
+            poller_handle: Some(poller_handle),
             config_file: std::sync::Mutex::new(config_path),
         })
     }
@@ -266,33 +397,31 @@ impl ExternalWorkerProcess {
         // A permanent "unable to observe" state for a real worker will still
         // surface later as a dead probe once grace elapses, rather than a
         // false-positive restart storm triggered by nonsensical paths.
-        let Some(home) = iii_home() else {
+        if iii_home().is_none() {
             return self.spawned_at.elapsed() < SPAWN_GRACE;
-        };
-
-        for pidfile in pid_file_candidates(&home, &self.name) {
-            // `read_pid_hardened` uses O_NOFOLLOW + euid-ownership check
-            // to reject attacker-planted symlinks or foreign-owned files;
-            // see its docstring for the attacker model.
-            if let Some(pid) = read_pid_hardened(&pidfile) {
-                #[cfg(unix)]
-                {
-                    use nix::sys::signal::kill;
-                    use nix::unistd::Pid;
-                    if kill(Pid::from_raw(pid as i32), None).is_ok() {
-                        return true;
-                    }
-                }
-                #[cfg(not(unix))]
-                {
-                    let _ = pid;
-                    return true;
-                }
-            }
         }
 
-        // No live pidfile at either candidate. Grant a grace window from spawn
-        // so we don't misread a still-booting worker as dead.
+        if probe_pidfile_alive(&self.name) {
+            // Latch: we've seen this worker alive at least once. From
+            // here on, missing-pidfile means dead.
+            self.was_ever_alive.store(true, Ordering::SeqCst);
+            return true;
+        }
+
+        // No live pidfile at either candidate.
+        //
+        // If we've ever observed this worker alive, a missing pidfile now is
+        // definitive death — the most common cause is `iii worker add --force`
+        // killing the worker process and unlinking the pidfile while the
+        // engine's `running` Vec still tracks it. Without this latch the
+        // SPAWN_GRACE fallback below masks that as "still booting" and the
+        // reload's `promote_dead_unchanged` skips the restart.
+        if self.was_ever_alive.load(Ordering::SeqCst) {
+            return false;
+        }
+
+        // Never seen alive yet — grant the grace window from spawn so we
+        // don't misread a still-booting worker as dead.
         self.spawned_at.elapsed() < SPAWN_GRACE
     }
 
@@ -346,6 +475,17 @@ impl ExternalWorkerProcess {
 /// path so the happy path is a no-op here.
 impl Drop for ExternalWorkerProcess {
     fn drop(&mut self) {
+        // Abort the post-spawn polling task so it doesn't keep ticking
+        // after the process struct is destroyed. The poller has no
+        // deadline of its own (so it doesn't false-fail on slow cold
+        // boots), so Drop is the only thing that stops it. The
+        // `Arc<AtomicBool>` it captures stays alive until the task is
+        // dropped by the executor, but the task itself stops doing
+        // work immediately.
+        if let Some(handle) = self.poller_handle.take() {
+            handle.abort();
+        }
+
         if let Ok(mut guard) = self.config_file.lock()
             && let Some(path) = guard.take()
         {
@@ -504,6 +644,8 @@ mod tests {
             name: name.to_string(),
             child: Arc::new(Mutex::new(None)),
             spawned_at,
+            was_ever_alive: Arc::new(AtomicBool::new(false)),
+            poller_handle: None,
             config_file: std::sync::Mutex::new(None),
         }
     }
@@ -583,6 +725,8 @@ mod tests {
             name: "booting-worker".to_string(),
             child: Arc::new(Mutex::new(None)),
             spawned_at: std::time::Instant::now(),
+            was_ever_alive: Arc::new(AtomicBool::new(false)),
+            poller_handle: None,
             config_file: std::sync::Mutex::new(None),
         };
         assert!(
@@ -591,12 +735,167 @@ mod tests {
         );
     }
 
+    /// Regression: `iii worker add --force` kills the worker process and
+    /// unlinks the pidfile. Before the `was_ever_alive` latch, the engine's
+    /// next reload would see the worker as "alive (in grace window)" and
+    /// `promote_dead_unchanged` would keep it as unchanged — so no restart
+    /// fired and the worker stayed in `Phase::Queued` until the CLI's
+    /// `--wait` timed out at 120s. The latch makes a missing pidfile after
+    /// a prior alive observation report `dead`, regardless of grace.
+    #[test]
+    fn is_alive_reports_dead_after_external_kill_within_grace_window() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = HomeGuard::new(tmp.path());
+
+        // Set up a live pidfile under `~/.iii/managed/<name>/vm.pid` so the
+        // first probe latches was_ever_alive. Use our own PID — guaranteed
+        // responsive to signal 0 on unix.
+        let managed = tmp.path().join(".iii/managed").join("forced");
+        std::fs::create_dir_all(&managed).unwrap();
+        let pidfile = managed.join("vm.pid");
+        std::fs::write(&pidfile, std::process::id().to_string()).unwrap();
+
+        let process = ExternalWorkerProcess {
+            name: "forced".to_string(),
+            child: Arc::new(Mutex::new(None)),
+            // spawned_at recent: well inside SPAWN_GRACE. The grace would
+            // otherwise mask the kill as "still booting".
+            spawned_at: std::time::Instant::now(),
+            was_ever_alive: Arc::new(AtomicBool::new(false)),
+            poller_handle: None,
+            config_file: std::sync::Mutex::new(None),
+        };
+
+        // First probe sees the live pidfile → latches.
+        assert!(process.is_alive(), "live pidfile must report alive");
+        assert!(
+            process.was_ever_alive.load(Ordering::SeqCst),
+            "first alive observation must latch was_ever_alive"
+        );
+
+        // Simulate `iii worker add --force` killing + unlinking the pidfile
+        // (still inside SPAWN_GRACE).
+        std::fs::remove_file(&pidfile).unwrap();
+
+        assert!(
+            !process.is_alive(),
+            "pidfile removed after a prior alive observation must report dead, \
+             even within the spawn-grace window — otherwise --force is a no-op"
+        );
+    }
+
+    /// Regression: probe_pidfile_alive backs both `is_alive` and the
+    /// post-spawn polling task. Verify it picks up a real PID through
+    /// the OCI/VM pidfile path. This is the primitive that lets the
+    /// poller latch `was_ever_alive` without needing a reload to fire.
+    #[test]
+    fn probe_pidfile_alive_finds_live_pid() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = HomeGuard::new(tmp.path());
+
+        let name = "polled";
+        let managed = tmp.path().join(".iii/managed").join(name);
+        std::fs::create_dir_all(&managed).unwrap();
+        std::fs::write(managed.join("vm.pid"), std::process::id().to_string()).unwrap();
+
+        assert!(
+            probe_pidfile_alive(name),
+            "live pidfile must be detected by probe_pidfile_alive — \
+             this is what the spawn-time poller relies on"
+        );
+    }
+
+    #[test]
+    fn probe_pidfile_alive_returns_false_when_no_pidfile() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = HomeGuard::new(tmp.path());
+
+        assert!(
+            !probe_pidfile_alive("never-existed"),
+            "absent pidfile must not be detected as alive"
+        );
+    }
+
+    /// Regression: the truncate-then-append open sequence in `spawn`
+    /// must succeed. A prior version combined `truncate(true)` with
+    /// `append(true)` in one `OpenOptions` call — Rust's stdlib
+    /// rejects that flag combination at `open()` with
+    /// `InvalidInput`, which propagated out of the engine as
+    /// "Failed to open stdout log: creating or truncating a file
+    /// requires write or append access" and made the engine fail
+    /// to boot any external worker. Test runs the exact two-call
+    /// dance against a tempdir so this can't silently regress
+    /// again.
+    #[test]
+    fn spawn_log_open_sequence_is_legal() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let stdout_path = tmp.path().join("stdout.log");
+        let stderr_path = tmp.path().join("stderr.log");
+
+        // 1) Truncate via File::create. This is the legal way to wipe
+        //    prior content; OpenOptions cannot do truncate+append in
+        //    one shot.
+        let _ = std::fs::File::create(&stdout_path).expect("truncate stdout");
+        let _ = std::fs::File::create(&stderr_path).expect("truncate stderr");
+
+        // 2) Reopen append-only. This is what we hand to the
+        //    subprocess's cmd.stdout / cmd.stderr.
+        let stdout_file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&stdout_path)
+            .expect("reopen stdout for append");
+        let stderr_file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&stderr_path)
+            .expect("reopen stderr for append");
+
+        // Sanity: both fds are writable and pointed at the right
+        // paths.
+        use std::io::Write;
+        let mut s = stdout_file;
+        let mut e = stderr_file;
+        s.write_all(b"stdout-line\n").expect("write stdout");
+        e.write_all(b"stderr-line\n").expect("write stderr");
+
+        let stdout_contents = std::fs::read_to_string(&stdout_path).unwrap();
+        let stderr_contents = std::fs::read_to_string(&stderr_path).unwrap();
+        assert_eq!(stdout_contents, "stdout-line\n");
+        assert_eq!(stderr_contents, "stderr-line\n");
+    }
+
+    /// Counter-regression: prove the buggy combination IS illegal so
+    /// future contributors don't "fix" the two-call dance back into
+    /// the broken one-call form. If this test ever passes, Rust's
+    /// stdlib has loosened the rule and the production code can be
+    /// simplified.
+    #[test]
+    fn truncate_plus_append_open_options_combination_is_illegal() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("combo.log");
+        let result = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .append(true)
+            .open(&path);
+        let err = result.expect_err(
+            "truncate(true) + append(true) must remain illegal — if this passes, \
+             the spawn() log-open sequence can be simplified to a single OpenOptions call",
+        );
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
     #[test]
     fn external_worker_wrapper_name_format() {
         let process = ExternalWorkerProcess {
             name: "test-worker".to_string(),
             child: Arc::new(Mutex::new(None)),
             spawned_at: std::time::Instant::now(),
+            was_ever_alive: Arc::new(AtomicBool::new(false)),
+            poller_handle: None,
             config_file: std::sync::Mutex::new(None),
         };
         let wrapper = ExternalWorkerWrapper::new(process);
@@ -618,6 +917,8 @@ mod tests {
             name: "init-test".to_string(),
             child: Arc::new(Mutex::new(None)),
             spawned_at: std::time::Instant::now(),
+            was_ever_alive: Arc::new(AtomicBool::new(false)),
+            poller_handle: None,
             config_file: std::sync::Mutex::new(None),
         };
         let wrapper = ExternalWorkerWrapper::new(process);
@@ -636,6 +937,8 @@ mod tests {
                 name: "test-drop-cleanup".to_string(),
                 child: Arc::new(Mutex::new(None)),
                 spawned_at: std::time::Instant::now(),
+                was_ever_alive: Arc::new(AtomicBool::new(false)),
+                poller_handle: None,
                 config_file: std::sync::Mutex::new(Some(temp_path.clone())),
             };
             // process drops here without stop() being called
@@ -654,6 +957,8 @@ mod tests {
             name: name.to_string(),
             child: Arc::new(Mutex::new(None)),
             spawned_at: std::time::Instant::now(),
+            was_ever_alive: Arc::new(AtomicBool::new(false)),
+            poller_handle: None,
             config_file: std::sync::Mutex::new(Some(temp_path.clone())),
         };
 
@@ -669,6 +974,8 @@ mod tests {
             name: "destroy-test".to_string(),
             child: Arc::new(Mutex::new(None)),
             spawned_at: std::time::Instant::now(),
+            was_ever_alive: Arc::new(AtomicBool::new(false)),
+            poller_handle: None,
             config_file: std::sync::Mutex::new(None),
         };
         let wrapper = ExternalWorkerWrapper::new(process);


### PR DESCRIPTION
## Summary

Layered fixes for the `iii worker add /path --force` flow that previously showed up as "60-120s of silence then maybe-success." Three big pieces:

- **Live wait UI.** Spinner glyph + yellow elapsed counter + log-tail row + dynamic "stuck?" hint + terminal-width truncation. The headline counter (`Xs ⠋`) now visibly ticks every second, the `tail:` row surfaces the last line of `~/.iii/logs/<name>/stderr.log` (yellow during non-terminal phases so it pops), and the hint only fires when the log has actually gone silent for 10s+.
- **Reliable engine restart on `--force`.** Engine now latches `was_ever_alive` the moment it observes a worker pidfile, plus runs a post-spawn polling task that keeps probing until alive. Consecutive `iii worker add --force` calls inside the spawn-grace window now actually restart the worker instead of being silently no-op'd.
- **OCI pull with byte-level progress.** Replaced the monolithic `client.pull(...)` with a streaming `pull_with_progress` that walks each layer via `pull_blob_stream`, hashes the bytes with SHA256, and verifies against the manifest descriptor. A 2-second heartbeat task reports real `MiB/total MiB (pct%, MiB/s, elapsed)` progress to the wait UI.

Other changes folded in:

- `iii worker stop` drops the interactive `[y/N]` prompt (stop is reversible via `start`).
- Spinner module wrapping `indicatif::ProgressBar` with the existing aesthetic.
- Engine + libkrun + binary-worker log files open in append mode so subprocess writes don't truncate the parent's progress history.
- `host_shim::run_capturing_stderr` now passes through when stderr is a regular file (the engine-spawned subprocess case), not just a tty — without this, all progress eprintlns from `prepare_rootfs` / OCI heartbeats sat in a tempfile until the handler returned, and the wait UI's `tail:` row was stuck on `• starting <name>` for the entire pull.
- `last_stderr_line` is now hard-capped at 4 KiB via `Read::take` so a concurrent writer at MB/s can't turn a "tail read" into a "drain the firehose" call (this was making the elapsed counter visibly jump by 2 each redraw).
- `Duration::as_secs()` (truncation) replaces `{:.0}` (banker's rounding) for the elapsed display, so 0.5 / 1.5 / 2.5 boundaries no longer collapse the counter to 0, 2, 2, 4.

## Test plan

- [x] `cargo build -p iii` clean
- [x] `cargo build -p iii-worker --bin iii-worker` clean
- [x] `cargo test -p iii-worker --lib`: **793 passed** (added 14 regression tests: SHA256 verify ×5, spinner ×5, stderr_is_regular_file ×3, last_stderr_line bounded ×1, headline elapsed counter ×1)
- [x] `cargo test -p iii --lib`: **1650 passed** (added 4 regression tests in `registry_worker`: was_ever_alive latch, probe_pidfile_alive primitive ×2, OpenOptions truncate+append rejection)
- [x] `cargo fmt --all` clean
- [x] `make sandbox` (release build of iii-init + iii + iii-worker) clean
- [ ] Manual smoke test: `iii worker add ~/path/to/local-worker --force` end-to-end on a cold OCI cache. Expect live byte counter in `tail:` row, elapsed counter advancing by 1 each second, no `failed to open stdout log` regression.
- [ ] Smoke test consecutive `--force` calls within <30s: each should restart the worker (not silently no-op).
- [x] One known-pre-existing test failure: `extract_layer_does_not_chmod_symlinks` in `oci_worker_integration.rs:226`. Verified failing on `main` (3dff7f61c) too — unrelated to this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Steady-tick CLI spinners for network/install phases and conditional activation only on TTY.
  * Byte-level, per-layer OCI image pull progress with upfront layer/size summary and live progress lines.
  * Enhanced live worker status with elapsed-time, spinner overlay, and recent-log activity hints.

* **Bug Fixes**
  * Prevented truncation of existing logs by switching to append mode.
  * Properly detect when stderr is a regular file to avoid capturing live-tailed logs.

* **Improvements**
  * `stop` command no longer requires confirmation; `--yes` documented as a no-op for scripts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->