### PR TITLE
fix(iii-worker): replace existing bundle install on cross-project add

### DIFF
--- a/crates/iii-worker/src/cli/bundle_download.rs
+++ b/crates/iii-worker/src/cli/bundle_download.rs
@@ -33,12 +33,17 @@
 //!   slipping into a partially-cleaned-up state.
 //! - The final step is an atomic `std::fs::rename` from the staging dir
 //!   to `~/.iii/workers-bundle/{name}/`. Cross-filesystem renames fall
-//!   back to copy-then-delete.
+//!   back to copy-then-delete. A previous install of the same name is
+//!   parked aside as a `{name}.old.<unique>` sibling first and restored
+//!   if the new install fails (see `atomic_install`).
 //!
 //! Process-restart safety:
 //! - The `Drop` guard cannot run if the process is killed mid-install.
 //! - `sweep_orphans()` runs at engine/CLI startup and removes any
 //!   leftover staging directories. See T18.
+//! - `{name}.old.*` siblings leaked by a replacement that crashed
+//!   between rename-aside and cleanup are swept on the next install of
+//!   the same worker (`sweep_stale_old_siblings`).
 
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
@@ -788,8 +793,66 @@ pub fn extract_bundle_safely_blocking(
     Ok(())
 }
 
-/// Performs the atomic install step: rename the staging dir into its
-/// final home at `~/.iii/workers-bundle/{name}/`.
+/// Performs the atomic install step: move the staging dir into its
+/// final home at `~/.iii/workers-bundle/{name}/`, REPLACING any
+/// previous install of the same name.
+///
+/// Bundle installs are a machine-wide cache keyed by name, so an add
+/// from any project must land the freshly resolved payload rather than
+/// keep a possibly-stale one. Replacement is rename-aside: the previous
+/// install is renamed to a unique `<final_dir>.old.<unique>` sibling
+/// (same-fs, atomic), the new tree is installed via `install_fresh`,
+/// and the old sibling is removed best-effort. If the new install
+/// fails, the old sibling is renamed back so the previous install is
+/// never lost. Callers serialize per-worker through the staging fslock,
+/// so the rename-aside dance is not raced in production.
+pub fn atomic_install(staging_dir: &Path, name: &str) -> Result<PathBuf, WorkerOpError> {
+    let final_dir = super::config_file::bundle_worker_path(name);
+    if let Some(parent) = final_dir.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| WorkerOpError::ConfigIo {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+
+    sweep_stale_old_siblings(&final_dir);
+
+    if !final_dir.exists() {
+        return install_fresh(staging_dir, &final_dir);
+    }
+
+    // Move the previous install aside so install_fresh's final rename
+    // targets an absent `final_dir`.
+    let old_dir = sibling_old_dir(&final_dir);
+    if let Err(source) = std::fs::rename(&final_dir, &old_dir) {
+        // Nothing has moved yet — the previous install is intact.
+        return Err(WorkerOpError::ConfigIo {
+            path: final_dir,
+            source,
+        });
+    }
+
+    match install_fresh(staging_dir, &final_dir) {
+        Ok(p) => {
+            let _ = std::fs::remove_dir_all(&old_dir);
+            Ok(p)
+        }
+        Err(e) => {
+            // install_fresh only creates `final_dir` via its last atomic
+            // rename, so on failure `final_dir` is absent and the previous
+            // install can be restored. The exists() guard is defensive: a
+            // freshly-created final must never be clobbered by the old one.
+            if final_dir.exists() {
+                let _ = std::fs::remove_dir_all(&old_dir);
+            } else {
+                let _ = std::fs::rename(&old_dir, &final_dir);
+            }
+            Err(e)
+        }
+    }
+}
+
+/// Installs the staging tree into an absent `final_dir`.
 ///
 /// Same-filesystem fast path: a single `std::fs::rename` swaps the
 /// staging tree into its final location in O(1).
@@ -803,28 +866,15 @@ pub fn extract_bundle_safely_blocking(
 /// is left in place for the StagingGuard to clean — `final_dir` is
 /// never even touched, so a half-installed worker can never appear
 /// under `iii worker list`.
-pub fn atomic_install(staging_dir: &Path, name: &str) -> Result<PathBuf, WorkerOpError> {
-    let final_dir = super::config_file::bundle_worker_path(name);
-    if final_dir.exists() {
-        return Err(WorkerOpError::AlreadyExists {
-            name: name.to_string(),
-        });
-    }
-    if let Some(parent) = final_dir.parent() {
-        std::fs::create_dir_all(parent).map_err(|source| WorkerOpError::ConfigIo {
-            path: parent.to_path_buf(),
-            source,
-        })?;
-    }
-
-    match std::fs::rename(staging_dir, &final_dir) {
-        Ok(()) => Ok(final_dir),
+fn install_fresh(staging_dir: &Path, final_dir: &Path) -> Result<PathBuf, WorkerOpError> {
+    match std::fs::rename(staging_dir, final_dir) {
+        Ok(()) => Ok(final_dir.to_path_buf()),
         Err(e) if cross_device_or_busy(&e) => {
             // Cross-fs path: copy into a sibling of `final_dir` first,
             // then rename. This keeps the final rename inside one
             // filesystem (the bundle root's parent) so it stays atomic;
             // a partial copy can never poison `final_dir`.
-            let partial = sibling_partial_dir(&final_dir);
+            let partial = sibling_partial_dir(final_dir);
             // If a prior crashed install left a stale `*.partial.*`
             // sibling, sweep it before we begin. Best-effort — if remove
             // fails we'll surface the copy error below.
@@ -843,10 +893,10 @@ pub fn atomic_install(staging_dir: &Path, name: &str) -> Result<PathBuf, WorkerO
 
             // Same-filesystem rename: this either succeeds atomically
             // or fails without leaving `final_dir` in a half-state.
-            if let Err(source) = std::fs::rename(&partial, &final_dir) {
+            if let Err(source) = std::fs::rename(&partial, final_dir) {
                 let _ = std::fs::remove_dir_all(&partial);
                 return Err(WorkerOpError::ConfigIo {
-                    path: final_dir,
+                    path: final_dir.to_path_buf(),
                     source,
                 });
             }
@@ -855,10 +905,10 @@ pub fn atomic_install(staging_dir: &Path, name: &str) -> Result<PathBuf, WorkerO
             // StagingGuard would also do this on Drop, but doing it
             // here keeps the disk state predictable for the caller.
             let _ = std::fs::remove_dir_all(staging_dir);
-            Ok(final_dir)
+            Ok(final_dir.to_path_buf())
         }
         Err(source) => Err(WorkerOpError::ConfigIo {
-            path: final_dir,
+            path: final_dir.to_path_buf(),
             source,
         }),
     }
@@ -882,6 +932,53 @@ fn sibling_partial_dir(final_dir: &Path) -> PathBuf {
         .unwrap_or("bundle");
     let sibling_name = format!("{file_name}.partial.{ts}.{counter}");
     final_dir.with_file_name(sibling_name)
+}
+
+/// Builds a sibling path next to `final_dir` where a previous install
+/// is parked during replacement. Lives in the same parent directory so
+/// both the rename-aside and any restore are same-filesystem atomic
+/// renames. Distinct `.old.` infix keeps it from ever colliding with
+/// the cross-fs `.partial.` siblings.
+fn sibling_old_dir(final_dir: &Path) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let file_name = final_dir
+        .file_name()
+        .and_then(|os| os.to_str())
+        .unwrap_or("bundle");
+    let sibling_name = format!("{file_name}.old.{ts}.{counter}");
+    final_dir.with_file_name(sibling_name)
+}
+
+/// Best-effort sweep of `<final_dir>.old.*` siblings left behind when a
+/// previous replacement crashed between the rename-aside and its cleanup
+/// (`sweep_orphans` only covers the staging root). Runs under the
+/// per-worker install lock, so a parked dir belonging to a LIVE
+/// replacement can never be swept.
+fn sweep_stale_old_siblings(final_dir: &Path) {
+    let Some(parent) = final_dir.parent() else {
+        return;
+    };
+    let Some(file_name) = final_dir.file_name().and_then(|os| os.to_str()) else {
+        return;
+    };
+    let prefix = format!("{file_name}.old.");
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    for entry in entries.filter_map(|e| e.ok()) {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if name.starts_with(&prefix) {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
 }
 
 fn cross_device_or_busy(e: &std::io::Error) -> bool {

--- a/crates/iii-worker/src/cli/bundle_download.rs
+++ b/crates/iii-worker/src/cli/bundle_download.rs
@@ -42,8 +42,10 @@
 //! - `sweep_orphans()` runs at engine/CLI startup and removes any
 //!   leftover staging directories. See T18.
 //! - `{name}.old.*` siblings leaked by a replacement that crashed
-//!   between rename-aside and cleanup are swept on the next install of
-//!   the same worker (`sweep_stale_old_siblings`).
+//!   between rename-aside and cleanup are swept on the next SUCCESSFUL
+//!   install of the same worker (`sweep_stale_old_siblings`) — never
+//!   before, since a parked sibling with no `final_dir` is the only
+//!   remaining copy of the worker.
 
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
@@ -815,11 +817,19 @@ pub fn atomic_install(staging_dir: &Path, name: &str) -> Result<PathBuf, WorkerO
         })?;
     }
 
-    sweep_stale_old_siblings(&final_dir);
-
     if !final_dir.exists() {
-        return install_fresh(staging_dir, &final_dir);
+        // A missing final_dir with a parked `.old.*` sibling means a prior
+        // replacement crashed after its rename-aside: the parked dir is the
+        // only remaining copy of the worker. Sweep it only AFTER the new
+        // install has landed, so a failed install never destroys it.
+        let installed = install_fresh(staging_dir, &final_dir)?;
+        sweep_stale_old_siblings(&final_dir);
+        return Ok(installed);
     }
+
+    // final_dir exists, so any `.old.*` siblings are truly stale leftovers
+    // (the live install is final_dir itself) — safe to sweep before parking.
+    sweep_stale_old_siblings(&final_dir);
 
     // Move the previous install aside so install_fresh's final rename
     // targets an absent `final_dir`.

--- a/crates/iii-worker/src/cli/config_file.rs
+++ b/crates/iii-worker/src/cli/config_file.rs
@@ -677,16 +677,29 @@ pub fn bundle_worker_path(name: &str) -> std::path::PathBuf {
     bundle_workers_dir().join(name)
 }
 
+/// Returns true when a bundle worker named `name` is already installed at the
+/// global cache path (`~/.iii/workers-bundle/{name}/`) with a valid
+/// `iii.worker.yaml` manifest.
+///
+/// Bundle installs are shared machine-wide by name, not per project, so this
+/// is how a second project detects that another project already installed the
+/// bundle and can register it without re-downloading. Mirrors the bundle
+/// detection in `check_install_fallback`: a stray empty directory does NOT
+/// count as installed (manifest must be present).
+pub fn bundle_is_installed(name: &str) -> bool {
+    let bundle_dir = bundle_worker_path(name);
+    bundle_dir.is_dir() && bundle_dir.join("iii.worker.yaml").is_file()
+}
+
 /// Filesystem fallback precedence: bundle → binary → config-only.
 ///
 /// A bundle install is detected by the presence of `iii.worker.yaml` inside
 /// the bundle directory (not just dir existence) so a stray empty directory
 /// or escaped staging dir doesn't trigger a false-positive Bundle resolve.
 fn check_install_fallback(name: &str) -> ResolvedWorkerType {
-    let bundle_dir = bundle_worker_path(name);
-    if bundle_dir.is_dir() && bundle_dir.join("iii.worker.yaml").is_file() {
+    if bundle_is_installed(name) {
         return ResolvedWorkerType::Bundle {
-            worker_path: bundle_dir,
+            worker_path: bundle_worker_path(name),
         };
     }
     let binary_path = dirs::home_dir()

--- a/crates/iii-worker/src/cli/config_file.rs
+++ b/crates/iii-worker/src/cli/config_file.rs
@@ -646,7 +646,8 @@ fn resolve_worker_type_from_content(content: &str, name: &str) -> ResolvedWorker
 /// Bundle takes precedence over binary because the bundle install root is a
 /// distinct, newer install type (introduced for registry-published JS/Python
 /// workers). The two roots should never collide for the same name in
-/// practice; the `iii worker add` path returns W111 AlreadyExists if they do.
+/// practice; if they do, the bundle install wins and a re-add replaces it
+/// in place (`atomic_install`).
 pub fn resolve_worker_type(name: &str) -> ResolvedWorkerType {
     let path = std::path::Path::new(CONFIG_FILE);
     let content = match std::fs::read_to_string(path) {

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -193,9 +193,10 @@ pub async fn handle_binary_add(
 ///
 /// Runs the bundle install pipeline: acquire fslock + staging, stream
 /// archive, verify sha256, extract with bundle-tight limits, validate
-/// strict manifest, atomic install into `~/.iii/workers-bundle/{name}/`,
-/// and write a name-only entry to config.yaml so the resolver
-/// dispatches the worker on the next `iii worker start`.
+/// strict manifest, atomic install into `~/.iii/workers-bundle/{name}/`
+/// (replacing any previous install of the same name), and write a
+/// name-only entry to config.yaml so the resolver dispatches the worker
+/// on the next `iii worker start`.
 pub async fn handle_bundle_add(
     worker_name: &str,
     response: &BundleWorkerResponse,
@@ -220,50 +221,6 @@ pub async fn handle_bundle_add(
         eprintln!("  {} Resolved to bundle v{}", "✓".green(), response.version);
     }
 
-    // Fast path: bundle installs are a global, machine-wide cache keyed by
-    // NAME ONLY (~/.iii/workers-bundle/{name}/), shared across every project.
-    // If another project already installed this bundle, the payload is on
-    // disk and atomic_install (step 6) would refuse to clobber it, failing
-    // the whole add with W111 AlreadyExists BEFORE the worker is ever
-    // registered in THIS project's config.yaml. Detect the existing install
-    // and just register it — no second download, no install, no false
-    // "already exists" failure. append_worker is idempotent, so re-adding in
-    // a project that already has the entry is a harmless merge.
-    //
-    // Intentionally lock-free (unlike the install path, which holds the
-    // per-worker staging lock): this branch only mutates THIS project's
-    // config.yaml, never the shared bundle dir. A racing `iii worker update`
-    // could transiently remove the dir, but start-time re-resolves the
-    // filesystem, so the worst case is a name-only entry whose dir reappears.
-    if super::config_file::bundle_is_installed(worker_name) {
-        let final_dir = super::config_file::bundle_worker_path(worker_name);
-        // Name-only entry, same as the fresh-install path below (step 7), so
-        // the resolver routes starts through the immutable bundle install.
-        if let Err(e) = super::config_file::append_worker(worker_name, None) {
-            eprintln!("{} {}", "error:".red(), e);
-            return 1;
-        }
-        if !brief {
-            eprintln!(
-                "  {} Worker {} reused already-installed bundle at {}",
-                "✓".green(),
-                worker_name.bold(),
-                final_dir.display().to_string().dimmed(),
-            );
-            eprintln!(
-                "  {} bundle workers are shared by name across projects; the \
-                 on-disk bundle may differ from the resolved v{}. Run `iii \
-                 worker update {}` to refresh it.",
-                "note:".dimmed(),
-                response.version,
-                worker_name,
-            );
-        } else {
-            eprintln!("        {} {}", "✓".green(), worker_name.bold());
-        }
-        return 0;
-    }
-
     // 1. Acquire per-worker lock + staging directory.
     let mut guard = match super::bundle_download::acquire_staging(worker_name).await {
         Ok(g) => g,
@@ -273,6 +230,24 @@ pub async fn handle_bundle_add(
         }
     };
     let staging_dir = guard.staging_dir().to_path_buf();
+
+    // Bundle installs are a global, machine-wide cache keyed by NAME ONLY
+    // (~/.iii/workers-bundle/{name}/), shared across every project. An add
+    // always installs the freshly resolved version: when another project (or
+    // a previous add) already installed this bundle, atomic_install (step 6)
+    // replaces the on-disk payload so it can never go stale. This is also
+    // what lets `iii worker update` refresh bundles — update funnels here.
+    // Checked AFTER acquiring the per-worker lock so the answer can't be
+    // changed by a racing install before step 6 runs (the rollback in step 7
+    // relies on it).
+    let replacing = super::config_file::bundle_is_installed(worker_name);
+    if !brief && replacing {
+        eprintln!(
+            "  {} Replacing existing bundle install with v{}",
+            "✓".green(),
+            response.version,
+        );
+    }
 
     // 2. Stream-download + sha256 verify into staging/.archive.tar.gz.
     //    download_archive does seconds of work with no internal progress
@@ -404,12 +379,15 @@ pub async fn handle_bundle_add(
     //    install).
     if let Err(e) = super::config_file::append_worker(worker_name, None) {
         eprintln!("{} {}", "error:".red(), e);
-        // Roll back the installed bundle dir so a retry isn't blocked
-        // by `AlreadyExists` from atomic_install. The StagingGuard has
-        // already committed by this point — final_dir is the only
-        // on-disk state we still own. Cleanup errors are logged but
-        // the install still fails (return 1).
-        if let Err(rm_err) = std::fs::remove_dir_all(&final_dir) {
+        // FRESH installs are rolled back: the config.yaml entry never
+        // landed, so leaving the payload would strand a dir no project
+        // references. A REPLACE is kept: the previous install is already
+        // gone, and OTHER projects resolve this bundle by name from disk —
+        // deleting final_dir would break every one of them, while keeping
+        // the new payload breaks nobody. A retry re-runs the full pipeline
+        // either way. Cleanup errors are logged but the install still
+        // fails (return 1).
+        if !replacing && let Err(rm_err) = std::fs::remove_dir_all(&final_dir) {
             eprintln!(
                 "  {} failed to roll back bundle install dir {}: {}",
                 "warning:".yellow(),
@@ -2768,8 +2746,8 @@ pub fn delete_worker_artifacts(worker_name: &str) -> u64 {
 
     // Bundle worker: ~/.iii/workers-bundle/{name}/. Without this branch,
     // `iii worker remove foo` and `iii worker clear` would silently leak
-    // the bundle install dir, and `iii worker add foo --force` would
-    // hit `AlreadyExists` from atomic_install.
+    // the bundle install dir: nothing references it anymore, but the
+    // machine-wide payload would sit on disk until a re-add replaces it.
     let bundle_dir = super::config_file::bundle_worker_path(worker_name);
     if bundle_dir.is_dir() {
         freed += dir_size(&bundle_dir);

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -220,6 +220,50 @@ pub async fn handle_bundle_add(
         eprintln!("  {} Resolved to bundle v{}", "✓".green(), response.version);
     }
 
+    // Fast path: bundle installs are a global, machine-wide cache keyed by
+    // NAME ONLY (~/.iii/workers-bundle/{name}/), shared across every project.
+    // If another project already installed this bundle, the payload is on
+    // disk and atomic_install (step 6) would refuse to clobber it, failing
+    // the whole add with W111 AlreadyExists BEFORE the worker is ever
+    // registered in THIS project's config.yaml. Detect the existing install
+    // and just register it — no second download, no install, no false
+    // "already exists" failure. append_worker is idempotent, so re-adding in
+    // a project that already has the entry is a harmless merge.
+    //
+    // Intentionally lock-free (unlike the install path, which holds the
+    // per-worker staging lock): this branch only mutates THIS project's
+    // config.yaml, never the shared bundle dir. A racing `iii worker update`
+    // could transiently remove the dir, but start-time re-resolves the
+    // filesystem, so the worst case is a name-only entry whose dir reappears.
+    if super::config_file::bundle_is_installed(worker_name) {
+        let final_dir = super::config_file::bundle_worker_path(worker_name);
+        // Name-only entry, same as the fresh-install path below (step 7), so
+        // the resolver routes starts through the immutable bundle install.
+        if let Err(e) = super::config_file::append_worker(worker_name, None) {
+            eprintln!("{} {}", "error:".red(), e);
+            return 1;
+        }
+        if !brief {
+            eprintln!(
+                "  {} Worker {} reused already-installed bundle at {}",
+                "✓".green(),
+                worker_name.bold(),
+                final_dir.display().to_string().dimmed(),
+            );
+            eprintln!(
+                "  {} bundle workers are shared by name across projects; the \
+                 on-disk bundle may differ from the resolved v{}. Run `iii \
+                 worker update {}` to refresh it.",
+                "note:".dimmed(),
+                response.version,
+                worker_name,
+            );
+        } else {
+            eprintln!("        {} {}", "✓".green(), worker_name.bold());
+        }
+        return 0;
+    }
+
     // 1. Acquire per-worker lock + staging directory.
     let mut guard = match super::bundle_download::acquire_staging(worker_name).await {
         Ok(g) => g,

--- a/crates/iii-worker/tests/bundle_worker_integration.rs
+++ b/crates/iii-worker/tests/bundle_worker_integration.rs
@@ -153,6 +153,18 @@ fn write_archive(dir: &Path, name: &str, bytes: &[u8]) -> std::path::PathBuf {
     p
 }
 
+/// Names of `.old.*` (parked previous install) / `.partial.*` (cross-fs
+/// copy) sibling dirs leaked next to a bundle install — replacement and
+/// cross-fs installs must always clean these up.
+fn sibling_leftovers(parent: &Path) -> Vec<String> {
+    std::fs::read_dir(parent)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.contains(".old.") || n.contains(".partial."))
+        .collect()
+}
+
 fn write_manifest(dir: &Path, body: &str) {
     std::fs::write(dir.join("iii.worker.yaml"), body).unwrap();
 }
@@ -613,22 +625,95 @@ fn dep_graph_rejects_excessive_breadth() {
 
 #[test]
 #[serial]
-fn atomic_install_refuses_existing_target() {
+fn atomic_install_replaces_existing_target() {
     let tmp = tempfile::tempdir().unwrap();
     let _home = HomeGuard::set(tmp.path());
 
-    // Pre-populate the final dir.
+    // Pre-populate the final dir with a previous install, including a
+    // file the new payload does NOT carry.
     let final_dir = bundle_worker_path("collide");
     std::fs::create_dir_all(&final_dir).unwrap();
-    std::fs::write(final_dir.join("iii.worker.yaml"), "name: collide").unwrap();
+    std::fs::write(
+        final_dir.join("iii.worker.yaml"),
+        "name: collide\nold: true\n",
+    )
+    .unwrap();
+    std::fs::write(final_dir.join("stale.txt"), "left over").unwrap();
 
     let staging = bundle_staging_root().join("collide-fresh");
     std::fs::create_dir_all(&staging).unwrap();
-    let err = atomic_install(&staging, "collide").expect_err("collision");
+    std::fs::write(
+        staging.join("iii.worker.yaml"),
+        "name: collide\nnew: true\n",
+    )
+    .unwrap();
+
+    let installed = atomic_install(&staging, "collide").expect("replace ok");
+    assert_eq!(installed, final_dir);
+
+    let manifest = std::fs::read_to_string(final_dir.join("iii.worker.yaml")).unwrap();
     assert!(
-        matches!(err, WorkerOpError::AlreadyExists { .. }),
-        "expected AlreadyExists, got {err:?}"
+        manifest.contains("new: true"),
+        "new payload landed: {manifest}"
     );
+    assert!(
+        !final_dir.join("stale.txt").exists(),
+        "old payload fully replaced, not merged"
+    );
+    assert!(!staging.exists(), "staging dir was consumed");
+
+    let leftovers = sibling_leftovers(final_dir.parent().unwrap());
+    assert!(leftovers.is_empty(), "sibling leftovers: {leftovers:?}");
+}
+
+#[test]
+#[serial]
+fn atomic_install_restores_previous_install_on_failure() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(tmp.path());
+
+    let final_dir = bundle_worker_path("keepme");
+    std::fs::create_dir_all(&final_dir).unwrap();
+    std::fs::write(final_dir.join("iii.worker.yaml"), "name: keepme\n").unwrap();
+
+    // Nonexistent staging: the install rename fails with ENOENT AFTER
+    // the previous install was parked aside, exercising the restore path.
+    let missing_staging = bundle_staging_root().join("keepme-missing");
+    let err = atomic_install(&missing_staging, "keepme").expect_err("install must fail");
+    assert!(matches!(err, WorkerOpError::ConfigIo { .. }), "got {err:?}");
+
+    // The previous install was restored, not lost.
+    let manifest = std::fs::read_to_string(final_dir.join("iii.worker.yaml"))
+        .expect("previous install restored at final path");
+    assert_eq!(manifest, "name: keepme\n");
+
+    let leftovers = sibling_leftovers(final_dir.parent().unwrap());
+    assert!(leftovers.is_empty(), "sibling leftovers: {leftovers:?}");
+}
+
+#[test]
+#[serial]
+fn atomic_install_sweeps_stale_old_siblings() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(tmp.path());
+
+    // A replacement that crashed between rename-aside and cleanup leaves
+    // the previous install parked as a `{name}.old.<unique>` sibling.
+    let final_dir = bundle_worker_path("crashy");
+    let parent = final_dir.parent().unwrap().to_path_buf();
+    let stale = parent.join("crashy.old.123.0");
+    std::fs::create_dir_all(&stale).unwrap();
+    std::fs::write(stale.join("iii.worker.yaml"), "name: crashy\n").unwrap();
+
+    let staging = bundle_staging_root().join("crashy-fresh");
+    std::fs::create_dir_all(&staging).unwrap();
+    std::fs::write(staging.join("iii.worker.yaml"), "name: crashy\n").unwrap();
+
+    atomic_install(&staging, "crashy").expect("install ok");
+
+    assert!(!stale.exists(), "stale .old sibling swept on next install");
+    let leftovers = sibling_leftovers(&parent);
+    assert!(leftovers.is_empty(), "sibling leftovers: {leftovers:?}");
 }
 
 #[test]
@@ -676,22 +761,35 @@ fn bundle_is_installed_detects_shared_global_install() {
 }
 
 // Regression: a bundle worker already installed by one project must be
-// reusable in a second project. Bundle installs are a global, machine-wide
-// cache keyed by name (~/.iii/workers-bundle/{name}/). Before the reuse
-// fast-path in `handle_bundle_add`, the second `iii worker add` ran the full
-// install pipeline and `atomic_install` refused to clobber the shared dir,
-// failing with W111 AlreadyExists (rc 1) BEFORE the worker was ever written
-// into the second project's config.yaml.
+// REPLACED, not reused, when a second project adds it. Bundle installs are a
+// global, machine-wide cache keyed by name (~/.iii/workers-bundle/{name}/),
+// so reusing whatever is on disk would pin every project to the first
+// project's (possibly stale) payload — and `iii worker update`, which
+// funnels bundles through `handle_bundle_add`, would never refresh anything.
+// The pipeline runs fully offline here: the archive is pre-seeded into the
+// sha256-keyed download cache, so the unreachable URL is never fetched.
 #[tokio::test]
 #[serial]
-async fn bundle_add_reuses_existing_install_in_second_project() {
+async fn bundle_add_replaces_existing_install_in_second_project() {
     let home = tempfile::tempdir().unwrap();
     let _home = HomeGuard::set(home.path());
 
-    // Project A already installed the shared bundle.
+    // The freshly resolved payload, pre-seeded into the download cache so
+    // download_archive serves it without network I/O.
+    let manifest: &[u8] = b"name: harness\nscripts:\n  start: node bundle.js\n";
+    let archive = make_targz(&[
+        ("iii.worker.yaml", manifest, tar::EntryType::Regular),
+        ("bundle.js", b"// new payload\n", tar::EntryType::Regular),
+    ]);
+    let digest = sha256_hex(&archive);
+    let src = write_archive(home.path(), "src.tar.gz", &archive);
+    store_in_cache(&src, &digest).unwrap();
+
+    // Project A's earlier (now stale) install of the shared bundle.
     let install_dir = bundle_worker_path("harness");
     std::fs::create_dir_all(&install_dir).unwrap();
     std::fs::write(install_dir.join("iii.worker.yaml"), "name: harness\n").unwrap();
+    std::fs::write(install_dir.join("old-marker.txt"), "from project A").unwrap();
 
     // Project B is a fresh working directory with no config.yaml yet.
     let project_b = tempfile::tempdir().unwrap();
@@ -700,13 +798,29 @@ async fn bundle_add_reuses_existing_install_in_second_project() {
     let response = BundleWorkerResponse {
         name: "harness".to_string(),
         version: "0.5.4".to_string(),
-        // Never fetched: the reuse path returns before any network I/O.
-        archive_url: "https://example.invalid/should-not-be-fetched.tar.gz".to_string(),
-        sha256: "0".repeat(64),
+        // SSRF-safe URL that is never fetched: the cache hit serves the
+        // archive before any network I/O.
+        archive_url: "https://example.invalid/harness.tar.gz".to_string(),
+        sha256: digest,
     };
 
     let rc = handle_bundle_add("harness", &response, true).await;
-    assert_eq!(rc, 0, "second-project add must succeed, not fail with W111");
+    assert_eq!(rc, 0, "second-project add must succeed and replace");
+
+    // On-disk install was replaced with the resolved payload.
+    assert!(
+        install_dir.join("bundle.js").is_file(),
+        "new payload landed on disk"
+    );
+    assert!(
+        !install_dir.join("old-marker.txt").exists(),
+        "stale payload fully replaced, not merged"
+    );
+    let on_disk = std::fs::read_to_string(install_dir.join("iii.worker.yaml")).unwrap();
+    assert!(
+        on_disk.contains("node bundle.js"),
+        "manifest refreshed, got:\n{on_disk}"
+    );
 
     let config = std::fs::read_to_string("config.yaml")
         .expect("config.yaml written in project B working dir");
@@ -1130,13 +1244,15 @@ fn sweep_orphans_skips_locked_staging_dir() {
 
 #[test]
 #[serial]
-fn atomic_install_concurrent_only_one_wins() {
+fn atomic_install_concurrent_both_safe() {
     // Two threads racing into atomic_install for the same target
     // name. The fslock in production serializes this, but
     // atomic_install is a public API and must be safe on its own.
-    // Outcome: exactly one Ok, exactly one Err (AlreadyExists or the
-    // platform ENOTEMPTY/EEXIST mapped to ConfigIo — both are valid
-    // loser outcomes).
+    // With replace semantics there is no single winner: the second
+    // thread may replace the first (last-writer-wins) or lose the
+    // rename race with a platform error mapped to ConfigIo. Either
+    // way `final_dir` must end up as a complete install from ONE of
+    // the stagings, with no `.old.*`/`.partial.*` siblings leaked.
     let tmp = tempfile::tempdir().unwrap();
     let _home = HomeGuard::set(tmp.path());
 
@@ -1164,15 +1280,18 @@ fn atomic_install_concurrent_only_one_wins() {
     let r2 = t2.join().unwrap();
 
     let oks = [&r1, &r2].iter().filter(|r| r.is_ok()).count();
-    let errs = [&r1, &r2].iter().filter(|r| r.is_err()).count();
-    assert_eq!(
-        oks, 1,
-        "exactly one race winner expected. r1={r1:?} r2={r2:?}"
+    assert!(
+        oks >= 1,
+        "at least one install must succeed. r1={r1:?} r2={r2:?}"
     );
-    assert_eq!(
-        errs, 1,
-        "exactly one race loser expected. r1={r1:?} r2={r2:?}"
-    );
+
+    let final_dir = bundle_worker_path("race");
+    let manifest = std::fs::read_to_string(final_dir.join("iii.worker.yaml"))
+        .expect("final dir holds a complete install");
+    assert_eq!(manifest, "name: race\n");
+
+    let leftovers = sibling_leftovers(final_dir.parent().unwrap());
+    assert!(leftovers.is_empty(), "sibling leftovers: {leftovers:?}");
 }
 
 #[test]

--- a/crates/iii-worker/tests/bundle_worker_integration.rs
+++ b/crates/iii-worker/tests/bundle_worker_integration.rs
@@ -45,11 +45,13 @@ use iii_worker::cli::bundle_download::{
     validate_bundle_manifest,
 };
 use iii_worker::cli::config_file::{
-    ResolvedWorkerType, bundle_worker_path, bundle_workers_dir, resolve_worker_type,
+    ResolvedWorkerType, bundle_is_installed, bundle_worker_path, bundle_workers_dir,
+    resolve_worker_type,
 };
+use iii_worker::cli::managed::handle_bundle_add;
 use iii_worker::cli::registry::{
-    MAX_DEPENDENCY_DEPTH, MAX_TRANSITIVE_DEPS, ResolvedEdge, ResolvedRoot, ResolvedWorker,
-    ResolvedWorkerGraph, enforce_dep_graph_bounds,
+    BundleWorkerResponse, MAX_DEPENDENCY_DEPTH, MAX_TRANSITIVE_DEPS, ResolvedEdge, ResolvedRoot,
+    ResolvedWorker, ResolvedWorkerGraph, enforce_dep_graph_bounds,
 };
 use iii_worker::core::error::WorkerOpError;
 
@@ -645,6 +647,87 @@ fn atomic_install_renames_into_place() {
     assert!(!staging.exists(), "staging dir was consumed by rename");
 }
 
+#[test]
+#[serial]
+fn bundle_is_installed_detects_shared_global_install() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(tmp.path());
+
+    // Nothing installed yet.
+    assert!(!bundle_is_installed("harness"), "absent before any install");
+
+    // Simulate project A installing the shared bundle.
+    let dir = bundle_worker_path("harness");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("iii.worker.yaml"), "name: harness\n").unwrap();
+    assert!(
+        bundle_is_installed("harness"),
+        "detected once the manifest is on disk"
+    );
+
+    // A bare directory with no manifest must NOT count as installed,
+    // matching the resolver's bundle detection (manifest-gated).
+    let empty = bundle_worker_path("empty");
+    std::fs::create_dir_all(&empty).unwrap();
+    assert!(
+        !bundle_is_installed("empty"),
+        "empty dir without manifest is not a valid install"
+    );
+}
+
+// Regression: a bundle worker already installed by one project must be
+// reusable in a second project. Bundle installs are a global, machine-wide
+// cache keyed by name (~/.iii/workers-bundle/{name}/). Before the reuse
+// fast-path in `handle_bundle_add`, the second `iii worker add` ran the full
+// install pipeline and `atomic_install` refused to clobber the shared dir,
+// failing with W111 AlreadyExists (rc 1) BEFORE the worker was ever written
+// into the second project's config.yaml.
+#[tokio::test]
+#[serial]
+async fn bundle_add_reuses_existing_install_in_second_project() {
+    let home = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(home.path());
+
+    // Project A already installed the shared bundle.
+    let install_dir = bundle_worker_path("harness");
+    std::fs::create_dir_all(&install_dir).unwrap();
+    std::fs::write(install_dir.join("iii.worker.yaml"), "name: harness\n").unwrap();
+
+    // Project B is a fresh working directory with no config.yaml yet.
+    let project_b = tempfile::tempdir().unwrap();
+    let _cwd = CwdGuard::set(project_b.path());
+
+    let response = BundleWorkerResponse {
+        name: "harness".to_string(),
+        version: "0.5.4".to_string(),
+        // Never fetched: the reuse path returns before any network I/O.
+        archive_url: "https://example.invalid/should-not-be-fetched.tar.gz".to_string(),
+        sha256: "0".repeat(64),
+    };
+
+    let rc = handle_bundle_add("harness", &response, true).await;
+    assert_eq!(rc, 0, "second-project add must succeed, not fail with W111");
+
+    let config = std::fs::read_to_string("config.yaml")
+        .expect("config.yaml written in project B working dir");
+    assert!(
+        config.contains("harness"),
+        "worker registered in project B config.yaml, got:\n{config}"
+    );
+    // Must be a name-only (bundle-shaped) entry: the resolver routes starts to
+    // the immutable bundle install ONLY when neither worker_path nor image is
+    // present. A regression that wrote either would break bundle dispatch at
+    // start while still passing the substring check above.
+    assert!(
+        !config.contains("worker_path:"),
+        "bundle entry must not carry worker_path, got:\n{config}"
+    );
+    assert!(
+        !config.contains("image:"),
+        "bundle entry must not carry image, got:\n{config}"
+    );
+}
+
 // StagingGuard drop semantics are covered by the in-module unit test
 // in `bundle_download.rs`. Constructing one from this integration test
 // crate would require a test-only public constructor; we deliberately
@@ -1235,6 +1318,27 @@ impl Drop for HomeGuard {
                 None => std::env::remove_var("HOME"),
             }
         }
+    }
+}
+
+/// RAII guard that switches the process working directory and restores it
+/// on drop. Process CWD is global; all callers must be `#[serial]`.
+/// Used to simulate running `iii worker add` from a second project dir.
+struct CwdGuard {
+    previous: std::path::PathBuf,
+}
+
+impl CwdGuard {
+    fn set(path: &Path) -> Self {
+        let previous = std::env::current_dir().unwrap();
+        std::env::set_current_dir(path).unwrap();
+        Self { previous }
+    }
+}
+
+impl Drop for CwdGuard {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.previous);
     }
 }
 

--- a/crates/iii-worker/tests/bundle_worker_integration.rs
+++ b/crates/iii-worker/tests/bundle_worker_integration.rs
@@ -716,6 +716,44 @@ fn atomic_install_sweeps_stale_old_siblings() {
     assert!(leftovers.is_empty(), "sibling leftovers: {leftovers:?}");
 }
 
+// Regression: when a prior replacement crashed after its rename-aside,
+// final_dir is missing and the parked `.old.*` sibling is the ONLY
+// remaining copy of the worker. A failed next install must not sweep it
+// — cleanup is deferred until an install actually lands.
+#[test]
+#[serial]
+fn atomic_install_failure_preserves_parked_old_sibling() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(tmp.path());
+
+    let final_dir = bundle_worker_path("crashed");
+    let parent = final_dir.parent().unwrap().to_path_buf();
+    let parked = parent.join("crashed.old.123.0");
+    std::fs::create_dir_all(&parked).unwrap();
+    std::fs::write(parked.join("iii.worker.yaml"), "name: crashed\n").unwrap();
+
+    // The next install fails (nonexistent staging → ENOENT on rename).
+    let missing_staging = bundle_staging_root().join("crashed-missing");
+    atomic_install(&missing_staging, "crashed").expect_err("install must fail");
+
+    // The only good copy must survive the failed install.
+    let manifest = std::fs::read_to_string(parked.join("iii.worker.yaml"))
+        .expect("parked previous install preserved");
+    assert_eq!(manifest, "name: crashed\n");
+
+    // A later successful install sweeps it.
+    let staging = bundle_staging_root().join("crashed-fresh");
+    std::fs::create_dir_all(&staging).unwrap();
+    std::fs::write(staging.join("iii.worker.yaml"), "name: crashed\n").unwrap();
+    atomic_install(&staging, "crashed").expect("install ok");
+    assert!(
+        !parked.exists(),
+        "parked copy swept after a successful install"
+    );
+    let leftovers = sibling_leftovers(&parent);
+    assert!(leftovers.is_empty(), "sibling leftovers: {leftovers:?}");
+}
+
 #[test]
 #[serial]
 fn atomic_install_renames_into_place() {


### PR DESCRIPTION
## Problem

`iii worker add <bundle>` fails when the same bundle worker is already installed in another project on the machine:

```
✓ Downloaded bundle harness (0.0s)
✓ Extracted bundle (0.0s)
error: worker "harness" already exists
error: [W900] internal: iii worker add exited with rc 1
```

Once any project installs a bundle worker, no other project on the same machine can add it.

## Root cause

Bundle workers install to a **global, machine-wide** directory keyed by name only — `~/.iii/workers-bundle/{name}/` (`config_file.rs:bundle_worker_path`) — shared across every project. `handle_bundle_add` always ran the full pipeline and called `atomic_install`, which hard-failed if the target dir exists (W111 `AlreadyExists`). So a second project's add aborted at the install step, **before** the worker was ever registered in that project's `config.yaml`. The "already exists" was about the shared on-disk bundle, not a duplicate in your project.

## Fix

Every add now runs the full pipeline and **replaces** the on-disk bundle with the freshly resolved version (rather than reusing whatever the first project installed, which would pin every project to a possibly-stale payload):

- `atomic_install` replaces instead of refusing: an existing install is parked aside as a unique `{name}.old.<unique>` sibling (same-fs atomic rename), the new tree is installed (`install_fresh`: rename, with the existing `.partial` cross-fs fallback), and the parked dir is removed. If the new install fails, the previous install is **restored** — it's never lost. Stale `.old.*` siblings from a replacement that crashed mid-swap are swept on the next install. The whole swap runs under the existing per-worker staging fslock.
- `config_file::bundle_is_installed(name)` — manifest-gated detection of the global install, reused by `check_install_fallback` and to decide rollback behavior.
- On `append_worker` failure, only **fresh** installs are rolled back. A replaced install is kept: the previous payload is already gone and other projects resolve the bundle by name from disk — deleting it would break all of them, keeping the new one breaks nobody.
- Side effect: `iii worker update` funnels bundles through `handle_bundle_add`, so it now actually refreshes the on-disk install (previously it was a no-op once any install existed).

This covers both direct adds and transitive dependency installs — both route through `handle_bundle_add`, the sole caller of `atomic_install`.

## Known limitation

The global cache is keyed by name with no version, so two projects can't independently pin different bundle versions — the last add wins machine-wide (always the freshly resolved version, so it can't go stale). True per-project version pinning is a separate, larger change (version-keyed install dirs touching resolver/list/start/update).

## Test plan

- [x] `atomic_install_replaces_existing_target` — existing install fully replaced, no `.old.*`/`.partial.*` leftovers
- [x] `atomic_install_restores_previous_install_on_failure` — failed install restores the previous payload
- [x] `atomic_install_sweeps_stale_old_siblings` — crash-leaked `.old.*` dirs swept on next install
- [x] `atomic_install_concurrent_both_safe` — unserialized racing installs end with a complete install, no leaks
- [x] `bundle_add_replaces_existing_install_in_second_project` — full pipeline offline (sha256 cache pre-seeded): second project's add replaces the stale payload and registers a name-only `config.yaml` entry
- [x] `bundle_is_installed_detects_shared_global_install`
- [x] `cargo test -p iii-worker` — 49 integration + 793 lib tests pass; clippy clean for changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster global bundle reuse: installed bundles are detected by their manifest and can be reused across projects.
  * Crash-safe replace installs: replacements use a safe rename-and-sweep flow to avoid corruption.

* **Bug Fixes**
  * Improved atomic install and rollback: prevents leaked .old/.partial siblings, handles cross-filesystem moves, and ensures concurrent installs remain safe.

* **Tests**
  * New regression and integration tests for detection, reuse, replace semantics, atomic installs, and concurrency.

* **Documentation**
  * Updated install docs describing replacement and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->