### PR TITLE
refactor(rust-sdk)!: add iii_sdk::trigger submodule

### DIFF
--- a/docs/next/sdk-reference/rust-sdk.mdx
+++ b/docs/next/sdk-reference/rust-sdk.mdx
@@ -64,6 +64,10 @@ pub fn register_trigger(
 Drop the trigger with `trigger.unregister()` on the returned handle. There is no free-function
 `unregister_trigger`.
 
+The `Trigger`, `TriggerConfig`, `TriggerHandler`, and `IIITrigger` types are exported from the
+`iii_sdk::trigger` submodule (`use iii_sdk::trigger::IIITrigger`). They stay reachable at the crate
+root as deprecated re-exports.
+
 ### `register_trigger_type`
 
 Declare a new trigger type that this worker advertises.

--- a/docs/next/sdk-reference/rust-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/rust-sdk.mdx.skill.md
@@ -62,6 +62,10 @@ pub fn register_trigger(
 Drop the trigger with `trigger.unregister()` on the returned handle. There is no free-function
 `unregister_trigger`.
 
+The `Trigger`, `TriggerConfig`, `TriggerHandler`, and `IIITrigger` types are exported from the
+`iii_sdk::trigger` submodule (`use iii_sdk::trigger::IIITrigger`). They stay reachable at the crate
+root as deprecated re-exports.
+
 ### `register_trigger_type`
 
 Declare a new trigger type that this worker advertises.

--- a/sdk/packages/rust/iii-example/src/cron_trigger_example.rs
+++ b/sdk/packages/rust/iii-example/src/cron_trigger_example.rs
@@ -1,5 +1,6 @@
 use iii_sdk::builtin_triggers::*;
-use iii_sdk::{III, IIIError, IIITrigger, RegisterFunction};
+use iii_sdk::trigger::IIITrigger;
+use iii_sdk::{III, IIIError, RegisterFunction};
 use serde_json::json;
 
 /// Examples using built-in trigger types with the typed `IIITrigger` enum.

--- a/sdk/packages/rust/iii-example/src/custom_trigger_example.rs
+++ b/sdk/packages/rust/iii-example/src/custom_trigger_example.rs
@@ -1,4 +1,5 @@
-use iii_sdk::{III, IIIError, RegisterTriggerType, TriggerConfig, TriggerHandler};
+use iii_sdk::trigger::{TriggerConfig, TriggerHandler};
+use iii_sdk::{III, IIIError, RegisterTriggerType};
 use serde_json::json;
 
 // ── Example 1: Typed trigger with full config ───────────────────────────

--- a/sdk/packages/rust/iii-example/src/http_example.rs
+++ b/sdk/packages/rust/iii-example/src/http_example.rs
@@ -1,6 +1,7 @@
 use iii_observability::{Logger, execute_traced_request};
 use iii_sdk::builtin_triggers::{HttpMethod, HttpTriggerConfig};
-use iii_sdk::{ApiRequest, ApiResponse, III, IIIError, IIITrigger, RegisterFunction};
+use iii_sdk::trigger::IIITrigger;
+use iii_sdk::{ApiRequest, ApiResponse, III, IIIError, RegisterFunction};
 use serde_json::json;
 
 pub fn setup(iii: &III) {

--- a/sdk/packages/rust/iii-example/src/trigger_type_example.rs
+++ b/sdk/packages/rust/iii-example/src/trigger_type_example.rs
@@ -1,4 +1,5 @@
-use iii_sdk::{III, IIIError, RegisterTriggerType, TriggerConfig, TriggerHandler, TriggerRequest};
+use iii_sdk::trigger::{TriggerConfig, TriggerHandler};
+use iii_sdk::{III, IIIError, RegisterTriggerType, TriggerRequest};
 use serde::Deserialize;
 
 /// Minimal deserialization target for `engine::triggers::list` rows used

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -9,8 +9,16 @@ pub mod structs;
 pub mod triggers;
 pub mod types;
 
+/// Public trigger types. (Stage 1 submodule grouping.)
+pub mod trigger {
+    pub use crate::builtin_triggers::IIITrigger;
+    pub use crate::triggers::{Trigger, TriggerConfig, TriggerHandler};
+}
+
+#[deprecated(since = "0.19.0", note = "import from iii_sdk::trigger")]
+pub use builtin_triggers::IIITrigger;
 pub use builtin_triggers::{
-    IIITrigger, StreamCallRequest, StreamEventDetail, StreamEventType, StreamJoinLeaveCallRequest,
+    StreamCallRequest, StreamEventDetail, StreamEventType, StreamJoinLeaveCallRequest,
     StreamJoinLeaveTriggerConfig, StreamTriggerConfig,
 };
 pub use channels::{ChannelReader, ChannelWriter, StreamChannelRef};
@@ -30,6 +38,7 @@ pub use structs::{
     OnFunctionRegistrationResult, OnTriggerRegistrationInput, OnTriggerRegistrationResult,
     OnTriggerTypeRegistrationInput, OnTriggerTypeRegistrationResult,
 };
+#[deprecated(since = "0.19.0", note = "import from iii_sdk::trigger")]
 pub use triggers::{Trigger, TriggerConfig, TriggerHandler};
 pub use types::{
     ApiRequest, ApiResponse, Channel, DeleteResult, SetResult, StreamAuthInput, StreamAuthResult,
@@ -143,3 +152,14 @@ fn _ensure_is_channel_ref_not_top_level() {}
 /// ```
 #[allow(dead_code)]
 fn _ensure_create_channel_not_on_instance() {}
+
+// ---------------------------------------------------------------------------
+// Stage 1 trigger submodule: trigger types are reachable at their new
+// canonical path `iii_sdk::trigger`.
+// ---------------------------------------------------------------------------
+
+/// ```rust,no_run
+/// use iii_sdk::trigger::{IIITrigger, Trigger, TriggerConfig, TriggerHandler};
+/// ```
+#[allow(dead_code)]
+fn _ensure_trigger_submodule_path() {}

--- a/sdk/packages/rust/iii/tests/rbac_workers.rs
+++ b/sdk/packages/rust/iii/tests/rbac_workers.rs
@@ -231,16 +231,16 @@ fn ensure_functions_registered() {
         {
             struct NoopHandler;
             #[async_trait::async_trait]
-            impl iii_sdk::TriggerHandler for NoopHandler {
+            impl iii_sdk::trigger::TriggerHandler for NoopHandler {
                 async fn register_trigger(
                     &self,
-                    _config: iii_sdk::TriggerConfig,
+                    _config: iii_sdk::trigger::TriggerConfig,
                 ) -> Result<(), iii_sdk::IIIError> {
                     Ok(())
                 }
                 async fn unregister_trigger(
                     &self,
-                    _config: iii_sdk::TriggerConfig,
+                    _config: iii_sdk::trigger::TriggerConfig,
                 ) -> Result<(), iii_sdk::IIIError> {
                     Ok(())
                 }
@@ -475,16 +475,16 @@ async fn should_deny_trigger_type_registration_via_hook() {
     {
         struct DeniedHandler;
         #[async_trait::async_trait]
-        impl iii_sdk::TriggerHandler for DeniedHandler {
+        impl iii_sdk::trigger::TriggerHandler for DeniedHandler {
             async fn register_trigger(
                 &self,
-                _config: iii_sdk::TriggerConfig,
+                _config: iii_sdk::trigger::TriggerConfig,
             ) -> Result<(), iii_sdk::IIIError> {
                 Ok(())
             }
             async fn unregister_trigger(
                 &self,
-                _config: iii_sdk::TriggerConfig,
+                _config: iii_sdk::trigger::TriggerConfig,
             ) -> Result<(), iii_sdk::IIIError> {
                 Ok(())
             }


### PR DESCRIPTION
Groups the trigger types under a new `iii_sdk::trigger` submodule: `Trigger`, `TriggerConfig`, `TriggerHandler`, and the built-in `IIITrigger` factory enum. Canonical path is now `iii_sdk::trigger::*`.

The crate root keeps the same names as deprecated re-exports, so existing `iii_sdk::TriggerHandler`, `iii_sdk::IIITrigger`, etc. still resolve. No behavior change; pure submodule grouping. (`IIITrigger` keeps its name; any rename is deferred to the cross-lang built-in trigger work.)

- `lib.rs`: `pub mod trigger` grouping + deprecated root aliases + a doctest pinning the new path.
- Integration tests and the `iii-example` crate repointed to `iii_sdk::trigger::*` (keeps `clippy --all-targets -D warnings` clean).
- Reference docs updated (`rust-sdk.mdx` + skill companion).