### PR TITLE
refactor(rust-sdk)!: add iii_sdk::channel submodule

### DIFF
--- a/docs/next/sdk-reference/rust-sdk.mdx
+++ b/docs/next/sdk-reference/rust-sdk.mdx
@@ -146,6 +146,10 @@ pub enum IIIError {
 
 ## Channels
 
+Import channel types from the `iii_sdk::channel` submodule
+(`use iii_sdk::channel::{ChannelReader, ChannelWriter}`). They stay reachable at the crate root as
+deprecated re-exports.
+
 `ChannelReader` and `ChannelWriter` wrap the engine's stream WebSockets. `StreamChannelRef`
 identifies a channel:
 

--- a/docs/next/sdk-reference/rust-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/rust-sdk.mdx.skill.md
@@ -144,6 +144,10 @@ pub enum IIIError {
 
 ## Channels
 
+Import channel types from the `iii_sdk::channel` submodule
+(`use iii_sdk::channel::{ChannelReader, ChannelWriter}`). They stay reachable at the crate root as
+deprecated re-exports.
+
 `ChannelReader` and `ChannelWriter` wrap the engine's stream WebSockets. `StreamChannelRef`
 identifies a channel:
 

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -38,13 +38,13 @@ pub use structs::{
     OnTriggerTypeRegistrationInput, OnTriggerTypeRegistrationResult,
 };
 pub use triggers::{Trigger, TriggerConfig, TriggerHandler};
+#[deprecated(since = "0.19.0", note = "import from iii_sdk::channel")]
+pub use types::Channel;
 pub use types::{
     ApiRequest, ApiResponse, DeleteResult, SetResult, StreamAuthInput, StreamAuthResult,
     StreamDeleteInput, StreamGetInput, StreamJoinResult, StreamListGroupsInput, StreamListInput,
     StreamSetInput, StreamUpdateInput, UpdateOp, UpdateOpError, UpdateResult,
 };
-#[deprecated(since = "0.19.0", note = "import from iii_sdk::channel")]
-pub use types::Channel;
 
 /// Configuration options passed to [`register_worker`].
 ///

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -9,10 +9,17 @@ pub mod structs;
 pub mod triggers;
 pub mod types;
 
+/// Public channel types. (Stage 1 submodule grouping.)
+pub mod channel {
+    pub use crate::channels::{ChannelReader, ChannelWriter, StreamChannelRef};
+    pub use crate::types::Channel;
+}
+
 pub use builtin_triggers::{
     IIITrigger, StreamCallRequest, StreamEventDetail, StreamEventType, StreamJoinLeaveCallRequest,
     StreamJoinLeaveTriggerConfig, StreamTriggerConfig,
 };
+#[deprecated(since = "0.19.0", note = "import from iii_sdk::channel")]
 pub use channels::{ChannelReader, ChannelWriter, StreamChannelRef};
 pub use error::IIIError;
 pub use iii::{
@@ -32,10 +39,12 @@ pub use structs::{
 };
 pub use triggers::{Trigger, TriggerConfig, TriggerHandler};
 pub use types::{
-    ApiRequest, ApiResponse, Channel, DeleteResult, SetResult, StreamAuthInput, StreamAuthResult,
+    ApiRequest, ApiResponse, DeleteResult, SetResult, StreamAuthInput, StreamAuthResult,
     StreamDeleteInput, StreamGetInput, StreamJoinResult, StreamListGroupsInput, StreamListInput,
     StreamSetInput, StreamUpdateInput, UpdateOp, UpdateOpError, UpdateResult,
 };
+#[deprecated(since = "0.19.0", note = "import from iii_sdk::channel")]
+pub use types::Channel;
 
 /// Configuration options passed to [`register_worker`].
 ///
@@ -143,3 +152,14 @@ fn _ensure_is_channel_ref_not_top_level() {}
 /// ```
 #[allow(dead_code)]
 fn _ensure_create_channel_not_on_instance() {}
+
+// ---------------------------------------------------------------------------
+// Stage 1 channel submodule: channel types are reachable at their new
+// canonical path `iii_sdk::channel`.
+// ---------------------------------------------------------------------------
+
+/// ```rust,no_run
+/// use iii_sdk::channel::{Channel, ChannelReader, ChannelWriter, StreamChannelRef};
+/// ```
+#[allow(dead_code)]
+fn _ensure_channel_submodule_path() {}

--- a/sdk/packages/rust/iii/tests/api_triggers.rs
+++ b/sdk/packages/rust/iii/tests/api_triggers.rs
@@ -141,8 +141,8 @@ async fn raw_json_request_body() {
                     .map(|(_, r)| r.clone())
                     .expect("missing reader ref");
 
-                let writer = iii_sdk::ChannelWriter::new(iii.address(), &writer_ref);
-                let reader = iii_sdk::ChannelReader::new(iii.address(), &reader_ref);
+                let writer = iii_sdk::channel::ChannelWriter::new(iii.address(), &writer_ref);
+                let reader = iii_sdk::channel::ChannelReader::new(iii.address(), &reader_ref);
                 let raw = reader
                     .read_all()
                     .await
@@ -427,7 +427,7 @@ async fn download_pdf_streaming() {
                     .map(|(_, r)| r.clone())
                     .expect("missing writer ref");
 
-                let writer = iii_sdk::ChannelWriter::new(iii.address(), &writer_ref);
+                let writer = iii_sdk::channel::ChannelWriter::new(iii.address(), &writer_ref);
 
                 writer
                     .send_message(
@@ -541,8 +541,8 @@ async fn upload_pdf_streaming() {
                     .map(|(_, r)| r.clone())
                     .expect("missing reader ref");
 
-                let writer = iii_sdk::ChannelWriter::new(iii.address(), &writer_ref);
-                let reader = iii_sdk::ChannelReader::new(iii.address(), &reader_ref);
+                let writer = iii_sdk::channel::ChannelWriter::new(iii.address(), &writer_ref);
+                let reader = iii_sdk::channel::ChannelReader::new(iii.address(), &reader_ref);
 
                 writer
                     .send_message(
@@ -646,7 +646,7 @@ async fn sse_streaming() {
                     .map(|(_, r)| r.clone())
                     .expect("missing writer ref");
 
-                let writer = iii_sdk::ChannelWriter::new(iii.address(), &writer_ref);
+                let writer = iii_sdk::channel::ChannelWriter::new(iii.address(), &writer_ref);
 
                 writer
                     .send_message(
@@ -786,8 +786,8 @@ async fn urlencoded_form_data() {
                     .map(|(_, r)| r.clone())
                     .expect("missing reader ref");
 
-                let writer = iii_sdk::ChannelWriter::new(iii.address(), &writer_ref);
-                let reader = iii_sdk::ChannelReader::new(iii.address(), &reader_ref);
+                let writer = iii_sdk::channel::ChannelWriter::new(iii.address(), &writer_ref);
+                let reader = iii_sdk::channel::ChannelReader::new(iii.address(), &reader_ref);
 
                 let raw = reader
                     .read_all()
@@ -937,8 +937,8 @@ async fn multipart_form_data() {
                     .map(|(_, r)| r.clone())
                     .expect("missing reader ref");
 
-                let writer = iii_sdk::ChannelWriter::new(iii.address(), &writer_ref);
-                let reader = iii_sdk::ChannelReader::new(iii.address(), &reader_ref);
+                let writer = iii_sdk::channel::ChannelWriter::new(iii.address(), &writer_ref);
+                let reader = iii_sdk::channel::ChannelReader::new(iii.address(), &reader_ref);
 
                 let raw = reader
                     .read_all()

--- a/sdk/packages/rust/iii/tests/data_channels.rs
+++ b/sdk/packages/rust/iii/tests/data_channels.rs
@@ -31,7 +31,7 @@ async fn stream_data_from_sender_to_processor() {
                     .map(|(_, r)| r.clone())
                     .expect("missing reader channel ref");
 
-                let reader = iii_sdk::ChannelReader::new(iii.address(), &reader_ref);
+                let reader = iii_sdk::channel::ChannelReader::new(iii.address(), &reader_ref);
                 let raw = reader.read_all().await.map_err(|e| IIIError::Handler(e.to_string()))?;
                 let records: Vec<Value> = serde_json::from_slice(&raw)
                     .map_err(|e| IIIError::Handler(e.to_string()))?;
@@ -176,8 +176,8 @@ async fn bidirectional_streaming() {
                     .map(|(_, r)| r.clone())
                     .expect("missing writer");
 
-                let reader = iii_sdk::ChannelReader::new(iii.address(), &reader_ref);
-                let writer = iii_sdk::ChannelWriter::new(iii.address(), &writer_ref);
+                let reader = iii_sdk::channel::ChannelReader::new(iii.address(), &reader_ref);
+                let writer = iii_sdk::channel::ChannelWriter::new(iii.address(), &writer_ref);
 
                 let mut chunks: Vec<Vec<u8>> = Vec::new();
                 let mut chunk_count = 0;


### PR DESCRIPTION
Groups the channel types under a new `iii_sdk::channel` submodule: `ChannelReader`, `ChannelWriter`, `StreamChannelRef`, `Channel`. Canonical path is now `iii_sdk::channel::*`.

The crate root keeps the same names as deprecated re-exports, so existing `iii_sdk::ChannelReader` etc. still resolve. No behavior change; pure submodule grouping.

- `lib.rs`: `pub mod channel` grouping + deprecated root aliases + a doctest pinning the new path.
- Integration tests repointed to `iii_sdk::channel::*` (keeps `clippy --all-targets -D warnings` clean).
- Reference docs updated (`rust-sdk.mdx` + skill companion).