### PR TITLE
style(blog): format tables and improve mobile responsiveness

### DIFF
--- a/blog/src/styles/global.css
+++ b/blog/src/styles/global.css
@@ -317,6 +317,56 @@ video {
   border-radius: 6px;
 }
 
+/* ============= TABLES ============= */
+/* Markdown tables render as a bare <table>; turn the table itself into a
+   horizontal scroll container so wide tables never burst the layout on
+   small screens, and give cells real borders/padding. */
+article table {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  border-collapse: collapse;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  margin: 1.6rem 0;
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+article thead th {
+  border-bottom: 2px solid var(--ink);
+}
+article th {
+  text-align: left;
+  vertical-align: bottom;
+  font-weight: 700;
+  color: var(--ink);
+  padding: 0.6rem 0.9rem;
+  white-space: nowrap;
+}
+article td {
+  vertical-align: top;
+  color: var(--ink-2);
+  padding: 0.7rem 0.9rem;
+  border-bottom: 1px solid var(--rule);
+}
+article tbody tr:last-child td {
+  border-bottom: 0;
+}
+article tbody tr:nth-child(even) {
+  background: var(--paper-2);
+}
+/* Inline code inside cells should wrap rather than force the column wide.
+   overflow-wrap (not word-break) prefers natural break points such as the
+   hyphen in worker names (iii-/directory) and only splits a token mid-word
+   when it genuinely cannot fit. */
+article td code,
+article th code {
+  white-space: normal;
+  overflow-wrap: break-word;
+}
+
 /* ============= FOOTER ============= */
 .foot {
   border-top: 1px solid var(--rule);
@@ -379,18 +429,68 @@ video {
   color: var(--ink-2);
 }
 
+/* ============= TABLET ============= */
+@media (max-width: 1024px) {
+  body {
+    padding: 24px 12px 40px;
+  }
+  .nav {
+    padding: 16px 22px;
+  }
+  main {
+    padding: 44px 24px 64px;
+  }
+  .foot {
+    padding: 36px 24px 8px;
+  }
+}
+
+/* ============= MOBILE ============= */
 @media (max-width: 640px) {
   body {
     padding: 16px 8px 24px;
   }
   .nav {
-    padding: 14px 18px;
+    padding: 14px 16px;
+    gap: 12px;
+  }
+  .nav-right {
+    gap: 14px;
+    font-size: 0.8rem;
   }
   main {
-    padding: 36px 18px 56px;
+    padding: 32px 16px 48px;
+  }
+  h1,
+  article header h1 {
+    font-size: 1.6rem;
+  }
+  h2 {
+    font-size: 1.2rem;
+  }
+  h3 {
+    font-size: 1.05rem;
+  }
+  p,
+  article ul,
+  article ol {
+    line-height: 1.65;
+  }
+  /* Long inline-code tokens (e.g. iii://<worker>/<function>) must wrap on
+     phones instead of forcing horizontal page scroll. */
+  :not(pre) > code {
+    white-space: normal;
+    overflow-wrap: break-word;
+  }
+  article table {
+    font-size: 0.82rem;
+  }
+  article th,
+  article td {
+    padding: 0.55rem 0.65rem;
   }
   .foot {
-    padding: 32px 18px 8px;
+    padding: 32px 16px 8px;
   }
   .foot-cols {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary

Follow-up to #1706. The blog's markdown tables had **no styling** and inline `code` was forced `white-space: nowrap`, so the worker table rendered as cramped, borderless columns that overflowed horizontally on phones. The layout also only had a single mobile breakpoint.

This PR makes the blog readable on phones and tablets:

- **Tables**: bordered, zebra-striped cells with a bold header row + separator, real cell padding, and the table is now a horizontal-scroll container so wide tables never burst the layout.
- **In-cell code** wraps at natural break points via `overflow-wrap` (e.g. `iii-`/`directory`, `turn-`/`orchestrator`) instead of forcing the column wide.
- **Tablet breakpoint** (`max-width: 1024px`) tightens page padding.
- **Mobile breakpoint** (`max-width: 640px`) scales down headings, reduces table type/padding, and lets long inline-code tokens (e.g. `iii://<worker>/<function>`) wrap instead of triggering horizontal page scroll.

All styling uses the existing CSS design tokens, so it works in both light and dark themes.

## Test plan

- [x] `astro dev` renders the post with formatted tables (header separator, zebra rows, padding, borders)
- [x] Desktop (760px content): table fits, no horizontal overflow
- [x] Mobile (390px): table content wraps, scrollWidth equals clientWidth (no horizontal page scroll), worker names break at the hyphen
- [ ] Reviewer: confirm dark-mode table contrast looks right


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced table presentation with scrollable layout, borders, and improved formatting for better readability.
  * Refined responsive design for tablet and mobile viewports with adjusted spacing, typography, and table sizing for optimal display across devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->