### PR TITLE
Fix cli telemetry latency

### DIFF
--- a/engine/src/cli/telemetry.rs
+++ b/engine/src/cli/telemetry.rs
@@ -105,6 +105,12 @@ fn send_fire_and_forget(event: AmplitudeEvent) {
     });
 }
 
+fn send_fire_and_forget_with_timeout(event: AmplitudeEvent, timeout: std::time::Duration) {
+    tokio::spawn(async move {
+        let _ = tokio::time::timeout(timeout, send_direct(event)).await;
+    });
+}
+
 pub async fn send_install_lifecycle_event(event_type: &str, properties: serde_json::Value) {
     let install_method = properties
         .get("install_method")
@@ -132,9 +138,9 @@ fn build_cli_usage_event(command_path: &str) -> Option<AmplitudeEvent> {
     )
 }
 
-pub async fn send_cli_usage(command_path: &str) {
+pub fn send_cli_usage(command_path: &str) {
     if let Some(event) = build_cli_usage_event(command_path) {
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(3), send_direct(event)).await;
+        send_fire_and_forget_with_timeout(event, std::time::Duration::from_secs(3));
     }
 }
 

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -263,7 +263,7 @@ async fn main() -> anyhow::Result<()> {
         },
     };
 
-    cli::telemetry::send_cli_usage(&cli_usage_command_path(&cli_args)).await;
+    cli::telemetry::send_cli_usage(&cli_usage_command_path(&cli_args));
 
     if cli_args.version {
         println!("{}", env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
## Summary

- Move CLI usage telemetry off the critical path by sending it in a background task.
- Keep the existing 3s telemetry timeout inside the spawned task.
- Stop awaiting CLI usage tracking before executing commands like `iii trigger` and `iii --version`.

## Root Cause

`e6cfdaf5b` added `cli::telemetry::send_cli_usage(...).await` before command dispatch. When telemetry endpoints were slow or unreachable, every CLI command waited on that network path, which made `iii trigger engine::triggers::list` take about 3s even though the engine builtin itself was fast.

## Validation

- `cargo fmt --all`
- `cargo test -p iii test_build_cli_usage_event_uses_sanitized_command_path`
- `cargo test -p iii cli_usage_command_path`
- `cargo build -p iii --release`
- Timed `env -u III_TELEMETRY_DEV -u III_TELEMETRY_ENABLED ./target/release/iii trigger engine::triggers::list`: before ~3.016s, after ~0.023-0.028s warm.
- Timed `env -u III_TELEMETRY_DEV -u III_TELEMETRY_ENABLED ./target/release/iii --version`: before ~3.016s, after ~0.017s warm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * CLI commands feel more responsive: telemetry is dispatched in the background and no longer blocks command execution.
  * Telemetry dispatch will still attempt delivery briefly using a fixed timeout while letting the CLI proceed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->