### PR TITLE
fix(observability): honor trace sort order and treat HTTP <400 as non-error

### DIFF
--- a/console/packages/console-frontend/src/hooks/useTraceData.ts
+++ b/console/packages/console-frontend/src/hooks/useTraceData.ts
@@ -2,22 +2,11 @@ import { useQuery } from '@tanstack/react-query'
 import { useEffect, useRef, useState } from 'react'
 import { fetchTraces } from '@/api'
 import type { TracesFilterParams } from '@/api/observability/traces'
-import { toMs } from '@/lib/traceTransform'
+import { buildTraceGroups, type TraceGroup, traceGroupsFingerprint } from '@/lib/traceGroups'
 
 const DEFAULT_TRACE_LIMIT = 500
 
-export interface TraceGroup {
-  traceId: string
-  rootOperation: string
-  functionId?: string
-  topic?: string
-  status: 'ok' | 'error' | 'pending'
-  startTime: number
-  endTime?: number
-  duration?: number
-  spanCount: number
-  services: string[]
-}
+export type { TraceGroup } from '@/lib/traceGroups'
 
 export interface UseTraceDataOptions {
   filterParams: TracesFilterParams
@@ -77,41 +66,12 @@ export function useTraceData({
     if (!tracesData) return
 
     if (tracesData.spans && tracesData.spans.length > 0) {
-      const traces: TraceGroup[] = tracesData.spans.map((span) => {
-        const startTime = toMs(span.start_time_unix_nano)
-        const endTime = toMs(span.end_time_unix_nano)
-        const duration = endTime - startTime
+      // Preserve the server-provided order: the backend already sorts by the
+      // requested sort_by/sort_order. Re-sorting here would override the user's
+      // sort selection (e.g. Duration Asc/Desc).
+      const traces = buildTraceGroups(tracesData.spans)
 
-        const attrs: Record<string, unknown> = {}
-        if (Array.isArray(span.attributes)) {
-          for (const item of span.attributes) {
-            if (Array.isArray(item) && item.length >= 2) {
-              attrs[String(item[0])] = item[1]
-            }
-          }
-        } else if (span.attributes) {
-          Object.assign(attrs, span.attributes)
-        }
-        const functionId = (attrs['faas.invoked_name'] || attrs.function_id) as string | undefined
-        const topic = attrs['messaging.destination.name'] as string | undefined
-
-        return {
-          traceId: span.trace_id,
-          rootOperation: span.name,
-          functionId,
-          topic,
-          status: span.status.toLowerCase() === 'error' ? 'error' : 'ok',
-          startTime,
-          endTime,
-          duration,
-          spanCount: 1,
-          services: [span.service_name || 'unknown'],
-        }
-      })
-
-      traces.sort((a, b) => b.startTime - a.startTime)
-
-      const fingerprint = `${traces.length}:${traces[0]?.traceId}:${traces[traces.length - 1]?.traceId}:${traces[traces.length - 1]?.startTime}`
+      const fingerprint = traceGroupsFingerprint(traces)
       if (fingerprint === fingerprintRef.current) return
       fingerprintRef.current = fingerprint
 

--- a/console/packages/console-frontend/src/lib/traceGroups.test.ts
+++ b/console/packages/console-frontend/src/lib/traceGroups.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import type { StoredSpan } from '@/api/observability/traces'
+import { buildTraceGroups, traceGroupsFingerprint } from './traceGroups'
+
+function span(overrides: Partial<StoredSpan> & Pick<StoredSpan, 'trace_id'>): StoredSpan {
+  return {
+    span_id: overrides.span_id ?? overrides.trace_id,
+    name: 'op',
+    start_time_unix_nano: 0,
+    end_time_unix_nano: 0,
+    status: 'ok',
+    attributes: [],
+    events: [],
+    links: [],
+    ...overrides,
+  }
+}
+
+describe('buildTraceGroups', () => {
+  // Regression for iii-hq/iii: the trace list re-sorted spans by start time on
+  // the client, silently overriding the server's sort_by/sort_order. Duration
+  // Asc/Desc then appeared to do nothing (or the reverse of what was selected).
+  // The server already sorts; the mapper must preserve that order.
+  it('preserves the server-provided order (does not re-sort by start time)', () => {
+    // Server order for "Duration Asc": shortest first. Start times are chosen so
+    // that re-sorting by start time descending would reorder to [s2, s3, s1].
+    const spans = [
+      span({ trace_id: 's1', start_time_unix_nano: 10, end_time_unix_nano: 20 }), // dur 10
+      span({ trace_id: 's2', start_time_unix_nano: 300, end_time_unix_nano: 320 }), // dur 20
+      span({ trace_id: 's3', start_time_unix_nano: 200, end_time_unix_nano: 230 }), // dur 30
+    ]
+
+    const groups = buildTraceGroups(spans)
+
+    expect(groups.map((g) => g.traceId)).toEqual(['s1', 's2', 's3'])
+  })
+
+  it('computes duration and maps error status', () => {
+    const [group] = buildTraceGroups([
+      span({ trace_id: 't1', start_time_unix_nano: 100, end_time_unix_nano: 175, status: 'ERROR' }),
+    ])
+
+    expect(group.duration).toBe(75)
+    expect(group.status).toBe('error')
+  })
+})
+
+describe('traceGroupsFingerprint', () => {
+  // Regression for iii-hq/iii: the old fingerprint was length + first id + last
+  // id + last startTime, so a middle-only reorder ([A,B,C,D] -> [A,C,B,D]) — the
+  // exact shape a sort_by change produces — fingerprinted identically and the
+  // list froze on the old order. The fingerprint must reflect full ordering.
+  it('changes when only the middle order changes (same first, last, length)', () => {
+    const s1 = span({ trace_id: 'a', start_time_unix_nano: 100 })
+    const s2 = span({ trace_id: 'b', start_time_unix_nano: 200 })
+    const s3 = span({ trace_id: 'c', start_time_unix_nano: 300 })
+    const s4 = span({ trace_id: 'd', start_time_unix_nano: 400 })
+
+    const original = traceGroupsFingerprint(buildTraceGroups([s1, s2, s3, s4]))
+    const reordered = traceGroupsFingerprint(buildTraceGroups([s1, s3, s2, s4]))
+
+    expect(reordered).not.toBe(original)
+  })
+
+  it('is stable for identical input so unchanged polls are skipped', () => {
+    const spans = [
+      span({ trace_id: 'a', start_time_unix_nano: 100, end_time_unix_nano: 150 }),
+      span({ trace_id: 'b', start_time_unix_nano: 200, end_time_unix_nano: 260 }),
+    ]
+
+    expect(traceGroupsFingerprint(buildTraceGroups(spans))).toBe(
+      traceGroupsFingerprint(buildTraceGroups(spans)),
+    )
+  })
+
+  it('changes when a row content changes (status or timing) at the same id', () => {
+    const base = traceGroupsFingerprint(
+      buildTraceGroups([
+        span({ trace_id: 'a', start_time_unix_nano: 100, end_time_unix_nano: 150 }),
+      ]),
+    )
+    const statusChanged = traceGroupsFingerprint(
+      buildTraceGroups([
+        span({
+          trace_id: 'a',
+          start_time_unix_nano: 100,
+          end_time_unix_nano: 150,
+          status: 'ERROR',
+        }),
+      ]),
+    )
+    const timingChanged = traceGroupsFingerprint(
+      buildTraceGroups([
+        span({ trace_id: 'a', start_time_unix_nano: 100, end_time_unix_nano: 999 }),
+      ]),
+    )
+
+    expect(statusChanged).not.toBe(base)
+    expect(timingChanged).not.toBe(base)
+  })
+})

--- a/console/packages/console-frontend/src/lib/traceGroups.ts
+++ b/console/packages/console-frontend/src/lib/traceGroups.ts
@@ -1,0 +1,68 @@
+import type { StoredSpan } from '@/api/observability/traces'
+import { toMs } from './traceTransform'
+
+export interface TraceGroup {
+  traceId: string
+  rootOperation: string
+  functionId?: string
+  topic?: string
+  status: 'ok' | 'error' | 'pending'
+  startTime: number
+  endTime?: number
+  duration?: number
+  spanCount: number
+  services: string[]
+}
+
+/**
+ * Map raw spans to display rows, preserving the server-provided order.
+ *
+ * The order matters: the backend already sorts by the requested
+ * `sort_by`/`sort_order`. Re-sorting here would silently override the user's
+ * sort selection (e.g. Duration Asc/Desc), so callers must keep this order.
+ */
+export function buildTraceGroups(spans: StoredSpan[]): TraceGroup[] {
+  return spans.map((span) => {
+    const startTime = toMs(span.start_time_unix_nano)
+    const endTime = toMs(span.end_time_unix_nano)
+    const duration = endTime - startTime
+
+    const attrs: Record<string, unknown> = {}
+    if (Array.isArray(span.attributes)) {
+      for (const item of span.attributes) {
+        if (Array.isArray(item) && item.length >= 2) {
+          attrs[String(item[0])] = item[1]
+        }
+      }
+    } else if (span.attributes) {
+      Object.assign(attrs, span.attributes)
+    }
+    const functionId = (attrs['faas.invoked_name'] || attrs.function_id) as string | undefined
+    const topic = attrs['messaging.destination.name'] as string | undefined
+
+    return {
+      traceId: span.trace_id,
+      rootOperation: span.name,
+      functionId,
+      topic,
+      status: span.status.toLowerCase() === 'error' ? 'error' : 'ok',
+      startTime,
+      endTime,
+      duration,
+      spanCount: 1,
+      services: [span.service_name || 'unknown'],
+    }
+  })
+}
+
+/**
+ * Fingerprint a list of trace rows for change detection.
+ *
+ * Reflects order AND per-row content so a re-sort (e.g. switching sort_by) or
+ * an in-place update (status/timing change) is detected. A coarse fingerprint
+ * (length + first/last id) silently misses middle-only reorders like
+ * `[A,B,C,D] -> [A,C,B,D]`, which would freeze the list on a sort change.
+ */
+export function traceGroupsFingerprint(groups: TraceGroup[]): string {
+  return groups.map((g) => `${g.traceId}:${g.status}:${g.startTime}:${g.endTime ?? ''}`).join('|')
+}

--- a/engine/src/invocation/http_invoker.rs
+++ b/engine/src/invocation/http_invoker.rs
@@ -20,6 +20,16 @@ use crate::{
     protocol::ErrorBody,
 };
 
+/// Treat any HTTP response below 400 as a successful invocation.
+///
+/// Matches the observability rule: 1xx/2xx/3xx are not errors; only responses
+/// with status >= 400 (4xx client errors, 5xx server errors) are failures.
+/// `reqwest::StatusCode::is_success` would reject 3xx, so we compare on the
+/// numeric code instead.
+fn is_non_error_status(status: reqwest::StatusCode) -> bool {
+    status.as_u16() < 400
+}
+
 /// Format a reqwest error including the full cause chain for actionable messages.
 fn format_reqwest_error(err: &reqwest::Error) -> String {
     use std::error::Error;
@@ -224,7 +234,7 @@ impl HttpInvoker {
             stacktrace: None,
         })?;
 
-        if response.status().is_success() {
+        if is_non_error_status(response.status()) {
             return Ok(());
         }
 
@@ -281,6 +291,9 @@ impl HttpInvoker {
         })?;
 
         if status.is_success() {
+            // 2xx: a function result is expected to be JSON (or empty). A
+            // malformed body here is a genuine contract violation, so it stays
+            // an error.
             if bytes.is_empty() {
                 return Ok(None);
             }
@@ -290,6 +303,13 @@ impl HttpInvoker {
                 stacktrace: None,
             })?;
             return Ok(Some(result));
+        }
+
+        if is_non_error_status(status) {
+            // 1xx/3xx: not an error and not a function result (e.g. a redirect
+            // carrying an HTML body). Treat it as a result-less success rather
+            // than failing on a non-JSON body. Surface a JSON body if present.
+            return Ok(serde_json::from_slice::<Value>(&bytes).ok());
         }
 
         Err(Self::parse_error_response(status, &bytes))
@@ -327,6 +347,24 @@ mod tests {
     use tokio::net::TcpListener;
 
     use super::*;
+
+    #[test]
+    fn is_non_error_status_treats_below_400_as_success() {
+        // Anything < 400 (1xx, 2xx, 3xx) is a successful invocation, not an error.
+        for code in [100u16, 200, 201, 204, 301, 302, 304, 307, 308, 399] {
+            assert!(
+                is_non_error_status(reqwest::StatusCode::from_u16(code).unwrap()),
+                "status {code} should be treated as success"
+            );
+        }
+        // >= 400 stays an error.
+        for code in [400u16, 404, 422, 500, 502, 503] {
+            assert!(
+                !is_non_error_status(reqwest::StatusCode::from_u16(code).unwrap()),
+                "status {code} should be treated as error"
+            );
+        }
+    }
 
     #[derive(Clone, Default)]
     struct RequestCapture {
@@ -404,6 +442,12 @@ mod tests {
         (StatusCode::BAD_REQUEST, "bad request")
     }
 
+    async fn redirect_html_handler() -> (StatusCode, &'static str) {
+        // 3xx (< 400) with a non-JSON body — must be treated as a result-less
+        // success, not an `invalid_response` error.
+        (StatusCode::FOUND, "<html>redirecting</html>")
+    }
+
     async fn webhook_handler(
         State(capture): State<RequestCapture>,
         method: AxumMethod,
@@ -425,6 +469,7 @@ mod tests {
             .route("/invalid", any(invalid_handler))
             .route("/error-json", any(error_json_handler))
             .route("/error-plain", any(error_plain_handler))
+            .route("/redirect-html", any(redirect_html_handler))
             .route("/webhook", any(webhook_handler))
             .with_state(capture);
 
@@ -754,6 +799,34 @@ mod tests {
             .expect_err("error response should fail");
         assert_eq!(error.code, "upstream_failure");
         assert_eq!(error.message, "gateway failed");
+    }
+
+    #[tokio::test]
+    async fn invoke_http_treats_redirect_with_non_json_body_as_non_error() {
+        // Regression: a 3xx (< 400) response carrying a non-JSON body (e.g. an
+        // HTML redirect page) must be a result-less success, not an
+        // `invalid_response` error that would surface as an error trace.
+        let capture = RequestCapture::default();
+        let base_url = spawn_server(capture).await;
+        let invoker = permissive_invoker();
+        let url = format!("{base_url}/redirect-html");
+        let timeout: Option<u64> = None;
+        let headers = HashMap::new();
+        let auth = None;
+        let endpoint = HttpEndpointParams {
+            url: &url,
+            method: &HttpMethod::Get,
+            timeout_ms: &timeout,
+            headers: &headers,
+            auth: &auth,
+        };
+
+        let result = invoker
+            .invoke_http("svc.redirect", &endpoint, Uuid::nil(), json!({}), None, None)
+            .await
+            .expect("3xx with non-JSON body should be a result-less success, not an error");
+
+        assert_eq!(result, None);
     }
 
     #[tokio::test]

--- a/engine/src/invocation/http_invoker.rs
+++ b/engine/src/invocation/http_invoker.rs
@@ -822,7 +822,14 @@ mod tests {
         };
 
         let result = invoker
-            .invoke_http("svc.redirect", &endpoint, Uuid::nil(), json!({}), None, None)
+            .invoke_http(
+                "svc.redirect",
+                &endpoint,
+                Uuid::nil(),
+                json!({}),
+                None,
+                None,
+            )
             .await
             .expect("3xx with non-JSON body should be a result-less success, not an error");
 

--- a/engine/src/workers/rest_api/views.rs
+++ b/engine/src/workers/rest_api/views.rs
@@ -32,6 +32,15 @@ fn generate_error_id() -> String {
     format!("{:x}", timestamp & 0xFFFFFFFFFFFF)
 }
 
+/// Map an HTTP response status code to an OTel span status string.
+///
+/// Only responses with status >= 400 are treated as errors; 1xx/2xx/3xx
+/// (anything below 400) are not. A 3xx redirect is a normal outcome, not a
+/// failure, so it must not surface as an error in observability traces.
+fn otel_status_for(status_code: u16) -> &'static str {
+    if status_code < 400 { "OK" } else { "ERROR" }
+}
+
 use super::{HttpWorker, api_core::RouterMatch, types::TriggerMetadata};
 use crate::engine::{Engine, EngineTrait};
 
@@ -567,8 +576,7 @@ pub async fn dynamic_handler(
                                     let status_code = http_response.status_code;
 
                                     tracing::Span::current().record("http.response.status_code", status_code);
-                                    let otel = if (200..300).contains(&status_code) { "OK" } else { "ERROR" };
-                                    tracing::Span::current().record("otel.status_code", otel);
+                                    tracing::Span::current().record("otel.status_code", otel_status_for(status_code));
 
                                     channel_mgr.remove_channel(&res_ch_id);
                                     channel_mgr.remove_channel(&req_ch_id);
@@ -640,8 +648,7 @@ pub async fn dynamic_handler(
 
                 // Build streaming response from accumulated control messages + binary body
                 tracing::Span::current().record("http.response.status_code", status_code);
-                let otel = if (200..300).contains(&status_code) { "OK" } else { "ERROR" };
-                tracing::Span::current().record("otel.status_code", otel);
+                tracing::Span::current().record("otel.status_code", otel_status_for(status_code));
 
                 channel_mgr.remove_channel(&res_ch_id);
                 channel_mgr.remove_channel(&req_ch_id);
@@ -701,8 +708,7 @@ pub async fn dynamic_handler(
                     let http_response = HttpResponse::from_function_return(result);
                     let sc = http_response.status_code;
                     tracing::Span::current().record("http.response.status_code", sc);
-                    let otel = if (200..300).contains(&sc) { "OK" } else { "ERROR" };
-                    tracing::Span::current().record("otel.status_code", otel);
+                    tracing::Span::current().record("otel.status_code", otel_status_for(sc));
                     http_response.into_axum_response()
                 }
                 Ok(Err(err)) => {
@@ -763,6 +769,27 @@ pub async fn dynamic_handler(
 mod tests {
     use super::*;
     use axum::http::{HeaderName, HeaderValue, header::HeaderMap};
+
+    // ── otel_status_for ────────────────────────────────────────────────
+
+    #[test]
+    fn test_otel_status_for_below_400_is_ok() {
+        // Anything < 400 must not be an error: 1xx, 2xx, and 3xx all map to OK.
+        for code in [100u16, 101, 200, 201, 204, 301, 302, 304, 307, 308, 399] {
+            assert_eq!(otel_status_for(code), "OK", "status {code} should be OK");
+        }
+    }
+
+    #[test]
+    fn test_otel_status_for_400_and_above_is_error() {
+        for code in [400u16, 404, 422, 499, 500, 502, 503] {
+            assert_eq!(
+                otel_status_for(code),
+                "ERROR",
+                "status {code} should be ERROR"
+            );
+        }
+    }
 
     // ── generate_error_id ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Two independent observability fixes, both verified against a live engine.

### 1. Trace list ignored the sort selection (`console`)
`useTraceData` re-sorted spans by start time on every fetch, discarding the server's `sort_by`/`sort_order`. Selecting **Duration → Asc/Desc** had no real effect on the list.

- Extracted the span→row mapping into a pure `buildTraceGroups()` that **preserves server order**; removed the client re-sort.
- Replaced the change-detection fingerprint (length + first id + last id + last startTime), which missed middle-only reorders like `[A,B,C,D] → [A,C,B,D]` and froze the list on a sort-field change. `traceGroupsFingerprint()` now keys on the full ordered `(id, status, startTime, endTime)` list.

### 2. HTTP status `< 400` shown as an error (`engine`)
API request spans classified status with `(200..300)`, so every 3xx (redirects, 304 Not Modified) surfaced as an **ERROR** trace.

- Added `otel_status_for()` (`< 400` = OK, else ERROR), applied at all three response paths in `rest_api/views.rs`. Genuine 500/404 paths untouched.
- Outbound invoker: `is_non_error_status()` replaces `is_success()` (2xx-only) in `deliver_webhook`/`invoke_http`; `invoke_http` treats a 1xx/3xx response with a non-JSON body as a result-less success instead of an `invalid_response` error. The 2xx "must be JSON" contract is preserved.

## Test plan

- [x] Frontend unit tests (`traceGroups.test.ts`): order preservation, middle-reorder fingerprint, content-change fingerprint, duration/status mapping — pass; `tsc -b` and biome clean.
- [x] Engine unit tests: `views.rs` `otel_status_for` (1xx/2xx/3xx → OK, ≥400 → ERROR) and `http_invoker` `is_non_error_status` + redirect-with-HTML-body → `Ok(None)`; existing 2xx-contract test still asserts `invalid_response`. Full `rest_api::views` (68) and `http_invoker` (9) suites pass.
- [x] Live engine verification: drove `GET /status/:code` across 200–503 and confirmed span status via `engine::traces::list` — 301/302/304/307 now `ok`, ≥400 `error`. Confirmed `sort_by=duration` asc/desc returns correctly ordered spans.

## Notes
- This implements the explicit `≥ 400` rule (strict OTel server-span convention marks only 5xx as error). SDK instrumentation (node/python/rust) already used `>= 400`; the engine is now consistent with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved trace grouping: durations, status mapping, and server-provided ordering are preserved for trace lists

* **Bug Fixes**
  * HTTP invocations now treat redirect (3xx) and other <400 responses as successful for invocation and tracing
  * Tracing status now marks <400 codes as OK and 400+ as ERROR

* **Tests**
  * Added tests for trace grouping/fingerprinting and updated tests for HTTP status handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/iii/pull/1713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->