### PR TITLE
fix(observability): strip ANSI codes from stored logs

### DIFF
--- a/engine/src/workers/observability/logs_layer.rs
+++ b/engine/src/workers/observability/logs_layer.rs
@@ -527,6 +527,28 @@ mod tests {
     }
 
     #[test]
+    fn layer_strips_ansi_from_body() {
+        let (_, logs) = with_layer(|| {
+            // Simulate a colorized message like `"[REGISTERED]".green()` produces.
+            tracing::info!("\u{1b}[32m[REGISTERED]\u{1b}[0m Function \u{1b}[35mabc\u{1b}[0m");
+        });
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].body, "[REGISTERED] Function abc");
+    }
+
+    #[test]
+    fn layer_strips_ansi_from_string_attribute() {
+        let (_, logs) = with_layer(|| {
+            tracing::info!(colored = "\u{1b}[31mred\u{1b}[0m", "with colored attr");
+        });
+        assert_eq!(logs.len(), 1);
+        assert_eq!(
+            logs[0].attributes.get("colored"),
+            Some(&serde_json::Value::String("red".to_string()))
+        );
+    }
+
+    #[test]
     fn otel_logs_layer_new_stores_service_name() {
         let storage = Arc::new(InMemoryLogStorage::new(10));
         let layer = OtelLogsLayer::new(storage.clone(), "my-svc".to_string());

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -3694,7 +3694,10 @@ mod tests {
             logs[0].attributes.get("colored"),
             Some(&serde_json::Value::String("red".to_string()))
         );
-        assert_eq!(logs[0].attributes.get("count"), Some(&serde_json::json!(42)));
+        assert_eq!(
+            logs[0].attributes.get("count"),
+            Some(&serde_json::json!(42))
+        );
     }
 
     #[test]

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -2184,6 +2184,32 @@ impl std::fmt::Debug for InMemoryLogStorage {
     }
 }
 
+/// Strip ANSI/terminal escape codes from a log's body and string attribute
+/// values before it enters storage.
+///
+/// Logs are colorized at their emission site — engine `tracing` macros (e.g.
+/// `"[REGISTERED]".green()`) and worker output forwarded over OTLP. Color is a
+/// terminal-display concern, but stored logs are queried as structured data via
+/// `engine::logs::list` and the web console, so they must be plain text in every
+/// output mode. `store`/`add_logs` are the single chokepoint that all stored-log
+/// sources funnel through (engine tracing layer, OTLP ingest, the `log`
+/// function), so stripping here covers them all in one place. Terminal coloring
+/// is untouched: console rendering happens before storage (see
+/// `emit_log_to_console`) and via a separate fmt layer, both of which see the
+/// pre-strip value.
+fn strip_ansi_from_log(log: &mut StoredLog) {
+    if let std::borrow::Cow::Owned(clean) = console::strip_ansi_codes(&log.body) {
+        log.body = clean;
+    }
+    for value in log.attributes.values_mut() {
+        if let serde_json::Value::String(s) = value
+            && let std::borrow::Cow::Owned(clean) = console::strip_ansi_codes(s)
+        {
+            *s = clean;
+        }
+    }
+}
+
 impl InMemoryLogStorage {
     pub fn new(max_logs: usize) -> Self {
         let (tx, _) = broadcast::channel(1024);
@@ -2194,7 +2220,8 @@ impl InMemoryLogStorage {
         }
     }
 
-    pub fn store(&self, log: StoredLog) {
+    pub fn store(&self, mut log: StoredLog) {
+        strip_ansi_from_log(&mut log);
         let mut logs = self.logs.write().unwrap();
         if logs.len() >= self.max_logs {
             logs.pop_front();
@@ -2207,7 +2234,8 @@ impl InMemoryLogStorage {
 
     pub fn add_logs(&self, new_logs: Vec<StoredLog>) {
         let mut logs = self.logs.write().unwrap();
-        for log in new_logs {
+        for mut log in new_logs {
+            strip_ansi_from_log(&mut log);
             if logs.len() >= self.max_logs {
                 logs.pop_front();
             }
@@ -3617,6 +3645,79 @@ mod tests {
         assert_eq!(logs[0].body, "Log message 2");
         assert_eq!(logs[1].body, "Log message 3");
         assert_eq!(logs[2].body, "Log message 4");
+    }
+
+    fn ansi_log(body: &str, attrs: HashMap<String, serde_json::Value>) -> StoredLog {
+        StoredLog {
+            timestamp_unix_nano: 1704067200000000000,
+            observed_timestamp_unix_nano: 1704067200000000000,
+            severity_number: 9,
+            severity_text: "INFO".to_string(),
+            body: body.to_string(),
+            attributes: attrs,
+            trace_id: None,
+            span_id: None,
+            resource: HashMap::new(),
+            service_name: "test".to_string(),
+            instrumentation_scope_name: None,
+            instrumentation_scope_version: None,
+        }
+    }
+
+    #[test]
+    fn store_strips_ansi_from_body() {
+        let storage = InMemoryLogStorage::new(10);
+        // Colorized like `"[REGISTERED]".green()` produces.
+        storage.store(ansi_log(
+            "\u{1b}[32m[REGISTERED]\u{1b}[0m Function \u{1b}[35mfoo\u{1b}[0m",
+            HashMap::new(),
+        ));
+        let logs = storage.get_logs();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].body, "[REGISTERED] Function foo");
+    }
+
+    #[test]
+    fn store_strips_ansi_from_string_attributes() {
+        let storage = InMemoryLogStorage::new(10);
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "colored".to_string(),
+            serde_json::Value::String("\u{1b}[31mred\u{1b}[0m".to_string()),
+        );
+        // Non-string attributes must pass through untouched.
+        attrs.insert("count".to_string(), serde_json::json!(42));
+        storage.store(ansi_log("plain", attrs));
+        let logs = storage.get_logs();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(
+            logs[0].attributes.get("colored"),
+            Some(&serde_json::Value::String("red".to_string()))
+        );
+        assert_eq!(logs[0].attributes.get("count"), Some(&serde_json::json!(42)));
+    }
+
+    #[test]
+    fn add_logs_strips_ansi_worker_otlp_path() {
+        // Worker logs ingested over OTLP land via `add_logs`, not the tracing
+        // layer — this is the path the per-source fix used to miss.
+        let storage = InMemoryLogStorage::new(10);
+        storage.add_logs(vec![
+            ansi_log("\u{1b}[33mworker warn\u{1b}[0m", HashMap::new()),
+            ansi_log("plain worker line", HashMap::new()),
+        ]);
+        let logs = storage.get_logs();
+        assert_eq!(logs.len(), 2);
+        let bodies: Vec<&str> = logs.iter().map(|l| l.body.as_str()).collect();
+        assert!(bodies.contains(&"worker warn"));
+        assert!(bodies.contains(&"plain worker line"));
+    }
+
+    #[test]
+    fn store_leaves_plain_text_untouched() {
+        let storage = InMemoryLogStorage::new(10);
+        storage.store(ansi_log("just plain text", HashMap::new()));
+        assert_eq!(storage.get_logs()[0].body, "just plain text");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`iii trigger engine::logs::list` (and the web console) returned log bodies/attributes containing raw ANSI escape codes, e.g.:

```json
"body": "[32m[REGISTERED][0m Trigger Type [35mhttp[0m"
```

Engine logs are colorized at their emission site (`"[REGISTERED]".green()`, `id.purple()`), which bakes ANSI escapes into the message string before any layer sees it. Worker logs forwarded over OTLP can carry ANSI too. Those codes were stored verbatim and surfaced in the structured logs API — color leaking into data that should be plain text. Whether it appeared depended on the engine's output format mode (TTY/`colored` override), which is the wrong thing to couple stored data to.

## Fix

Strip ANSI in `InMemoryLogStorage::store` / `add_logs` — the single chokepoint that **all** stored-log sources funnel through:

1. `OtelLogsLayer` — engine's own `tracing` events
2. `ingest_otlp_logs` → `add_logs` — worker logs over OTLP/WS
3. the `log` function handler — SDK/worker-submitted logs

Stripping at the storage layer (instead of per-source) means one source of truth and covers the worker OTLP path that a per-layer fix misses.

Terminal coloring is preserved: console rendering runs **before** storage (`emit_log_to_console` executes prior to `add_logs`) and the engine's fmt layer renders independently of storage — both see the pre-strip value.

| Surface | Color? |
|---|---|
| Engine stdout / worker → terminal | ✅ colored |
| `engine::logs::list` (API/JSON) | ❌ clean |
| Web console (reads the API) | ❌ clean |

## Tests

- `store_strips_ansi_from_body`
- `store_strips_ansi_from_string_attributes` (non-string attrs untouched)
- `add_logs_strips_ansi_worker_otlp_path` (worker OTLP path)
- `store_leaves_plain_text_untouched`
- `logs_layer` ANSI tests now validate end-to-end through storage

All 325 observability lib tests pass.
