### PR TITLE
fix(console): worker detail crash when worker has no functions array

### DIFF
--- a/console/packages/console-frontend/package.json
+++ b/console/packages/console-frontend/package.json
@@ -11,6 +11,7 @@
     "build": "tsc -b && vite build",
     "build:binary": "vite build --mode binary",
     "preview": "vite preview",
+    "test": "vitest run",
     "lint": "biome check src",
     "lint:fix": "biome check src --write",
     "format": "biome format src --write"
@@ -53,6 +54,7 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^4",
     "typescript": "^5",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^2.1.9"
   }
 }

--- a/console/packages/console-frontend/src/api/index.ts
+++ b/console/packages/console-frontend/src/api/index.ts
@@ -64,12 +64,7 @@ export type {
   SdkMetric,
   WorkerPoolMetrics,
 } from './observability/metrics'
-export {
-  fetchDetailedMetrics,
-  fetchMetrics,
-  fetchMetricsHistory,
-  fetchRollups,
-} from './observability/metrics'
+export { fetchDetailedMetrics, fetchMetrics, fetchRollups } from './observability/metrics'
 // Observability - Traces
 export type {
   SpanEvent,

--- a/console/packages/console-frontend/src/api/observability/metrics.ts
+++ b/console/packages/console-frontend/src/api/observability/metrics.ts
@@ -83,17 +83,6 @@ export async function fetchMetrics(): Promise<MetricsSnapshot> {
   return unwrapResponse(res)
 }
 
-export async function fetchMetricsHistory(
-  limit?: number,
-): Promise<{ history: MetricsSnapshot[]; count: number }> {
-  const url = limit
-    ? `${getDevtoolsApi()}/metrics/history?limit=${limit}`
-    : `${getDevtoolsApi()}/metrics/history`
-  const res = await fetch(url)
-  if (!res.ok) throw new Error('Failed to fetch metrics history')
-  return unwrapResponse(res)
-}
-
 export async function fetchDetailedMetrics(options?: {
   start_time?: number
   end_time?: number

--- a/console/packages/console-frontend/src/api/queries.ts
+++ b/console/packages/console-frontend/src/api/queries.ts
@@ -9,12 +9,7 @@ import {
 } from './events/functions'
 import { fetchFlowConfig, fetchFlows } from './flows/flows'
 import { fetchLogs, fetchOtelLogs } from './observability/logs'
-import {
-  fetchDetailedMetrics,
-  fetchMetrics,
-  fetchMetricsHistory,
-  fetchRollups,
-} from './observability/metrics'
+import { fetchDetailedMetrics, fetchMetrics, fetchRollups } from './observability/metrics'
 import { fetchTraces, fetchTraceTree } from './observability/traces'
 import { fetchDlqMessages, fetchDlqTopics, fetchQueueDetail, fetchQueues } from './queues'
 import { fetchStateGroups, fetchStateItems } from './state/state'
@@ -67,13 +62,6 @@ export const metricsQuery = queryOptions({
   queryKey: ['metrics'],
   queryFn: fetchMetrics,
 })
-
-// Metrics history
-export const metricsHistoryQuery = (limit?: number) =>
-  queryOptions({
-    queryKey: ['metrics-history', limit],
-    queryFn: () => fetchMetricsHistory(limit),
-  })
 
 // Events info
 export const eventsInfoQuery = queryOptions({

--- a/console/packages/console-frontend/src/api/system/workers.test.ts
+++ b/console/packages/console-frontend/src/api/system/workers.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchWorkers } from './workers'
+
+function mockFetchResolving(payload: unknown): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      json: async () => payload,
+    })),
+  )
+}
+
+describe('fetchWorkers', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  // Regression for iii-hq/iii#1708: in-process/built-in workers (e.g. `configuration`)
+  // are reported with `function_count` but no `functions` array. The worker detail page
+  // reads `selectedWorker.functions.length`, which threw "Cannot read properties of
+  // undefined (reading 'length')" before normalization.
+  it('defaults `functions` to an empty array when the engine omits it', async () => {
+    mockFetchResolving({
+      workers: [{ id: 'configuration', name: 'configuration', function_count: 5 }],
+      timestamp: 1,
+    })
+
+    const { workers } = await fetchWorkers()
+
+    expect(workers[0].functions).toEqual([])
+    expect(() => workers[0].functions.length).not.toThrow()
+  })
+
+  it('preserves an existing `functions` array for external SDK workers', async () => {
+    mockFetchResolving({
+      workers: [{ id: 'w1', name: 'sdk', function_count: 2, functions: ['a::run', 'b::run'] }],
+      timestamp: 1,
+    })
+
+    const { workers } = await fetchWorkers()
+
+    expect(workers[0].functions).toEqual(['a::run', 'b::run'])
+  })
+})

--- a/console/packages/console-frontend/src/api/system/workers.ts
+++ b/console/packages/console-frontend/src/api/system/workers.ts
@@ -48,9 +48,17 @@ export async function fetchWorkers(): Promise<{
   const res = await fetch(`${getDevtoolsApi()}/workers`)
   if (!res.ok) throw new Error('Failed to fetch workers')
   const data = await unwrapResponse<{ workers: WorkerInfo[]; timestamp: number }>(res)
+  // In-process/built-in workers (configuration, iii-telemetry, etc.) are reported
+  // with `function_count` but no `functions` array. Normalize so the non-optional
+  // `functions: string[]` contract holds for every consumer (e.g. the worker
+  // detail page reads `worker.functions.length`).
+  const workers = (data.workers || []).map((worker) => ({
+    ...worker,
+    functions: worker.functions ?? [],
+  }))
   return {
-    workers: data.workers || [],
-    count: (data.workers || []).length,
+    workers,
+    count: workers.length,
     timestamp: data.timestamp,
   }
 }

--- a/console/packages/console-frontend/src/routes/index.tsx
+++ b/console/packages/console-frontend/src/routes/index.tsx
@@ -8,21 +8,14 @@ import {
   Database,
   Globe,
   MessageSquare,
-  TrendingUp,
   Users,
   Wifi,
   Zap,
 } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect } from 'react'
 import { createMetricsSubscription } from '@/api'
 import { useConfig } from '@/api/config-provider'
-import {
-  functionsQuery,
-  metricsHistoryQuery,
-  statusQuery,
-  streamsQuery,
-  triggersQuery,
-} from '@/api/queries'
+import { functionsQuery, statusQuery, streamsQuery, triggersQuery } from '@/api/queries'
 import { Badge, Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -37,149 +30,31 @@ export const Route = createFileRoute('/')({
       queryClient.prefetchQuery(functionsQuery()),
       queryClient.prefetchQuery(triggersQuery()),
       queryClient.prefetchQuery(streamsQuery),
-      queryClient.prefetchQuery(metricsHistoryQuery(100)),
     ])
     throw redirect({ to: '/workers' })
   },
 })
 
-interface MiniChartProps {
-  data: number[]
-  color: string
-  height?: number
-}
-
-function MiniChart({ data, color, height = 40 }: MiniChartProps) {
-  if (data.length < 2) {
-    return (
-      <svg
-        viewBox={`0 0 100 ${height}`}
-        className="w-full h-8"
-        preserveAspectRatio="none"
-        aria-hidden="true"
-      >
-        <defs>
-          <linearGradient id="skeleton-pulse" x1="0" y1="0" x2="1" y2="0">
-            <stop offset="0%" stopColor={color} stopOpacity="0.08">
-              <animate
-                attributeName="stop-opacity"
-                values="0.08;0.2;0.08"
-                dur="2s"
-                repeatCount="indefinite"
-              />
-            </stop>
-            <stop offset="50%" stopColor={color} stopOpacity="0.15">
-              <animate
-                attributeName="stop-opacity"
-                values="0.15;0.3;0.15"
-                dur="2s"
-                repeatCount="indefinite"
-              />
-            </stop>
-            <stop offset="100%" stopColor={color} stopOpacity="0.08">
-              <animate
-                attributeName="stop-opacity"
-                values="0.08;0.2;0.08"
-                dur="2s"
-                repeatCount="indefinite"
-              />
-            </stop>
-          </linearGradient>
-        </defs>
-        <polyline
-          points="0,28 12,22 25,26 37,18 50,20 62,14 75,18 87,12 100,16"
-          fill="none"
-          stroke={color}
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeOpacity="0.2"
-          vectorEffect="non-scaling-stroke"
-        />
-        <polygon
-          points="0,32 0,28 12,22 25,26 37,18 50,20 62,14 75,18 87,12 100,16 100,32"
-          fill="url(#skeleton-pulse)"
-        />
-      </svg>
-    )
-  }
-
-  const max = Math.max(...data)
-  const min = Math.min(...data)
-  const range = max - min || 1
-
-  const points = data
-    .map((value, i) => {
-      const x = (i / (data.length - 1)) * 100
-      const y = ((max - value) / range) * height
-      return `${x},${y}`
-    })
-    .join(' ')
-
-  const areaPoints = `0,${height} ${points} 100,${height}`
-
-  return (
-    <svg
-      viewBox={`0 0 100 ${height}`}
-      className="w-full h-full"
-      preserveAspectRatio="none"
-      aria-hidden="true"
-    >
-      <defs>
-        <linearGradient id={`gradient-${color}`} x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor={color} stopOpacity="0.3" />
-          <stop offset="100%" stopColor={color} stopOpacity="0" />
-        </linearGradient>
-      </defs>
-      <polygon points={areaPoints} fill={`url(#gradient-${color})`} />
-      <polyline
-        points={points}
-        fill="none"
-        stroke={color}
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        vectorEffect="non-scaling-stroke"
-      />
-    </svg>
-  )
-}
-
 interface MetricsChartProps {
   title: string
   value: number | string
-  data: number[]
   color: string
   icon: React.ElementType
-  trend?: number
   href?: string
 }
 
-function MetricsChart({ title, value, data, color, icon: Icon, trend, href }: MetricsChartProps) {
+function MetricsChart({ title, value, color, icon: Icon, href }: MetricsChartProps) {
   const content = (
     <div className="bg-elevated rounded-[var(--radius-lg)] border border-border-subtle p-4 transition-all duration-200 group-hover:border-muted/40 group-hover:-translate-y-0.5 cursor-pointer">
-      <div className="flex items-center justify-between mb-2">
-        <div className="flex items-center gap-2">
-          <div className="p-1.5 rounded-md" style={{ backgroundColor: `${color}20` }}>
-            <Icon className="w-4 h-4" style={{ color }} />
-          </div>
-          <span className="font-sans font-semibold text-xs text-muted uppercase tracking-[0.04em]">
-            {title}
-          </span>
+      <div className="flex items-center gap-2 mb-2">
+        <div className="p-1.5 rounded-md" style={{ backgroundColor: `${color}20` }}>
+          <Icon className="w-4 h-4" style={{ color }} />
         </div>
-        {trend !== undefined && trend !== 0 && (
-          <div
-            className={`flex items-center gap-1 text-xs font-medium ${trend > 0 ? 'text-success' : 'text-error'}`}
-          >
-            <TrendingUp className={`w-3 h-3 ${trend < 0 ? 'rotate-180' : ''}`} />
-            {Math.abs(trend)}%
-          </div>
-        )}
+        <span className="font-sans font-semibold text-xs text-muted uppercase tracking-[0.04em]">
+          {title}
+        </span>
       </div>
-      <div className="font-mono text-2xl font-bold mb-2">{value}</div>
-      <div className="h-8 opacity-60 group-hover:opacity-100 transition-opacity">
-        <MiniChart data={data} color={color} height={32} />
-      </div>
+      <div className="font-mono text-2xl font-bold">{value}</div>
     </div>
   )
 
@@ -196,13 +71,11 @@ function MetricsChart({ title, value, data, color, icon: Icon, trend, href }: Me
 
 function DashboardPage() {
   const queryClient = useQueryClient()
-  const [lastUpdate, setLastUpdate] = useState<Date | null>(null)
 
   const { data: statusData, isLoading: statusLoading } = useQuery(statusQuery)
   const { data: functionsData, isLoading: functionsLoading } = useQuery(functionsQuery())
   const { data: triggersData, isLoading: triggersLoading } = useQuery(triggersQuery())
   const { data: streamsData } = useQuery(streamsQuery)
-  const { data: metricsHistoryData } = useQuery(metricsHistoryQuery(100))
 
   const config = useConfig()
   const loading = statusLoading || functionsLoading || triggersLoading
@@ -217,49 +90,13 @@ function DashboardPage() {
     }
   }, [queryClient])
 
-  // Track last update when metrics change
-  useEffect(() => {
-    if (metricsHistoryData?.history?.length) {
-      setLastUpdate(new Date())
-    }
-  }, [metricsHistoryData])
-
   const status = statusData ?? null
   const triggers = triggersData?.triggers ?? []
   const functions = functionsData?.functions ?? []
   const streams = streamsData?.streams ?? []
-  const metricsHistory = metricsHistoryData?.history ?? []
 
   const userTriggers = triggers.filter((t) => !t.internal)
   const userFunctions = functions.filter((f) => !f.internal)
-
-  const functionsChartData = useMemo(
-    () => metricsHistory.map((m) => m.functions_count),
-    [metricsHistory],
-  )
-
-  const triggersChartData = useMemo(
-    () => metricsHistory.map((m) => m.triggers_count),
-    [metricsHistory],
-  )
-
-  const workersData = useMemo(() => metricsHistory.map((m) => m.workers_count), [metricsHistory])
-
-  const streamsChartData = useMemo(
-    () => metricsHistory.map(() => streams.filter((s) => !s.internal).length),
-    [metricsHistory, streams],
-  )
-
-  const calculateTrend = useCallback((data: number[]): number => {
-    if (data.length < 2) return 0
-    const recent = data.slice(-5)
-    const older = data.slice(0, 5)
-    if (older.length === 0 || recent.length === 0) return 0
-    const recentAvg = recent.reduce((a, b) => a + b, 0) / recent.length
-    const olderAvg = older.reduce((a, b) => a + b, 0) / older.length
-    if (olderAvg === 0) return 0
-    return Math.round(((recentAvg - olderAvg) / olderAvg) * 100)
-  }, [])
 
   return (
     <div className="p-4 md:p-6 space-y-4 md:space-y-6 max-w-[1800px] mx-auto">
@@ -274,36 +111,28 @@ function DashboardPage() {
         <MetricsChart
           title="Functions"
           value={loading ? '—' : userFunctions.length}
-          data={functionsChartData}
           color="var(--success)"
           icon={Activity}
-          trend={calculateTrend(functionsChartData)}
           href="/functions"
         />
         <MetricsChart
           title="Triggers"
           value={loading ? '—' : userTriggers.length}
-          data={triggersChartData}
           color="var(--accent)"
           icon={Zap}
-          trend={calculateTrend(triggersChartData)}
           href="/triggers"
         />
         <MetricsChart
           title="Workers"
           value={loading ? '—' : (status?.workers ?? 0)}
-          data={workersData}
           color="#06B6D4"
           icon={Users}
-          trend={calculateTrend(workersData)}
         />
         <MetricsChart
           title="Streams"
           value={loading ? '—' : streams.filter((s) => !s.internal).length}
-          data={streamsChartData}
           color="var(--info)"
           icon={Wifi}
-          trend={calculateTrend(streamsChartData)}
           href="/streams"
         />
       </div>
@@ -647,13 +476,6 @@ function DashboardPage() {
                 <div className="font-mono text-[13px] font-medium">:{config.wsPort}</div>
               </div>
             </div>
-
-            {lastUpdate && (
-              <div className="flex items-center justify-center gap-1.5 text-xs text-muted">
-                <span className="w-1.5 h-1.5 rounded-full bg-yellow animate-pulse" />
-                Last update {lastUpdate.toLocaleTimeString()}
-              </div>
-            )}
           </CardContent>
         </Card>
       </div>

--- a/console/packages/console-frontend/vitest.config.ts
+++ b/console/packages/console-frontend/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+// Standalone config (does not extend vite.config.ts) so unit tests run without
+// the app's Vite plugins. Tests mock network/IO and target node by default.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@25.3.3)(happy-dom@17.6.3)(lightningcss@1.31.1)
 
   docs:
     devDependencies:


### PR DESCRIPTION
## Summary

Fixes the console crash reported in #1708: clicking an in-process worker
(`configuration`, `iii-telemetry`, `iii-engine-functions`, `iii-worker-manager`,
`iii-http`) on the Workers page threw `Cannot read properties of undefined
(reading 'length')` and blanked the page.

Two independent changes:

**Crash fix.** The engine's `_console/workers` response reports in-process workers
with `function_count` but no `functions` array. `WorkerInfo.functions` is typed
`string[]` (non-optional), and `workers.tsx:600` read `selectedWorker.functions.length`,
so `functions` being `undefined` at runtime crashed the page. Fix normalizes
`functions` to `[]` at the `fetchWorkers` boundary, so the type contract holds for
every consumer. The issue author guessed the culprit was triggers, but this console
renders functions, not triggers — the real access was `functions.length`.

**Dead `metrics/history` path removal.** `_console/metrics/history` was never
registered in the console-rust bridge (`triggers.rs` registers `metrics/detailed`
and `rollups`, no `history`), so `fetchMetricsHistory` always 404'd and spammed the
console. Its only caller was the home dashboard, whose loader redirects to `/workers`
before rendering — so the history-driven sparklines never displayed. Removed
`fetchMetricsHistory`, `metricsHistoryQuery`, the loader prefetch, and the now-dead
`MiniChart`/`trend` rendering on the dashboard cards. The live websocket metrics feed
(different cache key) is untouched.

## Changes

- `src/api/system/workers.ts` — normalize `functions ?? []` in `fetchWorkers`
- `src/api/system/workers.test.ts` — regression test (new; bootstraps vitest)
- `vitest.config.ts`, `package.json`, `pnpm-lock.yaml` — vitest test infra
- `src/routes/index.tsx`, `src/api/queries.ts`, `src/api/observability/metrics.ts`, `src/api/index.ts` — remove dead metrics/history path

## Test coverage

New `fetchWorkers` regression test: a worker with no `functions` field normalizes to
`functions: []` (would crash before the fix); a worker with `functions` keeps them.
Verified the test fails without the fix and passes with it.

## Verification

- `tsc --noEmit` — clean
- `biome check src` — clean
- `vitest run` — 2/2 pass

## Notes

- This is a regression in 0.16: the in-process workers didn't exist as separately
  listed workers in 0.13, so the UI never exercised this path before.
- Pre-existing (not changed here): the `/` route loader unconditionally redirects to
  `/workers`, so `DashboardPage` is unreachable dead code. A separate cleanup could
  remove it entirely.

Closes #1708

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added test framework integration for the frontend.

* **UI Changes**
  * Simplified dashboard metrics display by removing historical trend charts.

* **Bug Fixes**
  * Improved worker data handling to prevent errors when functions data is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1710?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->