### PR TITLE
refactor(python-sdk): add iii.channel submodule

### DIFF
--- a/docs/next/sdk-reference/python-sdk.mdx
+++ b/docs/next/sdk-reference/python-sdk.mdx
@@ -141,6 +141,10 @@ distinguish categories:
 
 ## Channels
 
+Import channel types from the `iii.channel` submodule
+(`from iii.channel import ChannelReader, ChannelWriter`). They stay importable from the package root
+as deprecated re-exports.
+
 `ChannelReader` and `ChannelWriter` wrap the engine's stream WebSockets. `StreamChannelRef`
 identifies a channel:
 

--- a/docs/next/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/python-sdk.mdx.skill.md
@@ -139,6 +139,10 @@ distinguish categories:
 
 ## Channels
 
+Import channel types from the `iii.channel` submodule
+(`from iii.channel import ChannelReader, ChannelWriter`). They stay importable from the package root
+as deprecated re-exports.
+
 `ChannelReader` and `ChannelWriter` wrap the engine's stream WebSockets. `StreamChannelRef`
 identifies a channel:
 

--- a/sdk/packages/python/iii/src/iii/channel.py
+++ b/sdk/packages/python/iii/src/iii/channel.py
@@ -1,0 +1,7 @@
+"""Public channel types."""
+
+from .channels import ChannelReader, ChannelWriter
+from .iii_types import StreamChannelRef
+from .types import Channel
+
+__all__ = ["Channel", "ChannelReader", "ChannelWriter", "StreamChannelRef"]

--- a/sdk/packages/python/iii/tests/test_channel_submodule.py
+++ b/sdk/packages/python/iii/tests/test_channel_submodule.py
@@ -1,0 +1,14 @@
+"""The iii.channel submodule exposes the channel types; the root keeps the shims."""
+
+
+def test_channel_subpath() -> None:
+    from iii.channel import Channel, ChannelReader, ChannelWriter, StreamChannelRef
+
+    assert all(x is not None for x in (ChannelReader, ChannelWriter, StreamChannelRef, Channel))
+
+
+def test_channel_root_shim() -> None:
+    import iii
+    from iii.channel import ChannelReader as SubReader
+
+    assert iii.ChannelReader is SubReader


### PR DESCRIPTION
Adds the `iii.channel` submodule, a curated barrel exporting `ChannelReader`, `ChannelWriter`, `StreamChannelRef`, and `Channel` (`from iii.channel import ...`).

These symbols stay importable from the package root, which remains the deprecated path. No behavior change; pure relocation of the canonical import path.

- New `src/iii/channel.py` barrel.
- Reference docs updated (`python-sdk.mdx` + skill companion).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a dedicated channel module providing clearer organization of channel-related types and imports.

* **Documentation**
  * Updated Python SDK reference documentation to clarify where channel types are imported from and to document deprecated re-export paths available at the package root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->