### PR TITLE
refactor(node-sdk)!: add iii-sdk/trigger subpath

### DIFF
--- a/docs/next/sdk-reference/node-sdk.mdx
+++ b/docs/next/sdk-reference/node-sdk.mdx
@@ -58,6 +58,10 @@ worker.registerTrigger(trigger: RegisterTriggerInput): Trigger;
 The returned `Trigger` carries the runtime handle. Drop the trigger with `Trigger.unregister()`;
 there is no top-level `unregisterTrigger` function.
 
+The `Trigger`, `TriggerConfig`, and `TriggerHandler` types are exported from the `iii-sdk/trigger`
+subpath (`import type { TriggerHandler } from 'iii-sdk/trigger'`). They stay re-exported from the
+package root as deprecated aliases.
+
 ### `registerTriggerType`
 
 Declare a new trigger type that this worker advertises so other workers can bind their functions to

--- a/docs/next/sdk-reference/node-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/node-sdk.mdx.skill.md
@@ -56,6 +56,10 @@ worker.registerTrigger(trigger: RegisterTriggerInput): Trigger;
 The returned `Trigger` carries the runtime handle. Drop the trigger with `Trigger.unregister()`;
 there is no top-level `unregisterTrigger` function.
 
+The `Trigger`, `TriggerConfig`, and `TriggerHandler` types are exported from the `iii-sdk/trigger`
+subpath (`import type { TriggerHandler } from 'iii-sdk/trigger'`). They stay re-exported from the
+package root as deprecated aliases.
+
 ### `registerTriggerType`
 
 Declare a new trigger type that this worker advertises so other workers can bind their functions to

--- a/sdk/packages/node/iii/package.json
+++ b/sdk/packages/node/iii/package.json
@@ -41,6 +41,11 @@
       "types": "./dist/helpers.d.ts",
       "import": "./dist/helpers.mjs",
       "require": "./dist/helpers.cjs"
+    },
+    "./trigger": {
+      "types": "./dist/trigger.d.ts",
+      "import": "./dist/trigger.mjs",
+      "require": "./dist/trigger.cjs"
     }
   },
   "dependencies": {

--- a/sdk/packages/node/iii/src/index.ts
+++ b/sdk/packages/node/iii/src/index.ts
@@ -27,7 +27,8 @@ export type {
   TriggerRequest,
 } from './iii-types'
 
-export type { TriggerConfig, TriggerHandler } from './triggers'
+/** @deprecated Import trigger types from `iii-sdk/trigger`. */
+export type { Trigger, TriggerConfig, TriggerHandler } from './trigger'
 
 export type {
   ApiRequest,
@@ -43,7 +44,6 @@ export type {
   RegisterTriggerInput,
   RegisterTriggerTypeInput,
   RemoteFunctionHandler,
-  Trigger,
   TriggerTypeRef,
 } from './types'
 

--- a/sdk/packages/node/iii/src/trigger.ts
+++ b/sdk/packages/node/iii/src/trigger.ts
@@ -1,0 +1,2 @@
+export type { TriggerConfig, TriggerHandler } from './triggers'
+export type { Trigger } from './types'

--- a/sdk/packages/node/iii/tests/exports.test.ts
+++ b/sdk/packages/node/iii/tests/exports.test.ts
@@ -22,4 +22,8 @@ describe('Package Exports', () => {
     expect(stateModule.StateEventType).toBeDefined()
     expect(Object.keys(stateModule).length).toBeGreaterThan(0)
   })
+
+  it('should import the trigger subpath module', async () => {
+    await expect(import('../src/trigger')).resolves.toBeDefined()
+  })
 })

--- a/sdk/packages/node/iii/tsdown.config.ts
+++ b/sdk/packages/node/iii/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['./src/index.ts', './src/stream.ts', './src/state.ts', './src/helpers.ts'],
+  entry: ['./src/index.ts', './src/stream.ts', './src/state.ts', './src/helpers.ts', './src/trigger.ts'],
   format: ['esm', 'cjs'],
   dts: true,
   sourcemap: true,


### PR DESCRIPTION
Adds the `iii-sdk/trigger` subpath exporting the `Trigger`, `TriggerConfig`, and `TriggerHandler` types.

These types stay exported from the package root as deprecated re-exports, so existing imports keep working. No behavior change; pure relocation of the public import path. (`TriggerActionVoid` is intentionally not part of this move; its placement is still open in dev sync.)

- New build entry + `./trigger` subpath export (`tsdown.config.ts`, `package.json`).
- `src/trigger.ts` barrel; root `index.ts` re-exports it (JSDoc-deprecated).
- Reference docs updated (`node-sdk.mdx` + skill companion).