### PR TITLE
refactor(python-sdk): add iii.runtime submodule

### DIFF
--- a/docs/next/sdk-reference/python-sdk.mdx
+++ b/docs/next/sdk-reference/python-sdk.mdx
@@ -58,6 +58,10 @@ def register_function(
 `request_format` / `response_format` accept either a JSON Schema dict or a `RegisterFunctionFormat`
 helper. They are stored alongside the function for the iii console and the agent-readable skills.
 
+The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii.runtime` submodule
+(`from iii.runtime import FunctionRef`). They stay importable from the package root as deprecated
+re-exports.
+
 ### `register_trigger`
 
 Bind a registered function to a configured trigger instance.

--- a/docs/next/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/python-sdk.mdx.skill.md
@@ -56,6 +56,10 @@ def register_function(
 `request_format` / `response_format` accept either a JSON Schema dict or a `RegisterFunctionFormat`
 helper. They are stored alongside the function for the iii console and the agent-readable skills.
 
+The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii.runtime` submodule
+(`from iii.runtime import FunctionRef`). They stay importable from the package root as deprecated
+re-exports.
+
 ### `register_trigger`
 
 Bind a registered function to a configured trigger instance.

--- a/sdk/packages/python/iii/src/iii/runtime.py
+++ b/sdk/packages/python/iii/src/iii/runtime.py
@@ -1,0 +1,6 @@
+"""Public runtime types."""
+
+from .iii_constants import FunctionRef
+from .triggers import TriggerTypeRef
+
+__all__ = ["FunctionRef", "TriggerTypeRef"]

--- a/sdk/packages/python/iii/tests/test_runtime_submodule.py
+++ b/sdk/packages/python/iii/tests/test_runtime_submodule.py
@@ -1,0 +1,15 @@
+"""The iii.runtime submodule exposes the runtime types; the root keeps the shims."""
+
+
+def test_runtime_subpath() -> None:
+    from iii.runtime import FunctionRef, TriggerTypeRef
+
+    assert FunctionRef is not None
+    assert TriggerTypeRef is not None
+
+
+def test_runtime_root_shim() -> None:
+    import iii
+    from iii.runtime import FunctionRef as SubFunctionRef
+
+    assert iii.FunctionRef is SubFunctionRef


### PR DESCRIPTION
Adds the `iii.runtime` submodule, a curated barrel exporting the `FunctionRef` and `TriggerTypeRef` handle types (`from iii.runtime import ...`).

These types stay importable from the package root, which remains the deprecated path. No behavior change; pure relocation of the canonical import path.

- New `src/iii/runtime.py` barrel.
- Reference docs updated (`python-sdk.mdx` + skill companion).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Python SDK reference to clarify proper import paths for runtime types, documenting the recommended submodule import method and deprecated package root alternatives.

* **Tests**
  * Added test coverage to verify runtime type imports work correctly from the submodule and maintain backward compatibility with legacy package root imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->