### PR TITLE
refactor(rust-sdk)!: add iii_sdk::runtime submodule

### DIFF
--- a/docs/next/sdk-reference/rust-sdk.mdx
+++ b/docs/next/sdk-reference/rust-sdk.mdx
@@ -183,6 +183,11 @@ pub enum IIIConnectionState {
 
 ## Info types
 
+The runtime/worker types (`FunctionRef`, `TriggerTypeRef`, `IIIConnectionState`, `WorkerMetadata`,
+`FunctionInfo`, `TriggerInfo`, `WorkerInfo`) are exported from the `iii_sdk::runtime` submodule
+(`use iii_sdk::runtime::FunctionInfo`). They stay reachable at the crate root as deprecated
+re-exports.
+
 The SDK re-exports the engine's structured introspection types:
 
 - `FunctionInfo`. `function_id`, optional `description`, optional `request_format` /

--- a/docs/next/sdk-reference/rust-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/rust-sdk.mdx.skill.md
@@ -181,6 +181,11 @@ pub enum IIIConnectionState {
 
 ## Info types
 
+The runtime/worker types (`FunctionRef`, `TriggerTypeRef`, `IIIConnectionState`, `WorkerMetadata`,
+`FunctionInfo`, `TriggerInfo`, `WorkerInfo`) are exported from the `iii_sdk::runtime` submodule
+(`use iii_sdk::runtime::FunctionInfo`). They stay reachable at the crate root as deprecated
+re-exports.
+
 The SDK re-exports the engine's structured introspection types:
 
 - `FunctionInfo`. `function_id`, optional `description`, optional `request_format` /

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -9,16 +9,26 @@ pub mod structs;
 pub mod triggers;
 pub mod types;
 
+/// Public runtime/worker types. (Stage 1 submodule grouping.)
+pub mod runtime {
+    pub use crate::iii::{
+        FunctionInfo, FunctionRef, IIIConnectionState, TriggerInfo, TriggerTypeRef, WorkerInfo,
+        WorkerMetadata,
+    };
+}
+
 pub use builtin_triggers::{
     IIITrigger, StreamCallRequest, StreamEventDetail, StreamEventType, StreamJoinLeaveCallRequest,
     StreamJoinLeaveTriggerConfig, StreamTriggerConfig,
 };
 pub use channels::{ChannelReader, ChannelWriter, StreamChannelRef};
 pub use error::IIIError;
+#[deprecated(since = "0.19.0", note = "import from iii_sdk::runtime")]
 pub use iii::{
-    FunctionInfo, FunctionRef, III, IIIConnectionState, RegisterFunction, RegisterTriggerType,
-    TriggerInfo, TriggerTypeRef, WorkerInfo, WorkerMetadata,
+    FunctionInfo, FunctionRef, IIIConnectionState, TriggerInfo, TriggerTypeRef, WorkerInfo,
+    WorkerMetadata,
 };
+pub use iii::{III, RegisterFunction, RegisterTriggerType};
 pub use protocol::{
     EnqueueResult, ErrorBody, FunctionMessage, HttpAuthConfig, HttpInvocationConfig, HttpMethod,
     Message, RegisterFunctionMessage, RegisterTriggerInput, RegisterTriggerMessage,
@@ -48,7 +58,7 @@ pub use types::{
 #[derive(Debug, Clone, Default)]
 pub struct InitOptions {
     /// Custom worker metadata. Auto-detected if `None`.
-    pub metadata: Option<WorkerMetadata>,
+    pub metadata: Option<iii::WorkerMetadata>,
     /// Custom HTTP headers sent during the WebSocket handshake.
     pub headers: Option<std::collections::HashMap<String, String>>,
     /// OpenTelemetry configuration.
@@ -143,3 +153,17 @@ fn _ensure_is_channel_ref_not_top_level() {}
 /// ```
 #[allow(dead_code)]
 fn _ensure_create_channel_not_on_instance() {}
+
+// ---------------------------------------------------------------------------
+// Stage 1 runtime submodule: runtime/worker types are reachable at their new
+// canonical path `iii_sdk::runtime`.
+// ---------------------------------------------------------------------------
+
+/// ```rust,no_run
+/// use iii_sdk::runtime::{
+///     FunctionInfo, FunctionRef, IIIConnectionState, TriggerInfo, TriggerTypeRef, WorkerInfo,
+///     WorkerMetadata,
+/// };
+/// ```
+#[allow(dead_code)]
+fn _ensure_runtime_submodule_path() {}

--- a/sdk/packages/rust/iii/tests/bridge.rs
+++ b/sdk/packages/rust/iii/tests/bridge.rs
@@ -10,7 +10,8 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
 
-use iii_sdk::{FunctionInfo, RegisterFunction, TriggerAction, TriggerRequest};
+use iii_sdk::runtime::FunctionInfo;
+use iii_sdk::{RegisterFunction, TriggerAction, TriggerRequest};
 
 #[tokio::test]
 async fn connect_successfully() {

--- a/sdk/packages/rust/iii/tests/hold_process.rs
+++ b/sdk/packages/rust/iii/tests/hold_process.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
-use iii_sdk::{IIIConnectionState, InitOptions, register_worker};
+use iii_sdk::runtime::IIIConnectionState;
+use iii_sdk::{InitOptions, register_worker};
 
 #[test]
 fn shutdown_stops_connection_thread() {

--- a/sdk/packages/rust/iii/tests/http_external_functions.rs
+++ b/sdk/packages/rust/iii/tests/http_external_functions.rs
@@ -11,9 +11,9 @@ use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
+use iii_sdk::runtime::FunctionInfo;
 use iii_sdk::{
-    FunctionInfo, HttpInvocationConfig, HttpMethod, RegisterFunction, RegisterTriggerInput,
-    TriggerRequest,
+    HttpInvocationConfig, HttpMethod, RegisterFunction, RegisterTriggerInput, TriggerRequest,
 };
 
 fn unique_function_id(prefix: &str) -> String {

--- a/sdk/packages/rust/iii/tests/rbac_workers.rs
+++ b/sdk/packages/rust/iii/tests/rbac_workers.rs
@@ -11,11 +11,12 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use serial_test::serial;
 
+use iii_sdk::runtime::IIIConnectionState;
 use iii_sdk::{
-    AuthInput, AuthResult, IIIConnectionState, InitOptions, MiddlewareFunctionInput,
-    OnFunctionRegistrationInput, OnFunctionRegistrationResult, OnTriggerRegistrationInput,
-    OnTriggerRegistrationResult, OnTriggerTypeRegistrationInput, OnTriggerTypeRegistrationResult,
-    RegisterFunction, TriggerRequest, register_worker,
+    AuthInput, AuthResult, InitOptions, MiddlewareFunctionInput, OnFunctionRegistrationInput,
+    OnFunctionRegistrationResult, OnTriggerRegistrationInput, OnTriggerRegistrationResult,
+    OnTriggerTypeRegistrationInput, OnTriggerTypeRegistrationResult, RegisterFunction,
+    TriggerRequest, register_worker,
 };
 use serde::Deserialize;
 

--- a/sdk/packages/rust/iii/tests/registration_dedup.rs
+++ b/sdk/packages/rust/iii/tests/registration_dedup.rs
@@ -19,9 +19,10 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
+use iii_sdk::runtime::IIIConnectionState;
 use iii_sdk::{
-    III, IIIConnectionState, IIIError, InitOptions, RegisterFunction, RegisterTriggerInput,
-    RegisterTriggerType, TriggerConfig, TriggerHandler, register_worker,
+    III, IIIError, InitOptions, RegisterFunction, RegisterTriggerInput, RegisterTriggerType,
+    TriggerConfig, TriggerHandler, register_worker,
 };
 
 use common::mock_engine::{MockEngine, count_register, count_type};

--- a/sdk/packages/rust/iii/tests/trigger_type_lifecycle.rs
+++ b/sdk/packages/rust/iii/tests/trigger_type_lifecycle.rs
@@ -7,9 +7,10 @@ use std::sync::{Arc, Mutex};
 use serial_test::serial;
 
 use async_trait::async_trait;
+use iii_sdk::runtime::IIIConnectionState;
 use iii_sdk::{
-    IIIConnectionState, IIIError, InitOptions, RegisterFunction, RegisterTriggerInput,
-    TriggerConfig, TriggerHandler, TriggerRequest, register_worker,
+    IIIError, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerConfig, TriggerHandler,
+    TriggerRequest, register_worker,
 };
 use serde_json::{Value, json};
 use tokio::time::Duration;


### PR DESCRIPTION
Groups the runtime/worker types under a new `iii_sdk::runtime` submodule: `FunctionRef`, `TriggerTypeRef`, `IIIConnectionState`, `WorkerMetadata`, `FunctionInfo`, `TriggerInfo`, `WorkerInfo`. Canonical path is now `iii_sdk::runtime::*`.

The crate root keeps the same names as deprecated re-exports, so existing `iii_sdk::FunctionInfo`, `iii_sdk::IIIConnectionState`, etc. still resolve. `III`, `RegisterFunction`, and `RegisterTriggerType` stay at the root (not part of this group). No behavior change; pure submodule grouping.

- `lib.rs`: `pub mod runtime` grouping + deprecated root aliases + a doctest pinning the new path. `InitOptions.metadata` now references `iii::WorkerMetadata` directly.
- Integration tests repointed to `iii_sdk::runtime::*` (keeps `clippy --all-targets -D warnings` clean).
- Reference docs updated (`rust-sdk.mdx` + skill companion).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Rust SDK reference to clarify preferred import paths for runtime and worker-related types.

* **Refactor**
  * Runtime and worker-related types are now exported from `iii_sdk::runtime`. Previous crate-root imports are deprecated and should be updated to use the new module path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->