### PR TITLE
fix: make queue/DLQ ops discoverable and typed, point skill docs at engine contracts

### DIFF
--- a/crates/iii-worker/src/sandbox_daemon/skills/SKILL.md
+++ b/crates/iii-worker/src/sandbox_daemon/skills/SKILL.md
@@ -2,17 +2,36 @@
 name: iii-sandbox
 description: >-
   Ephemeral microVM sandboxes for running untrusted or agent-generated code in
-  isolation — a one-call `sandbox::run`, a create/exec/stop lifecycle, and ten
-  `sandbox::fs::*` file operations.
+  isolation — a one-call run path, a create/exec/stop lifecycle, and a set of
+  filesystem operations.
 ---
 
 # iii-sandbox
 
-The `iii-sandbox` worker boots ephemeral libkrun microVMs and runs code inside them, isolated from the host. Each sandbox boots in a few hundred milliseconds, runs commands or file operations scoped to the engine it lives on, and is reaped when idle; the overlay filesystem is discarded on stop. Callers reach it through sixteen `sandbox::*` functions invoked with `iii.trigger({ function_id: 'sandbox::...', payload })` (or `agent_trigger { function: 'sandbox::...' }` from the agent loop).
+The `iii-sandbox` worker boots ephemeral libkrun microVMs and runs code inside them, isolated from the host. Each sandbox boots in a few hundred milliseconds, runs commands or file operations scoped to the engine it lives on, and is reaped when idle; the overlay filesystem is discarded on stop. Its `sandbox::*` functions are called like any other iii function.
 
-There are two ways in. `sandbox::run` is the fast path: it boots a VM, runs a code snippet, captures stdout/stderr, and tears the VM down in a single call. For multi-step work — several commands, multiple files, or inspecting a VM between steps — use the `sandbox::create` → `sandbox::exec` / `sandbox::fs::*` → `sandbox::stop` lifecycle and carry the returned `sandbox_id` across calls.
+There are two ways in. `sandbox::run` is the fast path: it boots a VM, runs a code snippet, captures stdout/stderr, and tears the VM down in a single call. For multi-step work — several commands, multiple files, or inspecting a VM between steps — use the `sandbox::create` → `sandbox::exec` / `sandbox::fs::*` → `sandbox::stop` lifecycle and carry the returned sandbox id across calls.
 
-Prerequisites: the worker is enabled by adding `iii-sandbox` to `config.yaml`, and the host needs hardware virtualization (Apple Silicon, or `/dev/kvm` on Linux) — Intel Macs and Windows cannot boot sandboxes. Bootable images are catalog names gated by a fail-closed allowlist, not arbitrary OCI references.
+Prerequisites: the worker is enabled by adding `iii-sandbox` to `config.yaml`, and the host needs hardware virtualization (Apple Silicon, or `/dev/kvm` on Linux) — Intel Macs and Windows cannot boot sandboxes.
+
+## Get the contract from the engine
+
+This page tells you WHEN and HOW to use the sandbox; the engine is the source of truth for every function's exact arguments and responses. Before you call any `sandbox::*` function, fetch its contract and build your payload from that — do not guess field names, types, or formats from memory:
+
+```
+engine::functions::info { function_id: "sandbox::<fn>" }
+```
+
+(e.g. `{ function_id: "sandbox::fs::write" }`). The returned schema is authoritative; this skill never restates it.
+
+## Running an iii worker inside a sandbox
+
+To author an iii worker (read the `iii` skill first), you write the worker code into the sandbox, install its deps, and run it as a process there — but the worker must still join the HOST engine bus to be useful.
+
+- Reaching the host engine: enable networking when you create the sandbox (the field is in the `sandbox::create` contract — fetch it), AND set the worker's engine-URL env (`III_ENGINE_URL`, e.g. `ws://localhost:49134`) IN THE `sandbox::create` `env` — NOT later at exec/run time. The localhost→host rewrite happens ONLY for the create-time `env`: a `localhost` / `127.0.0.1` engine URL set there is rewritten to the per-sandbox gateway so the worker reaches the host bus. The same `localhost` URL passed at `sandbox::exec` time is NOT rewritten — it points at the sandbox's own loopback, the worker silently fails to connect, and you will waste turns debugging TCP. So: put the engine URL in the create `env`; the worker process inherits it already rewritten.
+- Run it backgrounded, never as a foreground `exec`: starting the worker with `sandbox::exec "node index.mjs"` blocks and times out (`S200 exec timed out`), because the process never returns. Launch it detached (`… &`, `nohup`, or `sandbox::run` shell mode) so the exec call returns while the worker keeps running — see the serialized-exec boundary below.
+- Find the result: once the worker connects, its functions appear in `engine::functions::list` and any `http` trigger it binds is served by the `iii-http` worker; verify endpoints with `web::fetch`, not `curl`.
+- EPHEMERAL by nature: a worker hosted in a sandbox dies when the sandbox is stopped or reaped (the overlay is discarded). That is fine for a demo, test, or one-off. For a worker that must stay up, install it as a managed worker (`worker::add`, see the `iii` skill) instead of hosting it in a sandbox.
 
 ## When to Use
 
@@ -23,21 +42,25 @@ Prerequisites: the worker is enabled by adding `iii-sandbox` to `config.yaml`, a
 
 ## Boundaries
 
+- A sandbox is for running code and build steps, NOT for hosting a long-lived server. To expose an HTTP API or any always-on endpoint, author an iii worker and register a trigger for it (an `http` trigger is served by the `iii-http` worker) — do NOT start a server process (`express`, `http.createServer`, a framework `listen()`) inside the sandbox. A server you start here is not routed by iii, is unreachable as an iii endpoint, and as a foreground process hangs the exec slot until it times out. If the task is "build an iii worker," the deliverable is registered functions plus a trigger, not a running server.
 - Not for long-lived services or durable state — the overlay is wiped on stop. Use a regular worker for daemons and `iii-state` for persistence.
-- `image` is a catalog name (`node`, `python`, or an operator-registered custom image), never an OCI ref — unknown names return `S100`; discover the live set with `sandbox::catalog::list`.
-- `sandbox::exec` runs one command at a time per sandbox (serialized) — a concurrent call returns `S003`, and waiting does NOT free the slot when the in-flight command is a long-running or foreground process (a server, `npm install`, a build). Run those detached (`nohup … &`, or `sandbox::run` with `lang: "shell"`), or recover by replacing the sandbox with `sandbox::stop` then `sandbox::create`.
-- `sandbox::exec` is not a shell — for pipes, `&&`, redirects, or variable expansion use `sandbox::run` with `lang: "shell"` or wrap in `sh -c`.
-- Requires host virtualization; boot failures on unsupported hosts surface as `S300`.
+- Bootable images are catalog NAMES (`node`, `python`, or an operator-registered custom image), never arbitrary OCI references. Discover the live set with `sandbox::catalog::list`; an unknown name fails fast.
+- `sandbox::exec` runs one command at a time per sandbox (serialized). A concurrent call is rejected, and waiting does NOT free the slot when the in-flight command is long-running or foreground (a server, `npm install`, a build) — it holds the slot until it exits. Run those in the background, or use `sandbox::run` in shell mode, or recover by replacing the sandbox (`sandbox::stop` then `sandbox::create`).
+- `sandbox::exec` is not a shell — for pipes, `&&`, redirects, or variable expansion use `sandbox::run` in shell mode, or wrap the command in `sh -c`.
+- Requires host virtualization; boot failures on unsupported hosts are reported as errors, not silent hangs.
+- Sandboxes are network-isolated by default; reaching host services is opt-in at create time — see `engine::functions::info` on `sandbox::create` for how to enable it.
 
 ## Functions
 
-- `sandbox::run` — boot a VM, run a code snippet (`lang` selects the interpreter), capture output, and auto-stop, in one call.
-- `sandbox::create` — boot a microVM from a catalog image; returns the `sandbox_id` every other op uses.
+A map of what exists. For the arguments and response of any one, call `engine::functions::info { function_id: "<id>" }`.
+
+- `sandbox::run` — boot a VM, run a code snippet, capture output, and auto-stop, in one call.
+- `sandbox::create` — boot a microVM you then drive with the lifecycle ops; returns the id every other op uses.
 - `sandbox::exec` — run a single command inside a running sandbox.
 - `sandbox::stop` — destroy a sandbox and reclaim its resources.
 - `sandbox::list` — enumerate sandboxes currently running on this engine.
 - `sandbox::catalog::list` — list bootable image names (bundled presets plus operator custom images).
-- `sandbox::fs::write` — write a file into a sandbox; the body is exactly one of `content` (UTF-8 string), `content_b64` (base64 binary), or `content` as a `StreamChannelRef` for streaming uploads.
+- `sandbox::fs::write` — write a file into a sandbox.
 - `sandbox::fs::read` — read a file out of a sandbox.
 - `sandbox::fs::ls` — list the entries of a directory.
 - `sandbox::fs::stat` — read metadata for a single path.
@@ -48,4 +71,4 @@ Prerequisites: the worker is enabled by adding `iii-sandbox` to `config.yaml`, a
 - `sandbox::fs::grep` — recursive regex search across files.
 - `sandbox::fs::sed` — regex find-and-replace across files.
 
-The `env` field on `create`, `exec`, and `run` accepts both `["K=V"]` and `{ "K": "V" }` shapes. Every error is returned as JSON inside `error.message` carrying `code`/`type`/`retryable` and a self-healing `fix` payload — parse and read it before retrying. With `network: true`, `localhost`/`127.0.0.1` URLs in the boot `env` are rewritten to the per-sandbox gateway at create time so guest code can reach host services. For exact request and response shapes, call `iii get function info` on any `sandbox::*` function id.
+Every error comes back structured with a machine-readable hint describing how to fix it — read it and apply the fix before retrying, rather than re-sending the same call.

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -1007,7 +1007,15 @@ impl EngineFunctionsWorker {
         let mut functions = self.list_function_summaries().await;
 
         if !input.include_internal.unwrap_or(false) {
-            functions.retain(|f| !f.function_id.starts_with("engine::"));
+            // Hide engine-internal builtins by default, EXCEPT the caller-facing
+            // queue ops (`engine::queue::*`: list_topics / topic_stats /
+            // dlq_topics / dlq_messages). Those are a public queue/DLQ API a
+            // client legitimately needs to discover — keeping them out of the
+            // default list left agents unable to find the DLQ-inspection surface.
+            functions.retain(|f| {
+                !f.function_id.starts_with("engine::")
+                    || f.function_id.starts_with("engine::queue::")
+            });
         }
 
         if let Some(prefix) = input.prefix.as_deref() {

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -2375,6 +2375,14 @@ mod tests {
         }
     }
 
+    fn topic_stats_input(v: Value) -> TopicStatsInput {
+        serde_json::from_value(v).expect("valid TopicStatsInput")
+    }
+
+    fn dlq_messages_input(v: Value) -> DlqMessagesInput {
+        serde_json::from_value(v).expect("valid DlqMessagesInput")
+    }
+
     // =========================================================================
     // console_topic_stats tests
     // =========================================================================
@@ -2382,7 +2390,9 @@ mod tests {
     #[tokio::test]
     async fn console_topic_stats_empty_topic_returns_failure() {
         let (_engine, module, _adapter) = setup_queue_module();
-        let result = module.console_topic_stats(json!({})).await;
+        let result = module
+            .console_topic_stats(topic_stats_input(json!({"topic": ""})))
+            .await;
         match result {
             FunctionResult::Failure(e) => {
                 assert_eq!(e.code, "topic_required");
@@ -2402,7 +2412,7 @@ mod tests {
         };
 
         let result = module
-            .console_topic_stats(json!({"topic": "default"}))
+            .console_topic_stats(topic_stats_input(json!({"topic": "default"})))
             .await;
         match result {
             FunctionResult::Success(Some(val)) => {
@@ -2427,7 +2437,7 @@ mod tests {
             .store(true, Ordering::SeqCst);
 
         let result = module
-            .console_topic_stats(json!({"topic": "some-topic"}))
+            .console_topic_stats(topic_stats_input(json!({"topic": "some-topic"})))
             .await;
         match result {
             FunctionResult::Failure(e) => {
@@ -2487,7 +2497,9 @@ mod tests {
     #[tokio::test]
     async fn console_dlq_messages_empty_topic_returns_failure() {
         let (_engine, module, _adapter) = setup_queue_module();
-        let result = module.console_dlq_messages(json!({})).await;
+        let result = module
+            .console_dlq_messages(dlq_messages_input(json!({"topic": ""})))
+            .await;
         match result {
             FunctionResult::Failure(e) => {
                 assert_eq!(e.code, "topic_required");
@@ -2509,7 +2521,7 @@ mod tests {
         }];
 
         let result = module
-            .console_dlq_messages(json!({"topic": "my-queue", "offset": 0, "limit": 50}))
+            .console_dlq_messages(dlq_messages_input(json!({"topic": "my-queue", "offset": 0, "limit": 50})))
             .await;
         match result {
             FunctionResult::Success(Some(val)) => {
@@ -2529,7 +2541,7 @@ mod tests {
         *adapter.dlq_peek_result.lock().await = vec![];
 
         let result = module
-            .console_dlq_messages(json!({"topic": "default"}))
+            .console_dlq_messages(dlq_messages_input(json!({"topic": "default"})))
             .await;
         // Should succeed (even with empty results)
         assert!(matches!(result, FunctionResult::Success(_)));
@@ -2541,7 +2553,7 @@ mod tests {
         adapter.dlq_peek_should_fail.store(true, Ordering::SeqCst);
 
         let result = module
-            .console_dlq_messages(json!({"topic": "my-queue"}))
+            .console_dlq_messages(dlq_messages_input(json!({"topic": "my-queue"})))
             .await;
         match result {
             FunctionResult::Failure(e) => {
@@ -2558,7 +2570,7 @@ mod tests {
 
         // Only provide topic, offset and limit should default
         let result = module
-            .console_dlq_messages(json!({"topic": "my-queue"}))
+            .console_dlq_messages(dlq_messages_input(json!({"topic": "my-queue"})))
             .await;
         assert!(matches!(result, FunctionResult::Success(_)));
     }

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -2521,7 +2521,9 @@ mod tests {
         }];
 
         let result = module
-            .console_dlq_messages(dlq_messages_input(json!({"topic": "my-queue", "offset": 0, "limit": 50})))
+            .console_dlq_messages(dlq_messages_input(
+                json!({"topic": "my-queue", "offset": 0, "limit": 50}),
+            ))
             .await;
         match result {
             FunctionResult::Success(Some(val)) => {

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -52,7 +52,9 @@ pub struct QueueInput {
 
 #[derive(Deserialize, JsonSchema)]
 pub struct RedriveInput {
-    /// Queue name whose dead-letter messages should be moved back to the main queue.
+    /// Queue or topic whose dead-letter messages should be moved back to the main
+    /// queue. For a durable topic this is the topic name.
+    #[serde(alias = "topic")]
     queue: String,
 }
 
@@ -64,9 +66,12 @@ pub struct RedriveResult {
 
 #[derive(Deserialize, JsonSchema)]
 pub struct RedriveSingleInput {
-    /// Queue name owning the dead-letter message.
+    /// Queue or topic owning the dead-letter message. For a durable topic this is
+    /// the topic name.
+    #[serde(alias = "topic")]
     queue: String,
-    /// Identifier of the dead-letter message to redrive.
+    /// Identifier of the dead-letter message to redrive (from
+    /// `engine::queue::dlq_messages`).
     message_id: String,
 }
 
@@ -75,6 +80,31 @@ pub struct RedriveSingleResult {
     pub queue: String,
     pub message_id: String,
     pub redriven: u64,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct TopicStatsInput {
+    /// Topic or named queue to inspect. For a durable topic this is the topic name.
+    #[serde(alias = "queue")]
+    topic: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct DlqMessagesInput {
+    /// Topic or named queue whose dead-letter messages to browse. For a durable
+    /// topic this is the topic name.
+    #[serde(alias = "queue")]
+    topic: String,
+    /// Number of messages to skip (default 0).
+    #[serde(default)]
+    offset: u64,
+    /// Maximum number of messages to return (default 50).
+    #[serde(default = "default_dlq_limit")]
+    limit: u64,
+}
+
+fn default_dlq_limit() -> u64 {
+    50
 }
 
 #[service(name = "queue")]
@@ -400,9 +430,9 @@ impl QueueWorker {
     )]
     pub async fn console_topic_stats(
         &self,
-        input: Value,
+        input: TopicStatsInput,
     ) -> FunctionResult<Option<Value>, ErrorBody> {
-        let topic = input.get("topic").and_then(|v| v.as_str()).unwrap_or("");
+        let topic = input.topic;
         if topic.is_empty() {
             return FunctionResult::Failure(ErrorBody {
                 code: "topic_required".into(),
@@ -411,13 +441,13 @@ impl QueueWorker {
             });
         }
 
-        let resolved = self.resolve_queue_key(topic);
+        let resolved = self.resolve_queue_key(&topic);
         match self.adapter.topic_stats(&resolved).await {
             Ok(mut stats) => {
                 // Adapters report consumer_count=0 for function queues because
                 // internal consumers aren't tracked in the subscription map.
                 // Override with the configured concurrency.
-                if let Some(config) = self._config.queue_configs.get(topic) {
+                if let Some(config) = self._config.queue_configs.get(&topic) {
                     stats.consumer_count = config.concurrency as u64;
                 }
                 FunctionResult::Success(Some(serde_json::to_value(&stats).unwrap_or(json!({}))))
@@ -475,9 +505,9 @@ impl QueueWorker {
     )]
     pub async fn console_dlq_messages(
         &self,
-        input: Value,
+        input: DlqMessagesInput,
     ) -> FunctionResult<Option<Value>, ErrorBody> {
-        let topic = input.get("topic").and_then(|v| v.as_str()).unwrap_or("");
+        let topic = input.topic;
         if topic.is_empty() {
             return FunctionResult::Failure(ErrorBody {
                 code: "topic_required".into(),
@@ -485,10 +515,10 @@ impl QueueWorker {
                 stacktrace: None,
             });
         }
-        let offset = input.get("offset").and_then(|v| v.as_u64()).unwrap_or(0);
-        let limit = input.get("limit").and_then(|v| v.as_u64()).unwrap_or(50);
+        let offset = input.offset;
+        let limit = input.limit;
 
-        let resolved = self.resolve_queue_key(topic);
+        let resolved = self.resolve_queue_key(&topic);
         match self.adapter.dlq_peek(&resolved, offset, limit).await {
             Ok(messages) => {
                 FunctionResult::Success(Some(serde_json::to_value(&messages).unwrap_or(json!([]))))

--- a/engine/src/workers/rest_api/skills/SKILL.md
+++ b/engine/src/workers/rest_api/skills/SKILL.md
@@ -26,6 +26,10 @@ engine::triggers::info { id: "http" }
 
 returns the `http` trigger's configuration schema (the route fields — path, method, optional route gating, per-route middleware) and the request envelope your handler receives. For the response envelope your handler must return, inspect a bound handler with `engine::functions::info { function_id: "<your-handler-id>" }`. Use `engine::triggers::list` to discover trigger types in the first place.
 
+## Set the right HTTP status
+
+YOUR handler chooses the HTTP status code — it is a field on the response envelope (fetch its exact name/shape from the contract above; do not hardcode it from memory). The status is NOT inferred from the body, so a handler that just returns a value or an error object yields `200` by default. For error cases, set the matching status explicitly: a not-found path returns `404`, a bad request `400`, and so on. Returning `200` with an `{ error: ... }` body is a bug — it "isn't a 500," but it also isn't the status the requirement asked for, and callers (and tests) will read it as success. Avoiding a crash is not the same as returning the right status.
+
 ## When to Use
 
 - Expose a function as a REST endpoint without standing up a separate HTTP server.

--- a/engine/src/workers/rest_api/skills/SKILL.md
+++ b/engine/src/workers/rest_api/skills/SKILL.md
@@ -3,63 +3,60 @@ name: iii-http
 description: >-
   Expose registered functions as HTTP endpoints via an `http` trigger, with a
   preHandler middleware chain for auth, rate limiting, and logging. Reach for it
-  to serve REST without a separate web server.
+  to serve REST without standing up a separate web server.
 ---
 
 # iii-http
 
-The `iii-http` worker exposes registered functions as HTTP endpoints. It runs an axum server on the configured `port`/`host`, routes inbound requests against `http` triggers (the only trigger type it provides), and invokes the bound function with a structured `HttpRequest`. The handler returns an `HttpResponse` envelope (`status_code`/`headers`/`body`) which the worker serializes to the wire — JSON, plain text, or bytes depending on the `Content-Type` the handler sets.
+The `iii-http` worker exposes registered functions as HTTP endpoints. It runs an HTTP server on the configured host/port, matches each inbound request against the `http` triggers you bind, and invokes the bound function with the request. The handler returns a response envelope that the worker serializes to the wire — JSON, plain text, or bytes, depending on the `Content-Type` the handler sets.
 
-The worker has no callable functions. Its surface is the `http` trigger plus a middleware system that runs before each handler. Routes are registered through `iii.registerTrigger({ type: 'http', ... })`. Middleware are plain registered functions referenced either globally (`iii-config.yaml` → `middleware:`) or per-route (`middleware_function_ids` on the trigger); the worker invokes them in order before the request reaches its handler.
+The worker has no callable functions of its own — you never invoke an `http::*` id. Its surface is the `http` trigger TYPE plus a middleware chain that runs before each handler. You expose an endpoint by registering a normal function and binding an `http` trigger to it.
+
+## Do NOT stand up your own web server
+
+This is the way to serve HTTP on iii, and the only one: register a function, then bind an `http` trigger to it. Do NOT write or run your own web server — no `express`, no `http.createServer`, no `fastify`, no framework listening on a port. iii does not route to a server you start yourself; such a process is unreachable as an iii endpoint, and running it as a foreground process (e.g. inside a sandbox) just hangs. If you are reaching for a web framework or a `listen()` call, stop — that instinct is from another ecosystem. The iii equivalent is one `iii.registerTrigger({ type: 'http', ... })` per route; this worker is the server.
+
+## Get the contract from the engine
+
+This page explains WHEN and HOW to serve HTTP; the engine is the source of truth for the exact shapes. Before you bind a trigger or write a handler, fetch the contract and build to it — do not guess field names, types, or defaults from memory:
+
+```
+engine::triggers::info { id: "http" }
+```
+
+returns the `http` trigger's configuration schema (the route fields — path, method, optional route gating, per-route middleware) and the request envelope your handler receives. For the response envelope your handler must return, inspect a bound handler with `engine::functions::info { function_id: "<your-handler-id>" }`. Use `engine::triggers::list` to discover trigger types in the first place.
 
 ## When to Use
 
-- Exposing a function as a REST endpoint without standing up a separate HTTP server.
-- You need URL path parameters (`/users/:id`) or query strings parsed and surfaced to the handler.
-- You want condition-gated routes (`condition_function_id`) or per-route preHandler middleware.
-- You need one not-found handler for unmatched routes (`not_found_function`).
+- Expose a function as a REST endpoint without standing up a separate HTTP server.
+- You need URL path parameters or query strings parsed and handed to the handler.
+- You want condition-gated routes or per-route preHandler middleware.
+- You need a single not-found handler for unmatched routes.
 
 ## Boundaries
 
-- No callable functions — never invoked through an `http::*` id; routes are bound with `iii.registerTrigger`.
-- Two routes on the same `(api_path, http_method)` conflict; the hot router resolves to the most recently registered.
-- `query_params` is a single-valued map — repeated keys keep only the last value; pre-encode multi-valued params.
-- Middleware runs before body parsing, so it sees headers/path/query but not `body`; use it for preconditions, not response logic (that is the handler).
+- No callable functions — the worker is never reached through an `http::*` id; routes are bound with `iii.registerTrigger`, not called.
+- Two routes on the same path + method conflict; the router resolves to the most recently registered one.
+- Query-string parsing is single-valued — a repeated key keeps only the last value; pre-encode multi-valued params yourself.
+- Middleware runs BEFORE body parsing, so it sees headers, path, and query but not the body — use it for preconditions, not response logic (that belongs in the handler).
 
-## Reactive triggers
+## Binding a route
 
-Bind an `http` trigger when a registered function should be invoked by an inbound request matching an `(api_path, http_method)` pair. The worker handles routing, parsing, body limits, CORS, and timeouts; the handler receives an `HttpRequest` and returns an `HttpResponse`.
+Register your handler as a normal function, then bind an `http` trigger to it with `iii.registerTrigger` using the `http` trigger type. Shape the trigger config to what `engine::triggers::info { id: "http" }` describes — the route path and method, an optional gating function evaluated before the handler, and per-route middleware. Path segments you declare in the route arrive as string path parameters on the request; the gating function, if set, can veto a request before the handler runs.
 
-### How to bind
+## Where your route is served
 
-1. Register a handler: `iii.registerFunction('api::get-user', handler)`.
-2. Register the trigger:
-
-```typescript
-iii.registerTrigger({
-  type: 'http',
-  function_id: 'api::get-user',
-  config: {
-    api_path: '/users/:id',   // required. `:name` segments become path_params.
-    http_method: 'GET',       // required.
-    // condition_function_id and middleware_function_ids are also supported.
-  },
-})
-```
-
-`:name` segments arrive as string `path_params`; `condition_function_id` gates the firing; `middleware_function_ids` runs per-route preHandlers after the global chain. For the `HttpRequest` / `HttpResponse` shapes, call `iii get function info` on the handler function id.
+Your bound route is served by the `iii-http` worker on its configured host and port — NOT on a port you pick. The default port is `3111` (host `0.0.0.0`), so a route with path `/example` is reachable at `http://localhost:3111/example` on a default deployment. Do NOT guess other ports (3000, 8080, the engine's WS port): if the deployment overrides the default, read the live host/port from the `iii-http` worker's configuration (`config.yaml`) or its status rather than probing. Verify a live endpoint with `web::fetch` against that base URL, never `curl`.
 
 ## Middleware
 
-Register a middleware function when the same logic must run before multiple routes — authentication, rate limiting, request logging, header normalization. A middleware is a regular registered function that receives a subset of the request (no `body`) and returns one of two shapes: `{ action: 'continue', context? }` to proceed (optionally enriching `HttpRequest.context`), or `{ action: 'respond', response }` to short-circuit with an immediate `HttpResponse`.
+Register a middleware function when the same logic must run before multiple routes — authentication, rate limiting, request logging, header normalization. A middleware is a regular registered function that receives a subset of the request (without the body) and either lets the request proceed (optionally enriching its context) or short-circuits with an immediate response. Target middleware two ways:
 
-Target middleware at routes two ways:
+- Globally — via the worker's middleware config in `config.yaml`; runs on every matched route, in priority order.
+- Per-route — via the trigger's middleware list; runs after the global chain, in the order given.
 
-- Global — list ids in `iii-config.yaml` → `middleware:` (each `{ function_id, phase: preHandler, priority }`); runs on every matched route, sorted by `priority` ascending.
-- Per-route — `middleware_function_ids` on the `http` trigger; runs after the global chain, in array order.
-
-The full preHandler order per request: route match → global middleware → route `condition_function_id` → per-route middleware → body parsing → handler.
+The full preHandler order per request: route match → global middleware → route gating function → per-route middleware → body parsing → handler.
 
 ## Configuration
 
-Worker config keys: `port` (default `3111`), `host` (default `0.0.0.0`), `default_timeout` (ms, default `30000`), `concurrency_request_limit` (default `1024`), `body_limit` (bytes, default `1048576`), `trust_proxy` (default `false`), `request_id_header` (default `x-request-id`), `ignore_trailing_slash` (default `false`), `not_found_function`, `cors.allowed_origins`, `cors.allowed_methods`, and the `middleware:` array described above.
+The worker is configured in `config.yaml`: the listen host and port, request timeout, concurrency and body-size limits, proxy trust and request-id header, trailing-slash handling, a not-found handler function, CORS, and the global middleware chain. For the full set of keys and their defaults, read the worker's configuration rather than hardcoding values from memory.


### PR DESCRIPTION
## Summary

- **Expose `engine::queue::*` in the default functions list** (`engine/src/workers/engine_fn/mod.rs`): engine-internal builtins are still hidden by default, but the caller-facing queue ops (`list_topics` / `topic_stats` / `dlq_topics` / `dlq_messages`) are now discoverable without `include_internal` — previously agents couldn't find the DLQ-inspection surface at all.
- **Typed inputs for queue console ops** (`engine/src/workers/queue/queue.rs`): `console_topic_stats` and `console_dlq_messages` now take typed inputs (`TopicStatsInput`, `DlqMessagesInput`) instead of raw `Value`, so their schemas document `topic`, `offset`, and `limit` (default 50). `topic`/`queue` serde aliases are accepted on these and on the redrive inputs, so callers can use either name for durable topics.
- **SKILL.md rewrites** (`iii-sandbox`, `iii-http`): defer exact request/response shapes to the engine (`engine::functions::info` / `engine::triggers::info`) instead of restating schemas that drift. Adds guidance on hosting an iii worker inside a sandbox (create-time `env` rewrite, backgrounded launch, ephemerality), an explicit "do NOT stand up your own web server" boundary, and where `iii-http` routes are actually served (default port 3111).

## Test plan

- [ ] `cargo build` / `cargo test` in `engine` pass
- [ ] `engine::functions::list` without `include_internal` returns `engine::queue::*` ops and no other `engine::*` builtins
- [ ] `engine::queue::topic_stats` / `dlq_messages` accept both `topic` and `queue` field names; `dlq_messages` defaults to `offset=0`, `limit=50`
- [ ] Redrive ops accept `topic` as an alias for `queue`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified sandbox isolation, lifecycle, network/host access, detached execution, ephemeral behavior, and error hints.
  * Rewrote HTTP worker docs to clarify serving model, route/middleware boundaries, status handling, and configuration guidance.

* **New Features**
  * Queue/DLQ inspection surfaces now appear by default in function listings.

* **Bug Fixes**
  * Console queue inspection APIs accept typed inputs, validate them more strictly, and provide clearer results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->