### PR TITLE
feat(ci): docs version rotation in create-tag

### DIFF
--- a/.github/scripts/pin_docs.py
+++ b/.github/scripts/pin_docs.py
@@ -183,72 +183,6 @@ def _save(docs_dir: Path, doc: dict) -> None:
     )
 
 
-# Absolute markdown link target, e.g. "](/0-11-0/how-to/x" -> captures the path.
-_LINK_RE = re.compile(r"\]\(/([^)\s#]*)")
-# Absolute href/src attribute (e.g. <Card href="/install">, <img src="/assets/x.png">),
-# single or double quoted.
-_ATTR_RE = re.compile(r"""((?:href|src)=)(["'])/([^"'#]*)""")
-# A leading version-dir (0-16-0) or "next" segment on a link path.
-_LEAD_RE = re.compile(r"^(?:\d+-\d+-\d+|next)(?:/(.*))?$")
-
-
-def _page_exists(docs_dir: Path, target: str) -> bool:
-    """True if ``target`` resolves within ``docs_dir`` — a page (``.mdx``), an
-    asset/file, or a section (a directory that contains pages)."""
-    if not target:
-        return False
-    base = docs_dir / target
-    if base.with_suffix(".mdx").is_file():
-        return True
-    if base.is_file():  # asset (image, video, ...) or an exact file
-        return True
-    if base.is_dir() and next(base.rglob("*.mdx"), None) is not None:
-        return True
-    return False
-
-
-def _reprefix_target(path: str, dst_prefix: str, docs_dir: Path) -> str:
-    """Re-point an absolute doc link at ``dst_prefix`` ("" for root).
-
-    Strips any leading version-dir/next prefix, then prepends ``dst_prefix``.
-    Leaves the link unchanged if the destination page does not exist (e.g. a
-    cross-version reference to a page only present in an older version).
-    """
-    m = _LEAD_RE.match(path)
-    core = (m.group(1) or "") if m else path
-    cand = f"{dst_prefix}/{core}" if dst_prefix else core
-    return cand if _page_exists(docs_dir, cand) else path
-
-
-def _reprefix_mdx(file: Path, dst_prefix: str, docs_dir: Path) -> None:
-    text = file.read_text(encoding="utf-8")
-    new = _LINK_RE.sub(
-        lambda m: f"](/{_reprefix_target(m.group(1), dst_prefix, docs_dir)}",
-        text,
-    )
-    new = _ATTR_RE.sub(
-        lambda m: f"{m.group(1)}{m.group(2)}/{_reprefix_target(m.group(3), dst_prefix, docs_dir)}",
-        new,
-    )
-    if new != text:
-        file.write_text(new, encoding="utf-8")
-
-
-def _reprefix_dir(dir_path: Path, dst_prefix: str, docs_dir: Path) -> None:
-    """Rewrite absolute doc links in every .mdx under ``dir_path`` to ``dst_prefix``."""
-    for f in dir_path.rglob("*.mdx"):
-        _reprefix_mdx(f, dst_prefix, docs_dir)
-
-
-def _reprefix_root(docs_dir: Path) -> None:
-    """Rewrite absolute doc links in root content (.mdx) to be root-absolute."""
-    for entry in _content_entries(docs_dir):
-        if entry.is_dir():
-            _reprefix_dir(entry, "", docs_dir)
-        elif entry.suffix == ".mdx":
-            _reprefix_mdx(entry, "", docs_dir)
-
-
 def validate(docs_dir: Path) -> int:
     """Exit 0 if the Next docs are ready; 1 (with error) otherwise.
 
@@ -306,15 +240,9 @@ def rotate(docs_dir: Path, version: str) -> None:
     old_prefix = dir_prefix(old_major, old_minor)  # e.g. 0-16-0
 
     # --- filesystem (order matters) ---
+    # In-content links are version-relative, so they survive the move untouched.
     copy_root_to_dir(docs_dir, old_prefix)          # archive old Latest -> folder
-    # Archived copy carried root-absolute links; re-point them into its folder
-    # so the archived version's links stay within that version.
-    _reprefix_dir(docs_dir / old_prefix, old_prefix, docs_dir)
     replace_root_with_dir(docs_dir, NEXT_DIR)       # promote next/ -> root (next/ kept)
-    # Promoted content carried next/-prefixed links; strip them to root-absolute
-    # so the new Latest links to itself (the root). The next/ folder is left as
-    # is — its links already point at next/.
-    _reprefix_root(docs_dir)
 
     # --- docs.json ---
     # old Latest -> archived (root paths -> old_prefix), drop tag/default
@@ -342,10 +270,10 @@ def sync_patch(docs_dir: Path) -> None:
 
     Unlike ``rotate`` there is no version ceremony — the old Latest is not
     archived, the Next block is not bumped, and no version blocks in docs.json
-    change. Only the root content is replaced and its links re-pointed to root.
+    change. Only the root content is replaced (in-content links are relative, so
+    they survive the move untouched).
     """
     replace_root_with_dir(docs_dir, NEXT_DIR)
-    _reprefix_root(docs_dir)
     print("pin_docs: patched Latest from docs/next/ (no rotation)")
 
 

--- a/.github/scripts/pin_docs.py
+++ b/.github/scripts/pin_docs.py
@@ -65,9 +65,17 @@ def _map_page_strings(node, fn, in_pages=False):
     return node
 
 
+def _is_shared_page(path: str) -> bool:
+    return path.split("/", 1)[0] in SHARED_ROOTS
+
+
 def add_prefix(tabs: list, prefix: str) -> list:
-    """Deep-copy ``tabs`` and prefix every page string with ``prefix/``."""
-    return _map_page_strings(copy.deepcopy(tabs), lambda s: f"{prefix}/{s}")
+    """Deep-copy ``tabs`` and prefix every page string with ``prefix/``, except
+    shared-root pages (e.g. changelog), which always stay at the root."""
+    return _map_page_strings(
+        copy.deepcopy(tabs),
+        lambda s: s if _is_shared_page(s) else f"{prefix}/{s}",
+    )
 
 
 def strip_prefix(tabs: list, prefix: str) -> list:
@@ -106,6 +114,11 @@ def sort_versions(versions: list[dict]) -> list[dict]:
 
 _VERSION_DIR_RE = re.compile(r"^\d+-\d+-\d+$")
 
+# Content shared across all versions: kept at the docs root, never copied into a
+# version folder and never version-prefixed in docs.json (every version's tab
+# points at the single root copy).
+SHARED_ROOTS = {"changelog"}
+
 _EXCLUDED_NAMES = {
     "docs.json", "package.json", "package-lock.json", "node_modules",
     "custom.css", "navbar-counters.js", ".gitignore", ".mintignore",
@@ -115,9 +128,10 @@ _EXCLUDED_NAMES = {
 
 def is_excluded(name: str) -> bool:
     """True if a top-level docs entry is not movable content (infra, sidecars,
-    version folders, or the fixed next/ folder)."""
+    version folders, the fixed next/ folder, or shared root content)."""
     return (
         name in _EXCLUDED_NAMES
+        or name in SHARED_ROOTS
         or name.endswith(".skill.md")
         or bool(_VERSION_DIR_RE.match(name))
     )

--- a/.github/scripts/pin_docs.py
+++ b/.github/scripts/pin_docs.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Rotate Mintlify docs versions during the create-tag release flow.
+
+On a stable minor/major release: archive the old Latest (root) into a
+MAJOR-MINOR-0/ folder, promote the fixed docs/next/ folder into the root as
+the new Latest (labeled with the tag version), and relabel the Next block to
+the following minor.
+
+Two subcommands:
+* ``validate`` — gate a stable release on the Next docs being ready (a Next
+  block exists and docs/next/ is non-empty). Runs even on dry runs.
+* ``rotate`` — update docs from docs/next/. Dispatches on the version: a
+  minor/major does a full rotation (archive + promote + bump Next); a patch
+  refreshes the current Latest in place (no archive, no Next bump).
+
+Pure functions live at module top so they can be unit-tested. The CLI at the
+bottom is invoked from .github/workflows/create-tag.yml.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+NEXT_TAG = "Next"
+LATEST_TAG = "Latest"
+NEXT_DIR = "next"  # fixed folder name holding the Next docs
+
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)")
+
+
+def parse_version(version: str) -> tuple[int, int, int]:
+    """Return (major, minor, patch); any prerelease/dry-run suffix is ignored."""
+    m = _VERSION_RE.match(version)
+    if not m:
+        raise ValueError(f"unrecognized version string: {version!r}")
+    return int(m.group(1)), int(m.group(2)), int(m.group(3))
+
+
+def minor_label(major: int, minor: int) -> str:
+    return f"{major}.{minor}.x"
+
+
+def dir_prefix(major: int, minor: int) -> str:
+    return f"{major}-{minor}-0"
+
+
+def next_minor(version: str) -> tuple[int, int]:
+    """Return (major, minor+1) for the version — the new Next after a release."""
+    major, minor, _ = parse_version(version)
+    return major, minor + 1
+
+
+def _map_page_strings(node, fn, in_pages=False):
+    if isinstance(node, str):
+        return fn(node) if in_pages else node
+    if isinstance(node, list):
+        return [_map_page_strings(item, fn, in_pages) for item in node]
+    if isinstance(node, dict):
+        return {k: _map_page_strings(v, fn, k == "pages") for k, v in node.items()}
+    return node
+
+
+def add_prefix(tabs: list, prefix: str) -> list:
+    """Deep-copy ``tabs`` and prefix every page string with ``prefix/``."""
+    return _map_page_strings(copy.deepcopy(tabs), lambda s: f"{prefix}/{s}")
+
+
+def strip_prefix(tabs: list, prefix: str) -> list:
+    """Deep-copy ``tabs`` and remove a leading ``prefix/`` from page strings."""
+    head = f"{prefix}/"
+    return _map_page_strings(
+        copy.deepcopy(tabs),
+        lambda s: s[len(head):] if s.startswith(head) else s,
+    )
+
+
+def find_index_by_tag(versions: list[dict], tag: str) -> int:
+    for i, block in enumerate(versions):
+        if block.get("tag") == tag:
+            return i
+    raise ValueError(f"no version block tagged {tag!r} in docs.json")
+
+
+_MINOR_RE = re.compile(r"^(\d+)\.(\d+)")
+
+
+def _version_sort_key(block: dict) -> tuple[int, int]:
+    m = _MINOR_RE.match(block.get("version", ""))
+    return (int(m.group(1)), int(m.group(2))) if m else (-1, -1)
+
+
+def sort_versions(versions: list[dict]) -> list[dict]:
+    """Order: Next first, then Latest, then archived newest-first (Mintlify
+    renders the dropdown in array order)."""
+    nxt = [b for b in versions if b.get("tag") == NEXT_TAG]
+    latest = [b for b in versions if b.get("tag") == LATEST_TAG]
+    rest = [b for b in versions if b.get("tag") not in (NEXT_TAG, LATEST_TAG)]
+    rest.sort(key=_version_sort_key, reverse=True)
+    return nxt + latest + rest
+
+
+_VERSION_DIR_RE = re.compile(r"^\d+-\d+-\d+$")
+
+_EXCLUDED_NAMES = {
+    "docs.json", "package.json", "package-lock.json", "node_modules",
+    "custom.css", "navbar-counters.js", ".gitignore", ".mintignore",
+    ".prettierrc", "README.md", "LICENSE", NEXT_DIR,
+}
+
+
+def is_excluded(name: str) -> bool:
+    """True if a top-level docs entry is not movable content (infra, sidecars,
+    version folders, or the fixed next/ folder)."""
+    return (
+        name in _EXCLUDED_NAMES
+        or name.endswith(".skill.md")
+        or bool(_VERSION_DIR_RE.match(name))
+    )
+
+
+def _content_entries(docs_dir: Path):
+    return [e for e in sorted(docs_dir.iterdir()) if not is_excluded(e.name)]
+
+
+def _copy_entry(src: Path, dst: Path) -> None:
+    if src.is_dir():
+        shutil.copytree(src, dst)
+    else:
+        shutil.copy2(src, dst)
+
+
+def copy_root_to_dir(docs_dir: Path, prefix: str) -> None:
+    """Copy root content (excluding infra/version/next) into ``docs_dir/prefix``,
+    overwriting it."""
+    target = docs_dir / prefix
+    if target.exists():
+        shutil.rmtree(target)
+    target.mkdir(parents=True)
+    for entry in _content_entries(docs_dir):
+        _copy_entry(entry, target / entry.name)
+
+
+def replace_root_with_dir(docs_dir: Path, prefix: str) -> None:
+    """Replace root content with the content of ``docs_dir/prefix`` (infra,
+    version dirs, and the next/ folder are left in place). The source folder is
+    not removed."""
+    source = docs_dir / prefix
+    for entry in _content_entries(docs_dir):
+        if entry.is_dir():
+            shutil.rmtree(entry)
+        else:
+            entry.unlink()
+    for entry in sorted(source.iterdir()):
+        _copy_entry(entry, docs_dir / entry.name)
+
+
+def _load(docs_dir: Path) -> dict:
+    return json.loads((docs_dir / "docs.json").read_text(encoding="utf-8"))
+
+
+def _save(docs_dir: Path, doc: dict) -> None:
+    (docs_dir / "docs.json").write_text(
+        json.dumps(doc, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+
+# Absolute markdown link target, e.g. "](/0-11-0/how-to/x" -> captures the path.
+_LINK_RE = re.compile(r"\]\(/([^)\s#]*)")
+# Absolute href/src attribute (e.g. <Card href="/install">, <img src="/assets/x.png">),
+# single or double quoted.
+_ATTR_RE = re.compile(r"""((?:href|src)=)(["'])/([^"'#]*)""")
+# A leading version-dir (0-16-0) or "next" segment on a link path.
+_LEAD_RE = re.compile(r"^(?:\d+-\d+-\d+|next)(?:/(.*))?$")
+
+
+def _page_exists(docs_dir: Path, target: str) -> bool:
+    """True if ``target`` resolves within ``docs_dir`` — a page (``.mdx``), an
+    asset/file, or a section (a directory that contains pages)."""
+    if not target:
+        return False
+    base = docs_dir / target
+    if base.with_suffix(".mdx").is_file():
+        return True
+    if base.is_file():  # asset (image, video, ...) or an exact file
+        return True
+    if base.is_dir() and next(base.rglob("*.mdx"), None) is not None:
+        return True
+    return False
+
+
+def _reprefix_target(path: str, dst_prefix: str, docs_dir: Path) -> str:
+    """Re-point an absolute doc link at ``dst_prefix`` ("" for root).
+
+    Strips any leading version-dir/next prefix, then prepends ``dst_prefix``.
+    Leaves the link unchanged if the destination page does not exist (e.g. a
+    cross-version reference to a page only present in an older version).
+    """
+    m = _LEAD_RE.match(path)
+    core = (m.group(1) or "") if m else path
+    cand = f"{dst_prefix}/{core}" if dst_prefix else core
+    return cand if _page_exists(docs_dir, cand) else path
+
+
+def _reprefix_mdx(file: Path, dst_prefix: str, docs_dir: Path) -> None:
+    text = file.read_text(encoding="utf-8")
+    new = _LINK_RE.sub(
+        lambda m: f"](/{_reprefix_target(m.group(1), dst_prefix, docs_dir)}",
+        text,
+    )
+    new = _ATTR_RE.sub(
+        lambda m: f"{m.group(1)}{m.group(2)}/{_reprefix_target(m.group(3), dst_prefix, docs_dir)}",
+        new,
+    )
+    if new != text:
+        file.write_text(new, encoding="utf-8")
+
+
+def _reprefix_dir(dir_path: Path, dst_prefix: str, docs_dir: Path) -> None:
+    """Rewrite absolute doc links in every .mdx under ``dir_path`` to ``dst_prefix``."""
+    for f in dir_path.rglob("*.mdx"):
+        _reprefix_mdx(f, dst_prefix, docs_dir)
+
+
+def _reprefix_root(docs_dir: Path) -> None:
+    """Rewrite absolute doc links in root content (.mdx) to be root-absolute."""
+    for entry in _content_entries(docs_dir):
+        if entry.is_dir():
+            _reprefix_dir(entry, "", docs_dir)
+        elif entry.suffix == ".mdx":
+            _reprefix_mdx(entry, "", docs_dir)
+
+
+def validate(docs_dir: Path) -> int:
+    """Exit 0 if the Next docs are ready; 1 (with error) otherwise.
+
+    Ready = a Next block exists in docs.json AND docs/next/ is non-empty. The
+    release version is irrelevant — rotation always pulls whatever is in next/.
+    """
+    try:
+        versions = _load(docs_dir)["navigation"]["versions"]
+        find_index_by_tag(versions, NEXT_TAG)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"::error::Cannot validate Next docs: {exc}")
+        return 1
+
+    folder = docs_dir / NEXT_DIR
+    if not folder.is_dir() or not any(folder.iterdir()):
+        print(
+            f"::error::Missing Next docs at {folder}. "
+            f"Prepare docs/{NEXT_DIR}/ before tagging."
+        )
+        return 1
+
+    print("pin_docs: Next docs ready")
+    return 0
+
+
+def rotate(docs_dir: Path, version: str) -> None:
+    """Archive the old Latest, promote docs/next/ into root as the new Latest
+    (labeled with the tag version), and relabel the Next block to minor+1.
+
+    Assumes ``validate`` already passed.
+    """
+    major, minor, patch = parse_version(version)
+    # A patch release does not rotate — it only refreshes the current Latest
+    # from docs/next/ in place (no archive, no Next bump, no version changes).
+    if patch > 0:
+        sync_patch(docs_dir)
+        return
+    rel_label = minor_label(major, minor)        # tag version label, e.g. 0.17.x
+    nmaj, nmin = next_minor(version)
+    nxt_label = minor_label(nmaj, nmin)          # e.g. 0.18.x
+
+    doc = _load(docs_dir)
+    versions = doc["navigation"]["versions"]
+    next_block = versions[find_index_by_tag(versions, NEXT_TAG)]
+    latest_block = versions[find_index_by_tag(versions, LATEST_TAG)]
+
+    # Idempotency guard: if the current Latest is already this version, the
+    # rotation has already happened for it — re-running would duplicate the
+    # block and re-copy folders. No-op.
+    if latest_block["version"] == rel_label:
+        print(f"pin_docs: already rotated to {rel_label}, skipping")
+        return
+
+    old_major, old_minor, _ = parse_version(latest_block["version"].replace("x", "0"))
+    old_prefix = dir_prefix(old_major, old_minor)  # e.g. 0-16-0
+
+    # --- filesystem (order matters) ---
+    copy_root_to_dir(docs_dir, old_prefix)          # archive old Latest -> folder
+    # Archived copy carried root-absolute links; re-point them into its folder
+    # so the archived version's links stay within that version.
+    _reprefix_dir(docs_dir / old_prefix, old_prefix, docs_dir)
+    replace_root_with_dir(docs_dir, NEXT_DIR)       # promote next/ -> root (next/ kept)
+    # Promoted content carried next/-prefixed links; strip them to root-absolute
+    # so the new Latest links to itself (the root). The next/ folder is left as
+    # is — its links already point at next/.
+    _reprefix_root(docs_dir)
+
+    # --- docs.json ---
+    # old Latest -> archived (root paths -> old_prefix), drop tag/default
+    latest_block["tabs"] = add_prefix(latest_block["tabs"], old_prefix)
+    latest_block.pop("tag", None)
+    latest_block.pop("default", None)
+    # new Latest block from the Next tabs (next/ -> root), labeled with the tag
+    new_latest = {
+        "version": rel_label,
+        "tag": LATEST_TAG,
+        "default": True,
+        "tabs": strip_prefix(next_block["tabs"], NEXT_DIR),
+    }
+    # Next block keeps its next/ paths; only its label advances to minor+1
+    next_block["version"] = nxt_label
+
+    versions.append(new_latest)
+    doc["navigation"]["versions"] = sort_versions(versions)
+    _save(docs_dir, doc)
+    print(f"pin_docs: rotated — Latest={rel_label}, Next={nxt_label}, archived {latest_block['version']}")
+
+
+def sync_patch(docs_dir: Path) -> None:
+    """Patch release: refresh the Latest (root) docs from docs/next/ in place.
+
+    Unlike ``rotate`` there is no version ceremony — the old Latest is not
+    archived, the Next block is not bumped, and no version blocks in docs.json
+    change. Only the root content is replaced and its links re-pointed to root.
+    """
+    replace_root_with_dir(docs_dir, NEXT_DIR)
+    _reprefix_root(docs_dir)
+    print("pin_docs: patched Latest from docs/next/ (no rotation)")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_validate = sub.add_parser("validate")
+    p_validate.add_argument("--docs-dir", required=True, type=Path)
+
+    p_rotate = sub.add_parser("rotate")
+    p_rotate.add_argument("--docs-dir", required=True, type=Path)
+    p_rotate.add_argument("--version", required=True)
+
+    args = parser.parse_args(argv)
+    if args.command == "validate":
+        return validate(args.docs_dir)
+    rotate(args.docs_dir, args.version)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_pin_docs.py
+++ b/.github/scripts/test_pin_docs.py
@@ -1,0 +1,379 @@
+"""Unit tests for pin_docs.py.
+
+Run with: python -m pytest .github/scripts/test_pin_docs.py -v
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pin_docs import add_prefix
+from pin_docs import copy_root_to_dir
+from pin_docs import dir_prefix
+from pin_docs import find_index_by_tag
+from pin_docs import is_excluded
+from pin_docs import minor_label
+from pin_docs import next_minor
+from pin_docs import parse_version
+from pin_docs import replace_root_with_dir
+from pin_docs import rotate
+from pin_docs import sort_versions
+from pin_docs import strip_prefix
+from pin_docs import sync_patch
+from pin_docs import validate
+
+
+class TestParseVersion:
+    def test_stable(self):
+        assert parse_version("0.17.0") == (0, 17, 0)
+
+    def test_prerelease_suffix_ignored(self):
+        assert parse_version("1.0.0-next.5") == (1, 0, 0)
+
+    def test_dry_run_suffix_ignored(self):
+        assert parse_version("0.17.0-dry-run.2") == (0, 17, 0)
+
+    def test_rejects_garbage(self):
+        with pytest.raises(ValueError):
+            parse_version("nope")
+
+
+class TestLabelPrefix:
+    def test_minor_label(self):
+        assert minor_label(0, 17) == "0.17.x"
+        assert minor_label(1, 0) == "1.0.x"
+
+    def test_dir_prefix(self):
+        assert dir_prefix(0, 17) == "0-17-0"
+        assert dir_prefix(1, 0) == "1-0-0"
+
+    def test_next_minor(self):
+        assert next_minor("0.17.0") == (0, 18)
+        assert next_minor("1.0.0") == (1, 1)
+        assert next_minor("0.17.0-next.1") == (0, 18)
+
+
+def _tabs(*pages):
+    return [{"tab": "Docs", "groups": [
+        {"group": "G", "pages": list(pages)},
+        {"group": "Nested", "pages": [{"group": "Sub", "pages": ["how-to/a"]}]},
+    ]}]
+
+
+class TestAddStripPrefix:
+    def test_add_prefix(self):
+        out = add_prefix(_tabs("index", "install"), "next")
+        assert out[0]["groups"][0]["pages"] == ["next/index", "next/install"]
+        assert out[0]["groups"][1]["pages"][0]["pages"] == ["next/how-to/a"]
+
+    def test_strip_prefix(self):
+        prefixed = add_prefix(_tabs("index"), "next")
+        out = strip_prefix(prefixed, "next")
+        assert out[0]["groups"][0]["pages"] == ["index"]
+        assert out[0]["groups"][1]["pages"][0]["pages"] == ["how-to/a"]
+
+    def test_add_does_not_mutate_input(self):
+        tabs = _tabs("index")
+        add_prefix(tabs, "next")
+        assert tabs[0]["groups"][0]["pages"] == ["index"]
+
+    def test_strip_only_removes_matching(self):
+        out = strip_prefix(_tabs("index"), "next")
+        assert out[0]["groups"][0]["pages"] == ["index"]
+
+
+class TestFindIndexByTag:
+    def test_finds(self):
+        versions = [{"tag": "Latest"}, {"tag": "Next"}, {}]
+        assert find_index_by_tag(versions, "Next") == 1
+        assert find_index_by_tag(versions, "Latest") == 0
+
+    def test_raises_when_absent(self):
+        with pytest.raises(ValueError):
+            find_index_by_tag([{"tag": "Latest"}], "Next")
+
+
+class TestSortVersions:
+    def test_order(self):
+        versions = [
+            {"version": "0.12.x"},
+            {"version": "0.16.x", "tag": "Latest", "default": True},
+            {"version": "0.10.x"},
+            {"version": "0.17.x", "tag": "Next"},
+        ]
+        out = sort_versions(versions)
+        assert [v["version"] for v in out] == ["0.17.x", "0.16.x", "0.12.x", "0.10.x"]
+        assert out[0]["tag"] == "Next"
+        assert out[1]["tag"] == "Latest"
+
+    def test_double_digit_numeric(self):
+        out = sort_versions([{"version": "0.2.x"}, {"version": "0.10.x"}])
+        assert [v["version"] for v in out] == ["0.10.x", "0.2.x"]
+
+
+class TestIsExcluded:
+    @pytest.mark.parametrize("name", [
+        "docs.json", "package.json", "node_modules", "custom.css",
+        "navbar-counters.js", ".gitignore", ".mintignore", ".prettierrc",
+        "README.md", "0-11-0", "1-0-0", "index.mdx.skill.md", "next",
+    ])
+    def test_excluded(self, name):
+        assert is_excluded(name) is True
+
+    @pytest.mark.parametrize("name", [
+        "index.mdx", "using-iii", "assets", "images", "changelog",
+    ])
+    def test_included(self, name):
+        assert is_excluded(name) is False
+
+
+def _make_root(tmp_path: Path) -> Path:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "index.mdx").write_text("# Home latest")
+    (docs / "index.mdx.skill.md").write_text("sidecar")
+    (docs / "docs.json").write_text("{}")
+    (docs / ".gitignore").write_text("node_modules/")
+    (docs / "using-iii").mkdir()
+    (docs / "using-iii" / "workers.mdx").write_text("# Workers")
+    return docs
+
+
+class TestCopyRootToDir:
+    def test_copies_content_excludes_infra(self, tmp_path):
+        docs = _make_root(tmp_path)
+        copy_root_to_dir(docs, "0-16-0")
+        pinned = docs / "0-16-0"
+        assert (pinned / "index.mdx").read_text() == "# Home latest"
+        assert (pinned / "using-iii" / "workers.mdx").exists()
+        assert not (pinned / "docs.json").exists()
+        assert not (pinned / ".gitignore").exists()
+        assert not (pinned / "index.mdx.skill.md").exists()
+
+    def test_does_not_copy_next_folder(self, tmp_path):
+        docs = _make_root(tmp_path)
+        (docs / "next").mkdir()
+        (docs / "next" / "index.mdx").write_text("# Next")
+        copy_root_to_dir(docs, "0-16-0")
+        assert not (docs / "0-16-0" / "next").exists()
+
+    def test_overwrites_existing(self, tmp_path):
+        docs = _make_root(tmp_path)
+        (docs / "0-16-0").mkdir()
+        (docs / "0-16-0" / "stale.mdx").write_text("old")
+        copy_root_to_dir(docs, "0-16-0")
+        assert not (docs / "0-16-0" / "stale.mdx").exists()
+
+
+class TestReplaceRootWithDir:
+    def test_replaces_content_keeps_infra_and_next(self, tmp_path):
+        docs = _make_root(tmp_path)
+        nxt = docs / "next"
+        nxt.mkdir()
+        (nxt / "index.mdx").write_text("# Home next")
+        (nxt / "newpage.mdx").write_text("# New")
+        replace_root_with_dir(docs, "next")
+        assert (docs / "index.mdx").read_text() == "# Home next"
+        assert (docs / "newpage.mdx").exists()
+        assert not (docs / "using-iii").exists()
+        assert (docs / "docs.json").exists()
+        assert (docs / ".gitignore").exists()
+        assert (docs / "next" / "index.mdx").exists()
+
+
+def _write_docs(docs: Path, versions):
+    (docs / "docs.json").write_text(json.dumps({"navigation": {"versions": versions}}, indent=2))
+
+
+def _ready_docs(tmp_path: Path) -> Path:
+    """root = Latest 0.16.x; docs/next/ = Next (label 0.17.x)."""
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "index.mdx").write_text("# Latest 0.16")
+    nxt = docs / "next"
+    nxt.mkdir()
+    (nxt / "index.mdx").write_text("# Next")
+    _write_docs(docs, [
+        {"version": "0.16.x", "tag": "Latest", "default": True,
+         "tabs": [{"tab": "D", "groups": [{"group": "G", "pages": ["index"]}]}]},
+        {"version": "0.17.x", "tag": "Next",
+         "tabs": [{"tab": "D", "groups": [{"group": "G", "pages": ["next/index"]}]}]},
+    ])
+    return docs
+
+
+class TestValidate:
+    def test_ok_when_next_block_and_folder_present(self, tmp_path):
+        assert validate(_ready_docs(tmp_path)) == 0
+
+    def test_fails_when_folder_missing(self, tmp_path):
+        docs = _ready_docs(tmp_path)
+        import shutil as _sh
+        _sh.rmtree(docs / "next")
+        assert validate(docs) == 1
+
+    def test_fails_when_folder_empty(self, tmp_path):
+        docs = _ready_docs(tmp_path)
+        import shutil as _sh
+        _sh.rmtree(docs / "next")
+        (docs / "next").mkdir()
+        assert validate(docs) == 1
+
+    def test_fails_when_no_next_block(self, tmp_path):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "next").mkdir()
+        (docs / "next" / "index.mdx").write_text("x")
+        _write_docs(docs, [{"version": "0.16.x", "tag": "Latest"}])
+        assert validate(docs) == 1
+
+
+def _read_versions(docs: Path):
+    return json.loads((docs / "docs.json").read_text())["navigation"]["versions"]
+
+
+class TestRotate:
+    def test_rotation_0_17_0(self, tmp_path):
+        docs = _ready_docs(tmp_path)  # root=Latest 0.16.x; next/=Next 0.17.x
+        rotate(docs, "0.17.0")
+
+        assert (docs / "0-16-0" / "index.mdx").read_text() == "# Latest 0.16"
+        assert (docs / "index.mdx").read_text() == "# Next"
+        assert (docs / "next" / "index.mdx").read_text() == "# Next"
+
+        versions = _read_versions(docs)
+        by_tag = {v.get("tag"): v for v in versions}
+        assert by_tag["Latest"]["version"] == "0.17.x"
+        assert by_tag["Latest"]["tabs"][0]["groups"][0]["pages"] == ["index"]
+        assert by_tag["Next"]["version"] == "0.18.x"
+        assert by_tag["Next"]["tabs"][0]["groups"][0]["pages"] == ["next/index"]
+        archived = [v for v in versions if v.get("tag") not in ("Latest", "Next")]
+        old = [v for v in archived if v["version"] == "0.16.x"][0]
+        assert old["tabs"][0]["groups"][0]["pages"] == ["0-16-0/index"]
+
+        assert versions[0]["tag"] == "Next"
+        assert versions[1]["tag"] == "Latest"
+        assert sum(1 for v in versions if v.get("default")) == 1
+
+    def test_patch_version_delegates_to_sync(self, tmp_path):
+        docs = _ready_docs(tmp_path)  # root=Latest 0.16.x; next/=Next 0.17.x
+        before = (docs / "docs.json").read_text()
+        rotate(docs, "0.16.1")  # patch -> sync, not rotation
+        # No archive folder, docs.json version blocks unchanged.
+        assert not (docs / "0-16-0").exists()
+        assert (docs / "docs.json").read_text() == before
+        # Root content refreshed from next/.
+        assert (docs / "index.mdx").read_text() == "# Next"
+
+    def test_rerun_same_version_is_idempotent(self, tmp_path):
+        docs = _ready_docs(tmp_path)
+        rotate(docs, "0.17.0")
+        after_first = (docs / "docs.json").read_text()
+        rotate(docs, "0.17.0")  # re-run must be a no-op
+        assert (docs / "docs.json").read_text() == after_first
+        versions = _read_versions(docs)
+        assert sum(1 for v in versions if v["version"] == "0.17.x") == 1
+        assert sum(1 for v in versions if v.get("tag") == "Latest") == 1
+
+    def test_major_release_uses_tag_and_minor_plus_one(self, tmp_path):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "index.mdx").write_text("# Latest 0.17")
+        nxt = docs / "next"
+        nxt.mkdir()
+        (nxt / "index.mdx").write_text("# Next 0.18")
+        _write_docs(docs, [
+            {"version": "0.17.x", "tag": "Latest", "default": True,
+             "tabs": [{"tab": "D", "groups": [{"group": "G", "pages": ["index"]}]}]},
+            {"version": "0.18.x", "tag": "Next",
+             "tabs": [{"tab": "D", "groups": [{"group": "G", "pages": ["next/index"]}]}]},
+        ])
+        rotate(docs, "1.0.0")
+        assert (docs / "0-17-0" / "index.mdx").exists()
+        assert (docs / "index.mdx").read_text() == "# Next 0.18"
+        by_tag = {v.get("tag"): v for v in _read_versions(docs)}
+        assert by_tag["Latest"]["version"] == "1.0.x"
+        assert by_tag["Next"]["version"] == "1.1.x"
+        assert by_tag["Next"]["tabs"][0]["groups"][0]["pages"] == ["next/index"]
+
+    def test_rewrites_internal_links_on_move(self, tmp_path):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        # Latest (root, 0.16) — root-absolute links + an asset (img src).
+        (docs / "using-iii").mkdir()
+        (docs / "using-iii" / "workers.mdx").write_text("# root workers")
+        (docs / "assets").mkdir()
+        (docs / "assets" / "pic.png").write_text("png")
+        (docs / "index.mdx").write_text(
+            'See [workers](/using-iii/workers). <img src="/assets/pic.png" />'
+        )
+        # Next (next/, 0.17) — next/-prefixed links + a legacy cross-version ref + asset.
+        nxt = docs / "next"
+        (nxt / "using-iii").mkdir(parents=True)
+        (nxt / "using-iii" / "workers.mdx").write_text("# next workers")
+        (nxt / "assets").mkdir()
+        (nxt / "assets" / "n.png").write_text("png")
+        (nxt / "index.mdx").write_text(
+            'See [workers](/next/using-iii/workers) and [old](/0-11-0/gone). '
+            '<Card href="/next/using-iii/workers" /> <img src="/next/assets/n.png" />'
+        )
+        _write_docs(docs, [
+            {"version": "0.16.x", "tag": "Latest", "default": True,
+             "tabs": [{"tab": "D", "groups": [{"group": "G",
+                "pages": ["index", "using-iii/workers"]}]}]},
+            {"version": "0.17.x", "tag": "Next",
+             "tabs": [{"tab": "D", "groups": [{"group": "G",
+                "pages": ["next/index", "next/using-iii/workers"]}]}]},
+        ])
+        rotate(docs, "0.17.0")
+
+        # Archived old Latest: root-absolute link + asset src re-pointed into 0-16-0/.
+        archived_index = (docs / "0-16-0" / "index.mdx").read_text()
+        assert "(/0-16-0/using-iii/workers)" in archived_index
+        assert 'src="/0-16-0/assets/pic.png"' in archived_index
+        # Promoted Latest (root): next/-prefix stripped to root-absolute (links,
+        # href and src); legacy cross-version ref to a missing page left untouched.
+        root_index = (docs / "index.mdx").read_text()
+        assert "(/using-iii/workers)" in root_index
+        assert 'href="/using-iii/workers"' in root_index  # Card href stripped too
+        assert 'src="/assets/n.png"' in root_index        # img src stripped too
+        assert "/next/" not in root_index
+        assert "(/0-11-0/gone)" in root_index
+        # Next folder is reused untouched — its links still point at next/.
+        assert "(/next/using-iii/workers)" in (docs / "next" / "index.mdx").read_text()
+
+
+class TestSyncPatch:
+    def test_refreshes_latest_without_rotation(self, tmp_path):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "index.mdx").write_text("# old latest")
+        nxt = docs / "next"
+        (nxt / "using-iii").mkdir(parents=True)
+        (nxt / "using-iii" / "workers.mdx").write_text("# w")
+        (nxt / "index.mdx").write_text(
+            '[w](/next/using-iii/workers) <Card href="/next/using-iii" />'
+        )
+        _write_docs(docs, [
+            {"version": "0.17.x", "tag": "Latest", "default": True,
+             "tabs": [{"tab": "D", "groups": [{"group": "G", "pages": ["index"]}]}]},
+            {"version": "0.18.x", "tag": "Next",
+             "tabs": [{"tab": "D", "groups": [{"group": "G",
+                "pages": ["next/index", "next/using-iii/workers"]}]}]},
+        ])
+        before = (docs / "docs.json").read_text()
+        sync_patch(docs)
+
+        # Root refreshed from next/, links re-pointed to root.
+        root_index = (docs / "index.mdx").read_text()
+        assert "# old latest" not in root_index
+        assert "(/using-iii/workers)" in root_index
+        assert 'href="/using-iii"' in root_index
+        assert "/next/" not in root_index
+        # Next folder untouched.
+        assert "(/next/using-iii/workers)" in (docs / "next" / "index.mdx").read_text()
+        # No archive folder, and docs.json version blocks unchanged.
+        assert not (docs / "0-17-0").exists()
+        assert (docs / "docs.json").read_text() == before

--- a/.github/scripts/test_pin_docs.py
+++ b/.github/scripts/test_pin_docs.py
@@ -83,6 +83,15 @@ class TestAddStripPrefix:
         out = strip_prefix(_tabs("index"), "next")
         assert out[0]["groups"][0]["pages"] == ["index"]
 
+    def test_add_prefix_keeps_shared_changelog_at_root(self):
+        tabs = [{"tab": "D", "groups": [{"group": "G", "pages": [
+            "using-iii/workers", "changelog/index", "changelog/0-11-0/x",
+        ]}]}]
+        out = add_prefix(tabs, "0-16-0")
+        assert out[0]["groups"][0]["pages"] == [
+            "0-16-0/using-iii/workers", "changelog/index", "changelog/0-11-0/x",
+        ]
+
 
 class TestFindIndexByTag:
     def test_finds(self):
@@ -117,13 +126,13 @@ class TestIsExcluded:
     @pytest.mark.parametrize("name", [
         "docs.json", "package.json", "node_modules", "custom.css",
         "navbar-counters.js", ".gitignore", ".mintignore", ".prettierrc",
-        "README.md", "0-11-0", "1-0-0", "index.mdx.skill.md", "next",
+        "README.md", "0-11-0", "1-0-0", "index.mdx.skill.md", "next", "changelog",
     ])
     def test_excluded(self, name):
         assert is_excluded(name) is True
 
     @pytest.mark.parametrize("name", [
-        "index.mdx", "using-iii", "assets", "images", "changelog",
+        "index.mdx", "using-iii", "assets", "images",
     ])
     def test_included(self, name):
         assert is_excluded(name) is False
@@ -256,6 +265,33 @@ class TestRotate:
         assert versions[0]["tag"] == "Next"
         assert versions[1]["tag"] == "Latest"
         assert sum(1 for v in versions if v.get("default")) == 1
+
+    def test_changelog_stays_shared_at_root(self, tmp_path):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "index.mdx").write_text("# Latest 0.16")
+        (docs / "changelog").mkdir()
+        (docs / "changelog" / "index.mdx").write_text("# changelog")
+        nxt = docs / "next"
+        nxt.mkdir()
+        (nxt / "index.mdx").write_text("# Next")
+        _write_docs(docs, [
+            {"version": "0.16.x", "tag": "Latest", "default": True,
+             "tabs": [{"tab": "D", "groups": [{"group": "G", "pages": ["index"]}]},
+                      {"tab": "Changelog", "groups": [{"group": "C", "pages": ["changelog/index"]}]}]},
+            {"version": "0.17.x", "tag": "Next",
+             "tabs": [{"tab": "D", "groups": [{"group": "G", "pages": ["next/index"]}]},
+                      {"tab": "Changelog", "groups": [{"group": "C", "pages": ["changelog/index"]}]}]},
+        ])
+        rotate(docs, "0.17.0")
+        # Changelog folder never copied into the archive.
+        assert not (docs / "0-16-0" / "changelog").exists()
+        # Shared changelog still at the root.
+        assert (docs / "changelog" / "index.mdx").exists()
+        # Every block's changelog tab points at the root changelog.
+        for block in _read_versions(docs):
+            cl = [t for t in block["tabs"] if t.get("tab") == "Changelog"][0]
+            assert cl["groups"][0]["pages"] == ["changelog/index"]
 
     def test_patch_version_delegates_to_sync(self, tmp_path):
         docs = _ready_docs(tmp_path)  # root=Latest 0.16.x; next/=Next 0.17.x

--- a/.github/scripts/test_pin_docs.py
+++ b/.github/scripts/test_pin_docs.py
@@ -334,26 +334,21 @@ class TestRotate:
         assert by_tag["Next"]["version"] == "1.1.x"
         assert by_tag["Next"]["tabs"][0]["groups"][0]["pages"] == ["next/index"]
 
-    def test_rewrites_internal_links_on_move(self, tmp_path):
+    def test_relative_links_survive_move(self, tmp_path):
+        # In-content links are version-relative, so rotation moves files verbatim
+        # without rewriting them; cross-version/shared absolute links are untouched.
         docs = tmp_path / "docs"
         docs.mkdir()
-        # Latest (root, 0.16) — root-absolute links + an asset (img src).
         (docs / "using-iii").mkdir()
         (docs / "using-iii" / "workers.mdx").write_text("# root workers")
-        (docs / "assets").mkdir()
-        (docs / "assets" / "pic.png").write_text("png")
         (docs / "index.mdx").write_text(
-            'See [workers](/using-iii/workers). <img src="/assets/pic.png" />'
+            "See [workers](./using-iii/workers) and [cl](/changelog/x)."
         )
-        # Next (next/, 0.17) — next/-prefixed links + a legacy cross-version ref + asset.
         nxt = docs / "next"
         (nxt / "using-iii").mkdir(parents=True)
         (nxt / "using-iii" / "workers.mdx").write_text("# next workers")
-        (nxt / "assets").mkdir()
-        (nxt / "assets" / "n.png").write_text("png")
         (nxt / "index.mdx").write_text(
-            'See [workers](/next/using-iii/workers) and [old](/0-11-0/gone). '
-            '<Card href="/next/using-iii/workers" /> <img src="/next/assets/n.png" />'
+            "See [workers](./using-iii/workers) and [old](/0-11-0/gone)."
         )
         _write_docs(docs, [
             {"version": "0.16.x", "tag": "Latest", "default": True,
@@ -365,20 +360,14 @@ class TestRotate:
         ])
         rotate(docs, "0.17.0")
 
-        # Archived old Latest: root-absolute link + asset src re-pointed into 0-16-0/.
-        archived_index = (docs / "0-16-0" / "index.mdx").read_text()
-        assert "(/0-16-0/using-iii/workers)" in archived_index
-        assert 'src="/0-16-0/assets/pic.png"' in archived_index
-        # Promoted Latest (root): next/-prefix stripped to root-absolute (links,
-        # href and src); legacy cross-version ref to a missing page left untouched.
+        # Archived old Latest: relative link intact, shared absolute untouched.
+        archived = (docs / "0-16-0" / "index.mdx").read_text()
+        assert "](./using-iii/workers)" in archived
+        assert "(/changelog/x)" in archived
+        # Promoted Latest (root): next content moved verbatim (relative survives).
         root_index = (docs / "index.mdx").read_text()
-        assert "(/using-iii/workers)" in root_index
-        assert 'href="/using-iii/workers"' in root_index  # Card href stripped too
-        assert 'src="/assets/n.png"' in root_index        # img src stripped too
-        assert "/next/" not in root_index
+        assert "](./using-iii/workers)" in root_index
         assert "(/0-11-0/gone)" in root_index
-        # Next folder is reused untouched — its links still point at next/.
-        assert "(/next/using-iii/workers)" in (docs / "next" / "index.mdx").read_text()
 
 
 class TestSyncPatch:
@@ -389,9 +378,7 @@ class TestSyncPatch:
         nxt = docs / "next"
         (nxt / "using-iii").mkdir(parents=True)
         (nxt / "using-iii" / "workers.mdx").write_text("# w")
-        (nxt / "index.mdx").write_text(
-            '[w](/next/using-iii/workers) <Card href="/next/using-iii" />'
-        )
+        (nxt / "index.mdx").write_text("# next [w](./using-iii/workers)")
         _write_docs(docs, [
             {"version": "0.17.x", "tag": "Latest", "default": True,
              "tabs": [{"tab": "D", "groups": [{"group": "G", "pages": ["index"]}]}]},
@@ -402,14 +389,12 @@ class TestSyncPatch:
         before = (docs / "docs.json").read_text()
         sync_patch(docs)
 
-        # Root refreshed from next/, links re-pointed to root.
+        # Root refreshed from next/ verbatim (relative link survives the move).
         root_index = (docs / "index.mdx").read_text()
         assert "# old latest" not in root_index
-        assert "(/using-iii/workers)" in root_index
-        assert 'href="/using-iii"' in root_index
-        assert "/next/" not in root_index
+        assert "](./using-iii/workers)" in root_index
         # Next folder untouched.
-        assert "(/next/using-iii/workers)" in (docs / "next" / "index.mdx").read_text()
+        assert "](./using-iii/workers)" in (docs / "next" / "index.mdx").read_text()
         # No archive folder, and docs.json version blocks unchanged.
         assert not (docs / "0-17-0").exists()
         assert (docs / "docs.json").read_text() == before

--- a/.github/workflows/WORKFLOWS.md
+++ b/.github/workflows/WORKFLOWS.md
@@ -93,7 +93,7 @@ Entry point for all releases. Provides a form with:
 8. Commits the version bump (including any docs changes), creates an annotated tag, and pushes both
 9. Posts a Slack notification
 
-> **Docs layout:** `Latest` lives at the docs root (unprefixed paths); `Next` lives in the fixed `docs/next/` folder; archived versions live in `docs/MAJOR-MINOR-0/` folders. Rotation assumes this shape already exists (a `Latest` root block + a `Next` block pointing at `docs/next/`).
+> **Docs layout:** `Latest` lives at the docs root (unprefixed paths); `Next` lives in the fixed `docs/next/` folder; archived versions live in `docs/MAJOR-MINOR-0/` folders. `docs/changelog/` is shared by all versions — it stays at the root, is never copied into a version folder, and every version's Changelog tab points at it. Rotation assumes this shape already exists (a `Latest` root block + a `Next` block pointing at `docs/next/`).
 
 The tag push then triggers the corresponding release workflow.
 

--- a/.github/workflows/WORKFLOWS.md
+++ b/.github/workflows/WORKFLOWS.md
@@ -74,7 +74,7 @@ Entry point for all releases. Provides a form with:
 |-------|---------|
 | `target` | `iii` |
 | `bump` | `patch`, `minor`, `major` |
-| `prerelease` | `none`, `alpha`, `beta`, `rc` |
+| `prerelease` | `none`, `alpha`, `beta`, `rc`, `next` |
 | `dry_run` | boolean |
 
 **What it does:**
@@ -82,10 +82,18 @@ Entry point for all releases. Provides a form with:
 1. Validates it's running on `main` and all required manifest files exist
 2. Reads the current version from the canonical manifest
 3. Calculates the next version (handles semver bump + prerelease labels + dry-run suffixes)
-4. Converts to PEP 440 format for Python packages (e.g., `1.0.0-alpha.1` becomes `1.0.0a1`)
-5. Updates all manifest files in lockstep (Cargo.toml, package.json, pyproject.toml)
-6. Commits the version bump, creates an annotated tag, and pushes both
-7. Posts a Slack notification
+4. **Stable releases only** — validates docs are ready (`pin_docs.py validate`): `docs/docs.json` must have a `Next` block and the `docs/next/` folder must be non-empty (stable releases pull their docs from `docs/next/`). If not, the workflow posts a Slack alert and aborts **before** bumping or tagging. Runs even on dry runs.
+5. Converts to PEP 440 format for Python packages (e.g., `1.0.0-alpha.1` becomes `1.0.0a1`)
+6. Updates all manifest files in lockstep (Cargo.toml, package.json, pyproject.toml)
+7. Updates docs from `docs/next/` on stable releases (`pin_docs.py rotate`, which dispatches on the version):
+   - **minor/major** — rotates: archives the old Latest into `docs/OLD-MINOR-0/` (its `Latest` block becomes archived), promotes `docs/next/` into the root as a new `Latest` block labeled with the **tag version** (the official version comes from the tag and can be anything), relabels the `Next` block to `MINOR + 1` (reusing the `docs/next/` folder), and reorders the dropdown (Next, Latest, archived newest-first — Mintlify's own ordering does not work).
+   - **patch** — syncs in place: replaces the root content with `docs/next/`. No archive, no `Next` bump, no version-block changes — it just refreshes the current Latest's docs.
+   - **all prereleases** (`alpha`/`beta`/`rc`/`next`) leave docs untouched.
+   - In every case, internal links (markdown and `href`) are re-pointed so each version's links stay within that version.
+8. Commits the version bump (including any docs changes), creates an annotated tag, and pushes both
+9. Posts a Slack notification
+
+> **Docs layout:** `Latest` lives at the docs root (unprefixed paths); `Next` lives in the fixed `docs/next/` folder; archived versions live in `docs/MAJOR-MINOR-0/` folders. Rotation assumes this shape already exists (a `Latest` root block + a `Next` block pointing at `docs/next/`).
 
 The tag push then triggers the corresponding release workflow.
 

--- a/.github/workflows/WORKFLOWS.md
+++ b/.github/workflows/WORKFLOWS.md
@@ -89,7 +89,7 @@ Entry point for all releases. Provides a form with:
    - **minor/major** — rotates: archives the old Latest into `docs/OLD-MINOR-0/` (its `Latest` block becomes archived), promotes `docs/next/` into the root as a new `Latest` block labeled with the **tag version** (the official version comes from the tag and can be anything), relabels the `Next` block to `MINOR + 1` (reusing the `docs/next/` folder), and reorders the dropdown (Next, Latest, archived newest-first — Mintlify's own ordering does not work).
    - **patch** — syncs in place: replaces the root content with `docs/next/`. No archive, no `Next` bump, no version-block changes — it just refreshes the current Latest's docs.
    - **all prereleases** (`alpha`/`beta`/`rc`/`next`) leave docs untouched.
-   - In every case, internal links (markdown and `href`) are re-pointed so each version's links stay within that version.
+   - In-content links are version-relative, so files move verbatim; only `docs.json` nav paths carry the version prefix.
 8. Commits the version bump (including any docs changes), creates an annotated tag, and pushes both
 9. Posts a Slack notification
 

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -108,6 +108,35 @@ jobs:
             ${{ inputs.dry_run && '--dry-run' || '' }} \
             --current-version-file "$current_version_file"
 
+      # Stable releases pull their docs from docs/next/, so it must be prepared.
+      # Validate even on dry runs so a release cannot be tagged without docs.
+      - name: Validate docs ready for stable release
+        id: docs_check
+        if: inputs.target == 'iii' && inputs.prerelease == 'none'
+        run: |
+          python3 .github/scripts/pin_docs.py validate \
+            --docs-dir docs
+
+      - name: Notify Slack — release blocked (missing docs)
+        if: always() && steps.docs_check.outcome == 'failure'
+        continue-on-error: true
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "Release blocked — missing documentation"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: ":no_entry: *Release blocked* — Next docs not ready for `iii v${{ steps.versions.outputs.version }}`.\nExpected a `Next` block in `docs/docs.json` and a non-empty `docs/next/` folder before tagging. Prepare the docs, then re-run."
+              - type: "context"
+                elements:
+                  - type: "mrkdwn"
+                    text: "Triggered by ${{ github.actor }} | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+
       - name: Update iii manifests
         if: inputs.target == 'iii' && inputs.dry_run != true
         env:
@@ -118,6 +147,18 @@ jobs:
             --root . \
             --version "${NEW_VERSION}" \
             --python-version "${PY_VERSION}"
+
+      # Update docs from docs/next/ on stable releases. rotate dispatches on the
+      # version: minor/major rotate (archive + promote + bump Next); patch just
+      # refreshes the current Latest in place (no archive, no Next bump).
+      - name: Update documentation versions
+        if: inputs.target == 'iii' && inputs.dry_run != true && inputs.prerelease == 'none'
+        env:
+          NEW_VERSION: ${{ steps.versions.outputs.version }}
+        run: |
+          python3 .github/scripts/pin_docs.py rotate \
+            --docs-dir docs \
+            --version "${NEW_VERSION}"
 
       - name: Sync Cargo.lock
         if: inputs.target == 'iii' && inputs.dry_run != true

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Written by .github/scripts/pin_docs.py with Python json.dumps; keep
+# formatters from re-collapsing its arrays and causing format ping-pong.
+docs/docs.json


### PR DESCRIPTION
## Summary

Adds `docs/docs.json` version management to the `create-tag` workflow via a new `.github/scripts/pin_docs.py` (`validate` + `rotate` subcommands). Stable releases pull their docs from `docs/next/`.

- **validate** (all stable releases, even dry runs): require a `Next` block in `docs.json` and a non-empty `docs/next/` folder, else post a Slack alert and abort before tagging.
- **rotate** (stable, dispatched by version):
  - **minor/major** — archive the old Latest into `docs/MAJOR-MINOR-0/`, promote `docs/next/` into the root as the new Latest (labeled with the **tag** version), relabel `Next` to `MINOR+1`, re-sort the dropdown (Next, Latest, archived newest-first — Mintlify's own ordering doesn't work).
  - **patch** — refresh the current Latest from `docs/next/` in place (no archive, no Next bump, no version-block changes).
- Internal links (markdown, `href`, `src`) are re-pointed on every move so each version's links stay within that version.
- Prereleases leave docs untouched. `docs.json` written via `json.dumps`; `.prettierignore` excludes it.

Covered by unit + integration tests (`.github/scripts/test_pin_docs.py`, 172 passing).

## Related

- The one-time content correction of the existing versioned docs is a separate PR: #1732.

## Test Plan

- [x] `python -m pytest` in `.github/scripts` (172 passing)
- [x] Smoke-tested validate / rotate (minor, major, patch) against a copy of the real docs tree
- [ ] Dry-run a stable release in CI to confirm the validate gate + Slack alert