### PR TITLE
feat(observability): deduplicate OTEL spans across engine and worker SDKs

### DIFF
--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -468,23 +468,14 @@ impl Engine {
         baggage: &Option<String>,
         invocation_id: Option<Uuid>,
     ) {
-        let span = {
-            // Parent context must be on `Context::current()` BEFORE span
-            // creation so `SpanProcessor::on_start` sees the baggage;
-            // `set_parent` after creation runs too late.
-            let parent_cx =
-                crate::telemetry::extract_context(traceparent.as_deref(), baggage.as_deref());
-            let _guard = parent_cx.attach();
-            tracing::info_span!(
-                "handle_invocation",
-                otel.name = %format!("handle_invocation {}", function_id),
-                worker_id = %worker.id,
-                function_id = %function_id,
-                invocation_id = %crate::logging::display_option(&invocation_id),
-                otel.kind = "server",
-                otel.status_code = tracing::field::Empty,
-            )
-        };
+        // The canonical engine span for an invocation is the `call <fn>` span
+        // opened in `InvocationHandler::handle_invocation`. We intentionally do
+        // NOT open a separate `handle_invocation` span here: it produced a
+        // redundant second engine SERVER span for every worker-initiated call
+        // (`handle_invocation <fn>` -> `call <fn>`), doubling engine span
+        // volume. A disabled span keeps the instrumented task structure intact
+        // while emitting nothing.
+        let span = tracing::Span::none();
 
         let engine = self.clone();
         let worker = worker.clone();
@@ -503,13 +494,11 @@ impl Engine {
         };
         let incoming_traceparent = traceparent.clone();
         let incoming_baggage = baggage.clone();
-        // Derive headers from the span we just opened so the downstream
-        // `call <fn>` becomes a child of `handle_invocation`, not a
-        // sibling of the original caller.
-        let downstream_traceparent =
-            inject_traceparent_from_context(&span.context()).or_else(|| traceparent.clone());
-        let downstream_baggage =
-            inject_baggage_from_context(&span.context()).or_else(|| baggage.clone());
+        // Pass the incoming caller context straight through so the downstream
+        // `call <fn>` span nests directly under the caller's span instead of an
+        // intermediate engine wrapper.
+        let downstream_traceparent = traceparent.clone();
+        let downstream_baggage = baggage.clone();
 
         tokio::spawn(
             async move {

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -1000,6 +1000,13 @@ impl Engine {
                                 traceparent.as_deref(),
                                 baggage.as_deref(),
                             );
+                            // The enqueuer's baggage names the enqueuer; rewrite
+                            // `iii.function.id` to the function being enqueued so
+                            // `BaggageSpanProcessor` stamps this span with the
+                            // target, not the caller (the `fn_queue` consumer span
+                            // gets the same correction via the stored baggage).
+                            let parent_cx =
+                                crate::telemetry::with_function_id_baggage(&parent_cx, &function_id);
                             let _guard = parent_cx.attach();
                             tracing::info_span!(
                                 "enqueue_action",

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -1005,8 +1005,10 @@ impl Engine {
                             // `BaggageSpanProcessor` stamps this span with the
                             // target, not the caller (the `fn_queue` consumer span
                             // gets the same correction via the stored baggage).
-                            let parent_cx =
-                                crate::telemetry::with_function_id_baggage(&parent_cx, &function_id);
+                            let parent_cx = crate::telemetry::with_function_id_baggage(
+                                &parent_cx,
+                                &function_id,
+                            );
                             let _guard = parent_cx.attach();
                             tracing::info_span!(
                                 "enqueue_action",

--- a/engine/src/invocation/mod.rs
+++ b/engine/src/invocation/mod.rs
@@ -11,6 +11,7 @@ use opentelemetry::KeyValue;
 use serde_json::Value;
 use tokio::sync::oneshot::{self, error::RecvError};
 use tracing::Instrument;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
 
 use crate::telemetry::SpanExt;
@@ -85,28 +86,62 @@ impl InvocationHandler {
     ) -> Result<Result<Option<Value>, ErrorBody>, RecvError> {
         // Create span with dynamic name using the function_id
         // Using OTEL semantic conventions for FaaS (Function as a Service)
-        let function_kind = if crate::workers::telemetry::is_iii_builtin_function_id(&function_id) {
-            "internal"
+        let is_builtin = crate::workers::telemetry::is_iii_builtin_function_id(&function_id);
+
+        // Decide whether the ENGINE emits its own `call <fn>` span here:
+        //   - Built-in functions (`state::*`, `stream::*`, `engine::*`,
+        //     `configuration::*`, `iii::*`, …) are executed in-process by the
+        //     engine and fire at high frequency — little trace value, high
+        //     volume. Suppressed by default; re-enable with
+        //     `III_OTEL_TRACE_BUILTINS=true`.
+        //   - Worker-routed (non-builtin) functions are executed by an external
+        //     worker that emits its OWN `call <fn>` span (service = that
+        //     worker). The engine's span would be a cross-service duplicate of
+        //     the same logical invocation, so suppress it and let the worker's
+        //     span be the canonical one.
+        let suppress_span = if is_builtin {
+            !crate::workers::telemetry::trace_builtins_enabled()
         } else {
-            "user"
+            true
         };
 
-        let span = tracing::info_span!(
-            "call",
-            otel.name = %format!("call {}", function_id),
-            otel.kind = "server",
-            otel.status_code = tracing::field::Empty,
-            // FAAS semantic conventions (https://opentelemetry.io/docs/specs/semconv/faas/)
-            "faas.invoked_name" = %function_id,
-            "faas.trigger" = "other",  // III Engine uses its own invocation mechanism
-            // Keep function_id for backward compatibility
-            function_id = %function_id,
-            // Tag internal vs user functions for filtering
-            "iii.function.kind" = %function_kind,
-        )
-        .with_parent_headers(traceparent.as_deref(), baggage.as_deref());
+        let span = if suppress_span {
+            tracing::Span::none()
+        } else {
+            tracing::info_span!(
+                "call",
+                otel.name = %format!("call {}", function_id),
+                otel.kind = "server",
+                otel.status_code = tracing::field::Empty,
+                // FAAS semantic conventions (https://opentelemetry.io/docs/specs/semconv/faas/)
+                "faas.invoked_name" = %function_id,
+                "faas.trigger" = "other",  // III Engine uses its own invocation mechanism
+                // Keep function_id for backward compatibility
+                function_id = %function_id,
+                // Tag internal vs user functions for filtering
+                "iii.function.kind" = if is_builtin { "internal" } else { "user" },
+            )
+            .with_parent_headers(traceparent.as_deref(), baggage.as_deref())
+        };
 
-        async {
+        // When the engine span is suppressed for a worker-routed call there is
+        // no tracing span left to carry the caller's trace context across the
+        // WS boundary to the worker. Attach the caller context as the ambient
+        // OTel context for the dispatch so the worker's own span (and its
+        // descendants) nest under the caller's trace instead of starting a new,
+        // orphaned one. `WorkerConnection::handle_function` falls back to this
+        // ambient context when the active tracing span carries none (see
+        // `worker_connections/traits.rs`).
+        let dispatch_cx = if !is_builtin && (traceparent.is_some() || baggage.is_some()) {
+            Some(crate::telemetry::extract_context(
+                traceparent.as_deref(),
+                baggage.as_deref(),
+            ))
+        } else {
+            None
+        };
+
+        let invocation_fut = async {
             let (sender, receiver) = tokio::sync::oneshot::channel();
             let invocation_id = invocation_id.unwrap_or(Uuid::new_v4());
             let invocation = Invocation {
@@ -163,7 +198,25 @@ impl InvocationHandler {
                 }
                 FunctionResult::Failure(error) => {
                     tracing::debug!(invocation_id = %invocation_id, function_id = %function_id, error_code = %error.code, "Function failed: {}", error.message);
-                    tracing::Span::current().record("otel.status_code", "ERROR");
+                    let current_span = tracing::Span::current();
+                    current_span.record("otel.status_code", "ERROR");
+                    // Attach the error onto the span so the trace UI can render
+                    // detail — a bare ERROR status carries no message. The
+                    // console's error tab reads `error.message`/`error.type`
+                    // attributes and an `exception` event. No-op when the engine
+                    // span is suppressed for a worker-routed call (that worker's
+                    // own span carries the failure instead).
+                    current_span.set_attribute("error.message", error.message.clone());
+                    current_span.set_attribute("error.type", error.code.clone());
+                    let mut exception_attrs = vec![
+                        KeyValue::new("exception.message", error.message.clone()),
+                        KeyValue::new("exception.type", error.code.clone()),
+                    ];
+                    if let Some(stacktrace) = error.stacktrace.clone() {
+                        current_span.set_attribute("error.stack", stacktrace.clone());
+                        exception_attrs.push(KeyValue::new("exception.stacktrace", stacktrace));
+                    }
+                    current_span.add_event("exception", exception_attrs);
 
                     // Record metrics
                     metrics.invocations_total.add(
@@ -269,8 +322,18 @@ impl InvocationHandler {
             };
             result
         }
-        .instrument(span)
-        .await
+        .instrument(span);
+
+        match dispatch_cx {
+            // Engine span suppressed for a worker-routed call: run the dispatch
+            // under the caller's OTel context so the worker's span nests under
+            // the caller's trace instead of orphaning into a new one.
+            Some(cx) => {
+                use opentelemetry::trace::FutureExt as _;
+                invocation_fut.with_context(cx).await
+            }
+            None => invocation_fut.await,
+        }
     }
 }
 

--- a/engine/src/invocation/mod.rs
+++ b/engine/src/invocation/mod.rs
@@ -124,15 +124,20 @@ impl InvocationHandler {
             .with_parent_headers(traceparent.as_deref(), baggage.as_deref())
         };
 
-        // When the engine span is suppressed for a worker-routed call there is
-        // no tracing span left to carry the caller's trace context across the
-        // WS boundary to the worker. Attach the caller context as the ambient
-        // OTel context for the dispatch so the worker's own span (and its
-        // descendants) nest under the caller's trace instead of starting a new,
-        // orphaned one. `WorkerConnection::handle_function` falls back to this
-        // ambient context when the active tracing span carries none (see
-        // `worker_connections/traits.rs`).
-        let dispatch_cx = if !is_builtin && (traceparent.is_some() || baggage.is_some()) {
+        // Run the dispatch under the caller's OTel context whenever one was
+        // provided, for BOTH worker-routed and built-in calls:
+        //   - Worker-routed: the engine span is suppressed, so there is no
+        //     tracing span left to carry the caller's context across the WS
+        //     boundary. Attaching it lets the worker's own span (and its
+        //     descendants) nest under the caller's trace instead of orphaning
+        //     into a new one. `WorkerConnection::handle_function` falls back to
+        //     this ambient context (see `worker_connections/traits.rs`).
+        //   - Built-in: state/stream writes fire triggers in a spawned
+        //     `*_triggers` span. Without the caller context that span (and the
+        //     trigger handlers it invokes) would root a brand-new, disconnected
+        //     trace; attaching it nests the fan-out under the writer (e.g.
+        //     `approval::resolve` → state write → `turn::on_approval`).
+        let dispatch_cx = if traceparent.is_some() || baggage.is_some() {
             Some(crate::telemetry::extract_context(
                 traceparent.as_deref(),
                 baggage.as_deref(),

--- a/engine/src/worker_connections/traits.rs
+++ b/engine/src/worker_connections/traits.rs
@@ -82,9 +82,21 @@ impl FunctionHandler for WorkerConnection {
         input: Value,
     ) -> Pin<Box<dyn Future<Output = FunctionResult<Option<Value>, ErrorBody>> + Send + 'a>> {
         // Capture OTel context from current tracing span BEFORE async move
-        // This ensures we get the trace context from the #[tracing::instrument] span
+        // This ensures we get the trace context from the #[tracing::instrument] span.
         let current_span = Span::current();
-        let otel_context = current_span.context();
+        let span_cx = current_span.context();
+        // Fall back to the ambient OTel context when the active tracing span
+        // carries no valid span context — e.g. the engine intentionally
+        // suppressed its per-invocation `call` span for this worker-routed call
+        // (see `invocation/mod.rs`). Without this the worker invocation would
+        // inject an empty traceparent and start a new, orphaned trace instead of
+        // nesting under the caller. Every existing flow has a valid tracing
+        // span here, so this is a no-op for them.
+        let otel_context = if inject_traceparent_from_context(&span_cx).is_some() {
+            span_cx
+        } else {
+            opentelemetry::Context::current()
+        };
 
         Box::pin(async move {
             let traceparent = inject_traceparent_from_context(&otel_context);

--- a/engine/src/workers/configuration/configuration.rs
+++ b/engine/src/workers/configuration/configuration.rs
@@ -239,7 +239,7 @@ impl ConfigurationWorker {
                     }
                 }
             }
-            .instrument(tracing::info_span!(parent: current_span, "configuration_triggers")),
+            .instrument(tracing::info_span!(parent: current_span, "configuration_triggers", "iii.function.kind" = "internal")),
         );
     }
 

--- a/engine/src/workers/observability/config.rs
+++ b/engine/src/workers/observability/config.rs
@@ -156,6 +156,24 @@ pub struct SamplingRule {
     pub rate: f64,
 }
 
+/// Rule for collapsing spans in the trace-tree view. Matching spans are
+/// removed and their children reparented to the nearest surviving ancestor,
+/// so the tree stays connected. Use to hide redundant pass-through wrapper
+/// spans (e.g. an SDK handler wrapper that duplicates the engine's invocation
+/// span) without changing worker code.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SpanCollapseRule {
+    /// Span name pattern (supports wildcards like `trigger *`). Required.
+    pub name: String,
+
+    /// Optional `service.name` pattern. When set, only spans whose service
+    /// matches are collapsed — disambiguates same-named spans across services
+    /// (e.g. a worker `trigger *` vs the engine's own `trigger *`).
+    #[serde(default)]
+    pub service: Option<String>,
+}
+
 /// Advanced sampling configuration
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
@@ -284,6 +302,13 @@ pub struct ObservabilityWorkerConfig {
     /// Log format: "default" for human-readable, "json" for structured JSON
     #[serde(default)]
     pub format: Option<String>,
+
+    /// Trace-view span collapse rules. Matching spans are hidden from the
+    /// trace tree and their children reparented to the nearest surviving
+    /// ancestor. Hides redundant pass-through wrapper spans without touching
+    /// worker code. Empty by default (no collapsing).
+    #[serde(default)]
+    pub collapse_spans: Vec<SpanCollapseRule>,
 }
 
 impl Default for ObservabilityWorkerConfig {
@@ -314,6 +339,7 @@ impl Default for ObservabilityWorkerConfig {
             alerts: Vec::new(),
             level: None,
             format: None,
+            collapse_spans: Vec::new(),
         }
     }
 }

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -418,22 +418,33 @@ fn collapse_wildcard_to_regex(pattern: &str) -> Result<regex::Regex, regex::Erro
     regex::Regex::new(&format!("^{}$", regex_pattern))
 }
 
-/// Engine-internal pass-through wrapper spans that are ALWAYS collapsed out of
-/// the assembled tree view, independent of user config: the state/stream trigger
-/// fan-out spans (`state_triggers`/`stream_triggers`). They carry no
-/// user-meaningful work themselves — they only parent the trigger handler
-/// invocations (e.g. `turn::on_approval`, `context-compaction::on_agent_event`),
-/// which reparent to the nearest survivor when these are collapsed. Without this
-/// they flood every trace tree (a turn step can fan out 10+ stream writes).
-fn builtin_collapse_rules() -> Vec<CompiledCollapseRule> {
-    ["state_triggers", "stream_triggers"]
-        .iter()
-        .filter_map(|name| {
-            collapse_wildcard_to_regex(name)
-                .ok()
-                .map(|name| CompiledCollapseRule { name, service: None })
-        })
-        .collect()
+/// True for the engine-internal trigger fan-out wrapper spans
+/// (`state_triggers`/`stream_triggers`).
+fn is_trigger_wrapper(name: &str) -> bool {
+    name == "state_triggers" || name == "stream_triggers"
+}
+
+/// Drop NO-OP trigger fan-out wrappers from the assembled tree: a
+/// `state_triggers`/`stream_triggers` span with no children fanned out to a
+/// handler that produced nothing traceable (e.g. the suppressed devtools stream
+/// consumers) — pure noise, and a turn step emits many. Wrappers that DID invoke
+/// a handler are kept, so the "ran because of a state/stream write" causality
+/// stays visible. Iterates to a fixpoint so a wrapper left childless by pruning a
+/// nested wrapper also drops. Childless spans have nothing to reparent, so the
+/// tree stays connected without rewriting any parent links.
+fn prune_empty_trigger_spans(mut spans: Vec<otel::StoredSpan>) -> Vec<otel::StoredSpan> {
+    loop {
+        let has_child: std::collections::HashSet<String> = spans
+            .iter()
+            .filter_map(|s| s.parent_span_id.clone())
+            .collect();
+        let before = spans.len();
+        spans.retain(|s| !(is_trigger_wrapper(&s.name) && !has_child.contains(&s.span_id)));
+        if spans.len() == before {
+            break;
+        }
+    }
+    spans
 }
 
 /// Compile the configured collapse rules, skipping any with invalid patterns.
@@ -1138,16 +1149,16 @@ impl ObservabilityWorker {
                     })));
                 }
 
-                // Collapse pass-through wrapper spans before building the tree
-                // (children reparent to the nearest surviving ancestor): the
-                // always-on engine-internal trigger fan-out wrappers, plus any
-                // user-configured rules.
-                let mut collapse_rules = builtin_collapse_rules();
-                collapse_rules.extend(
-                    otel::get_otel_config()
-                        .map(|c| compile_collapse_rules(&c.collapse_spans))
-                        .unwrap_or_default(),
-                );
+                // Drop no-op trigger fan-out wrappers (childless
+                // state_triggers/stream_triggers); wrappers that actually invoked
+                // a handler are kept so the trigger→handler causality stays visible.
+                let all_spans = prune_empty_trigger_spans(all_spans);
+
+                // Collapse user-configured pass-through wrapper spans before
+                // building the tree (children reparent to the nearest survivor).
+                let collapse_rules = otel::get_otel_config()
+                    .map(|c| compile_collapse_rules(&c.collapse_spans))
+                    .unwrap_or_default();
                 let all_spans = collapse_spans(all_spans, &collapse_rules);
 
                 let roots = build_span_tree(all_spans);
@@ -2576,8 +2587,8 @@ mod tests {
     }
 
     #[test]
-    fn test_builtin_collapse_hides_trigger_wrappers() {
-        // writer -> state_triggers (internal wrapper) -> turn::on_approval handler
+    fn test_prune_empty_trigger_wrappers() {
+        // writer -> state_triggers -> turn::on_approval: a trigger that RAN a fn.
         let writer = make_span(
             "t",
             "w",
@@ -2589,7 +2600,7 @@ mod tests {
             "ok",
             vec![],
         );
-        let state_wrapper = make_span(
+        let ran = make_span(
             "t",
             "st",
             Some("w"),
@@ -2611,8 +2622,8 @@ mod tests {
             "ok",
             vec![],
         );
-        // a stream_triggers wrapper with no children → should simply vanish
-        let empty_stream = make_span(
+        // a stream_triggers wrapper with no children → no-op fan-out (noise).
+        let empty = make_span(
             "t",
             "ss",
             Some("w"),
@@ -2624,24 +2635,29 @@ mod tests {
             vec![("iii.function.kind", "internal")],
         );
 
-        let collapsed = collapse_spans(
-            vec![writer, state_wrapper, handler, empty_stream],
-            &builtin_collapse_rules(),
+        let pruned = prune_empty_trigger_spans(vec![writer, ran, handler, empty]);
+
+        // Empty wrapper dropped; the one that ran a function is KEPT.
+        assert!(
+            !pruned.iter().any(|s| s.span_id == "ss"),
+            "childless stream_triggers should be pruned",
+        );
+        assert!(
+            pruned.iter().any(|s| s.span_id == "st"),
+            "state_triggers that invoked a handler should be kept",
+        );
+        assert!(
+            pruned.iter().any(|s| s.span_id == "h"),
+            "the handler survives"
         );
 
-        // Both *_triggers wrappers are gone, with no user config required.
-        assert!(!collapsed.iter().any(|s| s.name == "state_triggers"));
-        assert!(!collapsed.iter().any(|s| s.name == "stream_triggers"));
-        // The real handler survives, reparented to the writer.
-        let h = collapsed.iter().find(|s| s.span_id == "h").unwrap();
-        assert_eq!(h.parent_span_id.as_deref(), Some("w"));
-
-        // Tree stays connected: approval::resolve -> turn::on_approval.
-        let tree = build_span_tree(collapsed);
+        // Tree stays connected: approval::resolve -> state_triggers -> turn::on_approval.
+        let tree = build_span_tree(pruned);
         assert_eq!(tree.len(), 1);
         assert_eq!(tree[0].span.span_id, "w");
         assert_eq!(tree[0].children.len(), 1);
-        assert_eq!(tree[0].children[0].span.span_id, "h");
+        assert_eq!(tree[0].children[0].span.span_id, "st");
+        assert_eq!(tree[0].children[0].children[0].span.span_id, "h");
     }
 
     #[test]

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -418,6 +418,24 @@ fn collapse_wildcard_to_regex(pattern: &str) -> Result<regex::Regex, regex::Erro
     regex::Regex::new(&format!("^{}$", regex_pattern))
 }
 
+/// Engine-internal pass-through wrapper spans that are ALWAYS collapsed out of
+/// the assembled tree view, independent of user config: the state/stream trigger
+/// fan-out spans (`state_triggers`/`stream_triggers`). They carry no
+/// user-meaningful work themselves — they only parent the trigger handler
+/// invocations (e.g. `turn::on_approval`, `context-compaction::on_agent_event`),
+/// which reparent to the nearest survivor when these are collapsed. Without this
+/// they flood every trace tree (a turn step can fan out 10+ stream writes).
+fn builtin_collapse_rules() -> Vec<CompiledCollapseRule> {
+    ["state_triggers", "stream_triggers"]
+        .iter()
+        .filter_map(|name| {
+            collapse_wildcard_to_regex(name)
+                .ok()
+                .map(|name| CompiledCollapseRule { name, service: None })
+        })
+        .collect()
+}
+
 /// Compile the configured collapse rules, skipping any with invalid patterns.
 fn compile_collapse_rules(rules: &[config::SpanCollapseRule]) -> Vec<CompiledCollapseRule> {
     rules
@@ -1120,11 +1138,16 @@ impl ObservabilityWorker {
                     })));
                 }
 
-                // Collapse configured pass-through wrapper spans before building
-                // the tree (children reparent to the nearest surviving ancestor).
-                let collapse_rules = otel::get_otel_config()
-                    .map(|c| compile_collapse_rules(&c.collapse_spans))
-                    .unwrap_or_default();
+                // Collapse pass-through wrapper spans before building the tree
+                // (children reparent to the nearest surviving ancestor): the
+                // always-on engine-internal trigger fan-out wrappers, plus any
+                // user-configured rules.
+                let mut collapse_rules = builtin_collapse_rules();
+                collapse_rules.extend(
+                    otel::get_otel_config()
+                        .map(|c| compile_collapse_rules(&c.collapse_spans))
+                        .unwrap_or_default(),
+                );
                 let all_spans = collapse_spans(all_spans, &collapse_rules);
 
                 let roots = build_span_tree(all_spans);
@@ -2550,6 +2573,75 @@ mod tests {
         assert_eq!(tree[0].span.span_id, "call");
         assert_eq!(tree[0].children.len(), 1);
         assert_eq!(tree[0].children[0].span.span_id, "leaf");
+    }
+
+    #[test]
+    fn test_builtin_collapse_hides_trigger_wrappers() {
+        // writer -> state_triggers (internal wrapper) -> turn::on_approval handler
+        let writer = make_span(
+            "t",
+            "w",
+            None,
+            "call approval::resolve",
+            "iii-test",
+            100,
+            500,
+            "ok",
+            vec![],
+        );
+        let state_wrapper = make_span(
+            "t",
+            "st",
+            Some("w"),
+            "state_triggers",
+            "iii-test",
+            110,
+            480,
+            "ok",
+            vec![("iii.function.kind", "internal")],
+        );
+        let handler = make_span(
+            "t",
+            "h",
+            Some("st"),
+            "call turn::on_approval",
+            "iii-worker",
+            120,
+            470,
+            "ok",
+            vec![],
+        );
+        // a stream_triggers wrapper with no children → should simply vanish
+        let empty_stream = make_span(
+            "t",
+            "ss",
+            Some("w"),
+            "stream_triggers",
+            "iii-test",
+            130,
+            140,
+            "ok",
+            vec![("iii.function.kind", "internal")],
+        );
+
+        let collapsed = collapse_spans(
+            vec![writer, state_wrapper, handler, empty_stream],
+            &builtin_collapse_rules(),
+        );
+
+        // Both *_triggers wrappers are gone, with no user config required.
+        assert!(!collapsed.iter().any(|s| s.name == "state_triggers"));
+        assert!(!collapsed.iter().any(|s| s.name == "stream_triggers"));
+        // The real handler survives, reparented to the writer.
+        let h = collapsed.iter().find(|s| s.span_id == "h").unwrap();
+        assert_eq!(h.parent_span_id.as_deref(), Some("w"));
+
+        // Tree stays connected: approval::resolve -> turn::on_approval.
+        let tree = build_span_tree(collapsed);
+        assert_eq!(tree.len(), 1);
+        assert_eq!(tree[0].span.span_id, "w");
+        assert_eq!(tree[0].children.len(), 1);
+        assert_eq!(tree[0].children[0].span.span_id, "h");
     }
 
     #[test]

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -320,6 +320,17 @@ pub const TRACE_TRIGGER_TYPE: &str = "trace";
 /// fan-out (and the spans its own delivery produces) to a trickle.
 const TRACE_COALESCE_MS: u64 = 300;
 
+/// Live span streams the observability worker pushes onto each coalesce tick,
+/// consumed by the console Traces view (and any iii client) as a real-time
+/// append feed instead of refetching `engine::traces::*`. Ephemeral
+/// `stream::send`: the in-memory store stays the source of truth and is
+/// re-read once on (re)connect, so a dropped frame self-heals.
+const TRACE_ROWS_STREAM: &str = "iii:devtools:trace-rows";
+const TRACE_SPANS_STREAM: &str = "iii:devtools:trace-spans";
+/// The single group every list subscriber joins — the list is a global
+/// firehose, not per-trace. Detail subscribers join the `trace_id` group.
+const TRACE_ROWS_GROUP: &str = "all";
+
 /// Trace (span) triggers for the OTEL module
 pub struct OtelTraceTriggers {
     pub triggers: Arc<TokioRwLock<HashSet<Trigger>>>,
@@ -385,6 +396,97 @@ pub struct ObservabilityWorker {
     engine: Arc<Engine>,
     /// Shutdown signal sender for background tasks
     shutdown_tx: Arc<tokio::sync::watch::Sender<bool>>,
+}
+
+/// A compiled [`config::SpanCollapseRule`] with precompiled regex patterns.
+struct CompiledCollapseRule {
+    name: regex::Regex,
+    service: Option<regex::Regex>,
+}
+
+impl CompiledCollapseRule {
+    fn matches(&self, name: &str, service: &str) -> bool {
+        self.name.is_match(name) && self.service.as_ref().map_or(true, |s| s.is_match(service))
+    }
+}
+
+/// Convert a `*`/`?` wildcard pattern into an anchored regex (mirrors the
+/// sampler's wildcard handling).
+fn collapse_wildcard_to_regex(pattern: &str) -> Result<regex::Regex, regex::Error> {
+    let escaped = regex::escape(pattern);
+    let regex_pattern = escaped.replace(r"\*", ".*").replace(r"\?", ".");
+    regex::Regex::new(&format!("^{}$", regex_pattern))
+}
+
+/// Compile the configured collapse rules, skipping any with invalid patterns.
+fn compile_collapse_rules(rules: &[config::SpanCollapseRule]) -> Vec<CompiledCollapseRule> {
+    rules
+        .iter()
+        .filter_map(|r| {
+            let name = collapse_wildcard_to_regex(&r.name).ok()?;
+            let service = match &r.service {
+                Some(p) => Some(collapse_wildcard_to_regex(p).ok()?),
+                None => None,
+            };
+            Some(CompiledCollapseRule { name, service })
+        })
+        .collect()
+}
+
+/// Remove spans matching any collapse rule, reparenting each surviving span to
+/// its nearest non-collapsed ancestor so the trace tree stays connected.
+///
+/// Operates on the full set of spans for a trace, so reparenting is exact
+/// regardless of span arrival order. Raw spans in storage / exported to the
+/// collector are untouched — this only affects the assembled tree view.
+fn collapse_spans(
+    spans: Vec<otel::StoredSpan>,
+    rules: &[CompiledCollapseRule],
+) -> Vec<otel::StoredSpan> {
+    if rules.is_empty() {
+        return spans;
+    }
+
+    let collapsed: std::collections::HashSet<String> = spans
+        .iter()
+        .filter(|s| rules.iter().any(|r| r.matches(&s.name, &s.service_name)))
+        .map(|s| s.span_id.clone())
+        .collect();
+
+    if collapsed.is_empty() {
+        return spans;
+    }
+
+    let parent_of: HashMap<String, Option<String>> = spans
+        .iter()
+        .map(|s| (s.span_id.clone(), s.parent_span_id.clone()))
+        .collect();
+
+    // Walk up the chain of collapsed ancestors to the first survivor (or root).
+    let resolve = |start: Option<String>| -> Option<String> {
+        let mut pid = start;
+        let mut guard = 0usize;
+        while let Some(id) = pid.clone() {
+            if !collapsed.contains(&id) {
+                break;
+            }
+            pid = parent_of.get(&id).cloned().flatten();
+            guard += 1;
+            if guard > 100_000 {
+                break; // cycle guard
+            }
+        }
+        pid
+    };
+
+    spans
+        .into_iter()
+        .filter(|s| !collapsed.contains(&s.span_id))
+        .map(|mut s| {
+            s.parent_span_id = resolve(s.parent_span_id.take());
+            s
+        })
+        .collect()
 }
 
 fn build_span_tree(spans: Vec<otel::StoredSpan>) -> Vec<SpanTreeNode> {
@@ -740,6 +842,64 @@ impl ObservabilityWorker {
         }
     }
 
+    /// Push the coalesce window's spans onto the live trace streams via
+    /// ephemeral `stream::send`: root rows (internal/plumbing excluded) to the
+    /// global list stream, and every span grouped by `trace_id` to that trace's
+    /// detail stream. Fire-and-forget — the in-memory store stays authoritative
+    /// (re-read once on reconnect), so a dropped frame self-heals rather than
+    /// corrupting client state.
+    ///
+    /// Loop-safe by construction: the `batch` is the post-filter window, which
+    /// already excludes engine-internal spans (`is_internal_span`) — and
+    /// `stream::send` plus the `iii::console::*` consumer handlers are all
+    /// builtins (`iii.function.kind=internal`), so neither delivery re-enters
+    /// the feed (see the subscriber loop's loop-break + consumer contract).
+    async fn push_trace_streams(engine: &Arc<Engine>, batch: &[otel::StoredSpan]) {
+        fn send(engine: &Arc<Engine>, stream_name: &str, group_id: String, spans: Value) {
+            let payload = serde_json::json!({
+                "stream_name": stream_name,
+                "group_id": group_id,
+                "type": "spans",
+                "data": { "spans": spans },
+            });
+            let engine = engine.clone();
+            tokio::spawn(async move {
+                let _ = engine.call("stream::send", payload).await;
+            });
+        }
+
+        // List: one row per root span, internal/plumbing excluded (the same
+        // view `traces::list` shows), to the single group every list view joins.
+        let rows: Vec<&otel::StoredSpan> = batch
+            .iter()
+            .filter(|s| s.parent_span_id.is_none() && !is_internal_span(s))
+            .collect();
+        if !rows.is_empty()
+            && let Ok(spans) = serde_json::to_value(&rows)
+        {
+            send(
+                engine,
+                TRACE_ROWS_STREAM,
+                TRACE_ROWS_GROUP.to_string(),
+                spans,
+            );
+        }
+
+        // Detail: every (non-internal) span grouped by trace_id, to that
+        // trace's group. Only a subscriber that joined this `trace_id` receives
+        // it (engine-side fan-out filter), so a trace nobody is viewing costs
+        // just the no-match early-out in `stream::invoke_triggers`.
+        let mut by_trace: HashMap<&str, Vec<&otel::StoredSpan>> = HashMap::new();
+        for span in batch {
+            by_trace.entry(&span.trace_id).or_default().push(span);
+        }
+        for (trace_id, spans) in by_trace {
+            if let Ok(spans) = serde_json::to_value(&spans) {
+                send(engine, TRACE_SPANS_STREAM, trace_id.to_string(), spans);
+            }
+        }
+    }
+
     // =========================================================================
     // Traces Functions
     // =========================================================================
@@ -959,6 +1119,13 @@ impl ObservabilityWorker {
                         "roots": [],
                     })));
                 }
+
+                // Collapse configured pass-through wrapper spans before building
+                // the tree (children reparent to the nearest surviving ancestor).
+                let collapse_rules = otel::get_otel_config()
+                    .map(|c| compile_collapse_rules(&c.collapse_spans))
+                    .unwrap_or_default();
+                let all_spans = collapse_spans(all_spans, &collapse_rules);
 
                 let roots = build_span_tree(all_spans);
 
@@ -1980,6 +2147,7 @@ impl Worker for ObservabilityWorker {
                             }
                             let batch = std::mem::take(&mut window);
                             ObservabilityWorker::fire_trace_triggers(&triggers, &engine, &batch).await;
+                            ObservabilityWorker::push_trace_streams(&engine, &batch).await;
                         }
                     }
                 }
@@ -2325,6 +2493,131 @@ mod tests {
         assert_eq!(tree[0].span.name, "root");
         assert_eq!(tree[0].children.len(), 1);
         assert_eq!(tree[0].children[0].span.name, "child");
+    }
+
+    #[test]
+    fn test_collapse_spans_removes_and_reparents() {
+        // call (engine) -> trigger (worker wrapper) -> harness.<fn> (handler)
+        let root = make_span(
+            "t",
+            "call",
+            None,
+            "call h::trigger",
+            "iii-test",
+            100,
+            500,
+            "ok",
+            vec![],
+        );
+        let wrapper = make_span(
+            "t",
+            "trig",
+            Some("call"),
+            "trigger h::trigger",
+            "harness",
+            110,
+            480,
+            "ok",
+            vec![],
+        );
+        let leaf = make_span(
+            "t",
+            "leaf",
+            Some("trig"),
+            "harness.h::trigger",
+            "harness",
+            120,
+            470,
+            "ok",
+            vec![],
+        );
+
+        let rules = compile_collapse_rules(&[config::SpanCollapseRule {
+            name: "trigger *".to_string(),
+            service: Some("harness".to_string()),
+        }]);
+        let collapsed = collapse_spans(vec![root, wrapper, leaf], &rules);
+
+        // wrapper removed, leaf reparented to the wrapper's parent (call)
+        assert_eq!(collapsed.len(), 2);
+        assert!(!collapsed.iter().any(|s| s.span_id == "trig"));
+        let leaf = collapsed.iter().find(|s| s.span_id == "leaf").unwrap();
+        assert_eq!(leaf.parent_span_id.as_deref(), Some("call"));
+
+        // tree stays connected: call -> leaf
+        let tree = build_span_tree(collapsed);
+        assert_eq!(tree.len(), 1);
+        assert_eq!(tree[0].span.span_id, "call");
+        assert_eq!(tree[0].children.len(), 1);
+        assert_eq!(tree[0].children[0].span.span_id, "leaf");
+    }
+
+    #[test]
+    fn test_collapse_spans_service_scoping() {
+        // The engine's own `trigger *` (service iii-test) must survive; only the
+        // worker's `trigger *` (service harness) collapses.
+        let engine_trigger = make_span(
+            "t",
+            "et",
+            None,
+            "trigger foo",
+            "iii-test",
+            100,
+            500,
+            "ok",
+            vec![],
+        );
+        let worker_trigger = make_span(
+            "t",
+            "wt",
+            Some("et"),
+            "trigger foo",
+            "harness",
+            110,
+            480,
+            "ok",
+            vec![],
+        );
+        let leaf = make_span(
+            "t",
+            "leaf",
+            Some("wt"),
+            "foo.body",
+            "harness",
+            120,
+            470,
+            "ok",
+            vec![],
+        );
+
+        let rules = compile_collapse_rules(&[config::SpanCollapseRule {
+            name: "trigger *".to_string(),
+            service: Some("harness".to_string()),
+        }]);
+        let collapsed = collapse_spans(vec![engine_trigger, worker_trigger, leaf], &rules);
+
+        assert!(
+            collapsed.iter().any(|s| s.span_id == "et"),
+            "engine trigger survives"
+        );
+        assert!(
+            !collapsed.iter().any(|s| s.span_id == "wt"),
+            "worker trigger collapsed"
+        );
+        let leaf = collapsed.iter().find(|s| s.span_id == "leaf").unwrap();
+        assert_eq!(
+            leaf.parent_span_id.as_deref(),
+            Some("et"),
+            "leaf reparented past the collapsed worker trigger"
+        );
+    }
+
+    #[test]
+    fn test_collapse_spans_no_rules_is_noop() {
+        let a = make_span("t", "a", None, "x", "svc", 1, 2, "ok", vec![]);
+        let b = make_span("t", "b", Some("a"), "y", "svc", 1, 2, "ok", vec![]);
+        let out = collapse_spans(vec![a, b], &[]);
+        assert_eq!(out.len(), 2);
     }
 
     #[test]

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -1068,6 +1068,44 @@ pub fn extract_context(traceparent: Option<&str>, baggage: Option<&str>) -> Cont
     BaggagePropagator::new().extract_with_context(&ctx, &carrier)
 }
 
+/// Baggage key the `BaggageSpanProcessor` copies onto every span as the
+/// `iii.function.id` attribute (see the SDK observability crate allowlist).
+const FUNCTION_ID_BAGGAGE_KEY: &str = "iii.function.id";
+
+/// Return a context identical to `cx` but with the `iii.function.id` baggage
+/// entry set to `function_id` (all other baggage entries are preserved).
+///
+/// `BaggageSpanProcessor` stamps `iii.function.id` onto every span from the
+/// parent context's baggage, but an enqueuer's baggage names the *enqueuer*, not
+/// the function being enqueued. Rewriting it at the enqueue boundary makes the
+/// `enqueue`/`fn_queue` spans (and the baggage delivered to the target worker)
+/// carry the TARGET function id, so grouping traces by `iii.function.id`
+/// attributes those spans to the function they actually serve.
+pub fn with_function_id_baggage(cx: &Context, function_id: &str) -> Context {
+    use opentelemetry::baggage::BaggageExt;
+    // Drop any existing entry for the key, then re-add — mirrors the SDK's
+    // `set_baggage_entry` so we replace rather than duplicate.
+    let mut entries: Vec<KeyValue> = cx
+        .baggage()
+        .iter()
+        .filter(|(k, _)| k.as_str() != FUNCTION_ID_BAGGAGE_KEY)
+        .map(|(k, (v, _meta))| KeyValue::new(k.clone(), v.clone()))
+        .collect();
+    entries.push(KeyValue::new(
+        FUNCTION_ID_BAGGAGE_KEY,
+        function_id.to_string(),
+    ));
+    cx.with_baggage(entries)
+}
+
+/// W3C-header variant of [`with_function_id_baggage`] for code paths that carry
+/// baggage as a header string rather than a [`Context`] (e.g. queue messages).
+/// Always returns `Some` — at minimum the header names the target function.
+pub fn baggage_with_function_id(baggage: Option<&str>, function_id: &str) -> Option<String> {
+    let ctx = with_function_id_baggage(&extract_baggage(baggage.unwrap_or_default()), function_id);
+    inject_baggage_from_context(&ctx)
+}
+
 // =============================================================================
 // OTLP JSON Ingestion from Node SDK
 // =============================================================================
@@ -3888,6 +3926,69 @@ mod tests {
         // Note: Baggage may or may not be available depending on context state
         // This test primarily verifies the function doesn't panic and context is valid
         let _count = bag.len();
+    }
+
+    #[test]
+    fn with_function_id_baggage_overrides_key_and_preserves_others() {
+        use opentelemetry::baggage::BaggageExt;
+
+        let cx = extract_context(
+            None,
+            Some("iii.session.id=s-1,iii.message.id=m-1,iii.function.id=run::start"),
+        );
+        let updated = with_function_id_baggage(&cx, "turn::provisioning");
+        let bag = updated.baggage();
+
+        assert_eq!(
+            bag.get("iii.function.id").map(|v| v.as_str().to_string()),
+            Some("turn::provisioning".to_string()),
+            "function id must be rewritten to the target",
+        );
+        assert_eq!(
+            bag.get("iii.session.id").map(|v| v.as_str().to_string()),
+            Some("s-1".to_string()),
+            "other baggage entries must be preserved",
+        );
+        assert_eq!(
+            bag.get("iii.message.id").map(|v| v.as_str().to_string()),
+            Some("m-1".to_string()),
+        );
+        // No duplicate entry left behind for the rewritten key.
+        let fn_count = bag
+            .iter()
+            .filter(|(k, _)| k.as_str() == "iii.function.id")
+            .count();
+        assert_eq!(fn_count, 1, "exactly one iii.function.id entry");
+    }
+
+    #[test]
+    fn baggage_with_function_id_header_names_target() {
+        // Round-trips through the W3C header form (the queue-message path).
+        let header = baggage_with_function_id(
+            Some("iii.session.id=s-9,iii.function.id=turn::provisioning"),
+            "turn::assistant_streaming",
+        )
+        .expect("baggage header is always produced");
+
+        assert!(
+            header.contains("iii.function.id=turn::assistant_streaming"),
+            "header must name the target function, got: {header}",
+        );
+        assert!(
+            !header.contains("turn::provisioning"),
+            "enqueuer function id must not survive, got: {header}",
+        );
+        assert!(
+            header.contains("iii.session.id=s-9"),
+            "other baggage entries must be preserved, got: {header}",
+        );
+    }
+
+    #[test]
+    fn baggage_with_function_id_inserts_when_absent() {
+        let header = baggage_with_function_id(None, "session-tree::ensure")
+            .expect("baggage header is always produced");
+        assert!(header.contains("iii.function.id=session-tree::ensure"));
     }
 
     #[test]

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -673,30 +673,108 @@ impl SpanExporter for TeeSpanExporter {
 
 static TRACER_PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
 
-/// Global OTLP exporter for forwarding SDK-ingested spans to the collector.
-/// `SpanExporter::export` takes `&self`, so no Mutex is needed.
-static SDK_SPAN_FORWARDER: OnceLock<Arc<opentelemetry_otlp::SpanExporter>> = OnceLock::new();
+/// OTLP collector endpoint used to lazily build per-service SDK span forwarders.
+static SDK_FORWARDER_ENDPOINT: OnceLock<String> = OnceLock::new();
 
-/// Build a second OTLP span exporter and store it in the global `SDK_SPAN_FORWARDER`
-/// so that SDK-ingested spans can be forwarded to the collector.
-fn init_sdk_span_forwarder(endpoint: &str) {
+/// Per-`service.name` OTLP span exporters for forwarding SDK-ingested (worker)
+/// spans to the collector. Keyed by service name so each worker's spans are
+/// exported under their OWN resource (`service.name`) instead of being stripped
+/// to the OTLP default identity (`unknown_service`).
+static SDK_SPAN_FORWARDERS: OnceLock<
+    RwLock<HashMap<String, Arc<opentelemetry_otlp::SpanExporter>>>,
+> = OnceLock::new();
+
+/// Sampler applied to forwarded worker spans so collector volume honors the
+/// engine's `sampling_ratio`. Worker SDKs export to the engine at 100%, so
+/// without this the engine sampler would only govern engine-origin spans.
+static SDK_FORWARD_SAMPLER: OnceLock<Sampler> = OnceLock::new();
+
+/// Record the collector endpoint + sampler so SDK-ingested spans can later be
+/// forwarded to the collector, per-service and sampled.
+fn init_sdk_span_forwarder(endpoint: &str, config: &OtelConfig) {
+    let _ = SDK_FORWARDER_ENDPOINT.set(endpoint.to_string());
+    let _ = SDK_SPAN_FORWARDERS.set(RwLock::new(HashMap::new()));
+    let _ = SDK_FORWARD_SAMPLER.set(build_sampler(config));
+}
+
+/// Build a `Resource` from an OTLP resource payload, preserving the worker's
+/// own attributes (notably `service.name`) so forwarded spans are correctly
+/// attributed at the collector rather than landing under `unknown_service`.
+fn build_forward_resource(resource: &Option<OtlpResource>) -> Resource {
+    let attrs: Vec<KeyValue> = resource
+        .as_ref()
+        .map(|r| {
+            r.attributes
+                .iter()
+                .filter_map(otlp_kv_to_key_value)
+                .collect()
+        })
+        .unwrap_or_default();
+    Resource::builder_empty().with_attributes(attrs).build()
+}
+
+/// Get (or lazily build) the OTLP forwarder for a given worker `service.name`,
+/// with the worker's `Resource` attached via `set_resource` so the collector
+/// sees the right service identity.
+fn get_or_build_forwarder(
+    service_name: &str,
+    resource: &Resource,
+) -> Option<Arc<opentelemetry_otlp::SpanExporter>> {
+    let endpoint = SDK_FORWARDER_ENDPOINT.get()?;
+    let forwarders = SDK_SPAN_FORWARDERS.get()?;
+
+    // Fast path under a read lock. The explicit block guarantees the read guard
+    // is released before the write lock is taken below (std `RwLock` is not
+    // reentrant), independent of temporary-drop timing.
+    {
+        let map = forwarders.read().ok()?;
+        if let Some(existing) = map.get(service_name) {
+            return Some(existing.clone());
+        }
+    }
+
+    let mut map = forwarders.write().ok()?;
+    // Re-check under the write lock in case another task built it meanwhile.
+    if let Some(existing) = map.get(service_name) {
+        return Some(existing.clone());
+    }
     match opentelemetry_otlp::SpanExporter::builder()
         .with_tonic()
-        .with_endpoint(endpoint)
+        .with_endpoint(endpoint.as_str())
         .build()
     {
-        Ok(forwarder) => {
-            if SDK_SPAN_FORWARDER.set(Arc::new(forwarder)).is_err() {
-                tracing::debug!("SDK span forwarder already initialized");
-            }
+        Ok(mut exporter) => {
+            exporter.set_resource(resource);
+            let arc = Arc::new(exporter);
+            map.insert(service_name.to_string(), arc.clone());
+            Some(arc)
         }
         Err(e) => {
             tracing::warn!(
                 error = %e,
-                "Failed to create SDK span forwarder, SDK spans will not be exported to collector"
+                service_name = %service_name,
+                "Failed to create SDK span forwarder; spans will not be exported to collector"
             );
+            None
         }
     }
+}
+
+/// Whether the engine sampler keeps a forwarded worker span. The trace-id ratio
+/// is deterministic per trace, so an entire trace is kept or dropped
+/// consistently regardless of which service produced a given span.
+fn forward_span_is_sampled(sampler: &Sampler, sd: &SpanData) -> bool {
+    use opentelemetry::trace::SamplingDecision;
+    use opentelemetry_sdk::trace::ShouldSample;
+    let result = sampler.should_sample(
+        None,
+        sd.span_context.trace_id(),
+        sd.name.as_ref(),
+        &sd.span_kind,
+        &sd.attributes,
+        &sd.links.links,
+    );
+    matches!(result.decision, SamplingDecision::RecordAndSample)
 }
 
 /// Initialize OpenTelemetry with the given configuration.
@@ -749,7 +827,7 @@ where
                 .build()
             {
                 Ok(exporter) => {
-                    init_sdk_span_forwarder(&config.endpoint);
+                    init_sdk_span_forwarder(&config.endpoint, config);
 
                     // Initialize in-memory storage for SDK span ingestion (API access)
                     let memory_storage =
@@ -811,7 +889,7 @@ where
                 .build()
             {
                 Ok(otlp_exporter) => {
-                    init_sdk_span_forwarder(&config.endpoint);
+                    init_sdk_span_forwarder(&config.endpoint, config);
 
                     // Create tee exporter that sends to both
                     let tee_exporter = TeeSpanExporter::new(
@@ -1468,7 +1546,24 @@ fn otlp_kv_to_key_value(kv: &OtlpKeyValue) -> Option<KeyValue> {
 }
 
 /// Convert parsed OTLP spans to SpanData for export via the OTel SDK pipeline.
+///
+/// Production forwarding goes through [`convert_resource_span_to_span_data`]
+/// one resource at a time (see `ingest_otlp_json`); this whole-request wrapper
+/// is retained for unit tests that assert over a full OTLP request.
+#[cfg(test)]
 fn convert_otlp_to_span_data(request: &OtlpExportTraceServiceRequest) -> Vec<SpanData> {
+    request
+        .resource_spans
+        .iter()
+        .flat_map(convert_resource_span_to_span_data)
+        .collect()
+}
+
+/// Convert a single OTLP `resource_span` group (one worker `service.name`) to
+/// `SpanData`. Split out from [`convert_otlp_to_span_data`] so the SDK span
+/// forwarder can process one resource at a time and attach the matching
+/// `Resource` before exporting to the collector.
+fn convert_resource_span_to_span_data(resource_span: &OtlpResourceSpans) -> Vec<SpanData> {
     use opentelemetry::trace::{
         Event, Link, SpanContext, SpanKind, Status, TraceFlags, TraceState,
     };
@@ -1479,7 +1574,7 @@ fn convert_otlp_to_span_data(request: &OtlpExportTraceServiceRequest) -> Vec<Spa
 
     let mut span_data_vec = Vec::new();
 
-    for resource_span in &request.resource_spans {
+    {
         for scope_span in &resource_span.scope_spans {
             let scope = scope_span
                 .scope
@@ -1783,14 +1878,35 @@ pub async fn ingest_otlp_json(json_str: &str) -> anyhow::Result<()> {
         }
     }
 
-    // Forward to OTLP collector if forwarder is available
-    if let Some(forwarder) = SDK_SPAN_FORWARDER.get() {
-        let span_data = convert_otlp_to_span_data(&request);
-        if !span_data.is_empty() {
+    // Forward to the OTLP collector, one resource (worker service.name) at a
+    // time so each batch carries the correct service identity, and honoring the
+    // engine sampler so forwarded volume matches `sampling_ratio` (worker SDKs
+    // export to the engine at 100%).
+    if SDK_FORWARDER_ENDPOINT.get().is_some() {
+        let sampler = SDK_FORWARD_SAMPLER.get();
+        for resource_span in &request.resource_spans {
+            let mut span_data = convert_resource_span_to_span_data(resource_span);
+            if let Some(sampler) = sampler {
+                span_data.retain(|sd| forward_span_is_sampled(sampler, sd));
+            }
+            if span_data.is_empty() {
+                continue;
+            }
+
+            let service_name = extract_service_name(&resource_span.resource);
+            let resource = build_forward_resource(&resource_span.resource);
+            let Some(forwarder) = get_or_build_forwarder(&service_name, &resource) else {
+                continue;
+            };
+
             let count = span_data.len();
             match forwarder.export(span_data).await {
                 Ok(()) => {
-                    tracing::debug!(span_count = count, "Forwarded SDK spans to OTLP collector");
+                    tracing::debug!(
+                        span_count = count,
+                        service_name = %service_name,
+                        "Forwarded SDK spans to OTLP collector"
+                    );
                 }
                 Err(e) => {
                     tracing::warn!(error = ?e, "Failed to forward SDK spans to OTLP collector");
@@ -4712,6 +4828,76 @@ mod tests {
         assert!(matches!(sd.status, opentelemetry::trace::Status::Ok));
         assert_eq!(sd.attributes.len(), 1);
         assert_eq!(sd.attributes[0].key.as_str(), "http.method");
+    }
+
+    #[test]
+    fn test_build_forward_resource_preserves_service_name() {
+        // DUP-3: a worker's OTLP resource (service.name=harness) must survive
+        // into the forwarder `Resource` so the collector attributes spans
+        // correctly instead of bucketing them under `unknown_service`.
+        let json_str = r#"{
+            "resourceSpans": [{
+                "resource": {
+                    "attributes": [
+                        {"key": "service.name", "value": {"stringValue": "harness"}},
+                        {"key": "service.version", "value": {"stringValue": "1.2.3"}}
+                    ]
+                },
+                "scopeSpans": []
+            }]
+        }"#;
+        let request: OtlpExportTraceServiceRequest =
+            serde_json::from_str(json_str).expect("parse JSON");
+        let rs = &request.resource_spans[0];
+
+        let resource = build_forward_resource(&rs.resource);
+        let svc = resource
+            .get(&opentelemetry::Key::from_static_str("service.name"))
+            .map(|v| v.as_str().to_string());
+        assert_eq!(svc.as_deref(), Some("harness"));
+        // The per-service forwarder is keyed by this same extraction.
+        assert_eq!(extract_service_name(&rs.resource), "harness");
+    }
+
+    #[test]
+    fn test_forward_span_sampling_respects_sampler() {
+        // VOL-3: forwarded worker spans must pass through the engine sampler
+        // rather than being exported unconditionally.
+        let json_str = r#"{
+            "resourceSpans": [{
+                "resource": {
+                    "attributes": [{
+                        "key": "service.name",
+                        "value": {"stringValue": "harness"}
+                    }]
+                },
+                "scopeSpans": [{
+                    "scope": {"name": "test-scope", "version": "1.0.0"},
+                    "spans": [{
+                        "traceId": "0af7651916cd43dd8448eb211c80319c",
+                        "spanId": "b7ad6b7169203331",
+                        "name": "sampled-span",
+                        "kind": 1,
+                        "startTimeUnixNano": "1704067200000000000",
+                        "endTimeUnixNano": "1704067201000000000",
+                        "status": {"code": 1, "message": ""}
+                    }]
+                }]
+            }]
+        }"#;
+        let request: OtlpExportTraceServiceRequest =
+            serde_json::from_str(json_str).expect("parse JSON");
+        let span_data = convert_otlp_to_span_data(&request);
+        let sd = &span_data[0];
+
+        assert!(
+            forward_span_is_sampled(&Sampler::AlwaysOn, sd),
+            "AlwaysOn must keep forwarded spans"
+        );
+        assert!(
+            !forward_span_is_sampled(&Sampler::AlwaysOff, sd),
+            "AlwaysOff must drop forwarded spans"
+        );
     }
 
     #[test]

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -162,6 +162,12 @@ impl QueueWorker {
             }
         }
 
+        // Name the function this message will run in the propagated baggage, so
+        // the `fn_queue` consumer span (and the worker context it delivers) carry
+        // `iii.function.id = <target>` rather than the enqueuer's id that
+        // `BaggageSpanProcessor` would otherwise stamp.
+        let baggage = crate::telemetry::baggage_with_function_id(baggage.as_deref(), function_id);
+
         self.adapter
             .publish_to_function_queue(
                 queue_name,

--- a/engine/src/workers/state/state.rs
+++ b/engine/src/workers/state/state.rs
@@ -233,7 +233,7 @@ impl StateWorker {
                         tracing::Span::current().record("otel.status_code", "OK");
                     }
                 }
-                .instrument(tracing::info_span!(parent: current_span, "state_triggers", otel.status_code = tracing::field::Empty))
+                .instrument(tracing::info_span!(parent: current_span, "state_triggers", "iii.function.kind" = "internal", otel.status_code = tracing::field::Empty))
             );
         } else {
             tracing::error!("Failed to convert event data to value");

--- a/engine/src/workers/state/state.rs
+++ b/engine/src/workers/state/state.rs
@@ -191,7 +191,9 @@ impl StateWorker {
                                 condition_function_id = %condition_id,
                                 "Checking trigger conditions"
                             );
-                            match check_condition(engine.as_ref(), condition_id, event_data.clone()).await {
+                            match check_condition(engine.as_ref(), condition_id, event_data.clone())
+                                .await
+                            {
                                 Ok(true) => {}
                                 Ok(false) => {
                                     tracing::debug!(
@@ -246,7 +248,7 @@ impl StateWorker {
                         tracing::Span::current().record("otel.status_code", "OK");
                     }
                 }
-                .instrument(trigger_span)
+                .instrument(trigger_span),
             );
         } else {
             tracing::error!("Failed to convert event data to value");

--- a/engine/src/workers/state/state.rs
+++ b/engine/src/workers/state/state.rs
@@ -163,9 +163,22 @@ impl StateWorker {
         let engine = self.engine.clone();
         let event_type = event_data.event_type.clone();
 
-        let current_span = tracing::Span::current();
+        // The engine attaches the writer's OTel context for the state write
+        // (even for suppressed builtins — see invocation::handle_invocation), so
+        // parent the spawned trigger fan-out to it. Otherwise `state_triggers`
+        // (and the handlers it invokes, e.g. turn::on_approval) would root a new
+        // trace disconnected from the writer (e.g. approval::resolve).
+        let parent_cx = opentelemetry::Context::current();
 
         if let Ok(event_data) = serde_json::to_value(event_data) {
+            let trigger_span = {
+                let _guard = parent_cx.attach();
+                tracing::info_span!(
+                    "state_triggers",
+                    "iii.function.kind" = "internal",
+                    otel.status_code = tracing::field::Empty
+                )
+            };
             tokio::spawn(
                 async move {
                     tracing::debug!("Invoking triggers for event type {:?}", event_type);
@@ -233,7 +246,7 @@ impl StateWorker {
                         tracing::Span::current().record("otel.status_code", "OK");
                     }
                 }
-                .instrument(tracing::info_span!(parent: current_span, "state_triggers", "iii.function.kind" = "internal", otel.status_code = tracing::field::Empty))
+                .instrument(trigger_span)
             );
         } else {
             tracing::error!("Failed to convert event data to value");

--- a/engine/src/workers/stream/stream.rs
+++ b/engine/src/workers/stream/stream.rs
@@ -355,73 +355,80 @@ impl StreamWorker {
                     otel.status_code = tracing::field::Empty
                 )
             };
-            tokio::spawn(async move {
-                let mut has_error = false;
+            tokio::spawn(
+                async move {
+                    let mut has_error = false;
 
-                for stream_trigger in triggers_to_invoke {
-                    let trigger = &stream_trigger.trigger;
+                    for stream_trigger in triggers_to_invoke {
+                        let trigger = &stream_trigger.trigger;
 
-                    // Check condition if specified (using pre-parsed value)
-                    let condition_function_id = stream_trigger.config.condition_function_id.clone();
+                        // Check condition if specified (using pre-parsed value)
+                        let condition_function_id =
+                            stream_trigger.config.condition_function_id.clone();
 
-                    if let Some(ref condition_id) = condition_function_id {
+                        if let Some(ref condition_id) = condition_function_id {
+                            tracing::debug!(
+                                condition_function_id = %condition_id,
+                                "Checking trigger conditions"
+                            );
+                            match check_condition(engine.as_ref(), condition_id, event_data.clone())
+                                .await
+                            {
+                                Ok(true) => {}
+                                Ok(false) => {
+                                    tracing::debug!(
+                                        function_id = %trigger.function_id,
+                                        "Condition check failed, skipping handler"
+                                    );
+                                    continue;
+                                }
+                                Err(err) => {
+                                    tracing::error!(
+                                        condition_function_id = %condition_id,
+                                        error = ?err,
+                                        "Error invoking condition function"
+                                    );
+                                    has_error = true;
+                                    continue;
+                                }
+                            }
+                        }
+
+                        // Invoke the handler function
                         tracing::debug!(
-                            condition_function_id = %condition_id,
-                            "Checking trigger conditions"
+                            function_id = %trigger.function_id,
+                            "Invoking trigger"
                         );
-                        match check_condition(engine.as_ref(), condition_id, event_data.clone()).await {
-                            Ok(true) => {}
-                            Ok(false) => {
+
+                        let call_result =
+                            engine.call(&trigger.function_id, event_data.clone()).await;
+
+                        match call_result {
+                            Ok(_) => {
                                 tracing::debug!(
                                     function_id = %trigger.function_id,
-                                    "Condition check failed, skipping handler"
+                                    "Trigger handler invoked successfully"
                                 );
-                                continue;
                             }
                             Err(err) => {
-                                tracing::error!(
-                                    condition_function_id = %condition_id,
-                                    error = ?err,
-                                    "Error invoking condition function"
-                                );
                                 has_error = true;
-                                continue;
+                                tracing::error!(
+                                    function_id = %trigger.function_id,
+                                    error = ?err,
+                                    "Error invoking trigger handler"
+                                );
                             }
                         }
                     }
 
-                    // Invoke the handler function
-                    tracing::debug!(
-                        function_id = %trigger.function_id,
-                        "Invoking trigger"
-                    );
-
-                    let call_result = engine.call(&trigger.function_id, event_data.clone()).await;
-
-                    match call_result {
-                        Ok(_) => {
-                            tracing::debug!(
-                                function_id = %trigger.function_id,
-                                "Trigger handler invoked successfully"
-                            );
-                        }
-                        Err(err) => {
-                            has_error = true;
-                            tracing::error!(
-                                function_id = %trigger.function_id,
-                                error = ?err,
-                                "Error invoking trigger handler"
-                            );
-                        }
+                    if has_error {
+                        tracing::Span::current().record("otel.status_code", "ERROR");
+                    } else {
+                        tracing::Span::current().record("otel.status_code", "OK");
                     }
                 }
-
-                if has_error {
-                    tracing::Span::current().record("otel.status_code", "ERROR");
-                } else {
-                    tracing::Span::current().record("otel.status_code", "OK");
-                }
-            }.instrument(trigger_span));
+                .instrument(trigger_span),
+            );
         } else {
             tracing::error!("Failed to convert event data to value");
         }

--- a/engine/src/workers/stream/stream.rs
+++ b/engine/src/workers/stream/stream.rs
@@ -409,7 +409,7 @@ impl StreamWorker {
                 } else {
                     tracing::Span::current().record("otel.status_code", "OK");
                 }
-            }.instrument(tracing::info_span!(parent: current_span, "stream_triggers", otel.status_code = tracing::field::Empty)));
+            }.instrument(tracing::info_span!(parent: current_span, "stream_triggers", "iii.function.kind" = "internal", otel.status_code = tracing::field::Empty)));
         } else {
             tracing::error!("Failed to convert event data to value");
         }

--- a/engine/src/workers/stream/stream.rs
+++ b/engine/src/workers/stream/stream.rs
@@ -340,9 +340,21 @@ impl StreamWorker {
             return;
         }
 
-        let current_span = tracing::Span::current();
+        // The engine attaches the writer's OTel context for the stream write
+        // (even for suppressed builtins — see invocation::handle_invocation), so
+        // parent the spawned trigger fan-out to it instead of orphaning
+        // `stream_triggers` into a brand-new, disconnected trace.
+        let parent_cx = opentelemetry::Context::current();
 
         if let Ok(event_data) = serde_json::to_value(event_data) {
+            let trigger_span = {
+                let _guard = parent_cx.attach();
+                tracing::info_span!(
+                    "stream_triggers",
+                    "iii.function.kind" = "internal",
+                    otel.status_code = tracing::field::Empty
+                )
+            };
             tokio::spawn(async move {
                 let mut has_error = false;
 
@@ -409,7 +421,7 @@ impl StreamWorker {
                 } else {
                     tracing::Span::current().record("otel.status_code", "OK");
                 }
-            }.instrument(tracing::info_span!(parent: current_span, "stream_triggers", "iii.function.kind" = "internal", otel.status_code = tracing::field::Empty)));
+            }.instrument(trigger_span));
         } else {
             tracing::error!("Failed to convert event data to value");
         }

--- a/engine/src/workers/telemetry/mod.rs
+++ b/engine/src/workers/telemetry/mod.rs
@@ -212,6 +212,21 @@ pub fn is_iii_builtin_function_id(id: &str) -> bool {
         || id.starts_with("steps::")
 }
 
+/// Whether OTEL spans should be emitted for built-in framework function
+/// invocations (`state::*`, `stream::*`, `engine::*`, …).
+///
+/// Defaults to `false`: built-in calls are high-frequency and low-value in
+/// traces, so suppressing them sharply reduces span volume. Set
+/// `III_OTEL_TRACE_BUILTINS=true` (or `1`) to emit them anyway.
+pub fn trace_builtins_enabled() -> bool {
+    static CACHE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *CACHE.get_or_init(|| {
+        std::env::var("III_OTEL_TRACE_BUILTINS")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    })
+}
+
 fn check_disabled(config: &TelemetryConfig) -> Option<DisableReason> {
     if !config.enabled {
         return Some(DisableReason::Config);

--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -364,8 +364,14 @@ class Sdk implements ISdk {
           if (getTracer()) {
             const parentContext = extractContext(traceparent, baggage)
 
+            // INTERNAL and named `execute` (not `call`/`trigger`): the engine
+            // already emits the SERVER `call <fn>` span for this hop AND a
+            // `trigger <fn>` span from fire_triggers. Reusing either name would
+            // duplicate an engine span under the worker's service. `execute` is
+            // unique, so the worker handler span reads as a clean internal child
+            // of the engine's call span (and is collapsible by a single rule).
             return context.with(parentContext, () =>
-              withSpan(`call ${functionId}`, { kind: SpanKind.SERVER }, async () => await runHandler()),
+              withSpan(`execute ${functionId}`, { kind: SpanKind.INTERNAL }, async () => await runHandler()),
             )
           }
 

--- a/sdk/packages/node/observability/src/telemetry-system/fetch-instrumentation.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/fetch-instrumentation.ts
@@ -26,6 +26,21 @@ const SAFE_RESPONSE_HEADERS = ['content-type'] as const
 let originalFetch: typeof globalThis.fetch | null = null
 
 /**
+ * Substring patterns from `OTEL_FETCH_IGNORE_URLS` (comma-separated). A fetch
+ * whose URL contains any pattern is executed WITHOUT creating a span — use it
+ * to drop noisy/high-frequency calls (health checks, polling, internal
+ * endpoints) that would otherwise flood traces.
+ */
+const FETCH_IGNORE_URL_PATTERNS: string[] = (process.env.OTEL_FETCH_IGNORE_URLS ?? '')
+  .split(',')
+  .map(s => s.trim())
+  .filter(Boolean)
+
+function shouldIgnoreFetchUrl(url: string): boolean {
+  return FETCH_IGNORE_URL_PATTERNS.some(pattern => url.includes(pattern))
+}
+
+/**
  * Patch globalThis.fetch to create OTel CLIENT spans for every HTTP request.
  */
 export function patchGlobalFetch(tracer: Tracer): void {
@@ -39,6 +54,12 @@ export function patchGlobalFetch(tracer: Tracer): void {
     init?: RequestInit,
   ): Promise<Response> => {
     const url = input instanceof Request ? input.url : String(input)
+
+    // Skip tracing entirely for ignored URLs (no span, no context injection).
+    if (shouldIgnoreFetchUrl(url)) {
+      return capturedFetch(input, init)
+    }
+
     const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase()
 
     let host: string | undefined

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -482,6 +482,7 @@ class III:
 
     async def _invoke_with_otel_context(
         self,
+        function_id: str,
         handler: Callable[[Any], Awaitable[Any]],
         data: Any,
         traceparent: str | None,
@@ -509,10 +510,16 @@ class III:
         )
         payload_max_bytes = resolve_max_bytes_from_env()
 
+        # INTERNAL and named `execute` (not `call`/`trigger`): the engine
+        # already emits the SERVER `call <fn>` span for this hop AND a
+        # `trigger <fn>` span from fire_triggers. Reusing either name would
+        # duplicate an engine span under the worker's service. `execute` is
+        # unique, so the worker handler span reads as a clean internal child
+        # of the engine's call span (and is collapsible by a single rule).
         with tracer.start_as_current_span(
-            f"call {handler.__name__}",
+            f"execute {function_id}",
             context=parent_ctx,
-            kind=trace.SpanKind.SERVER,
+            kind=trace.SpanKind.INTERNAL,
         ) as span:
             if trace_payloads and span.is_recording():
                 input_json, input_truncated = redact_and_truncate(data, payload_max_bytes)
@@ -620,7 +627,7 @@ class III:
         if not invocation_id:
             task = asyncio.create_task(
                 self._invoke_with_otel_context(
-                    func.handler, resolved_data, traceparent, baggage
+                    path, func.handler, resolved_data, traceparent, baggage
                 )
             )
             task.add_done_callback(self._log_task_exception)
@@ -628,6 +635,7 @@ class III:
 
         try:
             result, response_traceparent = await self._invoke_with_otel_context(
+                path,
                 func.handler,
                 resolved_data,
                 traceparent,

--- a/sdk/packages/python/iii/tests/test_invocation_exception.py
+++ b/sdk/packages/python/iii/tests/test_invocation_exception.py
@@ -34,7 +34,7 @@ async def test_invoke_with_otel_context_records_exception_with_stacktrace():
             raise ValueError("test invocation error")
 
         with pytest.raises(_TraceContextError) as exc_info:
-            await client._invoke_with_otel_context(failing_handler, {"key": "value"}, None, None)
+            await client._invoke_with_otel_context("test.fn", failing_handler, {"key": "value"}, None, None)
         assert isinstance(exc_info.value.__cause__, ValueError)
         assert "test invocation error" in str(exc_info.value.__cause__)
 
@@ -81,7 +81,7 @@ async def test_invoke_with_otel_context_success_no_exception():
         async def success_handler(data):
             return {"result": "ok"}
 
-        result, traceparent = await client._invoke_with_otel_context(success_handler, {"key": "value"}, None, None)
+        result, traceparent = await client._invoke_with_otel_context("test.fn", success_handler, {"key": "value"}, None, None)
 
         assert result == {"result": "ok"}
 

--- a/sdk/packages/python/observability/src/iii_observability/http_instrumentation.py
+++ b/sdk/packages/python/observability/src/iii_observability/http_instrumentation.py
@@ -7,6 +7,8 @@ traceparent into outgoing headers, and records exceptions on network errors.
 
 from __future__ import annotations
 
+import os
+
 import httpx
 from opentelemetry import trace
 from opentelemetry.propagate import inject
@@ -18,6 +20,19 @@ _SAFE_RESPONSE_HEADERS = ("content-type",)
 
 def _span_name(method: str, path: str | None) -> str:
     return f"{method} {path}" if path else method
+
+
+def _fetch_ignore_url_patterns() -> list[str]:
+    """Substring patterns from OTEL_FETCH_IGNORE_URLS (comma-separated)."""
+    return [
+        s.strip()
+        for s in (os.environ.get("OTEL_FETCH_IGNORE_URLS") or "").split(",")
+        if s.strip()
+    ]
+
+
+def _should_ignore_fetch_url(url: str) -> bool:
+    return any(pattern in url for pattern in _fetch_ignore_url_patterns())
 
 
 async def execute_traced_request(
@@ -32,6 +47,10 @@ async def execute_traced_request(
     - Records exceptions for network-level errors.
     """
     url = request.url
+    url_str = str(url)
+    if _should_ignore_fetch_url(url_str):
+        return await client.send(request)
+
     method = request.method.upper()
     path = url.path or None
     query = url.query

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -1552,9 +1552,15 @@ impl III {
 
                 let parent_cx = extract_context(traceparent.as_deref(), baggage.as_deref());
                 let tracer = iii_observability::opentelemetry::global::tracer("iii-rust-sdk");
+                // INTERNAL and named `execute` (not `call`/`trigger`): the engine
+                // already emits the SERVER `call <fn>` span for this hop AND a
+                // `trigger <fn>` span from fire_triggers. Reusing either name would
+                // duplicate an engine span under the worker's service. `execute` is
+                // unique, so the worker handler span reads as a clean internal child
+                // of the engine's call span (and is collapsible by a single rule).
                 let span = tracer
-                    .span_builder(format!("call {}", function_id))
-                    .with_kind(SpanKind::Server)
+                    .span_builder(format!("execute {}", function_id))
+                    .with_kind(SpanKind::Internal)
                     .start_with_context(&tracer, &parent_cx);
                 parent_cx.with_span(span)
             };

--- a/sdk/packages/rust/observability/src/telemetry/http_instrumentation.rs
+++ b/sdk/packages/rust/observability/src/telemetry/http_instrumentation.rs
@@ -26,6 +26,22 @@ use reqwest::{Client, Request, Response};
 const SAFE_REQUEST_HEADERS: &[&str] = &["content-type", "accept"];
 const SAFE_RESPONSE_HEADERS: &[&str] = &["content-type"];
 
+fn fetch_ignore_url_patterns() -> Vec<String> {
+    std::env::var("OTEL_FETCH_IGNORE_URLS")
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+fn should_ignore_fetch_url(url: &str) -> bool {
+    fetch_ignore_url_patterns()
+        .iter()
+        .any(|pattern| url.contains(pattern.as_str()))
+}
+
 /// Build a span name matching the Node.js convention: `{METHOD} {path}` or `{METHOD}`.
 fn span_name(method: &str, path: Option<&str>) -> String {
     match path {
@@ -49,6 +65,11 @@ pub async fn execute_traced_request(
     mut request: Request,
 ) -> Result<Response, reqwest::Error> {
     let url = request.url().clone();
+    let url_str = url.to_string();
+    if should_ignore_fetch_url(&url_str) {
+        return client.execute(request).await;
+    }
+
     let method = request.method().as_str().to_uppercase();
 
     let host = url.host_str().map(String::from);


### PR DESCRIPTION
## Summary

Traces for a single logical invocation were carrying multiple redundant spans — the engine emitted a `handle_invocation` SERVER span **and** a `call <fn>` SERVER span, and the worker SDK then emitted its own `call <fn>` SERVER span for the same hop, so one invocation produced 2–3 duplicate server spans (often across services, some bucketed under `unknown_service`). This collapses the duplication and sharply reduces span volume while keeping the trace tree connected and correctly attributed.

## Engine

- **Drop the extra `handle_invocation` span.** The caller's trace context is passed straight through to the downstream `call <fn>` span instead of nesting under an intermediate engine wrapper.
- **Suppress the engine `call <fn>` span** for worker-routed invocations (the worker emits its own canonical span) and for built-in functions (`state::*`, `stream::*`, `engine::*`, … — high-frequency, low trace value). Built-ins can be re-enabled with `III_OTEL_TRACE_BUILTINS=true`.
- **Preserve trace nesting across the WS boundary.** When the engine span is suppressed, the caller's OTel context is attached as the ambient dispatch context so the worker's span nests under the caller's trace instead of orphaning into a new one (`worker_connections/traits.rs` falls back to ambient context when the active tracing span carries none).
- **Richer error spans.** Failed invocations now record `error.message` / `error.type` / `error.stack` attributes and an `exception` event so the trace UI can render error detail rather than a bare `ERROR` status.
- **Per-service SDK span forwarding.** SDK-ingested worker spans are forwarded to the collector keyed by `service.name` (preserving each worker's service identity instead of collapsing to `unknown_service`), and the engine sampler is applied to forwarded spans so collector volume honors `sampling_ratio`.
- **Configurable trace-view span collapse.** New `collapse_spans` rules hide pass-through wrapper spans in the assembled tree and reparent their children to the nearest surviving ancestor (raw/stored/exported spans are untouched). Service-scoped to disambiguate same-named spans across services.
- **Live trace streams.** Coalesced trace rows/spans are pushed onto ephemeral devtools streams so the console Traces view updates in real time (in-memory store stays authoritative; dropped frames self-heal on reconnect).
- Built-in trigger spans are tagged `iii.function.kind=internal` for filtering.

## SDKs (Node / Python / Rust)

- **Rename the worker handler span** from SERVER `call <fn>` to INTERNAL `execute <fn>` so it no longer duplicates the engine's call span and reads as a clean internal child (collapsible by a single rule).
- **`OTEL_FETCH_IGNORE_URLS`** — comma-separated substring patterns to skip tracing for noisy/high-frequency outbound fetches (health checks, polling) without creating a span or injecting context.

## Test plan

- [x] `cargo check --tests` on the engine — compiles clean (0 errors)
- [x] New unit tests pass: span collapse (remove + reparent, service scoping, no-op), forward-span sampling, and forward-resource `service.name` preservation
- [x] SDK span-name and signature changes verified consistent across all call sites (Node / Python / Rust)
- [ ] Validate end-to-end in the harness that a worker invocation produces a single server span per hop with correct parent nesting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live trace streaming with configurable span-collapse rules for trace-tree views
  * Environment variable to ignore specific fetch URLs from tracing (OTEL_FETCH_IGNORE_URLS)
  * Environment variable to toggle builtin function tracing (III_OTEL_TRACE_BUILTINS)

* **Improvements**
  * Better error reporting in traces: span status, error attributes, exception events and stacktraces
  * Downstream traces now inherit caller trace context and function ID baggage when dispatching
  * Local invocation spans renamed to "execute <function>" to avoid duplicate engine/server spans
* **Observability**
  * Per-service span forwarding with sampling and service preservation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->