### PR TITLE
refactor(python-sdk)!: rename IIIInvocationError to InvocationError

### DIFF
--- a/docs/next/sdk-reference/python-sdk.mdx
+++ b/docs/next/sdk-reference/python-sdk.mdx
@@ -128,8 +128,8 @@ TriggerAction.Enqueue(queue="math")   # route through iii-queue; returns Trigger
 
 ## Error types
 
-Every invocation failure raises `IIIInvocationError`. Inspect its `code` attribute to
-distinguish categories:
+Every invocation failure raises `InvocationError`, imported from the `iii.errors` submodule
+(`from iii.errors import InvocationError`). Inspect its `code` attribute to distinguish categories:
 
 | `code`        | When raised                       |
 | ------------- | --------------------------------- |
@@ -137,7 +137,8 @@ distinguish categories:
 | `"TIMEOUT"`   | The invocation timed out.         |
 | other         | Any other engine-side rejection.  |
 
-`IIIInvocationError` has `code`, `message`, `function_id`, and `stacktrace` attributes.
+`InvocationError` has `code`, `message`, `function_id`, and `stacktrace` attributes. The former
+name `IIIInvocationError` stays importable from the package root as a deprecated alias.
 
 ## Channels
 

--- a/docs/next/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/python-sdk.mdx.skill.md
@@ -126,8 +126,8 @@ TriggerAction.Enqueue(queue="math")   # route through iii-queue; returns Trigger
 
 ## Error types
 
-Every invocation failure raises `IIIInvocationError`. Inspect its `code` attribute to
-distinguish categories:
+Every invocation failure raises `InvocationError`, imported from the `iii.errors` submodule
+(`from iii.errors import InvocationError`). Inspect its `code` attribute to distinguish categories:
 
 | `code`        | When raised                       |
 | ------------- | --------------------------------- |
@@ -135,7 +135,8 @@ distinguish categories:
 | `"TIMEOUT"`   | The invocation timed out.         |
 | other         | Any other engine-side rejection.  |
 
-`IIIInvocationError` has `code`, `message`, `function_id`, and `stacktrace` attributes.
+`InvocationError` has `code`, `message`, `function_id`, and `stacktrace` attributes. The former
+name `IIIInvocationError` stays importable from the package root as a deprecated alias.
 
 ## Channels
 

--- a/sdk/packages/python/iii/src/iii/__init__.py
+++ b/sdk/packages/python/iii/src/iii/__init__.py
@@ -1,7 +1,9 @@
 """III SDK for Python."""
 
+from typing import Any
+
 from .channels import ChannelReader, ChannelWriter
-from .errors import IIIInvocationError
+from .errors import InvocationError
 from .format_utils import extract_request_format, extract_response_format, python_type_to_format
 from .iii import TriggerAction, register_worker
 from .iii_constants import FunctionRef, InitOptions, TelemetryOptions
@@ -57,7 +59,7 @@ __all__ = [
     "ChannelReader",
     "ChannelWriter",
     # Errors
-    "IIIInvocationError",
+    "InvocationError",
     # Core
     "FunctionRef",
     "InitOptions",
@@ -118,3 +120,16 @@ __all__ = [
     "extract_response_format",
     "python_type_to_format",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "IIIInvocationError":
+        import warnings
+
+        warnings.warn(
+            "IIIInvocationError is deprecated; import InvocationError from iii.errors",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return InvocationError
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/sdk/packages/python/iii/src/iii/errors.py
+++ b/sdk/packages/python/iii/src/iii/errors.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from typing import Any
 
 
-class IIIInvocationError(Exception):
+class InvocationError(Exception):
     """Raised when an invocation dispatched by the SDK fails.
 
     Inspect ``err.code`` to react to a specific category (e.g.
     ``'FORBIDDEN'`` for RBAC denials, ``'TIMEOUT'`` for timeouts). Catch
     this class to handle every rejection. ``except Exception`` continues to
-    work because ``IIIInvocationError`` inherits from ``Exception``.
+    work because ``InvocationError`` inherits from ``Exception``.
 
     Attributes are read-only after construction. ``stacktrace`` is the
     engine-side trace when the remote handler raised; it may include
@@ -38,8 +38,8 @@ def _wrap_wire_error(
     *,
     function_id: str | None,
     invocation_id: str | None,
-) -> IIIInvocationError:
-    """Convert a wire ``ErrorBody``-shaped dict into an ``IIIInvocationError``.
+) -> InvocationError:
+    """Convert a wire ``ErrorBody``-shaped dict into an ``InvocationError``.
 
     The ``code`` field distinguishes categories (e.g. ``'FORBIDDEN'``,
     ``'TIMEOUT'``). Malformed shapes (non-dict, missing fields, non-string
@@ -56,7 +56,7 @@ def _wrap_wire_error(
         raw_stacktrace = error.get("stacktrace")
         stacktrace = raw_stacktrace if isinstance(raw_stacktrace, str) else None
 
-        return IIIInvocationError(
+        return InvocationError(
             code=code,
             message=message,
             function_id=function_id,
@@ -64,9 +64,13 @@ def _wrap_wire_error(
             invocation_id=invocation_id,
         )
 
-    return IIIInvocationError(
+    return InvocationError(
         code="UNKNOWN",
         message=str(error),
         function_id=function_id,
         invocation_id=invocation_id,
     )
+
+
+# Back-compat alias; renamed to InvocationError in Stage 1. Deprecated.
+IIIInvocationError = InvocationError

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -18,7 +18,7 @@ from iii_observability import OtelConfig
 from websockets.asyncio.client import ClientConnection
 
 from .channels import ChannelReader, ChannelWriter
-from .errors import IIIInvocationError, _wrap_wire_error
+from .errors import InvocationError, _wrap_wire_error
 from .format_utils import extract_request_format, extract_response_format
 from .iii_constants import (
     DEFAULT_RECONNECTION_CONFIG,
@@ -265,7 +265,7 @@ class III:
         for invocation_id, pending in list(self._pending.items()):
             if not pending.future.done():
                 pending.future.set_exception(
-                    IIIInvocationError(
+                    InvocationError(
                         code="SHUTDOWN",
                         message="iii is shutting down",
                         function_id=pending.function_id,
@@ -1081,7 +1081,7 @@ class III:
             actions.
 
         Raises:
-            IIIInvocationError: For any engine rejection. Inspect ``code``:
+            InvocationError: For any engine rejection. Inspect ``code``:
                 ``'TIMEOUT'`` if the invocation timed out, ``'FORBIDDEN'`` if
                 RBAC denied it.
 
@@ -1108,7 +1108,7 @@ class III:
             The result of the function invocation, or ``None`` for void calls.
 
         Raises:
-            IIIInvocationError: For any engine rejection. Inspect ``code``:
+            InvocationError: For any engine rejection. Inspect ``code``:
                 ``'TIMEOUT'`` if the invocation timed out, ``'FORBIDDEN'`` if
                 RBAC denied it.
 
@@ -1171,7 +1171,7 @@ class III:
             return await asyncio.wait_for(future, timeout=timeout_secs)
         except asyncio.TimeoutError:
             self._pending.pop(invocation_id, None)
-            raise IIIInvocationError(
+            raise InvocationError(
                 code="TIMEOUT",
                 message=f"invocation timed out after {timeout_ms}ms",
                 function_id=function_id,

--- a/sdk/packages/python/iii/tests/test_errors.py
+++ b/sdk/packages/python/iii/tests/test_errors.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import pytest
 
-from iii import IIIInvocationError
+from iii import InvocationError
 from iii.errors import _wrap_wire_error
 
 
-class TestIIIInvocationError:
+class TestInvocationError:
     def test_exposes_all_fields(self) -> None:
-        err = IIIInvocationError(
+        err = InvocationError(
             code="FORBIDDEN",
             message="function 'engine::functions::list' not allowed",
             function_id="engine::functions::list",
@@ -18,7 +18,7 @@ class TestIIIInvocationError:
             invocation_id="inv-123",
         )
         assert isinstance(err, Exception)
-        assert isinstance(err, IIIInvocationError)
+        assert isinstance(err, InvocationError)
         assert err.code == "FORBIDDEN"
         assert err.message == "function 'engine::functions::list' not allowed"
         assert err.function_id == "engine::functions::list"
@@ -26,7 +26,7 @@ class TestIIIInvocationError:
         assert err.invocation_id == "inv-123"
 
     def test_str_is_code_colon_message(self) -> None:
-        err = IIIInvocationError(
+        err = InvocationError(
             code="FORBIDDEN",
             message="function 'X' not allowed (add to rbac.expose_functions)",
             function_id="X",
@@ -35,13 +35,13 @@ class TestIIIInvocationError:
 
     def test_str_never_looks_like_raw_dict_repr(self) -> None:
         """Guards against the original Node [object Object] equivalent."""
-        err = IIIInvocationError(code="FORBIDDEN", message="nope")
+        err = InvocationError(code="FORBIDDEN", message="nope")
         assert str(err) != "{'code': 'FORBIDDEN', 'message': 'nope'}"
         assert str(err) != repr({"code": "FORBIDDEN", "message": "nope"})
 
     def test_str_does_not_leak_stacktrace(self) -> None:
         """Stacktrace is opt-in via .stacktrace attribute; str/repr must not include it."""
-        err = IIIInvocationError(
+        err = InvocationError(
             code="HANDLER",
             message="boom",
             stacktrace="/internal/path/secrets.py:line 42",
@@ -50,7 +50,7 @@ class TestIIIInvocationError:
         assert "/internal/path/secrets.py" not in repr(err)
 
     def test_supports_optional_fields(self) -> None:
-        err = IIIInvocationError(code="TIMEOUT", message="gone")
+        err = InvocationError(code="TIMEOUT", message="gone")
         assert err.function_id is None
         assert err.stacktrace is None
         assert err.invocation_id is None
@@ -61,28 +61,28 @@ class TestCodeDiscrimination:
     def test_categories_discriminated_by_code(self) -> None:
         """Categories are distinguished by ``code``, not by subclass."""
         for code in ("FORBIDDEN", "TIMEOUT", "UNKNOWN"):
-            err = IIIInvocationError(code=code, message="x")
-            assert isinstance(err, IIIInvocationError)
+            err = InvocationError(code=code, message="x")
+            assert isinstance(err, InvocationError)
             assert isinstance(err, Exception)
             assert err.code == code
 
     def test_base_catches_every_category(self) -> None:
         for err in (
-            IIIInvocationError(code="FORBIDDEN", message="x"),
-            IIIInvocationError(code="TIMEOUT", message="x"),
-            IIIInvocationError(code="UNKNOWN", message="x"),
+            InvocationError(code="FORBIDDEN", message="x"),
+            InvocationError(code="TIMEOUT", message="x"),
+            InvocationError(code="UNKNOWN", message="x"),
         ):
             try:
                 raise err
-            except IIIInvocationError as got:
+            except InvocationError as got:
                 assert got.code in {"FORBIDDEN", "TIMEOUT", "UNKNOWN"}
 
     def test_except_exception_still_works(self) -> None:
         """Migration guarantee: existing `except Exception:` handlers still catch."""
         try:
-            raise IIIInvocationError(code="FORBIDDEN", message="x")
+            raise InvocationError(code="FORBIDDEN", message="x")
         except Exception as got:
-            assert isinstance(got, IIIInvocationError)
+            assert isinstance(got, InvocationError)
 
 
 class TestWrapWireError:
@@ -92,7 +92,7 @@ class TestWrapWireError:
             function_id="engine::functions::list",
             invocation_id="inv-1",
         )
-        assert type(err) is IIIInvocationError
+        assert type(err) is InvocationError
         assert err.code == "FORBIDDEN"
         assert err.function_id == "engine::functions::list"
         assert err.invocation_id == "inv-1"
@@ -103,7 +103,7 @@ class TestWrapWireError:
             function_id="api::slow",
             invocation_id=None,
         )
-        assert type(err) is IIIInvocationError
+        assert type(err) is InvocationError
         assert err.code == "TIMEOUT"
 
     def test_unknown_code_falls_back_to_base(self) -> None:
@@ -112,7 +112,7 @@ class TestWrapWireError:
             function_id=None,
             invocation_id=None,
         )
-        assert type(err) is IIIInvocationError
+        assert type(err) is InvocationError
         assert err.code == "BUSINESS_RULE"
 
     def test_stacktrace_propagated_when_string(self) -> None:
@@ -139,7 +139,7 @@ class TestWrapWireError:
     def test_malformed_wire_errors_never_produce_raw_repr(self, bad_error: object) -> None:
         """Guards against stringified-dict regression for every pathological shape."""
         err = _wrap_wire_error(bad_error, function_id="fn", invocation_id=None)
-        assert isinstance(err, IIIInvocationError)
+        assert isinstance(err, InvocationError)
         assert str(err).startswith(("UNKNOWN:", "X:", "123:"))
         assert "{'" not in str(err), f"dict repr leaked into message: {err!s}"
         assert "': " not in str(err), f"dict repr leaked into message: {err!s}"
@@ -151,3 +151,20 @@ class TestWrapWireError:
             invocation_id=None,
         )
         assert err.stacktrace is None
+
+
+class TestErrorsSubmoduleAndBackCompat:
+    def test_subpath_import(self) -> None:
+        from iii.errors import InvocationError as FromErrors
+
+        assert FromErrors is InvocationError
+
+    def test_deprecated_alias_warns(self) -> None:
+        import warnings
+
+        import iii
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            assert iii.IIIInvocationError is InvocationError
+        assert any(issubclass(w.category, DeprecationWarning) for w in caught)

--- a/sdk/packages/python/iii/tests/test_rbac_workers.py
+++ b/sdk/packages/python/iii/tests/test_rbac_workers.py
@@ -8,8 +8,8 @@ import pytest
 from iii import (
     AuthInput,
     AuthResult,
-    IIIInvocationError,
     InitOptions,
+    InvocationError,
     MiddlewareFunctionInput,
     OnFunctionRegistrationInput,
     OnFunctionRegistrationResult,
@@ -349,7 +349,7 @@ class TestRbacWorkers:
             iii_client.shutdown()
 
     def test_forbidden_wrapped_as_typed_error(self, iii_server):
-        """FORBIDDEN rejections surface as IIIInvocationError (code='FORBIDDEN')
+        """FORBIDDEN rejections surface as InvocationError (code='FORBIDDEN')
         with function_id set and the engine's remediation phrase in the message."""
         iii_client = register_worker(
             EW_URL,
@@ -357,7 +357,7 @@ class TestRbacWorkers:
         )
 
         try:
-            with pytest.raises(IIIInvocationError) as excinfo:
+            with pytest.raises(InvocationError) as excinfo:
                 iii_client.trigger({
                     "function_id": "test::ew::private",
                     "payload": {},
@@ -430,7 +430,7 @@ class TestRbacWorkers:
         try:
             def handler(data: dict) -> dict:
                 # If the carve-out regresses, this nested trigger surfaces
-                # IIIInvocationError (code='FORBIDDEN') and the handler propagates it as a failure.
+                # InvocationError (code='FORBIDDEN') and the handler propagates it as a failure.
                 iii_client.trigger({
                     "function_id": "engine::log::info",
                     "payload": {
@@ -471,7 +471,7 @@ class TestRbacWorkers:
 
         try:
             # No exception == carve-out is working. If this raises
-            # IIIInvocationError (code='FORBIDDEN'), the carve-out regressed.
+            # InvocationError (code='FORBIDDEN'), the carve-out regressed.
             iii_client.trigger({
                 "function_id": "engine::log::info",
                 "payload": {"message": "carve-out direct invocation"},


### PR DESCRIPTION
Renames the Python SDK error class `IIIInvocationError` to `InvocationError`. Canonical import is now `from iii.errors import InvocationError`.

The old root name `IIIInvocationError` stays importable from the package root as a deprecated alias that emits a `DeprecationWarning` via module `__getattr__`, so existing `from iii import IIIInvocationError` keeps working. Behavior is identical; only the class name and the canonical import path change.

- `errors.py`: class renamed, module-level back-compat alias.
- `__init__.py`: exports `InvocationError`; `__getattr__` shim for the old name.
- Internal usages (`iii.py`) and tests updated.
- Reference docs updated (`python-sdk.mdx` + skill companion).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Python SDK invocation error docs: error type name, distinct error codes (`FORBIDDEN`, `TIMEOUT`, others), and exposed attributes (`code`, `message`, `function_id`, `stacktrace`).

* **Bug Fixes**
  * Errors now consistently surface the canonical invocation error type and remain backwards-compatible via a deprecated alias.

* **Tests**
  * Test suite updated to expect the canonical invocation error and verify stringification and deprecation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->