### PR TITLE
docs(sdk(go): fix pkg.go.dev rendering for the Go SDK

### DIFF
--- a/sdk/packages/go/iii/LICENSE
+++ b/sdk/packages/go/iii/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024 Motia LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sdk/packages/go/iii/README.md
+++ b/sdk/packages/go/iii/README.md
@@ -5,7 +5,8 @@ Go SDK for the [iii engine](https://github.com/iii-hq/iii). A process becomes an
 **triggers**; the engine invokes those functions and the worker replies over the same
 socket.
 
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../../../LICENSE)
+[![Go Reference](https://pkg.go.dev/badge/github.com/iii-hq/iii/sdk/packages/go/iii.svg)](https://pkg.go.dev/github.com/iii-hq/iii/sdk/packages/go/iii)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 ## Install
 
@@ -13,7 +14,7 @@ socket.
 go get github.com/iii-hq/iii/sdk/packages/go/iii
 ```
 
-Requires Go 1.23+.
+Requires Go 1.24+.
 
 ## Hello World
 

--- a/sdk/packages/go/iii/channels.go
+++ b/sdk/packages/go/iii/channels.go
@@ -38,7 +38,7 @@ const channelFlushDelay = 10 * time.Millisecond
 
 // Channel is a freshly created channel: a live writer/reader plus the refs for each end.
 // Pass WriterRef or ReaderRef to another worker (in a trigger payload) so it opens the
-// opposite end with OpenReader / OpenWriter.
+// opposite end with [OpenReader] / [OpenWriter]. Created by [Client.CreateChannel].
 type Channel struct {
 	Writer    *ChannelWriter
 	Reader    *ChannelReader

--- a/sdk/packages/go/iii/client.go
+++ b/sdk/packages/go/iii/client.go
@@ -113,8 +113,9 @@ func WithName(name string) Option {
 	return func(cl *Client) { cl.name = name }
 }
 
-// New creates a Client for the engine at url (e.g. DefaultEngineURL). It does not
-// connect; call Connect to start the connection lifecycle.
+// New creates a [Client] for the engine at url (e.g. [DefaultEngineURL]). It does not
+// connect; call [Client.Connect] to start the connection lifecycle, or use
+// [RegisterWorker] to create and connect in one step.
 func New(url string, opts ...Option) *Client {
 	c := &Client{
 		url:          url,
@@ -136,15 +137,16 @@ func New(url string, opts ...Option) *Client {
 	return c
 }
 
-// RegisterWorker creates a Client for the engine at url and starts the connection
+// RegisterWorker creates a [Client] for the engine at url and starts the connection
 // lifecycle in the background, returning immediately. It is the idiomatic entry point,
 // matching registerWorker in the Node SDK and register_worker in the Rust SDK. Register
 // functions and triggers on the returned client; they are (re)sent on each connection.
-// Call Close to stop.
+// Call [Client.Close] to stop.
 //
-// To wait for the first connection (or fail fast on a bad URL), call Connect instead of
-// — or after — RegisterWorker; Connect blocks until connected, ctx is done, or the
-// reconnect budget is exhausted.
+// To wait for the first connection (or fail fast on a bad URL), call [Client.Connect]
+// instead of — or after — RegisterWorker; it blocks until connected, ctx is done, or the
+// reconnect budget is exhausted. Use [New] if you want to build a client without starting
+// the connection.
 func RegisterWorker(url string, opts ...Option) *Client {
 	c := New(url, opts...)
 	c.startSupervisor()
@@ -227,9 +229,9 @@ func (c *Client) RegisterTrigger(id, triggerType, functionID string, config, met
 	return nil
 }
 
-// TriggerRequest is the input to Trigger. Exactly the Action field selects the
-// delivery semantics: nil/await (default) waits for the result; VoidAction is
-// fire-and-forget; EnqueueAction routes through a named queue and awaits its receipt.
+// TriggerRequest is the input to [Client.Trigger]. The Action field selects the delivery
+// semantics: nil/await (default) waits for the result; [VoidAction] is fire-and-forget;
+// [EnqueueAction] routes through a named queue and awaits its receipt.
 type TriggerRequest struct {
 	// FunctionID is the engine function to invoke (e.g. an EngineFunctions constant).
 	FunctionID string
@@ -237,17 +239,17 @@ type TriggerRequest struct {
 	Data json.RawMessage
 	// Action selects void/enqueue semantics; nil means the default await path.
 	Action *TriggerAction
-	// Timeout overrides DefaultInvocationTimeout for an await/enqueue call.
+	// Timeout overrides [DefaultInvocationTimeout] for an await/enqueue call.
 	Timeout time.Duration
 }
 
 // Trigger invokes a function on the engine. With the default (nil) or an enqueue action
-// it waits for the matching InvocationResult and returns its result, mapping a remote
-// error to *InvocationError and a missed deadline to ErrTimeout. With a void action it
-// is fire-and-forget and returns immediately with a nil result.
+// it waits for the matching invocation result and returns it, mapping a remote error to
+// [InvocationError] and a missed deadline to [ErrTimeout]. With a [VoidAction] it is
+// fire-and-forget and returns immediately with a nil result.
 //
-// ctx bounds the wait independently of Timeout: if ctx is cancelled first, its error is
-// returned and the pending entry is reclaimed.
+// ctx bounds the wait independently of [TriggerRequest.Timeout]: if ctx is cancelled
+// first, its error is returned and the pending entry is reclaimed.
 func (c *Client) Trigger(ctx context.Context, req TriggerRequest) (json.RawMessage, error) {
 	data := req.Data
 	if data == nil {

--- a/sdk/packages/go/iii/doc.go
+++ b/sdk/packages/go/iii/doc.go
@@ -1,0 +1,57 @@
+// Package iii is a Go SDK for the iii worker protocol.
+//
+// A process becomes an iii "worker" by opening a single WebSocket to the engine and
+// registering functions and triggers; the engine invokes those functions and the worker
+// replies over the same socket. The SDK handles the connection lifecycle (connect,
+// reconnect with backoff, offline buffering) so callers work in terms of functions and
+// triggers, not frames.
+//
+// # Quick start
+//
+// Create a worker, register a function, bind a trigger, and connect:
+//
+//	client := iii.RegisterWorker(iii.DefaultEngineURL) // ws://localhost:49134
+//
+//	client.RegisterFunction("hello::greet", func(ctx context.Context, data json.RawMessage) (any, error) {
+//		var req struct {
+//			Body struct {
+//				Name string `json:"name"`
+//			} `json:"body"`
+//		}
+//		_ = json.Unmarshal(data, &req)
+//		return map[string]any{
+//			"status_code": 200,
+//			"body":        map[string]string{"message": "Hello, " + req.Body.Name + "!"},
+//		}, nil
+//	})
+//
+//	client.RegisterTrigger("hello-http", "http", "hello::greet",
+//		json.RawMessage(`{"api_path":"/greet","http_method":"POST"}`), nil)
+//
+//	if err := client.Connect(context.Background()); err != nil {
+//		log.Fatal(err)
+//	}
+//	defer client.Close()
+//
+// # Invoking functions
+//
+// [Client.Trigger] invokes a function and, by default, awaits its result. The
+// [TriggerRequest] Action field selects the delivery semantics: the default (nil) awaits
+// the result, [VoidAction] is fire-and-forget, and [EnqueueAction] routes through a named
+// queue. Errors are typed: [ErrTimeout] for a missed deadline, [ErrNotConnected] for a
+// call cancelled by shutdown, and [InvocationError] (via errors.As) for a remote failure.
+//
+// # Schema inference
+//
+// [RegisterFunctionTyped] infers JSON Schemas for a function's request and response from
+// the Go types and advertises them to the engine — the Go counterpart of the Rust SDK's
+// JsonSchema derive.
+//
+// # Channels
+//
+// For bulk or streaming data, [Client.CreateChannel] opens a streaming data channel; see
+// [ChannelWriter] and [ChannelReader].
+//
+// The package mirrors the iii Node and Rust SDKs; see the repository README at
+// https://github.com/iii-hq/iii for the engine and the other SDKs.
+package iii

--- a/sdk/packages/go/iii/example_test.go
+++ b/sdk/packages/go/iii/example_test.go
@@ -1,0 +1,87 @@
+package iii_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+
+	iii "github.com/iii-hq/iii/sdk/packages/go/iii"
+)
+
+// Example_helloWorker is a complete hello-world worker: register a function, bind an HTTP
+// trigger to it, and connect. The handler speaks the engine's HTTP-trigger envelope (the
+// request body is under "body"; the response is {status_code, body}).
+func Example_helloWorker() {
+	client := iii.RegisterWorker(iii.DefaultEngineURL) // ws://localhost:49134
+
+	client.RegisterFunction("hello::greet", func(ctx context.Context, data json.RawMessage) (any, error) {
+		var req struct {
+			Body struct {
+				Name string `json:"name"`
+			} `json:"body"`
+		}
+		if err := json.Unmarshal(data, &req); err != nil {
+			return nil, err
+		}
+		return map[string]any{
+			"status_code": 200,
+			"body":        map[string]string{"message": "Hello, " + req.Body.Name + "!"},
+		}, nil
+	})
+
+	client.RegisterTrigger("hello-http", "http", "hello::greet",
+		json.RawMessage(`{"api_path":"/greet","http_method":"POST"}`), nil)
+
+	if err := client.Connect(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+}
+
+// ExampleClient_Trigger invokes a function and awaits its result, then shows the typed
+// error handling: ErrTimeout for a missed deadline and InvocationError for a remote
+// failure.
+func ExampleClient_Trigger() {
+	client := iii.RegisterWorker(iii.DefaultEngineURL)
+	defer client.Close()
+
+	res, err := client.Trigger(context.Background(), iii.TriggerRequest{
+		FunctionID: "orders::create",
+		Data:       json.RawMessage(`{"item":"widget"}`),
+	})
+	switch {
+	case errors.Is(err, iii.ErrTimeout):
+		fmt.Println("timed out")
+	case err != nil:
+		var ie *iii.InvocationError
+		if errors.As(err, &ie) {
+			fmt.Println("remote error:", ie.Code)
+		}
+	default:
+		fmt.Printf("result: %s\n", res)
+	}
+}
+
+// greetRequest and greetResponse describe a function's contract; their JSON Schemas are
+// inferred and advertised to the engine by RegisterFunctionTyped.
+type greetRequest struct {
+	Name string `json:"name" jsonschema:"required"`
+}
+
+type greetResponse struct {
+	Message string `json:"message"`
+}
+
+// ExampleRegisterFunctionTyped registers a function whose request and response schemas
+// are inferred from the Go types, the Go counterpart of the Rust SDK's JsonSchema derive.
+func ExampleRegisterFunctionTyped() {
+	client := iii.RegisterWorker(iii.DefaultEngineURL)
+	defer client.Close()
+
+	iii.RegisterFunctionTyped[greetRequest, greetResponse](client, "hello::greet",
+		func(ctx context.Context, req greetRequest) (greetResponse, error) {
+			return greetResponse{Message: "Hello, " + req.Name + "!"}, nil
+		})
+}

--- a/sdk/packages/go/iii/protocol.go
+++ b/sdk/packages/go/iii/protocol.go
@@ -1,11 +1,6 @@
-// Package iii is a Go SDK for the iii worker protocol. A process becomes an iii
-// "worker" by opening a single WebSocket to the engine and registering functions
-// and triggers; the engine invokes those functions and the worker replies over
-// the same socket.
-//
 // This file is the wire protocol: the message envelope and every message variant,
-// ported from the engine's source of truth at engine/src/protocol.rs. The Rust
-// engine declares its Message enum as:
+// ported from the engine's source of truth at engine/src/protocol.rs. The package
+// overview lives in doc.go. The Rust engine declares its Message enum as:
 //
 //	#[serde(tag = "type", rename_all = "lowercase")]
 //
@@ -224,9 +219,12 @@ type WorkerRegisteredMessage struct {
 	WorkerID string `json:"worker_id"`
 }
 
-// Ping and Pong are the two payloadless variants. They serialize to {"type":"ping"} /
-// {"type":"pong"} (engine/src/protocol.rs:121-122).
+// PingMessage is the payloadless keepalive the engine sends; it serializes to
+// {"type":"ping"} (engine/src/protocol.rs:121-122). The client replies with a PongMessage.
 type PingMessage struct{}
+
+// PongMessage is the payloadless reply to a PingMessage; it serializes to
+// {"type":"pong"} (engine/src/protocol.rs:121-122).
 type PongMessage struct{}
 
 // marshalEnvelope serializes a variant struct into a single tagged JSON object by

--- a/sdk/packages/go/iii/schema.go
+++ b/sdk/packages/go/iii/schema.go
@@ -30,14 +30,15 @@ type TypedHandler[Req any, Resp any] func(ctx context.Context, req Req) (Resp, e
 
 // RegisterFunctionTyped registers a function whose request and response schemas are
 // inferred from the Req and Resp type parameters and advertised to the engine. It is the
-// schema-aware counterpart of Client.RegisterFunction; reach for it when you want the
+// schema-aware counterpart of [Client.RegisterFunction]; reach for it when you want the
 // engine (and its dashboard / typed callers) to know the function's contract.
 //
 //	iii.RegisterFunctionTyped[CreateOrderRequest, OrderResult](client, "orders::create",
 //	    func(ctx context.Context, req CreateOrderRequest) (OrderResult, error) { ... })
 //
-// Use Client.RegisterFunction directly for schemaless functions or when you need to hand
-// the engine a hand-written schema.
+// Use [Client.RegisterFunction] directly for schemaless functions or when you need to
+// hand the engine a hand-written schema. See [InferSchema] to obtain a type's schema on
+// its own.
 func RegisterFunctionTyped[Req any, Resp any](c *Client, id string, handler TypedHandler[Req, Resp]) error {
 	if handler == nil {
 		return fmt.Errorf("iii: RegisterFunctionTyped(%q): handler is nil", id)


### PR DESCRIPTION
## What

<!-- Brief description of the change -->
Fixes the Go SDK's pkg.go.dev page, which showed "Documentation not displayed due to license restrictions" and rendered no docs.

Example below from [v0.19.0-next4](https://pkg.go.dev/github.com/iii-hq/iii/sdk/packages/go/iii@v0.19.0-next.4)
<img width="1906" height="577" alt="image" src="https://github.com/user-attachments/assets/fad5056e-2844-440f-b567-98a00dd5a9c8" />


- **LICENSE in the module** — copy `sdk/LICENSE` to the module root so the Apache-2.0
  license is inside the published proxy zip (pkg.go.dev only renders docs for modules it
  detects as redistributable). This is the fix for the hidden docs.
- **doc.go** — a clean package overview (synopsis + quick start + pointers to Trigger,
  schema inference, and channels). The protocol/serde detail that was the package comment
  doc.
- **Examples** — `Example_helloWorker`, `ExampleClient_Trigger`,
  `ExampleRegisterFunctionTyped` (render at the top of the page).
- **PongMessage** documented; README gets a pkg.go.dev badge and an in-module license
  link; Go version note corrected to 1.24+.

## Why

<!-- Motivation or context -->

The screenshot at `…/iii@v0.19.0-next.4` shows Redistributable license ✗ → docs hidden.
The license file existed in the repo but not in the module's zip, which is all the proxy
serves. Landing the license inside the module (plus the doc/example polish) makes the page
render properly once the next non-prerelease version is tagged.

## Notes

<!-- Anything reviewers should know (breaking changes, migration steps, etc.) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive GoDoc package docs covering worker model, quick-start, invocation semantics, error types, schema inference, and channel support
  * Included runnable examples demonstrating HTTP-triggered functions, remote invocation with typed error handling, and typed typed-function registration
  * Updated README badges and bumped documented minimum Go version to 1.24+

* **Chores**
  * Added full Apache License 2.0 text with copyright notice
<!-- end of auto-generated comment: release notes by coderabbit.ai -->