### PR TITLE
docs(stream): point client subscriptions to Browser SDK

### DIFF
--- a/engine/src/workers/stream/README.md
+++ b/engine/src/workers/stream/README.md
@@ -228,6 +228,6 @@ const roomMembers = await iii.trigger({
 
 ## Client Subscriptions
 
-Browser and client subscriptions use the Browser SDK (`iii-browser-sdk`), which subscribes to `stream` changes over a single engine WebSocket and re-renders on each change event. See the [Linkly frontend tutorial](https://iii.dev/docs/tutorials/linkly/frontend) for the end-to-end pattern.
+Browser and client subscriptions use the Browser SDK (`iii-browser-sdk`), which subscribes to `stream` changes over a single engine WebSocket and re-renders on each change event. Connections are gated by the [iii-worker-manager](https://workers.iii.dev/workers/iii-worker-manager) RBAC listener. See the [Linkly frontend tutorial](https://iii.dev/docs/tutorials/linkly/frontend) for the end-to-end pattern.
 
 Connecting directly to the stream port (`ws://host:3112/stream/<stream_name>/<group_id>/`) is deprecated in favor of the Browser SDK.

--- a/engine/src/workers/stream/README.md
+++ b/engine/src/workers/stream/README.md
@@ -226,4 +226,8 @@ const roomMembers = await iii.trigger({
 })
 ```
 
-Clients connect via WebSocket to `ws://host:3112/stream/presence/room-1/` and receive real-time updates when items change.
+## Client Subscriptions
+
+Browser and client subscriptions use the Browser SDK (`iii-browser-sdk`), which subscribes to `stream` changes over a single engine WebSocket and re-renders on each change event. See the [Linkly frontend tutorial](https://iii.dev/docs/tutorials/linkly/frontend) for the end-to-end pattern.
+
+Connecting directly to the stream port (`ws://host:3112/stream/<stream_name>/<group_id>/`) is deprecated in favor of the Browser SDK.

--- a/engine/src/workers/stream/skills/SKILL.md
+++ b/engine/src/workers/stream/skills/SKILL.md
@@ -12,7 +12,7 @@ The `iii-stream` worker stores real-time data as a three-level hierarchy (`strea
 
 A write persists the new value, dispatches matching `stream` triggers on a spawned task (fire-and-forget, so the originating call returns before handlers finish), and broadcasts the change to every WebSocket client subscribed to that `(stream_name, group_id)`. The `stream:join` trigger doubles as an authorization gate: returning `{ unauthorized: true }` from its handler rejects the subscription before any data flows. Pair it with the worker's `auth_function` config, which runs once per WebSocket handshake and stamps a `context` value into every join/leave event.
 
-Adapters: `kv` (default; in-memory or file-backed; single-instance only, no cross-process fan-out) or `redis` (required for multi-instance fleets that need real-time fan-out). Clients connect at `ws://host:{port}/stream/{stream_name}/{group_id}` and optionally `/{item_id}`.
+Adapters: `kv` (default; in-memory or file-backed; single-instance only, no cross-process fan-out) or `redis` (required for multi-instance fleets that need real-time fan-out). Browser and client subscriptions use the Browser SDK (`iii-browser-sdk`), which subscribes to `stream` changes over a single engine WebSocket. Connecting directly to the stream port (`ws://host:{port}/stream/{stream_name}/{group_id}`) is deprecated in favor of the Browser SDK.
 
 ## When to Use
 


### PR DESCRIPTION
Updates the iii-stream worker README and skill so client subscriptions point to the Browser SDK (`iii-browser-sdk`). Marks direct stream-port WebSocket connections as deprecated.

- `engine/src/workers/stream/README.md`
- `engine/src/workers/stream/skills/SKILL.md`

Backend function and trigger surface unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated real-time presence docs and usage example to reflect current client connection model
  * Direct WebSocket connections to stream endpoints are deprecated; use the Browser SDK and single WebSocket subscriptions instead
  * Clarified adapter differences (single-instance vs multi-instance) and noted that client subscriptions respect RBAC controls
<!-- end of auto-generated comment: release notes by coderabbit.ai -->