### PR TITLE
fix(website): stop session replay recording the animated SVG firehose

### DIFF
--- a/website/posthog-consent.js
+++ b/website/posthog-consent.js
@@ -58,6 +58,14 @@
       person_profiles: 'identified_only',
       capture_pageview: true,
       capture_pageleave: true,
+      session_recording: {
+        // The hero and agent visualizations animate SVG packets every frame,
+        // emitting ~900 DOM mutations/sec. Recording those mutations pegs CPU
+        // and grows memory unbounded in the replay buffer. Block the animated
+        // layers from session replay; the live page is unaffected.
+        blockSelector:
+          '#hv-packets, #hv-edges-ephemeral, #ag-a-packets, #ag-a-edges-eph',
+      },
     });
   };
 


### PR DESCRIPTION
## Problem

The hero and agent visualizations animate SVG packets every frame, rewriting `cx`/`cy` on SVG circles ~60fps. This emits roughly 900 DOM mutations/sec continuously while the page is open (measured live: 2789 mutations in 3s). PostHog session replay records every mutation, which pegs CPU and grows the replay buffer. Users reported Chrome consuming all memory and freezing their machines.

## Fix

Add `session_recording.blockSelector` to the PostHog init for the four animated layers:

- `#hv-packets`, `#hv-edges-ephemeral` (hero)
- `#ag-a-packets`, `#ag-a-edges-eph` (agent frame)

rrweb's `isBlocked` walks ancestors, so mutations inside these blocked groups are dropped from recording. The live page is unaffected (`blockSelector` only changes what replay captures). All four selectors were verified against the live DOM as the animated `<g>` groups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated session replay recording configuration to exclude specific animated visual elements from being recorded, optimizing performance and ensuring session replays focus on meaningful user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->