### PR TITLE
perf(engine): gate state/stream trigger spans on a matching trigger

### DIFF
--- a/engine/src/workers/state/state.rs
+++ b/engine/src/workers/state/state.rs
@@ -110,18 +110,58 @@ impl ConfigurableWorker for StateWorker {
     }
 }
 
+/// True when a state trigger's scope/key constraints match the event. Scope
+/// and key are local fields (no RPC); `condition_function_id` is evaluated
+/// separately, only after a scope/key match, inside the trigger span.
+fn state_trigger_matches(
+    config: &super::trigger::StateTriggerConfig,
+    event_scope: &str,
+    event_key: &str,
+) -> bool {
+    if let Some(scope) = &config.scope {
+        if scope != event_scope {
+            return false;
+        }
+    }
+    if let Some(key) = &config.key {
+        if key != event_key {
+            return false;
+        }
+    }
+    true
+}
+
 impl StateWorker {
-    /// Invoke triggers for a given event type with condition checks
+    /// Invoke triggers for a given event type with condition checks.
+    ///
+    /// Triggers are pre-filtered by scope/key BEFORE the `state_triggers` span
+    /// is created, so a write whose scope/key matches no registered trigger
+    /// emits NO span and spawns NO task. The engine fires one trigger
+    /// evaluation per state write, so gating here avoids the span (and its
+    /// CPU/memory/export cost) for the common no-match case. Matching triggers
+    /// still have their `condition_function_id` evaluated inside the span.
     async fn invoke_triggers(&self, event_data: StateEventData) {
-        // Collect triggers into Vec to release the lock before spawning
+        let event_scope = event_data.scope.clone();
+        let event_key = event_data.key.clone();
+
+        // Collect only the triggers whose scope/key match, releasing the lock
+        // before spawning.
         let triggers: Vec<StateTrigger> = {
             let triggers_guard = self.triggers.list.read().await;
-            triggers_guard.values().cloned().collect()
+            triggers_guard
+                .values()
+                .filter(|t| state_trigger_matches(&t.config, &event_scope, &event_key))
+                .cloned()
+                .collect()
         };
+
+        // No matching trigger → skip the eval span and the spawn entirely.
+        if triggers.is_empty() {
+            return;
+        }
+
         let engine = self.engine.clone();
         let event_type = event_data.event_type.clone();
-        let event_key = event_data.key.clone();
-        let event_scope = event_data.scope.clone();
 
         let current_span = tracing::Span::current();
 
@@ -132,40 +172,7 @@ impl StateWorker {
                     let mut has_error = false;
 
                     for trigger in triggers {
-                        let trigger = trigger.clone();
-
-                        if let Some(scope) = &trigger.config.scope {
-                            tracing::info!(
-                                scope = %scope,
-                                event_scope = %event_scope,
-                                "Checking trigger scope"
-                            );
-                            if scope != &event_scope {
-                                tracing::info!(
-                                    scope = %scope,
-                                    event_scope = %event_scope,
-                                    "Trigger scope does not match event scope, skipping trigger"
-                                );
-                                continue;
-                            }
-                        }
-
-                        if let Some(key) = &trigger.config.key {
-                            tracing::info!(
-                                key = %key,
-                                event_key = %event_key,
-                                "Checking trigger key"
-                            );
-                            if key != &event_key {
-                                tracing::info!(
-                                    key = %key,
-                                    event_key = %event_key,
-                                    "Trigger key does not match event key, skipping trigger"
-                                );
-                                continue;
-                            }
-                        }
-
+                        // Scope/key already matched in the pre-filter above.
                         if let Some(ref condition_id) = trigger.config.condition_function_id {
                             tracing::debug!(
                                 condition_function_id = %condition_id,
@@ -416,6 +423,56 @@ mod tests {
         state::adapters::kv_store::BuiltinKvStoreAdapter,
     };
     use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[test]
+    fn state_trigger_matches_respects_scope_and_key() {
+        use super::super::trigger::StateTriggerConfig;
+        let cfg = |scope: Option<&str>, key: Option<&str>| StateTriggerConfig {
+            scope: scope.map(String::from),
+            key: key.map(String::from),
+            condition_function_id: None,
+        };
+        // No scope/key constraints → matches any write.
+        assert!(state_trigger_matches(&cfg(None, None), "orders", "o1"));
+        // Scope constraint only.
+        assert!(state_trigger_matches(
+            &cfg(Some("orders"), None),
+            "orders",
+            "o1"
+        ));
+        assert!(!state_trigger_matches(
+            &cfg(Some("orders"), None),
+            "users",
+            "o1"
+        ));
+        // Key constraint only.
+        assert!(state_trigger_matches(
+            &cfg(None, Some("special")),
+            "s",
+            "special"
+        ));
+        assert!(!state_trigger_matches(
+            &cfg(None, Some("special")),
+            "s",
+            "other"
+        ));
+        // Both constraints.
+        assert!(state_trigger_matches(
+            &cfg(Some("orders"), Some("o1")),
+            "orders",
+            "o1"
+        ));
+        assert!(!state_trigger_matches(
+            &cfg(Some("orders"), Some("o1")),
+            "orders",
+            "o2"
+        ));
+        assert!(!state_trigger_matches(
+            &cfg(Some("orders"), Some("o1")),
+            "users",
+            "o1"
+        ));
+    }
 
     struct FakeStateAdapter {
         set_error: Option<&'static str>,

--- a/engine/src/workers/stream/stream.rs
+++ b/engine/src/workers/stream/stream.rs
@@ -332,6 +332,14 @@ impl StreamWorker {
             triggers
         };
 
+        // No trigger matches this stream write (name index already filtered by
+        // stream_name/group_id/item_id) → skip the `stream_triggers` eval span
+        // and the spawn entirely. The engine fires one evaluation per stream
+        // write, so this avoids the span/CPU/export for the common no-match case.
+        if triggers_to_invoke.is_empty() {
+            return;
+        }
+
         let current_span = tracing::Span::current();
 
         if let Ok(event_data) = serde_json::to_value(event_data) {


### PR DESCRIPTION
## Summary

`StateWorker::invoke_triggers` and `StreamWorker::invoke_triggers` create the `state_triggers` / `stream_triggers` evaluation span (and spawn a task) **unconditionally on every state/stream write** — even when no registered trigger matches the write's scope/key/stream. A write to a scope or stream that nothing subscribes to still emits a trigger-eval span purely as overhead; in agent traces these spans track the total write count 1:1 and dominate span volume.

This gates span creation on an actual match:

- **State** (`engine/src/workers/state/state.rs`): pre-filter the registered triggers by scope/key (new pure helper `state_trigger_matches`) **before** the span + `tokio::spawn`; early-return when none match. Scope/key are local fields, so this needs no RPC. Matching triggers still evaluate `condition_function_id` inside the span and dispatch exactly as before.
- **Stream** (`engine/src/workers/stream/stream.rs`): the trigger set is already name-indexed (`stream_triggers_by_name`); early-return when `triggers_to_invoke` is empty, skipping the span + spawn.

## Effect

A write whose scope/key/stream matches no registered trigger now emits **no** `state_triggers` / `stream_triggers` span and spawns no task — eliminating the span (and its CPU/memory/OTLP-export cost) at the source for the common no-match case. Writes that *do* match are unchanged.

## Before / After

Today only a couple of scopes have a registered trigger (e.g. `turn_state`, `approvals`); high-frequency writes to scopes like `messages`, `run_request`, `session_tree_mirror_len`, `lease` match **nothing** — yet each still produced an empty eval span.

**Write to a scope with no matching trigger** (e.g. `messages`):

```
before:                                          after:
handle_invocation state::set  (scope=messages)   handle_invocation state::set  (scope=messages)
└─ state_triggers   ← span + spawn, loop runs,      (no state_triggers span, no spawn)
                      0 triggers match, 0 handlers
```

**Write whose scope DOES match** (e.g. `turn_state`) — unchanged:

```
handle_invocation state::set  (scope=turn_state)
└─ state_triggers
   └─ call harness::fanout::session_created   ← matched handler still dispatched
```

Because the span previously fired once per write regardless of match, `state_triggers` count == total state-write count in a trace. After this change, only writes that match a trigger emit a span.

Code (state worker), condensed:

```rust
// before — span created unconditionally; scope/key checked INSIDE the spawned loop
let triggers = guard.values().cloned().collect::<Vec<_>>();
tokio::spawn(async move {
    for t in triggers {
        if let Some(s) = &t.config.scope { if s != &event_scope { continue; } } // span already exists
        if let Some(k) = &t.config.key   { if k != &event_key   { continue; } }
        /* condition_function_id + handler */
    }
}.instrument(info_span!(parent: current_span, "state_triggers", ...)));

// after — pre-filter by scope/key; no match ⇒ no span, no spawn
let triggers = guard.values()
    .filter(|t| state_trigger_matches(&t.config, &event_scope, &event_key))
    .cloned().collect::<Vec<_>>();
if triggers.is_empty() { return; }
tokio::spawn(async move {
    for t in triggers { /* condition_function_id + handler — scope/key already matched */ }
}.instrument(info_span!(parent: current_span, "state_triggers", ...)));
```

(Stream side is the same shape: it already builds `triggers_to_invoke` via the name index, so the change is a single `if triggers_to_invoke.is_empty() { return; }` before the span.)

## Behavior preserved

Trigger dispatch is identical for matching triggers — the scope/key checks moved from inside the spawned loop to a pre-filter; `condition_function_id` evaluation and handler invocation are unchanged, as is the `otel.status_code` recording on the matching path. The only observable difference is the absence of a span for writes that previously matched nothing.

## Test plan

- [x] New unit test `state_trigger_matches_respects_scope_and_key` (scope-only / key-only / both / none).
- [x] Existing `invoke_triggers` behavioral tests pass unchanged: `scope_filter`, `key_filter`, `matching_trigger_calls_function`, `condition_none_allows_handler`, `condition_error_skips_handler`, `handler_error_is_tolerated`.
- [x] `cargo test` green (state-worker suite 22/22; ~130 trigger tests across the crate); `cargo fmt` clean.
- [ ] CI: full engine suite + clippy.

## Notes

Complementary to the `otel-span-dedup-volume` effort: that collapses duplicate caller/callee spans and builtin `call` spans at/near export; this removes the no-match trigger-eval spans at creation. The two stack.
