### PR TITLE
fix(sdk/go): route connection-scoped replies through a per-connection queue

### DIFF
--- a/sdk/packages/go/iii/client.go
+++ b/sdk/packages/go/iii/client.go
@@ -36,9 +36,18 @@ type Client struct {
 	reconnect ReconnectConfig
 	name      string
 
-	// outbound carries already-marshaled frames to the single writer goroutine. It is
-	// the only path to the socket, so writes are serialized without a write mutex.
+	// outbound carries connection-AGNOSTIC frames (registrations + offline-buffered
+	// invokes) to the single writer goroutine. It is shared across the client's lifetime
+	// and its contents are meant to (re)send on whichever connection is live.
 	outbound chan []byte
+
+	// reply is the per-connection channel for connection-SCOPED replies (pong,
+	// InvocationResult, TriggerRegistrationResult): frames that are only meaningful on the
+	// socket that prompted them. A fresh channel is created per connection and discarded on
+	// teardown, so a reply can never leak onto the next connection (iii-hq/iii#1749).
+	// Guarded by replyMu; nil when there is no live connection.
+	replyMu sync.Mutex
+	reply   chan []byte
 
 	mu       sync.Mutex
 	state    ConnectionState
@@ -452,15 +461,23 @@ func (c *Client) runConnection() error {
 	// The engine can send large registration payloads; lift the default read limit.
 	conn.SetReadLimit(-1)
 
+	// A reply channel owned by THIS connection. Connection-scoped replies go here so they
+	// can never be drained by a later connection's writer (iii-hq/iii#1749).
+	reply := make(chan []byte, 64)
+	c.replyMu.Lock()
+	c.reply = reply
+	c.replyMu.Unlock()
+
 	c.mu.Lock()
 	c.conn = conn
 	c.state = StateConnected
 	c.mu.Unlock()
 
-	// Start the single writer for this connection.
+	// Start the single writer for this connection. It drains the shared outbound channel
+	// and this connection's own reply channel.
 	writerDone := make(chan struct{})
 	c.writerWG.Add(1)
-	go c.writeLoop(connCtx, conn, writerDone)
+	go c.writeLoop(connCtx, conn, reply, writerDone)
 
 	// Signal the first successful connection to Connect's caller.
 	c.connOnce.Do(func() { close(c.connected) })
@@ -472,7 +489,12 @@ func (c *Client) runConnection() error {
 	// Read loop runs until the socket errors or closes.
 	readErr := c.readLoop(connCtx, conn)
 
-	// Tear down this connection: stop the writer, close the socket, clear conn.
+	// Tear down this connection: stop the writer, close the socket, clear conn. Detach the
+	// reply channel first so any reply enqueued during teardown is dropped (it has no live
+	// socket to go to) rather than lingering for the next connection.
+	c.replyMu.Lock()
+	c.reply = nil
+	c.replyMu.Unlock()
 	cancel()
 	<-writerDone
 	_ = conn.CloseNow()
@@ -577,10 +599,13 @@ type workerMetadata struct {
 // process can wire this to the module version later.
 const sdkVersion = "0.1.0"
 
-// writeLoop is the single writer for one connection: it drains outbound until the
-// connection context is cancelled. Routing every send through here keeps the socket
+// writeLoop is the single writer for one connection. It drains the shared outbound
+// channel (connection-agnostic frames) and this connection's own reply channel
+// (connection-scoped replies) until the connection context is cancelled. reply is passed
+// in (not read from c.reply) so this loop only ever touches its own connection's replies,
+// even if a reconnect swaps c.reply. Routing every send through here keeps the socket
 // single-writer, as coder/websocket requires.
-func (c *Client) writeLoop(ctx context.Context, conn *websocket.Conn, done chan struct{}) {
+func (c *Client) writeLoop(ctx context.Context, conn *websocket.Conn, reply <-chan []byte, done chan struct{}) {
 	defer c.writerWG.Done()
 	defer close(done)
 	for {
@@ -592,6 +617,10 @@ func (c *Client) writeLoop(ctx context.Context, conn *websocket.Conn, done chan 
 		case frame := <-c.outbound:
 			if err := conn.Write(ctx, websocket.MessageText, frame); err != nil {
 				return // write failure ends the connection; supervisor reconnects
+			}
+		case frame := <-reply:
+			if err := conn.Write(ctx, websocket.MessageText, frame); err != nil {
+				return
 			}
 		}
 	}
@@ -639,12 +668,21 @@ func (c *Client) dispatch(ctx context.Context, dec *DecodedMessage) {
 	}
 }
 
-// enqueueOutboundDirect sends a frame to the writer without the offline-buffering path —
-// used for protocol replies (pong, invocation results) that are only meaningful on the
-// connection they answer.
+// enqueueOutboundDirect sends a connection-scoped reply (pong, InvocationResult,
+// TriggerRegistrationResult) on the current connection's reply channel. If there is no
+// live connection, the reply is dropped: it answers a request that arrived on a socket
+// that is now gone, so there is nowhere valid to send it (the engine re-drives on
+// reconnect if it still wants the work). This is what keeps a stale reply from leaking
+// onto the next connection (iii-hq/iii#1749).
 func (c *Client) enqueueOutboundDirect(frame []byte) {
+	c.replyMu.Lock()
+	reply := c.reply
+	c.replyMu.Unlock()
+	if reply == nil {
+		return
+	}
 	select {
-	case c.outbound <- frame:
+	case reply <- frame:
 	case <-c.shutdown:
 	}
 }

--- a/sdk/packages/go/iii/client_reply_test.go
+++ b/sdk/packages/go/iii/client_reply_test.go
@@ -72,17 +72,25 @@ func TestReplyChannelLifecycle(t *testing.T) {
 	}
 
 	// Drop the connection; the teardown detaches the reply channel. Poll for it to go nil
-	// (teardown runs on the connection goroutine).
+	// (teardown runs on the connection goroutine). Clear the recorded frames before the
+	// drop so the post-reconnect assertion sees every frame from the disconnect window
+	// onward — clearing later could erase a leaked pong during a fast reconnect.
+	m.clear()
 	m.closeActiveConnection()
 	deadline := time.Now().Add(2 * time.Second)
+	detached := false
 	for time.Now().Before(deadline) {
 		c.replyMu.Lock()
 		nilled := c.reply == nil
 		c.replyMu.Unlock()
 		if nilled {
+			detached = true
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+	if !detached {
+		t.Fatal("reply channel was not detached after disconnect")
 	}
 
 	// A reply enqueued in the disconnected window must be dropped (no panic, no block,
@@ -90,8 +98,8 @@ func TestReplyChannelLifecycle(t *testing.T) {
 	c.enqueueOutboundDirect([]byte(`{"type":"pong"}`))
 
 	// After reconnect, the mock must not receive that stale pong. Wait for reconnect
-	// (a fresh registration/metadata frame), then assert no pong was recorded.
-	m.clear()
+	// (a fresh registration/metadata frame), then assert no pong was recorded. Nothing
+	// was cleared since the disconnect, so a leaked pong cannot escape the snapshot.
 	got := m.waitFor(func(msgs []map[string]json.RawMessage) bool {
 		return len(msgs) >= 1 // some frame after reconnect (worker metadata)
 	}, 2*time.Second)

--- a/sdk/packages/go/iii/client_reply_test.go
+++ b/sdk/packages/go/iii/client_reply_test.go
@@ -1,0 +1,101 @@
+package iii
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// Regression tests for iii-hq/iii#1749: connection-scoped replies must not leak onto a
+// later connection. They ride a per-connection reply channel; when there is no live
+// connection the reply is dropped.
+
+// TestEnqueueOutboundDirectDropsWhenDisconnected is the deterministic core invariant:
+// with no live connection (c.reply == nil), a connection-scoped reply is dropped rather
+// than buffered for the next connection. This is what prevents the stale-reply leak.
+func TestEnqueueOutboundDirectDropsWhenDisconnected(t *testing.T) {
+	c := New("ws://localhost:0")
+	// No connection has been established, so reply is nil.
+	c.replyMu.Lock()
+	if c.reply != nil {
+		t.Fatal("reply channel should be nil before any connection")
+	}
+	c.replyMu.Unlock()
+
+	// Must return immediately without blocking and without queueing onto the shared
+	// outbound channel (which the next connection would drain).
+	done := make(chan struct{})
+	go func() {
+		c.enqueueOutboundDirect([]byte(`{"type":"pong"}`))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("enqueueOutboundDirect blocked when disconnected; want immediate drop")
+	}
+
+	select {
+	case f := <-c.outbound:
+		t.Fatalf("dropped reply leaked onto the shared outbound channel: %s", f)
+	default:
+		// good: nothing on the shared channel
+	}
+}
+
+// TestReplyChannelLifecycle verifies the per-connection reply channel is installed on
+// connect and detached on disconnect, so a reply enqueued after the socket drops is
+// dropped rather than delivered on the next connection.
+func TestReplyChannelLifecycle(t *testing.T) {
+	m := newMockEngine(t)
+	c := New(m.url, WithReconnectConfig(ReconnectConfig{
+		InitialDelay:      10 * time.Millisecond,
+		MaxDelay:          50 * time.Millisecond,
+		BackoffMultiplier: 2,
+		JitterFactor:      0,
+		MaxRetries:        -1,
+	}))
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := c.Connect(ctx); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	// Connected: a reply channel is installed.
+	c.replyMu.Lock()
+	haveReply := c.reply != nil
+	c.replyMu.Unlock()
+	if !haveReply {
+		t.Fatal("reply channel should be non-nil while connected")
+	}
+
+	// Drop the connection; the teardown detaches the reply channel. Poll for it to go nil
+	// (teardown runs on the connection goroutine).
+	m.closeActiveConnection()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c.replyMu.Lock()
+		nilled := c.reply == nil
+		c.replyMu.Unlock()
+		if nilled {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// A reply enqueued in the disconnected window must be dropped (no panic, no block,
+	// nothing left to leak onto the reconnected socket).
+	c.enqueueOutboundDirect([]byte(`{"type":"pong"}`))
+
+	// After reconnect, the mock must not receive that stale pong. Wait for reconnect
+	// (a fresh registration/metadata frame), then assert no pong was recorded.
+	m.clear()
+	got := m.waitFor(func(msgs []map[string]json.RawMessage) bool {
+		return len(msgs) >= 1 // some frame after reconnect (worker metadata)
+	}, 2*time.Second)
+	if countType(got, string(MsgPong)) != 0 {
+		t.Errorf("stale pong leaked onto the reconnected socket: %d pong frame(s)", countType(got, string(MsgPong)))
+	}
+}


### PR DESCRIPTION
Closes #1749

## What

<!-- Brief description of the change -->

Split the SDK's single outbound channel into two by connection semantics:
invokes) — these are meant to (re)send on whichever connection is live.
- A new **per-connection reply channel** carries connection-scoped replies (pong,`InvocationResult`, `TriggerRegistrationResult`), created on connect and detached on teardown.

## Why

<!-- Motivation or context -->
This was rasied in #1749 whwere `writeLoop` is per-connection but drained the shared channel. If a connection-scoped reply was buffered when the socket dropped (before the writer drained it), the next connection's `writeLoop` would send that stale reply on the wrong socket.

## Notes

<!-- Anything reviewers should know (breaking changes, migration steps, etc.) -->
- A reply enqueued with no live connection is **dropped** 
- writeLoop` reads its reply channel from a parameter (its own connection's)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented protocol replies from leaking across reconnections by scoping reply delivery to the active connection and dropping replies queued during teardown.

* **Tests**
  * Added regression tests to confirm reply-channel lifecycle and to ensure pong/reply frames are not delivered when disconnected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->