### PR TITLE
Move release profile to workspace root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,4 +59,4 @@ serial_test = "3"
 strip = true
 lto = true
 codegen-units = 1
-opt-level = "z"
+opt-level = "s"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,9 @@ ctrlc = "3"
 wiremock = "0.6"
 tempfile = "3"
 serial_test = "3"
+
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1
+opt-level = "z"

--- a/console/packages/console-rust/Cargo.toml
+++ b/console/packages/console-rust/Cargo.toml
@@ -42,9 +42,3 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Error handling
 anyhow = "1"
-
-[profile.release]
-strip = true
-lto = true
-codegen-units = 1
-opt-level = "z"


### PR DESCRIPTION
## Summary

- Moves the release optimization profile from the `iii-console` crate manifest to the workspace root manifest.
- Removes the ignored package-level `[profile.release]` block from `console/packages/console-rust/Cargo.toml`.
- Applies `strip`, `lto`, `codegen-units = 1`, and `opt-level = "s"` to all release binaries built from the workspace.

## Why

Cargo ignores profile settings declared in non-root workspace package manifests. As a result, the intended release optimization settings were not being applied from the console crate manifest.

Closes #1724.

## Binary size measurements

Measured with clean builds using `cargo clean` followed by `cargo build -r --workspace`.

| Binary | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| `iii` | 34.14 MiB | 14.28 MiB | 58.2% |
| `iii-console` | 12.05 MiB | 5.10 MiB | 57.7% |
| `iii-worker` | 29.64 MiB | 12.86 MiB | 56.6% |

## Validation

- `cargo fmt --all`
- `cargo build -r --workspace`
- Confirmed the `profiles for the non root package will be ignored` warning no longer appears.

Note: the existing `iii-console` frontend asset warning still appears during the build and falls back to placeholder assets, as it did before this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized release build configuration enabling binary stripping, link-time optimization (LTO), and adjusted code generation settings to produce more efficient production binaries with reduced file sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->