### PR TITLE
fix(install): retry transient 5xx/timeout failures in curl downloads

### DIFF
--- a/engine/install.sh
+++ b/engine/install.sh
@@ -11,6 +11,14 @@ release_version=""
 init_install_failed=""
 worker_install_failed=""
 
+# curl wrapper that retries transient network failures (504/502/503/timeouts).
+# Uses only flags available since curl 7.12.3 (2005); avoids --retry-all-errors
+# (7.71) so the script stays portable to old curl. HTTP 5xx is treated as a
+# transient error by --retry across all curl versions.
+curl_retry() {
+  curl --retry 5 --retry-delay 2 --retry-max-time 120 --connect-timeout 10 "$@"
+}
+
 # ---------------------------------------------------------------------------
 # Output helpers
 # ---------------------------------------------------------------------------
@@ -112,13 +120,13 @@ iii_emit_event() {
 
 github_api() {
   if [ -n "${GITHUB_TOKEN:-}" ]; then
-    curl -fsSL \
+    curl_retry -fsSL \
       -H "Accept:application/vnd.github+json" \
       -H "X-GitHub-Api-Version:2022-11-28" \
       -H "Authorization:Bearer $GITHUB_TOKEN" \
       "$1"
   else
-    curl -fsSL \
+    curl_retry -fsSL \
       -H "Accept:application/vnd.github+json" \
       -H "X-GitHub-Api-Version:2022-11-28" \
       "$1"
@@ -591,10 +599,10 @@ idx=1
 # Main binary (critical)
 printf '[%d/%d] downloading %s...\n' "$idx" "$total" "$asset_name"
 if [ -t 2 ]; then
-  curl -fL --progress-bar "$asset_url" -o "$main_tarball" \
+  curl_retry -fL --progress-bar "$asset_url" -o "$main_tarball" \
     || err "download" "failed to download $asset_url"
 else
-  curl -fsSL "$asset_url" -o "$main_tarball" \
+  curl_retry -fsSL "$asset_url" -o "$main_tarball" \
     || err "download" "failed to download $asset_url"
 fi
 
@@ -603,10 +611,10 @@ if [ -n "$init_url" ]; then
   idx=$((idx + 1))
   printf '[%d/%d] downloading %s...\n' "$idx" "$total" "$(basename "$init_tarball")"
   if [ -t 2 ]; then
-    curl -fL --progress-bar "$init_url" -o "$init_tarball" \
+    curl_retry -fL --progress-bar "$init_url" -o "$init_tarball" \
       || { warn "iii-init: download failed"; init_install_failed="1"; rm -f "$init_tarball"; init_tarball=""; }
   else
-    curl -fsSL "$init_url" -o "$init_tarball" \
+    curl_retry -fsSL "$init_url" -o "$init_tarball" \
       || { warn "iii-init: download failed"; init_install_failed="1"; rm -f "$init_tarball"; init_tarball=""; }
   fi
 fi
@@ -616,10 +624,10 @@ if [ -n "$worker_url" ]; then
   idx=$((idx + 1))
   printf '[%d/%d] downloading %s...\n' "$idx" "$total" "$(basename "$worker_tarball")"
   if [ -t 2 ]; then
-    curl -fL --progress-bar "$worker_url" -o "$worker_tarball" \
+    curl_retry -fL --progress-bar "$worker_url" -o "$worker_tarball" \
       || { warn "iii-worker: download failed"; worker_install_failed="1"; rm -f "$worker_tarball"; worker_tarball=""; }
   else
-    curl -fsSL "$worker_url" -o "$worker_tarball" \
+    curl_retry -fsSL "$worker_url" -o "$worker_tarball" \
       || { warn "iii-worker: download failed"; worker_install_failed="1"; rm -f "$worker_tarball"; worker_tarball=""; }
   fi
 fi


### PR DESCRIPTION
## Problem

The scheduled [quickstart-validator](https://github.com/iii-hq/quickstart-validator) run failed: a transient **504** from the download CDN (right after the `v0.19.0` publish) aborted the `iii-worker` download during `install.sh`. The binary was left uninstalled, then `iii worker add` failed the run.

Observed in the failed job:
```
[3/3] downloading iii-worker-x86_64-unknown-linux-gnu.tar.gz...
curl: (22) The requested URL returned error: 504
warning: iii-worker: download failed
note: iii-worker failed to install. VM isolation features will be unavailable
```

Root cause: every release-fetching `curl` in `install.sh` ran with **no retry**, so a single transient gateway error was fatal. A re-run (no 504) passed, confirming it was transient.

## Fix

Wrap all release-fetching curl calls in a `curl_retry()` helper that retries transient errors with backoff:

```sh
curl_retry() {
  curl --retry 5 --retry-delay 2 --retry-max-time 120 --connect-timeout 10 "$@"
}
```

Applied to: the GitHub release JSON fetch (`github_api`) and the main / `iii-init` / `iii-worker` tarball downloads.

### Portability
- Uses only flags available since **curl 7.12.3 (2005)**.
- Deliberately avoids `--retry-all-errors` (7.71) to stay portable to old curl.
- HTTP 5xx is treated as transient by `--retry` across all curl versions, so **504 is covered** without it.
- A wrapper function (not an unquoted flags variable) is used to avoid SC2086 in the CI shellcheck gate.

Rate-limit probe curls are left untouched — they intentionally inspect the 403/429 status code.

## Validation
- `sh -n engine/install.sh` — syntax OK
- `shellcheck -s sh engine/install.sh` (same as CI) — PASS
- `bats engine/tests/install_sh_unit.bats` — 19/20 (the 1 failure is a pre-existing macOS `ls`-mode quirk, unrelated; passes on the CI ubuntu runners)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation process reliability with automatic retry logic for transient network failures, such as timeouts and temporary service unavailability.
  * Enhanced download robustness for core components during installation while maintaining existing progress indicators and error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->