### PR TITLE
refactor(rust-sdk)!: drop serde_json::Value re-export

### DIFF
--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -40,8 +40,6 @@ pub use types::{
     UpdateOpError, UpdateResult,
 };
 
-pub use serde_json::Value;
-
 /// Configuration options passed to [`register_worker`].
 ///
 /// # Examples


### PR DESCRIPTION
Removes the `Value` re-export (`pub use serde_json::Value`) from the Rust SDK root. Import `serde_json::Value` directly. No callers in the workspace used the re-export. Hard delete, no shim (breaking).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * A previously exported type has been removed from this package's public API. Projects depending on that export must now import the type directly from its original dependency. Update import paths to restore builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->