### PR TITLE
refactor: consolidate HTTP types into one symmetric set across SDKs

### DIFF
--- a/engine/src/workers/rest_api/types.rs
+++ b/engine/src/workers/rest_api/types.rs
@@ -27,7 +27,7 @@ pub struct TriggerMetadata {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HttpRequest {
+pub struct InternalHttpRequest {
     pub query_params: HashMap<String, String>,
     pub path_params: HashMap<String, String>,
     pub headers: HashMap<String, String>,
@@ -376,12 +376,12 @@ mod tests {
     }
 
     // =========================================================================
-    // HttpRequest serialization
+    // InternalHttpRequest serialization
     // =========================================================================
 
     #[test]
-    fn http_request_serialize_deserialize() {
-        let req = HttpRequest {
+    fn internal_http_request_serialize_deserialize() {
+        let req = InternalHttpRequest {
             query_params: {
                 let mut m = HashMap::new();
                 m.insert("page".to_string(), "1".to_string());
@@ -409,7 +409,7 @@ mod tests {
             },
         };
         let json_str = serde_json::to_string(&req).unwrap();
-        let deserialized: HttpRequest = serde_json::from_str(&json_str).unwrap();
+        let deserialized: InternalHttpRequest = serde_json::from_str(&json_str).unwrap();
         assert_eq!(deserialized.path, "/api/test");
         assert_eq!(deserialized.method, "GET");
         assert_eq!(
@@ -420,8 +420,8 @@ mod tests {
     }
 
     #[test]
-    fn http_request_with_trigger() {
-        let req = HttpRequest {
+    fn internal_http_request_with_trigger() {
+        let req = InternalHttpRequest {
             query_params: HashMap::new(),
             path_params: HashMap::new(),
             headers: HashMap::new(),
@@ -447,5 +447,35 @@ mod tests {
         let json = serde_json::to_value(&req).unwrap();
         assert!(json.get("trigger").is_some());
         assert_eq!(json["trigger"]["type"], "http");
+    }
+
+    #[test]
+    fn internal_http_request_wire_field_names_are_stable() {
+        let req = InternalHttpRequest {
+            query_params: HashMap::new(),
+            path_params: HashMap::new(),
+            headers: HashMap::new(),
+            path: "/x".to_string(),
+            method: "GET".to_string(),
+            body: json!(null),
+            trigger: None,
+            request_body: StreamChannelRef {
+                channel_id: "c1".to_string(),
+                access_key: "k1".to_string(),
+                direction: crate::protocol::ChannelDirection::Read,
+            },
+            response: StreamChannelRef {
+                channel_id: "c2".to_string(),
+                access_key: "k2".to_string(),
+                direction: crate::protocol::ChannelDirection::Write,
+            },
+        };
+        let v = serde_json::to_value(&req).unwrap();
+        for key in [
+            "query_params", "path_params", "headers", "path", "method", "body",
+            "request_body", "response",
+        ] {
+            assert!(v.get(key).is_some(), "wire field `{key}` missing");
+        }
     }
 }

--- a/engine/src/workers/rest_api/views.rs
+++ b/engine/src/workers/rest_api/views.rs
@@ -19,7 +19,7 @@ use tracing::Instrument;
 
 use crate::{
     condition::check_condition,
-    workers::rest_api::types::{HttpRequest, HttpResponse},
+    workers::rest_api::types::{HttpResponse, InternalHttpRequest},
     workers::worker::channels::ChannelItem,
 };
 
@@ -434,7 +434,7 @@ pub async fn dynamic_handler(
                 Value::Null
             };
 
-            let api_request_value = HttpRequest {
+            let api_request_value = InternalHttpRequest {
                 query_params,
                 path_params: path_parameters,
                 headers: serialize_headers(&headers),
@@ -1456,7 +1456,7 @@ mod tests {
     use crate::protocol::ErrorBody;
     use crate::workers::observability::metrics::ensure_default_meter;
     use crate::workers::rest_api::api_core::{HttpWorker, PathRouter};
-    use crate::workers::rest_api::types::HttpRequest;
+    use crate::workers::rest_api::types::InternalHttpRequest;
     use crate::workers::worker::channels::ChannelItem;
     use axum::http::Method;
 
@@ -1510,7 +1510,7 @@ mod tests {
 
     async fn drain_request_body_channel(
         engine: &Engine,
-        request: &HttpRequest,
+        request: &InternalHttpRequest,
         timeout_message: &'static str,
     ) -> Vec<u8> {
         let mut rx = engine
@@ -2158,7 +2158,7 @@ mod tests {
             Handler::new(move |input: Value| {
                 let engine = engine_for_handler.clone();
                 async move {
-                    let request: HttpRequest = serde_json::from_value(input).unwrap();
+                    let request: InternalHttpRequest = serde_json::from_value(input).unwrap();
                     let raw = drain_request_body_channel(
                         &engine,
                         &request,
@@ -2222,7 +2222,7 @@ mod tests {
             Handler::new(move |input: Value| {
                 let engine = engine_for_handler.clone();
                 async move {
-                    let request: HttpRequest = serde_json::from_value(input).unwrap();
+                    let request: InternalHttpRequest = serde_json::from_value(input).unwrap();
                     let raw = drain_request_body_channel(
                         &engine,
                         &request,
@@ -2471,7 +2471,7 @@ mod tests {
             Handler::new(move |input: Value| {
                 let engine = engine_for_handler.clone();
                 async move {
-                    let request: HttpRequest = serde_json::from_value(input).unwrap();
+                    let request: InternalHttpRequest = serde_json::from_value(input).unwrap();
                     let tx = engine
                         .channel_manager
                         .take_sender(&request.response.channel_id, &request.response.access_key)
@@ -2549,7 +2549,7 @@ mod tests {
             Handler::new(move |input: Value| {
                 let engine = engine_for_handler.clone();
                 async move {
-                    let request: HttpRequest = serde_json::from_value(input).unwrap();
+                    let request: InternalHttpRequest = serde_json::from_value(input).unwrap();
                     let tx = engine
                         .channel_manager
                         .take_sender(&request.response.channel_id, &request.response.access_key)

--- a/sdk/packages/node/iii-browser/src/index.ts
+++ b/sdk/packages/node/iii-browser/src/index.ts
@@ -28,10 +28,10 @@ export type {
 export type { TriggerConfig, TriggerHandler } from './triggers'
 
 export type {
-  ApiRequest,
-  ApiResponse,
   Channel,
   FunctionRef,
+  HttpRequest,
+  HttpResponse,
   ISdk,
   RegisterFunctionInput,
   RegisterFunctionOptions,

--- a/sdk/packages/node/iii-browser/src/types.ts
+++ b/sdk/packages/node/iii-browser/src/types.ts
@@ -299,7 +299,7 @@ export type Channel = {
  *
  * @typeParam TBody - Type of the parsed request body.
  */
-export type ApiRequest<TBody = unknown> = {
+export type HttpRequest<TBody = unknown> = {
   path_params: Record<string, string>
   query_params: Record<string, string | string[]>
   body: TBody
@@ -315,14 +315,14 @@ export type ApiRequest<TBody = unknown> = {
  *
  * @example
  * ```typescript
- * const response: ApiResponse = {
+ * const response: HttpResponse = {
  *   status_code: 200,
  *   headers: { 'content-type': 'application/json' },
  *   body: { message: 'ok' },
  * }
  * ```
  */
-export type ApiResponse<TStatus extends number = number, TBody = string | Record<string, unknown>> = {
+export type HttpResponse<TStatus extends number = number, TBody = string | Record<string, unknown>> = {
   /** HTTP status code. */
   status_code: TStatus
   /** Response headers. */

--- a/sdk/packages/node/iii-example/src/hooks.ts
+++ b/sdk/packages/node/iii-example/src/hooks.ts
@@ -1,4 +1,4 @@
-import { type ApiRequest, type ApiResponse, Logger } from 'iii-sdk'
+import { type HttpRequest, type HttpResponse, Logger } from 'iii-sdk'
 import { iii } from './iii'
 
 // biome-ignore lint/suspicious/noExplicitAny: generic default requires any for handler flexibility
@@ -9,7 +9,7 @@ export const useApi = <TBody = any>(
     description?: string
     metadata?: Record<string, unknown>
   },
-  handler: (req: ApiRequest<TBody>, logger: Logger) => Promise<ApiResponse>,
+  handler: (req: HttpRequest<TBody>, logger: Logger) => Promise<HttpResponse>,
 ) => {
   const function_id = `api::${config.http_method.toLowerCase()}::${config.api_path}`
   const logger = new Logger(undefined, function_id)

--- a/sdk/packages/node/iii/src/index.ts
+++ b/sdk/packages/node/iii/src/index.ts
@@ -33,21 +33,20 @@ export { Logger } from '@iii-dev/observability'
 export type { TriggerConfig, TriggerHandler } from './triggers'
 
 export type {
-  ApiRequest,
-  ApiResponse,
   Channel,
   FunctionRef,
   HttpRequest,
   HttpResponse,
-  InternalHttpRequest,
   ISdk,
   RegisterFunctionInput,
   RegisterFunctionOptions,
   RegisterTriggerInput,
   RegisterTriggerTypeInput,
   RemoteFunctionHandler,
+  StreamingRequest,
+  StreamingResponse,
   Trigger,
   TriggerTypeRef,
 } from './types'
 
-export { http } from './utils'
+export { http, httpStream } from './utils'

--- a/sdk/packages/node/iii/src/types.test.ts
+++ b/sdk/packages/node/iii/src/types.test.ts
@@ -1,0 +1,21 @@
+import { expectTypeOf, test } from 'vitest'
+import type { HttpRequest, StreamingRequest, HttpResponse, StreamingResponse } from './types'
+
+test('HttpRequest is buffered: has body, no request_body', () => {
+  expectTypeOf<HttpRequest>().toHaveProperty('body')
+  expectTypeOf<HttpRequest>().not.toHaveProperty('request_body')
+})
+
+test('StreamingRequest streams: has request_body, no body', () => {
+  expectTypeOf<StreamingRequest>().toHaveProperty('request_body')
+  expectTypeOf<StreamingRequest>().not.toHaveProperty('body')
+})
+
+test('HttpResponse is the buffered value shape', () => {
+  expectTypeOf<HttpResponse>().toHaveProperty('status_code')
+})
+
+test('StreamingResponse is the handle', () => {
+  expectTypeOf<StreamingResponse>().toHaveProperty('stream')
+  expectTypeOf<StreamingResponse>().toHaveProperty('close')
+})

--- a/sdk/packages/node/iii/src/types.ts
+++ b/sdk/packages/node/iii/src/types.ts
@@ -320,11 +320,10 @@ export type InternalHttpRequest<TBody = unknown> = {
 }
 
 /**
- * Response object passed to HTTP function handlers. Use `status()` and
- * `headers()` to set response metadata, write to `stream` for streaming
- * responses, and call `close()` when done.
+ * Streaming response handle passed to HTTP function handlers. Use `status()`
+ * and `headers()` to set metadata, write to `stream`, and `close()` when done.
  */
-export type HttpResponse = {
+export type StreamingResponse = {
   /** Set the HTTP status code. */
   status: (statusCode: number) => void
   /** Set response headers. */
@@ -336,35 +335,33 @@ export type HttpResponse = {
 }
 
 /**
- * Incoming HTTP request received by a function registered with an HTTP trigger.
+ * Buffered HTTP request: parsed body, no streaming reader.
  *
  * @typeParam TBody - Type of the parsed request body.
  */
-export type HttpRequest<TBody = unknown> = Omit<InternalHttpRequest<TBody>, 'response'>
+export type HttpRequest<TBody = unknown> = Omit<InternalHttpRequest<TBody>, 'response' | 'request_body'>
 
 /**
- * Alias for {@link HttpRequest}. Represents an incoming API request.
- *
- * @typeParam TBody - Type of the parsed request body.
+ * Streaming HTTP request: exposes `request_body` reader, no pre-parsed body.
  */
-export type ApiRequest<TBody = unknown> = HttpRequest<TBody>
+export type StreamingRequest = Omit<InternalHttpRequest, 'response' | 'body'>
 
 /**
- * Structured API response returned from HTTP function handlers.
+ * Buffered structured response returned from HTTP function handlers.
  *
  * @typeParam TStatus - HTTP status code literal type.
  * @typeParam TBody - Type of the response body.
  *
  * @example
  * ```typescript
- * const response: ApiResponse = {
+ * const response: HttpResponse = {
  *   status_code: 200,
  *   headers: { 'content-type': 'application/json' },
  *   body: { message: 'ok' },
  * }
  * ```
  */
-export type ApiResponse<TStatus extends number = number, TBody = string | Buffer | Record<string, unknown>> = {
+export type HttpResponse<TStatus extends number = number, TBody = string | Buffer | Record<string, unknown>> = {
   /** HTTP status code. */
   status_code: TStatus
   /** Response headers. */

--- a/sdk/packages/node/iii/src/utils.test.ts
+++ b/sdk/packages/node/iii/src/utils.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+import { http, httpStream } from './utils'
+
+function fakeInternal() {
+  const sent: string[] = []
+  const response = {
+    sendMessage: (m: string) => {
+      sent.push(m)
+    },
+    stream: { end: vi.fn() } as any,
+    close: vi.fn(),
+  } as any
+  return {
+    sent,
+    req: {
+      path_params: {},
+      query_params: {},
+      headers: {},
+      method: 'GET',
+      path: '/x',
+      body: { a: 1 },
+      request_body: { read: vi.fn() } as any,
+      response,
+    } as any,
+  }
+}
+
+describe('http wrapper', () => {
+  it('delivers a buffered HttpRequest (body present, request_body stripped) and returns HttpResponse', async () => {
+    const { req } = fakeInternal()
+    const cb = vi.fn(async (r: any) => {
+      expect(r.body).toEqual({ a: 1 })
+      expect(r.request_body).toBeUndefined()
+      return { status_code: 200 }
+    })
+    const result = await http(cb)(req)
+    expect(result).toEqual({ status_code: 200 })
+  })
+})
+
+describe('httpStream wrapper', () => {
+  it('delivers a StreamingRequest (request_body present, body stripped)', async () => {
+    const { req } = fakeInternal()
+    const cb = vi.fn(async (r: any) => {
+      expect(r.request_body).toBeDefined()
+      expect(r.body).toBeUndefined()
+    })
+    await httpStream(cb)(req)
+    expect(cb).toHaveBeenCalled()
+  })
+})

--- a/sdk/packages/node/iii/src/utils.ts
+++ b/sdk/packages/node/iii/src/utils.ts
@@ -1,7 +1,14 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
+import type { ChannelWriter } from './channels'
 import type { StreamChannelRef } from './iii-types'
-import type { ApiResponse, HttpRequest, HttpResponse, InternalHttpRequest } from './types'
+import type {
+  HttpRequest,
+  HttpResponse,
+  InternalHttpRequest,
+  StreamingRequest,
+  StreamingResponse,
+} from './types'
 
 /**
  * Returns a project identifier for telemetry, derived from the current working
@@ -30,11 +37,20 @@ export function detectProjectName(cwd: string = process.cwd()): string | undefin
   return base || undefined
 }
 
+const makeStreamingResponse = (response: ChannelWriter): StreamingResponse => ({
+  status: (status_code: number) =>
+    response.sendMessage(JSON.stringify({ type: 'set_status', status_code })),
+  headers: (headers: Record<string, string>) =>
+    response.sendMessage(JSON.stringify({ type: 'set_headers', headers })),
+  stream: response.stream,
+  close: () => response.close(),
+})
+
 /**
- * Helper that wraps an HTTP-style handler (with separate `req`/`res` arguments)
- * into the function handler format expected by the SDK.
+ * Wrap a buffered HTTP handler. The handler receives a buffered {@link HttpRequest}
+ * and a {@link StreamingResponse}; it may return an {@link HttpResponse} or stream via `res`.
  *
- * @param callback - Async handler receiving an {@link HttpRequest} and {@link HttpResponse}.
+ * @param callback - Async handler receiving an {@link HttpRequest} and {@link StreamingResponse}.
  * @returns A function handler compatible with {@link ISdk.registerFunction}.
  *
  * @example
@@ -43,32 +59,49 @@ export function detectProjectName(cwd: string = process.cwd()): string | undefin
  *
  * iii.registerFunction(
  *   'my-api',
- *   http(async (req, res) => {
- *     res.status(200)
- *     res.headers({ 'content-type': 'application/json' })
- *     res.stream.end(JSON.stringify({ hello: 'world' }))
- *     res.close()
+ *   http(async (req) => {
+ *     return { status_code: 200, body: { hello: req.body } }
  *   }),
  * )
  * ```
  */
 export const http = (
   // biome-ignore lint/suspicious/noConfusingVoidType: void is necessary here
-  callback: (req: HttpRequest, res: HttpResponse) => Promise<void | ApiResponse>,
+  callback: (req: HttpRequest, res: StreamingResponse) => Promise<void | HttpResponse>,
 ) => {
   return async (req: InternalHttpRequest) => {
-    const { response, ...request } = req
+    const { response, request_body: _requestBody, ...request } = req
+    return callback(request as HttpRequest, makeStreamingResponse(response))
+  }
+}
 
-    const httpResponse: HttpResponse = {
-      status: (status_code: number) =>
-        response.sendMessage(JSON.stringify({ type: 'set_status', status_code })),
-      headers: (headers: Record<string, string>) =>
-        response.sendMessage(JSON.stringify({ type: 'set_headers', headers })),
-      stream: response.stream,
-      close: () => response.close(),
-    }
-
-    return callback(request, httpResponse)
+/**
+ * Wrap a streaming HTTP handler. The handler receives a {@link StreamingRequest}
+ * (exposing `request_body`) and a {@link StreamingResponse}.
+ *
+ * @param callback - Async handler receiving a {@link StreamingRequest} and {@link StreamingResponse}.
+ * @returns A function handler compatible with {@link ISdk.registerFunction}.
+ *
+ * @example
+ * ```typescript
+ * import { httpStream } from 'iii-sdk'
+ *
+ * iii.registerFunction(
+ *   'my-api',
+ *   httpStream(async (req, res) => {
+ *     for await (const chunk of req.request_body.stream) res.stream.write(chunk)
+ *     res.close()
+ *   }),
+ * )
+ * ```
+ */
+export const httpStream = (
+  // biome-ignore lint/suspicious/noConfusingVoidType: void is necessary here
+  callback: (req: StreamingRequest, res: StreamingResponse) => Promise<void | HttpResponse>,
+) => {
+  return async (req: InternalHttpRequest) => {
+    const { response, body: _body, ...request } = req
+    return callback(request as StreamingRequest, makeStreamingResponse(response))
   }
 }
 

--- a/sdk/packages/node/iii/tests/api-triggers.test.ts
+++ b/sdk/packages/node/iii/tests/api-triggers.test.ts
@@ -3,8 +3,8 @@ import * as path from 'node:path'
 import { pipeline } from 'node:stream/promises'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
-import { http, type ApiResponse, type HttpRequest } from '../src'
-import type { HttpResponse } from '../src/types'
+import type { HttpRequest, HttpResponse, StreamingRequest, StreamingResponse } from '../src/types'
+import { http, httpStream } from '../src/utils'
 import { engineHttpUrl, execute, httpRequest, iii, sleep } from './utils'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -14,10 +14,12 @@ describe('API Triggers', () => {
   it('should register GET endpoint', async () => {
     const fn = iii.registerFunction(
       'test.api.get',
-      async (_req: HttpRequest): Promise<ApiResponse> => ({
-        status_code: 200,
-        body: { message: 'Hello from GET' },
-      }),
+      http(
+        async (_req: HttpRequest): Promise<HttpResponse> => ({
+          status_code: 200,
+          body: { message: 'Hello from GET' },
+        }),
+      ),
     )
 
     const trigger = iii.registerTrigger({
@@ -43,13 +45,13 @@ describe('API Triggers', () => {
   it('should register POST endpoint with body', async () => {
     const fn = iii.registerFunction(
       'test.api.post',
-      async (req: HttpRequest): Promise<ApiResponse> => {
+      http(async (req: HttpRequest): Promise<HttpResponse> => {
         const body = (req.body as Record<string, unknown>) ?? {}
         return {
           status_code: 201,
           body: { received: body, created: true },
         }
-      },
+      }),
     )
 
     const trigger = iii.registerTrigger({
@@ -78,16 +80,17 @@ describe('API Triggers', () => {
 
     const fn = iii.registerFunction(
       'test::api::json::raw',
-      http(async (req: HttpRequest, response: HttpResponse) => {
+      httpStream(async (req: StreamingRequest, response: StreamingResponse) => {
         const rawBody = await req.request_body.readAll()
+        const rawText = rawBody.toString('utf-8')
 
         response.status(200)
         response.headers({ 'content-type': 'application/json' })
         response.stream.end(
           Buffer.from(
             JSON.stringify({
-              parsed_body: req.body,
-              raw_body: rawBody.toString('utf-8'),
+              parsed_body: JSON.parse(rawText),
+              raw_body: rawText,
             }),
           ),
         )
@@ -124,10 +127,12 @@ describe('API Triggers', () => {
   it('should handle path parameters', async () => {
     const fn = iii.registerFunction(
       'test.api.getById',
-      async (req: HttpRequest): Promise<ApiResponse> => ({
-        status_code: 200,
-        body: { id: req.path_params?.id },
-      }),
+      http(
+        async (req: HttpRequest): Promise<HttpResponse> => ({
+          status_code: 200,
+          body: { id: req.path_params?.id },
+        }),
+      ),
     )
 
     const trigger = iii.registerTrigger({
@@ -153,7 +158,7 @@ describe('API Triggers', () => {
   it('should handle query parameters', async () => {
     const fn = iii.registerFunction(
       'test.api.search',
-      async (req: HttpRequest): Promise<ApiResponse> => {
+      http(async (req: HttpRequest): Promise<HttpResponse> => {
         const q = req.query_params?.q
         const limit = req.query_params?.limit
         const qVal = Array.isArray(q) ? q[0] : q
@@ -162,7 +167,7 @@ describe('API Triggers', () => {
           status_code: 200,
           body: { query: qVal, limit: limitVal },
         }
-      },
+      }),
     )
 
     const trigger = iii.registerTrigger({
@@ -189,10 +194,12 @@ describe('API Triggers', () => {
   it('should return custom status code', async () => {
     const fn = iii.registerFunction(
       'test.api.notfound',
-      async (_req: HttpRequest): Promise<ApiResponse<404>> => ({
-        status_code: 404,
-        body: { error: 'Not found' },
-      }),
+      http(
+        async (_req: HttpRequest): Promise<HttpResponse<404>> => ({
+          status_code: 404,
+          body: { error: 'Not found' },
+        }),
+      ),
     )
 
     const trigger = iii.registerTrigger({
@@ -215,15 +222,18 @@ describe('API Triggers', () => {
     trigger.unregister()
   })
 
-  it('should honor Content-Type header when returning ApiResponse with string body', async () => {
-    const xmlBody = '<?xml version="1.0" encoding="UTF-8"?><note><to>user</to><body>hello</body></note>'
+  it('should honor Content-Type header when returning HttpResponse with string body', async () => {
+    const xmlBody =
+      '<?xml version="1.0" encoding="UTF-8"?><note><to>user</to><body>hello</body></note>'
     const fn = iii.registerFunction(
       'test.api.xml.return',
-      async (_req: HttpRequest): Promise<ApiResponse> => ({
-        status_code: 200,
-        headers: { 'Content-Type': 'text/xml' },
-        body: xmlBody,
-      }),
+      http(
+        async (_req: HttpRequest): Promise<HttpResponse> => ({
+          status_code: 200,
+          headers: { 'Content-Type': 'text/xml' },
+          body: xmlBody,
+        }),
+      ),
     )
 
     const trigger = iii.registerTrigger({
@@ -250,7 +260,7 @@ describe('API Triggers', () => {
     const originalPdf = fs.readFileSync(pdfPath)
     const fn = iii.registerFunction(
       'test.api.download.pdf',
-      http(async (_req: HttpRequest, response: HttpResponse) => {
+      http(async (_req: HttpRequest, response: StreamingResponse) => {
         const fileStream = fs.createReadStream(pdfPath)
 
         response.status(200)
@@ -290,7 +300,7 @@ describe('API Triggers', () => {
 
     const fn = iii.registerFunction(
       'test.api.upload.pdf',
-      http(async (req: HttpRequest, response: HttpResponse) => {
+      httpStream(async (req: StreamingRequest, response: StreamingResponse) => {
         const chunks: Buffer[] = []
 
         response.status(200)
@@ -345,7 +355,7 @@ describe('API Triggers', () => {
 
     const fn = iii.registerFunction(
       'test.api.sse',
-      http(async (_req: HttpRequest, response: HttpResponse) => {
+      http(async (_req: HttpRequest, response: StreamingResponse) => {
         response.status(200)
         response.headers({
           'content-type': 'text/event-stream',
@@ -419,7 +429,7 @@ describe('API Triggers', () => {
   it('should handle application/x-www-form-urlencoded request', async () => {
     const fn = iii.registerFunction(
       'test.api.form.urlencoded',
-      http(async (req: HttpRequest, response: HttpResponse) => {
+      httpStream(async (req: StreamingRequest, response: StreamingResponse) => {
         const chunks: Buffer[] = []
 
         for await (const chunk of req.request_body.stream) {
@@ -482,7 +492,7 @@ describe('API Triggers', () => {
 
     const fn = iii.registerFunction(
       'test.api.form.multipart',
-      http(async (req: HttpRequest, response: HttpResponse) => {
+      httpStream(async (req: StreamingRequest, response: StreamingResponse) => {
         const chunks: Buffer[] = []
 
         for await (const chunk of req.request_body.stream) {

--- a/sdk/packages/node/iii/tests/healthcheck.test.ts
+++ b/sdk/packages/node/iii/tests/healthcheck.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import type { ApiRequest, ApiResponse } from '../src'
+import type { HttpRequest, HttpResponse } from '../src'
 import { execute, httpRequest, iii } from './utils'
 
 describe('Healthcheck Endpoint', () => {
   it('should register a healthcheck function and trigger', async () => {
     const fn = iii.registerFunction(
       'test.healthcheck',
-      async (_req: ApiRequest): Promise<ApiResponse> => {
+      async (_req: HttpRequest): Promise<HttpResponse> => {
         return {
           status_code: 200,
           body: {

--- a/sdk/packages/node/iii/tests/middleware.test.ts
+++ b/sdk/packages/node/iii/tests/middleware.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { ApiResponse, HttpRequest } from '../src'
+import type { HttpRequest, HttpResponse } from '../src'
 import { engineHttpUrl, execute, httpRequest, iii, sleep } from './utils'
 
 describe('HTTP Middleware', () => {
@@ -13,7 +13,7 @@ describe('HTTP Middleware', () => {
 
     const handlerFn = iii.registerFunction(
       'test.mw.continue.handler',
-      async (_req: HttpRequest): Promise<ApiResponse> => ({
+      async (_req: HttpRequest): Promise<HttpResponse> => ({
         status_code: 200,
         body: { message: 'handler reached' },
       }),
@@ -55,7 +55,7 @@ describe('HTTP Middleware', () => {
 
     const handlerFn = iii.registerFunction(
       'test.mw.block.handler',
-      async (_req: HttpRequest): Promise<ApiResponse> => {
+      async (_req: HttpRequest): Promise<HttpResponse> => {
         handlerCalled = true
         return { status_code: 200, body: { message: 'should not reach' } }
       },
@@ -99,7 +99,7 @@ describe('HTTP Middleware', () => {
 
     const handlerFn = iii.registerFunction(
       'test.mw.order.handler',
-      async (_req: HttpRequest): Promise<ApiResponse> => {
+      async (_req: HttpRequest): Promise<HttpResponse> => {
         callOrder.push('handler')
         return { status_code: 200, body: { order: callOrder } }
       },
@@ -138,7 +138,7 @@ describe('HTTP Middleware', () => {
 
     const handlerFn = iii.registerFunction(
       'test.mw.meta.handler',
-      async (_req: HttpRequest): Promise<ApiResponse> => ({
+      async (_req: HttpRequest): Promise<HttpResponse> => ({
         status_code: 200,
         body: { ok: true },
       }),
@@ -174,7 +174,7 @@ describe('HTTP Middleware', () => {
   it('should work without middleware (regression)', async () => {
     const fn = iii.registerFunction(
       'test.mw.none',
-      async (_req: HttpRequest): Promise<ApiResponse> => ({
+      async (_req: HttpRequest): Promise<HttpResponse> => ({
         status_code: 200,
         body: { message: 'no middleware' },
       }),

--- a/sdk/packages/python/iii-example/src/hooks.py
+++ b/sdk/packages/python/iii-example/src/hooks.py
@@ -1,22 +1,22 @@
 import uuid
 from typing import Any, Awaitable, Callable
 
-from iii import ApiRequest, ApiResponse, IIIClient
+from iii import HttpRequest, HttpResponse, IIIClient
 from iii_observability import Logger
 
 
 def use_api(
     iii: IIIClient,
     config: dict[str, Any],
-    handler: Callable[[ApiRequest[Any], Logger], Awaitable[ApiResponse[Any]]],
+    handler: Callable[[HttpRequest[Any], Logger], Awaitable[HttpResponse[Any]]],
 ) -> None:
     api_path = config["api_path"]
     http_method = config["http_method"]
     function_id = f"api.{http_method.lower()}.{api_path}"
     logger = Logger(service_name=function_id)
 
-    async def wrapped(data: ApiRequest) -> dict[str, Any]:
-        req = ApiRequest(**data) if isinstance(data, dict) else data
+    async def wrapped(data: HttpRequest) -> dict[str, Any]:
+        req = HttpRequest(**data) if isinstance(data, dict) else data
         result = await handler(req, logger)
         return result.model_dump(by_alias=True)
 

--- a/sdk/packages/python/iii-example/src/main.py
+++ b/sdk/packages/python/iii-example/src/main.py
@@ -7,7 +7,7 @@ import urllib.request
 from datetime import datetime, timezone
 from typing import Any
 
-from iii import ApiRequest, ApiResponse, InitOptions, register_worker
+from iii import HttpRequest, HttpResponse, InitOptions, register_worker
 
 state: Any = None
 streams: Any = None
@@ -96,7 +96,7 @@ def _setup(iii) -> None:
     )
 
 
-async def _create_todo(req: ApiRequest, logger) -> ApiResponse:
+async def _create_todo(req: HttpRequest, logger) -> HttpResponse:
     logger.info("Creating new todo", {"body": req.body})
 
     description = req.body.get("description") if req.body else None
@@ -104,7 +104,7 @@ async def _create_todo(req: ApiRequest, logger) -> ApiResponse:
     todo_id = _generate_todo_id()
 
     if not description:
-        return ApiResponse(statusCode=400, body={"error": "Description is required"})
+        return HttpResponse(statusCode=400, body={"error": "Description is required"})
 
     new_todo = {
         "id": todo_id,
@@ -114,25 +114,25 @@ async def _create_todo(req: ApiRequest, logger) -> ApiResponse:
         "completedAt": None,
     }
     todo = await streams.set("todo", "inbox", todo_id, new_todo)
-    return ApiResponse(statusCode=201, body=todo, headers={"Content-Type": "application/json"})
+    return HttpResponse(statusCode=201, body=todo, headers={"Content-Type": "application/json"})
 
 
-async def _delete_todo(req: ApiRequest, logger) -> ApiResponse:
+async def _delete_todo(req: HttpRequest, logger) -> HttpResponse:
     todo_id = req.body.get("todoId") if req.body else None
 
     logger.info("Deleting todo", {"body": req.body})
 
     if not todo_id:
         logger.error("todoId is required")
-        return ApiResponse(statusCode=400, body={"error": "todoId is required"})
+        return HttpResponse(statusCode=400, body={"error": "todoId is required"})
 
     await streams.delete("todo", "inbox", todo_id)
 
     logger.info("Todo deleted successfully", {"todoId": todo_id})
-    return ApiResponse(statusCode=200, body={"success": True}, headers={"Content-Type": "application/json"})
+    return HttpResponse(statusCode=200, body={"success": True}, headers={"Content-Type": "application/json"})
 
 
-async def _update_todo(req: ApiRequest, logger) -> ApiResponse:
+async def _update_todo(req: HttpRequest, logger) -> HttpResponse:
     todo_id = req.path_params.get("id")
     existing_todo = await streams.get("todo", "inbox", todo_id) if todo_id else None
 
@@ -140,16 +140,16 @@ async def _update_todo(req: ApiRequest, logger) -> ApiResponse:
 
     if not existing_todo:
         logger.error("Todo not found")
-        return ApiResponse(statusCode=404, body={"error": "Todo not found"})
+        return HttpResponse(statusCode=404, body={"error": "Todo not found"})
 
     merged = {**existing_todo, **(req.body or {})}
     todo = await streams.set("todo", "inbox", todo_id, merged)
 
     logger.info("Todo updated successfully", {"todoId": todo_id})
-    return ApiResponse(statusCode=200, body=todo, headers={"Content-Type": "application/json"})
+    return HttpResponse(statusCode=200, body=todo, headers={"Content-Type": "application/json"})
 
 
-async def _create_state(req: ApiRequest, logger) -> ApiResponse:
+async def _create_state(req: HttpRequest, logger) -> HttpResponse:
     logger.info("Creating new todo", {"body": req.body})
 
     description = req.body.get("description") if req.body else None
@@ -157,7 +157,7 @@ async def _create_state(req: ApiRequest, logger) -> ApiResponse:
     todo_id = _generate_todo_id()
 
     if not description:
-        return ApiResponse(statusCode=400, body={"error": "Description is required"})
+        return HttpResponse(statusCode=400, body={"error": "Description is required"})
 
     new_todo = {
         "id": todo_id,
@@ -167,29 +167,29 @@ async def _create_state(req: ApiRequest, logger) -> ApiResponse:
         "completedAt": None,
     }
     todo = await state.set("todo", todo_id, new_todo)
-    return ApiResponse(statusCode=201, body=todo, headers={"Content-Type": "application/json"})
+    return HttpResponse(statusCode=201, body=todo, headers={"Content-Type": "application/json"})
 
 
-async def _get_state(req: ApiRequest, logger) -> ApiResponse:
+async def _get_state(req: HttpRequest, logger) -> HttpResponse:
     logger.info("Getting todo", req.path_params)
 
     todo_id = req.path_params.get("id")
     todo = await state.get("todo", todo_id)
-    return ApiResponse(statusCode=200, body=todo, headers={"Content-Type": "application/json"})
+    return HttpResponse(statusCode=200, body=todo, headers={"Content-Type": "application/json"})
 
 
-async def _error_test(req: ApiRequest, logger) -> ApiResponse:
+async def _error_test(req: HttpRequest, logger) -> HttpResponse:
     raise ValueError("Intentional error for OTEL stacktrace testing")
 
 
-async def _fetch_example(req: ApiRequest, logger) -> ApiResponse:
+async def _fetch_example(req: HttpRequest, logger) -> HttpResponse:
     logger.info("Fetching todo from JSONPlaceholder")
     with urllib.request.urlopen("https://jsonplaceholder.typicode.com/todos/1") as response:
         data = json.loads(response.read().decode())
-    return ApiResponse(statusCode=200, body=data, headers={"Content-Type": "application/json"})
+    return HttpResponse(statusCode=200, body=data, headers={"Content-Type": "application/json"})
 
 
-async def _post_example(req: ApiRequest, logger) -> ApiResponse:
+async def _post_example(req: HttpRequest, logger) -> HttpResponse:
     logger.info("Posting to httpbin", {"body": req.body})
     payload = json.dumps(req.body or {}).encode()
     post_req = urllib.request.Request(
@@ -200,7 +200,7 @@ async def _post_example(req: ApiRequest, logger) -> ApiResponse:
     )
     with urllib.request.urlopen(post_req) as response:
         data = json.loads(response.read().decode())
-    return ApiResponse(statusCode=200, body=data, headers={"Content-Type": "application/json"})
+    return HttpResponse(statusCode=200, body=data, headers={"Content-Type": "application/json"})
 
 
 def main() -> None:

--- a/sdk/packages/python/iii/src/iii/__init__.py
+++ b/sdk/packages/python/iii/src/iii/__init__.py
@@ -68,16 +68,15 @@ from .stream import (
 )
 from .triggers import Trigger, TriggerConfig, TriggerHandler, TriggerTypeRef
 from .types import (
-    ApiRequest,
-    ApiResponse,
     Channel,
     HttpRequest,
     HttpResponse,
     IIIClient,
-    InternalHttpRequest,
     RemoteFunctionHandler,
+    StreamingRequest,
+    StreamingResponse,
 )
-from .utils import http
+from .utils import http, http_stream
 
 __all__ = [
     # Telemetry helpers
@@ -150,14 +149,13 @@ __all__ = [
     "TriggerHandler",
     "TriggerTypeRef",
     # Types
-    "ApiRequest",
-    "ApiResponse",
     "Channel",
     "HttpRequest",
     "HttpResponse",
     "IIIClient",
-    "InternalHttpRequest",
     "RemoteFunctionHandler",
+    "StreamingRequest",
+    "StreamingResponse",
     # Stream
     "IStream",
     "StreamChangeEvent",
@@ -168,6 +166,7 @@ __all__ = [
     "StreamTriggerConfig",
     # Utilities
     "http",
+    "http_stream",
     # Format extraction
     "extract_request_format",
     "extract_response_format",

--- a/sdk/packages/python/iii/src/iii/types.py
+++ b/sdk/packages/python/iii/src/iii/types.py
@@ -114,18 +114,19 @@ class IIIClient(Protocol):
     def shutdown(self) -> None: ...
 
 
-class ApiRequest(BaseModel, Generic[TInput]):
-    """Represents an API request."""
+class HttpRequest(BaseModel, Generic[TInput]):
+    """Buffered HTTP request: parsed body, no streaming reader."""
 
     path_params: dict[str, str] = Field(default_factory=dict)
     query_params: dict[str, str | list[str]] = Field(default_factory=dict)
     body: Any | None = None
     headers: dict[str, str | list[str]] = Field(default_factory=dict)
     method: str = "GET"
+    path: str = ""
 
 
-class ApiResponse(BaseModel, Generic[TOutput]):
-    """Represents an API response."""
+class HttpResponse(BaseModel, Generic[TOutput]):
+    """Buffered HTTP response value."""
 
     model_config = ConfigDict(populate_by_name=True, arbitrary_types_allowed=True)
 
@@ -157,7 +158,19 @@ class InternalHttpRequest:
     request_body: ChannelReader
 
 
-class HttpResponse:
+@dataclass
+class StreamingRequest:
+    """Streaming HTTP request: exposes a reader for the request body channel."""
+
+    path_params: dict[str, str]
+    query_params: dict[str, str | list[str]]
+    headers: dict[str, str | list[str]]
+    method: str
+    request_body: ChannelReader
+    path: str = ""
+
+
+class StreamingResponse:
     """Streaming HTTP response built on top of a ChannelWriter."""
 
     def __init__(self, writer: ChannelWriter) -> None:
@@ -179,18 +192,6 @@ class HttpResponse:
 
     def close(self) -> None:
         self._writer.close()
-
-
-@dataclass
-class HttpRequest:
-    """HTTP request without the response writer."""
-
-    path_params: dict[str, str]
-    query_params: dict[str, str | list[str]]
-    body: Any
-    headers: dict[str, str | list[str]]
-    method: str
-    request_body: ChannelReader
 
 
 class StreamChannelRefDict(TypedDict):

--- a/sdk/packages/python/iii/src/iii/utils.py
+++ b/sdk/packages/python/iii/src/iii/utils.py
@@ -3,52 +3,67 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, cast
 
-from .types import HttpRequest, HttpResponse, InternalHttpRequest
+from .types import HttpRequest, InternalHttpRequest, StreamingRequest, StreamingResponse
 from .types import is_channel_ref as is_channel_ref  # noqa: F401 - re-exported from types
 
 if TYPE_CHECKING:
-    from .types import ApiResponse
+    from .types import HttpResponse
+
+
+def _to_internal(req: Any) -> InternalHttpRequest:
+    if isinstance(req, InternalHttpRequest):
+        return req
+    if isinstance(req, dict):
+        return InternalHttpRequest(
+            path_params=req.get("path_params", {}),
+            query_params=req.get("query_params", {}),
+            body=req.get("body"),
+            headers=req.get("headers", {}),
+            method=req.get("method", "GET"),
+            response=req["response"],
+            request_body=req["request_body"],
+        )
+    return cast(InternalHttpRequest, req)
 
 
 def http(
-    callback: Callable[[HttpRequest, HttpResponse], Awaitable[ApiResponse[Any] | None]],
-) -> Callable[[Any], Awaitable[ApiResponse[Any] | None]]:
-    """Wrap an HTTP handler so it receives typed HttpRequest and HttpResponse.
+    callback: Callable[[HttpRequest[Any], StreamingResponse], Awaitable[HttpResponse[Any] | None]],
+) -> Callable[[Any], Awaitable[HttpResponse[Any] | None]]:
+    """Wrap a buffered HTTP handler: receives HttpRequest + StreamingResponse."""
 
-    Takes a callback ``(req, res) -> ApiResponse | None`` and returns a
-    function the iii engine can invoke directly.  The wrapper converts the
-    raw dict (or ``InternalHttpRequest``) delivered by the engine into the
-    typed ``HttpRequest`` / ``HttpResponse`` pair that the callback expects.
-    """
-
-    async def wrapper(req: Any) -> ApiResponse[Any] | None:
-        if isinstance(req, InternalHttpRequest):
-            internal = req
-        elif isinstance(req, dict):
-            internal = InternalHttpRequest(
-                path_params=req.get("path_params", {}),
-                query_params=req.get("query_params", {}),
-                body=req.get("body"),
-                headers=req.get("headers", {}),
-                method=req.get("method", "GET"),
-                response=req["response"],
-                request_body=req["request_body"],
-            )
-        else:
-            internal = req
-
-        http_response = HttpResponse(internal.response)
-        http_request = HttpRequest(
+    async def wrapper(req: Any) -> HttpResponse[Any] | None:
+        internal = _to_internal(req)
+        res = StreamingResponse(internal.response)
+        http_request: HttpRequest[Any] = HttpRequest(
             path_params=internal.path_params,
             query_params=internal.query_params,
             body=internal.body,
             headers=internal.headers,
             method=internal.method,
+        )
+        return await callback(http_request, res)
+
+    return wrapper
+
+
+def http_stream(
+    callback: Callable[[StreamingRequest, StreamingResponse], Awaitable[HttpResponse[Any] | None]],
+) -> Callable[[Any], Awaitable[HttpResponse[Any] | None]]:
+    """Wrap a streaming HTTP handler: receives StreamingRequest + StreamingResponse."""
+
+    async def wrapper(req: Any) -> HttpResponse[Any] | None:
+        internal = _to_internal(req)
+        res = StreamingResponse(internal.response)
+        streaming_request = StreamingRequest(
+            path_params=internal.path_params,
+            query_params=internal.query_params,
+            headers=internal.headers,
+            method=internal.method,
             request_body=internal.request_body,
         )
-        return await callback(http_request, http_response)
+        return await callback(streaming_request, res)
 
     return wrapper
 

--- a/sdk/packages/python/iii/tests/test_api_triggers.py
+++ b/sdk/packages/python/iii/tests/test_api_triggers.py
@@ -9,9 +9,9 @@ from urllib.parse import urlencode
 import aiohttp
 import pytest
 
-from iii import http
+from iii import http, http_stream
 from iii.iii import III
-from iii.types import HttpRequest, HttpResponse
+from iii.types import HttpRequest, StreamingRequest, StreamingResponse
 
 TEST_ASSETS_DIR = Path(__file__).parent.parent.parent.parent.parent / "test-assets"
 TEST_FILE = TEST_ASSETS_DIR / "handbook.pdf"
@@ -92,15 +92,16 @@ async def test_raw_json_request_body(engine_http_url, iii_client: III):
     raw_json = '{"z":2, "a":1}'
     function_id = "test::api::json::raw::py"
 
-    @http
-    async def handler(req: HttpRequest, response: HttpResponse):
+    @http_stream
+    async def handler(req: StreamingRequest, response: StreamingResponse):
         raw = await req.request_body.read_all()
+        parsed = json.loads(raw.decode("utf-8")) if raw else None
 
         await response.status(200)
         await response.headers({"content-type": "application/json"})
         result = json.dumps(
             {
-                "parsed_body": req.body,
+                "parsed_body": parsed,
                 "raw_body": raw.decode("utf-8"),
             }
         ).encode("utf-8")
@@ -245,7 +246,7 @@ async def test_custom_status_code(engine_http_url, iii_client: III):
 
 @pytest.mark.asyncio
 async def test_content_type_on_api_response_return(engine_http_url, iii_client: III):
-    """Returning an ApiResponse dict with headers should set the response Content-Type."""
+    """Returning an HttpResponse dict with headers should set the response Content-Type."""
     xml_body = '<?xml version="1.0" encoding="UTF-8"?><note><to>user</to><body>hello</body></note>'
 
     def handler(_input_data):
@@ -288,7 +289,7 @@ async def test_download_pdf_streaming(engine_http_url, iii_client: III):
     original_pdf = TEST_FILE.read_bytes()
 
     @http
-    async def handler(req: HttpRequest, response: HttpResponse):
+    async def handler(req: HttpRequest, response: StreamingResponse):
         await response.status(200)
         await response.headers({"content-type": "application/pdf"})
         await response.writer.write(original_pdf)
@@ -330,8 +331,8 @@ async def test_upload_pdf_streaming(engine_http_url, iii_client: III):
 
     received_data = bytearray()
 
-    @http
-    async def handler(req: HttpRequest, response: HttpResponse):
+    @http_stream
+    async def handler(req: StreamingRequest, response: StreamingResponse):
         nonlocal received_data
         await response.status(200)
         await response.headers({"content-type": "application/json"})
@@ -385,7 +386,7 @@ async def test_sse_streaming(engine_http_url, iii_client: III):
     ]
 
     @http
-    async def handler(req: HttpRequest, response: HttpResponse):
+    async def handler(req: HttpRequest, response: StreamingResponse):
         await response.status(200)
         await response.headers(
             {
@@ -462,8 +463,8 @@ async def test_sse_streaming(engine_http_url, iii_client: III):
 async def test_urlencoded_form_data(engine_http_url, iii_client: III):
     """Handle application/x-www-form-urlencoded request."""
 
-    @http
-    async def handler(req: HttpRequest, response: HttpResponse):
+    @http_stream
+    async def handler(req: StreamingRequest, response: StreamingResponse):
         raw = await req.request_body.read_all()
         body = raw.decode("utf-8")
 
@@ -523,8 +524,8 @@ async def test_multipart_form_data(engine_http_url, iii_client: III):
 
     original_pdf = TEST_FILE.read_bytes()
 
-    @http
-    async def handler(req: HttpRequest, response: HttpResponse):
+    @http_stream
+    async def handler(req: StreamingRequest, response: StreamingResponse):
         raw = await req.request_body.read_all()
         content_type = req.headers.get("content-type", "")
 

--- a/sdk/packages/python/iii/tests/test_http_types.py
+++ b/sdk/packages/python/iii/tests/test_http_types.py
@@ -1,0 +1,19 @@
+from iii import HttpRequest, HttpResponse, StreamingRequest
+
+
+def test_http_request_buffered_has_body_no_reader():
+    req = HttpRequest(path="/x", method="GET", body={"a": 1})
+    assert req.body == {"a": 1}
+    assert not hasattr(req, "request_body")
+
+
+def test_http_response_buffered_shape():
+    resp = HttpResponse(statusCode=201, body={"ok": True})
+    assert resp.status_code == 201
+
+
+def test_streaming_request_has_reader_field():
+    import dataclasses
+    fields = {f.name for f in dataclasses.fields(StreamingRequest)}
+    assert "request_body" in fields
+    assert "body" not in fields

--- a/sdk/packages/python/iii/tests/test_http_types.py
+++ b/sdk/packages/python/iii/tests/test_http_types.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from iii import HttpRequest, HttpResponse, StreamingRequest
 
 
@@ -17,9 +19,6 @@ def test_streaming_request_has_reader_field():
     fields = {f.name for f in dataclasses.fields(StreamingRequest)}
     assert "request_body" in fields
     assert "body" not in fields
-
-
-import asyncio
 
 
 class _FakeWriter:

--- a/sdk/packages/python/iii/tests/test_http_types.py
+++ b/sdk/packages/python/iii/tests/test_http_types.py
@@ -17,3 +17,60 @@ def test_streaming_request_has_reader_field():
     fields = {f.name for f in dataclasses.fields(StreamingRequest)}
     assert "request_body" in fields
     assert "body" not in fields
+
+
+import asyncio
+
+
+class _FakeWriter:
+    def __init__(self):
+        self.sent = []
+
+    async def send_message_async(self, m):
+        self.sent.append(m)
+
+    @property
+    def stream(self):
+        return None
+
+    def close(self):
+        pass
+
+
+def test_http_wrapper_delivers_buffered_request():
+    from iii.utils import http
+    captured = {}
+
+    async def handler(req, res):
+        captured["body"] = req.body
+        captured["has_reader"] = hasattr(req, "request_body")
+        return None
+
+    wrapped = http(handler)
+    raw = {
+        "path_params": {}, "query_params": {}, "headers": {}, "method": "POST",
+        "path": "/x", "body": {"a": 1},
+        "request_body": object(), "response": _FakeWriter(),
+    }
+    asyncio.run(wrapped(raw))
+    assert captured["body"] == {"a": 1}
+    assert captured["has_reader"] is False
+
+
+def test_http_stream_wrapper_delivers_streaming_request():
+    from iii.utils import http_stream
+    captured = {}
+
+    async def handler(req, res):
+        captured["has_reader"] = hasattr(req, "request_body")
+        captured["has_body"] = hasattr(req, "body")
+
+    wrapped = http_stream(handler)
+    raw = {
+        "path_params": {}, "query_params": {}, "headers": {}, "method": "POST",
+        "path": "/x", "body": {"a": 1},
+        "request_body": object(), "response": _FakeWriter(),
+    }
+    asyncio.run(wrapped(raw))
+    assert captured["has_reader"] is True
+    assert captured["has_body"] is False

--- a/sdk/packages/rust/iii-example/src/http_example.rs
+++ b/sdk/packages/rust/iii-example/src/http_example.rs
@@ -1,6 +1,6 @@
 use iii_observability::{Logger, execute_traced_request};
 use iii_sdk::builtin_triggers::{HttpMethod, HttpTriggerConfig};
-use iii_sdk::{ApiRequest, ApiResponse, III, IIIError, IIITrigger, RegisterFunction};
+use iii_sdk::{HttpRequest, HttpResponse, III, IIIError, IIITrigger, RegisterFunction};
 use serde_json::json;
 
 pub fn setup(iii: &III) {
@@ -36,13 +36,13 @@ pub fn setup(iii: &III) {
                     .await
                     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
-                let api_response = ApiResponse {
+                let http_response = HttpResponse {
                     status_code: 200,
                     body: json!({ "upstream_status": status, "data": data }),
                     headers: [("Content-Type".into(), "application/json".into())].into(),
                 };
 
-                Ok(serde_json::to_value(api_response)?)
+                Ok(serde_json::to_value(http_response)?)
             }
         }),
     );
@@ -60,7 +60,7 @@ pub fn setup(iii: &III) {
             let client = post_client.clone();
             async move {
                 let logger = Logger::new();
-                let req: ApiRequest = serde_json::from_value(input)
+                let req: HttpRequest = serde_json::from_value(input)
                     .unwrap_or_else(|_| serde_json::from_value(json!({})).unwrap());
 
                 logger.info("Posting to httpbin", Some(json!({ "body": req.body })));
@@ -90,13 +90,13 @@ pub fn setup(iii: &III) {
                     .await
                     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
-                let api_response = ApiResponse {
+                let http_response = HttpResponse {
                     status_code: status,
                     body: json!({ "upstream_status": status, "data": data }),
                     headers: [("Content-Type".into(), "application/json".into())].into(),
                 };
 
-                Ok(serde_json::to_value(api_response)?)
+                Ok(serde_json::to_value(http_response)?)
             }
         }),
     );

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -19,7 +19,7 @@ impl<T> MutexExt<T> for Mutex<T> {
     }
 }
 
-use futures_util::{SinkExt, StreamExt};
+use futures_util::{SinkExt, StreamExt, future::BoxFuture};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::{
@@ -40,7 +40,10 @@ use crate::{
         UnregisterTriggerMessage, UnregisterTriggerTypeMessage,
     },
     triggers::{Trigger, TriggerConfig, TriggerHandler},
-    types::{Channel, RemoteFunctionData, RemoteFunctionHandler, RemoteTriggerTypeData},
+    types::{
+        Channel, HttpRequest, HttpResponse, RemoteFunctionData, RemoteFunctionHandler,
+        RemoteTriggerTypeData, StreamingRequest, StreamingResponse,
+    },
 };
 
 use iii_observability as telemetry;
@@ -1778,6 +1781,161 @@ impl III {
 // them; user code must continue to go through `crate::helpers::*`.
 // ---------------------------------------------------------------------------
 
+// =============================================================================
+// HTTP handler helpers
+// =============================================================================
+
+/// Extract the request-body channel reference from a raw HTTP-invocation wire
+/// value (`InternalHttpRequest`). Returns `None` if the `request_body` field is
+/// missing or is not a [`StreamChannelRef`].
+pub(crate) fn parse_request_body_ref(wire: &Value) -> Option<StreamChannelRef> {
+    serde_json::from_value(wire.get("request_body")?.clone()).ok()
+}
+
+/// Extract the response channel reference from a raw HTTP-invocation wire value
+/// (`InternalHttpRequest`). Returns `None` if the `response` field is missing or
+/// is not a [`StreamChannelRef`].
+pub(crate) fn parse_response_ref(wire: &Value) -> Option<StreamChannelRef> {
+    serde_json::from_value(wire.get("response")?.clone()).ok()
+}
+
+/// Adapt a `(HttpRequest, StreamingResponse)` async handler into the raw
+/// [`RemoteFunctionHandler`] the engine invokes for an HTTP function.
+///
+/// The buffered request is deserialized from the raw wire value, and the
+/// response channel is reconstructed from the `response` channel ref using
+/// `engine_ws_base` (the same WebSocket base URL passed to
+/// [`register_worker`](crate::register_worker)). If the user handler returns
+/// `Some(HttpResponse)` it is serialized back to JSON for the engine; `None`
+/// indicates the handler streamed the response itself via the
+/// [`StreamingResponse`].
+///
+/// # Examples
+/// ```rust,no_run
+/// use iii_sdk::{http, register_worker, HttpResponse, InitOptions, RegisterFunction};
+/// use std::collections::HashMap;
+///
+/// let iii = register_worker("ws://localhost:49134", InitOptions::default());
+/// let handler = http("ws://localhost:49134", |_req, res| async move {
+///     res.status(200).await.ok();
+///     res.close().await.ok();
+///     None
+/// });
+/// iii.register_function("my::api", RegisterFunction::new_async(handler));
+/// ```
+pub fn http<F, Fut>(
+    engine_ws_base: impl Into<String>,
+    callback: F,
+) -> impl Fn(Value) -> BoxFuture<'static, Result<Value, IIIError>> + Send + Sync + 'static
+where
+    F: Fn(HttpRequest, StreamingResponse) -> Fut + Send + Sync + 'static,
+    Fut: std::future::Future<Output = Option<HttpResponse>> + Send + 'static,
+{
+    let ws_base = engine_ws_base.into();
+    let callback = Arc::new(callback);
+    move |wire: Value| {
+        let ws_base = ws_base.clone();
+        let callback = callback.clone();
+        Box::pin(async move {
+            let request: HttpRequest = serde_json::from_value(wire.clone())
+                .map_err(|e| IIIError::Serde(e.to_string()))?;
+            let response_ref = parse_response_ref(&wire)
+                .ok_or_else(|| IIIError::Serde("missing 'response' channel ref".into()))?;
+            let response =
+                StreamingResponse::new(ChannelWriter::new(&ws_base, &response_ref));
+            let result = callback(request, response).await;
+            match result {
+                Some(resp) => {
+                    serde_json::to_value(&resp).map_err(|e| IIIError::Serde(e.to_string()))
+                }
+                None => Ok(Value::Null),
+            }
+        })
+    }
+}
+
+/// Adapt a `(StreamingRequest, StreamingResponse)` async handler into the raw
+/// [`RemoteFunctionHandler`] the engine invokes for a streaming HTTP function.
+///
+/// Both the request body reader and the response writer are reconstructed from
+/// their channel refs using `engine_ws_base` (the same WebSocket base URL passed
+/// to [`register_worker`](crate::register_worker)). If the user handler returns
+/// `Some(HttpResponse)` it is serialized back to JSON for the engine; `None`
+/// indicates the handler streamed the response itself.
+///
+/// # Examples
+/// ```rust,no_run
+/// use iii_sdk::{http_stream, register_worker, InitOptions, RegisterFunction};
+///
+/// let iii = register_worker("ws://localhost:49134", InitOptions::default());
+/// let handler = http_stream("ws://localhost:49134", |_req, res| async move {
+///     res.status(200).await.ok();
+///     res.close().await.ok();
+///     None
+/// });
+/// iii.register_function("my::stream", RegisterFunction::new_async(handler));
+/// ```
+pub fn http_stream<F, Fut>(
+    engine_ws_base: impl Into<String>,
+    callback: F,
+) -> impl Fn(Value) -> BoxFuture<'static, Result<Value, IIIError>> + Send + Sync + 'static
+where
+    F: Fn(StreamingRequest, StreamingResponse) -> Fut + Send + Sync + 'static,
+    Fut: std::future::Future<Output = Option<HttpResponse>> + Send + 'static,
+{
+    let ws_base = engine_ws_base.into();
+    let callback = Arc::new(callback);
+    move |wire: Value| {
+        let ws_base = ws_base.clone();
+        let callback = callback.clone();
+        Box::pin(async move {
+            let response_ref = parse_response_ref(&wire)
+                .ok_or_else(|| IIIError::Serde("missing 'response' channel ref".into()))?;
+            let request_body_ref = parse_request_body_ref(&wire)
+                .ok_or_else(|| IIIError::Serde("missing 'request_body' channel ref".into()))?;
+
+            let request = StreamingRequest {
+                query_params: parse_string_map(&wire, "query_params"),
+                path_params: parse_string_map(&wire, "path_params"),
+                headers: parse_string_map(&wire, "headers"),
+                path: wire
+                    .get("path")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                method: wire
+                    .get("method")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                request_body: ChannelReader::new(&ws_base, &request_body_ref),
+            };
+            let response =
+                StreamingResponse::new(ChannelWriter::new(&ws_base, &response_ref));
+            let result = callback(request, response).await;
+            match result {
+                Some(resp) => {
+                    serde_json::to_value(&resp).map_err(|e| IIIError::Serde(e.to_string()))
+                }
+                None => Ok(Value::Null),
+            }
+        })
+    }
+}
+
+/// Read a `HashMap<String, String>` from a JSON object field, defaulting to an
+/// empty map when the field is missing or not an object.
+fn parse_string_map(wire: &Value, key: &str) -> HashMap<String, String> {
+    wire.get(key)
+        .and_then(Value::as_object)
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 pub(crate) async fn internal_create_channel(
     iii: &III,
     buffer_size: Option<usize>,
@@ -1981,6 +2139,21 @@ mod tests {
         };
         let out = handler(json!({"name": "world"})).await.unwrap();
         assert_eq!(out, json!({"echo": {"name": "world"}}));
+    }
+
+    #[test]
+    fn parse_request_body_ref_reads_wire() {
+        let wire = serde_json::json!({
+            "path": "/up", "method": "POST",
+            "query_params": {}, "path_params": {}, "headers": {},
+            "body": null,
+            "request_body": {"channel_id": "c1", "access_key": "k1", "direction": "read"},
+            "response": {"channel_id": "c2", "access_key": "k2", "direction": "write"}
+        });
+        let reader_ref = parse_request_body_ref(&wire).unwrap();
+        assert_eq!(reader_ref.channel_id, "c1");
+        let resp_ref = parse_response_ref(&wire).unwrap();
+        assert_eq!(resp_ref.channel_id, "c2");
     }
 
     #[tokio::test]

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -18,7 +18,7 @@ pub use channels::{ChannelReader, ChannelWriter, StreamChannelRef};
 pub use error::IIIError;
 pub use iii::{
     FunctionInfo, FunctionRef, III, IIIConnectionState, RegisterFunction, RegisterTriggerType,
-    TriggerInfo, TriggerTypeInfo, TriggerTypeRef, WorkerInfo, WorkerMetadata,
+    TriggerInfo, TriggerTypeInfo, TriggerTypeRef, WorkerInfo, WorkerMetadata, http, http_stream,
 };
 pub use protocol::{
     EnqueueResult, ErrorBody, FunctionMessage, HttpAuthConfig, HttpInvocationConfig, HttpMethod,

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -34,10 +34,10 @@ pub use structs::{
 };
 pub use triggers::{Trigger, TriggerConfig, TriggerHandler};
 pub use types::{
-    ApiRequest, ApiResponse, Channel, DeleteResult, FieldPath, MergePath, SetResult,
+    Channel, DeleteResult, FieldPath, HttpRequest, HttpResponse, MergePath, SetResult,
     StreamAuthInput, StreamAuthResult, StreamDeleteInput, StreamGetInput, StreamJoinResult,
-    StreamListGroupsInput, StreamListInput, StreamSetInput, StreamUpdateInput, UpdateOp,
-    UpdateOpError, UpdateResult,
+    StreamListGroupsInput, StreamListInput, StreamSetInput, StreamUpdateInput, StreamingRequest,
+    StreamingResponse, UpdateOp, UpdateOpError, UpdateResult,
 };
 
 pub use serde_json::Value;

--- a/sdk/packages/rust/iii/src/types.rs
+++ b/sdk/packages/rust/iii/src/types.rs
@@ -373,7 +373,7 @@ pub struct RemoteTriggerTypeData {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ApiRequest<T = Value> {
+pub struct HttpRequest<T = Value> {
     #[serde(default)]
     pub query_params: HashMap<String, String>,
     #[serde(default)]
@@ -389,11 +389,52 @@ pub struct ApiRequest<T = Value> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ApiResponse<T = Value> {
+pub struct HttpResponse<T = Value> {
     pub status_code: u16,
     #[serde(default)]
     pub headers: HashMap<String, String>,
     pub body: T,
+}
+
+/// Streaming request: metadata plus a reader for the request body channel.
+pub struct StreamingRequest {
+    pub query_params: HashMap<String, String>,
+    pub path_params: HashMap<String, String>,
+    pub headers: HashMap<String, String>,
+    pub path: String,
+    pub method: String,
+    pub request_body: ChannelReader,
+}
+
+/// Streaming response handle backed by a channel writer.
+pub struct StreamingResponse {
+    writer: ChannelWriter,
+}
+
+impl StreamingResponse {
+    pub fn new(writer: ChannelWriter) -> Self {
+        Self { writer }
+    }
+
+    pub async fn status(&self, status_code: u16) -> Result<(), IIIError> {
+        self.writer
+            .send_message(&serde_json::json!({"type": "set_status", "status_code": status_code}).to_string())
+            .await
+    }
+
+    pub async fn headers(&self, headers: HashMap<String, String>) -> Result<(), IIIError> {
+        self.writer
+            .send_message(&serde_json::json!({"type": "set_headers", "headers": headers}).to_string())
+            .await
+    }
+
+    pub async fn write(&self, data: &[u8]) -> Result<(), IIIError> {
+        self.writer.write(data).await
+    }
+
+    pub async fn close(&self) -> Result<(), IIIError> {
+        self.writer.close().await
+    }
 }
 
 /// A streaming channel pair for worker-to-worker data transfer.
@@ -409,15 +450,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn api_request_defaults_when_missing_fields() {
-        let request: ApiRequest = serde_json::from_str("{}").unwrap();
-
+    fn http_request_defaults_when_missing_fields() {
+        let request: HttpRequest = serde_json::from_str("{}").unwrap();
         assert!(request.query_params.is_empty());
         assert!(request.path_params.is_empty());
         assert!(request.headers.is_empty());
         assert_eq!(request.path, "");
         assert_eq!(request.method, "");
         assert!(request.body.is_null());
+    }
+
+    #[test]
+    fn http_response_roundtrips() {
+        let resp: HttpResponse = serde_json::from_str(
+            r#"{"status_code":201,"headers":{"x":"y"},"body":{"ok":true}}"#,
+        )
+        .unwrap();
+        assert_eq!(resp.status_code, 201);
+        assert_eq!(resp.headers.get("x"), Some(&"y".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replaces the duplicated, inconsistent `Api*`/`Http*` HTTP types with one symmetric set, identical across all three SDKs, and closes the Rust SDK's streaming gap.

**Naming rule:** two axes — request/response × buffered/streaming. `Http*` = whole body in memory, `Streaming*` = chunked channel.

| | Buffered | Streaming |
|---|---|---|
| Request | `HttpRequest` | `StreamingRequest` |
| Response | `HttpResponse` | `StreamingResponse` |

- `HttpRequest` — buffered request (parsed `body`, no reader)
- `StreamingRequest` — streaming request (`request_body` reader, no body)
- `HttpResponse` — buffered return value `{ status_code, headers?, body? }`
- `StreamingResponse` — streaming handle (`status`/`headers`/`stream`/`close`)
- Wrappers: `http` (buffered req) + `httpStream`/`http_stream` (streaming req); both deliver a `StreamingResponse` and may return an `HttpResponse`
- `InternalHttpRequest` — internal wire shape, no longer publicly exported
- Old `ApiRequest`/`ApiResponse` removed (hard rename, no aliases — pre-1.0)

### Per layer
- **Engine:** wire struct renamed `HttpRequest` → `InternalHttpRequest`; JSON wire field names unchanged, locked by a serde stability test.
- **Rust SDK:** renamed `Api*` → `Http*`, added the previously-missing `StreamingRequest`/`StreamingResponse` + `http`/`http_stream` handler helpers.
- **Node + Python SDKs:** symmetric type set, `http`/`httpStream`(`http_stream`) wrappers, examples + tests migrated.
- **Browser SDK:** `Api*` → `Http*` rename.

## Test Plan
- [x] Engine: `cargo test -p iii rest_api` — 154 pass (incl. wire-stability test)
- [x] Rust SDK: `cargo test -p iii-sdk --lib` — 57 pass; doctests for `http`/`http_stream` compile
- [x] Node `iii-sdk`: build + `types.test`/`utils.test` — 6 pass
- [x] Browser `iii-browser-sdk`: build + 51 pass (incl. export-surface test)
- [x] Python: `ruff`/`mypy` clean, `test_http_types.py` — 5 pass
- [x] Cross-SDK export parity verified; no `ApiRequest`/`ApiResponse` left in code
- [ ] Engine-dependent integration tests (api-triggers/healthcheck/middleware) — require a live engine, run in CI