### PR TITLE
refactor(node-sdk)!: add iii-sdk/channel subpath

### DIFF
--- a/docs/next/sdk-reference/node-sdk.mdx
+++ b/docs/next/sdk-reference/node-sdk.mdx
@@ -128,6 +128,10 @@ Common `code` values come from the engine: `invocation_failed` (handler threw), 
 
 ## Channels
 
+Import channel symbols from the `iii-sdk/channel` subpath
+(`import { ChannelReader, ChannelWriter } from 'iii-sdk/channel'`). They stay exported from the
+package root as deprecated re-exports.
+
 `ChannelReader` and `ChannelWriter` are runtime classes wrapping the engine's stream WebSockets.
 `StreamChannelRef` is the type passed between SDK calls to identify a channel:
 

--- a/docs/next/sdk-reference/node-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/node-sdk.mdx.skill.md
@@ -126,6 +126,10 @@ Common `code` values come from the engine: `invocation_failed` (handler threw), 
 
 ## Channels
 
+Import channel symbols from the `iii-sdk/channel` subpath
+(`import { ChannelReader, ChannelWriter } from 'iii-sdk/channel'`). They stay exported from the
+package root as deprecated re-exports.
+
 `ChannelReader` and `ChannelWriter` are runtime classes wrapping the engine's stream WebSockets.
 `StreamChannelRef` is the type passed between SDK calls to identify a channel:
 

--- a/sdk/packages/node/iii/package.json
+++ b/sdk/packages/node/iii/package.json
@@ -41,6 +41,11 @@
       "types": "./dist/helpers.d.ts",
       "import": "./dist/helpers.mjs",
       "require": "./dist/helpers.cjs"
+    },
+    "./channel": {
+      "types": "./dist/channel.d.ts",
+      "import": "./dist/channel.mjs",
+      "require": "./dist/channel.cjs"
     }
   },
   "dependencies": {

--- a/sdk/packages/node/iii/src/channel.ts
+++ b/sdk/packages/node/iii/src/channel.ts
@@ -1,0 +1,3 @@
+export { ChannelReader, ChannelWriter } from './channels'
+export type { StreamChannelRef } from './iii-types'
+export type { Channel } from './types'

--- a/sdk/packages/node/iii/src/index.ts
+++ b/sdk/packages/node/iii/src/index.ts
@@ -1,4 +1,7 @@
-export { ChannelReader, ChannelWriter } from './channels'
+/** @deprecated Import channel symbols from `iii-sdk/channel`. */
+export { ChannelReader, ChannelWriter } from './channel'
+/** @deprecated Import `Channel` / `StreamChannelRef` from `iii-sdk/channel`. */
+export type { Channel, StreamChannelRef } from './channel'
 
 export { IIIInvocationError, type IIIInvocationErrorInit } from './errors'
 
@@ -23,7 +26,6 @@ export type {
   RegisterFunctionMessage,
   RegisterTriggerMessage,
   RegisterTriggerTypeMessage,
-  StreamChannelRef,
   TriggerRequest,
 } from './iii-types'
 
@@ -32,7 +34,6 @@ export type { TriggerConfig, TriggerHandler } from './triggers'
 export type {
   ApiRequest,
   ApiResponse,
-  Channel,
   FunctionRef,
   HttpRequest,
   HttpResponse,

--- a/sdk/packages/node/iii/tests/exports.test.ts
+++ b/sdk/packages/node/iii/tests/exports.test.ts
@@ -22,4 +22,13 @@ describe('Package Exports', () => {
     expect(stateModule.StateEventType).toBeDefined()
     expect(Object.keys(stateModule).length).toBeGreaterThan(0)
   })
+
+  it('should export channel symbols from the subpath and keep the deprecated root shim', async () => {
+    const ch = await import('../src/channel')
+    expect(ch.ChannelReader).toBeDefined()
+    expect(ch.ChannelWriter).toBeDefined()
+    const root = await import('../src/index')
+    expect(root.ChannelReader).toBe(ch.ChannelReader)
+    expect(root.ChannelWriter).toBe(ch.ChannelWriter)
+  })
 })

--- a/sdk/packages/node/iii/tsdown.config.ts
+++ b/sdk/packages/node/iii/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['./src/index.ts', './src/stream.ts', './src/state.ts', './src/helpers.ts'],
+  entry: ['./src/index.ts', './src/stream.ts', './src/state.ts', './src/helpers.ts', './src/channel.ts'],
   format: ['esm', 'cjs'],
   dts: true,
   sourcemap: true,


### PR DESCRIPTION
Adds the `iii-sdk/channel` subpath exporting `ChannelReader`, `ChannelWriter`, `StreamChannelRef`, and `Channel`.

These symbols stay exported from the package root as deprecated re-exports, so existing imports keep working. No behavior change; pure relocation of the public import path.

- New build entry + `./channel` subpath export (`tsdown.config.ts`, `package.json`).
- `src/channel.ts` barrel; root `index.ts` re-exports it (JSDoc-deprecated).
- Reference docs updated (`node-sdk.mdx` + skill companion).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new subpath export for importing channel-related symbols with a cleaner import path.

* **Documentation**
  * Updated SDK reference documentation to guide users on the recommended import path; existing import paths remain available but are now marked as deprecated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->