### PR TITLE
refactor(node-sdk)!: add iii-sdk/runtime subpath

### DIFF
--- a/docs/next/sdk-reference/node-sdk.mdx
+++ b/docs/next/sdk-reference/node-sdk.mdx
@@ -47,6 +47,10 @@ worker.registerFunction(
 `options` accepts `description`, `metadata`, and optional `request_format` / `response_format`
 JSON Schemas (stored alongside the function for the iii console and agent-readable skills).
 
+The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii-sdk/runtime`
+subpath (`import type { FunctionRef } from 'iii-sdk/runtime'`). They stay re-exported from the
+package root as deprecated aliases.
+
 ### `registerTrigger`
 
 Bind a registered function to a configured trigger instance.

--- a/docs/next/sdk-reference/node-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/node-sdk.mdx.skill.md
@@ -45,6 +45,10 @@ worker.registerFunction(
 `options` accepts `description`, `metadata`, and optional `request_format` / `response_format`
 JSON Schemas (stored alongside the function for the iii console and agent-readable skills).
 
+The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii-sdk/runtime`
+subpath (`import type { FunctionRef } from 'iii-sdk/runtime'`). They stay re-exported from the
+package root as deprecated aliases.
+
 ### `registerTrigger`
 
 Bind a registered function to a configured trigger instance.

--- a/sdk/packages/node/iii/package.json
+++ b/sdk/packages/node/iii/package.json
@@ -41,6 +41,11 @@
       "types": "./dist/helpers.d.ts",
       "import": "./dist/helpers.mjs",
       "require": "./dist/helpers.cjs"
+    },
+    "./runtime": {
+      "types": "./dist/runtime.d.ts",
+      "import": "./dist/runtime.mjs",
+      "require": "./dist/runtime.cjs"
     }
   },
   "dependencies": {

--- a/sdk/packages/node/iii/src/index.ts
+++ b/sdk/packages/node/iii/src/index.ts
@@ -33,7 +33,6 @@ export type {
   ApiRequest,
   ApiResponse,
   Channel,
-  FunctionRef,
   HttpRequest,
   HttpResponse,
   InternalHttpRequest,
@@ -44,7 +43,9 @@ export type {
   RegisterTriggerTypeInput,
   RemoteFunctionHandler,
   Trigger,
-  TriggerTypeRef,
 } from './types'
+
+/** @deprecated Import runtime types from `iii-sdk/runtime`. */
+export type { FunctionRef, TriggerTypeRef } from './runtime'
 
 export { http } from './utils'

--- a/sdk/packages/node/iii/src/runtime.ts
+++ b/sdk/packages/node/iii/src/runtime.ts
@@ -1,0 +1,1 @@
+export type { FunctionRef, TriggerTypeRef } from './types'

--- a/sdk/packages/node/iii/tests/exports.test.ts
+++ b/sdk/packages/node/iii/tests/exports.test.ts
@@ -22,4 +22,8 @@ describe('Package Exports', () => {
     expect(stateModule.StateEventType).toBeDefined()
     expect(Object.keys(stateModule).length).toBeGreaterThan(0)
   })
+
+  it('should import the runtime subpath module', async () => {
+    await expect(import('../src/runtime')).resolves.toBeDefined()
+  })
 })

--- a/sdk/packages/node/iii/tsdown.config.ts
+++ b/sdk/packages/node/iii/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['./src/index.ts', './src/stream.ts', './src/state.ts', './src/helpers.ts'],
+  entry: ['./src/index.ts', './src/stream.ts', './src/state.ts', './src/helpers.ts', './src/runtime.ts'],
   format: ['esm', 'cjs'],
   dts: true,
   sourcemap: true,


### PR DESCRIPTION
Adds the `iii-sdk/runtime` subpath exporting the `FunctionRef` and `TriggerTypeRef` handle types.

These types stay exported from the package root as deprecated re-exports, so existing imports keep working. No behavior change; pure relocation of the public import path.

- New build entry + `./runtime` subpath export (`tsdown.config.ts`, `package.json`).
- `src/runtime.ts` barrel; root `index.ts` re-exports it (JSDoc-deprecated).
- Reference docs updated (`node-sdk.mdx` + skill companion).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Node.js SDK reference to clarify that `FunctionRef` and `TriggerTypeRef` types should be imported from the `iii-sdk/runtime` subpath. Root package imports are now deprecated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->