### PR TITLE
refactor(rust-sdk)!: rename IIIError to Error, add iii_sdk::errors

### DIFF
--- a/docs/next/sdk-reference/rust-sdk.mdx
+++ b/docs/next/sdk-reference/rust-sdk.mdx
@@ -58,7 +58,7 @@ Bind a registered function to a configured trigger instance.
 pub fn register_trigger(
     &self,
     input: RegisterTriggerInput,
-) -> Result<Trigger, IIIError>;
+) -> Result<Trigger, Error>;
 ```
 
 Drop the trigger with `trigger.unregister()` on the returned handle. There is no free-function
@@ -95,7 +95,7 @@ Invoke a registered function. Always async; await the future to receive the resu
 pub async fn trigger(
     &self,
     request: impl Into<TriggerRequest>,
-) -> Result<serde_json::Value, IIIError>;
+) -> Result<serde_json::Value, Error>;
 ```
 
 The returned `Value` is the function's return JSON for synchronous calls, an `EnqueueResult`-shaped
@@ -125,11 +125,13 @@ Pass it in `TriggerRequest::action` as `Some(TriggerAction::Void)` or
 
 ## Error type
 
-`IIIError` is the public error enum. Most invocation failures arrive on the `Remote` or `Runtime`
-variants.
+`Error` is the public error enum, reachable at its canonical path `iii_sdk::errors::Error`. Most
+invocation failures arrive on the `Remote` or `Runtime` variants.
 
 ```rust
-pub enum IIIError {
+use iii_sdk::errors::Error;
+
+pub enum Error {
     NotConnected,
     Timeout,
     Runtime(String),
@@ -140,8 +142,11 @@ pub enum IIIError {
 }
 ```
 
+The former name `IIIError` stays reachable at the crate root as a deprecated alias; prefer
+`iii_sdk::errors::Error`.
+
 `ErrorBody` carries the engine's `{ code, message, stacktrace? }` payload; match on
-`IIIError::Remote(body) => body.code.as_str()` to branch on engine error codes
+`Error::Remote(body) => body.code.as_str()` to branch on engine error codes
 (`invocation_failed`, `invocation_stopped`, `function_not_found`, `FORBIDDEN`, `TIMEOUT`, etc.).
 
 ## Channels

--- a/docs/next/sdk-reference/rust-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/rust-sdk.mdx.skill.md
@@ -56,7 +56,7 @@ Bind a registered function to a configured trigger instance.
 pub fn register_trigger(
     &self,
     input: RegisterTriggerInput,
-) -> Result<Trigger, IIIError>;
+) -> Result<Trigger, Error>;
 ```
 
 Drop the trigger with `trigger.unregister()` on the returned handle. There is no free-function
@@ -93,7 +93,7 @@ Invoke a registered function. Always async; await the future to receive the resu
 pub async fn trigger(
     &self,
     request: impl Into<TriggerRequest>,
-) -> Result<serde_json::Value, IIIError>;
+) -> Result<serde_json::Value, Error>;
 ```
 
 The returned `Value` is the function's return JSON for synchronous calls, an `EnqueueResult`-shaped
@@ -123,11 +123,13 @@ Pass it in `TriggerRequest::action` as `Some(TriggerAction::Void)` or
 
 ## Error type
 
-`IIIError` is the public error enum. Most invocation failures arrive on the `Remote` or `Runtime`
-variants.
+`Error` is the public error enum, reachable at its canonical path `iii_sdk::errors::Error`. Most
+invocation failures arrive on the `Remote` or `Runtime` variants.
 
 ```rust
-pub enum IIIError {
+use iii_sdk::errors::Error;
+
+pub enum Error {
     NotConnected,
     Timeout,
     Runtime(String),
@@ -138,8 +140,11 @@ pub enum IIIError {
 }
 ```
 
+The former name `IIIError` stays reachable at the crate root as a deprecated alias; prefer
+`iii_sdk::errors::Error`.
+
 `ErrorBody` carries the engine's `{ code, message, stacktrace? }` payload; match on
-`IIIError::Remote(body) => body.code.as_str()` to branch on engine error codes
+`Error::Remote(body) => body.code.as_str()` to branch on engine error codes
 (`invocation_failed`, `invocation_stopped`, `function_not_found`, `FORBIDDEN`, `TIMEOUT`, etc.).
 
 ## Channels

--- a/sdk/packages/rust/iii-example/src/cron_trigger_example.rs
+++ b/sdk/packages/rust/iii-example/src/cron_trigger_example.rs
@@ -1,5 +1,5 @@
 use iii_sdk::builtin_triggers::*;
-use iii_sdk::{III, IIIError, IIITrigger, RegisterFunction};
+use iii_sdk::{Error, III, IIITrigger, RegisterFunction};
 use serde_json::json;
 
 /// Examples using built-in trigger types with the typed `IIITrigger` enum.
@@ -97,7 +97,7 @@ struct CronEvent {
     job_id: String,
 }
 
-fn scheduled_cleanup(input: CronEvent) -> Result<serde_json::Value, IIIError> {
+fn scheduled_cleanup(input: CronEvent) -> Result<serde_json::Value, Error> {
     Ok(json!({ "cleaned": true, "trigger": input.trigger, "job_id": input.job_id }))
 }
 
@@ -110,19 +110,19 @@ struct StateEvent {
     new_value: serde_json::Value,
 }
 
-fn on_user_updated(input: StateEvent) -> Result<serde_json::Value, IIIError> {
+fn on_user_updated(input: StateEvent) -> Result<serde_json::Value, Error> {
     Ok(json!({ "event": input.event_type, "scope": input.scope, "key": input.key }))
 }
 
-fn health_check(_input: serde_json::Value) -> Result<serde_json::Value, IIIError> {
+fn health_check(_input: serde_json::Value) -> Result<serde_json::Value, Error> {
     Ok(json!({ "status": "ok" }))
 }
 
-fn on_order_created(input: serde_json::Value) -> Result<serde_json::Value, IIIError> {
+fn on_order_created(input: serde_json::Value) -> Result<serde_json::Value, Error> {
     Ok(json!({ "processed": true, "order": input }))
 }
 
-fn process_email(input: serde_json::Value) -> Result<serde_json::Value, IIIError> {
+fn process_email(input: serde_json::Value) -> Result<serde_json::Value, Error> {
     Ok(json!({ "sent": true, "email": input }))
 }
 
@@ -132,10 +132,10 @@ struct LogEvent {
     body: String,
 }
 
-fn on_error_log(input: LogEvent) -> Result<serde_json::Value, IIIError> {
+fn on_error_log(input: LogEvent) -> Result<serde_json::Value, Error> {
     Ok(json!({ "alerted": true, "severity": input.severity_text, "message": input.body }))
 }
 
-fn on_chat_message(input: serde_json::Value) -> Result<serde_json::Value, IIIError> {
+fn on_chat_message(input: serde_json::Value) -> Result<serde_json::Value, Error> {
     Ok(json!({ "received": true, "event": input }))
 }

--- a/sdk/packages/rust/iii-example/src/custom_trigger_example.rs
+++ b/sdk/packages/rust/iii-example/src/custom_trigger_example.rs
@@ -1,4 +1,4 @@
-use iii_sdk::{III, IIIError, RegisterTriggerType, TriggerConfig, TriggerHandler};
+use iii_sdk::{Error, III, RegisterTriggerType, TriggerConfig, TriggerHandler};
 use serde_json::json;
 
 // ── Example 1: Typed trigger with full config ───────────────────────────
@@ -27,11 +27,11 @@ struct ScheduleHandler;
 
 #[async_trait::async_trait]
 impl TriggerHandler for ScheduleHandler {
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         println!("[schedule] Registered: {}", config.config);
         Ok(())
     }
-    async fn unregister_trigger(&self, _config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, _config: TriggerConfig) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -67,11 +67,11 @@ struct FileWatchHandler;
 
 #[async_trait::async_trait]
 impl TriggerHandler for FileWatchHandler {
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         println!("[file-watch] Watching: {}", config.config);
         Ok(())
     }
-    async fn unregister_trigger(&self, _config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, _config: TriggerConfig) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -82,10 +82,10 @@ struct NoopHandler;
 
 #[async_trait::async_trait]
 impl TriggerHandler for NoopHandler {
-    async fn register_trigger(&self, _config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, _config: TriggerConfig) -> Result<(), Error> {
         Ok(())
     }
-    async fn unregister_trigger(&self, _config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, _config: TriggerConfig) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -106,7 +106,7 @@ pub fn setup(iii: &III) {
 
     // register_function on the handle: enforces Fn(ScheduleCallRequest) -> ...
     schedule.register_function("example::send_report", |_input: ScheduleCallRequest| {
-        Ok::<_, IIIError>(json!({ "sent": true }))
+        Ok::<_, Error>(json!({ "sent": true }))
     });
 
     // register_trigger on the handle: enforces ScheduleTriggerConfig
@@ -134,7 +134,7 @@ pub fn setup(iii: &III) {
 
     // Compile-time safe: function input must be FileWatchCallRequest
     file_watch.register_function("example::process_csv", |input: FileWatchCallRequest| {
-        Ok::<_, IIIError>(json!({ "processed": true, "path": input.path }))
+        Ok::<_, Error>(json!({ "processed": true, "path": input.path }))
     });
 
     // Compile-time safe: config must be FileWatchConfig
@@ -157,7 +157,7 @@ pub fn setup(iii: &III) {
     ));
 
     custom.register_function("example::on_custom_event", |input: serde_json::Value| {
-        Ok::<_, IIIError>(json!({ "received": input }))
+        Ok::<_, Error>(json!({ "received": input }))
     });
 
     custom

--- a/sdk/packages/rust/iii-example/src/http_example.rs
+++ b/sdk/packages/rust/iii-example/src/http_example.rs
@@ -1,6 +1,6 @@
 use iii_observability::{Logger, execute_traced_request};
 use iii_sdk::builtin_triggers::{HttpMethod, HttpTriggerConfig};
-use iii_sdk::{ApiRequest, ApiResponse, III, IIIError, IIITrigger, RegisterFunction};
+use iii_sdk::{ApiRequest, ApiResponse, Error, III, IIITrigger, RegisterFunction};
 use serde_json::json;
 
 pub fn setup(iii: &III) {
@@ -19,11 +19,11 @@ pub fn setup(iii: &III) {
                 let request = client
                     .get("https://jsonplaceholder.typicode.com/todos/1")
                     .build()
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let response = execute_traced_request(&client, request)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let status = response.status().as_u16();
                 logger.info(
@@ -34,7 +34,7 @@ pub fn setup(iii: &III) {
                 let data: serde_json::Value = response
                     .json::<serde_json::Value>()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let api_response = ApiResponse {
                     status_code: 200,
@@ -76,11 +76,11 @@ pub fn setup(iii: &III) {
                     .header("Content-Type", "application/json")
                     .json(&payload)
                     .build()
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let response = execute_traced_request(&client, request)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let status = response.status().as_u16();
                 logger.info("Post completed", Some(json!({ "status": status })));
@@ -88,7 +88,7 @@ pub fn setup(iii: &III) {
                 let data: serde_json::Value = response
                     .json::<serde_json::Value>()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let api_response = ApiResponse {
                     status_code: status,

--- a/sdk/packages/rust/iii-example/src/logger_example.rs
+++ b/sdk/packages/rust/iii-example/src/logger_example.rs
@@ -1,5 +1,5 @@
 use iii_observability::Logger;
-use iii_sdk::{III, IIIError, RegisterFunction};
+use iii_sdk::{Error, III, RegisterFunction};
 use serde_json::{Value, json};
 
 pub fn setup(iii: &III) {
@@ -22,7 +22,7 @@ pub fn setup(iii: &III) {
 
             logger.info("Request processed successfully", None);
 
-            Ok::<Value, IIIError>(json!({ "status": "ok" }))
+            Ok::<Value, Error>(json!({ "status": "ok" }))
         })
         .description("Demonstrates Logger with all log levels"),
     );

--- a/sdk/packages/rust/iii-example/src/main.rs
+++ b/sdk/packages/rust/iii-example/src/main.rs
@@ -1,7 +1,7 @@
 use std::{thread::sleep, time::Duration};
 
 use iii_observability::OtelConfig;
-use iii_sdk::{IIIError, InitOptions, RegisterFunction, TriggerRequest, UpdateOp, register_worker};
+use iii_sdk::{Error, InitOptions, RegisterFunction, TriggerRequest, UpdateOp, register_worker};
 use serde_json::json;
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
@@ -12,7 +12,7 @@ struct EchoInput {
     prefix: String,
 }
 
-fn echo_message(input: EchoInput) -> Result<serde_json::Value, IIIError> {
+fn echo_message(input: EchoInput) -> Result<serde_json::Value, Error> {
     let mut result = input.message.repeat(input.repeat as usize);
     if input.uppercase {
         result = result.to_uppercase();
@@ -27,7 +27,7 @@ struct DelayEchoInput {
     suffix: String,
 }
 
-async fn delay_echo(input: DelayEchoInput) -> Result<serde_json::Value, IIIError> {
+async fn delay_echo(input: DelayEchoInput) -> Result<serde_json::Value, Error> {
     tokio::time::sleep(Duration::from_millis(input.delay_ms)).await;
     Ok(
         json!({ "echo": format!("{}{}", input.message, input.suffix), "delayed_ms": input.delay_ms }),

--- a/sdk/packages/rust/iii-example/src/trigger_type_example.rs
+++ b/sdk/packages/rust/iii-example/src/trigger_type_example.rs
@@ -1,4 +1,4 @@
-use iii_sdk::{III, IIIError, RegisterTriggerType, TriggerConfig, TriggerHandler, TriggerRequest};
+use iii_sdk::{Error, III, RegisterTriggerType, TriggerConfig, TriggerHandler, TriggerRequest};
 use serde::Deserialize;
 
 /// Minimal deserialization target for `engine::triggers::list` rows used
@@ -41,7 +41,7 @@ struct WebhookHandler;
 
 #[async_trait::async_trait]
 impl TriggerHandler for WebhookHandler {
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         println!(
             "[webhook] Registered trigger {} for function {} with config: {}",
             config.id, config.function_id, config.config
@@ -49,7 +49,7 @@ impl TriggerHandler for WebhookHandler {
         Ok(())
     }
 
-    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         println!("[webhook] Unregistered trigger {}", config.id);
         Ok(())
     }
@@ -81,7 +81,7 @@ pub fn setup(iii: &III) {
         .expect("failed to register webhook trigger");
 }
 
-fn handle_webhook(input: WebhookCallRequest) -> Result<serde_json::Value, IIIError> {
+fn handle_webhook(input: WebhookCallRequest) -> Result<serde_json::Value, Error> {
     Ok(serde_json::json!({
         "processed": true,
         "method": input.method,

--- a/sdk/packages/rust/iii/src/channels.rs
+++ b/sdk/packages/rust/iii/src/channels.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use tokio::sync::Mutex;
 use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
 
-use crate::error::IIIError;
+use crate::error::Error;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
@@ -85,7 +85,7 @@ impl ChannelWriter {
         }
     }
 
-    async fn ensure_connected(&self) -> Result<(), IIIError> {
+    async fn ensure_connected(&self) -> Result<(), Error> {
         let mut guard = self.ws.lock().await;
         if guard.is_some() {
             return Ok(());
@@ -98,25 +98,25 @@ impl ChannelWriter {
 
     const MAX_FRAME_SIZE: usize = 64 * 1024;
 
-    pub async fn write(&self, data: &[u8]) -> Result<(), IIIError> {
+    pub async fn write(&self, data: &[u8]) -> Result<(), Error> {
         self.ensure_connected().await?;
         let mut guard = self.ws.lock().await;
-        let ws = guard.as_mut().ok_or(IIIError::NotConnected)?;
+        let ws = guard.as_mut().ok_or(Error::NotConnected)?;
         for chunk in data.chunks(Self::MAX_FRAME_SIZE) {
             ws.send(WsMessage::Binary(chunk.to_vec().into())).await?;
         }
         Ok(())
     }
 
-    pub async fn send_message(&self, msg: &str) -> Result<(), IIIError> {
+    pub async fn send_message(&self, msg: &str) -> Result<(), Error> {
         self.ensure_connected().await?;
         let mut guard = self.ws.lock().await;
-        let ws = guard.as_mut().ok_or(IIIError::NotConnected)?;
+        let ws = guard.as_mut().ok_or(Error::NotConnected)?;
         ws.send(WsMessage::Text(msg.to_string().into())).await?;
         Ok(())
     }
 
-    pub async fn close(&self) -> Result<(), IIIError> {
+    pub async fn close(&self) -> Result<(), Error> {
         // Delay the close frame slightly to allow the TCP stack to flush
         // all buffered send() data. Without this, the close frame can arrive
         // at the engine before all data frames, causing data truncation.
@@ -154,7 +154,7 @@ impl ChannelReader {
         }
     }
 
-    async fn ensure_connected(&self) -> Result<(), IIIError> {
+    async fn ensure_connected(&self) -> Result<(), Error> {
         let mut guard = self.ws.lock().await;
         if guard.is_some() {
             return Ok(());
@@ -176,12 +176,12 @@ impl ChannelReader {
     /// Read the next binary chunk from the channel.
     /// Text messages are dispatched to registered callbacks.
     /// Returns `None` when the stream is closed.
-    pub async fn next_binary(&self) -> Result<Option<Vec<u8>>, IIIError> {
+    pub async fn next_binary(&self) -> Result<Option<Vec<u8>>, Error> {
         self.ensure_connected().await?;
 
         loop {
             let mut guard = self.ws.lock().await;
-            let mut reader = guard.take().ok_or(IIIError::NotConnected)?;
+            let mut reader = guard.take().ok_or(Error::NotConnected)?;
             drop(guard);
 
             let msg = reader.next().await;
@@ -200,13 +200,13 @@ impl ChannelReader {
                 }
                 Some(Ok(WsMessage::Close(_))) | None => return Ok(None),
                 Some(Ok(_)) => continue,
-                Some(Err(e)) => return Err(IIIError::WebSocket(e.to_string())),
+                Some(Err(e)) => return Err(Error::WebSocket(e.to_string())),
             }
         }
     }
 
     /// Read the entire stream into a single `Vec<u8>`.
-    pub async fn read_all(&self) -> Result<Vec<u8>, IIIError> {
+    pub async fn read_all(&self) -> Result<Vec<u8>, Error> {
         let mut buffer = Vec::new();
         while let Some(chunk) = self.next_binary().await? {
             buffer.extend_from_slice(&chunk);
@@ -214,7 +214,7 @@ impl ChannelReader {
         Ok(buffer)
     }
 
-    pub async fn close(&self) -> Result<(), IIIError> {
+    pub async fn close(&self) -> Result<(), Error> {
         let mut guard = self.ws.lock().await;
         *guard = None;
         Ok(())

--- a/sdk/packages/rust/iii/src/error.rs
+++ b/sdk/packages/rust/iii/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 /// Errors returned by the III SDK.
 #[derive(Debug, Error, Clone, Serialize, JsonSchema)]
-pub enum IIIError {
+pub enum Error {
     #[error("iii is not connected")]
     NotConnected,
     #[error("invocation timed out")]
@@ -25,26 +25,26 @@ pub enum IIIError {
     WebSocket(String),
 }
 
-impl From<serde_json::Error> for IIIError {
+impl From<serde_json::Error> for Error {
     fn from(err: serde_json::Error) -> Self {
-        IIIError::Serde(err.to_string())
+        Error::Serde(err.to_string())
     }
 }
 
-impl From<String> for IIIError {
+impl From<String> for Error {
     fn from(msg: String) -> Self {
-        IIIError::Handler(msg)
+        Error::Handler(msg)
     }
 }
 
-impl From<&str> for IIIError {
+impl From<&str> for Error {
     fn from(msg: &str) -> Self {
-        IIIError::Handler(msg.to_string())
+        Error::Handler(msg.to_string())
     }
 }
 
-impl From<tokio_tungstenite::tungstenite::Error> for IIIError {
+impl From<tokio_tungstenite::tungstenite::Error> for Error {
     fn from(err: tokio_tungstenite::tungstenite::Error) -> Self {
-        IIIError::WebSocket(err.to_string())
+        Error::WebSocket(err.to_string())
     }
 }

--- a/sdk/packages/rust/iii/src/helpers.rs
+++ b/sdk/packages/rust/iii/src/helpers.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use serde_json::Value;
 
-use crate::error::IIIError;
+use crate::error::Error;
 use crate::iii::{III, RegisterFunction};
 use crate::stream_provider::IStream;
 use crate::types::{
@@ -21,7 +21,7 @@ use crate::types::{
 /// Create a streaming channel pair for worker-to-worker data transfer.
 ///
 /// Free-function form of `III`'s former `create_channel` instance method.
-pub async fn create_channel(iii: &III, buffer_size: Option<usize>) -> Result<Channel, IIIError> {
+pub async fn create_channel(iii: &III, buffer_size: Option<usize>) -> Result<Channel, Error> {
     crate::iii::internal_create_channel(iii, buffer_size).await
 }
 
@@ -44,7 +44,7 @@ where
             let s = s.clone();
             async move {
                 let typed: StreamGetInput =
-                    serde_json::from_value(input).map_err(|e| IIIError::Serde(e.to_string()))?;
+                    serde_json::from_value(input).map_err(|e| Error::Serde(e.to_string()))?;
                 let out = s.get(typed).await?;
                 Ok(serde_json::to_value(out).unwrap_or_default())
             }
@@ -58,7 +58,7 @@ where
             let s = s.clone();
             async move {
                 let typed: StreamSetInput =
-                    serde_json::from_value(input).map_err(|e| IIIError::Serde(e.to_string()))?;
+                    serde_json::from_value(input).map_err(|e| Error::Serde(e.to_string()))?;
                 let out = s.set(typed).await?;
                 Ok(serde_json::to_value(out).unwrap_or_default())
             }
@@ -72,7 +72,7 @@ where
             let s = s.clone();
             async move {
                 let typed: StreamDeleteInput =
-                    serde_json::from_value(input).map_err(|e| IIIError::Serde(e.to_string()))?;
+                    serde_json::from_value(input).map_err(|e| Error::Serde(e.to_string()))?;
                 let out = s.delete(typed).await?;
                 Ok(serde_json::to_value(out).unwrap_or_default())
             }
@@ -86,7 +86,7 @@ where
             let s = s.clone();
             async move {
                 let typed: StreamListInput =
-                    serde_json::from_value(input).map_err(|e| IIIError::Serde(e.to_string()))?;
+                    serde_json::from_value(input).map_err(|e| Error::Serde(e.to_string()))?;
                 let out = s.list(typed).await?;
                 Ok(serde_json::to_value(out).unwrap_or_default())
             }
@@ -100,7 +100,7 @@ where
             let s = s.clone();
             async move {
                 let typed: StreamListGroupsInput =
-                    serde_json::from_value(input).map_err(|e| IIIError::Serde(e.to_string()))?;
+                    serde_json::from_value(input).map_err(|e| Error::Serde(e.to_string()))?;
                 let out = s.list_groups(typed).await?;
                 Ok(serde_json::to_value(out).unwrap_or_default())
             }

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -33,7 +33,7 @@ const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 use crate::{
     channels::{ChannelReader, ChannelWriter, StreamChannelRef},
-    error::IIIError,
+    error::Error,
     protocol::{
         ErrorBody, HttpInvocationConfig, Message, RegisterFunctionMessage, RegisterTriggerInput,
         RegisterTriggerMessage, RegisterTriggerTypeMessage, TriggerAction, TriggerRequest,
@@ -168,7 +168,7 @@ impl<C: Serialize, R> TriggerTypeRef<C, R> {
         &self,
         function_id: impl Into<String>,
         config: C,
-    ) -> Result<Trigger, IIIError> {
+    ) -> Result<Trigger, Error> {
         self.register_trigger_with_metadata(function_id, config, None)
     }
 
@@ -178,11 +178,11 @@ impl<C: Serialize, R> TriggerTypeRef<C, R> {
         function_id: impl Into<String>,
         config: C,
         metadata: Option<Value>,
-    ) -> Result<Trigger, IIIError> {
+    ) -> Result<Trigger, Error> {
         self.iii.register_trigger(RegisterTriggerInput {
             trigger_type: self.trigger_type_id.clone(),
             function_id: function_id.into(),
-            config: serde_json::to_value(config).map_err(|e| IIIError::Handler(e.to_string()))?,
+            config: serde_json::to_value(config).map_err(|e| Error::Handler(e.to_string()))?,
             metadata,
         })
     }
@@ -197,7 +197,7 @@ where
     pub fn register_function<O, F>(&self, id: impl Into<String>, f: F) -> FunctionRef
     where
         O: Serialize + schemars::JsonSchema + Send + 'static,
-        F: Fn(R) -> Result<O, IIIError> + Send + Sync + 'static,
+        F: Fn(R) -> Result<O, Error> + Send + Sync + 'static,
     {
         self.iii.register_function(id, RegisterFunction::new(f))
     }
@@ -208,7 +208,7 @@ where
     where
         O: Serialize + schemars::JsonSchema + Send + 'static,
         F: Fn(R) -> Fut + Send + Sync + 'static,
-        Fut: std::future::Future<Output = Result<O, IIIError>> + Send + 'static,
+        Fut: std::future::Future<Output = Result<O, Error>> + Send + 'static,
     {
         self.iii
             .register_function(id, RegisterFunction::new_async(f))
@@ -341,7 +341,7 @@ enum Outbound {
     Shutdown,
 }
 
-type PendingInvocation = oneshot::Sender<Result<Value, IIIError>>;
+type PendingInvocation = oneshot::Sender<Result<Value, Error>>;
 
 // WebSocket transmitter type alias
 type WsTx = futures_util::stream::SplitSink<
@@ -401,24 +401,24 @@ pub trait IntoSyncHandler<Marker>: Send + Sync + 'static {
 
 // 1-arg sync — deserializes the entire JSON input as T.
 //
-// Error type is fixed to [`IIIError`] (instead of generic `E: Display`) so
+// Error type is fixed to [`Error`] (instead of generic `E: Display`) so
 // closures using bare `Ok(...)` infer cleanly without explicit error
 // annotations — required for ergonomic registration of `Fn(Value) -> ...`
-// handlers. Other error types convert via `From<E> for IIIError` (impls
+// handlers. Other error types convert via `From<E> for Error` (impls
 // for `String` / `&str` / `serde_json::Error` ship with the SDK).
 impl<F, T, R> IntoSyncHandler<(T, R)> for F
 where
-    F: Fn(T) -> Result<R, IIIError> + Send + Sync + 'static,
+    F: Fn(T) -> Result<R, Error> + Send + Sync + 'static,
     T: serde::de::DeserializeOwned + schemars::JsonSchema + Send + 'static,
     R: serde::Serialize + schemars::JsonSchema + Send + 'static,
 {
     fn into_handler(self) -> RemoteFunctionHandler {
         Arc::new(move |input: Value| {
             let output = serde_json::from_value::<T>(input)
-                .map_err(|e| IIIError::Serde(e.to_string()))
+                .map_err(|e| Error::Serde(e.to_string()))
                 .and_then(&self)
                 .and_then(|val| {
-                    serde_json::to_value(&val).map_err(|e| IIIError::Serde(e.to_string()))
+                    serde_json::to_value(&val).map_err(|e| Error::Serde(e.to_string()))
                 });
             Box::pin(async move { output })
         })
@@ -452,32 +452,31 @@ pub trait IntoAsyncHandler<Marker>: Send + Sync + 'static {
 
 // 1-arg async — deserializes the entire JSON input as T.
 //
-// Error type is fixed to [`IIIError`] (see [`IntoSyncHandler`] for the
-// rationale). Use `From<E> for IIIError` to lift custom error types,
+// Error type is fixed to [`Error`] (see [`IntoSyncHandler`] for the
+// rationale). Use `From<E> for Error` to lift custom error types,
 // or `?` propagation in the closure body.
 impl<F, T, Fut, R> IntoAsyncHandler<(T, Fut, R)> for F
 where
     F: Fn(T) -> Fut + Send + Sync + 'static,
     T: serde::de::DeserializeOwned + schemars::JsonSchema + Send + 'static,
-    Fut: std::future::Future<Output = Result<R, IIIError>> + Send + 'static,
+    Fut: std::future::Future<Output = Result<R, Error>> + Send + 'static,
     R: serde::Serialize + schemars::JsonSchema + Send + 'static,
 {
     fn into_handler(self) -> RemoteFunctionHandler {
         Arc::new(
             move |input: Value| -> std::pin::Pin<
-                Box<dyn std::future::Future<Output = Result<Value, IIIError>> + Send>,
+                Box<dyn std::future::Future<Output = Result<Value, Error>> + Send>,
             > {
                 match serde_json::from_value::<T>(input) {
                     Ok(arg) => {
                         let fut = (self)(arg);
                         Box::pin(async move {
                             fut.await.and_then(|val| {
-                                serde_json::to_value(&val)
-                                    .map_err(|e| IIIError::Serde(e.to_string()))
+                                serde_json::to_value(&val).map_err(|e| Error::Serde(e.to_string()))
                             })
                         })
                     }
-                    Err(e) => Box::pin(async move { Err(IIIError::Serde(e.to_string())) }),
+                    Err(e) => Box::pin(async move { Err(Error::Serde(e.to_string())) }),
                 }
             },
         )
@@ -515,7 +514,7 @@ fn empty_message() -> RegisterFunctionMessage {
 ///
 /// Constructors:
 /// - [`RegisterFunction::new`] — sync function. Accepts both typed handlers
-///   (schemas auto-extracted via `schemars`) and `Fn(Value) -> Result<Value, IIIError>`
+///   (schemas auto-extracted via `schemars`) and `Fn(Value) -> Result<Value, Error>`
 ///   closures (permissive `AnyValue` schema, since `Value: JsonSchema`).
 /// - [`RegisterFunction::new_async`] — async equivalent of `new`.
 /// - [`RegisterFunction::http`] — function invoked over HTTP (Lambda,
@@ -820,7 +819,7 @@ impl III {
     ///
     /// # Examples
     /// ```rust,no_run
-    /// use iii_sdk::{register_worker, InitOptions, IIIError, RegisterFunction};
+    /// use iii_sdk::{register_worker, InitOptions, Error, RegisterFunction};
     /// use serde::{Deserialize, Serialize};
     /// use schemars::JsonSchema;
     ///
@@ -829,7 +828,7 @@ impl III {
     /// #[derive(Serialize, JsonSchema)]
     /// struct Output { message: String }
     ///
-    /// async fn greet(input: Input) -> Result<Output, IIIError> {
+    /// async fn greet(input: Input) -> Result<Output, Error> {
     ///     Ok(Output { message: format!("Hello, {}!", input.name) })
     /// }
     ///
@@ -886,8 +885,8 @@ impl III {
     /// # struct MyHandler;
     /// # #[async_trait::async_trait]
     /// # impl iii_sdk::TriggerHandler for MyHandler {
-    /// #     async fn register_trigger(&self, _: iii_sdk::TriggerConfig) -> Result<(), iii_sdk::IIIError> { Ok(()) }
-    /// #     async fn unregister_trigger(&self, _: iii_sdk::TriggerConfig) -> Result<(), iii_sdk::IIIError> { Ok(()) }
+    /// #     async fn register_trigger(&self, _: iii_sdk::TriggerConfig) -> Result<(), iii_sdk::Error> { Ok(()) }
+    /// #     async fn unregister_trigger(&self, _: iii_sdk::TriggerConfig) -> Result<(), iii_sdk::Error> { Ok(()) }
     /// # }
     /// # #[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)] struct MyConfig { url: String }
     /// # #[derive(serde::Deserialize, schemars::JsonSchema)] struct MyRequest { data: String }
@@ -899,7 +898,7 @@ impl III {
     /// );
     ///
     /// // Compile-time safe: config must be MyConfig, function input must be MyRequest
-    /// my_trigger.register_function("my::handler", |req: MyRequest| -> Result<serde_json::Value, iii_sdk::IIIError> {
+    /// my_trigger.register_function("my::handler", |req: MyRequest| -> Result<serde_json::Value, iii_sdk::Error> {
     ///     Ok(serde_json::json!({ "data": req.data }))
     /// });
     /// my_trigger.register_trigger("my::handler", MyConfig { url: "/hook".into() });
@@ -963,9 +962,9 @@ impl III {
     /// })?;
     /// // Later...
     /// trigger.unregister();
-    /// # Ok::<(), iii_sdk::IIIError>(())
+    /// # Ok::<(), iii_sdk::Error>(())
     /// ```
-    pub fn register_trigger(&self, input: RegisterTriggerInput) -> Result<Trigger, IIIError> {
+    pub fn register_trigger(&self, input: RegisterTriggerInput) -> Result<Trigger, Error> {
         let id = Uuid::new_v4().to_string();
         let message = RegisterTriggerMessage {
             id: id.clone(),
@@ -1007,7 +1006,7 @@ impl III {
     /// ```rust
     /// # use iii_sdk::{III, TriggerRequest, TriggerAction};
     /// # use serde_json::json;
-    /// # async fn example(iii: &III) -> Result<(), iii_sdk::IIIError> {
+    /// # async fn example(iii: &III) -> Result<(), iii_sdk::Error> {
     /// // Synchronous
     /// let result = iii.trigger(TriggerRequest {
     ///     function_id: "greet".to_string(),
@@ -1038,7 +1037,7 @@ impl III {
     pub async fn trigger(
         &self,
         request: impl Into<crate::protocol::TriggerRequest>,
-    ) -> Result<Value, IIIError> {
+    ) -> Result<Value, Error> {
         let req = request.into();
         let (tp, bg) = inject_trace_headers();
 
@@ -1076,10 +1075,10 @@ impl III {
 
         match tokio::time::timeout(timeout, rx).await {
             Ok(Ok(result)) => result,
-            Ok(Err(_)) => Err(IIIError::NotConnected),
+            Ok(Err(_)) => Err(Error::NotConnected),
             Err(_) => {
                 self.inner.pending.lock_or_recover().remove(&invocation_id);
-                Err(IIIError::Timeout)
+                Err(Error::Timeout)
             }
         }
     }
@@ -1122,7 +1121,7 @@ impl III {
         }
     }
 
-    fn send_message(&self, message: Message) -> Result<(), IIIError> {
+    fn send_message(&self, message: Message) -> Result<(), Error> {
         if !self.inner.running.load(Ordering::SeqCst) {
             return Ok(());
         }
@@ -1130,7 +1129,7 @@ impl III {
         self.inner
             .outbound
             .send(Outbound::Message(message))
-            .map_err(|_| IIIError::NotConnected)
+            .map_err(|_| Error::NotConnected)
     }
 
     async fn run_connection(&self, mut rx: mpsc::UnboundedReceiver<Outbound>) {
@@ -1354,11 +1353,7 @@ impl III {
         *queue = deduped_rev;
     }
 
-    async fn flush_queue(
-        &self,
-        ws_tx: &mut WsTx,
-        queue: &mut Vec<Message>,
-    ) -> Result<(), IIIError> {
+    async fn flush_queue(&self, ws_tx: &mut WsTx, queue: &mut Vec<Message>) -> Result<(), Error> {
         let mut drained = Vec::new();
         std::mem::swap(queue, &mut drained);
 
@@ -1374,13 +1369,13 @@ impl III {
         Ok(())
     }
 
-    async fn send_ws(&self, ws_tx: &mut WsTx, message: &Message) -> Result<(), IIIError> {
+    async fn send_ws(&self, ws_tx: &mut WsTx, message: &Message) -> Result<(), Error> {
         let payload = serde_json::to_string(message)?;
         ws_tx.send(WsMessage::Text(payload.into())).await?;
         Ok(())
     }
 
-    fn handle_frame(&self, frame: WsMessage) -> Result<(), IIIError> {
+    fn handle_frame(&self, frame: WsMessage) -> Result<(), Error> {
         match frame {
             WsMessage::Text(text) => self.handle_message(&text),
             WsMessage::Binary(bytes) => {
@@ -1391,7 +1386,7 @@ impl III {
         }
     }
 
-    fn handle_message(&self, payload: &str) -> Result<(), IIIError> {
+    fn handle_message(&self, payload: &str) -> Result<(), Error> {
         let message: Message = serde_json::from_str(payload)?;
 
         match message {
@@ -1461,7 +1456,7 @@ impl III {
         let sender = self.inner.pending.lock_or_recover().remove(&invocation_id);
         if let Some(sender) = sender {
             let result = match error {
-                Some(error) => Err(IIIError::Remote {
+                Some(error) => Err(Error::Remote {
                     code: error.code,
                     message: error.message,
                     stacktrace: error.stacktrace,
@@ -1620,7 +1615,7 @@ impl III {
                     Ok(_) => span.set_status(Status::Ok),
                     Err(err) => {
                         let (exc_type, exc_message, stacktrace) = match err {
-                            IIIError::Remote {
+                            Error::Remote {
                                 code,
                                 message,
                                 stacktrace,
@@ -1671,7 +1666,7 @@ impl III {
                     },
                     Err(err) => {
                         let error_body = match err {
-                            IIIError::Remote {
+                            Error::Remote {
                                 code,
                                 message,
                                 stacktrace,
@@ -1805,7 +1800,7 @@ impl III {
 pub(crate) async fn internal_create_channel(
     iii: &III,
     buffer_size: Option<usize>,
-) -> Result<Channel, IIIError> {
+) -> Result<Channel, Error> {
     let result = iii
         .trigger(TriggerRequest {
             function_id: "engine::channels::create".to_string(),
@@ -1819,17 +1814,17 @@ pub(crate) async fn internal_create_channel(
         result
             .get("writer")
             .cloned()
-            .ok_or_else(|| IIIError::Serde("missing 'writer' in channel response".into()))?,
+            .ok_or_else(|| Error::Serde("missing 'writer' in channel response".into()))?,
     )
-    .map_err(|e| IIIError::Serde(e.to_string()))?;
+    .map_err(|e| Error::Serde(e.to_string()))?;
 
     let reader_ref: StreamChannelRef = serde_json::from_value(
         result
             .get("reader")
             .cloned()
-            .ok_or_else(|| IIIError::Serde("missing 'reader' in channel response".into()))?,
+            .ok_or_else(|| Error::Serde("missing 'reader' in channel response".into()))?,
     )
-    .map_err(|e| IIIError::Serde(e.to_string()))?;
+    .map_err(|e| Error::Serde(e.to_string()))?;
 
     Ok(Channel {
         writer: ChannelWriter::new(&iii.inner.address, &writer_ref),
@@ -1960,7 +1955,7 @@ mod tests {
         struct Out {
             message: String,
         }
-        async fn greet(input: In) -> Result<Out, IIIError> {
+        async fn greet(input: In) -> Result<Out, Error> {
             Ok(Out {
                 message: format!("Hello, {}!", input.name),
             })
@@ -1982,7 +1977,7 @@ mod tests {
         struct In {
             name: String,
         }
-        async fn handler(input: In) -> Result<String, IIIError> {
+        async fn handler(input: In) -> Result<String, Error> {
             Ok(input.name)
         }
 
@@ -2019,7 +2014,7 @@ mod tests {
             })
             .await;
 
-        assert!(matches!(result, Err(IIIError::Timeout)));
+        assert!(matches!(result, Err(Error::Timeout)));
         assert!(iii.inner.pending.lock().unwrap().is_empty());
     }
 

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -9,12 +9,22 @@ pub mod structs;
 pub mod triggers;
 pub mod types;
 
+/// Public error types. (Stage 1 submodule grouping.)
+pub mod errors {
+    pub use crate::error::Error;
+}
+
 pub use builtin_triggers::{
     IIITrigger, StreamCallRequest, StreamEventDetail, StreamEventType, StreamJoinLeaveCallRequest,
     StreamJoinLeaveTriggerConfig, StreamTriggerConfig,
 };
 pub use channels::{ChannelReader, ChannelWriter, StreamChannelRef};
-pub use error::IIIError;
+pub use error::Error;
+#[deprecated(
+    since = "0.19.0",
+    note = "renamed to Error; import from iii_sdk::errors"
+)]
+pub use error::Error as IIIError;
 pub use iii::{
     FunctionInfo, FunctionRef, III, IIIConnectionState, RegisterFunction, RegisterTriggerType,
     TriggerInfo, TriggerTypeRef, WorkerInfo, WorkerMetadata,
@@ -143,3 +153,15 @@ fn _ensure_is_channel_ref_not_top_level() {}
 /// ```
 #[allow(dead_code)]
 fn _ensure_create_channel_not_on_instance() {}
+
+// ---------------------------------------------------------------------------
+// Stage 1 errors submodule: the renamed error type is reachable at its new
+// canonical path `iii_sdk::errors::Error`.
+// ---------------------------------------------------------------------------
+
+/// ```rust,no_run
+/// use iii_sdk::errors::Error;
+/// fn _takes(_e: Error) {}
+/// ```
+#[allow(dead_code)]
+fn _ensure_errors_submodule_path() {}

--- a/sdk/packages/rust/iii/src/stream_provider.rs
+++ b/sdk/packages/rust/iii/src/stream_provider.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use serde_json::Value;
 
-use crate::error::IIIError;
+use crate::error::Error;
 use crate::types::{
     DeleteResult, SetResult, StreamDeleteInput, StreamGetInput, StreamListGroupsInput,
     StreamListInput, StreamSetInput, StreamUpdateInput, UpdateResult,
@@ -12,10 +12,10 @@ use crate::types::{
 /// `create_stream` in the `helpers` submodule.
 #[async_trait]
 pub trait IStream: Send + Sync + 'static {
-    async fn get(&self, input: StreamGetInput) -> Result<Option<Value>, IIIError>;
-    async fn set(&self, input: StreamSetInput) -> Result<Option<SetResult>, IIIError>;
-    async fn delete(&self, input: StreamDeleteInput) -> Result<DeleteResult, IIIError>;
-    async fn list(&self, input: StreamListInput) -> Result<Vec<Value>, IIIError>;
-    async fn list_groups(&self, input: StreamListGroupsInput) -> Result<Vec<String>, IIIError>;
-    async fn update(&self, input: StreamUpdateInput) -> Result<Option<UpdateResult>, IIIError>;
+    async fn get(&self, input: StreamGetInput) -> Result<Option<Value>, Error>;
+    async fn set(&self, input: StreamSetInput) -> Result<Option<SetResult>, Error>;
+    async fn delete(&self, input: StreamDeleteInput) -> Result<DeleteResult, Error>;
+    async fn list(&self, input: StreamListInput) -> Result<Vec<Value>, Error>;
+    async fn list_groups(&self, input: StreamListGroupsInput) -> Result<Vec<String>, Error>;
+    async fn update(&self, input: StreamUpdateInput) -> Result<Option<UpdateResult>, Error>;
 }

--- a/sdk/packages/rust/iii/src/triggers.rs
+++ b/sdk/packages/rust/iii/src/triggers.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::Value;
 
-use crate::error::IIIError;
+use crate::error::Error;
 
 /// Configuration passed to a [`TriggerHandler`] when a trigger instance is
 /// registered or unregistered.
@@ -24,9 +24,9 @@ pub struct TriggerConfig {
 #[async_trait]
 pub trait TriggerHandler: Send + Sync {
     /// Called when a trigger instance is registered.
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError>;
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error>;
     /// Called when a trigger instance is unregistered.
-    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), IIIError>;
+    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), Error>;
 }
 
 /// Handle returned by [`III::register_trigger`](crate::III::register_trigger).

--- a/sdk/packages/rust/iii/src/types.rs
+++ b/sdk/packages/rust/iii/src/types.rs
@@ -7,13 +7,13 @@ use serde_json::Value;
 
 use crate::{
     channels::{ChannelReader, ChannelWriter, StreamChannelRef},
-    error::IIIError,
+    error::Error,
     protocol::{RegisterFunctionMessage, RegisterTriggerTypeMessage},
     triggers::TriggerHandler,
 };
 
 pub type RemoteFunctionHandler =
-    Arc<dyn Fn(Value) -> BoxFuture<'static, Result<Value, IIIError>> + Send + Sync>;
+    Arc<dyn Fn(Value) -> BoxFuture<'static, Result<Value, Error>> + Send + Sync>;
 
 // ============================================================================
 // Stream Update Types

--- a/sdk/packages/rust/iii/tests/api_triggers.rs
+++ b/sdk/packages/rust/iii/tests/api_triggers.rs
@@ -12,7 +12,7 @@ use serde_json::{Value, json};
 use serial_test::serial;
 use tokio::sync::Mutex;
 
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput};
+use iii_sdk::{Error, RegisterFunction, RegisterTriggerInput};
 use tokio::time::sleep;
 
 fn test_pdf_path() -> PathBuf {
@@ -146,7 +146,7 @@ async fn raw_json_request_body() {
                 let raw = reader
                     .read_all()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .send_message(
@@ -156,7 +156,7 @@ async fn raw_json_request_body() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .send_message(
@@ -166,23 +166,23 @@ async fn raw_json_request_body() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let response_body = serde_json::to_vec(&json!({
                     "parsed_body": parsed_body,
                     "raw_body": String::from_utf8(raw)
-                        .map_err(|e| IIIError::Handler(e.to_string()))?,
+                        .map_err(|e| Error::Handler(e.to_string()))?,
                 }))
-                .map_err(|e| IIIError::Handler(e.to_string()))?;
+                .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .write(&response_body)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 writer
                     .close()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 Ok(Value::Null)
             }
@@ -437,7 +437,7 @@ async fn download_pdf_streaming() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .send_message(
@@ -447,16 +447,16 @@ async fn download_pdf_streaming() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .write(&pdf_data)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 writer
                     .close()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 Ok(Value::Null)
             }
@@ -552,7 +552,7 @@ async fn upload_pdf_streaming() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .send_message(
@@ -562,25 +562,25 @@ async fn upload_pdf_streaming() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let data = reader
                     .read_all()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 let len = data.len();
                 *received.lock().await = data;
 
                 let body = serde_json::to_vec(&json!({"received_size": len}))
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 writer
                     .write(&body)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 writer
                     .close()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 Ok(Value::Null)
             }
@@ -656,7 +656,7 @@ async fn sse_streaming() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .send_message(
@@ -670,7 +670,7 @@ async fn sse_streaming() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 for event in &events {
                     let mut frame = String::new();
@@ -684,14 +684,14 @@ async fn sse_streaming() {
                     writer
                         .write(frame.as_bytes())
                         .await
-                        .map_err(|e| IIIError::Handler(e.to_string()))?;
+                        .map_err(|e| Error::Handler(e.to_string()))?;
                     tokio::time::sleep(Duration::from_millis(50)).await;
                 }
 
                 writer
                     .close()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 Ok(Value::Null)
             }
         }),
@@ -792,7 +792,7 @@ async fn urlencoded_form_data() {
                 let raw = reader
                     .read_all()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 let body = String::from_utf8_lossy(&raw);
 
                 let params: std::collections::HashMap<String, String> = body
@@ -815,7 +815,7 @@ async fn urlencoded_form_data() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .send_message(
@@ -825,23 +825,23 @@ async fn urlencoded_form_data() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let result = serde_json::to_vec(&json!({
                     "name": params.get("name"),
                     "email": params.get("email"),
                     "age": params.get("age"),
                 }))
-                .map_err(|e| IIIError::Handler(e.to_string()))?;
+                .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .write(&result)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 writer
                     .close()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 Ok(Value::Null)
             }
@@ -943,7 +943,7 @@ async fn multipart_form_data() {
                 let raw = reader
                     .read_all()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let content_type = input
                     .get("headers")
@@ -968,7 +968,7 @@ async fn multipart_form_data() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .send_message(
@@ -978,7 +978,7 @@ async fn multipart_form_data() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let result = serde_json::to_vec(&json!({
                     "has_boundary": has_boundary,
@@ -987,16 +987,16 @@ async fn multipart_form_data() {
                     "has_filename": has_filename,
                     "body_size": raw.len(),
                 }))
-                .map_err(|e| IIIError::Handler(e.to_string()))?;
+                .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .write(&result)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 writer
                     .close()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 Ok(Value::Null)
             }

--- a/sdk/packages/rust/iii/tests/data_channels.rs
+++ b/sdk/packages/rust/iii/tests/data_channels.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
 
-use iii_sdk::{IIIError, RegisterFunction, TriggerRequest};
+use iii_sdk::{Error, RegisterFunction, TriggerRequest};
 
 #[tokio::test]
 async fn stream_data_from_sender_to_processor() {
@@ -32,9 +32,9 @@ async fn stream_data_from_sender_to_processor() {
                     .expect("missing reader channel ref");
 
                 let reader = iii_sdk::ChannelReader::new(iii.address(), &reader_ref);
-                let raw = reader.read_all().await.map_err(|e| IIIError::Handler(e.to_string()))?;
+                let raw = reader.read_all().await.map_err(|e| Error::Handler(e.to_string()))?;
                 let records: Vec<Value> = serde_json::from_slice(&raw)
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let values: Vec<f64> = records
                     .iter()
@@ -69,20 +69,20 @@ async fn stream_data_from_sender_to_processor() {
                 let records = input["records"].clone();
                 let channel = iii_sdk::helpers::create_channel(&iii, None)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let payload =
-                    serde_json::to_vec(&records).map_err(|e| IIIError::Handler(e.to_string()))?;
+                    serde_json::to_vec(&records).map_err(|e| Error::Handler(e.to_string()))?;
                 channel
                     .writer
                     .write(&payload)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 channel
                     .writer
                     .close()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let result = iii
                     .trigger(TriggerRequest {
@@ -95,7 +95,7 @@ async fn stream_data_from_sender_to_processor() {
                         timeout_ms: None,
                     })
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 Ok(result)
             }
@@ -185,7 +185,7 @@ async fn bidirectional_streaming() {
                 while let Some(chunk) = reader
                     .next_binary()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?
+                    .map_err(|e| Error::Handler(e.to_string()))?
                 {
                     chunks.push(chunk);
                     chunk_count += 1;
@@ -198,7 +198,7 @@ async fn bidirectional_streaming() {
                             .unwrap(),
                         )
                         .await
-                        .map_err(|e| IIIError::Handler(e.to_string()))?;
+                        .map_err(|e| Error::Handler(e.to_string()))?;
                 }
 
                 let full_data: Vec<u8> = chunks.iter().flatten().copied().collect();
@@ -215,21 +215,21 @@ async fn bidirectional_streaming() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let result_json = serde_json::to_vec(&json!({
                     "words": &words[..5.min(words.len())],
                     "total": words.len(),
                 }))
-                .map_err(|e| IIIError::Handler(e.to_string()))?;
+                .map_err(|e| Error::Handler(e.to_string()))?;
                 writer
                     .write(&result_json)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 writer
                     .close()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 Ok(json!({"status": "done"}))
             }
@@ -247,10 +247,10 @@ async fn bidirectional_streaming() {
 
                 let input_channel = iii_sdk::helpers::create_channel(&iii, None)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 let output_channel = iii_sdk::helpers::create_channel(&iii, None)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let messages: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
                 let msgs_clone = messages.clone();
@@ -303,18 +303,18 @@ async fn bidirectional_streaming() {
                     .reader
                     .read_all()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 write_handle
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 let worker_result = call_handle
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let binary_result: Value = serde_json::from_slice(&result_data)
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 // Give a moment for async message callbacks to settle
                 tokio::time::sleep(Duration::from_millis(100)).await;

--- a/sdk/packages/rust/iii/tests/queue_integration.rs
+++ b/sdk/packages/rust/iii/tests/queue_integration.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
 
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput, TriggerAction, TriggerRequest};
+use iii_sdk::{Error, RegisterFunction, RegisterTriggerInput, TriggerAction, TriggerRequest};
 
 fn unique_topic(prefix: &str) -> String {
     let ts = std::time::SystemTime::now()
@@ -79,14 +79,14 @@ async fn enqueue_to_unknown_queue_returns_error() {
         .await;
 
     match result {
-        Err(IIIError::Remote { code, message, .. }) => {
+        Err(Error::Remote { code, message, .. }) => {
             assert_eq!(
                 code, "enqueue_error",
                 "expected enqueue_error code, got: {code}"
             );
             assert!(!message.is_empty(), "error message should not be empty");
         }
-        Err(other) => panic!("expected IIIError::Remote with enqueue_error code, got: {other:?}"),
+        Err(other) => panic!("expected Error::Remote with enqueue_error code, got: {other:?}"),
         Ok(val) => panic!("expected error, got success: {val}"),
     }
 }
@@ -155,7 +155,7 @@ async fn enqueue_fifo_missing_group_field_returns_error() {
         .await;
 
     match result {
-        Err(IIIError::Remote { code, message, .. }) => {
+        Err(Error::Remote { code, message, .. }) => {
             assert_eq!(
                 code, "enqueue_error",
                 "expected enqueue_error code, got: {code}"
@@ -165,7 +165,7 @@ async fn enqueue_fifo_missing_group_field_returns_error() {
                 "error message should mention the missing field 'transaction_id', got: {message}"
             );
         }
-        Err(other) => panic!("expected IIIError::Remote with enqueue_error code, got: {other:?}"),
+        Err(other) => panic!("expected Error::Remote with enqueue_error code, got: {other:?}"),
         Ok(val) => panic!("expected error for missing group field, got success: {val}"),
     }
 }
@@ -298,7 +298,7 @@ async fn chained_enqueue() {
                     timeout_ms: None,
                 })
                 .await
-                .map_err(|e| IIIError::Handler(e.to_string()))?;
+                .map_err(|e| Error::Handler(e.to_string()))?;
 
                 Ok(json!({ "step": "a_done" }))
             }

--- a/sdk/packages/rust/iii/tests/rbac_workers.rs
+++ b/sdk/packages/rust/iii/tests/rbac_workers.rs
@@ -142,7 +142,7 @@ fn ensure_functions_registered() {
                             context: json!({ "role": "prefixed", "user_id": "user-prefix" }),
                             function_registration_prefix: Some("test-prefix".to_string()),
                         }),
-                        _ => Err(iii_sdk::IIIError::Handler("invalid token".to_string())),
+                        _ => Err(iii_sdk::Error::Handler("invalid token".to_string())),
                     }
                 }
             }),
@@ -181,11 +181,11 @@ fn ensure_functions_registered() {
             "test::rbac-worker::on-function-reg",
             RegisterFunction::new_async(|input: OnFunctionRegistrationInput| async move {
                 if input.function_id.starts_with("denied::") {
-                    return Err(iii_sdk::IIIError::Handler(
+                    return Err(iii_sdk::Error::Handler(
                         "denied function registration".into(),
                     ));
                 }
-                Ok::<_, iii_sdk::IIIError>(OnFunctionRegistrationResult {
+                Ok::<_, iii_sdk::Error>(OnFunctionRegistrationResult {
                     function_id: Some(input.function_id),
                     ..Default::default()
                 })
@@ -201,11 +201,11 @@ fn ensure_functions_registered() {
                     let denied = input.trigger_type_id.starts_with("denied-tt::");
                     tt_reg_calls.lock().unwrap().push(input);
                     if denied {
-                        return Err(iii_sdk::IIIError::Handler(
+                        return Err(iii_sdk::Error::Handler(
                             "denied trigger type registration".into(),
                         ));
                     }
-                    Ok::<_, iii_sdk::IIIError>(OnTriggerTypeRegistrationResult::default())
+                    Ok::<_, iii_sdk::Error>(OnTriggerTypeRegistrationResult::default())
                 }
             }),
         ));
@@ -219,11 +219,11 @@ fn ensure_functions_registered() {
                     let denied = input.function_id.starts_with("denied-trig::");
                     trig_reg_calls.lock().unwrap().push(input);
                     if denied {
-                        return Err(iii_sdk::IIIError::Handler(
+                        return Err(iii_sdk::Error::Handler(
                             "denied trigger registration".into(),
                         ));
                     }
-                    Ok::<_, iii_sdk::IIIError>(OnTriggerRegistrationResult::default())
+                    Ok::<_, iii_sdk::Error>(OnTriggerRegistrationResult::default())
                 }
             }),
         ));
@@ -235,13 +235,13 @@ fn ensure_functions_registered() {
                 async fn register_trigger(
                     &self,
                     _config: iii_sdk::TriggerConfig,
-                ) -> Result<(), iii_sdk::IIIError> {
+                ) -> Result<(), iii_sdk::Error> {
                     Ok(())
                 }
                 async fn unregister_trigger(
                     &self,
                     _config: iii_sdk::TriggerConfig,
-                ) -> Result<(), iii_sdk::IIIError> {
+                ) -> Result<(), iii_sdk::Error> {
                     Ok(())
                 }
             }
@@ -479,13 +479,13 @@ async fn should_deny_trigger_type_registration_via_hook() {
             async fn register_trigger(
                 &self,
                 _config: iii_sdk::TriggerConfig,
-            ) -> Result<(), iii_sdk::IIIError> {
+            ) -> Result<(), iii_sdk::Error> {
                 Ok(())
             }
             async fn unregister_trigger(
                 &self,
                 _config: iii_sdk::TriggerConfig,
-            ) -> Result<(), iii_sdk::IIIError> {
+            ) -> Result<(), iii_sdk::Error> {
                 Ok(())
             }
         }
@@ -808,13 +808,13 @@ async fn infrastructure_logger_callable_from_user_handler_under_restricted_expos
                     })
                     .await
                     .map_err(|e| {
-                        iii_sdk::IIIError::Handler(format!(
+                        iii_sdk::Error::Handler(format!(
                             "engine::log::info must be allowed via \
                              INFRASTRUCTURE_FUNCTIONS carve-out under a \
                              restricted expose; got: {e}"
                         ))
                     })?;
-                Ok::<_, iii_sdk::IIIError>(json!({ "logged": true }))
+                Ok::<_, iii_sdk::Error>(json!({ "logged": true }))
             }
         }),
     );

--- a/sdk/packages/rust/iii/tests/registration_dedup.rs
+++ b/sdk/packages/rust/iii/tests/registration_dedup.rs
@@ -20,7 +20,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use iii_sdk::{
-    III, IIIConnectionState, IIIError, InitOptions, RegisterFunction, RegisterTriggerInput,
+    Error, III, IIIConnectionState, InitOptions, RegisterFunction, RegisterTriggerInput,
     RegisterTriggerType, TriggerConfig, TriggerHandler, register_worker,
 };
 
@@ -31,7 +31,7 @@ struct GreetInput {
     name: String,
 }
 
-fn greet(input: GreetInput) -> Result<String, IIIError> {
+fn greet(input: GreetInput) -> Result<String, Error> {
     Ok(format!("Hello, {}", input.name))
 }
 
@@ -40,7 +40,7 @@ struct EchoInput {
     payload: Value,
 }
 
-fn echo(input: EchoInput) -> Result<Value, IIIError> {
+fn echo(input: EchoInput) -> Result<Value, Error> {
     Ok(input.payload)
 }
 
@@ -48,10 +48,10 @@ struct NoopHandler;
 
 #[async_trait::async_trait]
 impl TriggerHandler for NoopHandler {
-    async fn register_trigger(&self, _: TriggerConfig) -> Result<(), iii_sdk::IIIError> {
+    async fn register_trigger(&self, _: TriggerConfig) -> Result<(), iii_sdk::Error> {
         Ok(())
     }
-    async fn unregister_trigger(&self, _: TriggerConfig) -> Result<(), iii_sdk::IIIError> {
+    async fn unregister_trigger(&self, _: TriggerConfig) -> Result<(), iii_sdk::Error> {
         Ok(())
     }
 }

--- a/sdk/packages/rust/iii/tests/stream_provider_trait.rs
+++ b/sdk/packages/rust/iii/tests/stream_provider_trait.rs
@@ -9,28 +9,22 @@ struct DummyStream;
 
 #[async_trait]
 impl IStream for DummyStream {
-    async fn get(&self, _: StreamGetInput) -> Result<Option<Value>, iii_sdk::IIIError> {
+    async fn get(&self, _: StreamGetInput) -> Result<Option<Value>, iii_sdk::Error> {
         Ok(None)
     }
-    async fn set(&self, _: StreamSetInput) -> Result<Option<SetResult>, iii_sdk::IIIError> {
+    async fn set(&self, _: StreamSetInput) -> Result<Option<SetResult>, iii_sdk::Error> {
         Ok(None)
     }
-    async fn delete(&self, _: StreamDeleteInput) -> Result<DeleteResult, iii_sdk::IIIError> {
+    async fn delete(&self, _: StreamDeleteInput) -> Result<DeleteResult, iii_sdk::Error> {
         Ok(DeleteResult::default())
     }
-    async fn list(&self, _: StreamListInput) -> Result<Vec<Value>, iii_sdk::IIIError> {
+    async fn list(&self, _: StreamListInput) -> Result<Vec<Value>, iii_sdk::Error> {
         Ok(vec![])
     }
-    async fn list_groups(
-        &self,
-        _: StreamListGroupsInput,
-    ) -> Result<Vec<String>, iii_sdk::IIIError> {
+    async fn list_groups(&self, _: StreamListGroupsInput) -> Result<Vec<String>, iii_sdk::Error> {
         Ok(vec![])
     }
-    async fn update(
-        &self,
-        _: StreamUpdateInput,
-    ) -> Result<Option<UpdateResult>, iii_sdk::IIIError> {
+    async fn update(&self, _: StreamUpdateInput) -> Result<Option<UpdateResult>, iii_sdk::Error> {
         Ok(None)
     }
 }

--- a/sdk/packages/rust/iii/tests/trigger_type_lifecycle.rs
+++ b/sdk/packages/rust/iii/tests/trigger_type_lifecycle.rs
@@ -8,8 +8,8 @@ use serial_test::serial;
 
 use async_trait::async_trait;
 use iii_sdk::{
-    IIIConnectionState, IIIError, InitOptions, RegisterFunction, RegisterTriggerInput,
-    TriggerConfig, TriggerHandler, TriggerRequest, register_worker,
+    Error, IIIConnectionState, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerConfig,
+    TriggerHandler, TriggerRequest, register_worker,
 };
 use serde_json::{Value, json};
 use tokio::time::Duration;
@@ -32,13 +32,13 @@ struct LifecycleTriggerHandler {
 
 #[async_trait]
 impl TriggerHandler for LifecycleTriggerHandler {
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         self.state.bindings.lock().unwrap().push(config.clone());
         self.state.register_calls.lock().unwrap().push(config);
         Ok(())
     }
 
-    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         let stored = {
             let mut bindings = self.state.bindings.lock().unwrap();
             let idx = bindings.iter().position(|b| b.id == config.id);


### PR DESCRIPTION
Renames the Rust SDK error enum `IIIError` to `Error`, grouped under a new `iii_sdk::errors` submodule. Canonical path is now `iii_sdk::errors::Error`.

The crate root keeps a deprecated `IIIError` alias (`#[deprecated] pub use error::Error as IIIError`), so `iii_sdk::IIIError` still resolves. The renamed type is also re-exported at the root as `iii_sdk::Error`.

- `error.rs`: enum renamed.
- `lib.rs`: `pub mod errors` grouping + deprecated root alias + a doctest pinning the new path.
- Internal modules, integration tests, and the `iii-example` crate updated to `Error` (keeps `clippy --all-targets -D warnings` clean).
- Reference docs updated (`rust-sdk.mdx` + skill companion).

No behavior change; pure rename plus submodule grouping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Rust SDK docs to prefer the new canonical error type path and mark the old name as deprecated.

* **Bug Fixes / Updates**
  * Unified SDK error handling to use the new Error type; legacy name kept as a deprecated alias.
  * Canonical error path exposed under the SDK errors module.

* **Examples & Tests**
  * All examples and tests updated to use the unified Error type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->