### PR TITLE
refactor(python-sdk)!: drop OTel suite re-export

### DIFF
--- a/sdk/packages/python/iii/src/iii/__init__.py
+++ b/sdk/packages/python/iii/src/iii/__init__.py
@@ -1,31 +1,5 @@
 """III SDK for Python."""
 
-from iii_observability import (
-    DEFAULT_ALLOWLIST,
-    REDACTED_PLACEHOLDER,
-    BaggageSpanProcessor,
-    OtelConfig,
-    ReconnectionConfig,
-    current_span_id,
-    current_span_is_recording,
-    current_trace_id,
-    execute_traced_request,
-    extract_baggage,
-    extract_traceparent,
-    flush_otel,
-    init_otel,
-    inject_baggage,
-    inject_traceparent,
-    record_span_event,
-    redact,
-    redact_and_truncate,
-    resolve_max_bytes_from_env,
-    set_current_span_attribute,
-    set_current_span_error,
-    shutdown_otel,
-    with_span,
-)
-
 from .channels import ChannelReader, ChannelWriter
 from .errors import IIIInvocationError
 from .format_utils import extract_request_format, extract_response_format, python_type_to_format
@@ -79,28 +53,6 @@ from .types import (
 from .utils import http
 
 __all__ = [
-    # Telemetry helpers
-    "BaggageSpanProcessor",
-    "DEFAULT_ALLOWLIST",
-    "REDACTED_PLACEHOLDER",
-    "current_span_id",
-    "current_span_is_recording",
-    "current_trace_id",
-    "execute_traced_request",
-    "extract_baggage",
-    "extract_traceparent",
-    "flush_otel",
-    "init_otel",
-    "inject_baggage",
-    "inject_traceparent",
-    "record_span_event",
-    "redact",
-    "redact_and_truncate",
-    "resolve_max_bytes_from_env",
-    "set_current_span_attribute",
-    "set_current_span_error",
-    "shutdown_otel",
-    "with_span",
     # Channels
     "ChannelReader",
     "ChannelWriter",
@@ -109,8 +61,6 @@ __all__ = [
     # Core
     "FunctionRef",
     "InitOptions",
-    "OtelConfig",
-    "ReconnectionConfig",
     "register_worker",
     "TelemetryOptions",
     "TriggerAction",


### PR DESCRIPTION
Removes the ~23 OpenTelemetry symbols re-exported from the Python `iii` package root (span/trace helpers, redaction utils, init/flush/shutdown, baggage/traceparent, plus `OtelConfig` and `ReconnectionConfig`). They already live in `iii_observability` — import them from there. Internal code is unaffected (it already imports from `iii_observability` directly). No test imports any removed symbol from `iii`. Hard delete, no shim (breaking). Note: touches the same `__init__.py` as PR 0.4 and 0.7; whichever merges last may need a trivial conflict resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Observability and telemetry utilities have been removed from the package public surface: tracing, span context helpers, OTEL setup/shutdown, baggage/trace helpers, redaction utilities, and bundled logger/config exports are no longer available.
  * Update your imports to the dedicated observability package or refactor code paths if you relied on these utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->