### PR TITLE
refactor(node-sdk,python-sdk)!: drop Logger re-export

### DIFF
--- a/docs/next/sdk-reference/node-sdk.mdx
+++ b/docs/next/sdk-reference/node-sdk.mdx
@@ -147,9 +147,9 @@ Node `Readable` plus `.sendMessage()` and `.onMessage()`; `ChannelWriter` expose
 ## Logger
 
 `Logger` is a runtime class with `info`, `warn`, `error`, and `debug` methods, each
-`(message: string, data?: unknown) => void`. The output integrates with the SDK's OpenTelemetry
-setup; see iii-observability for the export
-side.
+`(message: string, data?: unknown) => void`. Import it from `@iii-dev/observability`; it is no
+longer re-exported from `iii-sdk`. The output integrates with the SDK's OpenTelemetry setup; see
+iii-observability for the export side.
 
 ## Info types
 

--- a/docs/next/sdk-reference/node-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/node-sdk.mdx.skill.md
@@ -145,9 +145,9 @@ Node `Readable` plus `.sendMessage()` and `.onMessage()`; `ChannelWriter` expose
 ## Logger
 
 `Logger` is a runtime class with `info`, `warn`, `error`, and `debug` methods, each
-`(message: string, data?: unknown) => void`. The output integrates with the SDK's OpenTelemetry
-setup; see iii-observability for the export
-side.
+`(message: string, data?: unknown) => void`. Import it from `@iii-dev/observability`; it is no
+longer re-exported from `iii-sdk`. The output integrates with the SDK's OpenTelemetry setup; see
+iii-observability for the export side.
 
 ## Info types
 

--- a/docs/next/sdk-reference/python-sdk.mdx
+++ b/docs/next/sdk-reference/python-sdk.mdx
@@ -157,8 +157,8 @@ Both classes are constructed with the engine's WS base URL and a `StreamChannelR
 ## Logger
 
 `Logger` exposes `info`, `warn`, `error`, and `debug`, each accepting a message and an optional
-data dict. The output integrates with the SDK's OpenTelemetry setup; see
-iii-observability for the export side.
+data dict. Import it from `iii_observability`; it is no longer re-exported from `iii`. The output
+integrates with the SDK's OpenTelemetry setup; see iii-observability for the export side.
 
 ## Info types
 

--- a/docs/next/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/python-sdk.mdx.skill.md
@@ -155,8 +155,8 @@ Both classes are constructed with the engine's WS base URL and a `StreamChannelR
 ## Logger
 
 `Logger` exposes `info`, `warn`, `error`, and `debug`, each accepting a message and an optional
-data dict. The output integrates with the SDK's OpenTelemetry setup; see
-iii-observability for the export side.
+data dict. Import it from `iii_observability`; it is no longer re-exported from `iii`. The output
+integrates with the SDK's OpenTelemetry setup; see iii-observability for the export side.
 
 ## Info types
 

--- a/sdk/packages/node/iii/src/index.ts
+++ b/sdk/packages/node/iii/src/index.ts
@@ -28,8 +28,6 @@ export type {
   TriggerRequest,
 } from './iii-types'
 
-export { Logger } from '@iii-dev/observability'
-
 export type { TriggerConfig, TriggerHandler } from './triggers'
 
 export type {

--- a/sdk/packages/node/iii/tests/bridge-utils.ts
+++ b/sdk/packages/node/iii/tests/bridge-utils.ts
@@ -1,4 +1,5 @@
-import { registerWorker, Logger } from '../src/index'
+import { Logger } from '@iii-dev/observability'
+import { registerWorker } from '../src/index'
 
 const BRIDGE_WS_URL = process.env.III_BRIDGE_WS_URL ?? 'ws://localhost:49197'
 const RETRY_LIMIT = 100

--- a/sdk/packages/node/iii/tests/exports.test.ts
+++ b/sdk/packages/node/iii/tests/exports.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest'
-import { registerWorker, Logger } from '../src/index'
+import { registerWorker } from '../src/index'
 import { iii } from './utils'
 
 beforeAll(() => {
@@ -10,7 +10,6 @@ describe('Package Exports', () => {
   it('should export main SDK symbols', () => {
     expect(registerWorker).toBeDefined()
     expect(typeof registerWorker).toBe('function')
-    expect(Logger).toBeDefined()
   })
 
   it('should import stream module', async () => {

--- a/sdk/packages/node/iii/tests/logger-runtime.test.ts
+++ b/sdk/packages/node/iii/tests/logger-runtime.test.ts
@@ -43,8 +43,8 @@ beforeEach(() => emit.mockReset())
 
 it('keeps an active span context for handlers when tracer setup is disabled', async () => {
   vi.resetModules()
-  const { registerWorker, Logger } = await import('../src/index')
-  const { initOtel, shutdownOtel } = await import('@iii-dev/observability')
+  const { registerWorker } = await import('../src/index')
+  const { initOtel, shutdownOtel, Logger } = await import('@iii-dev/observability')
 
   // Register the AsyncLocalStorage context manager so that context.with
   // (used by the synthetic-span code path in iii.ts) correctly propagates

--- a/sdk/packages/node/iii/tests/utils.ts
+++ b/sdk/packages/node/iii/tests/utils.ts
@@ -1,5 +1,6 @@
 // import { iii } from 'iii-sdk'
-import { registerWorker, Logger } from '../src/index'
+import { Logger } from '@iii-dev/observability'
+import { registerWorker } from '../src/index'
 
 const ENGINE_WS_URL = process.env.III_URL ?? 'ws://localhost:49199'
 const ENGINE_HTTP_URL = process.env.III_HTTP_URL ?? 'http://localhost:3199'

--- a/sdk/packages/python/iii/src/iii/__init__.py
+++ b/sdk/packages/python/iii/src/iii/__init__.py
@@ -4,7 +4,6 @@ from iii_observability import (
     DEFAULT_ALLOWLIST,
     REDACTED_PLACEHOLDER,
     BaggageSpanProcessor,
-    Logger,
     OtelConfig,
     ReconnectionConfig,
     current_span_id,
@@ -142,8 +141,6 @@ __all__ = [
     "TriggerActionEnqueue",
     "TriggerActionVoid",
     "TriggerRequest",
-    # Logger
-    "Logger",
     # Triggers
     "Trigger",
     "TriggerConfig",

--- a/sdk/packages/python/iii/uv.lock
+++ b/sdk/packages/python/iii/uv.lock
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "iii-observability"
-version = "0.16.0.dev3"
+version = "0.18.0"
 source = { editable = "../observability" }
 dependencies = [
     { name = "httpx" },
@@ -572,7 +572,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "iii-sdk"
-version = "0.16.0.dev3"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "iii-observability" },


### PR DESCRIPTION
Removes the `Logger` re-export from the Node (`iii-sdk`) and Python (`iii`) packages. `Logger` already lives in the observability package — import it from `@iii-dev/observability` (Node) / `iii_observability` (Python). Internal logging is unaffected (Node uses `getLogger`; Python imports from `iii_observability` directly). Test helpers repointed. Hard delete, no shim (breaking).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Logger is no longer re-exported from the SDK. Import it from `@iii-dev/observability` (Node.js) or iii_observability (Python).

* **Documentation**
  * Updated SDK reference guides to clarify the new import location for Logger and its continued integration with the SDK’s OpenTelemetry setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->