### PR TITLE
refactor(python-sdk): add iii.trigger submodule

### DIFF
--- a/docs/next/sdk-reference/python-sdk.mdx
+++ b/docs/next/sdk-reference/python-sdk.mdx
@@ -69,6 +69,10 @@ def register_trigger(self, trigger: RegisterTriggerInput | dict[str, Any]) -> Tr
 Drop the trigger with `trigger.unregister()` on the returned handle. There is no top-level
 `unregister_trigger` method.
 
+The `Trigger`, `TriggerConfig`, and `TriggerHandler` types are exported from the `iii.trigger`
+submodule (`from iii.trigger import TriggerHandler`). They stay importable from the package root as
+deprecated re-exports.
+
 ### `register_trigger_type`
 
 Declare a new trigger type that this worker advertises.

--- a/docs/next/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/python-sdk.mdx.skill.md
@@ -67,6 +67,10 @@ def register_trigger(self, trigger: RegisterTriggerInput | dict[str, Any]) -> Tr
 Drop the trigger with `trigger.unregister()` on the returned handle. There is no top-level
 `unregister_trigger` method.
 
+The `Trigger`, `TriggerConfig`, and `TriggerHandler` types are exported from the `iii.trigger`
+submodule (`from iii.trigger import TriggerHandler`). They stay importable from the package root as
+deprecated re-exports.
+
 ### `register_trigger_type`
 
 Declare a new trigger type that this worker advertises.

--- a/sdk/packages/python/iii/src/iii/trigger.py
+++ b/sdk/packages/python/iii/src/iii/trigger.py
@@ -1,0 +1,5 @@
+"""Public trigger types."""
+
+from .triggers import Trigger, TriggerConfig, TriggerHandler
+
+__all__ = ["Trigger", "TriggerConfig", "TriggerHandler"]

--- a/sdk/packages/python/iii/tests/test_trigger_submodule.py
+++ b/sdk/packages/python/iii/tests/test_trigger_submodule.py
@@ -1,0 +1,14 @@
+"""The iii.trigger submodule exposes the trigger types; the root keeps the shims."""
+
+
+def test_trigger_subpath() -> None:
+    from iii.trigger import Trigger, TriggerConfig, TriggerHandler
+
+    assert all(x is not None for x in (Trigger, TriggerConfig, TriggerHandler))
+
+
+def test_trigger_root_shim() -> None:
+    import iii
+    from iii.trigger import Trigger as SubTrigger
+
+    assert iii.Trigger is SubTrigger


### PR DESCRIPTION
Adds the `iii.trigger` submodule, a curated barrel exporting `Trigger`, `TriggerConfig`, and `TriggerHandler` (`from iii.trigger import ...`).

These types stay importable from the package root, which remains the deprecated path. No behavior change; pure relocation of the canonical import path. (`TriggerActionVoid` is intentionally not part of this move; its placement is still open in dev sync.)

- New `src/iii/trigger.py` barrel.
- Reference docs updated (`python-sdk.mdx` + skill companion).