### PR TITLE
docs(changelog): add 0.19.0 entry for response_schema on triggers info

### DIFF
--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -6,6 +6,30 @@ type: "reference"
 ---
 
 <Update label="0.19.0" description="June 2026">
+  ## `engine::triggers::info` now exposes `response_schema`
+
+  Trigger types can declare the schema a bound handler must **return** when the trigger fires. `engine::triggers::info` surfaces it as a new optional `response_schema` field alongside the existing `configuration_schema` (how to configure the trigger) and `request_schema` (what the handler receives) — the full trigger contract is now discoverable from a single call:
+
+  ```json
+  {
+    "id": "http",
+    "configuration_schema": { "…": "route fields — path, method, middleware" },
+    "request_schema": { "…": "envelope your handler receives" },
+    "response_schema": {
+      "properties": {
+        "status_code": { "…": "HTTP status to send; defaults to 200 when omitted" },
+        "headers": { "…": "{ \"Header-Name\": \"value\" } map or [\"Header-Name: value\"] strings" },
+        "body": { "…": "serialized as JSON, text, or bytes per your Content-Type" }
+      }
+    },
+    "instance_count": 1
+  }
+  ```
+
+  The `http` trigger type is the first to declare a return contract: its `response_schema` is the response envelope the `iii-http` worker reads from a handler's return value — `status_code` / `headers` / `body`, every field optional. Previously, "what should my HTTP handler return" wasn't discoverable from the trigger itself: you had to inspect an already-bound handler via `engine::functions::info`, or guess field names (`status` vs `status_code` — it's `status_code`).
+
+  Trigger types that place no constraint on the handler's return omit the field entirely, so existing consumers of `engine::triggers::info` are unaffected. In-process (Rust) trigger types can declare their own contract with the new `TriggerType::with_call_response_format::<T>()` builder.
+
   ## SDK: inbound `unregistertrigger` for custom trigger types
 
   When a trigger instance is removed — via `trigger.unregister()` or because the subscribing worker disconnects — the engine notifies the worker that owns the trigger type so it can run `unregisterTrigger` and tear down listeners, routes, or subscriptions.


### PR DESCRIPTION
## Summary

Adds a 0.19.0 changelog entry to `docs/changelog/index.mdx` for #1748 (`feat(engine): expose response_schema on triggers info`).

The new section covers:

- The new optional `response_schema` field on `engine::triggers::info`, alongside the existing `configuration_schema` and `request_schema`, with an illustrative response payload
- The `http` trigger's return contract (`status_code` / `headers` / `body`, all optional; `status_code` defaults to 200 — not `status`)
- That trigger types with no fixed return contract omit the field, so existing consumers are unaffected
- The new `TriggerType::with_call_response_format::<T>()` builder for in-process (Rust) trigger types

Placed as the first section of the existing 0.19.0 `<Update>` block, before the `unregistertrigger` entry.

## Test plan

- [ ] Docs site renders the changelog page with the new section (MDX `<Update>` block unchanged structurally)
- [x] Entry facts verified against the merged diff of #1748 (`dbe3a96b7`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Trigger information queries now return complete contract details in a single request, including configuration, request, and response schemas, with detailed HTTP envelope structure
- Custom trigger providers can now receive notifications when instances are removed, enabling proper cleanup operations and supporting reconnection workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->