### PR TITLE
feat(worker-api)!: self-describing worker::* API + builtin worker descriptions

### DIFF
--- a/console/packages/console-frontend/src/components/queues/QueueDlqTab.test.ts
+++ b/console/packages/console-frontend/src/components/queues/QueueDlqTab.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { extractErrorMessage } from './dlq-error'
+
+describe('extractErrorMessage', () => {
+  it('extracts a plain message from the Rust ErrorBody debug format', () => {
+    const raw =
+      'ErrorBody { code: "invocation_failed", message: "Simulated failure", stacktrace: None }'
+    expect(extractErrorMessage(raw)).toBe('Simulated failure')
+  })
+
+  it('surfaces code and inner message from a worker-op JSON envelope with escaped quotes', () => {
+    const raw =
+      'ErrorBody { code: "W105", message: "{\\"type\\":\\"WorkerOpError\\",\\"code\\":\\"W105\\",\\"message\\":\\"invalid payload for \\\\\\"worker::add\\\\\\": missing field `source`\\",\\"details\\":{}}", stacktrace: None }'
+    const result = extractErrorMessage(raw)
+    expect(result).toContain('W105')
+    expect(result).toContain('missing field `source`')
+    expect(result).not.toContain('"type"')
+  })
+
+  it('humanizes a bare JSON envelope without the Debug wrapper', () => {
+    const raw =
+      '{"type":"WorkerOpError","code":"W110","message":"worker \\"x\\" not found","details":{"name":"x"}}'
+    expect(extractErrorMessage(raw)).toBe('W110: worker "x" not found')
+  })
+
+  it('truncates long plain strings', () => {
+    const raw = 'y'.repeat(150)
+    expect(extractErrorMessage(raw)).toBe(`${'y'.repeat(100)}...`)
+  })
+
+  it('returns short plain strings unchanged', () => {
+    expect(extractErrorMessage('boom')).toBe('boom')
+  })
+
+  it('caps an oversized envelope message extracted from the Debug wrapper', () => {
+    const long = 'z'.repeat(300)
+    const raw = `ErrorBody { code: "invocation_failed", message: "${long}", stacktrace: None }`
+    expect(extractErrorMessage(raw)).toBe(`${'z'.repeat(100)}...`)
+  })
+
+  it('caps an oversized bare JSON envelope', () => {
+    const raw = JSON.stringify({ type: 'WorkerOpError', code: 'W900', message: 'q'.repeat(300) })
+    const result = extractErrorMessage(raw)
+    expect(result.startsWith('W900: ')).toBe(true)
+    expect(result.endsWith('...')).toBe(true)
+    expect(result.length).toBe(103)
+  })
+
+  it('drops a non-string code and returns the message alone', () => {
+    expect(extractErrorMessage('{"message":"hi","code":123}')).toBe('hi')
+  })
+
+  it('returns the raw input for a json object without a message field', () => {
+    expect(extractErrorMessage('{"code":"W110"}')).toBe('{"code":"W110"}')
+  })
+})

--- a/console/packages/console-frontend/src/components/queues/QueueDlqTab.test.ts
+++ b/console/packages/console-frontend/src/components/queues/QueueDlqTab.test.ts
@@ -17,6 +17,12 @@ describe('extractErrorMessage', () => {
     expect(result).not.toContain('"type"')
   })
 
+  it('decodes escape sequences (newline, tab, unicode) instead of stripping backslashes', () => {
+    const raw =
+      'ErrorBody { code: "invocation_failed", message: "line1\\nline2\\ttabbed \\u2713", stacktrace: None }'
+    expect(extractErrorMessage(raw)).toBe('line1\nline2\ttabbed ✓')
+  })
+
   it('humanizes a bare JSON envelope without the Debug wrapper', () => {
     const raw =
       '{"type":"WorkerOpError","code":"W110","message":"worker \\"x\\" not found","details":{"name":"x"}}'

--- a/console/packages/console-frontend/src/components/queues/QueueDlqTab.tsx
+++ b/console/packages/console-frontend/src/components/queues/QueueDlqTab.tsx
@@ -17,15 +17,7 @@ import { EmptyState } from '@/components/ui/empty-state'
 import { JsonViewer } from '@/components/ui/json-viewer'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip } from '@/components/ui/tooltip'
-
-function extractErrorMessage(error: string): string {
-  // Extract human-readable message from Rust ErrorBody format:
-  // 'ErrorBody { code: "invocation_failed", message: "Simulated failure", stacktrace: ... }'
-  const msgMatch = error.match(/message:\s*"([^"]*)"/)
-  if (msgMatch) return msgMatch[1]
-  // Fallback: if it's a plain string, return as-is (truncated)
-  return error.length > 100 ? `${error.slice(0, 100)}...` : error
-}
+import { extractErrorMessage } from './dlq-error'
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`

--- a/console/packages/console-frontend/src/components/queues/dlq-error.ts
+++ b/console/packages/console-frontend/src/components/queues/dlq-error.ts
@@ -18,14 +18,28 @@ function truncate(s: string): string {
 export function extractErrorMessage(error: string): string {
   const msgMatch = error.match(/message:\s*"((?:[^"\\]|\\.)*)"/)
   if (msgMatch) {
-    const unescaped = msgMatch[1].replace(/\\(.)/g, '$1')
-    return truncate(humanizeEnvelope(unescaped))
+    return truncate(humanizeEnvelope(unescapeJsonString(msgMatch[1])))
   }
   // The error may already be the bare JSON envelope (no Debug wrapper).
   const direct = humanizeEnvelope(error)
   if (direct !== error) return truncate(direct)
   // Fallback: a plain string, returned as-is (capped).
   return truncate(error)
+}
+
+/**
+ * Decode the escape sequences captured from the Rust Debug `message: "..."`
+ * field. The capture is the raw inner content (escapes intact), so parsing it
+ * as a JSON string preserves `\n`, `\t`, `\uXXXX` instead of stripping the
+ * backslash from every escape. Malformed input falls back to a minimal
+ * quote-unescape so we never throw on worker-supplied text.
+ */
+function unescapeJsonString(inner: string): string {
+  try {
+    return JSON.parse(`"${inner}"`) as string
+  } catch {
+    return inner.replace(/\\"/g, '"')
+  }
 }
 
 /** If `raw` is a worker-op JSON envelope, surface `code: message`; otherwise return it unchanged. */

--- a/console/packages/console-frontend/src/components/queues/dlq-error.ts
+++ b/console/packages/console-frontend/src/components/queues/dlq-error.ts
@@ -1,0 +1,43 @@
+/**
+ * Extract a human-readable message from the Rust `ErrorBody` debug format:
+ * 'ErrorBody { code: "invocation_failed", message: "Simulated failure", stacktrace: ... }'
+ *
+ * The message may contain escaped quotes — worker-op errors embed a JSON
+ * envelope like {"type":"WorkerOpError","code":"W105","message":"..."} — so
+ * the regex matches escaped sequences instead of stopping at the first inner
+ * quote, and JSON envelopes are unwrapped to `code: message`.
+ */
+/** DLQ error strings are worker/handler-supplied and render one per row, so
+ * every path is length-capped to keep an oversized message out of the DOM. */
+const MAX_ERROR_LEN = 100
+
+function truncate(s: string): string {
+  return s.length > MAX_ERROR_LEN ? `${s.slice(0, MAX_ERROR_LEN)}...` : s
+}
+
+export function extractErrorMessage(error: string): string {
+  const msgMatch = error.match(/message:\s*"((?:[^"\\]|\\.)*)"/)
+  if (msgMatch) {
+    const unescaped = msgMatch[1].replace(/\\(.)/g, '$1')
+    return truncate(humanizeEnvelope(unescaped))
+  }
+  // The error may already be the bare JSON envelope (no Debug wrapper).
+  const direct = humanizeEnvelope(error)
+  if (direct !== error) return truncate(direct)
+  // Fallback: a plain string, returned as-is (capped).
+  return truncate(error)
+}
+
+/** If `raw` is a worker-op JSON envelope, surface `code: message`; otherwise return it unchanged. */
+function humanizeEnvelope(raw: string): string {
+  if (!raw.startsWith('{')) return raw
+  try {
+    const parsed = JSON.parse(raw) as { code?: unknown; message?: unknown }
+    if (typeof parsed.message === 'string') {
+      return typeof parsed.code === 'string' ? `${parsed.code}: ${parsed.message}` : parsed.message
+    }
+  } catch {
+    // not JSON — fall through
+  }
+  return raw
+}

--- a/console/packages/console-rust/src/main.rs
+++ b/console/packages/console-rust/src/main.rs
@@ -114,6 +114,9 @@ async fn main() -> Result<()> {
         iii_sdk::InitOptions {
             metadata: Some(iii_sdk::WorkerMetadata {
                 name: "iii-console".to_string(),
+                description: Some(
+                    "Web console UI and observability dashboard for the iii engine.".to_string(),
+                ),
                 ..iii_sdk::WorkerMetadata::default()
             }),
             otel: otel_config,

--- a/crates/iii-worker/Cargo.toml
+++ b/crates/iii-worker/Cargo.toml
@@ -48,7 +48,7 @@ serde_yml = "0.0.12"
 anyhow = "1.0.100"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 async-trait = "0.1.89"
-nix = { version = "0.30.1", features = ["signal", "process", "term"] }
+nix = { version = "0.30.1", features = ["fs", "signal", "process", "term"] }
 dirs = "6"
 sha2 = "0.10"
 hex = "0.4"

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -494,44 +494,12 @@ enum PreparedLockedWorker {
     },
 }
 
-struct ProjectOperationLock {
-    path: PathBuf,
-}
-
-impl ProjectOperationLock {
-    fn acquire() -> Result<Self, String> {
-        let path = PathBuf::from(".iii-worker.lock");
-        match std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&path)
-        {
-            Ok(mut file) => {
-                use std::io::Write as _;
-                let _ = writeln!(file, "pid={}", std::process::id());
-                Ok(Self { path })
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Err(format!(
-                "another iii worker operation is active (lock: {}). Wait for it to finish, \
-                 or remove the lock if the process crashed.",
-                path.display()
-            )),
-            Err(e) => Err(format!(
-                "failed to acquire iii worker operation lock {}: {e}",
-                path.display()
-            )),
-        }
-    }
-}
-
-impl Drop for ProjectOperationLock {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
-    }
-}
-
+/// Per-worker install mutex. Kernel advisory lock (`flock(2)`), so a
+/// crashed installer can never strand the worker — see
+/// `core::project::ProjectOperationLock` for the rationale. The lockfile
+/// persists; only the kernel lock state matters.
 struct WorkerActivationLock {
-    path: PathBuf,
+    _lock: nix::fcntl::Flock<std::fs::File>,
 }
 
 impl WorkerActivationLock {
@@ -541,31 +509,29 @@ impl WorkerActivationLock {
         std::fs::create_dir_all(&dir)
             .map_err(|e| format!("failed to create worker install directory: {e}"))?;
         let path = dir.join(format!(".{name}.lock"));
-        match std::fs::OpenOptions::new()
+        let file = std::fs::OpenOptions::new()
+            .read(true)
             .write(true)
-            .create_new(true)
+            .create(true)
+            .truncate(false)
             .open(&path)
-        {
-            Ok(mut file) => {
+            .map_err(|e| format!("failed to acquire activation lock for worker `{name}`: {e}"))?;
+        match nix::fcntl::Flock::lock(file, nix::fcntl::FlockArg::LockExclusiveNonblock) {
+            Ok(lock) => {
                 use std::io::Write as _;
-                let _ = writeln!(file, "pid={}", std::process::id());
-                Ok(Self { path })
+                let _ = (&*lock).set_len(0);
+                let _ = writeln!(&*lock, "pid={}", std::process::id());
+                Ok(Self { _lock: lock })
             }
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Err(format!(
+            Err((_, nix::errno::Errno::EWOULDBLOCK)) => Err(format!(
                 "worker `{name}` is being installed by another process (lock: {}). Wait and rerun \
                  `iii worker sync`.",
                 path.display()
             )),
-            Err(e) => Err(format!(
-                "failed to acquire activation lock for worker `{name}`: {e}"
+            Err((_, errno)) => Err(format!(
+                "failed to acquire activation lock for worker `{name}`: {errno}"
             )),
         }
-    }
-}
-
-impl Drop for WorkerActivationLock {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
     }
 }
 
@@ -673,13 +639,17 @@ pub async fn handle_worker_sync(frozen: bool) -> i32 {
     }
     let skipped_unmanaged = skipped_unmanaged_config_workers(&lockfile, &config_names);
 
-    let _operation_lock = match ProjectOperationLock::acquire() {
-        Ok(lock) => lock,
-        Err(e) => {
-            eprintln!("{} {}", "error:".red(), e);
-            return 1;
-        }
-    };
+    let _operation_lock =
+        match crate::core::ProjectOperationLock::acquire(std::path::Path::new(".")) {
+            Ok(lock) => lock,
+            Err(e) => {
+                eprintln!(
+                    "{} another iii worker operation is active ({e}). Wait for it to finish.",
+                    "error:".red()
+                );
+                return 1;
+            }
+        };
 
     match replay_lockfile(&lockfile).await {
         Ok(mut summary) => {
@@ -3599,28 +3569,6 @@ fn resolve_orphan_type(
 
 /// Pick the log directory with the most recently modified, non-empty log file.
 /// Returns `None` when no candidate contains any usable log content.
-fn pick_best_logs_dir(candidates: &[std::path::PathBuf]) -> Option<std::path::PathBuf> {
-    let mut best: Option<(std::path::PathBuf, std::time::SystemTime)> = None;
-
-    for dir in candidates {
-        let latest = ["stdout.log", "stderr.log"]
-            .iter()
-            .map(|f| dir.join(f))
-            .filter_map(|p| std::fs::metadata(&p).ok().map(|m| (p, m)))
-            .filter(|(_, m)| m.len() > 0)
-            .filter_map(|(_, m)| m.modified().ok())
-            .max();
-
-        if let Some(modified) = latest
-            && best.as_ref().is_none_or(|(_, t)| modified > *t)
-        {
-            best = Some((dir.clone(), modified));
-        }
-    }
-
-    best.map(|(dir, _)| dir)
-}
-
 fn file_len(path: &std::path::Path) -> u64 {
     std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
 }
@@ -3726,19 +3674,11 @@ pub async fn handle_managed_logs(
     let home = dirs::home_dir().unwrap_or_default();
 
     // Check all possible log locations and prefer the one with the most
-    // recently modified, non-empty log files. This avoids picking a stale
-    // directory (e.g. ~/.iii/logs/ from a binary worker) over the active
-    // one (e.g. ~/.iii/managed/ from a libkrun OCI worker).
-    let unified_logs_dir = home.join(".iii/logs").join(worker_name);
-    let legacy_managed_dir = home.join(".iii/managed").join(worker_name).join("logs");
-    let legacy_binary_dir = home.join(".iii/workers/logs").join(worker_name);
-
-    let logs_dir = pick_best_logs_dir(&[
-        unified_logs_dir.clone(),
-        legacy_managed_dir,
-        legacy_binary_dir,
-    ])
-    .unwrap_or(unified_logs_dir);
+    // recently modified, non-empty log files. Shared with the daemon's
+    // `worker::logs` trigger so both surfaces read the same directory.
+    let candidates = crate::core::logs::candidate_log_dirs(&home, worker_name);
+    let unified_logs_dir = candidates[0].clone();
+    let logs_dir = crate::core::logs::pick_best_logs_dir(&candidates).unwrap_or(unified_logs_dir);
 
     let worker_dir = logs_dir.clone();
 
@@ -5296,10 +5236,10 @@ dependencies:
             assert_eq!(rc, 0);
             assert!(home.join(".iii/workers").join(worker_name).exists());
             assert_eq!(std::fs::read_to_string("config.yaml").unwrap(), config);
-            assert!(
-                !std::path::Path::new(".iii-worker.lock").exists(),
-                "project operation lock should be removed after sync"
-            );
+            // The lockfile persists (flock semantics); the lock itself must
+            // be released so a fresh acquisition succeeds.
+            crate::core::ProjectOperationLock::acquire(std::path::Path::new("."))
+                .expect("project operation lock should be released after sync");
             server.abort();
         })
         .await;
@@ -5776,53 +5716,6 @@ dependencies:
     async fn read_new_bytes_missing_file_returns_offset() {
         let offset = read_new_bytes(std::path::Path::new("/no/such/file.log"), 42, false).await;
         assert_eq!(offset, 42);
-    }
-
-    #[test]
-    fn pick_best_logs_dir_prefers_most_recent() {
-        let root = tempfile::tempdir().unwrap();
-
-        // Create two candidate dirs, both with stdout.log
-        let stale_dir = root.path().join("stale");
-        let fresh_dir = root.path().join("fresh");
-        std::fs::create_dir_all(&stale_dir).unwrap();
-        std::fs::create_dir_all(&fresh_dir).unwrap();
-
-        std::fs::write(stale_dir.join("stdout.log"), "old content\n").unwrap();
-        // Ensure a time gap so the modification times differ
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        std::fs::write(fresh_dir.join("stdout.log"), "new content\n").unwrap();
-
-        let result = pick_best_logs_dir(&[stale_dir.clone(), fresh_dir.clone()]).unwrap();
-        assert_eq!(result, fresh_dir);
-    }
-
-    #[test]
-    fn pick_best_logs_dir_skips_empty_files() {
-        let root = tempfile::tempdir().unwrap();
-        let empty_dir = root.path().join("empty");
-        let content_dir = root.path().join("content");
-        std::fs::create_dir_all(&empty_dir).unwrap();
-        std::fs::create_dir_all(&content_dir).unwrap();
-
-        std::fs::write(empty_dir.join("stdout.log"), "").unwrap();
-        std::fs::write(content_dir.join("stdout.log"), "data\n").unwrap();
-
-        let result = pick_best_logs_dir(&[empty_dir.clone(), content_dir.clone()]).unwrap();
-        assert_eq!(result, content_dir);
-    }
-
-    #[test]
-    fn pick_best_logs_dir_returns_none_when_no_content() {
-        let root = tempfile::tempdir().unwrap();
-        let dir_a = root.path().join("a");
-        let dir_b = root.path().join("b");
-        std::fs::create_dir_all(&dir_a).unwrap();
-        // dir_b doesn't even exist
-
-        std::fs::write(dir_a.join("stdout.log"), "").unwrap();
-
-        assert!(pick_best_logs_dir(&[dir_a, dir_b]).is_none());
     }
 
     #[tokio::test]

--- a/crates/iii-worker/src/cli/registry.rs
+++ b/crates/iii-worker/src/cli/registry.rs
@@ -136,30 +136,7 @@ pub struct ResolvedRoot {
 /// `iii worker remove .locks` -> delete_worker_artifacts wipe every per-worker
 /// fslock system-wide. We blanket-reject leading-dot names so the rule is
 /// stable even as new internal directories are added.
-pub fn validate_worker_name(name: &str) -> Result<(), String> {
-    if name.is_empty() {
-        return Err("Worker name cannot be empty".into());
-    }
-    if name.contains("..") {
-        return Err(format!("Worker name '{}' contains '..' sequence", name));
-    }
-    if name.starts_with('.') {
-        return Err(format!(
-            "Worker name '{}' cannot start with '.' (reserved for internal control directories)",
-            name
-        ));
-    }
-    if !name
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
-    {
-        return Err(format!(
-            "Worker name '{}' contains invalid characters. Only alphanumeric, dash, underscore, and dot are allowed.",
-            name
-        ));
-    }
-    Ok(())
-}
+pub use crate::core::types::validate_worker_name;
 
 /// Parse "name@version" into (name, Some(version)) or just (name, None).
 pub fn parse_worker_input(input: &str) -> (String, Option<String>) {

--- a/crates/iii-worker/src/cli/worker_manager_daemon.rs
+++ b/crates/iii-worker/src/cli/worker_manager_daemon.rs
@@ -18,10 +18,10 @@ use std::sync::{Arc, Mutex};
 
 use crate::core::{
     AddOptions, AddOutcome, ClearOptions, ClearOutcome, EventSink, ListOptions, ListOutcome,
-    NullSink, ProjectCtx, RemoveOptions, RemoveOutcome, StartOptions, StartOutcome, StopOptions,
-    StopOutcome, UpdateOptions, UpdateOutcome, WorkerOpError, add as core_add, clear as core_clear,
-    list as core_list, remove as core_remove, start as core_start, stop as core_stop,
-    update as core_update,
+    LogsOptions, LogsOutcome, NullSink, ProjectCtx, RemoveOptions, RemoveOutcome, StartOptions,
+    StartOutcome, StopOptions, StopOutcome, UpdateOptions, UpdateOutcome, WorkerOpError,
+    WorkerOpErrorKind, add as core_add, clear as core_clear, list as core_list, logs as core_logs,
+    remove as core_remove, start as core_start, stop as core_stop, update as core_update,
 };
 use iii_observability::OtelConfig;
 use iii_sdk::{
@@ -29,7 +29,7 @@ use iii_sdk::{
     register_worker,
 };
 use schemars::{JsonSchema, schema_for};
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::cli::app::WorkerManagerDaemonArgs;
 use crate::cli::host_shim::CliHostShim;
@@ -53,6 +53,12 @@ pub async fn run(args: WorkerManagerDaemonArgs) -> i32 {
             otel: Some(OtelConfig::default()),
             metadata: Some(WorkerMetadata {
                 name: "iii-worker-ops".to_string(),
+                description: Some(
+                    "Manages installed workers: add/remove/update/start/stop/list/clear/logs, \
+                     plus worker::schema introspection and the `worker` lifecycle \
+                     trigger type."
+                        .to_string(),
+                ),
                 ..Default::default()
             }),
             ..Default::default()
@@ -94,31 +100,79 @@ pub fn err_payload(e: &WorkerOpError) -> String {
     serde_json::to_string(&e.to_payload()).unwrap_or_else(|_| e.to_string())
 }
 
-/// Map a serde failure into the W101 envelope so bad payloads return the
-/// same `{ type, code, details }` shape as handler-level errors.
+/// Map a serde failure into the W105 envelope so bad payloads return the
+/// same `{ type, code, details }` shape as handler-level errors. The
+/// envelope carries a `hint` pointing at `worker::schema` so callers (LLMs
+/// included) can self-correct without out-of-band docs.
 #[doc(hidden)]
-pub fn bad_request_payload(input_label: &str, e: &serde_json::Error) -> String {
-    let err = WorkerOpError::InvalidSource {
-        input: input_label.into(),
+pub fn bad_request_payload(function_id: &str, e: &serde_json::Error) -> String {
+    let err = WorkerOpError::BadRequest {
+        function_id: function_id.into(),
         reason: e.to_string(),
     };
     err_payload(&err)
 }
 
-fn handler_error(payload: String) -> IIIError {
-    IIIError::Handler(payload)
-}
-
+/// Surface op failures as `IIIError::Remote` so the wire `ErrorBody.code`
+/// is the stable W-code (instead of the generic `invocation_failed`) and no
+/// dispatch-loop backtrace gets attached to an expected error.
 fn op_error(e: &WorkerOpError) -> IIIError {
-    handler_error(err_payload(e))
+    IIIError::Remote {
+        code: e.kind().code().to_string(),
+        message: err_payload(e),
+        stacktrace: None,
+    }
 }
 
-fn bad_request_error(input_label: &str, e: &serde_json::Error) -> IIIError {
-    handler_error(bad_request_payload(input_label, e))
+fn bad_request_error(function_id: &str, e: &serde_json::Error) -> IIIError {
+    IIIError::Remote {
+        code: WorkerOpErrorKind::BadRequest.code().to_string(),
+        message: bad_request_payload(function_id, e),
+        stacktrace: None,
+    }
 }
 
 fn schema_for_value<T: JsonSchema>() -> Option<Value> {
     serde_json::to_value(schema_for!(T)).ok()
+}
+
+/// One-line description per op. Single source of truth shared by the
+/// function registrations (surfaced via `engine::functions::info`) and the
+/// `worker::schema` response.
+#[doc(hidden)]
+pub fn op_description(function_id: &str) -> &'static str {
+    match function_id {
+        "worker::add" => "Install a worker from registry name or OCI ref",
+        "worker::remove" => "Uninstall workers and clear their artifacts",
+        "worker::update" => "Reinstall workers preserving config",
+        "worker::start" => "Start a configured worker",
+        "worker::stop" => "Stop a running worker",
+        "worker::list" => "List installed workers",
+        "worker::clear" => "Wipe worker artifacts",
+        "worker::logs" => {
+            "Read a worker's recent stdout/stderr log lines from the engine host. \
+             `tail` bounds lines per stream (default 100, max 1000)."
+        }
+        "worker::schema" => {
+            "Introspect request/response schemas for worker::* triggers. \
+             Optional `function_id` filters to a single trigger."
+        }
+        _ => "",
+    }
+}
+
+/// Stamp the standard introspection contract onto a registration:
+/// description plus timeout/idempotency metadata. The request/response JSON
+/// Schemas come from the SDK's typed-handler auto-extraction (the handlers
+/// take the typed options structs directly), so together with this stamp
+/// `engine::functions::info { function_id: "worker::add" }` is
+/// self-sufficient for callers that have never seen this API.
+fn describe_op(rf: RegisterFunction, function_id: &str) -> RegisterFunction {
+    let (default_timeout_ms, idempotent) = op_metadata(function_id);
+    rf.description(op_description(function_id)).metadata(json!({
+        "default_timeout_ms": default_timeout_ms,
+        "idempotent": idempotent,
+    }))
 }
 
 fn register_all(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
@@ -129,6 +183,7 @@ fn register_all(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     register_stop(iii, project_root.clone(), sink.clone());
     register_list(iii, project_root.clone());
     register_clear(iii, project_root, sink);
+    register_logs(iii);
     register_schema(iii);
 }
 
@@ -151,8 +206,16 @@ struct SchemaEntry {
     idempotent: bool,
 }
 
-/// (default_timeout_ms, idempotent). Mirrors the table in
-/// `docs/workers/worker-management-triggers.mdx`.
+/// (default_timeout_ms, idempotent). Mirrors the table in the
+/// worker-management-triggers doc (currently
+/// `docs/0-11-0/workers/worker-management-triggers.mdx`).
+///
+/// `idempotent` describes the DEFAULT request: `worker::add`/`worker::update`
+/// are idempotent only when `force`/`reset_config` are unset. With `force:
+/// true` they stop the worker, delete artifacts, and re-run the manifest's
+/// install scripts — so an automation/LLM that retries a forced call based on
+/// this flag re-runs those side effects. Retry-on-timeout is safe for the
+/// default shape, not for forced replacement.
 #[doc(hidden)]
 pub fn op_metadata(function_id: &str) -> (u64, bool) {
     match function_id {
@@ -163,6 +226,7 @@ pub fn op_metadata(function_id: &str) -> (u64, bool) {
         "worker::stop" => (30_000, false),
         "worker::list" => (10_000, true),
         "worker::clear" => (30_000, true),
+        "worker::logs" => (10_000, true),
         "worker::schema" => (10_000, true),
         _ => (30_000, false),
     }
@@ -173,85 +237,105 @@ struct SchemaResponse {
     schemas: Vec<SchemaEntry>,
 }
 
-fn register_schema(iii: &III) {
-    let _ = iii.register_function(
-        "worker::schema",
-        RegisterFunction::new_async(|payload: Value| async move {
-            let req: SchemaRequest = serde_json::from_value(payload)
-                .map_err(|e| bad_request_error("worker::schema", &e))?;
-            let all = vec![
+/// The 9 worker::* (function_id, request, response) schema triples, built
+/// once via schemars reflection and reused on every `worker::schema` call.
+/// Regenerating all 16 schemas per invocation was wasted CPU/allocation on
+/// an endpoint LLM/automation callers hit repeatedly; only the matched
+/// entries are cloned per request.
+fn schema_table() -> &'static [(&'static str, Option<Value>, Option<Value>)] {
+    static TABLE: std::sync::LazyLock<Vec<(&'static str, Option<Value>, Option<Value>)>> =
+        std::sync::LazyLock::new(|| {
+            vec![
                 (
                     "worker::add",
-                    "Install a worker from registry name or OCI ref",
                     schema_for_value::<AddOptions>(),
                     schema_for_value::<AddOutcome>(),
                 ),
                 (
                     "worker::remove",
-                    "Uninstall workers and clear their artifacts",
                     schema_for_value::<RemoveOptions>(),
                     schema_for_value::<RemoveOutcome>(),
                 ),
                 (
                     "worker::update",
-                    "Reinstall workers preserving config",
                     schema_for_value::<UpdateOptions>(),
                     schema_for_value::<UpdateOutcome>(),
                 ),
                 (
                     "worker::start",
-                    "Start a configured worker",
                     schema_for_value::<StartOptions>(),
                     schema_for_value::<StartOutcome>(),
                 ),
                 (
                     "worker::stop",
-                    "Stop a running worker",
                     schema_for_value::<StopOptions>(),
                     schema_for_value::<StopOutcome>(),
                 ),
                 (
                     "worker::list",
-                    "List installed workers",
                     schema_for_value::<ListOptions>(),
                     schema_for_value::<ListOutcome>(),
                 ),
                 (
                     "worker::clear",
-                    "Wipe worker artifacts",
                     schema_for_value::<ClearOptions>(),
                     schema_for_value::<ClearOutcome>(),
                 ),
                 (
+                    "worker::logs",
+                    schema_for_value::<LogsOptions>(),
+                    schema_for_value::<LogsOutcome>(),
+                ),
+                (
                     "worker::schema",
-                    "Introspect request/response schemas for worker::* triggers",
                     schema_for_value::<SchemaRequest>(),
                     schema_for_value::<SchemaResponse>(),
                 ),
-            ];
+            ]
+        });
+    &TABLE
+}
+
+fn register_logs(iii: &III) {
+    let _ =
+        iii.register_function(
+            "worker::logs",
+            describe_op(
+                RegisterFunction::new_async_with_bad_request(
+                    |opts: LogsOptions| async move {
+                        core_logs::run(opts).await.map_err(|e| op_error(&e))
+                    },
+                    |e| bad_request_error("worker::logs", &e),
+                ),
+                "worker::logs",
+            ),
+        );
+}
+
+fn register_schema(iii: &III) {
+    let rf = RegisterFunction::new_async_with_bad_request(
+        |req: SchemaRequest| async move {
             let filter = req.function_id.as_deref();
-            let schemas: Vec<SchemaEntry> = all
-                .into_iter()
-                .filter(|(id, _, _, _)| filter.is_none_or(|f| f == *id))
-                .map(|(id, desc, req, resp)| {
+            let schemas: Vec<SchemaEntry> = schema_table()
+                .iter()
+                .filter(|(id, _, _)| filter.is_none_or(|f| f == *id))
+                .map(|(id, req, resp)| {
                     let (timeout_ms, idempotent) = op_metadata(id);
                     SchemaEntry {
-                        function_id: id.into(),
-                        description: desc.into(),
-                        request: req.unwrap_or(Value::Null),
-                        response: resp.unwrap_or(Value::Null),
+                        function_id: (*id).into(),
+                        description: op_description(id).into(),
+                        request: req.clone().unwrap_or(Value::Null),
+                        response: resp.clone().unwrap_or(Value::Null),
                         default_timeout_ms: timeout_ms,
                         idempotent,
                     }
                 })
                 .collect();
             Ok::<_, IIIError>(SchemaResponse { schemas })
-        })
-        .description(
-            "Introspect request/response schemas for worker::* triggers. \
-             Optional `function_id` filters to a single trigger.",
-        ),
+        },
+        |e| bad_request_error("worker::schema", &e),
     );
+    let _ = iii.register_function("worker::schema", describe_op(rf, "worker::schema"));
 }
 
 fn sink_ref<'a>(sink: &'a Arc<IIIEventSink>) -> &'a dyn EventSink {
@@ -264,144 +348,158 @@ fn sink_ref<'a>(sink: &'a Arc<IIIEventSink>) -> &'a dyn EventSink {
 fn register_add(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         "worker::add",
-        RegisterFunction::new_async(move |payload: Value| {
-            let project_root = project_root.clone();
-            let sink = sink.clone();
-            async move {
-                let opts: AddOptions = serde_json::from_value(payload)
-                    .map_err(|e| bad_request_error("worker::add", &e))?;
-                let ctx = ProjectCtx::open(project_root).map_err(|e| op_error(&e))?;
-                core_add::run(
-                    opts,
-                    &ctx,
-                    sink_ref(&sink),
-                    &CliHostShim,
-                    core_add::CallerMode::Trigger,
-                )
-                .await
-                .map_err(|e| op_error(&e))
-            }
-        })
-        .description("Install a worker from registry name or OCI ref"),
+        describe_op(
+            RegisterFunction::new_async_with_bad_request(
+                move |opts: AddOptions| {
+                    let project_root = project_root.clone();
+                    let sink = sink.clone();
+                    async move {
+                        let ctx = ProjectCtx::open(project_root).map_err(|e| op_error(&e))?;
+                        core_add::run(opts, &ctx, sink_ref(&sink), &CliHostShim)
+                            .await
+                            .map_err(|e| op_error(&e))
+                    }
+                },
+                |e| bad_request_error("worker::add", &e),
+            ),
+            "worker::add",
+        ),
     );
 }
 
 fn register_remove(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         "worker::remove",
-        RegisterFunction::new_async(move |payload: Value| {
-            let project_root = project_root.clone();
-            let sink = sink.clone();
-            async move {
-                let opts: RemoveOptions = serde_json::from_value(payload)
-                    .map_err(|e| bad_request_error("worker::remove", &e))?;
-                let ctx = ProjectCtx::open(project_root).map_err(|e| op_error(&e))?;
-                core_remove::run(opts, &ctx, sink_ref(&sink), &CliHostShim)
-                    .await
-                    .map_err(|e| op_error(&e))
-            }
-        })
-        .description("Uninstall workers and clear their artifacts"),
+        describe_op(
+            RegisterFunction::new_async_with_bad_request(
+                move |opts: RemoveOptions| {
+                    let project_root = project_root.clone();
+                    let sink = sink.clone();
+                    async move {
+                        let ctx = ProjectCtx::open(project_root).map_err(|e| op_error(&e))?;
+                        core_remove::run(opts, &ctx, sink_ref(&sink), &CliHostShim)
+                            .await
+                            .map_err(|e| op_error(&e))
+                    }
+                },
+                |e| bad_request_error("worker::remove", &e),
+            ),
+            "worker::remove",
+        ),
     );
 }
 
 fn register_update(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         "worker::update",
-        RegisterFunction::new_async(move |payload: Value| {
-            let project_root = project_root.clone();
-            let sink = sink.clone();
-            async move {
-                let opts: UpdateOptions = serde_json::from_value(payload)
-                    .map_err(|e| bad_request_error("worker::update", &e))?;
-                let ctx = ProjectCtx::open(project_root).map_err(|e| op_error(&e))?;
-                core_update::run(opts, &ctx, sink_ref(&sink), &CliHostShim)
-                    .await
-                    .map_err(|e| op_error(&e))
-            }
-        })
-        .description("Reinstall workers preserving config"),
+        describe_op(
+            RegisterFunction::new_async_with_bad_request(
+                move |opts: UpdateOptions| {
+                    let project_root = project_root.clone();
+                    let sink = sink.clone();
+                    async move {
+                        let ctx = ProjectCtx::open(project_root).map_err(|e| op_error(&e))?;
+                        core_update::run(opts, &ctx, sink_ref(&sink), &CliHostShim)
+                            .await
+                            .map_err(|e| op_error(&e))
+                    }
+                },
+                |e| bad_request_error("worker::update", &e),
+            ),
+            "worker::update",
+        ),
     );
 }
 
 fn register_start(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         "worker::start",
-        RegisterFunction::new_async(move |payload: Value| {
-            let project_root = project_root.clone();
-            let sink = sink.clone();
-            async move {
-                let opts: StartOptions = serde_json::from_value(payload)
-                    .map_err(|e| bad_request_error("worker::start", &e))?;
-                let ctx = ProjectCtx::open(project_root).map_err(|e| op_error(&e))?;
-                core_start::run(opts, &ctx, sink_ref(&sink), &CliHostShim)
-                    .await
-                    .map_err(|e| op_error(&e))
-            }
-        })
-        .description("Start a configured worker"),
+        describe_op(
+            RegisterFunction::new_async_with_bad_request(
+                move |opts: StartOptions| {
+                    let project_root = project_root.clone();
+                    let sink = sink.clone();
+                    async move {
+                        let ctx = ProjectCtx::open(project_root).map_err(|e| op_error(&e))?;
+                        core_start::run(opts, &ctx, sink_ref(&sink), &CliHostShim)
+                            .await
+                            .map_err(|e| op_error(&e))
+                    }
+                },
+                |e| bad_request_error("worker::start", &e),
+            ),
+            "worker::start",
+        ),
     );
 }
 
 fn register_stop(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         "worker::stop",
-        RegisterFunction::new_async(move |payload: Value| {
-            let project_root = project_root.clone();
-            let sink = sink.clone();
-            async move {
-                let opts: StopOptions = serde_json::from_value(payload)
-                    .map_err(|e| bad_request_error("worker::stop", &e))?;
-                let ctx = ProjectCtx::open(project_root).map_err(|e| op_error(&e))?;
-                core_stop::run(opts, &ctx, sink_ref(&sink), &CliHostShim)
-                    .await
-                    .map_err(|e| op_error(&e))
-            }
-        })
-        .description("Stop a running worker"),
+        describe_op(
+            RegisterFunction::new_async_with_bad_request(
+                move |opts: StopOptions| {
+                    let project_root = project_root.clone();
+                    let sink = sink.clone();
+                    async move {
+                        let ctx = ProjectCtx::open(project_root).map_err(|e| op_error(&e))?;
+                        core_stop::run(opts, &ctx, sink_ref(&sink), &CliHostShim)
+                            .await
+                            .map_err(|e| op_error(&e))
+                    }
+                },
+                |e| bad_request_error("worker::stop", &e),
+            ),
+            "worker::stop",
+        ),
     );
 }
 
 fn register_list(iii: &III, project_root: PathBuf) {
-    let _ = iii.register_function(
-        "worker::list",
-        RegisterFunction::new_async(move |payload: Value| {
+    // `Option<ListOptions>` keeps the lenient default: a `null` payload
+    // deserializes to `None` (→ defaults) and `{}` to `Some(default)`, while
+    // any other malformed shape still fails deserialization and returns the
+    // W105 envelope so the caller can tell typos apart from "no args".
+    let rf = RegisterFunction::new_async_with_bad_request(
+        move |opts: Option<ListOptions>| {
             let project_root = project_root.clone();
             async move {
-                // Lenient default only for null or empty object. Other shapes
-                // must deserialize cleanly or return the W101 envelope so the
-                // caller can tell typos apart from "no args".
-                let opts: ListOptions = match &payload {
-                    Value::Null => ListOptions::default(),
-                    Value::Object(map) if map.is_empty() => ListOptions::default(),
-                    _ => serde_json::from_value(payload)
-                        .map_err(|e| bad_request_error("worker::list", &e))?,
-                };
                 let ctx = ProjectCtx::open_unlocked(project_root);
-                core_list::run(opts, &ctx, &NullSink, &CliHostShim)
+                core_list::run(opts.unwrap_or_default(), &ctx, &NullSink, &CliHostShim)
                     .await
                     .map_err(|e| op_error(&e))
             }
-        })
-        .description("List installed workers"),
+        },
+        |e| bad_request_error("worker::list", &e),
     );
+    // `Option<T>` auto-extracts a nullable wrapper schema; override with the
+    // plain `ListOptions` schema so `engine::functions::info` serves the same
+    // bytes as `worker::schema`.
+    let mut rf = describe_op(rf, "worker::list");
+    if let Some(schema) = schema_for_value::<ListOptions>() {
+        rf = rf.request_format(schema);
+    }
+    let _ = iii.register_function("worker::list", rf);
 }
 
 fn register_clear(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         "worker::clear",
-        RegisterFunction::new_async(move |payload: Value| {
-            let project_root = project_root.clone();
-            let sink = sink.clone();
-            async move {
-                let opts: ClearOptions = serde_json::from_value(payload)
-                    .map_err(|e| bad_request_error("worker::clear", &e))?;
-                let ctx = ProjectCtx::open(project_root).map_err(|e| op_error(&e))?;
-                core_clear::run(opts, &ctx, sink_ref(&sink), &CliHostShim)
-                    .await
-                    .map_err(|e| op_error(&e))
-            }
-        })
-        .description("Wipe worker artifacts"),
+        describe_op(
+            RegisterFunction::new_async_with_bad_request(
+                move |opts: ClearOptions| {
+                    let project_root = project_root.clone();
+                    let sink = sink.clone();
+                    async move {
+                        let ctx = ProjectCtx::open(project_root).map_err(|e| op_error(&e))?;
+                        core_clear::run(opts, &ctx, sink_ref(&sink), &CliHostShim)
+                            .await
+                            .map_err(|e| op_error(&e))
+                    }
+                },
+                |e| bad_request_error("worker::clear", &e),
+            ),
+            "worker::clear",
+        ),
     );
 }

--- a/crates/iii-worker/src/core/add.rs
+++ b/crates/iii-worker/src/core/add.rs
@@ -1,9 +1,8 @@
 // Copyright Motia LLC and/or licensed to Motia LLC under one or more
 // contributor license agreements. Licensed under the Elastic License 2.0.
 
-//! `worker::add` orchestrator. Validates inputs, applies trigger-mode
-//! policies (e.g. local-path rejection), and delegates to a `WorkerHostShim`.
-//! Lock acquisition is the caller's responsibility.
+//! `worker::add` orchestrator. Validates inputs and delegates to a
+//! `WorkerHostShim`. Lock acquisition is the caller's responsibility.
 
 use crate::core::error::WorkerOpError;
 use crate::core::events::{EventSink, WorkerOpEvent};
@@ -11,6 +10,16 @@ use crate::core::host::WorkerHostShim;
 use crate::core::project::ProjectCtx;
 use crate::core::types::{AddOptions, AddOutcome, WorkerSource};
 
+/// Provenance of a worker op. Carried into `WorkerOpEvent`s so subscribers
+/// can tell a CLI invocation from a bus-triggered one.
+///
+/// NOTE: this no longer gates `kind: "local"`. Local installs used to be
+/// rejected over the trigger surface (W102); that guard was removed on
+/// purpose so `worker::add { source: { kind: "local", path } }` works over
+/// the bus. The path resolves on the DAEMON host and the install runs the
+/// manifest's setup/install/start scripts there — same trust as the CLI,
+/// now reachable by any connected caller. Keep that in mind before exposing
+/// the daemon to untrusted workers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CallerMode {
     Cli,
@@ -22,15 +31,7 @@ pub async fn run(
     ctx: &ProjectCtx,
     events: &dyn EventSink,
     shim: &dyn WorkerHostShim,
-    mode: CallerMode,
 ) -> Result<AddOutcome, WorkerOpError> {
-    if mode == CallerMode::Trigger
-        && let WorkerSource::Local { path } = &opts.source
-    {
-        return Err(WorkerOpError::local_path_not_allowed_via_trigger(
-            path.display().to_string(),
-        ));
-    }
     let label = source_label(&opts.source);
     events.emit(WorkerOpEvent::Started {
         op: "add",
@@ -154,7 +155,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trigger_mode_rejects_local_path() {
+    async fn local_source_installs() {
+        // Local-path installs are allowed regardless of caller. The W102
+        // trigger-surface rejection was removed on purpose; `run` no longer
+        // takes a CallerMode and never rejects `kind: "local"`.
         let dir = TempDir::new().unwrap();
         let ctx = ProjectCtx::open_unlocked(dir.path().to_path_buf());
         let sink = CapturingSink::new();
@@ -166,29 +170,7 @@ mod tests {
             reset_config: false,
             wait: true,
         };
-        let res = run(opts, &ctx, &sink, &StubShim, CallerMode::Trigger).await;
-        assert!(matches!(
-            res,
-            Err(WorkerOpError::LocalPathNotAllowedViaTrigger { .. })
-        ));
-    }
-
-    #[tokio::test]
-    async fn cli_mode_allows_local_path() {
-        let dir = TempDir::new().unwrap();
-        let ctx = ProjectCtx::open_unlocked(dir.path().to_path_buf());
-        let sink = CapturingSink::new();
-        let opts = AddOptions {
-            source: WorkerSource::Local {
-                path: "./my-worker".into(),
-            },
-            force: false,
-            reset_config: false,
-            wait: true,
-        };
-        let outcome = run(opts, &ctx, &sink, &StubShim, CallerMode::Cli)
-            .await
-            .unwrap();
+        let outcome = run(opts, &ctx, &sink, &StubShim).await.unwrap();
         assert_eq!(outcome.status, AddStatus::Installed);
     }
 
@@ -206,9 +188,7 @@ mod tests {
             reset_config: false,
             wait: true,
         };
-        let outcome = run(opts, &ctx, &sink, &StubShim, CallerMode::Trigger)
-            .await
-            .unwrap();
+        let outcome = run(opts, &ctx, &sink, &StubShim).await.unwrap();
         assert_eq!(outcome.name, "pdfkit");
     }
 
@@ -226,9 +206,7 @@ mod tests {
             reset_config: false,
             wait: true,
         };
-        let _ = run(opts, &ctx, &sink, &StubShim, CallerMode::Cli)
-            .await
-            .unwrap();
+        let _ = run(opts, &ctx, &sink, &StubShim).await.unwrap();
         let events = sink.events.lock().unwrap();
         assert_eq!(events.len(), 4, "expected 4 events on success: {events:?}");
         assert!(matches!(
@@ -332,7 +310,7 @@ mod tests {
             reset_config: false,
             wait: true,
         };
-        let res = run(opts, &ctx, &sink, &FailingShim, CallerMode::Trigger).await;
+        let res = run(opts, &ctx, &sink, &FailingShim).await;
         assert!(matches!(res, Err(WorkerOpError::NotFound { .. })));
 
         let events = sink.events.lock().unwrap();

--- a/crates/iii-worker/src/core/error.rs
+++ b/crates/iii-worker/src/core/error.rs
@@ -15,6 +15,7 @@ pub enum WorkerOpErrorKind {
     LocalPathNotAllowedViaTrigger, // W102
     MissingTarget,                 // W103
     ConsentRequired,               // W104
+    BadRequest,                    // W105
     NotFound,                      // W110
     AlreadyExists,                 // W111
     NotInstalled,                  // W112
@@ -47,6 +48,7 @@ impl WorkerOpErrorKind {
             Self::LocalPathNotAllowedViaTrigger => "W102",
             Self::MissingTarget => "W103",
             Self::ConsentRequired => "W104",
+            Self::BadRequest => "W105",
             Self::NotFound => "W110",
             Self::AlreadyExists => "W111",
             Self::NotInstalled => "W112",
@@ -78,9 +80,15 @@ pub enum WorkerOpError {
     #[error("invalid worker name {name:?}: {reason}")]
     InvalidName { name: String, reason: String },
 
+    /// Reserved. No production path constructs this since malformed
+    /// payloads moved to `BadRequest` (W105); kept for wire-code stability
+    /// because W101 is documented as a published code.
     #[error("invalid worker source {input:?}: {reason}")]
     InvalidSource { input: String, reason: String },
 
+    /// Reserved. Local-path installs are now permitted over the trigger
+    /// surface, so this is no longer constructed by any production path.
+    /// Kept for wire-code stability because W102 is a published code.
     #[error("local path {path:?} is not allowed via the worker::* trigger surface")]
     LocalPathNotAllowedViaTrigger { path: String },
 
@@ -89,6 +97,9 @@ pub enum WorkerOpError {
 
     #[error("{op:?} requires confirmation: pass yes:true")]
     ConsentRequired { op: String },
+
+    #[error("invalid payload for {function_id:?}: {reason}")]
+    BadRequest { function_id: String, reason: String },
 
     #[error("worker {name:?} not found")]
     NotFound { name: String },
@@ -192,6 +203,7 @@ impl WorkerOpError {
             Self::LocalPathNotAllowedViaTrigger { .. } => K::LocalPathNotAllowedViaTrigger,
             Self::MissingTarget { .. } => K::MissingTarget,
             Self::ConsentRequired { .. } => K::ConsentRequired,
+            Self::BadRequest { .. } => K::BadRequest,
             Self::NotFound { .. } => K::NotFound,
             Self::AlreadyExists { .. } => K::AlreadyExists,
             Self::NotInstalled { .. } => K::NotInstalled,
@@ -229,6 +241,20 @@ impl WorkerOpError {
             Self::LocalPathNotAllowedViaTrigger { path } => json!({ "path": path }),
             Self::MissingTarget { op, reason } => json!({ "op": op, "reason": reason }),
             Self::ConsentRequired { op } => json!({ "op": op }),
+            Self::BadRequest {
+                function_id,
+                reason,
+            } => {
+                json!({
+                    "function_id": function_id,
+                    "reason": reason,
+                    // LLM/automation recovery path: the request schema is one
+                    // call away and names every required field.
+                    "hint": format!(
+                        "call worker::schema {{ \"function_id\": {function_id:?} }} for the request schema"
+                    ),
+                })
+            }
             Self::NotFound { name }
             | Self::AlreadyExists { name }
             | Self::NotInstalled { name }
@@ -383,6 +409,27 @@ mod tests {
         let payload = err.to_payload();
         assert_eq!(payload["code"], "W170");
         assert_eq!(payload["details"], json!({}));
+    }
+
+    #[test]
+    fn bad_request_payload_carries_function_id_and_schema_hint() {
+        let err = WorkerOpError::BadRequest {
+            function_id: "worker::add".into(),
+            reason: "missing field `source`".into(),
+        };
+        let payload = err.to_payload();
+        assert_eq!(payload["code"], "W105");
+        assert_eq!(payload["details"]["function_id"], "worker::add");
+        assert_eq!(payload["details"]["reason"], "missing field `source`");
+        let hint = payload["details"]["hint"].as_str().unwrap();
+        assert!(
+            hint.contains("worker::schema") && hint.contains("worker::add"),
+            "hint must point the caller at worker::schema for this function: {hint}"
+        );
+        assert!(
+            err.to_string().starts_with("invalid payload for"),
+            "BadRequest must not reuse InvalidSource's 'invalid worker source' stem"
+        );
     }
 
     #[test]

--- a/crates/iii-worker/src/core/logs.rs
+++ b/crates/iii-worker/src/core/logs.rs
@@ -1,0 +1,204 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+//! `worker::logs` orchestrator.
+//!
+//! Unlike the lifecycle ops this is a pure host-filesystem read: no project
+//! lock, no events, no host shim. The log directories live under the
+//! daemon's `~/.iii`, not the project root, and reading them has no side
+//! effects worth fanning out to `worker` trigger subscribers.
+
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+use crate::core::error::WorkerOpError;
+use crate::core::types::{LogsOptions, LogsOutcome, validate_worker_name};
+
+/// Hard cap on `tail` so one call can't flood the bus.
+pub const LOGS_TAIL_MAX: usize = 1000;
+
+/// Only the trailing window of each log file is scanned, so a multi-GB log
+/// can't blow up the daemon's memory or stall the dispatch loop.
+const LOGS_READ_BYTES_MAX: u64 = 1024 * 1024;
+
+/// Candidate log directories for a worker, newest layout first: the unified
+/// location, then the legacy libkrun/OCI layout, then the legacy binary
+/// layout. Mirrors what `iii worker logs` checks on the CLI.
+pub fn candidate_log_dirs(home: &Path, name: &str) -> [PathBuf; 3] {
+    [
+        home.join(".iii/logs").join(name),
+        home.join(".iii/managed").join(name).join("logs"),
+        home.join(".iii/workers/logs").join(name),
+    ]
+}
+
+/// The candidate whose `stdout.log`/`stderr.log` was modified most recently
+/// (empty files don't count). Avoids picking a stale directory (e.g.
+/// `~/.iii/logs/` from a binary worker) over the active one (e.g.
+/// `~/.iii/managed/` from a libkrun OCI worker).
+pub fn pick_best_logs_dir(candidates: &[PathBuf]) -> Option<PathBuf> {
+    let mut best: Option<(PathBuf, std::time::SystemTime)> = None;
+
+    for dir in candidates {
+        let latest = ["stdout.log", "stderr.log"]
+            .iter()
+            .map(|f| dir.join(f))
+            .filter_map(|p| std::fs::metadata(&p).ok().map(|m| (p, m)))
+            .filter(|(_, m)| m.len() > 0)
+            .filter_map(|(_, m)| m.modified().ok())
+            .max();
+
+        if let Some(modified) = latest
+            && best.as_ref().is_none_or(|(_, t)| modified > *t)
+        {
+            best = Some((dir.clone(), modified));
+        }
+    }
+
+    best.map(|(dir, _)| dir)
+}
+
+/// Last `tail` lines of `path`, scanning at most the trailing
+/// [`LOGS_READ_BYTES_MAX`] bytes. Missing/unreadable files yield no lines.
+fn tail_lines(path: &Path, tail: usize) -> Vec<String> {
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return Vec::new();
+    };
+    let len = file.metadata().map(|m| m.len()).unwrap_or(0);
+    let start = len.saturating_sub(LOGS_READ_BYTES_MAX);
+    if start > 0 && file.seek(SeekFrom::Start(start)).is_err() {
+        return Vec::new();
+    }
+    let mut bytes = Vec::new();
+    if file.read_to_end(&mut bytes).is_err() {
+        return Vec::new();
+    }
+    let text = String::from_utf8_lossy(&bytes);
+    let mut lines: Vec<&str> = text.lines().collect();
+    if start > 0 && !lines.is_empty() {
+        // The window almost certainly opened mid-line; drop the partial.
+        lines.remove(0);
+    }
+    let skip = lines.len().saturating_sub(tail);
+    lines[skip..].iter().map(|s| s.to_string()).collect()
+}
+
+pub async fn run(opts: LogsOptions) -> Result<LogsOutcome, WorkerOpError> {
+    validate_worker_name(&opts.name).map_err(|reason| WorkerOpError::BadRequest {
+        function_id: "worker::logs".into(),
+        reason,
+    })?;
+    let tail = opts.tail.min(LOGS_TAIL_MAX);
+    let home = dirs::home_dir().unwrap_or_default();
+
+    let Some(dir) = pick_best_logs_dir(&candidate_log_dirs(&home, &opts.name)) else {
+        return Ok(LogsOutcome {
+            name: opts.name,
+            logs_dir: None,
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+        });
+    };
+
+    Ok(LogsOutcome {
+        stdout: tail_lines(&dir.join("stdout.log"), tail),
+        stderr: tail_lines(&dir.join("stderr.log"), tail),
+        logs_dir: Some(dir.display().to_string()),
+        name: opts.name,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::WorkerOpErrorKind;
+    use tempfile::TempDir;
+
+    fn write(dir: &Path, file: &str, contents: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join(file), contents).unwrap();
+    }
+
+    #[test]
+    fn pick_best_logs_dir_prefers_most_recent() {
+        let tmp = TempDir::new().unwrap();
+        let stale_dir = tmp.path().join("stale");
+        let fresh_dir = tmp.path().join("fresh");
+        write(&stale_dir, "stdout.log", "old\n");
+        write(&fresh_dir, "stdout.log", "new\n");
+        let old = std::time::SystemTime::now() - std::time::Duration::from_secs(3600);
+        let f = std::fs::File::options()
+            .write(true)
+            .open(stale_dir.join("stdout.log"))
+            .unwrap();
+        f.set_modified(old).unwrap();
+
+        let result = pick_best_logs_dir(&[stale_dir, fresh_dir.clone()]).unwrap();
+        assert_eq!(result, fresh_dir);
+    }
+
+    #[test]
+    fn pick_best_logs_dir_skips_empty_files() {
+        let tmp = TempDir::new().unwrap();
+        let empty_dir = tmp.path().join("empty");
+        let content_dir = tmp.path().join("content");
+        write(&empty_dir, "stdout.log", "");
+        write(&content_dir, "stderr.log", "boot\n");
+
+        let result = pick_best_logs_dir(&[empty_dir, content_dir.clone()]).unwrap();
+        assert_eq!(result, content_dir);
+    }
+
+    #[test]
+    fn pick_best_logs_dir_returns_none_when_no_content() {
+        let tmp = TempDir::new().unwrap();
+        let dir_a = tmp.path().join("a");
+        let dir_b = tmp.path().join("b");
+        write(&dir_a, "stdout.log", "");
+        std::fs::create_dir_all(&dir_b).unwrap();
+        assert!(pick_best_logs_dir(&[dir_a, dir_b]).is_none());
+    }
+
+    #[test]
+    fn tail_lines_returns_last_n() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("stdout.log");
+        std::fs::write(&path, "one\ntwo\nthree\nfour\n").unwrap();
+        assert_eq!(tail_lines(&path, 2), vec!["three", "four"]);
+        assert_eq!(tail_lines(&path, 100).len(), 4);
+        assert!(tail_lines(&tmp.path().join("missing.log"), 5).is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_rejects_traversal_names_with_bad_request() {
+        for name in ["../escape", "", ".hidden", "a/b"] {
+            let err = run(LogsOptions {
+                name: name.to_string(),
+                tail: 10,
+            })
+            .await
+            .unwrap_err();
+            assert_eq!(
+                err.kind(),
+                WorkerOpErrorKind::BadRequest,
+                "name {name:?} must be rejected as W105"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn run_caps_tail_at_max() {
+        // Unknown-but-valid worker: empty outcome, no error — the cap and
+        // the no-logs path are both exercised without touching real $HOME
+        // state for an unlikely name.
+        let outcome = run(LogsOptions {
+            name: "definitely-not-a-real-worker-name-xyz".to_string(),
+            tail: usize::MAX,
+        })
+        .await
+        .unwrap();
+        assert!(outcome.logs_dir.is_none());
+        assert!(outcome.stdout.is_empty());
+        assert!(outcome.stderr.is_empty());
+    }
+}

--- a/crates/iii-worker/src/core/mod.rs
+++ b/crates/iii-worker/src/core/mod.rs
@@ -18,6 +18,7 @@ pub mod events;
 pub use events::{CapturingSink, EventSink, NullSink, WorkerOpEvent};
 
 pub mod add;
+pub mod logs;
 
 pub mod remove;
 

--- a/crates/iii-worker/src/core/project.rs
+++ b/crates/iii-worker/src/core/project.rs
@@ -14,33 +14,42 @@ const CONFIG_NAME: &str = "iii.config.yaml";
 const CONFIG_CANDIDATES: &[&str] = &["iii.config.yaml", "config.yaml"];
 
 /// RAII guard for the project-wide install/lifecycle mutex.
+///
+/// Backed by a kernel advisory lock (`flock(2)`), so the lock dies with the
+/// process: a SIGKILLed or crashed holder can never strand the project the
+/// way the previous pidfile scheme did (a dead pid in `.iii-worker.lock`
+/// returned W120 forever until the file was removed by hand). The lockfile
+/// itself persists across acquisitions — unlinking a flocked path would let
+/// a new acquirer lock a fresh inode while a stale holder still owns the
+/// old one — and only carries the holder pid as W120 diagnostics.
 #[derive(Debug)]
 pub struct ProjectOperationLock {
-    path: PathBuf,
-    /// Exact bytes this guard wrote into the lockfile. `Drop` only unlinks
-    /// when the file's current contents still match — otherwise another
-    /// owner (recreated after a stale guard was reaped) keeps its lock.
-    marker: String,
+    _lock: nix::fcntl::Flock<fs::File>,
 }
 
 impl ProjectOperationLock {
     pub fn acquire(root: &Path) -> Result<Self, WorkerOpError> {
         let path = root.join(LOCKFILE_NAME);
-        match fs::OpenOptions::new()
+        let file = fs::OpenOptions::new()
+            .read(true)
             .write(true)
-            .create_new(true)
+            .create(true)
+            .truncate(false)
             .open(&path)
-        {
-            Ok(mut file) => {
+            .map_err(|source| WorkerOpError::LockIo {
+                path: path.clone(),
+                source,
+            })?;
+        match nix::fcntl::Flock::lock(file, nix::fcntl::FlockArg::LockExclusiveNonblock) {
+            Ok(lock) => {
                 let marker = format!("pid={}\n", std::process::id());
-                file.write_all(marker.as_bytes())
-                    .map_err(|source| WorkerOpError::LockIo {
-                        path: path.clone(),
-                        source,
-                    })?;
-                Ok(Self { path, marker })
+                (&*lock)
+                    .set_len(0)
+                    .and_then(|_| (&*lock).write_all(marker.as_bytes()))
+                    .map_err(|source| WorkerOpError::LockIo { path, source })?;
+                Ok(Self { _lock: lock })
             }
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            Err((_, nix::errno::Errno::EWOULDBLOCK)) => {
                 let holder_pid = fs::read_to_string(&path).ok().and_then(|s| {
                     s.lines()
                         .find_map(|l| l.strip_prefix("pid="))
@@ -48,18 +57,10 @@ impl ProjectOperationLock {
                 });
                 Err(WorkerOpError::LockBusy { holder_pid })
             }
-            Err(e) => Err(WorkerOpError::LockIo { path, source: e }),
-        }
-    }
-}
-
-impl Drop for ProjectOperationLock {
-    fn drop(&mut self) {
-        // Compare current contents to our marker so we never unlink a
-        // lockfile belonging to a different acquirer (e.g. one that
-        // recreated the file after we became a stale guard).
-        if fs::read_to_string(&self.path).ok().as_deref() == Some(self.marker.as_str()) {
-            let _ = fs::remove_file(&self.path);
+            Err((_, errno)) => Err(WorkerOpError::LockIo {
+                path,
+                source: errno.into(),
+            }),
         }
     }
 }
@@ -115,7 +116,22 @@ mod tests {
         let ctx = ProjectCtx::open(dir.path().to_path_buf()).unwrap();
         assert!(dir.path().join(".iii-worker.lock").exists());
         drop(ctx);
-        assert!(!dir.path().join(".iii-worker.lock").exists());
+        // The file persists (flock semantics) but the lock must be released:
+        // a fresh acquisition succeeds immediately.
+        ProjectCtx::open(dir.path().to_path_buf())
+            .expect("lock must be released when the guard drops");
+    }
+
+    #[test]
+    fn stale_lockfile_from_dead_process_does_not_block() {
+        // Regression: a holder that died without cleanup (SIGKILL, crash)
+        // used to strand the project with W120 forever — the pidfile scheme
+        // never checked holder liveness. With flock, an unheld lockfile is
+        // just a file: acquisition must succeed no matter what pid it names.
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join(".iii-worker.lock"), "pid=98708\n").unwrap();
+        ProjectCtx::open(dir.path().to_path_buf())
+            .expect("an orphaned lockfile must not block acquisition");
     }
 
     #[test]

--- a/crates/iii-worker/src/core/types.rs
+++ b/crates/iii-worker/src/core/types.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 #[schemars(
-    description = "Where to fetch the worker from. Use `registry` for the public iii worker registry, `oci` for an arbitrary container image, or `local` for a developer machine path (CLI-only; rejected via trigger with W102)."
+    description = "Where to fetch the worker from. Use `registry` for the public iii worker registry, `oci` for an arbitrary container image, or `local` for a filesystem path on the engine/daemon host (works over the trigger too; the path is resolved on the host, not the caller)."
 )]
 pub enum WorkerSource {
     Registry {
@@ -27,7 +27,7 @@ pub enum WorkerSource {
     },
     Local {
         #[schemars(
-            description = "Local filesystem path. Trigger surface rejects this with W102; CLI-only."
+            description = "Filesystem path on the engine/daemon host (NOT the caller's machine). Installs run the manifest's setup/install/start scripts on the host. Works over the trigger as well as the CLI."
         )]
         path: PathBuf,
     },
@@ -212,6 +212,69 @@ pub struct ListOptions {
 
 fn list_options_example() -> serde_json::Value {
     serde_json::json!({"running_only": false})
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(example = "logs_options_example")]
+pub struct LogsOptions {
+    #[schemars(description = "Worker whose logs to read, e.g. \"pdfkit\".")]
+    pub name: String,
+    #[serde(default = "default_logs_tail")]
+    #[schemars(
+        description = "Trailing lines to return per stream. Default 100, capped at 1000. Only the last 1 MiB of each log file is scanned."
+    )]
+    pub tail: usize,
+}
+
+fn default_logs_tail() -> usize {
+    100
+}
+
+fn logs_options_example() -> serde_json::Value {
+    serde_json::json!({"name": "pdfkit", "tail": 100})
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct LogsOutcome {
+    #[schemars(description = "Worker whose logs were read.")]
+    pub name: String,
+    #[schemars(
+        description = "Host directory the logs were read from. Null when the worker has no log directory yet (never started on this host, or logs were cleared)."
+    )]
+    pub logs_dir: Option<String>,
+    #[schemars(description = "Trailing stdout lines — the worker/guest console stream.")]
+    pub stdout: Vec<String>,
+    #[schemars(
+        description = "Trailing stderr lines — host-side boot/runtime messages; during startup these chronologically precede stdout."
+    )]
+    pub stderr: Vec<String>,
+}
+
+/// Reject names that could escape the per-worker directories these names
+/// are joined into (`~/.iii/logs/<name>`, `~/.iii/workers/<name>`, …).
+pub fn validate_worker_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("Worker name cannot be empty".into());
+    }
+    if name.contains("..") {
+        return Err(format!("Worker name '{}' contains '..' sequence", name));
+    }
+    if name.starts_with('.') {
+        return Err(format!(
+            "Worker name '{}' cannot start with '.' (reserved for internal control directories)",
+            name
+        ));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return Err(format!(
+            "Worker name '{}' contains invalid characters. Only alphanumeric, dash, underscore, and dot are allowed.",
+            name
+        ));
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -87,8 +87,7 @@ async fn main() -> anyhow::Result<()> {
                 // user sees as extra noise that scrolls real progress
                 // off-screen. Keep the sink quiet on the CLI path.
                 let sink = StderrSink::new(true);
-                let result =
-                    core_add::run(opts, &ctx, &sink, &CliHostShim, core_add::CallerMode::Cli).await;
+                let result = core_add::run(opts, &ctx, &sink, &CliHostShim).await;
 
                 if let Err(e) = result {
                     eprintln!("error: [{}] {}", e.kind().code(), e);
@@ -173,9 +172,7 @@ async fn main() -> anyhow::Result<()> {
                 // policy so we don't duplicate Stage events on top of
                 // the inner handler's progress output.
                 let sink = StderrSink::new(true);
-                if let Err(e) =
-                    core_add::run(opts, &ctx, &sink, &CliHostShim, core_add::CallerMode::Cli).await
-                {
+                if let Err(e) = core_add::run(opts, &ctx, &sink, &CliHostShim).await {
                     eprintln!("error: [{}] {}", e.kind().code(), e);
                     fail_count += 1;
                 }

--- a/crates/iii-worker/src/sandbox_daemon/mod.rs
+++ b/crates/iii-worker/src/sandbox_daemon/mod.rs
@@ -122,6 +122,10 @@ pub async fn serve(config: SandboxConfig, engine_url: &str) -> anyhow::Result<()
             otel: Some(OtelConfig::default()),
             metadata: Some(WorkerMetadata {
                 name: "iii-sandbox".to_string(),
+                description: Some(
+                    "Launch and manage isolated worker sandboxes (create, exec, stop, list)."
+                        .to_string(),
+                ),
                 ..Default::default()
             }),
             ..Default::default()

--- a/crates/iii-worker/tests/worker_trigger_integration.rs
+++ b/crates/iii-worker/tests/worker_trigger_integration.rs
@@ -13,7 +13,9 @@
 use iii_worker::cli::host_shim::{
     classify_handler_error, resolve_clear_targets, resolve_remove_targets,
 };
-use iii_worker::cli::worker_manager_daemon::{bad_request_payload, err_payload, op_metadata};
+use iii_worker::cli::worker_manager_daemon::{
+    bad_request_payload, err_payload, op_description, op_metadata,
+};
 use iii_worker::core::{
     AddOptions, ClearOptions, ListOptions, RemoveOptions, StartOptions, StopOptions, UpdateOptions,
     WorkerOpError, WorkerOpErrorKind, WorkerSource,
@@ -44,24 +46,24 @@ fn parse_envelope(envelope: &str) -> (String, String, Value) {
     (code, type_, details)
 }
 
-/// Try to deserialize `payload` as `T`. On failure, return the W101 envelope
+/// Try to deserialize `payload` as `T`. On failure, return the W105 envelope
 /// the daemon would emit. Mirrors `register_*` handler body.
 fn try_deserialize<T: serde::de::DeserializeOwned>(op: &str, payload: Value) -> Result<T, String> {
     serde_json::from_value(payload).map_err(|e| bad_request_payload(op, &e))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 1. WorkerSource adversarial serde — every malformed shape lands on W101
+// 1. WorkerSource adversarial serde — every malformed shape lands on W105
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[test]
-fn worker_source_missing_kind_is_w101() {
+fn worker_source_missing_kind_is_w105() {
     let err =
         try_deserialize::<AddOptions>("worker::add", json!({"source": {"name": "x"}})).unwrap_err();
     let (code, type_, details) = parse_envelope(&err);
-    assert_eq!(code, "W101");
+    assert_eq!(code, "W105");
     assert_eq!(type_, "WorkerOpError");
-    assert_eq!(details["input"], "worker::add");
+    assert_eq!(details["function_id"], "worker::add");
     assert!(
         details["reason"].as_str().unwrap().contains("kind"),
         "details.reason mentions the missing field"
@@ -69,18 +71,18 @@ fn worker_source_missing_kind_is_w101() {
 }
 
 #[test]
-fn worker_source_unknown_kind_is_w101() {
+fn worker_source_unknown_kind_is_w105() {
     let err = try_deserialize::<AddOptions>(
         "worker::add",
         json!({"source": {"kind": "magic", "name": "x"}}),
     )
     .unwrap_err();
     let (code, _, _) = parse_envelope(&err);
-    assert_eq!(code, "W101");
+    assert_eq!(code, "W105");
 }
 
 #[test]
-fn worker_source_capitalized_kind_is_w101() {
+fn worker_source_capitalized_kind_is_w105() {
     // Tag enum is `rename_all = "snake_case"` — Registry must be rejected.
     let err = try_deserialize::<AddOptions>(
         "worker::add",
@@ -88,29 +90,29 @@ fn worker_source_capitalized_kind_is_w101() {
     )
     .unwrap_err();
     let (code, _, _) = parse_envelope(&err);
-    assert_eq!(code, "W101");
+    assert_eq!(code, "W105");
 }
 
 #[test]
-fn worker_source_registry_without_name_is_w101() {
+fn worker_source_registry_without_name_is_w105() {
     let err = try_deserialize::<AddOptions>("worker::add", json!({"source": {"kind": "registry"}}))
         .unwrap_err();
     let (code, _, details) = parse_envelope(&err);
-    assert_eq!(code, "W101");
+    assert_eq!(code, "W105");
     assert!(details["reason"].as_str().unwrap().contains("name"));
 }
 
 #[test]
-fn worker_source_oci_without_reference_is_w101() {
+fn worker_source_oci_without_reference_is_w105() {
     let err = try_deserialize::<AddOptions>("worker::add", json!({"source": {"kind": "oci"}}))
         .unwrap_err();
     let (code, _, details) = parse_envelope(&err);
-    assert_eq!(code, "W101");
+    assert_eq!(code, "W105");
     assert!(details["reason"].as_str().unwrap().contains("reference"));
 }
 
 #[test]
-fn worker_source_oci_with_name_field_is_w101() {
+fn worker_source_oci_with_name_field_is_w105() {
     // `name` is the registry-variant field; OCI variant requires `reference`.
     let err = try_deserialize::<AddOptions>(
         "worker::add",
@@ -118,81 +120,81 @@ fn worker_source_oci_with_name_field_is_w101() {
     )
     .unwrap_err();
     let (code, _, details) = parse_envelope(&err);
-    assert_eq!(code, "W101");
+    assert_eq!(code, "W105");
     assert!(details["reason"].as_str().unwrap().contains("reference"));
 }
 
 #[test]
-fn worker_source_local_without_path_is_w101() {
+fn worker_source_local_without_path_is_w105() {
     let err = try_deserialize::<AddOptions>("worker::add", json!({"source": {"kind": "local"}}))
         .unwrap_err();
     let (code, _, details) = parse_envelope(&err);
-    assert_eq!(code, "W101");
+    assert_eq!(code, "W105");
     assert!(details["reason"].as_str().unwrap().contains("path"));
 }
 
 #[test]
-fn add_payload_with_no_source_is_w101() {
+fn add_payload_with_no_source_is_w105() {
     let err = try_deserialize::<AddOptions>("worker::add", json!({})).unwrap_err();
     let (code, _, details) = parse_envelope(&err);
-    assert_eq!(code, "W101");
+    assert_eq!(code, "W105");
     assert!(details["reason"].as_str().unwrap().contains("source"));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 2. Type strictness — wrong primitive types map to W101
+// 2. Type strictness — wrong primitive types map to W105
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[test]
-fn source_as_string_is_w101() {
+fn source_as_string_is_w105() {
     let err =
         try_deserialize::<AddOptions>("worker::add", json!({"source": "iii-state"})).unwrap_err();
-    assert_eq!(parse_envelope(&err).0, "W101");
+    assert_eq!(parse_envelope(&err).0, "W105");
 }
 
 #[test]
-fn yes_as_string_is_w101() {
+fn yes_as_string_is_w105() {
     let err = try_deserialize::<StopOptions>(
         "worker::stop",
         json!({"name": "image-resize", "yes": "true"}),
     )
     .unwrap_err();
-    assert_eq!(parse_envelope(&err).0, "W101");
+    assert_eq!(parse_envelope(&err).0, "W105");
 }
 
 #[test]
-fn names_as_string_is_w101() {
+fn names_as_string_is_w105() {
     let err =
         try_deserialize::<RemoveOptions>("worker::remove", json!({"names": "x", "yes": true}))
             .unwrap_err();
-    assert_eq!(parse_envelope(&err).0, "W101");
+    assert_eq!(parse_envelope(&err).0, "W105");
 }
 
 #[test]
-fn all_as_string_is_w101() {
+fn all_as_string_is_w105() {
     let err = try_deserialize::<ClearOptions>("worker::clear", json!({"all": "yes", "yes": true}))
         .unwrap_err();
-    assert_eq!(parse_envelope(&err).0, "W101");
+    assert_eq!(parse_envelope(&err).0, "W105");
 }
 
 #[test]
-fn wait_as_number_is_w101() {
+fn wait_as_number_is_w105() {
     let err = try_deserialize::<AddOptions>(
         "worker::add",
         json!({"source": {"kind": "registry", "name": "x"}, "wait": 1}),
     )
     .unwrap_err();
-    assert_eq!(parse_envelope(&err).0, "W101");
+    assert_eq!(parse_envelope(&err).0, "W105");
 }
 
 #[test]
-fn registry_name_null_is_w101() {
+fn registry_name_null_is_w105() {
     let err = try_deserialize::<AddOptions>(
         "worker::add",
         json!({"source": {"kind": "registry", "name": null}}),
     )
     .unwrap_err();
-    assert_eq!(parse_envelope(&err).0, "W101");
+    assert_eq!(parse_envelope(&err).0, "W105");
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -391,6 +393,7 @@ fn every_kind_has_distinct_code() {
         LocalPathNotAllowedViaTrigger,
         MissingTarget,
         ConsentRequired,
+        BadRequest,
         NotFound,
         AlreadyExists,
         NotInstalled,
@@ -427,6 +430,9 @@ fn every_kind_has_distinct_code() {
     }
 }
 
+// W102 is reserved: local-path installs are now allowed over the trigger,
+// so nothing produces this variant in practice. This pins its wire envelope
+// shape in case the code is ever re-used.
 #[test]
 fn local_path_not_allowed_via_trigger_envelope_carries_path() {
     let err = WorkerOpError::LocalPathNotAllowedViaTrigger {
@@ -495,6 +501,26 @@ fn remove_options_every_field_has_description() {
     assert!(
         missing.is_empty(),
         "RemoveOptions fields missing description: {missing:?}"
+    );
+}
+
+#[test]
+fn logs_options_every_field_has_description() {
+    let schema = serde_json::to_value(schema_for!(iii_worker::core::LogsOptions)).unwrap();
+    let missing = fields_missing_description(&schema);
+    assert!(
+        missing.is_empty(),
+        "LogsOptions fields missing description: {missing:?}"
+    );
+}
+
+#[test]
+fn logs_outcome_every_field_has_description() {
+    let schema = serde_json::to_value(schema_for!(iii_worker::core::LogsOutcome)).unwrap();
+    let missing = fields_missing_description(&schema);
+    assert!(
+        missing.is_empty(),
+        "LogsOutcome fields missing description: {missing:?}"
     );
 }
 
@@ -591,8 +617,20 @@ const ALL_OPS: &[&str] = &[
     "worker::stop",
     "worker::list",
     "worker::clear",
+    "worker::logs",
     "worker::schema",
 ];
+
+#[test]
+fn every_op_has_nonempty_description() {
+    for op in ALL_OPS {
+        assert!(
+            !op_description(op).is_empty(),
+            "{op} has an empty description — it would surface blank in \
+             engine::functions::info and worker::schema"
+        );
+    }
+}
 
 #[test]
 fn every_op_has_positive_timeout() {
@@ -628,6 +666,7 @@ fn read_only_ops_are_idempotent() {
         "worker::list",
         "worker::schema",
         "worker::clear",
+        "worker::logs",
     ] {
         let (_, idempotent) = op_metadata(op);
         assert!(idempotent, "{op} should be declared idempotent");
@@ -693,6 +732,78 @@ fn list_options_null_or_missing_defaults_cleanly() {
     assert!(!opts.running_only);
 }
 
+#[test]
+fn list_wire_path_option_wrapper_preserves_leniency_and_w105() {
+    // The daemon's list handler deserializes `Option<ListOptions>` through
+    // the SDK typed path and falls back to defaults. Pin the wire behavior:
+    // null / {} / [] stay lenient, valid objects parse, and malformed shapes
+    // produce the same W105 reason text the bare `ListOptions` path did.
+    for payload in [json!(null), json!({}), json!([])] {
+        let opts = try_deserialize::<Option<ListOptions>>("worker::list", payload.clone())
+            .unwrap_or_else(|e| panic!("payload {payload} must stay lenient, got {e}"))
+            .unwrap_or_default();
+        assert!(!opts.running_only);
+    }
+
+    let opts =
+        try_deserialize::<Option<ListOptions>>("worker::list", json!({"running_only": true}))
+            .unwrap()
+            .unwrap_or_default();
+    assert!(opts.running_only);
+
+    for payload in [
+        json!({"running_only": "yes"}),
+        json!("hello"),
+        json!([1, 2]),
+    ] {
+        let bare_err = serde_json::from_value::<ListOptions>(payload.clone()).unwrap_err();
+        let envelope = try_deserialize::<Option<ListOptions>>("worker::list", payload).unwrap_err();
+        let (code, _, details) = parse_envelope(&envelope);
+        assert_eq!(code, "W105");
+        // `Option<T>` forwards non-null payloads to T's deserializer
+        // verbatim, so the W105 reason matches the pre-typed-handler text.
+        assert_eq!(
+            details.get("reason").and_then(|r| r.as_str()),
+            Some(bare_err.to_string().as_str())
+        );
+    }
+}
+
+#[test]
+fn typed_handler_draft07_extraction_matches_schema_for_bytes() {
+    // The daemon's request schemas now come from the SDK's typed-handler
+    // auto-extraction (SchemaSettings::draft07), while worker::schema serves
+    // schemars::schema_for! output. Pin that the two generators agree for
+    // every options struct so the two introspection surfaces never drift.
+    fn draft07<T: schemars::JsonSchema>() -> Value {
+        serde_json::to_value(
+            schemars::r#gen::SchemaSettings::draft07()
+                .into_generator()
+                .into_root_schema_for::<T>(),
+        )
+        .unwrap()
+    }
+    macro_rules! assert_schema_parity {
+        ($($t:ty),+ $(,)?) => {$(
+            assert_eq!(
+                serde_json::to_value(schema_for!($t)).unwrap(),
+                draft07::<$t>(),
+                concat!("schema drift for ", stringify!($t)),
+            );
+        )+};
+    }
+    assert_schema_parity!(
+        AddOptions,
+        RemoveOptions,
+        UpdateOptions,
+        StartOptions,
+        StopOptions,
+        ClearOptions,
+        ListOptions,
+        iii_worker::core::LogsOptions,
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // 9. WorkerSource serde round-trips (happy path)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -730,7 +841,7 @@ fn worker_source_local_round_trips() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 10. bad_request_payload produces parseable W101 for arbitrary serde failures
+// 10. bad_request_payload produces parseable W105 for arbitrary serde failures
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[test]
@@ -739,8 +850,8 @@ fn bad_request_payload_is_always_valid_json() {
     let envelope = bad_request_payload("worker::add", &err);
     let parsed: Value = serde_json::from_str(&envelope).expect("envelope is JSON");
     assert_eq!(parsed["type"], "WorkerOpError");
-    assert_eq!(parsed["code"], "W101");
-    assert_eq!(parsed["details"]["input"], "worker::add");
+    assert_eq!(parsed["code"], "W105");
+    assert_eq!(parsed["details"]["function_id"], "worker::add");
     assert!(parsed["details"]["reason"].is_string());
 }
 
@@ -749,7 +860,7 @@ fn bad_request_payload_propagates_op_label() {
     let err = serde_json::from_value::<StopOptions>(json!({})).unwrap_err();
     let envelope = bad_request_payload("worker::stop", &err);
     let parsed: Value = serde_json::from_str(&envelope).unwrap();
-    assert_eq!(parsed["details"]["input"], "worker::stop");
+    assert_eq!(parsed["details"]["function_id"], "worker::stop");
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/docs/0-11-0/workers/worker-management-triggers.mdx
+++ b/docs/0-11-0/workers/worker-management-triggers.mdx
@@ -29,8 +29,13 @@ The injection is idempotent, so an explicit entry simply takes precedence.
 | `worker::stop`   | `StopOptions`    | `StopOutcome`    | 30s                    |
 | `worker::list`   | `ListOptions`    | `ListOutcome`    | 10s                    |
 | `worker::clear`  | `ClearOptions`   | `ClearOutcome`   | 30s                    |
+| `worker::logs`   | `LogsOptions`    | `LogsOutcome`    | 10s                    |
 
-`worker::add` rejects local-path sources via the trigger surface (W102) — local paths remain CLI-only because a sandboxed worker has no meaningful filesystem mapping to the host. Use registry names or OCI references instead.
+`worker::logs` reads a worker's recent `stdout`/`stderr` lines from the engine host (the same directories `iii worker logs` checks), so a remote caller can diagnose a worker it installed or started over the trigger. `tail` bounds the lines returned per stream (default 100, capped at 1000), and only the trailing 1 MiB of each log file is scanned. Log contents are whatever the worker printed — treat them as sensitive when exposing the daemon to untrusted callers.
+
+`worker::add` accepts local-path sources over the trigger as well as the CLI. The `path` is resolved on the engine/daemon host (not the caller's machine), and the install runs the manifest's setup/install/start scripts there — so a remote caller can only use it for code already on the host. Treat this as host-level code execution when exposing the daemon to untrusted callers; prefer registry names or OCI references for distributed workers.
+
+The `idempotent` flag reported in each op's metadata (via `engine::functions::info` / `worker::schema`) describes the default request. `worker::add` and `worker::update` are idempotent only when `force`/`reset_config` are unset — with `force: true` they stop the worker, delete artifacts, and re-run the manifest's install scripts, so retrying a forced call repeats those side effects. Retry-on-timeout is safe for the default shape, not for forced replacement.
 
 ## Example: install a peer worker from a Rust worker
 
@@ -55,7 +60,7 @@ let resp = iii.trigger(TriggerRequest {
 
 - `{ "kind": "registry", "name": "pdfkit", "version": "1.0.0" }` — registry name with optional version
 - `{ "kind": "oci", "reference": "ghcr.io/iii-hq/node:latest" }` — full OCI reference
-- `{ "kind": "local", "path": "./my-worker" }` — local path (CLI only; rejected via trigger with W102)
+- `{ "kind": "local", "path": "./my-worker" }` — local path, resolved on the engine/daemon host (works over the trigger as well as the CLI)
 
 ## Error envelope
 
@@ -75,8 +80,9 @@ Trigger errors return a flat JSON envelope mirroring the `SandboxError` pattern,
 | W-code | Variant                          | Meaning                                                  |
 |--------|----------------------------------|----------------------------------------------------------|
 | W100   | `InvalidName`                    | Worker name failed validation                             |
-| W101   | `InvalidSource`                  | Source string is malformed                                |
-| W102   | `LocalPathNotAllowedViaTrigger`  | Local-path sources are CLI-only                           |
+| W101   | `InvalidSource`                  | Reserved (superseded by W105 for malformed payloads)      |
+| W102   | `LocalPathNotAllowedViaTrigger`  | Reserved (local-path sources now work over the trigger)   |
+| W105   | `BadRequest`                     | Payload failed validation; `details.hint` names the `worker::schema` recovery call |
 | W110   | `NotFound`                       | Worker is not registered                                  |
 | W111   | `AlreadyExists`                  | Worker already installed                                  |
 | W112   | `NotInstalled`                   | Worker not present on disk                                |

--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -6,6 +6,17 @@ type: "reference"
 ---
 
 <Update label="0.19.0" description="June 2026">
+  ## `worker::*` management API is self-describing — and `kind: "local"` now works over the trigger
+
+  Every `worker::*` op (`add`/`remove`/`update`/`start`/`stop`/`list`/`clear`/`schema`) now publishes its request JSON Schema, a description, and `default_timeout_ms` / `idempotent` metadata through `engine::functions::info` and `worker::schema`, so an LLM or automation caller can discover the full contract without out-of-band docs. Workers can also report a one-line `description` (Node, Go, Rust, and Python SDKs) that surfaces in `engine::workers::list` / `engine::workers::info`.
+
+  **Breaking — error codes on the wire:**
+
+  - Malformed `worker::*` payloads now return **W105** (`BadRequest`) instead of **W101** (`InvalidSource`). The envelope's `details.hint` names the `worker::schema` call that returns the request schema. **W101** and **W102** are now reserved (documented but never emitted) — consumers matching `W101` for malformed payloads should match `W105`.
+  - `worker::*` op failures now surface the **W-code** as the transport `ErrorBody.code` (previously the generic `"invocation_failed"`, with the W-code only inside the message envelope). Consumers that matched `code == "invocation_failed"` to detect worker-op failures should match the W-code instead.
+
+  **Breaking — `worker::add { kind: "local" }` over the trigger:** the identical request that previously returned **W102** (rejection) now **succeeds**. The `path` resolves on the engine/daemon host and the install runs the manifest's `setup`/`install`/`start` scripts there. Because the engine does not authenticate worker identity, treat a daemon reachable by untrusted workers as a host-level code-execution surface — prefer registry names or OCI references for distributed workers, and lock down the daemon when exposing it.
+
   ## `engine::triggers::info` now exposes `response_schema`
 
   Trigger types can declare the schema a bound handler must **return** when the trigger fires. `engine::triggers::info` surfaces it as a new optional `response_schema` field alongside the existing `configuration_schema` (how to configure the trigger) and `request_schema` (what the handler receives) — the full trigger contract is now discoverable from a single call:

--- a/docs/creating-workers/workers.mdx
+++ b/docs/creating-workers/workers.mdx
@@ -68,6 +68,7 @@ process can be deployed anywhere reachable on the network.
     if (!url) throw new Error("III_URL must be set");
     const worker = registerWorker(url, {
       workerName: "my-worker",
+      workerDescription: "One-line summary of what this worker does",
     });
     ```
 
@@ -79,7 +80,10 @@ process can be deployed anywhere reachable on the network.
 
     worker = register_worker(
         os.environ.get("III_URL"),
-        InitOptions(worker_name="my-worker"),
+        InitOptions(
+            worker_name="my-worker",
+            worker_description="One-line summary of what this worker does",
+        ),
     )
     ```
 
@@ -94,6 +98,7 @@ process can be deployed anywhere reachable on the network.
         InitOptions {
             metadata: Some(WorkerMetadata {
                 name: "my-worker".into(),
+                description: Some("One-line summary of what this worker does".into()),
                 ..Default::default()
             }),
             ..Default::default()
@@ -440,6 +445,7 @@ that iii starts automatically when they're specified in iii's
 
 ```yaml
 name: math-worker
+description: Evaluate math expressions over iii functions.
 runtime:
   kind: python
   package_manager: pip
@@ -448,6 +454,9 @@ scripts:
   install: "pip install -r requirements.txt"
   start: "python math_worker.py"
 ```
+
+`description` is an optional one-line, human/LLM-readable summary of what the worker does; the
+iii CLI displays it when installing or inspecting the worker.
 
 The manifest is metadata about _starting_ the Worker. Once the Worker is running iii treats them all
 the same. A Worker started by `iii` via its `config.yaml`, via `iii worker start`, or a manually run

--- a/docs/creating-workers/workers.mdx.skill.md
+++ b/docs/creating-workers/workers.mdx.skill.md
@@ -64,6 +64,7 @@ process can be deployed anywhere reachable on the network.
     if (!url) throw new Error("III_URL must be set");
     const worker = registerWorker(url, {
       workerName: "my-worker",
+      workerDescription: "One-line summary of what this worker does",
     });
     ```
 
@@ -75,7 +76,10 @@ process can be deployed anywhere reachable on the network.
 
     worker = register_worker(
         os.environ.get("III_URL"),
-        InitOptions(worker_name="my-worker"),
+        InitOptions(
+            worker_name="my-worker",
+            worker_description="One-line summary of what this worker does",
+        ),
     )
     ```
 
@@ -90,6 +94,7 @@ process can be deployed anywhere reachable on the network.
         InitOptions {
             metadata: Some(WorkerMetadata {
                 name: "my-worker".into(),
+                description: Some("One-line summary of what this worker does".into()),
                 ..Default::default()
             }),
             ..Default::default()
@@ -436,6 +441,7 @@ that iii starts automatically when they're specified in iii's
 
 ```yaml
 name: math-worker
+description: Evaluate math expressions over iii functions.
 runtime:
   kind: python
   package_manager: pip
@@ -444,6 +450,9 @@ scripts:
   install: "pip install -r requirements.txt"
   start: "python math_worker.py"
 ```
+
+`description` is an optional one-line, human/LLM-readable summary of what the worker does; the
+iii CLI displays it when installing or inspecting the worker.
 
 The manifest is metadata about _starting_ the Worker. Once the Worker is running iii treats them all
 the same. A Worker started by `iii` via its `config.yaml`, via `iii worker start`, or a manually run

--- a/docs/next/creating-workers/workers.mdx
+++ b/docs/next/creating-workers/workers.mdx
@@ -68,6 +68,7 @@ process can be deployed anywhere reachable on the network.
     if (!url) throw new Error("III_URL must be set");
     const worker = registerWorker(url, {
       workerName: "my-worker",
+      workerDescription: "One-line summary of what this worker does",
     });
     ```
 
@@ -79,7 +80,10 @@ process can be deployed anywhere reachable on the network.
 
     worker = register_worker(
         os.environ.get("III_URL"),
-        InitOptions(worker_name="my-worker"),
+        InitOptions(
+            worker_name="my-worker",
+            worker_description="One-line summary of what this worker does",
+        ),
     )
     ```
 
@@ -94,6 +98,7 @@ process can be deployed anywhere reachable on the network.
         InitOptions {
             metadata: Some(WorkerMetadata {
                 name: "my-worker".into(),
+                description: Some("One-line summary of what this worker does".into()),
                 ..Default::default()
             }),
             ..Default::default()
@@ -440,6 +445,7 @@ that iii starts automatically when they're specified in iii's
 
 ```yaml
 name: math-worker
+description: Evaluate math expressions over iii functions.
 runtime:
   kind: python
   package_manager: pip
@@ -448,6 +454,9 @@ scripts:
   install: "pip install -r requirements.txt"
   start: "python math_worker.py"
 ```
+
+`description` is an optional one-line, human/LLM-readable summary of what the worker does; the
+iii CLI displays it when installing or inspecting the worker.
 
 The manifest is metadata about _starting_ the Worker. Once the Worker is running iii treats them all
 the same. A Worker started by `iii` via its `config.yaml`, via `iii worker start`, or a manually run

--- a/docs/next/creating-workers/workers.mdx.skill.md
+++ b/docs/next/creating-workers/workers.mdx.skill.md
@@ -64,6 +64,7 @@ process can be deployed anywhere reachable on the network.
     if (!url) throw new Error("III_URL must be set");
     const worker = registerWorker(url, {
       workerName: "my-worker",
+      workerDescription: "One-line summary of what this worker does",
     });
     ```
 
@@ -75,7 +76,10 @@ process can be deployed anywhere reachable on the network.
 
     worker = register_worker(
         os.environ.get("III_URL"),
-        InitOptions(worker_name="my-worker"),
+        InitOptions(
+            worker_name="my-worker",
+            worker_description="One-line summary of what this worker does",
+        ),
     )
     ```
 
@@ -90,6 +94,7 @@ process can be deployed anywhere reachable on the network.
         InitOptions {
             metadata: Some(WorkerMetadata {
                 name: "my-worker".into(),
+                description: Some("One-line summary of what this worker does".into()),
                 ..Default::default()
             }),
             ..Default::default()
@@ -436,6 +441,7 @@ that iii starts automatically when they're specified in iii's
 
 ```yaml
 name: math-worker
+description: Evaluate math expressions over iii functions.
 runtime:
   kind: python
   package_manager: pip
@@ -444,6 +450,9 @@ scripts:
   install: "pip install -r requirements.txt"
   start: "python math_worker.py"
 ```
+
+`description` is an optional one-line, human/LLM-readable summary of what the worker does; the
+iii CLI displays it when installing or inspecting the worker.
 
 The manifest is metadata about _starting_ the Worker. Once the Worker is running iii treats them all
 the same. A Worker started by `iii` via its `config.yaml`, via `iii worker start`, or a manually run

--- a/docs/next/sdk-reference/engine-sdk.mdx
+++ b/docs/next/sdk-reference/engine-sdk.mdx
@@ -37,7 +37,7 @@ The console UI runs on `3113` and is launched separately by `iii console`.
 A worker opens the SDK WebSocket (default `ws://127.0.0.1:49134`) and sends the registrations it
 holds in memory: each `RegisterFunction`, `RegisterTrigger`, and `RegisterTriggerType` it intends to
 expose. The worker then calls `engine::workers::register` to publish its own metadata (runtime,
-version, OS, PID, isolation), and the engine answers with a `WorkerRegistered { worker_id }` frame
+version, OS, PID, isolation, and an optional one-line `description`), and the engine answers with a `WorkerRegistered { worker_id }` frame
 carrying the assigned UUID.
 
 The connection is bidirectional from that point on: the engine pushes `InvokeFunction` frames at the
@@ -202,7 +202,7 @@ and worker lifecycle. Defined in
 | `engine::workers::list`       | List every connected worker with metrics.                                     |
 | `engine::triggers::list`      | List every registered trigger (filterable by `include_internal`).             |
 | `engine::trigger-types::list` | List every registered trigger type with its config and call request schemas.  |
-| `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation). |
+| `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation, optional `description`). |
 
 ## Engine discovery triggers
 

--- a/docs/next/sdk-reference/engine-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/engine-sdk.mdx.skill.md
@@ -35,7 +35,7 @@ The console UI runs on `3113` and is launched separately by `iii console`.
 A worker opens the SDK WebSocket (default `ws://127.0.0.1:49134`) and sends the registrations it
 holds in memory: each `RegisterFunction`, `RegisterTrigger`, and `RegisterTriggerType` it intends to
 expose. The worker then calls `engine::workers::register` to publish its own metadata (runtime,
-version, OS, PID, isolation), and the engine answers with a `WorkerRegistered { worker_id }` frame
+version, OS, PID, isolation, and an optional one-line `description`), and the engine answers with a `WorkerRegistered { worker_id }` frame
 carrying the assigned UUID.
 
 The connection is bidirectional from that point on: the engine pushes `InvokeFunction` frames at the
@@ -200,7 +200,7 @@ and worker lifecycle. Defined in
 | `engine::workers::list`       | List every connected worker with metrics.                                     |
 | `engine::triggers::list`      | List every registered trigger (filterable by `include_internal`).             |
 | `engine::trigger-types::list` | List every registered trigger type with its config and call request schemas.  |
-| `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation). |
+| `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation, optional `description`). |
 
 ## Engine discovery triggers
 

--- a/docs/next/sdk-reference/node-sdk.mdx
+++ b/docs/next/sdk-reference/node-sdk.mdx
@@ -29,7 +29,8 @@ function registerWorker(address: string, options?: InitOptions): ISdk;
 ```
 
 Pass the engine's SDK WebSocket URL (e.g. `process.env.III_URL`) as `address`. `options` configures
-worker identity, timeouts, reconnection, and OpenTelemetry. The returned `ISdk` carries every
+worker identity (`workerName`, plus an optional `workerDescription`, a one-line summary surfaced
+in `engine::workers::list` / `engine::workers::info`), timeouts, reconnection, and OpenTelemetry. The returned `ISdk` carries every
 method below.
 
 ### `registerFunction`
@@ -157,8 +158,10 @@ The SDK re-exports the structured types the engine returns when listing system s
 - `FunctionInfo`. `function_id`, optional `description`, optional `request_format` /
   `response_format`, optional `metadata`.
 - `TriggerInfo`. `id`, `trigger_type`, `function_id`, optional `config`, optional `metadata`.
-- `WorkerInfo`. `id`, `name`, runtime/version/OS fields, IP, `status`, `connected_at_ms`,
-  `function_count`, registered `functions`, `active_invocations`, optional `isolation`.
+- `WorkerInfo`. `id`, `name`, optional `description` (the worker's self-reported one-line
+  summary; every engine builtin ships one), runtime/version/OS fields, IP, `status`,
+  `connected_at_ms`, `function_count`, registered `functions`, `active_invocations`, optional
+  `isolation`.
 
 `WorkerMetadata` is not part of this SDK; use `WorkerInfo` for worker-side metadata.
 

--- a/docs/next/sdk-reference/node-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/node-sdk.mdx.skill.md
@@ -27,7 +27,8 @@ function registerWorker(address: string, options?: InitOptions): ISdk;
 ```
 
 Pass the engine's SDK WebSocket URL (e.g. `process.env.III_URL`) as `address`. `options` configures
-worker identity, timeouts, reconnection, and OpenTelemetry. The returned `ISdk` carries every
+worker identity (`workerName`, plus an optional `workerDescription`, a one-line summary surfaced
+in `engine::workers::list` / `engine::workers::info`), timeouts, reconnection, and OpenTelemetry. The returned `ISdk` carries every
 method below.
 
 ### `registerFunction`
@@ -155,8 +156,10 @@ The SDK re-exports the structured types the engine returns when listing system s
 - `FunctionInfo`. `function_id`, optional `description`, optional `request_format` /
   `response_format`, optional `metadata`.
 - `TriggerInfo`. `id`, `trigger_type`, `function_id`, optional `config`, optional `metadata`.
-- `WorkerInfo`. `id`, `name`, runtime/version/OS fields, IP, `status`, `connected_at_ms`,
-  `function_count`, registered `functions`, `active_invocations`, optional `isolation`.
+- `WorkerInfo`. `id`, `name`, optional `description` (the worker's self-reported one-line
+  summary; every engine builtin ships one), runtime/version/OS fields, IP, `status`,
+  `connected_at_ms`, `function_count`, registered `functions`, `active_invocations`, optional
+  `isolation`.
 
 `WorkerMetadata` is not part of this SDK; use `WorkerInfo` for worker-side metadata.
 

--- a/docs/next/sdk-reference/python-sdk.mdx
+++ b/docs/next/sdk-reference/python-sdk.mdx
@@ -30,8 +30,9 @@ Connect a worker to a running iii engine and return its handle.
 def register_worker(address: str, options: InitOptions | None = None) -> III: ...
 ```
 
-`address` is the engine's SDK WebSocket URL. `options` configures worker identity and
-reconnection. The returned `III` instance carries every method below.
+`address` is the engine's SDK WebSocket URL. `options` configures worker identity (`worker_name`, plus an optional
+`worker_description`, a one-line summary surfaced in `engine::workers::list` /
+`engine::workers::info`) and reconnection. The returned `III` instance carries every method below.
 
 <Note>
   The SDK's OpenTelemetry hookup is wired through `options` as well; the export and rollup side is

--- a/docs/next/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/python-sdk.mdx.skill.md
@@ -28,8 +28,9 @@ Connect a worker to a running iii engine and return its handle.
 def register_worker(address: str, options: InitOptions | None = None) -> III: ...
 ```
 
-`address` is the engine's SDK WebSocket URL. `options` configures worker identity and
-reconnection. The returned `III` instance carries every method below.
+`address` is the engine's SDK WebSocket URL. `options` configures worker identity (`worker_name`, plus an optional
+`worker_description`, a one-line summary surfaced in `engine::workers::list` /
+`engine::workers::info`) and reconnection. The returned `III` instance carries every method below.
 
 <Note>
   The SDK's OpenTelemetry hookup is wired through `options` as well; the export and rollup side is

--- a/docs/next/sdk-reference/rust-sdk.mdx
+++ b/docs/next/sdk-reference/rust-sdk.mdx
@@ -188,10 +188,13 @@ The SDK re-exports the engine's structured introspection types:
 - `FunctionInfo`. `function_id`, optional `description`, optional `request_format` /
   `response_format`, optional `metadata`.
 - `TriggerInfo`. `id`, `trigger_type`, `function_id`, optional `config` / `metadata`.
-- `WorkerInfo`. `id`, `name`, runtime / version / OS fields, IP, `status`, `connected_at_ms`,
-  `function_count`, registered `functions`, `active_invocations`, optional `isolation`.
+- `WorkerInfo`. `id`, `name`, optional `description` (the worker's self-reported one-line
+  summary; every engine builtin ships one), runtime / version / OS fields, IP, `status`,
+  `connected_at_ms`, `function_count`, registered `functions`, `active_invocations`, optional
+  `isolation`.
 - `WorkerMetadata`. The structured metadata a worker reports about itself: `runtime`, `version`,
-  `name`, `os`, `pid`, `telemetry` (an optional `WorkerTelemetryMeta` carrying language /
+  `name`, `os`, optional `description` (a one-line, human/LLM-readable summary of what the worker
+  does, surfaced in `engine::workers::list` / `engine::workers::info`), `pid`, `telemetry` (an optional `WorkerTelemetryMeta` carrying language /
   framework / project labels plus an Amplitude key, used by iii-telemetry for anonymous usage
   reporting; distinct from the OpenTelemetry observability surfaces owned by iii-observability),
   `isolation`. Rust is the only SDK that surfaces this as a distinct type today.

--- a/docs/next/sdk-reference/rust-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/rust-sdk.mdx.skill.md
@@ -186,10 +186,13 @@ The SDK re-exports the engine's structured introspection types:
 - `FunctionInfo`. `function_id`, optional `description`, optional `request_format` /
   `response_format`, optional `metadata`.
 - `TriggerInfo`. `id`, `trigger_type`, `function_id`, optional `config` / `metadata`.
-- `WorkerInfo`. `id`, `name`, runtime / version / OS fields, IP, `status`, `connected_at_ms`,
-  `function_count`, registered `functions`, `active_invocations`, optional `isolation`.
+- `WorkerInfo`. `id`, `name`, optional `description` (the worker's self-reported one-line
+  summary; every engine builtin ships one), runtime / version / OS fields, IP, `status`,
+  `connected_at_ms`, `function_count`, registered `functions`, `active_invocations`, optional
+  `isolation`.
 - `WorkerMetadata`. The structured metadata a worker reports about itself: `runtime`, `version`,
-  `name`, `os`, `pid`, `telemetry` (an optional `WorkerTelemetryMeta` carrying language /
+  `name`, `os`, optional `description` (a one-line, human/LLM-readable summary of what the worker
+  does, surfaced in `engine::workers::list` / `engine::workers::info`), `pid`, `telemetry` (an optional `WorkerTelemetryMeta` carrying language /
   framework / project labels plus an Amplitude key, used by iii-telemetry for anonymous usage
   reporting; distinct from the OpenTelemetry observability surfaces owned by iii-observability),
   `isolation`. Rust is the only SDK that surfaces this as a distinct type today.

--- a/docs/next/using-iii/functions.mdx
+++ b/docs/next/using-iii/functions.mdx
@@ -148,7 +148,7 @@ response schemas are in the
 | `engine::triggers::list`      | List every registered trigger binding.                                                                                     |
 | `engine::trigger-types::list` | List every advertised trigger type along with its config and call-request schemas.                                         |
 | `engine::channels::create`    | Allocate a streaming channel reader / writer pair. The SDK wraps this as `worker.createChannel()`; rarely called directly. |
-| `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID). The SDK calls this automatically on connect.            |
+| `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, optional `description`). The SDK calls this automatically on connect. |
 
 The engine also publishes two subscription triggers in the same family. Bind a function to one of
 these to react to the registry changing:

--- a/docs/next/using-iii/functions.mdx.skill.md
+++ b/docs/next/using-iii/functions.mdx.skill.md
@@ -146,7 +146,7 @@ response schemas are in the
 | `engine::triggers::list`      | List every registered trigger binding.                                                                                     |
 | `engine::trigger-types::list` | List every advertised trigger type along with its config and call-request schemas.                                         |
 | `engine::channels::create`    | Allocate a streaming channel reader / writer pair. The SDK wraps this as `worker.createChannel()`; rarely called directly. |
-| `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID). The SDK calls this automatically on connect.            |
+| `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, optional `description`). The SDK calls this automatically on connect. |
 
 The engine also publishes two subscription triggers in the same family. Bind a function to one of
 these to react to the registry changing:

--- a/docs/sdk-reference/engine-sdk.mdx
+++ b/docs/sdk-reference/engine-sdk.mdx
@@ -37,7 +37,7 @@ The console UI runs on `3113` and is launched separately by `iii console`.
 A worker opens the SDK WebSocket (default `ws://127.0.0.1:49134`) and sends the registrations it
 holds in memory: each `RegisterFunction`, `RegisterTrigger`, and `RegisterTriggerType` it intends to
 expose. The worker then calls `engine::workers::register` to publish its own metadata (runtime,
-version, OS, PID, isolation), and the engine answers with a `WorkerRegistered { worker_id }` frame
+version, OS, PID, isolation, and an optional one-line `description`), and the engine answers with a `WorkerRegistered { worker_id }` frame
 carrying the assigned UUID.
 
 The connection is bidirectional from that point on: the engine pushes `InvokeFunction` frames at the
@@ -202,7 +202,7 @@ and worker lifecycle. Defined in
 | `engine::workers::list`       | List every connected worker with metrics.                                     |
 | `engine::triggers::list`      | List every registered trigger (filterable by `include_internal`).             |
 | `engine::trigger-types::list` | List every registered trigger type with its config and call request schemas.  |
-| `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation). |
+| `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation, optional `description`). |
 
 ## Engine discovery triggers
 

--- a/docs/sdk-reference/engine-sdk.mdx.skill.md
+++ b/docs/sdk-reference/engine-sdk.mdx.skill.md
@@ -35,7 +35,7 @@ The console UI runs on `3113` and is launched separately by `iii console`.
 A worker opens the SDK WebSocket (default `ws://127.0.0.1:49134`) and sends the registrations it
 holds in memory: each `RegisterFunction`, `RegisterTrigger`, and `RegisterTriggerType` it intends to
 expose. The worker then calls `engine::workers::register` to publish its own metadata (runtime,
-version, OS, PID, isolation), and the engine answers with a `WorkerRegistered { worker_id }` frame
+version, OS, PID, isolation, and an optional one-line `description`), and the engine answers with a `WorkerRegistered { worker_id }` frame
 carrying the assigned UUID.
 
 The connection is bidirectional from that point on: the engine pushes `InvokeFunction` frames at the
@@ -200,7 +200,7 @@ and worker lifecycle. Defined in
 | `engine::workers::list`       | List every connected worker with metrics.                                     |
 | `engine::triggers::list`      | List every registered trigger (filterable by `include_internal`).             |
 | `engine::trigger-types::list` | List every registered trigger type with its config and call request schemas.  |
-| `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation). |
+| `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation, optional `description`). |
 
 ## Engine discovery triggers
 

--- a/docs/sdk-reference/node-sdk.mdx
+++ b/docs/sdk-reference/node-sdk.mdx
@@ -29,7 +29,8 @@ function registerWorker(address: string, options?: InitOptions): ISdk;
 ```
 
 Pass the engine's SDK WebSocket URL (e.g. `process.env.III_URL`) as `address`. `options` configures
-worker identity, timeouts, reconnection, and OpenTelemetry. The returned `ISdk` carries every
+worker identity (`workerName`, plus an optional `workerDescription`, a one-line summary surfaced
+in `engine::workers::list` / `engine::workers::info`), timeouts, reconnection, and OpenTelemetry. The returned `ISdk` carries every
 method below.
 
 ### `registerFunction`
@@ -157,8 +158,10 @@ The SDK re-exports the structured types the engine returns when listing system s
 - `FunctionInfo`. `function_id`, optional `description`, optional `request_format` /
   `response_format`, optional `metadata`.
 - `TriggerInfo`. `id`, `trigger_type`, `function_id`, optional `config`, optional `metadata`.
-- `WorkerInfo`. `id`, `name`, runtime/version/OS fields, IP, `status`, `connected_at_ms`,
-  `function_count`, registered `functions`, `active_invocations`, optional `isolation`.
+- `WorkerInfo`. `id`, `name`, optional `description` (the worker's self-reported one-line
+  summary; every engine builtin ships one), runtime/version/OS fields, IP, `status`,
+  `connected_at_ms`, `function_count`, registered `functions`, `active_invocations`, optional
+  `isolation`.
 
 `WorkerMetadata` is not part of this SDK; use `WorkerInfo` for worker-side metadata.
 

--- a/docs/sdk-reference/node-sdk.mdx.skill.md
+++ b/docs/sdk-reference/node-sdk.mdx.skill.md
@@ -27,7 +27,8 @@ function registerWorker(address: string, options?: InitOptions): ISdk;
 ```
 
 Pass the engine's SDK WebSocket URL (e.g. `process.env.III_URL`) as `address`. `options` configures
-worker identity, timeouts, reconnection, and OpenTelemetry. The returned `ISdk` carries every
+worker identity (`workerName`, plus an optional `workerDescription`, a one-line summary surfaced
+in `engine::workers::list` / `engine::workers::info`), timeouts, reconnection, and OpenTelemetry. The returned `ISdk` carries every
 method below.
 
 ### `registerFunction`
@@ -155,8 +156,10 @@ The SDK re-exports the structured types the engine returns when listing system s
 - `FunctionInfo`. `function_id`, optional `description`, optional `request_format` /
   `response_format`, optional `metadata`.
 - `TriggerInfo`. `id`, `trigger_type`, `function_id`, optional `config`, optional `metadata`.
-- `WorkerInfo`. `id`, `name`, runtime/version/OS fields, IP, `status`, `connected_at_ms`,
-  `function_count`, registered `functions`, `active_invocations`, optional `isolation`.
+- `WorkerInfo`. `id`, `name`, optional `description` (the worker's self-reported one-line
+  summary; every engine builtin ships one), runtime/version/OS fields, IP, `status`,
+  `connected_at_ms`, `function_count`, registered `functions`, `active_invocations`, optional
+  `isolation`.
 
 `WorkerMetadata` is not part of this SDK; use `WorkerInfo` for worker-side metadata.
 

--- a/docs/sdk-reference/python-sdk.mdx
+++ b/docs/sdk-reference/python-sdk.mdx
@@ -30,8 +30,9 @@ Connect a worker to a running iii engine and return its handle.
 def register_worker(address: str, options: InitOptions | None = None) -> III: ...
 ```
 
-`address` is the engine's SDK WebSocket URL. `options` configures worker identity and
-reconnection. The returned `III` instance carries every method below.
+`address` is the engine's SDK WebSocket URL. `options` configures worker identity (`worker_name`, plus an optional
+`worker_description`, a one-line summary surfaced in `engine::workers::list` /
+`engine::workers::info`) and reconnection. The returned `III` instance carries every method below.
 
 <Note>
   The SDK's OpenTelemetry hookup is wired through `options` as well; the export and rollup side is

--- a/docs/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/sdk-reference/python-sdk.mdx.skill.md
@@ -28,8 +28,9 @@ Connect a worker to a running iii engine and return its handle.
 def register_worker(address: str, options: InitOptions | None = None) -> III: ...
 ```
 
-`address` is the engine's SDK WebSocket URL. `options` configures worker identity and
-reconnection. The returned `III` instance carries every method below.
+`address` is the engine's SDK WebSocket URL. `options` configures worker identity (`worker_name`, plus an optional
+`worker_description`, a one-line summary surfaced in `engine::workers::list` /
+`engine::workers::info`) and reconnection. The returned `III` instance carries every method below.
 
 <Note>
   The SDK's OpenTelemetry hookup is wired through `options` as well; the export and rollup side is

--- a/docs/sdk-reference/rust-sdk.mdx
+++ b/docs/sdk-reference/rust-sdk.mdx
@@ -188,10 +188,13 @@ The SDK re-exports the engine's structured introspection types:
 - `FunctionInfo`. `function_id`, optional `description`, optional `request_format` /
   `response_format`, optional `metadata`.
 - `TriggerInfo`. `id`, `trigger_type`, `function_id`, optional `config` / `metadata`.
-- `WorkerInfo`. `id`, `name`, runtime / version / OS fields, IP, `status`, `connected_at_ms`,
-  `function_count`, registered `functions`, `active_invocations`, optional `isolation`.
+- `WorkerInfo`. `id`, `name`, optional `description` (the worker's self-reported one-line
+  summary; every engine builtin ships one), runtime / version / OS fields, IP, `status`,
+  `connected_at_ms`, `function_count`, registered `functions`, `active_invocations`, optional
+  `isolation`.
 - `WorkerMetadata`. The structured metadata a worker reports about itself: `runtime`, `version`,
-  `name`, `os`, `pid`, `telemetry` (an optional `WorkerTelemetryMeta` carrying language /
+  `name`, `os`, optional `description` (a one-line, human/LLM-readable summary of what the worker
+  does, surfaced in `engine::workers::list` / `engine::workers::info`), `pid`, `telemetry` (an optional `WorkerTelemetryMeta` carrying language /
   framework / project labels plus an Amplitude key, used by iii-telemetry for anonymous usage
   reporting; distinct from the OpenTelemetry observability surfaces owned by iii-observability),
   `isolation`. Rust is the only SDK that surfaces this as a distinct type today.

--- a/docs/sdk-reference/rust-sdk.mdx.skill.md
+++ b/docs/sdk-reference/rust-sdk.mdx.skill.md
@@ -186,10 +186,13 @@ The SDK re-exports the engine's structured introspection types:
 - `FunctionInfo`. `function_id`, optional `description`, optional `request_format` /
   `response_format`, optional `metadata`.
 - `TriggerInfo`. `id`, `trigger_type`, `function_id`, optional `config` / `metadata`.
-- `WorkerInfo`. `id`, `name`, runtime / version / OS fields, IP, `status`, `connected_at_ms`,
-  `function_count`, registered `functions`, `active_invocations`, optional `isolation`.
+- `WorkerInfo`. `id`, `name`, optional `description` (the worker's self-reported one-line
+  summary; every engine builtin ships one), runtime / version / OS fields, IP, `status`,
+  `connected_at_ms`, `function_count`, registered `functions`, `active_invocations`, optional
+  `isolation`.
 - `WorkerMetadata`. The structured metadata a worker reports about itself: `runtime`, `version`,
-  `name`, `os`, `pid`, `telemetry` (an optional `WorkerTelemetryMeta` carrying language /
+  `name`, `os`, optional `description` (a one-line, human/LLM-readable summary of what the worker
+  does, surfaced in `engine::workers::list` / `engine::workers::info`), `pid`, `telemetry` (an optional `WorkerTelemetryMeta` carrying language /
   framework / project labels plus an Amplitude key, used by iii-telemetry for anonymous usage
   reporting; distinct from the OpenTelemetry observability surfaces owned by iii-observability),
   `isolation`. Rust is the only SDK that surfaces this as a distinct type today.

--- a/docs/using-iii/functions.mdx
+++ b/docs/using-iii/functions.mdx
@@ -148,7 +148,7 @@ response schemas are in the
 | `engine::triggers::list`      | List every registered trigger binding.                                                                                     |
 | `engine::trigger-types::list` | List every advertised trigger type along with its config and call-request schemas.                                         |
 | `engine::channels::create`    | Allocate a streaming channel reader / writer pair. The SDK wraps this as `worker.createChannel()`; rarely called directly. |
-| `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID). The SDK calls this automatically on connect.            |
+| `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, optional `description`). The SDK calls this automatically on connect. |
 
 The engine also publishes two subscription triggers in the same family. Bind a function to one of
 these to react to the registry changing:

--- a/docs/using-iii/functions.mdx.skill.md
+++ b/docs/using-iii/functions.mdx.skill.md
@@ -146,7 +146,7 @@ response schemas are in the
 | `engine::triggers::list`      | List every registered trigger binding.                                                                                     |
 | `engine::trigger-types::list` | List every advertised trigger type along with its config and call-request schemas.                                         |
 | `engine::channels::create`    | Allocate a streaming channel reader / writer pair. The SDK wraps this as `worker.createChannel()`; rarely called directly. |
-| `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID). The SDK calls this automatically on connect.            |
+| `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, optional `description`). The SDK calls this automatically on connect. |
 
 The engine also publishes two subscription triggers in the same family. Bind a function to one of
 these to react to the registry changing:

--- a/engine/examples/custom_queue_adapter.rs
+++ b/engine/examples/custom_queue_adapter.rs
@@ -273,7 +273,11 @@ impl ConfigurableWorker for CustomQueueModule {
     }
 }
 
-iii::register_worker!("my::CustomQueueModule", CustomQueueModule);
+iii::register_worker!(
+    "my::CustomQueueModule",
+    CustomQueueModule,
+    description = "Example queue worker backed by a custom adapter."
+);
 
 impl FunctionHandler for CustomQueueModule {
     fn handle_function(

--- a/engine/src/cli_trigger/help.rs
+++ b/engine/src/cli_trigger/help.rs
@@ -62,10 +62,14 @@ async fn fetch_fn_meta(
     let url = format!("ws://{}:{}", address, port);
     let iii = register_worker(&url, InitOptions::default());
 
+    // `engine::functions::info` is the only surface that carries the
+    // request/response schemas — `engine::functions::list` returns slim
+    // summaries (id + description) and would leave the Parameters table
+    // permanently empty.
     let result = iii
         .trigger(TriggerRequest {
-            function_id: "engine::functions::list".to_string(),
-            payload: json!({ "include_internal": true }),
+            function_id: "engine::functions::info".to_string(),
+            payload: json!({ "function_id": fn_path }),
             action: None,
             timeout_ms: Some(timeout_ms),
         })
@@ -73,23 +77,74 @@ async fn fetch_fn_meta(
 
     iii.shutdown_async().await;
 
-    let value = result.map_err(|e| anyhow::anyhow!("{}", e))?;
-    let functions = value
-        .get("functions")
-        .and_then(|v| v.as_array())
-        .ok_or_else(|| anyhow::anyhow!("unexpected response shape from engine::functions::list"))?;
+    match result {
+        Ok(value) => Ok(Some(value)),
+        Err(e) => {
+            // Distinguish two "not found" shapes (case-insensitive):
+            // 1. The dispatcher couldn't find `engine::functions::info`
+            //    itself — an engine that predates the introspection fn.
+            //    Surface as Err so `print()` degrades to static help
+            //    instead of falsely claiming the TARGET function is absent.
+            // 2. The target function isn't registered — map to Ok(None)
+            //    so the caller prints the friendly "not found" hint.
+            let msg = e.to_string().to_ascii_lowercase();
+            let looks_not_found = msg.contains("not_found")
+                || msg.contains("not found")
+                || msg.contains("not registered");
+            if looks_not_found && msg.contains("engine::functions::info") {
+                Err(anyhow::anyhow!(
+                    "engine does not support engine::functions::info; showing static help"
+                ))
+            } else if looks_not_found {
+                Ok(None)
+            } else {
+                Err(anyhow::anyhow!("{}", e))
+            }
+        }
+    }
+}
 
-    Ok(functions
-        .iter()
-        .find(|f| f.get("function_id").and_then(|s| s.as_str()) == Some(fn_path))
-        .cloned())
+/// True for characters a worker-supplied string must never carry onto the
+/// terminal: control chars (ANSI ESC, C1, DEL) plus the Unicode bidi
+/// override/isolate range (U+202A–202E, U+2066–2069 — the Trojan-Source
+/// class) and the line/paragraph separators U+2028/U+2029. `\n` is handled
+/// by callers (kept for the about block, collapsed in table cells).
+fn is_unsafe_terminal_char(c: char) -> bool {
+    c.is_control()
+        || matches!(c, '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}' | '\u{2028}' | '\u{2029}')
+}
+
+/// Engine-provided strings originate from whatever worker registered the
+/// function — strip unsafe characters before printing to the user's terminal
+/// so a malicious worker can't smuggle cursor/clipboard/hyperlink escape
+/// sequences (or bidi spoofing) into `--help` output. Newlines are kept;
+/// descriptions may legitimately span lines.
+fn sanitize_terminal(s: &str) -> String {
+    s.chars()
+        .filter(|c| !is_unsafe_terminal_char(*c) || *c == '\n')
+        .collect()
+}
+
+/// Like `sanitize_terminal`, but for a single markdown table cell: every
+/// field rendered into the Parameters table (`name`, `type`, `description`)
+/// is worker-controlled, so newlines/tabs are collapsed to spaces (a cell
+/// must stay on one row) and all remaining control characters are stripped.
+/// Without this, a property keyed with an ANSI/OSC sequence — or a multi-line
+/// description — reaches the operator's terminal or splits the table.
+fn sanitize_cell(s: &str) -> String {
+    s.chars()
+        .map(|c| if c == '\n' || c == '\t' { ' ' } else { c })
+        .filter(|c| !is_unsafe_terminal_char(*c))
+        .collect()
 }
 
 fn render_fn_help(fn_path: &str, meta: &Value) {
-    let description = meta
-        .get("description")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let description = sanitize_terminal(
+        meta.get("description")
+            .and_then(|v| v.as_str())
+            .unwrap_or(""),
+    );
+    let description = description.as_str();
 
     // Drive sections individually via print_template so we can place the
     // schema-driven Parameters table BEFORE the generic Options table that
@@ -132,7 +187,12 @@ fn render_fn_help(fn_path: &str, meta: &Value) {
 /// can display in the same style as clap-help's Options table. Returns
 /// `None` when there is nothing useful to show.
 fn parameters_md(meta: &Value) -> Option<String> {
-    let schema = meta.get("request_format").filter(|v| !v.is_null())?;
+    // `functions::info` names the field `request_schema`; accept the legacy
+    // `request_format` key as a fallback for older engines.
+    let schema = meta
+        .get("request_schema")
+        .or_else(|| meta.get("request_format"))
+        .filter(|v| !v.is_null())?;
     let props = schema.get("properties").and_then(|p| p.as_object())?;
     if props.is_empty() {
         return None;
@@ -150,18 +210,27 @@ fn parameters_md(meta: &Value) -> Option<String> {
     for (name, prop) in props {
         // Escape `|` so multi-type values like `string|null` do not split the
         // markdown row into extra columns.
-        let ty = schema_type(prop).replace('|', "\\|");
+        let ty = sanitize_cell(&schema_type(prop)).replace('|', "\\|");
         let req = if required.contains(&name.as_str()) {
             "yes"
         } else {
             "no"
         };
-        let desc = prop
-            .get("description")
-            .and_then(|d| d.as_str())
-            .unwrap_or("")
-            .replace('|', "\\|");
-        md.push_str(&format!("|`{}`|{}|{}|{}|\n", name, ty, req, desc));
+        let desc = sanitize_cell(
+            prop.get("description")
+                .and_then(|d| d.as_str())
+                .unwrap_or(""),
+        )
+        .replace('|', "\\|");
+        // The property key is worker-controlled too — sanitize it before it
+        // reaches the terminal.
+        md.push_str(&format!(
+            "|`{}`|{}|{}|{}|\n",
+            sanitize_cell(name),
+            ty,
+            req,
+            desc
+        ));
     }
     md.push_str("|-\n");
     Some(md)
@@ -188,4 +257,93 @@ fn print_static_help() {
         "Tip:".bold()
     );
     println!("  function's description and request schema.");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn sanitize_terminal_strips_controls_but_keeps_newlines_and_multibyte() {
+        assert_eq!(sanitize_terminal("a\u{1b}[31mb\u{7f}c"), "a[31mbc");
+        assert_eq!(sanitize_terminal("line1\nline2"), "line1\nline2");
+        assert_eq!(sanitize_terminal("\u{1b}\u{0007}"), "");
+        assert_eq!(sanitize_terminal(""), "");
+        assert_eq!(
+            sanitize_terminal("caf\u{e9} \u{1f600}"),
+            "caf\u{e9} \u{1f600}"
+        );
+        // Bidi overrides/isolates (Trojan-Source) are stripped, newline kept.
+        assert_eq!(sanitize_terminal("a\u{202e}b\u{2066}c"), "abc");
+    }
+
+    #[test]
+    fn sanitize_cell_collapses_newlines_and_strips_controls() {
+        // Newlines/tabs become spaces so a worker-supplied value can't split
+        // the markdown row; other control chars (ESC/DEL/BEL) and bidi
+        // overrides are dropped.
+        assert_eq!(sanitize_cell("a\nb\tc"), "a b c");
+        assert_eq!(sanitize_cell("x\u{1b}]8;;evil\u{7}y"), "x]8;;evily");
+        assert_eq!(sanitize_cell("\u{7f}\u{0007}"), "");
+        assert_eq!(sanitize_cell("a\u{202e}b"), "ab");
+        assert_eq!(sanitize_cell("plain"), "plain");
+    }
+
+    #[test]
+    fn parameters_md_sanitizes_worker_controlled_name_and_type() {
+        // A malicious worker controls its own request_schema, including
+        // property keys and the `type` string. Neither may carry control
+        // bytes into the operator's terminal via `--help`.
+        let meta = json!({
+            "request_schema": {
+                "properties": {
+                    "ev\u{1b}[31mil": { "type": "str\u{7f}ing", "description": "d" }
+                }
+            }
+        });
+        let md = parameters_md(&meta).unwrap();
+        assert!(!md.contains('\u{1b}'), "ESC must not reach the table: {md}");
+        assert!(!md.contains('\u{7f}'), "DEL must not reach the table: {md}");
+    }
+
+    #[test]
+    fn parameters_md_prefers_request_schema_then_falls_back_to_request_format() {
+        let with_new = json!({
+            "request_schema": { "properties": { "name": { "type": "string" } } }
+        });
+        assert!(parameters_md(&with_new).is_some());
+
+        let with_legacy = json!({
+            "request_format": { "properties": { "name": { "type": "string" } } }
+        });
+        assert!(parameters_md(&with_legacy).is_some());
+    }
+
+    #[test]
+    fn parameters_md_none_when_empty_null_or_missing() {
+        assert!(parameters_md(&json!({ "request_schema": { "properties": {} } })).is_none());
+        assert!(parameters_md(&json!({ "request_schema": null })).is_none());
+        assert!(parameters_md(&json!({})).is_none());
+    }
+
+    #[test]
+    fn parameters_md_marks_required_fields_and_escapes_pipes() {
+        let meta = json!({
+            "request_schema": {
+                "properties": {
+                    "source": { "description": "where from", "type": "object" },
+                    "wait": { "type": ["boolean", "null"] }
+                },
+                "required": ["source"]
+            }
+        });
+        let md = parameters_md(&meta).unwrap();
+        assert!(md.contains("source"));
+        assert!(md.contains("yes"), "required column marks `source` as yes");
+        assert!(
+            !md.contains("boolean|null"),
+            "multi-type values must escape `|` so the markdown table doesn't split"
+        );
+    }
 }

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -1999,6 +1999,7 @@ mod tests {
         engine.upsert_runtime_worker(crate::worker_connections::RuntimeWorkerInfo {
             id: "iii-state".to_string(),
             name: "iii-state".to_string(),
+            description: None,
             worker_type: "iii-state".to_string(),
             connected_at: chrono::Utc::now(),
             function_ids: vec!["state::get".to_string()],

--- a/engine/src/worker_connections/mod.rs
+++ b/engine/src/worker_connections/mod.rs
@@ -33,6 +33,9 @@ pub struct WorkerConnectionTelemetryMeta {
 pub struct RuntimeWorkerInfo {
     pub id: String,
     pub name: String,
+    /// One-line summary of what this builtin worker does, sourced from its
+    /// `WorkerRegistration`. Surfaces in `engine::workers::list` / `info`.
+    pub description: Option<String>,
     pub worker_type: String,
     pub connected_at: DateTime<Utc>,
     pub function_ids: Vec<String>,
@@ -63,6 +66,13 @@ impl WorkerConnectionRegistry {
 
     pub fn get_worker(&self, id: &Uuid) -> Option<WorkerConnection> {
         self.workers.get(id).map(|w| w.value().clone())
+    }
+
+    /// Name-only lookup. Avoids cloning the whole `WorkerConnection`
+    /// (function-id sets, telemetry, session) when callers just attribute
+    /// ownership by name.
+    pub fn get_worker_name(&self, id: &Uuid) -> Option<String> {
+        self.workers.get(id).and_then(|w| w.value().name.clone())
     }
 
     pub fn register_worker(&self, worker: WorkerConnection) {
@@ -130,6 +140,7 @@ impl WorkerConnectionRegistry {
         runtime: String,
         version: Option<String>,
         name: Option<String>,
+        description: Option<String>,
         os: Option<String>,
         telemetry: Option<WorkerConnectionTelemetryMeta>,
         pid: Option<u32>,
@@ -140,6 +151,9 @@ impl WorkerConnectionRegistry {
             worker.version = version;
             if name.is_some() {
                 worker.name = name;
+            }
+            if description.is_some() {
+                worker.description = description;
             }
             if os.is_some() {
                 worker.os = os;
@@ -218,6 +232,8 @@ pub struct WorkerConnection {
     pub version: Option<String>,
     pub connected_at: DateTime<Utc>,
     pub name: Option<String>,
+    /// One-line summary reported by the worker via `engine::workers::register`.
+    pub description: Option<String>,
     pub os: Option<String>,
     pub status: WorkerConnectionStatus,
     pub telemetry: Option<WorkerConnectionTelemetryMeta>,
@@ -239,6 +255,7 @@ impl WorkerConnection {
             version: None,
             connected_at: Utc::now(),
             name: None,
+            description: None,
             os: None,
             status: WorkerConnectionStatus::Connected,
             telemetry: None,
@@ -260,6 +277,7 @@ impl WorkerConnection {
             version: None,
             connected_at: Utc::now(),
             name: None,
+            description: None,
             os: None,
             status: WorkerConnectionStatus::Connected,
             telemetry: None,
@@ -477,6 +495,7 @@ mod tests {
             "node".to_string(),
             Some("1.0.0".to_string()),
             Some("worker-a".to_string()),
+            None,
             Some("linux".to_string()),
             Some(telemetry.clone()),
             None,
@@ -516,6 +535,7 @@ mod tests {
             &worker_id,
             "node".to_string(),
             Some("18.0.0".to_string()),
+            None,
             None,
             None,
             None,

--- a/engine/src/workers/bridge_client/mod.rs
+++ b/engine/src/workers/bridge_client/mod.rs
@@ -275,7 +275,11 @@ impl Worker for BridgeClientWorker {
     }
 }
 
-crate::register_worker!("iii-bridge", BridgeClientWorker);
+crate::register_worker!(
+    "iii-bridge",
+    BridgeClientWorker,
+    description = "Connect to another iii instance over iii-sdk to expose and forward functions."
+);
 
 #[cfg(test)]
 mod tests {

--- a/engine/src/workers/config.rs
+++ b/engine/src/workers/config.rs
@@ -435,6 +435,13 @@ fn mandatory_worker_names() -> HashSet<&'static str> {
         .collect()
 }
 
+fn builtin_worker_description(worker_type: &str) -> Option<&'static str> {
+    inventory::iter::<WorkerRegistration>
+        .into_iter()
+        .find(|registration| registration.name == worker_type)
+        .map(|registration| registration.description)
+}
+
 pub(crate) fn runtime_worker_info_from_registration(
     entry: &WorkerEntry,
     worker: &dyn Worker,
@@ -452,6 +459,7 @@ pub(crate) fn runtime_worker_info_from_registration(
     Some(crate::worker_connections::RuntimeWorkerInfo {
         id: entry.name.clone(),
         name: worker_type.clone(),
+        description: builtin_worker_description(&worker_type).map(|s| s.to_string()),
         worker_type: worker_type.clone(),
         connected_at: chrono::Utc::now(),
         function_ids,
@@ -1870,6 +1878,10 @@ modules:
         assert_eq!(listed.worker_type, "test::Listed");
         assert_eq!(listed.function_ids, vec!["listed::fn"]);
         assert!(!listed.internal);
+        assert!(
+            listed.description.is_none(),
+            "non-inventory workers have no builtin description"
+        );
 
         builder.destroy().await.expect("destroy engine");
 
@@ -1877,6 +1889,30 @@ modules:
             engine.list_runtime_workers().is_empty(),
             "runtime snapshots should be removed on destroy"
         );
+    }
+
+    #[test]
+    fn every_builtin_worker_registration_has_description() {
+        let mut seen = 0;
+        for registration in inventory::iter::<WorkerRegistration> {
+            seen += 1;
+            assert!(
+                !registration.description.trim().is_empty(),
+                "builtin worker '{}' must have a non-empty description",
+                registration.name
+            );
+            assert_eq!(
+                builtin_worker_description(registration.name),
+                Some(registration.description),
+                "description lookup must resolve builtin worker '{}'",
+                registration.name
+            );
+        }
+        assert!(
+            seen > 0,
+            "expected builtin worker registrations in inventory"
+        );
+        assert!(builtin_worker_description("not-a-builtin").is_none());
     }
 
     #[tokio::test]

--- a/engine/src/workers/configuration/configuration.rs
+++ b/engine/src/workers/configuration/configuration.rs
@@ -452,7 +452,12 @@ impl ConfigurationWorker {
     }
 }
 
-crate::register_worker!("configuration", ConfigurationWorker, mandatory);
+crate::register_worker!(
+    "configuration",
+    ConfigurationWorker,
+    description = "Register, store, and watch typed configuration values for the engine.",
+    mandatory
+);
 
 #[cfg(test)]
 mod tests {

--- a/engine/src/workers/configuration/iii.worker.yaml
+++ b/engine/src/workers/configuration/iii.worker.yaml
@@ -1,7 +1,7 @@
 iii: v1
 name: configuration
 type: engine
-description: Configuration worker for the iii engine.
+description: Register, store, and watch typed configuration values for the engine.
 repo: https://github.com/iii-hq/iii
 config:
   adapter:

--- a/engine/src/workers/cron/cron.rs
+++ b/engine/src/workers/cron/cron.rs
@@ -166,7 +166,12 @@ impl ConfigurableWorker for CronWorker {
     }
 }
 
-crate::register_worker!("iii-cron", CronWorker, enabled_by_default = true);
+crate::register_worker!(
+    "iii-cron",
+    CronWorker,
+    description = "Schedule functions with cron expressions.",
+    enabled_by_default = true
+);
 
 #[cfg(test)]
 mod tests {

--- a/engine/src/workers/engine_fn/README.md
+++ b/engine/src/workers/engine_fn/README.md
@@ -81,7 +81,7 @@ For exact parameter and response shapes, call `engine::functions::info { functio
 | `worker::clear` | Delete cached artifacts under `~/.iii/managed/{name}/`. Requires `yes: true`. Does not touch config or lock. |
 | `worker::schema` | JSON Schemas for every op plus `default_timeout_ms` and `idempotent` hints. |
 
-> **Note:** `worker::add` with `source.kind: "local"` works on the CLI only (returns **W102** via the trigger surface). Destructive ops (`remove`, `stop`, `clear`) require `yes: true` (boolean, not string).
+> **Note:** `worker::add` with `source.kind: "local"` works over the trigger as well as the CLI; the `path` is resolved on the engine/daemon host (not the caller). Destructive ops (`remove`, `stop`, `clear`) require `yes: true` (boolean, not string).
 
 Merge `worker::list` with `engine::workers::list` by `name` for a complete worker picture — daemon-managed providers such as `iii-http` may not appear in `engine::workers::list` even when serving traffic.
 

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -29,6 +29,34 @@ pub const TRIGGER_WORKERS_AVAILABLE: &str = "engine::workers-available";
 /// Maximum length of `config_summary` strings produced by
 /// `engine::registered-triggers::list`.
 const CONFIG_SUMMARY_MAX_LEN: usize = 80;
+/// Self-reported worker descriptions are untrusted free text rendered by
+/// consoles, CLIs, and LLM agents — cap the length and strip control
+/// characters at the ingest boundary.
+const WORKER_DESCRIPTION_MAX_LEN: usize = 280;
+
+/// True for characters untrusted worker text must never carry onto a
+/// console/terminal/LLM display surface: C0/C1/DEL control chars, plus the
+/// Unicode bidirectional override/isolate range (U+202A–202E, U+2066–2069 —
+/// the Trojan-Source / CVE-2021-42574 class) and the line/paragraph
+/// separators U+2028/U+2029.
+fn is_unsafe_display_char(c: char) -> bool {
+    c.is_control()
+        || matches!(c, '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}' | '\u{2028}' | '\u{2029}')
+}
+
+fn sanitize_worker_text(raw: String) -> Option<String> {
+    let cleaned: String = raw
+        .chars()
+        .filter(|c| !is_unsafe_display_char(*c))
+        .take(WORKER_DESCRIPTION_MAX_LEN)
+        .collect();
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct EmptyInput {}
@@ -228,8 +256,10 @@ pub struct RegisteredTriggerDetail {
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct WorkerSummary {
     pub name: Option<String>,
-    /// Always `null` for engine-side workers; carried as a shared core
-    /// field so a parser can walk both the engine and registry surfaces.
+    /// One-line summary self-reported by the worker via
+    /// `engine::workers::register`. `null` when the worker did not provide
+    /// one; carried as a shared core field so a parser can walk both the
+    /// engine and registry surfaces.
     pub description: Option<String>,
     pub version: Option<String>,
     pub id: String,
@@ -313,6 +343,10 @@ pub struct RegisterWorkerInput {
     pub version: Option<String>,
     /// Friendly worker name used in dashboards and logs.
     pub name: Option<String>,
+    /// One-line summary of what the worker does. Surfaces in
+    /// `engine::workers::list` / `engine::workers::info`.
+    #[serde(default)]
+    pub description: Option<String>,
     /// Worker host operating system.
     pub os: Option<String>,
     /// Telemetry metadata reported by the worker (anonymous device id,
@@ -420,23 +454,29 @@ impl EngineFunctionsWorker {
         Self::first_segment(function_id)
     }
 
-    /// Resolves the worker name that owns a trigger type. Tries, in order:
-    /// the `worker_id` Uuid on the `TriggerType` (populated only by
-    /// WebSocket-connected workers), the static `BUILTIN_TRIGGER_TYPES` map
-    /// (used for in-process workers, which always register with
-    /// `worker_id: None`), and finally the first `::` segment of the id.
-    fn worker_name_for_trigger_type(&self, tt_id: &str) -> String {
-        if let Some(tt) = self.engine.trigger_registry.trigger_types.get(tt_id)
-            && let Some(worker_id) = tt.worker_id
-            && let Some(worker) = self.engine.worker_registry.get_worker(&worker_id)
-            && let Some(name) = worker.name
+    /// Resolves the worker name that owns a trigger type from an
+    /// already-fetched `TriggerType`. Tries, in order: the `worker_id` Uuid
+    /// (populated only by WebSocket-connected workers), the static
+    /// `BUILTIN_TRIGGER_TYPES` map (used for in-process workers, which
+    /// always register with `worker_id: None`), and finally the first `::`
+    /// segment of the id.
+    ///
+    /// Takes the borrowed `TriggerType` instead of an id on purpose: callers
+    /// usually sit inside `trigger_types` iteration or a `.get()` guard, and
+    /// a by-id variant would re-enter the same DashMap — a re-entrant
+    /// same-shard read can deadlock against a queued writer (parking_lot
+    /// RwLocks are writer-fair). Only `worker_registry` (a different map) is
+    /// touched here.
+    fn owner_name_for_trigger_type(&self, tt: &crate::trigger::TriggerType) -> String {
+        if let Some(worker_id) = tt.worker_id
+            && let Some(name) = self.engine.worker_registry.get_worker_name(&worker_id)
         {
             return name;
         }
-        if let Some(name) = builtin_trigger_type_owner(tt_id) {
+        if let Some(name) = builtin_trigger_type_owner(&tt.id) {
             return name.to_string();
         }
-        Self::first_segment(tt_id)
+        Self::first_segment(&tt.id)
     }
 
     fn instance_count_for_type(&self, tt_id: &str) -> usize {
@@ -493,7 +533,8 @@ impl EngineFunctionsWorker {
                 let tt = entry.value();
                 TriggerTypeSummary {
                     id: tt.id.clone(),
-                    worker_name: self.worker_name_for_trigger_type(&tt.id),
+                    // Guard-safe: we're inside `trigger_types.iter()`.
+                    worker_name: self.owner_name_for_trigger_type(tt),
                     description: tt._description.clone(),
                 }
             })
@@ -542,7 +583,7 @@ impl EngineFunctionsWorker {
 
             worker_summaries.push(WorkerSummary {
                 name: w.name.clone(),
-                description: None,
+                description: w.description.clone(),
                 version: w.version.clone(),
                 id: worker_id,
                 runtime: w.runtime.clone(),
@@ -566,7 +607,7 @@ impl EngineFunctionsWorker {
             let functions = runtime_worker.function_ids.clone();
             worker_summaries.push(WorkerSummary {
                 name: Some(runtime_worker.name.clone()),
-                description: None,
+                description: runtime_worker.description.clone(),
                 version: Some(env!("CARGO_PKG_VERSION").to_string()),
                 id: runtime_worker.id.clone(),
                 runtime: Some("engine".to_string()),
@@ -614,7 +655,8 @@ impl EngineFunctionsWorker {
         let tt = self.engine.trigger_registry.trigger_types.get(tt_id)?;
         Some(TriggerTypeDetail {
             id: tt.id.clone(),
-            worker_name: self.worker_name_for_trigger_type(&tt.id),
+            // Guard-safe: we hold the `.get()` guard on this entry.
+            worker_name: self.owner_name_for_trigger_type(tt.value()),
             description: tt._description.clone(),
             configuration_schema: tt.trigger_request_format.clone(),
             request_schema: tt.call_request_format.clone(),
@@ -659,7 +701,7 @@ impl EngineFunctionsWorker {
     ) -> WorkerDetailEnvelope {
         WorkerDetailEnvelope {
             name: w.name.clone(),
-            description: None,
+            description: w.description.clone(),
             version: w.version.clone(),
             id: w.id.to_string(),
             runtime: w.runtime.clone(),
@@ -680,7 +722,7 @@ impl EngineFunctionsWorker {
         let functions = w.function_ids.clone();
         WorkerDetailEnvelope {
             name: Some(w.name.clone()),
-            description: None,
+            description: w.description.clone(),
             version: Some(env!("CARGO_PKG_VERSION").to_string()),
             id: w.id.clone(),
             runtime: Some("engine".to_string()),
@@ -735,7 +777,6 @@ impl EngineFunctionsWorker {
             return None;
         }
 
-        let worker_id = envelope.id.clone();
         let worker_name = envelope.name.clone();
         let index = self.function_owner_index().await;
         let mut functions: Vec<FunctionSummary> = function_ids
@@ -756,34 +797,35 @@ impl EngineFunctionsWorker {
             .trigger_registry
             .trigger_types
             .iter()
-            .filter(|entry| {
+            .filter_map(|entry| {
+                // Attribute by resolved owner NAME — the same index
+                // `engine::triggers::list` uses — so the two surfaces cannot
+                // disagree. Id-based attribution diverged whenever several
+                // connections shared one worker name (e.g. a stale
+                // `iii-worker-ops` daemon reconnecting next to a fresh one):
+                // the name resolved to one connection's id while the trigger
+                // type stayed pinned to another, and the type silently
+                // vanished from `workers::info`.
+                //
+                // Trust caveat: worker names are self-reported, so a worker
+                // that adopts another worker's name will have its trigger
+                // types merged into that name's view here — exactly as
+                // `triggers::list` already behaves. The engine does not
+                // authenticate worker identity today (a connected worker can
+                // likewise shadow function ids); fixing that is identity/auth
+                // work, not attribution logic.
                 let tt = entry.value();
-                // WebSocket workers attribute via `worker_id` Uuid.
-                if let Some(wid) = tt.worker_id {
-                    return self
-                        .engine
-                        .worker_registry
-                        .get_worker(&wid)
-                        .map(|w| w.id.to_string())
-                        .as_deref()
-                        == Some(&worker_id);
+                // Guard-safe resolution: we're inside `trigger_types.iter()`,
+                // and the owner is resolved exactly once per entry.
+                let owner = self.owner_name_for_trigger_type(tt);
+                if worker_name.as_deref() != Some(owner.as_str()) {
+                    return None;
                 }
-                // In-process workers register trigger types with
-                // `worker_id: None`, so fall back to the static
-                // BUILTIN_TRIGGER_TYPES map keyed by trigger-type id.
-                worker_name
-                    .as_deref()
-                    .zip(builtin_trigger_type_owner(&tt.id))
-                    .map(|(name, owner)| name == owner)
-                    .unwrap_or(false)
-            })
-            .map(|entry| {
-                let tt = entry.value();
-                TriggerTypeSummary {
+                Some(TriggerTypeSummary {
                     id: tt.id.clone(),
-                    worker_name: self.worker_name_for_trigger_type(&tt.id),
+                    worker_name: owner,
                     description: tt._description.clone(),
-                }
+                })
             })
             .collect();
         trigger_types.sort_by(|a, b| a.id.cmp(&b.id));
@@ -834,7 +876,8 @@ impl EngineFunctionsWorker {
             &worker_id,
             runtime,
             input.version,
-            input.name,
+            input.name.and_then(sanitize_worker_text),
+            input.description.and_then(sanitize_worker_text),
             input.os,
             input.telemetry,
             input.pid,
@@ -1290,7 +1333,12 @@ impl EngineFunctionsWorker {
     }
 }
 
-crate::register_worker!("iii-engine-functions", EngineFunctionsWorker, mandatory);
+crate::register_worker!(
+    "iii-engine-functions",
+    EngineFunctionsWorker,
+    description = "Core engine introspection (engine::*) and platform authoring reference.",
+    mandatory
+);
 
 #[cfg(test)]
 mod tests {
@@ -1458,6 +1506,7 @@ mod tests {
         engine.upsert_runtime_worker(crate::worker_connections::RuntimeWorkerInfo {
             id: "iii-state".to_string(),
             name: "iii-state".to_string(),
+            description: None,
             worker_type: "iii-state".to_string(),
             connected_at: chrono::Utc::now(),
             function_ids: vec!["state::get".to_string()],
@@ -1566,6 +1615,7 @@ mod tests {
         engine.upsert_runtime_worker(crate::worker_connections::RuntimeWorkerInfo {
             id: "iii-state".to_string(),
             name: "iii-state".to_string(),
+            description: Some("Distributed key-value state management.".to_string()),
             worker_type: "iii-state".to_string(),
             connected_at: chrono::Utc::now(),
             function_ids: vec!["state::get".to_string(), "state::set".to_string()],
@@ -1580,8 +1630,10 @@ mod tests {
         assert_eq!(workers[0].isolation.as_deref(), Some("in-process"));
         assert_eq!(workers[0].status, "available");
         assert_eq!(workers[0].function_count, 2);
-        // Description is always null on the engine surface.
-        assert!(workers[0].description.is_none());
+        assert_eq!(
+            workers[0].description.as_deref(),
+            Some("Distributed key-value state management.")
+        );
     }
 
     #[tokio::test]
@@ -1594,6 +1646,7 @@ mod tests {
         engine.upsert_runtime_worker(crate::worker_connections::RuntimeWorkerInfo {
             id: "iii-stream".to_string(),
             name: "iii-stream".to_string(),
+            description: None,
             worker_type: "iii-stream".to_string(),
             connected_at: chrono::Utc::now(),
             function_ids: vec!["stream::list".to_string()],
@@ -1615,6 +1668,7 @@ mod tests {
             runtime: Some("node".to_string()),
             version: Some("1.0".to_string()),
             name: Some("test-worker".to_string()),
+            description: None,
             os: Some("linux".to_string()),
             telemetry: None,
             pid: None,
@@ -1636,6 +1690,7 @@ mod tests {
             runtime: None,
             version: Some("2.0".to_string()),
             name: Some("my-worker".to_string()),
+            description: None,
             os: Some("darwin".to_string()),
             telemetry: None,
             pid: None,
@@ -2013,6 +2068,7 @@ mod tests {
         engine.upsert_runtime_worker(crate::worker_connections::RuntimeWorkerInfo {
             id: "iii-state".to_string(),
             name: "iii-state".to_string(),
+            description: None,
             worker_type: "iii-state".to_string(),
             connected_at: chrono::Utc::now(),
             function_ids: vec!["state::get".to_string()],
@@ -2456,6 +2512,7 @@ mod tests {
         engine.upsert_runtime_worker(crate::worker_connections::RuntimeWorkerInfo {
             id: "iii-state".to_string(),
             name: "iii-state".to_string(),
+            description: None,
             worker_type: "iii-state".to_string(),
             connected_at: chrono::Utc::now(),
             function_ids: vec!["state::get".to_string()],
@@ -2464,6 +2521,7 @@ mod tests {
         engine.upsert_runtime_worker(crate::worker_connections::RuntimeWorkerInfo {
             id: "iii-queue".to_string(),
             name: "iii-queue".to_string(),
+            description: None,
             worker_type: "iii-queue".to_string(),
             connected_at: chrono::Utc::now(),
             function_ids: vec![],
@@ -2512,6 +2570,7 @@ mod tests {
         engine.upsert_runtime_worker(crate::worker_connections::RuntimeWorkerInfo {
             id: "iii-state".to_string(),
             name: "iii-state".to_string(),
+            description: None,
             worker_type: "iii-state".to_string(),
             connected_at: chrono::Utc::now(),
             function_ids: vec!["state::get".to_string(), "state::set".to_string()],
@@ -2539,6 +2598,156 @@ mod tests {
                 assert_eq!(detail.registered_triggers.len(), 1);
                 assert_eq!(detail.registered_triggers[0].id, "trg-state");
                 assert!(detail.worker.internal == false);
+            }
+            _ => panic!("expected success"),
+        }
+    }
+
+    #[tokio::test]
+    async fn workers_info_attributes_ws_trigger_types_like_triggers_list() {
+        let (engine, module) = setup_engine_and_module();
+
+        // The name resolves to a runtime entry first…
+        engine.upsert_runtime_worker(crate::worker_connections::RuntimeWorkerInfo {
+            id: "ops-worker".to_string(),
+            name: "ops-worker".to_string(),
+            description: None,
+            worker_type: "ops-worker".to_string(),
+            connected_at: chrono::Utc::now(),
+            function_ids: vec![],
+            internal: false,
+        });
+
+        // …while the trigger type is pinned to a same-named WS connection's
+        // Uuid (the stale-daemon / duplicate-name scenario). Id-based
+        // attribution dropped the type here; name-based attribution — the
+        // index `engine::triggers::list` uses — must keep it.
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let conn = crate::worker_connections::WorkerConnection::new(tx);
+        let conn_id = conn.id;
+        engine.worker_registry.register_worker(conn);
+        engine.worker_registry.update_worker_metadata(
+            &conn_id,
+            "rust".to_string(),
+            Some("1.0.0".to_string()),
+            Some("ops-worker".to_string()),
+            None,
+            Some("linux".to_string()),
+            None,
+            None,
+            None,
+        );
+        let tt = crate::trigger::TriggerType::new(
+            "worker",
+            "Worker lifecycle events",
+            Box::new(module.clone()),
+            Some(conn_id),
+        );
+        engine
+            .trigger_registry
+            .register_trigger_type(tt)
+            .await
+            .unwrap();
+
+        let result = module
+            .workers_info(WorkerInfoInput {
+                name: "ops-worker".to_string(),
+            })
+            .await;
+        match result {
+            FunctionResult::Success(detail) => {
+                let ids: Vec<&str> = detail.trigger_types.iter().map(|t| t.id.as_str()).collect();
+                assert_eq!(
+                    ids,
+                    vec!["worker"],
+                    "workers::info must attribute WS-registered trigger types by \
+                     owner name, matching engine::triggers::list"
+                );
+            }
+            _ => panic!("expected success"),
+        }
+    }
+
+    #[test]
+    fn sanitize_worker_text_strips_controls_and_caps_length() {
+        assert_eq!(
+            sanitize_worker_text("ok\u{1b}[31m text\u{7f}".to_string()),
+            Some("ok[31m text".to_string()),
+            "ESC/C0/C1 control chars are stripped, printable remainder kept"
+        );
+        assert_eq!(sanitize_worker_text("  \u{1b}\u{0007} ".to_string()), None);
+        let long = "x".repeat(WORKER_DESCRIPTION_MAX_LEN + 50);
+        assert_eq!(
+            sanitize_worker_text(long).map(|s| s.chars().count()),
+            Some(WORKER_DESCRIPTION_MAX_LEN)
+        );
+        // Cap is by char, not byte: a multibyte input must truncate on a char
+        // boundary (no panic, valid UTF-8) and yield exactly MAX chars.
+        let multibyte = "\u{1f600}".repeat(WORKER_DESCRIPTION_MAX_LEN + 10);
+        let out = sanitize_worker_text(multibyte).unwrap();
+        assert_eq!(out.chars().count(), WORKER_DESCRIPTION_MAX_LEN);
+        // Trojan-Source bidi overrides/isolates are stripped (CVE-2021-42574).
+        assert_eq!(
+            sanitize_worker_text("a\u{202e}b\u{2066}c".to_string()),
+            Some("abc".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn workers_info_excludes_trigger_types_owned_by_other_workers() {
+        let (engine, module) = setup_engine_and_module();
+
+        engine.upsert_runtime_worker(crate::worker_connections::RuntimeWorkerInfo {
+            id: "ops-worker".to_string(),
+            name: "ops-worker".to_string(),
+            description: None,
+            worker_type: "ops-worker".to_string(),
+            connected_at: chrono::Utc::now(),
+            function_ids: vec![],
+            internal: false,
+        });
+
+        // A trigger type pinned to a DIFFERENT worker name must never be
+        // attributed to the queried worker (guards against an over-broad
+        // attribution regression — e.g. matching everything).
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let conn = crate::worker_connections::WorkerConnection::new(tx);
+        let conn_id = conn.id;
+        engine.worker_registry.register_worker(conn);
+        engine.worker_registry.update_worker_metadata(
+            &conn_id,
+            "rust".to_string(),
+            Some("1.0.0".to_string()),
+            Some("other-worker".to_string()),
+            None,
+            Some("linux".to_string()),
+            None,
+            None,
+            None,
+        );
+        let tt = crate::trigger::TriggerType::new(
+            "foreign",
+            "Owned by other-worker",
+            Box::new(module.clone()),
+            Some(conn_id),
+        );
+        engine
+            .trigger_registry
+            .register_trigger_type(tt)
+            .await
+            .unwrap();
+
+        let result = module
+            .workers_info(WorkerInfoInput {
+                name: "ops-worker".to_string(),
+            })
+            .await;
+        match result {
+            FunctionResult::Success(detail) => {
+                assert!(
+                    detail.trigger_types.iter().all(|t| t.id != "foreign"),
+                    "workers::info must not attribute another worker's trigger type"
+                );
             }
             _ => panic!("expected success"),
         }
@@ -2575,6 +2784,7 @@ mod tests {
             "node".to_string(),
             Some("1.0.0".to_string()),
             Some("named-worker".to_string()),
+            None,
             Some("linux".to_string()),
             None,
             Some(4242),
@@ -2685,6 +2895,7 @@ mod tests {
                 runtime: Some("node".to_string()),
                 version: Some("1.0.0".to_string()),
                 name: Some("my-worker".to_string()),
+                description: None,
                 os: Some("linux".to_string()),
                 telemetry: None,
                 pid: None,

--- a/engine/src/workers/engine_fn/skills/SKILL.md
+++ b/engine/src/workers/engine_fn/skills/SKILL.md
@@ -82,7 +82,7 @@ When one fits, install it: `worker::add { source: { kind: 'registry', name: '<wo
 // worker::add { source: { kind: 'registry', name: 'iii-directory' }, wait: true }
 ```
 
-**3. Build a worker.** Only when steps 1 and 2 both come up empty. Author it with the SDK (below), then deploy it. Discover the deployment/runtime surface the same way as any other capability — `directory::registry::workers::list` / `::info` and its skill — rather than assuming a worker name. (The harness can't side-load local code through `worker::add` — `kind: 'local'` is CLI-only — so a runtime/sandbox worker from the registry is how hand-authored code joins the bus.)
+**3. Build a worker.** Only when steps 1 and 2 both come up empty. Author it with the SDK (below), then deploy it. Discover the deployment/runtime surface the same way as any other capability — `directory::registry::workers::list` / `::info` and its skill — rather than assuming a worker name. (`worker::add { kind: 'local', path }` works over the bus, but `path` resolves on the **engine/daemon host**, not on the caller — so it only helps when your code already lives on that host. For un-published code that lives elsewhere, run it via a runtime/sandbox worker.)
 
 > Discover in order. Don't jump to a worker you remember; the registry may hold a better fit, and the right surface is whatever the live engine and registry report — not training-data recall.
 
@@ -213,8 +213,10 @@ From the caller's side, your custom type is indistinguishable from any built-in 
 Install, run, and remove workers. Each op is also `iii worker <cmd>` on the CLI. Fetch exact request/response shapes from the engine rather than trusting this list:
 
 ```jsonc
-// engine::functions::info { function_id: 'worker::add' }   → request/response JSON Schema
-// worker::schema { function_id: 'worker::add' }            → same, plus timeout/idempotency hints
+// engine::functions::info { function_id: 'worker::add' }   → request/response JSON Schema,
+//                            plus metadata { default_timeout_ms, idempotent }
+// worker::schema { function_id: 'worker::add' }            → same data, batched for all worker::* ops
+// On a malformed payload the W105 error envelope's details.hint points back at worker::schema.
 ```
 
 | Op | Does |
@@ -228,7 +230,7 @@ Install, run, and remove workers. Each op is also `iii worker <cmd>` on the CLI.
 | `worker::clear` | Delete cached artifacts (keeps config). Requires `yes: true`. |
 | `worker::schema` | JSON Schemas for every op. |
 
-- **`worker::add` source variants:** `{ kind: 'registry', name, version? }`, `{ kind: 'oci', reference }`, and `{ kind: 'local', path }` — the last is **CLI-only** (rejected over the trigger surface).
+- **`worker::add` source variants:** `{ kind: 'registry', name, version? }`, `{ kind: 'oci', reference }`, and `{ kind: 'local', path }` — `path` is resolved on the **engine/daemon host** (works over the trigger as well as the CLI).
 - **Consent:** `remove`, `stop`, and `clear` require exactly `yes: true` (the boolean, not `"true"`).
 - Reach for `worker::list` before any other op when you don't already know what is installed.
 

--- a/engine/src/workers/http_functions/mod.rs
+++ b/engine/src/workers/http_functions/mod.rs
@@ -174,7 +174,11 @@ impl Worker for HttpFunctionsWorker {
     }
 }
 
-crate::register_worker!("iii-http-functions", HttpFunctionsWorker);
+crate::register_worker!(
+    "iii-http-functions",
+    HttpFunctionsWorker,
+    description = "Expose external HTTP endpoints from config as callable functions."
+);
 
 #[cfg(test)]
 mod tests {

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -2358,7 +2358,12 @@ impl Worker for ObservabilityWorker {
     }
 }
 
-crate::register_worker!("iii-observability", ObservabilityWorker, mandatory);
+crate::register_worker!(
+    "iii-observability",
+    ObservabilityWorker,
+    description = "OpenTelemetry-based traces, metrics, logs, alerts, and sampling.",
+    mandatory
+);
 
 #[cfg(test)]
 mod tests {

--- a/engine/src/workers/pubsub/pubsub.rs
+++ b/engine/src/workers/pubsub/pubsub.rs
@@ -192,7 +192,12 @@ impl ConfigurableWorker for PubSubWorker {
     }
 }
 
-crate::register_worker!("iii-pubsub", PubSubWorker, enabled_by_default = true);
+crate::register_worker!(
+    "iii-pubsub",
+    PubSubWorker,
+    description = "Topic-based publish/subscribe messaging for real-time event distribution.",
+    enabled_by_default = true
+);
 
 #[cfg(test)]
 mod tests {

--- a/engine/src/workers/queue/iii.worker.yaml
+++ b/engine/src/workers/queue/iii.worker.yaml
@@ -1,7 +1,7 @@
 iii: v1
 name: iii-queue
 type: engine
-description: Queue worker for async job processing with named queues, retries, and dead-letter support.
+description: Async job processing with named queues, retries, and dead-letter support.
 repo: https://github.com/iii-hq/iii
 config:
   adapter:

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -880,7 +880,12 @@ impl ConfigurableWorker for QueueWorker {
     }
 }
 
-crate::register_worker!("iii-queue", QueueWorker, enabled_by_default = true);
+crate::register_worker!(
+    "iii-queue",
+    QueueWorker,
+    description = "Async job processing with named queues, retries, and dead-letter support.",
+    enabled_by_default = true
+);
 
 #[cfg(test)]
 mod tests {

--- a/engine/src/workers/registry.rs
+++ b/engine/src/workers/registry.rs
@@ -74,6 +74,9 @@ pub type WorkerFuture = Pin<Box<dyn Future<Output = anyhow::Result<Box<dyn Worke
 
 pub struct WorkerRegistration {
     pub name: &'static str,
+    /// One-line, human/LLM-readable summary of what this worker does.
+    /// Surfaces in `engine::workers::list` / `engine::workers::info`.
+    pub description: &'static str,
     pub factory: fn(Arc<Engine>, Option<Value>) -> WorkerFuture,
     pub is_default: bool,
     pub mandatory: bool,
@@ -81,30 +84,33 @@ pub struct WorkerRegistration {
 
 #[macro_export]
 macro_rules! register_worker {
-    ($name:expr, $worker:ty, mandatory) => {
+    ($name:expr, $worker:ty, description = $description:expr, mandatory) => {
         ::inventory::submit! {
             $crate::workers::registry::WorkerRegistration {
                 name: $name,
+                description: $description,
                 factory: < $worker as $crate::workers::traits::Worker >::make_worker,
                 is_default: true,
                 mandatory: true,
             }
         }
     };
-    ($name:expr, $worker:ty, enabled_by_default = $enabled_by_default:expr) => {
+    ($name:expr, $worker:ty, description = $description:expr, enabled_by_default = $enabled_by_default:expr) => {
         ::inventory::submit! {
             $crate::workers::registry::WorkerRegistration {
                 name: $name,
+                description: $description,
                 factory: < $worker as $crate::workers::traits::Worker >::make_worker,
                 is_default: $enabled_by_default,
                 mandatory: false,
             }
         }
     };
-    ($name:expr, $worker:ty) => {
+    ($name:expr, $worker:ty, description = $description:expr) => {
         ::inventory::submit! {
             $crate::workers::registry::WorkerRegistration {
                 name: $name,
+                description: $description,
                 factory: < $worker as $crate::workers::traits::Worker >::make_worker,
                 is_default: false,
                 mandatory: false,
@@ -146,11 +152,13 @@ mod tests {
     fn worker_registration_fields() {
         let reg = WorkerRegistration {
             name: "test-worker",
+            description: "A test worker.",
             factory: dummy_worker_factory,
             is_default: true,
             mandatory: false,
         };
         assert_eq!(reg.name, "test-worker");
+        assert_eq!(reg.description, "A test worker.");
         assert!(reg.is_default);
         assert!(!reg.mandatory);
     }

--- a/engine/src/workers/rest_api/api_core.rs
+++ b/engine/src/workers/rest_api/api_core.rs
@@ -526,7 +526,12 @@ impl TriggerRegistrator for HttpWorker {
     }
 }
 
-crate::register_worker!("iii-http", HttpWorker, enabled_by_default = true);
+crate::register_worker!(
+    "iii-http",
+    HttpWorker,
+    description = "Expose functions as HTTP endpoints.",
+    enabled_by_default = true
+);
 
 #[cfg(test)]
 mod tests {

--- a/engine/src/workers/shell/worker.rs
+++ b/engine/src/workers/shell/worker.rs
@@ -65,7 +65,12 @@ impl Worker for ExecWorker {
     }
 }
 
-crate::register_worker!("iii-exec", ExecWorker, enabled_by_default = false);
+crate::register_worker!(
+    "iii-exec",
+    ExecWorker,
+    description = "Execute shell commands as part of engine startup.",
+    enabled_by_default = false
+);
 
 #[cfg(test)]
 mod tests {

--- a/engine/src/workers/state/state.rs
+++ b/engine/src/workers/state/state.rs
@@ -428,7 +428,12 @@ impl StateWorker {
     }
 }
 
-crate::register_worker!("iii-state", StateWorker, enabled_by_default = true);
+crate::register_worker!(
+    "iii-state",
+    StateWorker,
+    description = "Distributed key-value state management with reactive change triggers.",
+    enabled_by_default = true
+);
 
 #[cfg(test)]
 mod tests {

--- a/engine/src/workers/stream/stream.rs
+++ b/engine/src/workers/stream/stream.rs
@@ -901,7 +901,12 @@ impl StreamWorker {
     }
 }
 
-crate::register_worker!("iii-stream", StreamWorker, enabled_by_default = true);
+crate::register_worker!(
+    "iii-stream",
+    StreamWorker,
+    description = "Build durable streams for real-time data subscriptions.",
+    enabled_by_default = true
+);
 
 #[cfg(test)]
 mod tests {

--- a/engine/src/workers/telemetry/mod.rs
+++ b/engine/src/workers/telemetry/mod.rs
@@ -996,7 +996,12 @@ impl Worker for TelemetryWorker {
     }
 }
 
-crate::register_worker!("iii-telemetry", TelemetryWorker, mandatory);
+crate::register_worker!(
+    "iii-telemetry",
+    TelemetryWorker,
+    description = "Anonymous usage telemetry and heartbeat reporting for the engine.",
+    mandatory
+);
 
 #[cfg(test)]
 mod tests {

--- a/engine/src/workers/worker/mod.rs
+++ b/engine/src/workers/worker/mod.rs
@@ -257,7 +257,12 @@ async fn otel_ws_handler(
     })
 }
 
-crate::register_worker!("iii-worker-manager", WorkerManager, mandatory);
+crate::register_worker!(
+    "iii-worker-manager",
+    WorkerManager,
+    description = "WebSocket listener that SDK workers connect to. Supports RBAC, middleware, registration hooks, and channels.",
+    mandatory
+);
 
 #[cfg(test)]
 mod tests {

--- a/engine/tests/builtin_functions_e2e.rs
+++ b/engine/tests/builtin_functions_e2e.rs
@@ -238,9 +238,12 @@ async fn workers_info_returns_full_surface_for_runtime_worker() {
         worker.get("name").and_then(|v| v.as_str()),
         Some("iii-state")
     );
-    // description is shared core: always serialized, always null on engine.
-    assert!(worker.get("description").is_some());
-    assert!(worker.get("description").unwrap().is_null());
+    // description is shared core: builtin workers self-describe via their
+    // WorkerRegistration.
+    assert_eq!(
+        worker.get("description").and_then(|v| v.as_str()),
+        Some("Distributed key-value state management with reactive change triggers.")
+    );
     // internal is always present on the info envelope.
     assert!(worker.get("internal").and_then(|v| v.as_bool()).is_some());
 

--- a/sdk/packages/go/iii/client.go
+++ b/sdk/packages/go/iii/client.go
@@ -32,9 +32,10 @@ import (
 // A Client is safe for concurrent use. Register* may be called before or after Connect;
 // registrations are kept in memory and (re)sent to the engine on every (re)connection.
 type Client struct {
-	url       string
-	reconnect ReconnectConfig
-	name      string
+	url         string
+	reconnect   ReconnectConfig
+	name        string
+	description string
 
 	// outbound carries already-marshaled frames to the single writer goroutine. It is
 	// the only path to the socket, so writes are serialized without a write mutex.
@@ -99,6 +100,12 @@ type Option func(*Client)
 // WithReconnectConfig overrides the default reconnect schedule.
 func WithReconnectConfig(c ReconnectConfig) Option {
 	return func(cl *Client) { cl.reconnect = c }
+}
+
+// WithDescription sets a one-line, human/LLM-readable summary of what this
+// worker does. Surfaces in engine::workers::list / engine::workers::info.
+func WithDescription(description string) Option {
+	return func(c *Client) { c.description = description }
 }
 
 // WithName sets the worker name reported to the engine (default: "hostname:pid").
@@ -537,11 +544,12 @@ func (c *Client) onConnect() {
 func (c *Client) registerWorkerMetadata() {
 	pid := os.Getpid()
 	meta := workerMetadata{
-		Runtime: runtimeTag,
-		Version: sdkVersion,
-		Name:    c.name,
-		OS:      fmt.Sprintf("%s %s", runtime.GOOS, runtime.GOARCH),
-		PID:     &pid,
+		Runtime:     runtimeTag,
+		Version:     sdkVersion,
+		Name:        c.name,
+		Description: c.description,
+		OS:          fmt.Sprintf("%s %s", runtime.GOOS, runtime.GOARCH),
+		PID:         &pid,
 	}
 	data, err := json.Marshal(meta)
 	if err != nil {
@@ -566,11 +574,12 @@ func (c *Client) registerWorkerMetadata() {
 // open question #3 in iii-hq/iii#1719). Optional fields use omitempty to match the
 // engine's skip_serializing_if discipline.
 type workerMetadata struct {
-	Runtime string `json:"runtime"`
-	Version string `json:"version"`
-	Name    string `json:"name"`
-	OS      string `json:"os"`
-	PID     *int   `json:"pid,omitempty"`
+	Runtime     string `json:"runtime"`
+	Version     string `json:"version"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	OS          string `json:"os"`
+	PID         *int   `json:"pid,omitempty"`
 }
 
 // sdkVersion is reported in the worker metadata. Kept as a const for v1; a release

--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -92,6 +92,11 @@ export type TelemetryOptions = {
 export type InitOptions = {
   /** Display name for this worker. Defaults to `hostname:pid`. */
   workerName?: string
+  /**
+   * One-line, human/LLM-readable summary of what this worker does.
+   * Surfaces in `engine::workers::list` / `engine::workers::info`.
+   */
+  workerDescription?: string
   /** Enable worker metrics via OpenTelemetry. Defaults to `true`. */
   enableMetricsReporting?: boolean
   /** Default timeout for `trigger()` in milliseconds. Defaults to `30000`. */
@@ -122,6 +127,7 @@ class Sdk implements ISdk {
   private triggerTypes = new Map<string, RemoteTriggerTypeData>()
   private messagesToSend: Record<string, unknown>[] = []
   private workerName: string
+  private workerDescription?: string
   private workerId?: string
   private reconnectTimeout?: NodeJS.Timeout
   private metricsReportingEnabled: boolean
@@ -136,6 +142,7 @@ class Sdk implements ISdk {
     private readonly options?: InitOptions,
   ) {
     this.workerName = options?.workerName ?? getDefaultWorkerName()
+    this.workerDescription = options?.workerDescription
     this.metricsReportingEnabled = options?.enableMetricsReporting ?? true
     this.invocationTimeoutMs = options?.invocationTimeoutMs ?? DEFAULT_INVOCATION_TIMEOUT_MS
     this.reconnectionConfig = {
@@ -527,6 +534,7 @@ class Sdk implements ISdk {
         runtime: 'node',
         version: SDK_VERSION,
         name: this.workerName,
+        description: this.workerDescription,
         os: getOsInfo(),
         pid: process.pid,
         isolation: process.env.III_ISOLATION || null,

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -1235,7 +1235,7 @@ class III:
             ),
         }
 
-        return {
+        metadata: dict[str, Any] = {
             "runtime": "python",
             "version": sdk_version,
             "name": worker_name,
@@ -1244,6 +1244,11 @@ class III:
             "isolation": os.environ.get("III_ISOLATION") or None,
             "telemetry": telemetry,
         }
+        # Optional, like the other SDKs: only send `description` when set so the
+        # engine's `#[serde(default)]` field stays absent otherwise.
+        if self._options.worker_description:
+            metadata["description"] = self._options.worker_description
+        return metadata
 
     def _register_worker_metadata(self) -> None:
         msg = InvokeFunctionMessage(

--- a/sdk/packages/python/iii/src/iii/iii_constants.py
+++ b/sdk/packages/python/iii/src/iii/iii_constants.py
@@ -47,6 +47,8 @@ class InitOptions:
 
     Attributes:
         worker_name: Display name for this worker. Defaults to ``hostname:pid``.
+        worker_description: One-line, human/LLM-readable summary of what this
+            worker does. Surfaces in ``engine::workers::list`` / ``engine::workers::info``.
         enable_metrics_reporting: Enable worker metrics via OpenTelemetry. Default ``True``.
         invocation_timeout_ms: Default timeout for ``trigger()`` in milliseconds. Default ``30000``.
         reconnection_config: WebSocket reconnection behavior.
@@ -56,6 +58,7 @@ class InitOptions:
     """
 
     worker_name: str | None = None
+    worker_description: str | None = None
     enable_metrics_reporting: bool = True
     invocation_timeout_ms: int = DEFAULT_INVOCATION_TIMEOUT_MS
     reconnection_config: ReconnectionConfig | None = None

--- a/sdk/packages/python/iii/tests/test_worker_metadata.py
+++ b/sdk/packages/python/iii/tests/test_worker_metadata.py
@@ -47,6 +47,18 @@ def test_get_worker_metadata_forwards_iii_isolation_env_var(
     assert metadata["isolation"] == "docker"
 
 
+def test_get_worker_metadata_omits_description_when_unset() -> None:
+    metadata = _call_metadata_method()
+
+    assert "description" not in metadata
+
+
+def test_get_worker_metadata_includes_worker_description_when_set() -> None:
+    metadata = _call_metadata_method(InitOptions(worker_description="resizes images"))
+
+    assert metadata["description"] == "resizes images"
+
+
 @requires_tomllib
 def test_detect_project_name_reads_pyproject_name(tmp_path: Path) -> None:
     (tmp_path / "pyproject.toml").write_text('[project]\nname = "my-pkg"\n')

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -235,6 +235,10 @@ pub struct WorkerMetadata {
     pub version: String,
     pub name: String,
     pub os: String,
+    /// One-line, human/LLM-readable summary of what this worker does.
+    /// Surfaces in `engine::workers::list` / `engine::workers::info`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pid: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -269,6 +273,7 @@ impl Default for WorkerMetadata {
             version: SDK_VERSION.to_string(),
             name: format!("{}:{}", hostname, pid),
             os: os_info,
+            description: None,
             pid: Some(pid),
             telemetry: Some(WorkerTelemetryMeta {
                 language,
@@ -450,6 +455,43 @@ pub trait IntoAsyncHandler<Marker>: Send + Sync + 'static {
     }
 }
 
+/// Build the dispatchable handler for a typed async function: deserialize
+/// the JSON input as `T`, run `f`, serialize the result. Deserialization
+/// failures map through `on_bad_request` — [`IntoAsyncHandler`] passes the
+/// default [`IIIError::Serde`] mapper,
+/// [`RegisterFunction::new_async_with_bad_request`] a caller-supplied one.
+fn async_handler_with<F, T, Fut, R>(
+    f: F,
+    on_bad_request: impl Fn(serde_json::Error) -> IIIError + Send + Sync + 'static,
+) -> RemoteFunctionHandler
+where
+    F: Fn(T) -> Fut + Send + Sync + 'static,
+    T: serde::de::DeserializeOwned + Send + 'static,
+    Fut: std::future::Future<Output = Result<R, IIIError>> + Send + 'static,
+    R: serde::Serialize + Send + 'static,
+{
+    Arc::new(
+        move |input: Value| -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<Value, IIIError>> + Send>,
+        > {
+            match serde_json::from_value::<T>(input) {
+                Ok(arg) => {
+                    let fut = f(arg);
+                    Box::pin(async move {
+                        fut.await.and_then(|val| {
+                            serde_json::to_value(&val).map_err(|e| IIIError::Serde(e.to_string()))
+                        })
+                    })
+                }
+                Err(e) => {
+                    let err = on_bad_request(e);
+                    Box::pin(async move { Err(err) })
+                }
+            }
+        },
+    )
+}
+
 // 1-arg async — deserializes the entire JSON input as T.
 //
 // Error type is fixed to [`IIIError`] (see [`IntoSyncHandler`] for the
@@ -463,24 +505,7 @@ where
     R: serde::Serialize + schemars::JsonSchema + Send + 'static,
 {
     fn into_handler(self) -> RemoteFunctionHandler {
-        Arc::new(
-            move |input: Value| -> std::pin::Pin<
-                Box<dyn std::future::Future<Output = Result<Value, IIIError>> + Send>,
-            > {
-                match serde_json::from_value::<T>(input) {
-                    Ok(arg) => {
-                        let fut = (self)(arg);
-                        Box::pin(async move {
-                            fut.await.and_then(|val| {
-                                serde_json::to_value(&val)
-                                    .map_err(|e| IIIError::Serde(e.to_string()))
-                            })
-                        })
-                    }
-                    Err(e) => Box::pin(async move { Err(IIIError::Serde(e.to_string())) }),
-                }
-            },
-        )
+        async_handler_with(self, |e| IIIError::Serde(e.to_string()))
     }
 
     fn request_format() -> Option<Value> {
@@ -518,6 +543,9 @@ fn empty_message() -> RegisterFunctionMessage {
 ///   (schemas auto-extracted via `schemars`) and `Fn(Value) -> Result<Value, IIIError>`
 ///   closures (permissive `AnyValue` schema, since `Value: JsonSchema`).
 /// - [`RegisterFunction::new_async`] — async equivalent of `new`.
+/// - [`RegisterFunction::new_async_with_bad_request`] — typed async handler
+///   that routes payload-deserialization failures through a caller-supplied
+///   mapper instead of the SDK's generic [`IIIError::Serde`].
 /// - [`RegisterFunction::http`] — function invoked over HTTP (Lambda,
 ///   Cloudflare Workers, etc.).
 ///
@@ -563,6 +591,31 @@ impl RegisterFunction {
         Self {
             message,
             handler: Some(f.into_handler()),
+        }
+    }
+
+    /// Like [`RegisterFunction::new_async`], but payload-deserialization
+    /// failures are routed through `on_bad_request` instead of becoming the
+    /// SDK's generic [`IIIError::Serde`] (which the dispatch loop surfaces as
+    /// `invocation_failed`). Lets a registration keep typed-handler schema
+    /// extraction while owning its wire error contract for malformed
+    /// payloads — e.g. a stable error code plus a recovery hint.
+    pub fn new_async_with_bad_request<F, T, Fut, R>(
+        f: F,
+        on_bad_request: impl Fn(serde_json::Error) -> IIIError + Send + Sync + 'static,
+    ) -> Self
+    where
+        F: Fn(T) -> Fut + Send + Sync + 'static,
+        T: serde::de::DeserializeOwned + schemars::JsonSchema + Send + 'static,
+        Fut: std::future::Future<Output = Result<R, IIIError>> + Send + 'static,
+        R: serde::Serialize + schemars::JsonSchema + Send + 'static,
+    {
+        let mut message = empty_message();
+        message.request_format = json_schema_for::<T>();
+        message.response_format = json_schema_for::<R>();
+        Self {
+            message,
+            handler: Some(async_handler_with(f, on_bad_request)),
         }
     }
 
@@ -1646,6 +1699,9 @@ impl III {
                                 KeyValue::new("exception.stacktrace", stacktrace.clone()),
                             ],
                         );
+                        // Consumed only by the non-`Remote` fallback arm when
+                        // building the wire ErrorBody below; `Remote` passes
+                        // its own (possibly absent) stacktrace through.
                         error_stacktrace = Some(stacktrace);
                     }
                 }
@@ -1678,9 +1734,11 @@ impl III {
                             } => ErrorBody {
                                 code,
                                 message,
-                                stacktrace: stacktrace.or(error_stacktrace).or_else(|| {
-                                    Some(std::backtrace::Backtrace::force_capture().to_string())
-                                }),
+                                // `Remote` is a structured, expected error owned by
+                                // the handler — respect `stacktrace: None` instead of
+                                // backfilling the dispatch-loop backtrace, which
+                                // points at the SDK event loop, not the error site.
+                                stacktrace,
                             },
                             other => ErrorBody {
                                 code: "invocation_failed".to_string(),
@@ -1974,6 +2032,56 @@ mod tests {
             reg.message.response_format.as_ref().unwrap()["title"],
             "Out"
         );
+    }
+
+    #[tokio::test]
+    async fn new_async_with_bad_request_maps_deser_failure_and_extracts_schemas() {
+        #[derive(serde::Deserialize, schemars::JsonSchema)]
+        struct In {
+            name: String,
+        }
+        #[derive(serde::Serialize, schemars::JsonSchema)]
+        struct Out {
+            message: String,
+        }
+
+        let reg = RegisterFunction::new_async_with_bad_request(
+            |input: In| async move {
+                Ok(Out {
+                    message: format!("Hello, {}!", input.name),
+                })
+            },
+            |e| IIIError::Remote {
+                code: "W105".to_string(),
+                message: e.to_string(),
+                stacktrace: None,
+            },
+        );
+
+        // Schema extraction matches the plain typed constructor.
+        assert_eq!(reg.message.request_format.as_ref().unwrap()["title"], "In");
+        assert_eq!(
+            reg.message.response_format.as_ref().unwrap()["title"],
+            "Out"
+        );
+
+        let handler = reg.handler.as_ref().unwrap();
+
+        // Malformed payload routes through the custom mapper, not Serde.
+        let err = handler(json!({"name": 42})).await.unwrap_err();
+        match err {
+            IIIError::Remote {
+                code, stacktrace, ..
+            } => {
+                assert_eq!(code, "W105");
+                assert!(stacktrace.is_none());
+            }
+            other => panic!("expected Remote, got {other:?}"),
+        }
+
+        // Valid payload still runs the handler.
+        let ok = handler(json!({"name": "iii"})).await.unwrap();
+        assert_eq!(ok["message"], "Hello, iii!");
     }
 
     #[tokio::test]

--- a/sdk/packages/rust/iii/tests/common/mock_engine.rs
+++ b/sdk/packages/rust/iii/tests/common/mock_engine.rs
@@ -67,8 +67,14 @@ impl MockEngine {
                                 return;
                             }
                             out = out_rx.recv() => {
-                                if let Ok(text) = out {
-                                    let _ = tx.send(Message::Text(text.into())).await;
+                                match out {
+                                    Ok(text) => {
+                                        if tx.send(Message::Text(text.into())).await.is_err() {
+                                            return;
+                                        }
+                                    }
+                                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                                    Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
                                 }
                             }
                             msg = rx.next() => {

--- a/sdk/packages/rust/iii/tests/common/mock_engine.rs
+++ b/sdk/packages/rust/iii/tests/common/mock_engine.rs
@@ -20,6 +20,7 @@ pub struct MockEngine {
     received: Arc<Mutex<Vec<Value>>>,
     new_message: Arc<Notify>,
     close_active: broadcast::Sender<()>,
+    to_client: broadcast::Sender<String>,
     accept_task: AbortHandle,
 }
 
@@ -37,10 +38,12 @@ impl MockEngine {
         let received = Arc::new(Mutex::new(Vec::<Value>::new()));
         let new_message = Arc::new(Notify::new());
         let (close_active, _) = broadcast::channel::<()>(16);
+        let (to_client, _) = broadcast::channel::<String>(16);
 
         let received_acc = received.clone();
         let new_message_acc = new_message.clone();
         let close_active_acc = close_active.clone();
+        let to_client_acc = to_client.clone();
 
         let accept_task = tokio::spawn(async move {
             loop {
@@ -52,6 +55,7 @@ impl MockEngine {
                 };
                 let (mut tx, mut rx) = ws.split();
                 let mut close_rx = close_active_acc.subscribe();
+                let mut out_rx = to_client_acc.subscribe();
                 let received = received_acc.clone();
                 let new_message = new_message_acc.clone();
 
@@ -61,6 +65,11 @@ impl MockEngine {
                             _ = close_rx.recv() => {
                                 let _ = tx.close().await;
                                 return;
+                            }
+                            out = out_rx.recv() => {
+                                if let Ok(text) = out {
+                                    let _ = tx.send(Message::Text(text.into())).await;
+                                }
                             }
                             msg = rx.next() => {
                                 match msg {
@@ -96,6 +105,7 @@ impl MockEngine {
             received,
             new_message,
             close_active,
+            to_client,
             accept_task,
         }
     }
@@ -113,6 +123,12 @@ impl MockEngine {
     /// mock will accept the next handshake on the same listener.
     pub fn close_active_connection(&self) {
         let _ = self.close_active.send(());
+    }
+
+    /// Push a frame to every currently connected client (the SDK under
+    /// test). Lets tests drive engine→worker flows like `invokefunction`.
+    pub fn send_to_client(&self, frame: Value) {
+        let _ = self.to_client.send(frame.to_string());
     }
 
     /// Wait until `predicate` returns true on the current message list,

--- a/sdk/packages/rust/iii/tests/error_wire.rs
+++ b/sdk/packages/rust/iii/tests/error_wire.rs
@@ -1,0 +1,122 @@
+//! Wire-level tests for handler error mapping (no running engine needed).
+//!
+//! `IIIError::Remote` is a structured, expected error owned by the handler:
+//! its `code` must reach the wire `ErrorBody.code` verbatim and
+//! `stacktrace: None` must NOT be backfilled with a dispatch-loop backtrace.
+//! Non-`Remote` handler errors keep the legacy `invocation_failed` code with
+//! a backfilled backtrace.
+
+mod common;
+
+use std::time::Duration;
+
+use serde_json::{Value, json};
+
+use common::mock_engine::{MockEngine, count_type};
+use iii_sdk::{IIIError, InitOptions, RegisterFunction, register_worker};
+
+fn find_result<'a>(msgs: &'a [Value], invocation_id: &str) -> Option<&'a Value> {
+    msgs.iter()
+        .find(|m| m["type"] == "invocationresult" && m["invocation_id"] == invocation_id)
+}
+
+#[tokio::test]
+async fn remote_error_passes_code_through_without_backfilled_stacktrace() {
+    let mock = MockEngine::start().await;
+    let iii = register_worker(mock.url(), InitOptions::default());
+
+    let _f = iii.register_function(
+        "test::remote_err",
+        RegisterFunction::new_async(|_: Value| async move {
+            Err::<Value, _>(IIIError::Remote {
+                code: "W105".to_string(),
+                message: "{\"code\":\"W105\",\"type\":\"WorkerOpError\"}".to_string(),
+                stacktrace: None,
+            })
+        }),
+    );
+
+    mock.wait_for(
+        |msgs| count_type(msgs, "registerfunction") >= 1,
+        Duration::from_secs(5),
+    )
+    .await;
+
+    let inv_id = "00000000-0000-4000-8000-000000000001";
+    mock.send_to_client(json!({
+        "type": "invokefunction",
+        "invocation_id": inv_id,
+        "function_id": "test::remote_err",
+        "data": {}
+    }));
+
+    let msgs = mock
+        .wait_for(
+            |msgs| find_result(msgs, inv_id).is_some(),
+            Duration::from_secs(5),
+        )
+        .await;
+    let result = find_result(&msgs, inv_id).expect("invocationresult frame for remote_err");
+    let error = &result["error"];
+    assert_eq!(
+        error["code"], "W105",
+        "Remote code must reach the wire: {error}"
+    );
+    assert_eq!(
+        error["message"],
+        "{\"code\":\"W105\",\"type\":\"WorkerOpError\"}"
+    );
+    assert!(
+        error.get("stacktrace").is_none_or(Value::is_null),
+        "Remote stacktrace: None must not be backfilled with a dispatch backtrace: {error}"
+    );
+
+    iii.shutdown_async().await;
+}
+
+#[tokio::test]
+async fn non_remote_error_keeps_invocation_failed_with_backfilled_stacktrace() {
+    let mock = MockEngine::start().await;
+    let iii = register_worker(mock.url(), InitOptions::default());
+
+    let _f = iii.register_function(
+        "test::handler_err",
+        RegisterFunction::new_async(|_: Value| async move {
+            Err::<Value, _>(IIIError::Handler("boom".to_string()))
+        }),
+    );
+
+    mock.wait_for(
+        |msgs| count_type(msgs, "registerfunction") >= 1,
+        Duration::from_secs(5),
+    )
+    .await;
+
+    let inv_id = "00000000-0000-4000-8000-000000000002";
+    mock.send_to_client(json!({
+        "type": "invokefunction",
+        "invocation_id": inv_id,
+        "function_id": "test::handler_err",
+        "data": {}
+    }));
+
+    let msgs = mock
+        .wait_for(
+            |msgs| find_result(msgs, inv_id).is_some(),
+            Duration::from_secs(5),
+        )
+        .await;
+    let result = find_result(&msgs, inv_id).expect("invocationresult frame for handler_err");
+    let error = &result["error"];
+    assert_eq!(error["code"], "invocation_failed");
+    assert!(
+        error["message"].as_str().unwrap_or("").contains("boom"),
+        "handler message preserved: {error}"
+    );
+    assert!(
+        error["stacktrace"].as_str().is_some_and(|s| !s.is_empty()),
+        "non-Remote errors keep the backfilled stacktrace: {error}"
+    );
+
+    iii.shutdown_async().await;
+}


### PR DESCRIPTION
## Summary

Makes the entire worker surface discoverable by LLM and automation callers: the `worker::*` management ops self-describe with real schemas, and every builtin worker now carries a description surfaced in `engine::workers::list` / `engine::workers::info`.

### Worker-op introspection (`2230f52c2`)
- All 8 `worker::*` registrations attach typed request schemas, descriptions, and metadata (`default_timeout_ms`, `idempotent`) via a shared `describe_op` helper; `op_description` is the single source of truth shared with `worker::schema`. Schema table built once via `LazyLock`.
- `iii trigger <fn> --help` fetches `engine::functions::info` and renders a parameter table; degrades gracefully against older engines.
- Workers self-describe: `description` added to the Rust/Node/Go/Python SDK `WorkerMetadata`, capped and sanitized at the engine ingest boundary.
- New `WorkerOpError::BadRequest` (W105) for malformed payloads with a `details.hint` naming `worker::schema`; W101 retained as a reserved wire code. Worker-op failures map to `IIIError::Remote` so `ErrorBody.code` carries the stable W-code.
- `workers::info` trigger-type attribution resolves by owner name, fixing trigger types vanishing when several connections share one worker name; DashMap re-entrancy deadlock avoided in owner resolution.
- Console DLQ tab unwraps the W-code JSON envelope and caps message paths against DOM flooding.
- `--help` sanitizes all worker-controlled fields (incl. Unicode bidi / Trojan-Source overrides); worker-reported names sanitized at ingest.

### Builtin worker descriptions (`94349acac`)
- `WorkerRegistration` gains a required `description: &'static str`; the `register_worker!` macro mandates `description = "..."` in all three variants, so future builtins cannot register without one.
- All 14 in-process builtins described (cron, queue, state, stream, pubsub, http, http-functions, observability, telemetry, configuration, exec, bridge, worker-manager, engine-functions), reusing `iii.worker.yaml` text where it existed; `configuration` and `queue` manifests synced.
- `RuntimeWorkerInfo` carries the description (inventory lookup), replacing the hardcoded `description: None` in both `workers::list` and `workers::info`. Programmatically registered workers stay `None`.
- SDK-connected first-party daemons `iii-sandbox` and `iii-console` now set `WorkerMetadata.description` (`iii-worker-ops` already did).

## Breaking changes

- `worker::add { source: { kind: "local", path } }` over the trigger now succeeds (previously rejected with W102). **Security posture change (intentional, explicitly decided):** a local install makes the daemon execute manifest setup/install/start scripts on the engine host with daemon privileges, reachable by any connected worker. Treat the daemon as a host-level code-execution surface when reachable by untrusted callers.
- Malformed `worker::*` payloads return W105 (was W101); worker-op failures surface the W-code as `ErrorBody.code` (was `invocation_failed`).
- `WorkerMetadata.description` is source-breaking for Rust SDK consumers constructing the struct without `..Default::default()`.
- `register_worker!` now requires the `description` argument (compile error otherwise).

## Test plan

- [x] `cargo test -p iii --lib` — 1682 passed
- [x] `cargo test -p iii --test builtin_functions_e2e` — 6 passed (null-description assertion flipped to pin the real text)
- [x] `cargo check -p iii -p iii-worker --all-targets` and `cargo check -p iii-console` clean
- [x] New guard test `every_builtin_worker_registration_has_description` (inventory coverage + lookup)
- [x] `worker_trigger_integration` (W105 envelope, op metadata/description), SDK `error_wire`, help.rs sanitizer coverage, Python description present/absent
- [x] Multi-model pre-landing review on the first commit; 15-agent adversarial review on the second (caught the missing `iii-console` description)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workers can publish an optional one-line description shown in listings/info.
  * Local worker installs via triggers are now supported.
  * Worker schemas now include description, default timeout, and idempotency metadata.
  * Help output and function descriptions are sanitized for terminal safety.
  * Improved dead-letter queue error message extraction and truncation.

* **Bug Fixes**
  * Malformed request payloads now return W105 (BadRequest) with actionable details.

* **Documentation**
  * Updated guides and SDK references to document metadata, schema, and trigger behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->