### PR TITLE
fix(observability): drop getTracer/getMeter/SpanKind from public Node API

### DIFF
--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -27,13 +27,13 @@ import {
   type WorkerRegisteredMessage,
 } from './iii-types'
 import { registerWorkerGauges, stopWorkerGauges } from '@iii-dev/observability'
+import { getMeter, getTracer } from '@iii-dev/observability/internal'
+import { SpanKind } from '@opentelemetry/api'
 import type { IStream } from './stream'
 import { detectProjectName } from './utils'
 import {
   extractContext,
   getLogger,
-  getMeter,
-  getTracer,
   initOtel,
   injectBaggage,
   injectTraceparent,
@@ -43,7 +43,6 @@ import {
   resolveMaxBytesFromEnv,
   SeverityNumber,
   shutdownOtel,
-  SpanKind,
   withSpan,
 } from '@iii-dev/observability'
 import type { TriggerHandler } from './triggers'

--- a/sdk/packages/node/iii/tests/fetch-instrumentation.test.ts
+++ b/sdk/packages/node/iii/tests/fetch-instrumentation.test.ts
@@ -84,7 +84,8 @@ vi.mock('../../observability/src/telemetry-system/connection', () => ({
   })),
 }))
 
-import { initOtel, shutdownOtel, getTracer } from '@iii-dev/observability'
+import { initOtel, shutdownOtel } from '@iii-dev/observability'
+import { getTracer } from '@iii-dev/observability/internal'
 
 describe('Fetch instrumentation', () => {
   const originalEnv = process.env

--- a/sdk/packages/node/iii/tests/logger-runtime.test.ts
+++ b/sdk/packages/node/iii/tests/logger-runtime.test.ts
@@ -25,10 +25,16 @@ vi.mock('@iii-dev/observability', async (importOriginal) => {
     configurable: true,
   })
 
+  return { ...mod }
+})
+
+// Return null tracer so iii.ts falls back to the synthetic-span path when
+// OTel is disabled, which is the behaviour this test exercises. iii.ts reads
+// getTracer from the internal entry point, so the override lives here.
+vi.mock('@iii-dev/observability/internal', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@iii-dev/observability/internal')>()
   return {
     ...mod,
-    // Return null tracer so iii.ts falls back to the synthetic-span path when
-    // OTel is disabled, which is the behaviour this test exercises.
     getTracer: () => null,
   }
 })

--- a/sdk/packages/node/iii/tests/otel-defaults.test.ts
+++ b/sdk/packages/node/iii/tests/otel-defaults.test.ts
@@ -82,13 +82,8 @@ vi.mock('../../observability/src/telemetry-system/connection', () => ({
   })),
 }))
 
-import {
-  initOtel,
-  shutdownOtel,
-  getTracer,
-  getMeter,
-  getLogger,
-} from '@iii-dev/observability'
+import { initOtel, shutdownOtel, getLogger } from '@iii-dev/observability'
+import { getTracer, getMeter } from '@iii-dev/observability/internal'
 
 describe('OTel default-enabled behavior', () => {
   const originalEnv = process.env

--- a/sdk/packages/node/iii/vitest.config.ts
+++ b/sdk/packages/node/iii/vitest.config.ts
@@ -7,6 +7,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 export default defineConfig({
   resolve: {
     alias: {
+      '@iii-dev/observability/internal': path.resolve(
+        __dirname,
+        '../observability/src/internal.ts',
+      ),
       '@iii-dev/observability': path.resolve(__dirname, '../observability/src/index.ts'),
     },
   },

--- a/sdk/packages/node/observability/package.json
+++ b/sdk/packages/node/observability/package.json
@@ -17,6 +17,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
+    },
+    "./internal": {
+      "types": "./dist/internal.d.ts",
+      "import": "./dist/internal.mjs",
+      "require": "./dist/internal.cjs"
     }
   },
   "scripts": {

--- a/sdk/packages/node/observability/src/index.ts
+++ b/sdk/packages/node/observability/src/index.ts
@@ -14,8 +14,6 @@ export {
   getAllBaggage,
   getBaggageEntry,
   getLogger,
-  getMeter,
-  getTracer,
   initOtel,
   injectBaggage,
   injectTraceparent,
@@ -30,7 +28,6 @@ export {
   setCurrentSpanError,
   SeverityNumber,
   shutdownOtel,
-  SpanKind,
   withSpan,
 } from './telemetry-system'
 export type {

--- a/sdk/packages/node/observability/src/internal.ts
+++ b/sdk/packages/node/observability/src/internal.ts
@@ -1,0 +1,5 @@
+// Internal entry point: primitives shared with other first-party iii packages
+// (e.g. @iii-dev/iii) but intentionally kept out of the public API surface.
+// External consumers should use withSpan/initOtel and import SpanKind from
+// @opentelemetry/api directly.
+export { getMeter, getTracer } from './telemetry-system'

--- a/sdk/packages/node/observability/tsdown.config.ts
+++ b/sdk/packages/node/observability/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/internal.ts'],
   format: ['esm', 'cjs'],
   dts: true,
   sourcemap: true,


### PR DESCRIPTION
## What

Follow-up to #1678. That PR consolidated observability into `@iii-dev/observability` but left three symbols exported from the public entry point that the migration plan marked as **drop**:

| Symbol | Plan | Before |
|--------|------|--------|
| `getTracer` | drop | still exported publicly |
| `getMeter` | drop | still exported publicly |
| `SpanKind` | drop | still exported publicly (re-export of otel) |

## Why

These were never meant to be part of the public Node surface. `SpanKind` is just an `@opentelemetry/api` re-export, and `getTracer`/`getMeter` are first-party internals — only `@iii-dev/iii` consumes them. Leaving them exported diverges from the Rust crate (`pub(crate)`) and the agreed plan.

## How

- **`SpanKind`** — removed from the `@iii-dev/observability` public export. `iii.ts` now imports it directly from `@opentelemetry/api` (already a direct dependency).
- **`getTracer` / `getMeter`** — moved to a new `@iii-dev/observability/internal` entry point. The public root stays clean; first-party packages import from `/internal`. `tsdown` emits a shared `telemetry-system` chunk, so the OTel singleton state is preserved across both the root and internal entries.
- `iii.ts` and the affected tests import `getTracer`/`getMeter` from `/internal`; `vitest` aliases the new subpath to source so the singleton stays shared under test.

## Verification

- `pnpm build` (observability) — green; emits shared `telemetry-system` chunk + tiny `index`/`internal` stubs.
- `tsc --noEmit` (iii) — clean.
- `pnpm exec vitest run` on the affected tests — `otel-defaults` (19), `fetch-instrumentation` (20), `logger-runtime` (1) all pass.
- Observability suite + `iii-browser` exports test (asserts these symbols absent) — pass.
- Full `iii` suite compared branch vs `main` baseline: **identical failure set (75 = 75, zero diff)**. All failures are pre-existing engine-integration timeouts (no local engine running), not regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized observability module exports to refine the public API surface
  * Removed certain tracer and meter utilities from public re-exports
  * Added an internal entry point to the observability package

* **Chores**
  * Updated build configuration to include new internal module entry point
  * Adjusted test mocking setup to align with reorganized module structure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->