### PR TITLE
refactor(rust-sdk)!: delete FieldPath, de-export MergePath

### DIFF
--- a/engine/benches/kv_store_bench.rs
+++ b/engine/benches/kv_store_bench.rs
@@ -5,7 +5,7 @@ use std::{sync::Arc, time::Instant};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use futures::future::join_all;
 use iii::builtins::kv::BuiltinKvStore;
-use iii_sdk::{FieldPath, UpdateOp};
+use iii_sdk::UpdateOp;
 use serde_json::json;
 use tokio::runtime::Runtime;
 
@@ -92,7 +92,7 @@ fn kv_update_benchmark(c: &mut Criterion) {
                     "bench".to_string(),
                     "update-key".to_string(),
                     vec![UpdateOp::Set {
-                        path: FieldPath("name".to_string()),
+                        path: "name".to_string(),
                         value: Some(json!("B")),
                     }],
                 )
@@ -110,7 +110,7 @@ fn kv_update_benchmark(c: &mut Criterion) {
                     "bench".to_string(),
                     "update-key".to_string(),
                     vec![UpdateOp::Increment {
-                        path: FieldPath("counter".to_string()),
+                        path: "counter".to_string(),
                         by: 1,
                     }],
                 )
@@ -170,7 +170,7 @@ fn kv_contention_benchmark(c: &mut Criterion) {
                                         "bench".to_string(),
                                         "contended-key".to_string(),
                                         vec![UpdateOp::Increment {
-                                            path: FieldPath("counter".to_string()),
+                                            path: "counter".to_string(),
                                             by: 1,
                                         }],
                                     )

--- a/engine/benches/state_adapter_bench.rs
+++ b/engine/benches/state_adapter_bench.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use iii::workers::state::adapters::{StateAdapter, kv_store::BuiltinKvStoreAdapter};
-use iii_sdk::{FieldPath, UpdateOp};
+use iii_sdk::UpdateOp;
 use serde_json::json;
 use tokio::runtime::Runtime;
 
@@ -89,7 +89,7 @@ fn state_crud_benchmark(c: &mut Criterion) {
                         "bench-scope",
                         "update-key",
                         vec![UpdateOp::Increment {
-                            path: FieldPath("counter".to_string()),
+                            path: "counter".to_string(),
                             by: 1,
                         }],
                     )

--- a/engine/src/builtins/kv.rs
+++ b/engine/src/builtins/kv.rs
@@ -500,7 +500,7 @@ impl BuiltinKvStore {
 
 #[cfg(test)]
 mod test {
-    use iii_sdk::{FieldPath, UpdateOp};
+    use iii_sdk::UpdateOp;
 
     use super::*;
 
@@ -642,7 +642,7 @@ mod test {
                 index.to_string(),
                 key.to_string(),
                 vec![UpdateOp::Set {
-                    path: FieldPath("name".to_string()),
+                    path: "name".to_string(),
                     value: Some(serde_json::json!("B")),
                 }],
             )
@@ -658,7 +658,7 @@ mod test {
                 index.to_string(),
                 key.to_string(),
                 vec![UpdateOp::Increment {
-                    path: FieldPath("counter".to_string()),
+                    path: "counter".to_string(),
                     by: 5,
                 }],
             )
@@ -672,7 +672,7 @@ mod test {
                 index.to_string(),
                 key.to_string(),
                 vec![UpdateOp::Decrement {
-                    path: FieldPath("counter".to_string()),
+                    path: "counter".to_string(),
                     by: 2,
                 }],
             )
@@ -686,7 +686,7 @@ mod test {
                 index.to_string(),
                 key.to_string(),
                 vec![UpdateOp::Remove {
-                    path: FieldPath("name".to_string()),
+                    path: "name".to_string(),
                 }],
             )
             .await;
@@ -730,15 +730,15 @@ mod test {
                 key.to_string(),
                 vec![
                     UpdateOp::Set {
-                        path: FieldPath("name".to_string()),
+                        path: "name".to_string(),
                         value: Some(Value::String("Z".to_string())),
                     },
                     UpdateOp::Increment {
-                        path: FieldPath("counter".to_string()),
+                        path: "counter".to_string(),
                         by: 10,
                     },
                     UpdateOp::Set {
-                        path: FieldPath("status".to_string()),
+                        path: "status".to_string(),
                         value: Some(Value::String("active".to_string())),
                     },
                 ],
@@ -760,7 +760,7 @@ mod test {
                 index.to_string(),
                 key.to_string(),
                 vec![UpdateOp::Increment {
-                    path: FieldPath("counter".to_string()),
+                    path: "counter".to_string(),
                     by: 1,
                 }],
             )
@@ -912,7 +912,7 @@ mod test {
                     index.to_string(),
                     key.to_string(),
                     vec![UpdateOp::Increment {
-                        path: FieldPath("counter".to_string()),
+                        path: "counter".to_string(),
                         by: 2,
                     }],
                 );
@@ -929,7 +929,7 @@ mod test {
                         index.to_string(),
                         key.to_string(),
                         vec![UpdateOp::Set {
-                            path: FieldPath("name".to_string()),
+                            path: "name".to_string(),
                             value: Some(Value::String(name)),
                         }],
                     )
@@ -996,11 +996,11 @@ mod test {
                         key.to_string(),
                         vec![
                             UpdateOp::Increment {
-                                path: FieldPath("counter".to_string()),
+                                path: "counter".to_string(),
                                 by: 2,
                             },
                             UpdateOp::Set {
-                                path: FieldPath("name".to_string()),
+                                path: "name".to_string(),
                                 value: Some(Value::String(name)),
                             },
                         ],
@@ -1072,11 +1072,11 @@ mod test {
                         key.to_string(),
                         vec![
                             UpdateOp::Increment {
-                                path: FieldPath("counter".to_string()),
+                                path: "counter".to_string(),
                                 by: 2,
                             },
                             UpdateOp::Set {
-                                path: FieldPath("name".to_string()),
+                                path: "name".to_string(),
                                 value: Some(Value::String(name)),
                             },
                         ],

--- a/engine/src/update_ops.rs
+++ b/engine/src/update_ops.rs
@@ -333,15 +333,15 @@ pub(crate) fn apply_update_ops(
     for (op_index, op) in ops.iter().enumerate() {
         match op {
             UpdateOp::Set { path, value } => {
-                let segments = field_path_segments(&path.0);
+                let segments = field_path_segments(path);
                 if !validate_op_path("set", op_index, segments, &mut errors) {
                     continue;
                 }
-                if path.0.is_empty() {
+                if path.is_empty() {
                     current = value.clone().unwrap_or(Value::Null);
                     using_missing_default = false;
                 } else if let Value::Object(ref mut map) = current {
-                    map.insert(path.0.clone(), value.clone().unwrap_or(Value::Null));
+                    map.insert(path.clone(), value.clone().unwrap_or(Value::Null));
                     using_missing_default = false;
                 } else {
                     errors.push(err(
@@ -349,7 +349,7 @@ pub(crate) fn apply_update_ops(
                         ERR_SET_TARGET_NOT_OBJECT,
                         format!(
                             "Cannot set at path '{}': target is {}, expected object.",
-                            path_label(&path.0),
+                            path_label(path),
                             json_type_name(&current)
                         ),
                     ));
@@ -393,11 +393,11 @@ pub(crate) fn apply_update_ops(
                 }
             }
             UpdateOp::Increment { path, by } => {
-                let segments = field_path_segments(&path.0);
+                let segments = field_path_segments(path);
                 if !validate_op_path("increment", op_index, segments, &mut errors) {
                     continue;
                 }
-                if path.0.is_empty() {
+                if path.is_empty() {
                     if using_missing_default {
                         current = Value::Number(Number::from(*by));
                     } else if let Some(updated) = increment_number(&current, *by) {
@@ -408,7 +408,7 @@ pub(crate) fn apply_update_ops(
                             ERR_INCREMENT_NOT_NUMBER,
                             format!(
                                 "Expected number at path '{}', got {}.",
-                                path_label(&path.0),
+                                path_label(path),
                                 json_type_name(&current)
                             ),
                         ));
@@ -416,7 +416,7 @@ pub(crate) fn apply_update_ops(
                     }
                     using_missing_default = false;
                 } else if let Value::Object(ref mut map) = current {
-                    if let Some(existing_val) = map.get_mut(&path.0) {
+                    if let Some(existing_val) = map.get_mut(path) {
                         if let Some(updated) = increment_number(existing_val, *by) {
                             *existing_val = updated;
                         } else {
@@ -425,14 +425,14 @@ pub(crate) fn apply_update_ops(
                                 ERR_INCREMENT_NOT_NUMBER,
                                 format!(
                                     "Expected number at path '{}', got {}.",
-                                    path_label(&path.0),
+                                    path_label(path),
                                     json_type_name(existing_val)
                                 ),
                             ));
                             continue;
                         }
                     } else {
-                        map.insert(path.0.clone(), Value::Number(Number::from(*by)));
+                        map.insert(path.clone(), Value::Number(Number::from(*by)));
                     }
                     using_missing_default = false;
                 } else {
@@ -441,18 +441,18 @@ pub(crate) fn apply_update_ops(
                         ERR_INCREMENT_TARGET_NOT_OBJECT,
                         format!(
                             "Cannot increment at path '{}': target is {}, expected object.",
-                            path_label(&path.0),
+                            path_label(path),
                             json_type_name(&current)
                         ),
                     ));
                 }
             }
             UpdateOp::Decrement { path, by } => {
-                let segments = field_path_segments(&path.0);
+                let segments = field_path_segments(path);
                 if !validate_op_path("decrement", op_index, segments, &mut errors) {
                     continue;
                 }
-                if path.0.is_empty() {
+                if path.is_empty() {
                     if using_missing_default {
                         current = missing_decrement_value(*by);
                     } else if let Some(updated) = decrement_number(&current, *by) {
@@ -463,7 +463,7 @@ pub(crate) fn apply_update_ops(
                             ERR_DECREMENT_NOT_NUMBER,
                             format!(
                                 "Expected number at path '{}', got {}.",
-                                path_label(&path.0),
+                                path_label(path),
                                 json_type_name(&current)
                             ),
                         ));
@@ -471,7 +471,7 @@ pub(crate) fn apply_update_ops(
                     }
                     using_missing_default = false;
                 } else if let Value::Object(ref mut map) = current {
-                    if let Some(existing_val) = map.get_mut(&path.0) {
+                    if let Some(existing_val) = map.get_mut(path) {
                         if let Some(updated) = decrement_number(existing_val, *by) {
                             *existing_val = updated;
                         } else {
@@ -480,14 +480,14 @@ pub(crate) fn apply_update_ops(
                                 ERR_DECREMENT_NOT_NUMBER,
                                 format!(
                                     "Expected number at path '{}', got {}.",
-                                    path_label(&path.0),
+                                    path_label(path),
                                     json_type_name(existing_val)
                                 ),
                             ));
                             continue;
                         }
                     } else {
-                        map.insert(path.0.clone(), missing_decrement_value(*by));
+                        map.insert(path.clone(), missing_decrement_value(*by));
                     }
                     using_missing_default = false;
                 } else {
@@ -496,7 +496,7 @@ pub(crate) fn apply_update_ops(
                         ERR_DECREMENT_TARGET_NOT_OBJECT,
                         format!(
                             "Cannot decrement at path '{}': target is {}, expected object.",
-                            path_label(&path.0),
+                            path_label(path),
                             json_type_name(&current)
                         ),
                     ));
@@ -569,15 +569,15 @@ pub(crate) fn apply_update_ops(
                 }
             }
             UpdateOp::Remove { path } => {
-                let segments = field_path_segments(&path.0);
+                let segments = field_path_segments(path);
                 if !validate_op_path("remove", op_index, segments, &mut errors) {
                     continue;
                 }
-                if path.0.is_empty() {
+                if path.is_empty() {
                     current = Value::Null;
                     using_missing_default = false;
                 } else if let Value::Object(ref mut map) = current {
-                    map.remove(&path.0);
+                    map.remove(path);
                     using_missing_default = false;
                 } else {
                     errors.push(err(
@@ -585,7 +585,7 @@ pub(crate) fn apply_update_ops(
                         ERR_REMOVE_TARGET_NOT_OBJECT,
                         format!(
                             "Cannot remove at path '{}': target is {}, expected object.",
-                            path_label(&path.0),
+                            path_label(path),
                             json_type_name(&current)
                         ),
                     ));
@@ -656,7 +656,7 @@ fn initial_append_value(value: &Value) -> Value {
 
 #[cfg(test)]
 mod tests {
-    use iii_sdk::{FieldPath, UpdateOp, types::MergePath};
+    use iii_sdk::{UpdateOp, types::MergePath};
     use serde_json::{Number, json};
 
     use super::apply_update_ops;
@@ -963,7 +963,7 @@ mod tests {
         let updated = run(
             Some(json!({ "user.name": ["A"], "user": { "name": ["B"] } })),
             &[UpdateOp::Append {
-                path: Some(FieldPath("user.name".to_string()).into()),
+                path: Some(MergePath::Single("user.name".to_string())),
                 value: json!("C"),
             }],
         );

--- a/engine/src/workers/state/state.rs
+++ b/engine/src/workers/state/state.rs
@@ -991,7 +991,7 @@ mod tests {
             scope: "scope".to_string(),
             key: "k".to_string(),
             ops: vec![iii_sdk::UpdateOp::Set {
-                path: iii_sdk::FieldPath("count".to_string()),
+                path: "count".to_string(),
                 value: Some(serde_json::json!(42)),
             }],
         };

--- a/engine/tests/state_stream_update_e2e.rs
+++ b/engine/tests/state_stream_update_e2e.rs
@@ -19,7 +19,7 @@ async fn fresh_store() -> BuiltinKvStore {
     BuiltinKvStore::new(None)
 }
 
-fn set_op(path: impl Into<iii_sdk::FieldPath>, value: serde_json::Value) -> UpdateOp {
+fn set_op(path: impl Into<String>, value: serde_json::Value) -> UpdateOp {
     UpdateOp::Set {
         path: path.into(),
         value: Some(value),
@@ -653,7 +653,7 @@ async fn append_root_when_state_is_empty_array_pushes_value() {
             SCOPE.to_string(),
             key.clone(),
             vec![UpdateOp::Set {
-                path: iii_sdk::FieldPath::from(""),
+                path: String::new(),
                 value: Some(json!([])),
             }],
         )

--- a/engine/tests/state_stream_update_redis_e2e.rs
+++ b/engine/tests/state_stream_update_redis_e2e.rs
@@ -40,7 +40,7 @@ async fn fresh_key(adapter: &StateRedisAdapter, key: &str) {
 // test (root issue from #1612 was a wire-format divergence).
 fn set_op(path: &str, value: serde_json::Value) -> UpdateOp {
     UpdateOp::Set {
-        path: iii_sdk::FieldPath::from(path),
+        path: path.to_string(),
         value: Some(value),
     }
 }

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -34,10 +34,9 @@ pub use structs::{
 };
 pub use triggers::{Trigger, TriggerConfig, TriggerHandler};
 pub use types::{
-    ApiRequest, ApiResponse, Channel, DeleteResult, FieldPath, MergePath, SetResult,
-    StreamAuthInput, StreamAuthResult, StreamDeleteInput, StreamGetInput, StreamJoinResult,
-    StreamListGroupsInput, StreamListInput, StreamSetInput, StreamUpdateInput, UpdateOp,
-    UpdateOpError, UpdateResult,
+    ApiRequest, ApiResponse, Channel, DeleteResult, SetResult, StreamAuthInput, StreamAuthResult,
+    StreamDeleteInput, StreamGetInput, StreamJoinResult, StreamListGroupsInput, StreamListInput,
+    StreamSetInput, StreamUpdateInput, UpdateOp, UpdateOpError, UpdateResult,
 };
 
 pub use serde_json::Value;

--- a/sdk/packages/rust/iii/src/types.rs
+++ b/sdk/packages/rust/iii/src/types.rs
@@ -19,32 +19,6 @@ pub type RemoteFunctionHandler =
 // Stream Update Types
 // ============================================================================
 
-/// Represents a path to a field in a JSON object
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
-pub struct FieldPath(pub String);
-
-impl FieldPath {
-    pub fn new(path: impl Into<String>) -> Self {
-        Self(path.into())
-    }
-
-    pub fn root() -> Self {
-        Self(String::new())
-    }
-}
-
-impl From<&str> for FieldPath {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}
-
-impl From<String> for FieldPath {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
 /// Path target for a [`UpdateOp::Merge`] operation. Accepts either a
 /// single string (legacy / first-level field) or an array of literal
 /// segments (nested path).
@@ -95,26 +69,12 @@ impl From<Vec<&str>> for MergePath {
     }
 }
 
-// Compatibility shim for callers that constructed paths via `FieldPath`
-// before `Append.path` widened to `Option<MergePath>` in PR #1552-fix.
-// `impl From<FieldPath> for Option<MergePath>` would violate Rust orphan
-// rules (both `From` and `Option` are foreign); call sites needing the
-// `Option` wrapping use `.map(Into::into)` or `Some(fp.into())`.
-impl From<FieldPath> for MergePath {
-    fn from(value: FieldPath) -> Self {
-        Self::Single(value.0)
-    }
-}
-
 /// Operations that can be performed atomically on a stream value
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum UpdateOp {
     /// Set a value at path (overwrite)
-    Set {
-        path: FieldPath,
-        value: Option<Value>,
-    },
+    Set { path: String, value: Option<Value> },
 
     /// Merge object into existing value (object-only). Path may be
     /// omitted (root merge), a single first-level key, or an array of
@@ -126,10 +86,10 @@ pub enum UpdateOp {
     },
 
     /// Increment numeric value
-    Increment { path: FieldPath, by: i64 },
+    Increment { path: String, by: i64 },
 
     /// Decrement numeric value
-    Decrement { path: FieldPath, by: i64 },
+    Decrement { path: String, by: i64 },
 
     /// Append an element to an array or concatenate a string at the
     /// optional path. Path may be omitted (root append), a single
@@ -142,12 +102,12 @@ pub enum UpdateOp {
     },
 
     /// Remove a field
-    Remove { path: FieldPath },
+    Remove { path: String },
 }
 
 impl UpdateOp {
     /// Create a Set operation
-    pub fn set(path: impl Into<FieldPath>, value: impl Into<Option<Value>>) -> Self {
+    pub fn set(path: impl Into<String>, value: impl Into<Option<Value>>) -> Self {
         Self::Set {
             path: path.into(),
             value: value.into(),
@@ -155,7 +115,7 @@ impl UpdateOp {
     }
 
     /// Create an Increment operation
-    pub fn increment(path: impl Into<FieldPath>, by: i64) -> Self {
+    pub fn increment(path: impl Into<String>, by: i64) -> Self {
         Self::Increment {
             path: path.into(),
             by,
@@ -163,7 +123,7 @@ impl UpdateOp {
     }
 
     /// Create a Decrement operation
-    pub fn decrement(path: impl Into<FieldPath>, by: i64) -> Self {
+    pub fn decrement(path: impl Into<String>, by: i64) -> Self {
         Self::Decrement {
             path: path.into(),
             by,
@@ -204,7 +164,7 @@ impl UpdateOp {
     }
 
     /// Create a Remove operation
-    pub fn remove(path: impl Into<FieldPath>) -> Self {
+    pub fn remove(path: impl Into<String>) -> Self {
         Self::Remove { path: path.into() }
     }
 
@@ -518,15 +478,6 @@ mod tests {
                 other => panic!("expected root append for {raw:?}, got {other:?}"),
             }
         }
-    }
-
-    #[test]
-    fn append_field_path_into_merge_path_compat() {
-        // Legacy callers constructed paths via `FieldPath`; the
-        // `From<FieldPath> for MergePath` shim keeps them compiling.
-        let fp = FieldPath::new("legacy");
-        let mp: MergePath = fp.into();
-        assert_eq!(mp, MergePath::Single("legacy".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
Deletes the `FieldPath` newtype from the Rust SDK. It was a transparent wrapper over `String`, so `UpdateOp` Set/Increment/Decrement/Remove paths now take `String` directly — byte-identical on the wire. Removes `FieldPath` and `MergePath` from the crate-root re-export; `MergePath` stays an internal type (it encodes a load-bearing untagged string|array wire union for Merge/Append and cannot collapse). Hard delete, no shim (breaking: `iii_sdk::FieldPath`/`iii_sdk::MergePath` no longer exported).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the `FieldPath`/`MergePath` helpers: update operations (`Set`, `Increment`, `Decrement`, `Remove`) now take plain string paths. Constructor helpers accept impl Into<String>. Update any callers and imports accordingly.
* **Tests**
  * Test helpers and suites updated to use string paths instead of the removed helper types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->