### PR TITLE
refactor(python-sdk)!: delete IIIForbiddenError/IIITimeoutError

### DIFF
--- a/docs/next/sdk-reference/python-sdk.mdx
+++ b/docs/next/sdk-reference/python-sdk.mdx
@@ -128,17 +128,16 @@ TriggerAction.Enqueue(queue="math")   # route through iii-queue; returns Trigger
 
 ## Error types
 
-The base class is `IIIInvocationError`. The SDK's wire-error decoder maps engine error codes to
-two known subclasses; everything else stays on the base class:
+Every invocation failure raises `IIIInvocationError`. Inspect its `code` attribute to
+distinguish categories:
 
-| Class                | When raised                       |
-| -------------------- | --------------------------------- |
-| `IIIInvocationError` | Any engine-side invocation error. |
-| `IIIForbiddenError`  | `code == "FORBIDDEN"` (RBAC).     |
-| `IIITimeoutError`    | `code == "TIMEOUT"`.              |
+| `code`        | When raised                       |
+| ------------- | --------------------------------- |
+| `"FORBIDDEN"` | RBAC denied the invocation.       |
+| `"TIMEOUT"`   | The invocation timed out.         |
+| other         | Any other engine-side rejection.  |
 
-All three are exported. The base class has `code`, `message`, `function_id`, and `stacktrace`
-attributes.
+`IIIInvocationError` has `code`, `message`, `function_id`, and `stacktrace` attributes.
 
 ## Channels
 

--- a/docs/next/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/python-sdk.mdx.skill.md
@@ -126,17 +126,16 @@ TriggerAction.Enqueue(queue="math")   # route through iii-queue; returns Trigger
 
 ## Error types
 
-The base class is `IIIInvocationError`. The SDK's wire-error decoder maps engine error codes to
-two known subclasses; everything else stays on the base class:
+Every invocation failure raises `IIIInvocationError`. Inspect its `code` attribute to
+distinguish categories:
 
-| Class                | When raised                       |
-| -------------------- | --------------------------------- |
-| `IIIInvocationError` | Any engine-side invocation error. |
-| `IIIForbiddenError`  | `code == "FORBIDDEN"` (RBAC).     |
-| `IIITimeoutError`    | `code == "TIMEOUT"`.              |
+| `code`        | When raised                       |
+| ------------- | --------------------------------- |
+| `"FORBIDDEN"` | RBAC denied the invocation.       |
+| `"TIMEOUT"`   | The invocation timed out.         |
+| other         | Any other engine-side rejection.  |
 
-All three are exported. The base class has `code`, `message`, `function_id`, and `stacktrace`
-attributes.
+`IIIInvocationError` has `code`, `message`, `function_id`, and `stacktrace` attributes.
 
 ## Channels
 

--- a/sdk/packages/python/iii/src/iii/__init__.py
+++ b/sdk/packages/python/iii/src/iii/__init__.py
@@ -28,7 +28,7 @@ from iii_observability import (
 )
 
 from .channels import ChannelReader, ChannelWriter
-from .errors import IIIForbiddenError, IIIInvocationError, IIITimeoutError
+from .errors import IIIInvocationError
 from .format_utils import extract_request_format, extract_response_format, python_type_to_format
 from .iii import TriggerAction, register_worker
 from .iii_constants import FunctionRef, InitOptions, TelemetryOptions
@@ -106,9 +106,7 @@ __all__ = [
     "ChannelReader",
     "ChannelWriter",
     # Errors
-    "IIIForbiddenError",
     "IIIInvocationError",
-    "IIITimeoutError",
     # Core
     "FunctionRef",
     "InitOptions",

--- a/sdk/packages/python/iii/src/iii/errors.py
+++ b/sdk/packages/python/iii/src/iii/errors.py
@@ -6,13 +6,10 @@ from typing import Any
 class IIIInvocationError(Exception):
     """Raised when an invocation dispatched by the SDK fails.
 
-    Subclass by code:
-      - ``IIIForbiddenError``  (``code == 'FORBIDDEN'``)
-      - ``IIITimeoutError``    (``code == 'TIMEOUT'``)
-
-    Catch the base to handle every rejection; catch a subclass to react to
-    a specific category. ``except Exception`` continues to work because
-    ``IIIInvocationError`` inherits from ``Exception``.
+    Inspect ``err.code`` to react to a specific category (e.g.
+    ``'FORBIDDEN'`` for RBAC denials, ``'TIMEOUT'`` for timeouts). Catch
+    this class to handle every rejection. ``except Exception`` continues to
+    work because ``IIIInvocationError`` inherits from ``Exception``.
 
     Attributes are read-only after construction. ``stacktrace`` is the
     engine-side trace when the remote handler raised; it may include
@@ -36,26 +33,18 @@ class IIIInvocationError(Exception):
         self.invocation_id = invocation_id
 
 
-class IIIForbiddenError(IIIInvocationError):
-    """Raised when RBAC denies an invocation. ``code == 'FORBIDDEN'``."""
-
-
-class IIITimeoutError(IIIInvocationError):
-    """Raised when an invocation exceeds its timeout. ``code == 'TIMEOUT'``."""
-
-
 def _wrap_wire_error(
     error: Any,
     *,
     function_id: str | None,
     invocation_id: str | None,
 ) -> IIIInvocationError:
-    """Convert a wire ``ErrorBody``-shaped dict into a typed exception.
+    """Convert a wire ``ErrorBody``-shaped dict into an ``IIIInvocationError``.
 
-    Dispatches to ``IIIForbiddenError`` / ``IIITimeoutError`` based on
-    ``error['code']``. Malformed shapes (non-dict, missing fields, non-string
-    values) fall back to ``IIIInvocationError(code='UNKNOWN', ...)`` so no
-    rejection path prints as a raw dict repr.
+    The ``code`` field distinguishes categories (e.g. ``'FORBIDDEN'``,
+    ``'TIMEOUT'``). Malformed shapes (non-dict, missing fields, non-string
+    values) fall back to ``code='UNKNOWN'`` so no rejection path prints as a
+    raw dict repr.
     """
     if isinstance(error, dict):
         raw_code = error.get("code")
@@ -67,12 +56,7 @@ def _wrap_wire_error(
         raw_stacktrace = error.get("stacktrace")
         stacktrace = raw_stacktrace if isinstance(raw_stacktrace, str) else None
 
-        cls: type[IIIInvocationError] = {
-            "FORBIDDEN": IIIForbiddenError,
-            "TIMEOUT": IIITimeoutError,
-        }.get(code, IIIInvocationError)
-
-        return cls(
+        return IIIInvocationError(
             code=code,
             message=message,
             function_id=function_id,

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -18,7 +18,7 @@ from iii_observability import OtelConfig
 from websockets.asyncio.client import ClientConnection
 
 from .channels import ChannelReader, ChannelWriter
-from .errors import IIIInvocationError, IIITimeoutError, _wrap_wire_error
+from .errors import IIIInvocationError, _wrap_wire_error
 from .format_utils import extract_request_format, extract_response_format
 from .iii_constants import (
     DEFAULT_RECONNECTION_CONFIG,
@@ -1073,9 +1073,9 @@ class III:
             actions.
 
         Raises:
-            IIITimeoutError: If the invocation times out. ``code == 'TIMEOUT'``.
-            IIIForbiddenError: If RBAC denies the invocation. ``code == 'FORBIDDEN'``.
-            IIIInvocationError: For any other engine rejection.
+            IIIInvocationError: For any engine rejection. Inspect ``code``:
+                ``'TIMEOUT'`` if the invocation timed out, ``'FORBIDDEN'`` if
+                RBAC denied it.
 
         Examples:
             >>> result = iii.trigger({'function_id': 'greet', 'payload': {'name': 'World'}})
@@ -1100,9 +1100,9 @@ class III:
             The result of the function invocation, or ``None`` for void calls.
 
         Raises:
-            IIITimeoutError: If the invocation times out. ``code == 'TIMEOUT'``.
-            IIIForbiddenError: If RBAC denies the invocation. ``code == 'FORBIDDEN'``.
-            IIIInvocationError: For any other engine rejection.
+            IIIInvocationError: For any engine rejection. Inspect ``code``:
+                ``'TIMEOUT'`` if the invocation timed out, ``'FORBIDDEN'`` if
+                RBAC denied it.
 
         Examples:
             >>> result = await iii.trigger_async({'function_id': 'greet', 'payload': {'name': 'World'}})
@@ -1163,7 +1163,7 @@ class III:
             return await asyncio.wait_for(future, timeout=timeout_secs)
         except asyncio.TimeoutError:
             self._pending.pop(invocation_id, None)
-            raise IIITimeoutError(
+            raise IIIInvocationError(
                 code="TIMEOUT",
                 message=f"invocation timed out after {timeout_ms}ms",
                 function_id=function_id,

--- a/sdk/packages/python/iii/tests/test_errors.py
+++ b/sdk/packages/python/iii/tests/test_errors.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from iii import IIIForbiddenError, IIIInvocationError, IIITimeoutError
+from iii import IIIInvocationError
 from iii.errors import _wrap_wire_error
 
 
@@ -57,34 +57,19 @@ class TestIIIInvocationError:
         assert str(err) == "TIMEOUT: gone"
 
 
-class TestSubclassHierarchy:
-    def test_forbidden_is_invocation_error(self) -> None:
-        err = IIIForbiddenError(code="FORBIDDEN", message="x")
-        assert isinstance(err, IIIInvocationError)
-        assert isinstance(err, IIIForbiddenError)
-        assert isinstance(err, Exception)
+class TestCodeDiscrimination:
+    def test_categories_discriminated_by_code(self) -> None:
+        """Categories are distinguished by ``code``, not by subclass."""
+        for code in ("FORBIDDEN", "TIMEOUT", "UNKNOWN"):
+            err = IIIInvocationError(code=code, message="x")
+            assert isinstance(err, IIIInvocationError)
+            assert isinstance(err, Exception)
+            assert err.code == code
 
-    def test_timeout_is_invocation_error(self) -> None:
-        err = IIITimeoutError(code="TIMEOUT", message="x")
-        assert isinstance(err, IIIInvocationError)
-        assert isinstance(err, IIITimeoutError)
-        assert isinstance(err, Exception)
-
-    def test_except_ordering_catches_subclass_first(self) -> None:
-        """`except IIIForbiddenError` fires before `except IIIInvocationError`."""
-        caught: str | None = None
-        try:
-            raise IIIForbiddenError(code="FORBIDDEN", message="x")
-        except IIIForbiddenError:
-            caught = "forbidden"
-        except IIIInvocationError:
-            caught = "base"
-        assert caught == "forbidden"
-
-    def test_base_catches_every_subclass(self) -> None:
+    def test_base_catches_every_category(self) -> None:
         for err in (
-            IIIForbiddenError(code="FORBIDDEN", message="x"),
-            IIITimeoutError(code="TIMEOUT", message="x"),
+            IIIInvocationError(code="FORBIDDEN", message="x"),
+            IIIInvocationError(code="TIMEOUT", message="x"),
             IIIInvocationError(code="UNKNOWN", message="x"),
         ):
             try:
@@ -95,30 +80,30 @@ class TestSubclassHierarchy:
     def test_except_exception_still_works(self) -> None:
         """Migration guarantee: existing `except Exception:` handlers still catch."""
         try:
-            raise IIIForbiddenError(code="FORBIDDEN", message="x")
+            raise IIIInvocationError(code="FORBIDDEN", message="x")
         except Exception as got:
             assert isinstance(got, IIIInvocationError)
 
 
 class TestWrapWireError:
-    def test_forbidden_dict_dispatches_to_forbidden_error(self) -> None:
+    def test_forbidden_dict_sets_forbidden_code(self) -> None:
         err = _wrap_wire_error(
             {"code": "FORBIDDEN", "message": "not allowed"},
             function_id="engine::functions::list",
             invocation_id="inv-1",
         )
-        assert isinstance(err, IIIForbiddenError)
+        assert type(err) is IIIInvocationError
         assert err.code == "FORBIDDEN"
         assert err.function_id == "engine::functions::list"
         assert err.invocation_id == "inv-1"
 
-    def test_timeout_dict_dispatches_to_timeout_error(self) -> None:
+    def test_timeout_dict_sets_timeout_code(self) -> None:
         err = _wrap_wire_error(
             {"code": "TIMEOUT", "message": "gone"},
             function_id="api::slow",
             invocation_id=None,
         )
-        assert isinstance(err, IIITimeoutError)
+        assert type(err) is IIIInvocationError
         assert err.code == "TIMEOUT"
 
     def test_unknown_code_falls_back_to_base(self) -> None:

--- a/sdk/packages/python/iii/tests/test_rbac_workers.py
+++ b/sdk/packages/python/iii/tests/test_rbac_workers.py
@@ -8,7 +8,6 @@ import pytest
 from iii import (
     AuthInput,
     AuthResult,
-    IIIForbiddenError,
     IIIInvocationError,
     InitOptions,
     MiddlewareFunctionInput,
@@ -350,22 +349,21 @@ class TestRbacWorkers:
             iii_client.shutdown()
 
     def test_forbidden_wrapped_as_typed_error(self, iii_server):
-        """FORBIDDEN rejections surface as IIIForbiddenError with function_id set
-        and the engine's remediation phrase in the message."""
+        """FORBIDDEN rejections surface as IIIInvocationError (code='FORBIDDEN')
+        with function_id set and the engine's remediation phrase in the message."""
         iii_client = register_worker(
             EW_URL,
             InitOptions(otel={"enabled": False}, headers={"x-test-token": "valid-token"}),
         )
 
         try:
-            with pytest.raises(IIIForbiddenError) as excinfo:
+            with pytest.raises(IIIInvocationError) as excinfo:
                 iii_client.trigger({
                     "function_id": "test::ew::private",
                     "payload": {},
                 })
 
             err = excinfo.value
-            assert isinstance(err, IIIInvocationError)  # base class
             assert err.code == "FORBIDDEN"
             assert err.function_id == "test::ew::private"
             assert "FORBIDDEN" in str(err)
@@ -432,7 +430,7 @@ class TestRbacWorkers:
         try:
             def handler(data: dict) -> dict:
                 # If the carve-out regresses, this nested trigger surfaces
-                # IIIForbiddenError and the handler propagates it as a failure.
+                # IIIInvocationError (code='FORBIDDEN') and the handler propagates it as a failure.
                 iii_client.trigger({
                     "function_id": "engine::log::info",
                     "payload": {
@@ -473,7 +471,7 @@ class TestRbacWorkers:
 
         try:
             # No exception == carve-out is working. If this raises
-            # IIIForbiddenError, the carve-out regressed.
+            # IIIInvocationError (code='FORBIDDEN'), the carve-out regressed.
             iii_client.trigger({
                 "function_id": "engine::log::info",
                 "payload": {"message": "carve-out direct invocation"},


### PR DESCRIPTION
Deletes the `IIIForbiddenError` and `IIITimeoutError` subclasses from the Python SDK. Every invocation failure now raises the base `IIIInvocationError`; inspect `err.code` (`'FORBIDDEN'`, `'TIMEOUT'`, …) to distinguish categories — matching the Node and Rust SDKs. The wire-error decoder and the timeout path build the base class with `code` set. Hard delete, no shim (breaking: the two names are no longer importable from `iii`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * All invocation failures now raise a unified error type. Use the error's `code` attribute to distinguish categories: `"FORBIDDEN"` for access denial, `"TIMEOUT"` for timeout conditions, and other values for engine-side rejections.

* **Documentation**
  * Updated Python SDK error documentation with the new unified error approach, attribute reference, and categorization guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->