### PR TITLE
refactor(rust-sdk)!: remove orphan TriggerTypeInfo

### DIFF
--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -86,17 +86,6 @@ pub struct TriggerInfo {
     pub metadata: Option<Value>,
 }
 
-/// Trigger type information returned by `engine::trigger-types::list`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TriggerTypeInfo {
-    pub id: String,
-    pub description: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub trigger_request_format: Option<Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub call_request_format: Option<Value>,
-}
-
 /// Builder for registering a custom trigger type with optional format schemas.
 ///
 /// Type parameters:

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -18,7 +18,7 @@ pub use channels::{ChannelReader, ChannelWriter, StreamChannelRef};
 pub use error::IIIError;
 pub use iii::{
     FunctionInfo, FunctionRef, III, IIIConnectionState, RegisterFunction, RegisterTriggerType,
-    TriggerInfo, TriggerTypeInfo, TriggerTypeRef, WorkerInfo, WorkerMetadata,
+    TriggerInfo, TriggerTypeRef, WorkerInfo, WorkerMetadata,
 };
 pub use protocol::{
     EnqueueResult, ErrorBody, FunctionMessage, HttpAuthConfig, HttpInvocationConfig, HttpMethod,


### PR DESCRIPTION
Removes the `TriggerTypeInfo` struct from the Rust SDK. It is an orphan: no producer or consumer in any SDK, engine, or example — its endpoint `engine::trigger-types::list` was removed (trigger types are now served by `engine::triggers::list` -> `TriggerInfo`). Deletes the struct and its crate-root re-export. Hard delete, no shim (breaking: `iii_sdk::TriggerTypeInfo` no longer exported).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed a public API component from the Rust SDK. Code that depends on this component for response data will require updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->