### PR TITLE
fix: clear stale lockfile state for missing manifests

### DIFF
--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -1397,9 +1397,9 @@ fn load_cwd_manifest_dependencies() -> Option<std::collections::BTreeMap<String,
 
 /// Populate [`super::lockfile::WorkerLockfile::manifest_hash`] and
 /// [`super::lockfile::WorkerLockfile::declared_dependencies`] from the
-/// current cwd manifest. No-ops when the manifest is absent, leaving both
-/// fields at whatever they were before (preserves previous writer's
-/// values across incremental `iii worker add` runs).
+/// current cwd manifest. When the manifest is absent (or unreadable via the
+/// downgraded loader), both fields are cleared to `None` so stale lockfile
+/// state does not survive incremental `iii worker add` runs.
 fn populate_manifest_hash_fields(lockfile: &mut super::lockfile::WorkerLockfile) {
     let Some(deps) = load_cwd_manifest_dependencies() else {
         // FIX: If the manifest is missing, we MUST clear any stale lockfile 

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -1402,8 +1402,13 @@ fn load_cwd_manifest_dependencies() -> Option<std::collections::BTreeMap<String,
 /// values across incremental `iii worker add` runs).
 fn populate_manifest_hash_fields(lockfile: &mut super::lockfile::WorkerLockfile) {
     let Some(deps) = load_cwd_manifest_dependencies() else {
+        // FIX: If the manifest is missing, we MUST clear any stale lockfile 
+        // state so the engine doesn't crash expecting a ghost file.
+        lockfile.manifest_hash = None;
+        lockfile.declared_dependencies = None;
         return;
     };
+    
     lockfile.manifest_hash = Some(super::sync::compute_manifest_hash(&deps));
     lockfile.declared_dependencies = Some(deps);
 }


### PR DESCRIPTION
## What

Updates `populate_manifest_hash_fields` in `managed.rs` to actively scrub `manifest_hash` and `declared_dependencies` (setting them to `None`) when the local manifest is not found.

## Why

When a local `iii.worker.yaml` file was deleted, the engine bailed out early via a `return` statement. This left a stale ("ghost") `manifest_hash` inside the lockfile in memory. Upon saving, the engine persisted this ghost hash. Subsequent commands saw the hash, tried to verify the nonexistent local manifest, and triggered a `ManifestMissing` panic. This patch ensures the lockfile correctly reflects the actual filesystem state.

## Notes

Tested locally: Replicated the crash by generating a lockfile, deleting the local manifest, and running an add command. After applying this patch, the engine correctly bypassed the panic, scrubbed the stale lockfile fields, and proceeded normally.

> **Note to maintainers:** I actually ran into this lockfile corruption bug locally while trying to reproduce Issue #1723! I realized #1723 is a separate registry/dependency issue, but I wanted to go ahead and submit the fix for this lockfile panic since it was blocking the CLI flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where stale dependency cache data persisted across incremental builds when manifest configuration was missing or invalid, ensuring accurate updates on each run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->