### PR TITLE
feat(engine): expose response_schema on triggers info

### DIFF
--- a/engine/src/trigger.rs
+++ b/engine/src/trigger.rs
@@ -62,6 +62,7 @@ pub struct TriggerType {
     pub _description: String,
     pub trigger_request_format: Option<Value>,
     pub call_request_format: Option<Value>,
+    pub call_response_format: Option<Value>,
     pub registrator: Box<dyn TriggerRegistrator>,
     pub worker_id: Option<Uuid>,
 }
@@ -76,11 +77,13 @@ impl TriggerType {
         let id = id.into();
         let trigger_request_format = Self::trigger_request_format_for(&id);
         let call_request_format = Self::call_request_format_for(&id);
+        let call_response_format = Self::call_response_format_for(&id);
         Self {
             id,
             _description: description.into(),
             trigger_request_format,
             call_request_format,
+            call_response_format,
             registrator,
             worker_id,
         }
@@ -93,6 +96,14 @@ impl TriggerType {
 
     pub fn with_call_request_format<T: schemars::JsonSchema>(mut self) -> Self {
         self.call_request_format = Self::schema_for::<T>();
+        self
+    }
+
+    /// Schema for what a bound handler must RETURN when this trigger fires
+    /// (e.g. the HTTP response envelope). Exposed via `engine::triggers::info`
+    /// as `response_schema` so callers can discover the return contract.
+    pub fn with_call_response_format<T: schemars::JsonSchema>(mut self) -> Self {
+        self.call_response_format = Self::schema_for::<T>();
         self
     }
 
@@ -128,6 +139,19 @@ impl TriggerType {
             "stream" => Self::schema_for::<StreamCallRequest>(),
             "log" => Self::schema_for::<LogCallRequest>(),
             "configuration" => Self::schema_for::<ConfigurationCallRequest>(),
+            _ => None,
+        }
+    }
+
+    /// Schema a bound handler must RETURN when this trigger fires. Only trigger
+    /// types whose handler return shape is fixed declare one. `http` returns an
+    /// `HttpCallResponse` (`status_code` / `headers` / `body`); most triggers
+    /// place no constraint on the return and report `None`.
+    fn call_response_format_for(id: &str) -> Option<Value> {
+        use crate::trigger_formats::*;
+
+        match id {
+            "http" => Self::schema_for::<HttpCallResponse>(),
             _ => None,
         }
     }

--- a/engine/src/trigger.rs
+++ b/engine/src/trigger.rs
@@ -867,4 +867,55 @@ mod tests {
         assert_eq!(deserialized.metadata, None);
         assert!(!json.contains("metadata"));
     }
+
+    fn assert_http_call_response_properties(schema: &Value) {
+        let properties = schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("call_response_format schema has a properties object");
+        for key in ["status_code", "headers", "body"] {
+            assert!(
+                properties.contains_key(key),
+                "expected property '{key}', got: {properties:?}"
+            );
+        }
+
+        // Pin optionality: the worker (`HttpResponse::from_function_return`) treats
+        // every field as optional (status_code defaults to 200, headers to empty,
+        // body to {}), so none of them may appear in the schema's `required` array.
+        if let Some(required) = schema.get("required").and_then(Value::as_array) {
+            for key in ["status_code", "headers", "body"] {
+                assert!(
+                    !required.iter().any(|v| v.as_str() == Some(key)),
+                    "'{key}' must not be required, got required: {required:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn http_trigger_type_populates_call_response_format() {
+        let tt = make_trigger_type("http");
+        let schema = tt
+            .call_response_format
+            .expect("http trigger type sets call_response_format");
+        assert_http_call_response_properties(&schema);
+    }
+
+    #[test]
+    fn cron_trigger_type_has_no_call_response_format() {
+        let tt = make_trigger_type("cron");
+        assert!(tt.call_response_format.is_none());
+    }
+
+    #[test]
+    fn with_call_response_format_sets_schema() {
+        use crate::trigger_formats::HttpCallResponse;
+
+        let tt = make_trigger_type("cron").with_call_response_format::<HttpCallResponse>();
+        let schema = tt
+            .call_response_format
+            .expect("with_call_response_format sets call_response_format");
+        assert_http_call_response_properties(&schema);
+    }
 }

--- a/engine/src/trigger_formats.rs
+++ b/engine/src/trigger_formats.rs
@@ -63,6 +63,23 @@ pub struct HttpCallRequest {
     pub body: Value,
 }
 
+/// Response envelope a bound HTTP handler returns. The `iii-http` worker reads
+/// these fields from the handler's return value; any absent field uses its
+/// default. This is the contract for "what should my HTTP handler return".
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct HttpCallResponse {
+    /// HTTP status code to send. Defaults to 200 when omitted, so set it
+    /// explicitly for error cases (e.g. 404 for not-found, 400 for bad input).
+    /// The field is `status_code` — not `status`.
+    pub status_code: u16,
+    /// Response headers as a `{ "Header-Name": "value" }` map. An array of
+    /// `"Name: value"` strings is also accepted.
+    pub headers: HashMap<String, String>,
+    /// Response body. Serialized to the wire as JSON, text, or bytes according to
+    /// the `Content-Type` header you set.
+    pub body: Value,
+}
+
 // ── Cron ────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/engine/src/trigger_formats.rs
+++ b/engine/src/trigger_formats.rs
@@ -64,20 +64,33 @@ pub struct HttpCallRequest {
 }
 
 /// Response envelope a bound HTTP handler returns. The `iii-http` worker reads
-/// these fields from the handler's return value; any absent field uses its
-/// default. This is the contract for "what should my HTTP handler return".
+/// these fields from the handler's return value; **every field is optional** and
+/// any absent field uses its default. This is the contract for "what should my
+/// HTTP handler return".
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct HttpCallResponse {
     /// HTTP status code to send. Defaults to 200 when omitted, so set it
     /// explicitly for error cases (e.g. 404 for not-found, 400 for bad input).
     /// The field is `status_code` — not `status`.
-    pub status_code: u16,
-    /// Response headers as a `{ "Header-Name": "value" }` map. An array of
-    /// `"Name: value"` strings is also accepted.
-    pub headers: HashMap<String, String>,
+    pub status_code: Option<u16>,
+    /// Response headers. Accepts either a `{ "Header-Name": "value" }` map or an
+    /// array of `"Header-Name: value"` strings. Defaults to no headers when omitted.
+    pub headers: Option<HttpResponseHeaders>,
     /// Response body. Serialized to the wire as JSON, text, or bytes according to
-    /// the `Content-Type` header you set.
-    pub body: Value,
+    /// the `Content-Type` header you set. Defaults to an empty object when omitted.
+    pub body: Option<Value>,
+}
+
+/// The two accepted forms for HTTP response headers. The `iii-http` worker reads
+/// both: a `{ "Header-Name": "value" }` object map, or an array of
+/// `"Header-Name: value"` strings.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum HttpResponseHeaders {
+    /// `{ "Header-Name": "value" }` object map.
+    Map(HashMap<String, String>),
+    /// Array of `"Header-Name: value"` strings.
+    List(Vec<String>),
 }
 
 // ── Cron ────────────────────────────────────────────────────────────────

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -185,6 +185,11 @@ pub struct TriggerTypeDetail {
     pub configuration_schema: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_schema: Option<Value>,
+    /// Schema a bound handler must RETURN when the trigger fires (e.g. the HTTP
+    /// response envelope). Present only for trigger types with a fixed return
+    /// contract; absent otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_schema: Option<Value>,
     pub instance_count: usize,
 }
 
@@ -613,6 +618,7 @@ impl EngineFunctionsWorker {
             description: tt._description.clone(),
             configuration_schema: tt.trigger_request_format.clone(),
             request_schema: tt.call_request_format.clone(),
+            response_schema: tt.call_response_format.clone(),
             instance_count: self.instance_count_for_type(&tt.id),
         })
     }
@@ -1817,6 +1823,7 @@ mod tests {
             description: "HTTP trigger".to_string(),
             configuration_schema: Some(serde_json::json!({"type": "object"})),
             request_schema: Some(serde_json::json!({"type": "object"})),
+            response_schema: None,
             instance_count: 2,
         };
         let json = serde_json::to_value(&detail).expect("serialize");

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -1829,6 +1829,7 @@ mod tests {
         let json = serde_json::to_value(&detail).expect("serialize");
         assert!(json.get("configuration_schema").is_some());
         assert!(json.get("request_schema").is_some());
+        assert!(json.get("response_schema").is_none());
         assert!(json.get("call_request_format").is_none());
         assert!(json.get("trigger_request_format").is_none());
         assert_eq!(json["instance_count"], 2);
@@ -2209,6 +2210,85 @@ mod tests {
                 assert_eq!(detail.instance_count, 2);
                 assert!(detail.configuration_schema.is_some());
                 assert!(detail.request_schema.is_some());
+                assert!(detail.response_schema.is_none());
+            }
+            _ => panic!("expected triggers_info success"),
+        }
+    }
+
+    #[tokio::test]
+    async fn triggers_info_returns_http_response_schema() {
+        let (engine, module) = setup_engine_and_module();
+        let tt = crate::trigger::TriggerType::new(
+            "http",
+            "HTTP trigger",
+            Box::new(module.clone()),
+            None,
+        );
+        engine
+            .trigger_registry
+            .register_trigger_type(tt)
+            .await
+            .unwrap();
+
+        let result = module
+            .triggers_info(TriggerInfoInput {
+                id: "http".to_string(),
+            })
+            .await;
+        match result {
+            FunctionResult::Success(detail) => {
+                let schema = detail
+                    .response_schema
+                    .clone()
+                    .expect("http trigger type exposes response_schema");
+                let properties = schema
+                    .get("properties")
+                    .and_then(Value::as_object)
+                    .expect("response_schema has a properties object");
+                for key in ["status_code", "headers", "body"] {
+                    assert!(
+                        properties.contains_key(key),
+                        "expected property '{key}', got: {properties:?}"
+                    );
+                }
+                // Pin optionality: the worker treats every field as optional, so
+                // none may be in the schema's `required` array.
+                if let Some(required) = schema.get("required").and_then(Value::as_array) {
+                    for key in ["status_code", "headers", "body"] {
+                        assert!(
+                            !required.iter().any(|v| v.as_str() == Some(key)),
+                            "'{key}' must not be required, got required: {required:?}"
+                        );
+                    }
+                }
+
+                let json = serde_json::to_value(&detail).expect("serialize");
+                let serialized_response_schema = json
+                    .get("response_schema")
+                    .expect("serialized response_schema present");
+                let serialized_properties = serialized_response_schema
+                    .get("properties")
+                    .and_then(Value::as_object)
+                    .expect("serialized response_schema has a properties object");
+                for key in ["status_code", "headers", "body"] {
+                    assert!(
+                        serialized_properties.contains_key(key),
+                        "expected serialized property '{key}', got: {serialized_properties:?}"
+                    );
+                }
+                // Pin optionality on the serialized form too.
+                if let Some(required) = serialized_response_schema
+                    .get("required")
+                    .and_then(Value::as_array)
+                {
+                    for key in ["status_code", "headers", "body"] {
+                        assert!(
+                            !required.iter().any(|v| v.as_str() == Some(key)),
+                            "'{key}' must not be required in serialized schema, got required: {required:?}"
+                        );
+                    }
+                }
             }
             _ => panic!("expected triggers_info success"),
         }

--- a/engine/src/workers/rest_api/skills/SKILL.md
+++ b/engine/src/workers/rest_api/skills/SKILL.md
@@ -24,11 +24,11 @@ This page explains WHEN and HOW to serve HTTP; the engine is the source of truth
 engine::triggers::info { id: "http" }
 ```
 
-returns the `http` trigger's configuration schema (the route fields — path, method, optional route gating, per-route middleware) and the request envelope your handler receives. For the response envelope your handler must return, inspect a bound handler with `engine::functions::info { function_id: "<your-handler-id>" }`. Use `engine::triggers::list` to discover trigger types in the first place.
+returns three schemas: `configuration_schema` (the route fields — path, method, optional route gating, per-route middleware), `request_schema` (the request envelope your handler receives), and `response_schema` (the response envelope your handler must return). Build to all three. Use `engine::triggers::list` to discover trigger types in the first place.
 
 ## Set the right HTTP status
 
-YOUR handler chooses the HTTP status code — it is a field on the response envelope (fetch its exact name/shape from the contract above; do not hardcode it from memory). The status is NOT inferred from the body, so a handler that just returns a value or an error object yields `200` by default. For error cases, set the matching status explicitly: a not-found path returns `404`, a bad request `400`, and so on. Returning `200` with an `{ error: ... }` body is a bug — it "isn't a 500," but it also isn't the status the requirement asked for, and callers (and tests) will read it as success. Avoiding a crash is not the same as returning the right status.
+YOUR handler chooses the HTTP status code — it is a field on the response envelope whose exact name is in the `response_schema` from `engine::triggers::info { id: "http" }` (read it; do not guess the field name from memory). The status is NOT inferred from the body, so a handler that just returns a value or an error object yields `200` by default. For error cases, set the matching status explicitly: a not-found path returns `404`, a bad request `400`, and so on. Returning `200` with an `{ error: ... }` body is a bug — it "isn't a 500," but it also isn't the status the requirement asked for, and callers (and tests) will read it as success. Avoiding a crash is not the same as returning the right status.
 
 ## When to Use
 


### PR DESCRIPTION
## Summary

- Add `call_response_format` to `TriggerType` so trigger types with a fixed handler return contract can declare it (`with_call_response_format::<T>()` builder + per-id defaults in `call_response_format_for`)
- Define `HttpCallResponse` (`status_code` / `headers` / `body`) in `trigger_formats.rs` — the response envelope the `iii-http` worker reads from a bound handler's return value
- Surface it via `engine::triggers::info` as `response_schema` on `TriggerTypeDetail` (omitted when the trigger places no constraint on the return)
- Update the REST API skill docs: handlers now read the return contract from `response_schema` on `engine::triggers::info { id: "http" }` instead of inspecting a bound handler via `engine::functions::info`

## Why

"What should my HTTP handler return" was not discoverable from the trigger contract itself — agents had to inspect an already-bound handler, or guess the field names (e.g. `status` vs `status_code`). Publishing the response envelope schema alongside the existing `configuration_schema` and `request_schema` makes the full contract available from one call.

## Test plan

- [x] Existing `TriggerTypeDetail` serialization test updated (`response_schema: None` skipped via `skip_serializing_if`)
- [ ] `cargo test -p engine` passes
- [ ] Manual: `engine::triggers::info { id: "http" }` returns `response_schema` with `status_code` / `headers` / `body`; non-http triggers omit the field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP triggers now expose a formal response schema describing status, headers, and body; handlers can opt to provide or override a response format.

* **Documentation**
  * Updated HTTP skill docs to show how to discover and use trigger response schemas (use trigger info/list to obtain response contract).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->