### PR TITLE
feat(queue): provision a built-in `default` queue

### DIFF
--- a/engine/src/workers/queue/config.rs
+++ b/engine/src/workers/queue/config.rs
@@ -10,6 +10,13 @@ use serde::Deserialize;
 
 use crate::workers::traits::AdapterEntry;
 
+/// Name of the always-present built-in queue. The engine provisions this queue
+/// with standard defaults during config load, so `TriggerAction::Enqueue {
+/// queue: "default" }` works with no `queue_configs` entry — a zero-config
+/// durable queue out of the box. An explicit `default` entry in user config
+/// takes precedence and is never overwritten.
+pub const DEFAULT_QUEUE_NAME: &str = "default";
+
 #[allow(dead_code)] // this is used as default value
 fn default_redis_url() -> String {
     "redis://localhost:6379".to_string()
@@ -81,6 +88,17 @@ pub struct QueueModuleConfig {
 }
 
 impl QueueModuleConfig {
+    /// Ensure the built-in [`DEFAULT_QUEUE_NAME`] queue exists. Called once
+    /// after config load (see `QueueWorker::build`) so callers get a durable
+    /// queue without declaring it in `config.yaml`. A user-supplied `default`
+    /// entry is preserved — `or_default` only inserts when the key is absent —
+    /// so operators can still tune its retries/concurrency/type if they want.
+    pub fn ensure_default_queue(&mut self) {
+        self.queue_configs
+            .entry(DEFAULT_QUEUE_NAME.to_string())
+            .or_default();
+    }
+
     pub fn validate(&self) -> anyhow::Result<()> {
         for (name, queue_config) in &self.queue_configs {
             if queue_config.r#type != "standard" && queue_config.r#type != "fifo" {
@@ -110,6 +128,61 @@ mod tests {
         let config = QueueModuleConfig::default();
         assert!(config.adapter.is_none());
         assert!(config.queue_configs.is_empty());
+    }
+
+    #[test]
+    fn ensure_default_queue_provisions_standard_queue_when_absent() {
+        let mut config = QueueModuleConfig::default();
+        config.ensure_default_queue();
+
+        let default = config
+            .queue_configs
+            .get(DEFAULT_QUEUE_NAME)
+            .expect("default queue should be provisioned");
+        // Standard defaults — a plain, concurrent, retrying queue.
+        assert_eq!(default.r#type, "standard");
+        assert_eq!(default.concurrency, default_concurrency());
+        assert_eq!(default.max_retries, default_max_retries());
+        assert!(default.message_group_field.is_none());
+        // The provisioned default must satisfy validation.
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn ensure_default_queue_preserves_explicit_user_config() {
+        let mut queue_configs = HashMap::new();
+        queue_configs.insert(
+            DEFAULT_QUEUE_NAME.to_string(),
+            FunctionQueueConfig {
+                r#type: "fifo".to_string(),
+                message_group_field: Some("session_id".to_string()),
+                max_retries: 9,
+                concurrency: 1,
+                ..Default::default()
+            },
+        );
+        let mut config = QueueModuleConfig {
+            adapter: None,
+            queue_configs,
+        };
+
+        config.ensure_default_queue();
+
+        // An operator who declares `default` keeps their tuned settings.
+        let default = config.queue_configs.get(DEFAULT_QUEUE_NAME).unwrap();
+        assert_eq!(default.r#type, "fifo");
+        assert_eq!(default.max_retries, 9);
+        assert_eq!(default.concurrency, 1);
+        assert_eq!(default.message_group_field.as_deref(), Some("session_id"));
+        assert_eq!(config.queue_configs.len(), 1);
+    }
+
+    #[test]
+    fn ensure_default_queue_is_idempotent() {
+        let mut config = QueueModuleConfig::default();
+        config.ensure_default_queue();
+        config.ensure_default_queue();
+        assert_eq!(config.queue_configs.len(), 1);
     }
 
     #[test]

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -821,7 +821,12 @@ impl ConfigurableWorker for QueueWorker {
         &REGISTRY
     }
 
-    fn build(engine: Arc<Engine>, config: Self::Config, adapter: Arc<Self::Adapter>) -> Self {
+    fn build(engine: Arc<Engine>, mut config: Self::Config, adapter: Arc<Self::Adapter>) -> Self {
+        // Provision the built-in `default` queue so enqueues to it work with no
+        // user config. Done here (the single construction site) so both the
+        // consumer spawn in `start_background_tasks` and the lookup in
+        // `enqueue_to_function_queue` see it.
+        config.ensure_default_queue();
         Self {
             engine,
             _config: config,
@@ -1525,6 +1530,54 @@ mod tests {
         let config = super::super::config::QueueModuleConfig::default();
         let module = QueueWorker::build(engine.clone(), config, adapter);
         assert_eq!(Worker::name(&module), "QueueModule");
+    }
+
+    #[test]
+    fn build_provisions_builtin_default_queue() {
+        use super::super::config::{DEFAULT_QUEUE_NAME, QueueModuleConfig};
+
+        crate::workers::observability::metrics::ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        let adapter: Arc<dyn QueueAdapter> = Arc::new(MockQueueAdapter::new());
+        // Empty config — the operator declared no queues.
+        let module = QueueWorker::build(engine, QueueModuleConfig::default(), adapter);
+        assert!(
+            module
+                ._config
+                .queue_configs
+                .contains_key(DEFAULT_QUEUE_NAME),
+            "build() must provision the built-in default queue"
+        );
+    }
+
+    #[tokio::test]
+    async fn enqueue_to_default_queue_succeeds_without_config() {
+        use super::super::config::{DEFAULT_QUEUE_NAME, QueueModuleConfig};
+
+        crate::workers::observability::metrics::ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        let adapter = Arc::new(MockQueueAdapter::new());
+        // A worker built from empty config — exactly what a user gets when they
+        // never touch `queue_configs` in config.yaml.
+        let module = QueueWorker::build(engine, QueueModuleConfig::default(), adapter.clone());
+
+        let result = module
+            .enqueue_to_function_queue(
+                DEFAULT_QUEUE_NAME,
+                "fn-1",
+                json!({"key": "value"}),
+                "test-msg-id",
+                None,
+                None,
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "enqueue to the built-in default queue should succeed, got: {:?}",
+            result.err()
+        );
+        assert_eq!(adapter.enqueue_to_queue_count.load(Ordering::SeqCst), 1);
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

Function-queue enqueues (`TriggerAction::Enqueue { queue }`) require the target queue to be declared in the `iii-queue` worker's `queue_configs`. Enqueueing to an undeclared queue fails at runtime with `Queue '<name>' not found`, and no consumer is ever spawned for it. As a result, even the conventional `default` queue used throughout the SDK examples must be hand-declared in `config.yaml` before it works.

This makes `default` an always-present built-in queue: it is provisioned with standard defaults during config load, so `TriggerAction::Enqueue { queue: "default" }` works out of the box with no `config.yaml` entry — a zero-config durable queue.

## Behavior

- A `default` queue is injected into `queue_configs` at worker construction using `FunctionQueueConfig::default()` — `type: standard`, `concurrency: 10`, `max_retries: 3`, `backoff_ms: 1000`. It satisfies `validate()` and gets a consumer spawned like any configured queue.
- An explicit `default` entry in user config is **preserved** — `or_default()` only inserts when the key is absent — so operators can still tune its type / retries / concurrency / grouping.
- All other queue names still require declaration (unchanged): enqueueing to an unknown, non-`default` queue still fails with `Queue '<name>' not found`.

## Implementation

- `engine/src/workers/queue/config.rs`: add `DEFAULT_QUEUE_NAME` constant and `QueueModuleConfig::ensure_default_queue()`.
- `engine/src/workers/queue/queue.rs`: call `ensure_default_queue()` in `QueueWorker::build()` — the single construction site — so both the consumer-spawn loop in `start_background_tasks` and the lookup in `enqueue_to_function_queue` observe it.

## Test plan

New unit tests (all passing locally — `18 passed, 0 failed`):

- `ensure_default_queue_provisions_standard_queue_when_absent` — provisions standard defaults and passes validation
- `ensure_default_queue_preserves_explicit_user_config` — a user-declared `default` is not overwritten
- `ensure_default_queue_is_idempotent`
- `build_provisions_builtin_default_queue` — `build()` injects the queue
- `enqueue_to_default_queue_succeeds_without_config` — enqueue to `default` succeeds from an empty config

```
cargo test -p iii -- workers::queue::config:: build_provisions_builtin_default_queue enqueue_to_default_queue_succeeds_without_config
# 18 passed, 0 failed
cargo fmt   # clean
```

> Note: running the filtered subset `cargo test -p iii workers::queue` surfaces one **pre-existing, unrelated** failure — `adapters::builtin::adapter::tests::function_handler_maps_engine_results_to_queue_worker_results` panics with `GLOBAL_METER not initialized`. It fails identically on `main` with this change stashed (that test drives `EngineMetrics::new()` but never calls `ensure_default_meter()`, so a filtered run that excludes the usual meter-initializer races). Not touched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queue workers now automatically provision a built-in default queue during initialization, ensuring it exists for enqueueing while preserving any user-configured default.
* **Bug Fixes / Reliability**
  * Default queue provisioning is idempotent and safe to run multiple times.
* **Tests**
  * Added tests covering provisioning, preservation of explicit defaults, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->