### PR TITLE
docs(next): import Logger from observability package in tutorials

### DIFF
--- a/docs/next/tutorials/linkly/channels.mdx
+++ b/docs/next/tutorials/linkly/channels.mdx
@@ -28,7 +28,8 @@ CSV in, and triggers `link::create` from the `link` worker for each row. Replace
 `bulk-importer/src/index.ts`:
 
 ```typescript bulk-importer/src/index.ts
-import { registerWorker, Logger } from "iii-sdk";
+import { registerWorker } from "iii-sdk";
+import { Logger } from "@iii-dev/observability";
 
 const worker = registerWorker(process.env.III_URL ?? "ws://localhost:49134", {
   workerName: "bulk-importer",

--- a/docs/next/tutorials/linkly/channels.mdx.skill.md
+++ b/docs/next/tutorials/linkly/channels.mdx.skill.md
@@ -24,7 +24,8 @@ CSV in, and triggers `link::create` from the `link` worker for each row. Replace
 `bulk-importer/src/index.ts`:
 
 ```typescript bulk-importer/src/index.ts
-import { registerWorker, Logger } from "iii-sdk";
+import { registerWorker } from "iii-sdk";
+import { Logger } from "@iii-dev/observability";
 
 const worker = registerWorker(process.env.III_URL ?? "ws://localhost:49134", {
   workerName: "bulk-importer",

--- a/docs/next/tutorials/linkly/durable-execution.mdx
+++ b/docs/next/tutorials/linkly/durable-execution.mdx
@@ -46,7 +46,8 @@ You already wrote `link::record_click` in Chapter 3, where `http::redirect` trig
 Nothing about the function changes. You only change how it's invoked. First import `TriggerAction`:
 
 ```typescript src/index.ts
-import { registerWorker, Logger, TriggerAction } from "iii-sdk";
+import { registerWorker, TriggerAction } from "iii-sdk";
+import { Logger } from "@iii-dev/observability";
 ```
 
 Then add an `action` to the existing `link::record_click` call in `http::redirect` so the
@@ -212,7 +213,8 @@ of every time that a new short link is created:
 import os
 from datetime import datetime, timezone
 
-from iii import register_worker, InitOptions, Logger
+from iii import register_worker, InitOptions
+from iii_observability import Logger
 
 worker = register_worker(
     os.environ.get("III_URL", "ws://localhost:49134"),

--- a/docs/next/tutorials/linkly/durable-execution.mdx.skill.md
+++ b/docs/next/tutorials/linkly/durable-execution.mdx.skill.md
@@ -41,7 +41,8 @@ You already wrote `link::record_click` in Chapter 3, where `http::redirect` trig
 Nothing about the function changes. You only change how it's invoked. First import `TriggerAction`:
 
 ```typescript src/index.ts
-import { registerWorker, Logger, TriggerAction } from "iii-sdk";
+import { registerWorker, TriggerAction } from "iii-sdk";
+import { Logger } from "@iii-dev/observability";
 ```
 
 Then add an `action` to the existing `link::record_click` call in `http::redirect` so the
@@ -207,7 +208,8 @@ of every time that a new short link is created:
 import os
 from datetime import datetime, timezone
 
-from iii import register_worker, InitOptions, Logger
+from iii import register_worker, InitOptions
+from iii_observability import Logger
 
 worker = register_worker(
     os.environ.get("III_URL", "ws://localhost:49134"),

--- a/docs/next/tutorials/linkly/foundations.mdx
+++ b/docs/next/tutorials/linkly/foundations.mdx
@@ -131,7 +131,8 @@ pasting one large file at once.
 `index.ts` with the connection setup and a small helper that generates random short codes:
 
 ```typescript src/index.ts
-import { registerWorker, Logger } from "iii-sdk";
+import { registerWorker } from "iii-sdk";
+import { Logger } from "@iii-dev/observability";
 
 const worker = registerWorker(process.env.III_URL ?? "ws://localhost:49134", {
   workerName: "link",

--- a/docs/next/tutorials/linkly/foundations.mdx.skill.md
+++ b/docs/next/tutorials/linkly/foundations.mdx.skill.md
@@ -127,7 +127,8 @@ pasting one large file at once.
 `index.ts` with the connection setup and a small helper that generates random short codes:
 
 ```typescript src/index.ts
-import { registerWorker, Logger } from "iii-sdk";
+import { registerWorker } from "iii-sdk";
+import { Logger } from "@iii-dev/observability";
 
 const worker = registerWorker(process.env.III_URL ?? "ws://localhost:49134", {
   workerName: "link",

--- a/docs/next/tutorials/linkly/frontend.mdx
+++ b/docs/next/tutorials/linkly/frontend.mdx
@@ -65,7 +65,8 @@ The `auth` worker owns connection gating, so the `link` worker stays focused on 
 arbitrary context). Throw to reject. Replace the generated `auth/src/index.ts`:
 
 ```typescript auth/src/index.ts
-import { registerWorker, Logger } from "iii-sdk";
+import { registerWorker } from "iii-sdk";
+import { Logger } from "@iii-dev/observability";
 
 const worker = registerWorker(process.env.III_URL ?? "ws://localhost:49134", {
   workerName: "auth",

--- a/docs/next/tutorials/linkly/frontend.mdx.skill.md
+++ b/docs/next/tutorials/linkly/frontend.mdx.skill.md
@@ -59,7 +59,8 @@ The `auth` worker owns connection gating, so the `link` worker stays focused on 
 arbitrary context). Throw to reject. Replace the generated `auth/src/index.ts`:
 
 ```typescript auth/src/index.ts
-import { registerWorker, Logger } from "iii-sdk";
+import { registerWorker } from "iii-sdk";
+import { Logger } from "@iii-dev/observability";
 
 const worker = registerWorker(process.env.III_URL ?? "ws://localhost:49134", {
   workerName: "auth",

--- a/docs/next/tutorials/linkly/persistence.mdx
+++ b/docs/next/tutorials/linkly/persistence.mdx
@@ -55,8 +55,9 @@ The worker owns its schema. Build up the changes to `link/src/index.ts` in piece
 
 First add the `DB` constant near the top of the file:
 
-```typescript {3} src/index.ts
-import { registerWorker, Logger } from "iii-sdk";
+```typescript {4} src/index.ts
+import { registerWorker } from "iii-sdk";
+import { Logger } from "@iii-dev/observability";
 
 const DB = "primary";
 ```

--- a/docs/next/tutorials/linkly/persistence.mdx.skill.md
+++ b/docs/next/tutorials/linkly/persistence.mdx.skill.md
@@ -50,8 +50,9 @@ The worker owns its schema. Build up the changes to `link/src/index.ts` in piece
 
 First add the `DB` constant near the top of the file:
 
-```typescript {3} src/index.ts
-import { registerWorker, Logger } from "iii-sdk";
+```typescript {4} src/index.ts
+import { registerWorker } from "iii-sdk";
+import { Logger } from "@iii-dev/observability";
 
 const DB = "primary";
 ```

--- a/docs/next/tutorials/linkly/streaming.mdx
+++ b/docs/next/tutorials/linkly/streaming.mdx
@@ -68,7 +68,8 @@ a `clicks` stream with `stream::set`. A `stream::set` both stores the item and p
 WebSocket subscribed to that stream and group. Replace the generated `click-streamer/src/index.ts`:
 
 ```typescript click-streamer/src/index.ts
-import { registerWorker, Logger } from "iii-sdk";
+import { registerWorker } from "iii-sdk";
+import { Logger } from "@iii-dev/observability";
 
 const worker = registerWorker(process.env.III_URL ?? "ws://localhost:49134", {
   workerName: "click-streamer",

--- a/docs/next/tutorials/linkly/streaming.mdx.skill.md
+++ b/docs/next/tutorials/linkly/streaming.mdx.skill.md
@@ -65,7 +65,8 @@ a `clicks` stream with `stream::set`. A `stream::set` both stores the item and p
 WebSocket subscribed to that stream and group. Replace the generated `click-streamer/src/index.ts`:
 
 ```typescript click-streamer/src/index.ts
-import { registerWorker, Logger } from "iii-sdk";
+import { registerWorker } from "iii-sdk";
+import { Logger } from "@iii-dev/observability";
 
 const worker = registerWorker(process.env.III_URL ?? "ws://localhost:49134", {
   workerName: "click-streamer",


### PR DESCRIPTION
## Summary

`Logger` is no longer re-exported from the `iii` / `iii-sdk` package roots (dropped in #1772). The next-channel Linkly tutorials still imported it from there, so following them against the next SDK fails at import time.

This updates the next-channel tutorials to import `Logger` from its new home:

- Python → `from iii_observability import Logger`
- Node → `import { Logger } from "@iii-dev/observability"`

Both the `.mdx` sources and their rendered `.skill.md` mirrors are updated in sync (the `skill-check` workflow verifies they match). The `persistence` code block's highlight directive was bumped `{3}` → `{4}` because the split import shifts the highlighted line down by one.

Stable docs, archived version docs (`0-10-0` / `0-11-0`), and the changelog before/after example are intentionally left unchanged — `from iii import Logger` is still correct there.

## Files

6 `.mdx` + 6 `.skill.md` under `docs/next/tutorials/linkly/` (channels, durable-execution, foundations, frontend, persistence, streaming).

## Test plan

- [ ] `skill-check` passes (`.mdx` / `.skill.md` in sync)
- [ ] Imports match the post-#1772 SDK reference (`docs/next/sdk-reference/{python,node}-sdk.mdx`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linkly tutorial code examples across multiple chapters (foundations, channels, streaming, persistence, durable-execution, and frontend) to reflect the correct import source for the Logger utility, now sourced from the observability module instead of the SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->