### PR TITLE
Stage 1: Organize sdk imports

### DIFF
--- a/docs/changelog/0-20-0/organize-sdk-imports.mdx
+++ b/docs/changelog/0-20-0/organize-sdk-imports.mdx
@@ -1,0 +1,79 @@
+---
+title: 'Grouping SDK exports into submodules'
+description: 'The invocation error types are renamed (InvocationError, Error) and the channel, trigger, and runtime types move to named submodules across the Node, Python, and Rust SDKs. The old root paths keep working as deprecated aliases.'
+---
+
+## What changed
+
+The flat root export surface of the three SDKs is being reorganized into named submodules. This slice covers four groups. Old import paths continue to work as deprecated re-exports, so upgrading requires no immediate code changes.
+
+| Group | Node subpath | Python submodule | Rust module |
+| --- | --- | --- | --- |
+| errors | `iii-sdk/errors` | `iii.errors` | `iii_sdk::errors` |
+| channel | `iii-sdk/channel` | `iii.channel` | `iii_sdk::channel` |
+| trigger | `iii-sdk/trigger` | `iii.trigger` | `iii_sdk::trigger` |
+| runtime | `iii-sdk/runtime` | `iii.runtime` | `iii_sdk::runtime` |
+
+## Errors renamed
+
+The `III` prefix is dropped from the invocation error types.
+
+| SDK | Before | After | Canonical path |
+| --- | --- | --- | --- |
+| Node | `IIIInvocationError` | `InvocationError` | `iii-sdk/errors` |
+| Node | `IIIInvocationErrorInit` | `InvocationErrorInit` | `iii-sdk/errors` |
+| Python | `IIIInvocationError` | `InvocationError` | `iii.errors` |
+| Rust | `IIIError` | `Error` | `iii_sdk::errors::Error` |
+
+Behavior is unchanged. In Node, the thrown error's `name` is now `InvocationError`. In Python, importing `IIIInvocationError` from the package root emits a `DeprecationWarning`. The old names stay exported from the package root as deprecated aliases.
+
+## Submodule contents
+
+| Group | Symbols |
+| --- | --- |
+| channel | `ChannelReader`, `ChannelWriter`, `StreamChannelRef`, `Channel` |
+| trigger | `Trigger`, `TriggerConfig`, `TriggerHandler` (Rust also: `IIITrigger`) |
+| runtime | `FunctionRef`, `TriggerTypeRef` (Rust also: `IIIConnectionState`, `WorkerMetadata`, `FunctionInfo`, `TriggerInfo`, `WorkerInfo`) |
+
+The set per language matches each SDK's existing surface. Symbols absent from a language are not added in this slice; cross language parity is tracked separately.
+
+## Migration
+
+Update imports to the new paths. No runtime change is required until the deprecated root re-exports are removed in a future breaking release.
+
+Node:
+
+```ts
+// Before
+import { IIIInvocationError, ChannelReader, FunctionRef } from 'iii-sdk'
+// After
+import { InvocationError } from 'iii-sdk/errors'
+import { ChannelReader } from 'iii-sdk/channel'
+import type { FunctionRef } from 'iii-sdk/runtime'
+```
+
+Python:
+
+```python
+# Before
+from iii import IIIInvocationError, ChannelReader, FunctionRef
+# After
+from iii.errors import InvocationError
+from iii.channel import ChannelReader
+from iii.runtime import FunctionRef
+```
+
+Rust:
+
+```rust
+// Before
+use iii_sdk::{ChannelReader, FunctionRef, IIIError};
+// After
+use iii_sdk::channel::ChannelReader;
+use iii_sdk::errors::Error;
+use iii_sdk::runtime::FunctionRef;
+```
+
+## Why
+
+The SDK root re-exported dozens of symbols flatly. Grouping them into `errors`, `channel`, `trigger`, and `runtime` submodules makes the surface navigable and prepares for extracting standalone libraries later. Shipping the moves with deprecated aliases keeps the change backward compatible while consumers migrate.

--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -5,6 +5,35 @@ owner: "devrel"
 type: "reference"
 ---
 
+<Update label="0.20.0" description="June 2026">
+  ## SDK: public exports grouped into submodules
+
+  The flat root export surface of the Node, Python, and Rust SDKs is being reorganized into named submodules. This first slice moves four groups and renames the invocation error types. Every old import path keeps working as a deprecated re-export, so this release is backward compatible at runtime.
+
+  | Group | Node | Python | Rust |
+  | --- | --- | --- | --- |
+  | errors | `iii-sdk/errors` | `iii.errors` | `iii_sdk::errors` |
+  | channel | `iii-sdk/channel` | `iii.channel` | `iii_sdk::channel` |
+  | trigger | `iii-sdk/trigger` | `iii.trigger` | `iii_sdk::trigger` |
+  | runtime | `iii-sdk/runtime` | `iii.runtime` | `iii_sdk::runtime` |
+
+  ### Errors renamed (the `III` prefix is dropped)
+
+  - Node: `IIIInvocationError` becomes `InvocationError` (and `IIIInvocationErrorInit` becomes `InvocationErrorInit`), exported from `iii-sdk/errors`. The thrown error's `name` is now `InvocationError`.
+  - Python: `IIIInvocationError` becomes `InvocationError`, exported from `iii.errors`. Importing the old name from the package root emits a `DeprecationWarning`.
+  - Rust: the `IIIError` enum becomes `Error`, at `iii_sdk::errors::Error`.
+
+  The former names stay available at the package root as deprecated aliases.
+
+  ### Submodule grouping
+
+  - **channel**: `ChannelReader`, `ChannelWriter`, `StreamChannelRef`, `Channel`.
+  - **trigger**: `Trigger`, `TriggerConfig`, `TriggerHandler` (Rust also groups the built-in `IIITrigger` factory here).
+  - **runtime**: `FunctionRef` and `TriggerTypeRef` in all SDKs; Rust additionally groups `IIIConnectionState`, `WorkerMetadata`, `FunctionInfo`, `TriggerInfo`, and `WorkerInfo`.
+
+  Prefer the new submodule paths. The root re-exports are deprecated and will be removed in a future breaking release. See [the migration entry](./0-20-0/organize-sdk-imports) for the full per-symbol detail and before/after imports.
+</Update>
+
 <Update label="0.19.0" description="June 2026">
   ## `engine::triggers::info` now exposes `response_schema`
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -157,6 +157,12 @@
                 ]
               },
               {
+                "group": "0.20.0",
+                "pages": [
+                  "changelog/0-20-0/organize-sdk-imports"
+                ]
+              },
+              {
                 "group": "0.16.0",
                 "pages": [
                   "changelog/0-16-0/align-rust-register-function-with-signature"

--- a/docs/next/sdk-reference/node-sdk.mdx
+++ b/docs/next/sdk-reference/node-sdk.mdx
@@ -47,6 +47,10 @@ worker.registerFunction(
 `options` accepts `description`, `metadata`, and optional `request_format` / `response_format`
 JSON Schemas (stored alongside the function for the iii console and agent-readable skills).
 
+The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii-sdk/runtime`
+subpath (`import type { FunctionRef } from 'iii-sdk/runtime'`). They stay re-exported from the
+package root as deprecated aliases.
+
 ### `registerTrigger`
 
 Bind a registered function to a configured trigger instance.

--- a/docs/next/sdk-reference/node-sdk.mdx
+++ b/docs/next/sdk-reference/node-sdk.mdx
@@ -117,18 +117,23 @@ The underlying type is the discriminated union `{ type: "enqueue"; queue: string
 
 ## Error type
 
-`IIIInvocationError extends Error`. Every failure that crosses the SDK boundary is thrown as an
+`InvocationError extends Error`. Every failure that crosses the SDK boundary is thrown as an
 instance of this class with a `code: string`, a `message: string`, an optional `function_id`, and
-an optional `stacktrace`.
+an optional `stacktrace`. Import it from the `iii-sdk/errors` subpath:
 
 ```typescript
-class IIIInvocationError extends Error {
+import { InvocationError } from "iii-sdk/errors";
+
+class InvocationError extends Error {
   code: string;
   message: string;
   function_id?: string;
   stacktrace?: string;
 }
 ```
+
+The former name `IIIInvocationError` is still exported from the package root as a deprecated alias.
+Prefer `InvocationError` from `iii-sdk/errors`.
 
 Common `code` values come from the engine: `invocation_failed` (handler threw), `invocation_stopped`
 (engine timeout), `function_not_found`, `function_not_invokable`, `TIMEOUT` (client-side timeout),

--- a/docs/next/sdk-reference/node-sdk.mdx
+++ b/docs/next/sdk-reference/node-sdk.mdx
@@ -58,6 +58,10 @@ worker.registerTrigger(trigger: RegisterTriggerInput): Trigger;
 The returned `Trigger` carries the runtime handle. Drop the trigger with `Trigger.unregister()`;
 there is no top-level `unregisterTrigger` function.
 
+The `Trigger`, `TriggerConfig`, and `TriggerHandler` types are exported from the `iii-sdk/trigger`
+subpath (`import type { TriggerHandler } from 'iii-sdk/trigger'`). They stay re-exported from the
+package root as deprecated aliases.
+
 ### `registerTriggerType`
 
 Declare a new trigger type that this worker advertises so other workers can bind their functions to

--- a/docs/next/sdk-reference/node-sdk.mdx
+++ b/docs/next/sdk-reference/node-sdk.mdx
@@ -128,6 +128,10 @@ Common `code` values come from the engine: `invocation_failed` (handler threw), 
 
 ## Channels
 
+Import channel symbols from the `iii-sdk/channel` subpath
+(`import { ChannelReader, ChannelWriter } from 'iii-sdk/channel'`). They stay exported from the
+package root as deprecated re-exports.
+
 `ChannelReader` and `ChannelWriter` are runtime classes wrapping the engine's stream WebSockets.
 `StreamChannelRef` is the type passed between SDK calls to identify a channel:
 

--- a/docs/next/sdk-reference/node-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/node-sdk.mdx.skill.md
@@ -126,6 +126,10 @@ Common `code` values come from the engine: `invocation_failed` (handler threw), 
 
 ## Channels
 
+Import channel symbols from the `iii-sdk/channel` subpath
+(`import { ChannelReader, ChannelWriter } from 'iii-sdk/channel'`). They stay exported from the
+package root as deprecated re-exports.
+
 `ChannelReader` and `ChannelWriter` are runtime classes wrapping the engine's stream WebSockets.
 `StreamChannelRef` is the type passed between SDK calls to identify a channel:
 

--- a/docs/next/sdk-reference/node-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/node-sdk.mdx.skill.md
@@ -115,18 +115,23 @@ The underlying type is the discriminated union `{ type: "enqueue"; queue: string
 
 ## Error type
 
-`IIIInvocationError extends Error`. Every failure that crosses the SDK boundary is thrown as an
+`InvocationError extends Error`. Every failure that crosses the SDK boundary is thrown as an
 instance of this class with a `code: string`, a `message: string`, an optional `function_id`, and
-an optional `stacktrace`.
+an optional `stacktrace`. Import it from the `iii-sdk/errors` subpath:
 
 ```typescript
-class IIIInvocationError extends Error {
+import { InvocationError } from "iii-sdk/errors";
+
+class InvocationError extends Error {
   code: string;
   message: string;
   function_id?: string;
   stacktrace?: string;
 }
 ```
+
+The former name `IIIInvocationError` is still exported from the package root as a deprecated alias.
+Prefer `InvocationError` from `iii-sdk/errors`.
 
 Common `code` values come from the engine: `invocation_failed` (handler threw), `invocation_stopped`
 (engine timeout), `function_not_found`, `function_not_invokable`, `TIMEOUT` (client-side timeout),

--- a/docs/next/sdk-reference/node-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/node-sdk.mdx.skill.md
@@ -56,6 +56,10 @@ worker.registerTrigger(trigger: RegisterTriggerInput): Trigger;
 The returned `Trigger` carries the runtime handle. Drop the trigger with `Trigger.unregister()`;
 there is no top-level `unregisterTrigger` function.
 
+The `Trigger`, `TriggerConfig`, and `TriggerHandler` types are exported from the `iii-sdk/trigger`
+subpath (`import type { TriggerHandler } from 'iii-sdk/trigger'`). They stay re-exported from the
+package root as deprecated aliases.
+
 ### `registerTriggerType`
 
 Declare a new trigger type that this worker advertises so other workers can bind their functions to

--- a/docs/next/sdk-reference/node-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/node-sdk.mdx.skill.md
@@ -45,6 +45,10 @@ worker.registerFunction(
 `options` accepts `description`, `metadata`, and optional `request_format` / `response_format`
 JSON Schemas (stored alongside the function for the iii console and agent-readable skills).
 
+The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii-sdk/runtime`
+subpath (`import type { FunctionRef } from 'iii-sdk/runtime'`). They stay re-exported from the
+package root as deprecated aliases.
+
 ### `registerTrigger`
 
 Bind a registered function to a configured trigger instance.

--- a/docs/next/sdk-reference/python-sdk.mdx
+++ b/docs/next/sdk-reference/python-sdk.mdx
@@ -136,8 +136,8 @@ TriggerAction.Enqueue(queue="math")   # route through iii-queue; returns Trigger
 
 ## Error types
 
-Every invocation failure raises `IIIInvocationError`. Inspect its `code` attribute to
-distinguish categories:
+Every invocation failure raises `InvocationError`, imported from the `iii.errors` submodule
+(`from iii.errors import InvocationError`). Inspect its `code` attribute to distinguish categories:
 
 | `code`        | When raised                       |
 | ------------- | --------------------------------- |
@@ -145,7 +145,8 @@ distinguish categories:
 | `"TIMEOUT"`   | The invocation timed out.         |
 | other         | Any other engine-side rejection.  |
 
-`IIIInvocationError` has `code`, `message`, `function_id`, and `stacktrace` attributes.
+`InvocationError` has `code`, `message`, `function_id`, and `stacktrace` attributes. The former
+name `IIIInvocationError` stays importable from the package root as a deprecated alias.
 
 ## Channels
 

--- a/docs/next/sdk-reference/python-sdk.mdx
+++ b/docs/next/sdk-reference/python-sdk.mdx
@@ -73,6 +73,10 @@ def register_trigger(self, trigger: RegisterTriggerInput | dict[str, Any]) -> Tr
 Drop the trigger with `trigger.unregister()` on the returned handle. There is no top-level
 `unregister_trigger` method.
 
+The `Trigger`, `TriggerConfig`, and `TriggerHandler` types are exported from the `iii.trigger`
+submodule (`from iii.trigger import TriggerHandler`). They stay importable from the package root as
+deprecated re-exports.
+
 ### `register_trigger_type`
 
 Declare a new trigger type that this worker advertises.

--- a/docs/next/sdk-reference/python-sdk.mdx
+++ b/docs/next/sdk-reference/python-sdk.mdx
@@ -58,6 +58,10 @@ def register_function(
 `request_format` / `response_format` accept either a JSON Schema dict or a `RegisterFunctionFormat`
 helper. They are stored alongside the function for the iii console and the agent-readable skills.
 
+The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii.runtime` submodule
+(`from iii.runtime import FunctionRef`). They stay importable from the package root as deprecated
+re-exports.
+
 ### `register_trigger`
 
 Bind a registered function to a configured trigger instance.

--- a/docs/next/sdk-reference/python-sdk.mdx
+++ b/docs/next/sdk-reference/python-sdk.mdx
@@ -149,6 +149,10 @@ distinguish categories:
 
 ## Channels
 
+Import channel types from the `iii.channel` submodule
+(`from iii.channel import ChannelReader, ChannelWriter`). They stay importable from the package root
+as deprecated re-exports.
+
 `ChannelReader` and `ChannelWriter` wrap the engine's stream WebSockets. `StreamChannelRef`
 identifies a channel:
 

--- a/docs/next/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/python-sdk.mdx.skill.md
@@ -134,8 +134,8 @@ TriggerAction.Enqueue(queue="math")   # route through iii-queue; returns Trigger
 
 ## Error types
 
-Every invocation failure raises `IIIInvocationError`. Inspect its `code` attribute to
-distinguish categories:
+Every invocation failure raises `InvocationError`, imported from the `iii.errors` submodule
+(`from iii.errors import InvocationError`). Inspect its `code` attribute to distinguish categories:
 
 | `code`        | When raised                       |
 | ------------- | --------------------------------- |
@@ -143,7 +143,8 @@ distinguish categories:
 | `"TIMEOUT"`   | The invocation timed out.         |
 | other         | Any other engine-side rejection.  |
 
-`IIIInvocationError` has `code`, `message`, `function_id`, and `stacktrace` attributes.
+`InvocationError` has `code`, `message`, `function_id`, and `stacktrace` attributes. The former
+name `IIIInvocationError` stays importable from the package root as a deprecated alias.
 
 ## Channels
 

--- a/docs/next/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/python-sdk.mdx.skill.md
@@ -147,6 +147,10 @@ distinguish categories:
 
 ## Channels
 
+Import channel types from the `iii.channel` submodule
+(`from iii.channel import ChannelReader, ChannelWriter`). They stay importable from the package root
+as deprecated re-exports.
+
 `ChannelReader` and `ChannelWriter` wrap the engine's stream WebSockets. `StreamChannelRef`
 identifies a channel:
 

--- a/docs/next/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/python-sdk.mdx.skill.md
@@ -56,6 +56,10 @@ def register_function(
 `request_format` / `response_format` accept either a JSON Schema dict or a `RegisterFunctionFormat`
 helper. They are stored alongside the function for the iii console and the agent-readable skills.
 
+The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii.runtime` submodule
+(`from iii.runtime import FunctionRef`). They stay importable from the package root as deprecated
+re-exports.
+
 ### `register_trigger`
 
 Bind a registered function to a configured trigger instance.

--- a/docs/next/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/python-sdk.mdx.skill.md
@@ -71,6 +71,10 @@ def register_trigger(self, trigger: RegisterTriggerInput | dict[str, Any]) -> Tr
 Drop the trigger with `trigger.unregister()` on the returned handle. There is no top-level
 `unregister_trigger` method.
 
+The `Trigger`, `TriggerConfig`, and `TriggerHandler` types are exported from the `iii.trigger`
+submodule (`from iii.trigger import TriggerHandler`). They stay importable from the package root as
+deprecated re-exports.
+
 ### `register_trigger_type`
 
 Declare a new trigger type that this worker advertises.

--- a/docs/next/sdk-reference/rust-sdk.mdx
+++ b/docs/next/sdk-reference/rust-sdk.mdx
@@ -64,6 +64,10 @@ pub fn register_trigger(
 Drop the trigger with `trigger.unregister()` on the returned handle. There is no free-function
 `unregister_trigger`.
 
+The `Trigger`, `TriggerConfig`, `TriggerHandler`, and `IIITrigger` types are exported from the
+`iii_sdk::trigger` submodule (`use iii_sdk::trigger::IIITrigger`). They stay reachable at the crate
+root as deprecated re-exports.
+
 ### `register_trigger_type`
 
 Declare a new trigger type that this worker advertises.

--- a/docs/next/sdk-reference/rust-sdk.mdx
+++ b/docs/next/sdk-reference/rust-sdk.mdx
@@ -58,7 +58,7 @@ Bind a registered function to a configured trigger instance.
 pub fn register_trigger(
     &self,
     input: RegisterTriggerInput,
-) -> Result<Trigger, IIIError>;
+) -> Result<Trigger, Error>;
 ```
 
 Drop the trigger with `trigger.unregister()` on the returned handle. There is no free-function
@@ -95,7 +95,7 @@ Invoke a registered function. Always async; await the future to receive the resu
 pub async fn trigger(
     &self,
     request: impl Into<TriggerRequest>,
-) -> Result<serde_json::Value, IIIError>;
+) -> Result<serde_json::Value, Error>;
 ```
 
 The returned `Value` is the function's return JSON for synchronous calls, an `EnqueueResult`-shaped
@@ -125,11 +125,13 @@ Pass it in `TriggerRequest::action` as `Some(TriggerAction::Void)` or
 
 ## Error type
 
-`IIIError` is the public error enum. Most invocation failures arrive on the `Remote` or `Runtime`
-variants.
+`Error` is the public error enum, reachable at its canonical path `iii_sdk::errors::Error`. Most
+invocation failures arrive on the `Remote` or `Runtime` variants.
 
 ```rust
-pub enum IIIError {
+use iii_sdk::errors::Error;
+
+pub enum Error {
     NotConnected,
     Timeout,
     Runtime(String),
@@ -140,8 +142,11 @@ pub enum IIIError {
 }
 ```
 
+The former name `IIIError` stays reachable at the crate root as a deprecated alias; prefer
+`iii_sdk::errors::Error`.
+
 `ErrorBody` carries the engine's `{ code, message, stacktrace? }` payload; match on
-`IIIError::Remote(body) => body.code.as_str()` to branch on engine error codes
+`Error::Remote(body) => body.code.as_str()` to branch on engine error codes
 (`invocation_failed`, `invocation_stopped`, `function_not_found`, `FORBIDDEN`, `TIMEOUT`, etc.).
 
 ## Channels

--- a/docs/next/sdk-reference/rust-sdk.mdx
+++ b/docs/next/sdk-reference/rust-sdk.mdx
@@ -151,6 +151,10 @@ The former name `IIIError` stays reachable at the crate root as a deprecated ali
 
 ## Channels
 
+Import channel types from the `iii_sdk::channel` submodule
+(`use iii_sdk::channel::{ChannelReader, ChannelWriter}`). They stay reachable at the crate root as
+deprecated re-exports.
+
 `ChannelReader` and `ChannelWriter` wrap the engine's stream WebSockets. `StreamChannelRef`
 identifies a channel:
 

--- a/docs/next/sdk-reference/rust-sdk.mdx
+++ b/docs/next/sdk-reference/rust-sdk.mdx
@@ -196,6 +196,11 @@ pub enum IIIConnectionState {
 
 ## Info types
 
+The runtime/worker types (`FunctionRef`, `TriggerTypeRef`, `IIIConnectionState`, `WorkerMetadata`,
+`FunctionInfo`, `TriggerInfo`, `WorkerInfo`) are exported from the `iii_sdk::runtime` submodule
+(`use iii_sdk::runtime::FunctionInfo`). They stay reachable at the crate root as deprecated
+re-exports.
+
 The SDK re-exports the engine's structured introspection types:
 
 - `FunctionInfo`. `function_id`, optional `description`, optional `request_format` /

--- a/docs/next/sdk-reference/rust-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/rust-sdk.mdx.skill.md
@@ -62,6 +62,10 @@ pub fn register_trigger(
 Drop the trigger with `trigger.unregister()` on the returned handle. There is no free-function
 `unregister_trigger`.
 
+The `Trigger`, `TriggerConfig`, `TriggerHandler`, and `IIITrigger` types are exported from the
+`iii_sdk::trigger` submodule (`use iii_sdk::trigger::IIITrigger`). They stay reachable at the crate
+root as deprecated re-exports.
+
 ### `register_trigger_type`
 
 Declare a new trigger type that this worker advertises.

--- a/docs/next/sdk-reference/rust-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/rust-sdk.mdx.skill.md
@@ -56,7 +56,7 @@ Bind a registered function to a configured trigger instance.
 pub fn register_trigger(
     &self,
     input: RegisterTriggerInput,
-) -> Result<Trigger, IIIError>;
+) -> Result<Trigger, Error>;
 ```
 
 Drop the trigger with `trigger.unregister()` on the returned handle. There is no free-function
@@ -93,7 +93,7 @@ Invoke a registered function. Always async; await the future to receive the resu
 pub async fn trigger(
     &self,
     request: impl Into<TriggerRequest>,
-) -> Result<serde_json::Value, IIIError>;
+) -> Result<serde_json::Value, Error>;
 ```
 
 The returned `Value` is the function's return JSON for synchronous calls, an `EnqueueResult`-shaped
@@ -123,11 +123,13 @@ Pass it in `TriggerRequest::action` as `Some(TriggerAction::Void)` or
 
 ## Error type
 
-`IIIError` is the public error enum. Most invocation failures arrive on the `Remote` or `Runtime`
-variants.
+`Error` is the public error enum, reachable at its canonical path `iii_sdk::errors::Error`. Most
+invocation failures arrive on the `Remote` or `Runtime` variants.
 
 ```rust
-pub enum IIIError {
+use iii_sdk::errors::Error;
+
+pub enum Error {
     NotConnected,
     Timeout,
     Runtime(String),
@@ -138,8 +140,11 @@ pub enum IIIError {
 }
 ```
 
+The former name `IIIError` stays reachable at the crate root as a deprecated alias; prefer
+`iii_sdk::errors::Error`.
+
 `ErrorBody` carries the engine's `{ code, message, stacktrace? }` payload; match on
-`IIIError::Remote(body) => body.code.as_str()` to branch on engine error codes
+`Error::Remote(body) => body.code.as_str()` to branch on engine error codes
 (`invocation_failed`, `invocation_stopped`, `function_not_found`, `FORBIDDEN`, `TIMEOUT`, etc.).
 
 ## Channels

--- a/docs/next/sdk-reference/rust-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/rust-sdk.mdx.skill.md
@@ -149,6 +149,10 @@ The former name `IIIError` stays reachable at the crate root as a deprecated ali
 
 ## Channels
 
+Import channel types from the `iii_sdk::channel` submodule
+(`use iii_sdk::channel::{ChannelReader, ChannelWriter}`). They stay reachable at the crate root as
+deprecated re-exports.
+
 `ChannelReader` and `ChannelWriter` wrap the engine's stream WebSockets. `StreamChannelRef`
 identifies a channel:
 

--- a/docs/next/sdk-reference/rust-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/rust-sdk.mdx.skill.md
@@ -194,6 +194,11 @@ pub enum IIIConnectionState {
 
 ## Info types
 
+The runtime/worker types (`FunctionRef`, `TriggerTypeRef`, `IIIConnectionState`, `WorkerMetadata`,
+`FunctionInfo`, `TriggerInfo`, `WorkerInfo`) are exported from the `iii_sdk::runtime` submodule
+(`use iii_sdk::runtime::FunctionInfo`). They stay reachable at the crate root as deprecated
+re-exports.
+
 The SDK re-exports the engine's structured introspection types:
 
 - `FunctionInfo`. `function_id`, optional `description`, optional `request_format` /

--- a/sdk/packages/node/iii/package.json
+++ b/sdk/packages/node/iii/package.json
@@ -41,6 +41,11 @@
       "types": "./dist/helpers.d.ts",
       "import": "./dist/helpers.mjs",
       "require": "./dist/helpers.cjs"
+    },
+    "./channel": {
+      "types": "./dist/channel.d.ts",
+      "import": "./dist/channel.mjs",
+      "require": "./dist/channel.cjs"
     }
   },
   "dependencies": {

--- a/sdk/packages/node/iii/package.json
+++ b/sdk/packages/node/iii/package.json
@@ -46,6 +46,11 @@
       "types": "./dist/channel.d.ts",
       "import": "./dist/channel.mjs",
       "require": "./dist/channel.cjs"
+    },
+    "./trigger": {
+      "types": "./dist/trigger.d.ts",
+      "import": "./dist/trigger.mjs",
+      "require": "./dist/trigger.cjs"
     }
   },
   "dependencies": {

--- a/sdk/packages/node/iii/package.json
+++ b/sdk/packages/node/iii/package.json
@@ -56,6 +56,11 @@
       "types": "./dist/runtime.d.ts",
       "import": "./dist/runtime.mjs",
       "require": "./dist/runtime.cjs"
+    },
+    "./errors": {
+      "types": "./dist/errors.d.ts",
+      "import": "./dist/errors.mjs",
+      "require": "./dist/errors.cjs"
     }
   },
   "dependencies": {

--- a/sdk/packages/node/iii/package.json
+++ b/sdk/packages/node/iii/package.json
@@ -51,6 +51,11 @@
       "types": "./dist/trigger.d.ts",
       "import": "./dist/trigger.mjs",
       "require": "./dist/trigger.cjs"
+    },
+    "./runtime": {
+      "types": "./dist/runtime.d.ts",
+      "import": "./dist/runtime.mjs",
+      "require": "./dist/runtime.cjs"
     }
   },
   "dependencies": {

--- a/sdk/packages/node/iii/src/channel.ts
+++ b/sdk/packages/node/iii/src/channel.ts
@@ -1,0 +1,3 @@
+export { ChannelReader, ChannelWriter } from './channels'
+export type { StreamChannelRef } from './iii-types'
+export type { Channel } from './types'

--- a/sdk/packages/node/iii/src/errors.ts
+++ b/sdk/packages/node/iii/src/errors.ts
@@ -11,21 +11,21 @@
  * prefix in the message, and `function_id` field together make a rejection
  * self-describing.
  */
-export type IIIInvocationErrorInit = {
+export type InvocationErrorInit = {
   code: string
   message: string
   function_id?: string
   stacktrace?: string
 }
 
-export class IIIInvocationError extends Error {
+export class InvocationError extends Error {
   public readonly code: string
   public readonly function_id?: string
   public readonly stacktrace?: string
 
-  constructor(init: IIIInvocationErrorInit) {
+  constructor(init: InvocationErrorInit) {
     super(`${init.code}: ${init.message}`)
-    this.name = 'IIIInvocationError'
+    this.name = 'InvocationError'
     this.code = init.code
     this.function_id = init.function_id
     this.stacktrace = init.stacktrace
@@ -36,7 +36,7 @@ export class IIIInvocationError extends Error {
  * True when `value` looks like the wire `ErrorBody` the engine sends in
  * `InvocationResult.error`: `{ code: string, message: string, stacktrace?: string }`.
  * Used to distinguish an engine rejection (which we wrap in
- * {@link IIIInvocationError}) from a JS `Error` thrown elsewhere.
+ * {@link InvocationError}) from a JS `Error` thrown elsewhere.
  */
 export function isErrorBody(value: unknown): value is {
   code: string
@@ -51,3 +51,16 @@ export function isErrorBody(value: unknown): value is {
     (v.stacktrace === undefined || typeof v.stacktrace === 'string')
   )
 }
+
+/**
+ * @deprecated Renamed to {@link InvocationError}; import from `iii-sdk/errors`.
+ */
+export const IIIInvocationError = InvocationError
+/**
+ * @deprecated Renamed to {@link InvocationError}.
+ */
+export type IIIInvocationError = InvocationError
+/**
+ * @deprecated Renamed to {@link InvocationErrorInit}.
+ */
+export type IIIInvocationErrorInit = InvocationErrorInit

--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module'
 import * as os from 'node:os'
 import { type Data, WebSocket } from 'ws'
 import { ChannelReader, ChannelWriter } from './channels'
-import { IIIInvocationError, isErrorBody } from './errors'
+import { InvocationError, isErrorBody } from './errors'
 import {
   DEFAULT_BRIDGE_RECONNECTION_CONFIG,
   DEFAULT_INVOCATION_TIMEOUT_MS,
@@ -483,7 +483,7 @@ class Sdk implements ISdk {
         if (invocation) {
           this.invocations.delete(invocation_id)
           reject(
-            new IIIInvocationError({
+            new InvocationError({
               code: 'TIMEOUT',
               message: `invocation timed out after ${effectiveTimeout}ms`,
               function_id,
@@ -808,7 +808,7 @@ class Sdk implements ISdk {
   }
 
   /**
-   * Wrap a wire-format `ErrorBody` in {@link IIIInvocationError} so callers get
+   * Wrap a wire-format `ErrorBody` in {@link InvocationError} so callers get
    * a real `Error` with a readable `.message` and a typed `.code`. Pass-through
    * for values that are already `Error` subclasses. Everything else is wrapped
    * under an `UNKNOWN` code so `String(err) !== '[object Object]'` holds for
@@ -819,7 +819,7 @@ class Sdk implements ISdk {
       return error
     }
     if (isErrorBody(error)) {
-      return new IIIInvocationError({
+      return new InvocationError({
         code: error.code,
         message: error.message,
         function_id,
@@ -834,7 +834,7 @@ class Sdk implements ISdk {
       typeof error === 'string'
         ? error
         : (JSON.stringify(error) ?? String(error))
-    return new IIIInvocationError({
+    return new InvocationError({
       code: 'UNKNOWN',
       message,
       function_id,

--- a/sdk/packages/node/iii/src/index.ts
+++ b/sdk/packages/node/iii/src/index.ts
@@ -29,7 +29,8 @@ export type {
   TriggerRequest,
 } from './iii-types'
 
-export type { TriggerConfig, TriggerHandler } from './triggers'
+/** @deprecated Import trigger types from `iii-sdk/trigger`. */
+export type { Trigger, TriggerConfig, TriggerHandler } from './trigger'
 
 export type {
   ApiRequest,
@@ -44,7 +45,6 @@ export type {
   RegisterTriggerInput,
   RegisterTriggerTypeInput,
   RemoteFunctionHandler,
-  Trigger,
   TriggerTypeRef,
 } from './types'
 

--- a/sdk/packages/node/iii/src/index.ts
+++ b/sdk/packages/node/iii/src/index.ts
@@ -3,6 +3,8 @@ export { ChannelReader, ChannelWriter } from './channel'
 /** @deprecated Import `Channel` / `StreamChannelRef` from `iii-sdk/channel`. */
 export type { Channel, StreamChannelRef } from './channel'
 
+export { InvocationError, type InvocationErrorInit } from './errors'
+/** @deprecated Renamed; import `InvocationError` / `InvocationErrorInit` from `iii-sdk/errors`. */
 export { IIIInvocationError, type IIIInvocationErrorInit } from './errors'
 
 export { type InitOptions, registerWorker, TriggerAction } from './iii'

--- a/sdk/packages/node/iii/src/index.ts
+++ b/sdk/packages/node/iii/src/index.ts
@@ -1,4 +1,7 @@
-export { ChannelReader, ChannelWriter } from './channels'
+/** @deprecated Import channel symbols from `iii-sdk/channel`. */
+export { ChannelReader, ChannelWriter } from './channel'
+/** @deprecated Import `Channel` / `StreamChannelRef` from `iii-sdk/channel`. */
+export type { Channel, StreamChannelRef } from './channel'
 
 export { IIIInvocationError, type IIIInvocationErrorInit } from './errors'
 
@@ -23,7 +26,6 @@ export type {
   RegisterFunctionMessage,
   RegisterTriggerMessage,
   RegisterTriggerTypeMessage,
-  StreamChannelRef,
   TriggerRequest,
 } from './iii-types'
 
@@ -32,7 +34,6 @@ export type { TriggerConfig, TriggerHandler } from './triggers'
 export type {
   ApiRequest,
   ApiResponse,
-  Channel,
   FunctionRef,
   HttpRequest,
   HttpResponse,

--- a/sdk/packages/node/iii/src/index.ts
+++ b/sdk/packages/node/iii/src/index.ts
@@ -35,7 +35,6 @@ export type { Trigger, TriggerConfig, TriggerHandler } from './trigger'
 export type {
   ApiRequest,
   ApiResponse,
-  FunctionRef,
   HttpRequest,
   HttpResponse,
   InternalHttpRequest,
@@ -45,7 +44,9 @@ export type {
   RegisterTriggerInput,
   RegisterTriggerTypeInput,
   RemoteFunctionHandler,
-  TriggerTypeRef,
 } from './types'
+
+/** @deprecated Import runtime types from `iii-sdk/runtime`. */
+export type { FunctionRef, TriggerTypeRef } from './runtime'
 
 export { http } from './utils'

--- a/sdk/packages/node/iii/src/runtime.ts
+++ b/sdk/packages/node/iii/src/runtime.ts
@@ -1,0 +1,1 @@
+export type { FunctionRef, TriggerTypeRef } from './types'

--- a/sdk/packages/node/iii/src/trigger.ts
+++ b/sdk/packages/node/iii/src/trigger.ts
@@ -1,0 +1,2 @@
+export type { TriggerConfig, TriggerHandler } from './triggers'
+export type { Trigger } from './types'

--- a/sdk/packages/node/iii/tests/errors.test.ts
+++ b/sdk/packages/node/iii/tests/errors.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { IIIInvocationError } from '../src/index'
+import { InvocationError } from '../src/index'
 import { isErrorBody } from '../src/errors'
 
-describe('IIIInvocationError', () => {
+describe('InvocationError', () => {
   it('exposes code, function_id, stacktrace and a readable message', () => {
-    const err = new IIIInvocationError({
+    const err = new InvocationError({
       code: 'FORBIDDEN',
       message: "function 'engine::functions::list' not allowed",
       function_id: 'engine::functions::list',
@@ -13,8 +13,8 @@ describe('IIIInvocationError', () => {
     })
 
     expect(err).toBeInstanceOf(Error)
-    expect(err).toBeInstanceOf(IIIInvocationError)
-    expect(err.name).toBe('IIIInvocationError')
+    expect(err).toBeInstanceOf(InvocationError)
+    expect(err.name).toBe('InvocationError')
     expect(err.code).toBe('FORBIDDEN')
     expect(err.function_id).toBe('engine::functions::list')
     expect(err.stacktrace).toBe('trace here')
@@ -22,7 +22,7 @@ describe('IIIInvocationError', () => {
   })
 
   it('does NOT serialize to "[object Object]" (the original bug)', () => {
-    const err = new IIIInvocationError({
+    const err = new InvocationError({
       code: 'FORBIDDEN',
       message: "function 'engine::functions::list' not allowed",
       function_id: 'engine::functions::list',
@@ -31,18 +31,18 @@ describe('IIIInvocationError', () => {
     // The bug reporter saw `[object Object]` when printing a plain ErrorBody.
     // Real Error subclasses stringify as `Name: message`, not `[object Object]`.
     expect(String(err)).not.toBe('[object Object]')
-    expect(String(err)).toContain('IIIInvocationError')
+    expect(String(err)).toContain('InvocationError')
     expect(String(err)).toContain("engine::functions::list")
   })
 
   it('propagates stack traces as a real Error subclass', () => {
-    const err = new IIIInvocationError({ code: 'UNKNOWN', message: 'oops' })
+    const err = new InvocationError({ code: 'UNKNOWN', message: 'oops' })
     expect(err.stack).toBeTruthy()
     expect(typeof err.stack).toBe('string')
   })
 
   it('supports errors without function_id or stacktrace', () => {
-    const err = new IIIInvocationError({ code: 'TIMEOUT', message: 'gone' })
+    const err = new InvocationError({ code: 'TIMEOUT', message: 'gone' })
     expect(err.function_id).toBeUndefined()
     expect(err.stacktrace).toBeUndefined()
     expect(err.message).toBe('TIMEOUT: gone')
@@ -64,5 +64,23 @@ describe('isErrorBody', () => {
     expect(isErrorBody({ message: 'Y' })).toBe(false)
     expect(isErrorBody({ code: 1, message: 'Y' })).toBe(false)
     expect(isErrorBody(new Error('plain'))).toBe(false)
+  })
+})
+
+describe('errors subpath and back-compat', () => {
+  it('exports InvocationError from the iii-sdk/errors subpath', async () => {
+    const errs = await import('../src/errors')
+    expect(errs.InvocationError).toBeDefined()
+    expect(typeof errs.InvocationError).toBe('function')
+    const root = await import('../src/index')
+    expect(root.InvocationError).toBe(errs.InvocationError)
+  })
+
+  it('keeps the deprecated IIIInvocationError alias pointing at InvocationError', async () => {
+    const errs = await import('../src/errors')
+    const root = await import('../src/index')
+    expect(root.IIIInvocationError).toBe(errs.InvocationError)
+    const err = new root.IIIInvocationError({ code: 'FORBIDDEN', message: 'nope' })
+    expect(err).toBeInstanceOf(errs.InvocationError)
   })
 })

--- a/sdk/packages/node/iii/tests/exports.test.ts
+++ b/sdk/packages/node/iii/tests/exports.test.ts
@@ -31,4 +31,8 @@ describe('Package Exports', () => {
     expect(root.ChannelReader).toBe(ch.ChannelReader)
     expect(root.ChannelWriter).toBe(ch.ChannelWriter)
   })
+
+  it('should import the trigger subpath module', async () => {
+    await expect(import('../src/trigger')).resolves.toBeDefined()
+  })
 })

--- a/sdk/packages/node/iii/tests/exports.test.ts
+++ b/sdk/packages/node/iii/tests/exports.test.ts
@@ -35,4 +35,8 @@ describe('Package Exports', () => {
   it('should import the trigger subpath module', async () => {
     await expect(import('../src/trigger')).resolves.toBeDefined()
   })
+
+  it('should import the runtime subpath module', async () => {
+    await expect(import('../src/runtime')).resolves.toBeDefined()
+  })
 })

--- a/sdk/packages/node/iii/tests/exports.test.ts
+++ b/sdk/packages/node/iii/tests/exports.test.ts
@@ -22,4 +22,13 @@ describe('Package Exports', () => {
     expect(stateModule.StateEventType).toBeDefined()
     expect(Object.keys(stateModule).length).toBeGreaterThan(0)
   })
+
+  it('should export channel symbols from the subpath and keep the deprecated root shim', async () => {
+    const ch = await import('../src/channel')
+    expect(ch.ChannelReader).toBeDefined()
+    expect(ch.ChannelWriter).toBeDefined()
+    const root = await import('../src/index')
+    expect(root.ChannelReader).toBe(ch.ChannelReader)
+    expect(root.ChannelWriter).toBe(ch.ChannelWriter)
+  })
 })

--- a/sdk/packages/node/iii/tests/rbac-workers.test.ts
+++ b/sdk/packages/node/iii/tests/rbac-workers.test.ts
@@ -10,7 +10,7 @@ import type {
   OnTriggerTypeRegistrationInput,
   OnTriggerTypeRegistrationResult,
 } from '../src/index'
-import { IIIInvocationError, registerWorker } from '../src/index'
+import { InvocationError, registerWorker } from '../src/index'
 import { EngineFunctions } from '../src/iii-constants'
 import { iii, sleep } from './utils'
 
@@ -362,7 +362,7 @@ describe('RBAC Workers', () => {
     }
   })
 
-  it('wraps FORBIDDEN rejection in IIIInvocationError with function_id', async () => {
+  it('wraps FORBIDDEN rejection in InvocationError with function_id', async () => {
     const iiiClient = registerWorker(EW_URL, {
       headers: { 'x-test-token': 'valid-token' },
       otel: { enabled: false },
@@ -381,8 +381,8 @@ describe('RBAC Workers', () => {
       }
 
       expect(caught).toBeInstanceOf(Error)
-      expect(caught).toBeInstanceOf(IIIInvocationError)
-      const err = caught as IIIInvocationError
+      expect(caught).toBeInstanceOf(InvocationError)
+      const err = caught as InvocationError
       expect(err.code).toBe('FORBIDDEN')
       expect(err.function_id).toBe('test::ew::private')
       expect(err.message).toContain('FORBIDDEN')

--- a/sdk/packages/node/iii/tsdown.config.ts
+++ b/sdk/packages/node/iii/tsdown.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     './src/channel.ts',
     './src/trigger.ts',
     './src/runtime.ts',
+    './src/errors.ts',
   ],
   format: ['esm', 'cjs'],
   dts: true,

--- a/sdk/packages/node/iii/tsdown.config.ts
+++ b/sdk/packages/node/iii/tsdown.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['./src/index.ts', './src/stream.ts', './src/state.ts', './src/helpers.ts', './src/channel.ts'],
+  entry: [
+    './src/index.ts',
+    './src/stream.ts',
+    './src/state.ts',
+    './src/helpers.ts',
+    './src/channel.ts',
+    './src/trigger.ts',
+  ],
   format: ['esm', 'cjs'],
   dts: true,
   sourcemap: true,

--- a/sdk/packages/node/iii/tsdown.config.ts
+++ b/sdk/packages/node/iii/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['./src/index.ts', './src/stream.ts', './src/state.ts', './src/helpers.ts'],
+  entry: ['./src/index.ts', './src/stream.ts', './src/state.ts', './src/helpers.ts', './src/channel.ts'],
   format: ['esm', 'cjs'],
   dts: true,
   sourcemap: true,

--- a/sdk/packages/node/iii/tsdown.config.ts
+++ b/sdk/packages/node/iii/tsdown.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     './src/helpers.ts',
     './src/channel.ts',
     './src/trigger.ts',
+    './src/runtime.ts',
   ],
   format: ['esm', 'cjs'],
   dts: true,

--- a/sdk/packages/python/iii/src/iii/__init__.py
+++ b/sdk/packages/python/iii/src/iii/__init__.py
@@ -1,7 +1,9 @@
 """III SDK for Python."""
 
+from typing import Any
+
 from .channels import ChannelReader, ChannelWriter
-from .errors import IIIInvocationError
+from .errors import InvocationError
 from .format_utils import extract_request_format, extract_response_format, python_type_to_format
 from .iii import TriggerAction, register_worker
 from .iii_constants import FunctionRef, InitOptions, TelemetryOptions
@@ -57,7 +59,7 @@ __all__ = [
     "ChannelReader",
     "ChannelWriter",
     # Errors
-    "IIIInvocationError",
+    "InvocationError",
     # Core
     "FunctionRef",
     "InitOptions",
@@ -118,3 +120,16 @@ __all__ = [
     "extract_response_format",
     "python_type_to_format",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "IIIInvocationError":
+        import warnings
+
+        warnings.warn(
+            "IIIInvocationError is deprecated; import InvocationError from iii.errors",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return InvocationError
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/sdk/packages/python/iii/src/iii/channel.py
+++ b/sdk/packages/python/iii/src/iii/channel.py
@@ -1,0 +1,7 @@
+"""Public channel types."""
+
+from .channels import ChannelReader, ChannelWriter
+from .iii_types import StreamChannelRef
+from .types import Channel
+
+__all__ = ["Channel", "ChannelReader", "ChannelWriter", "StreamChannelRef"]

--- a/sdk/packages/python/iii/src/iii/errors.py
+++ b/sdk/packages/python/iii/src/iii/errors.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from typing import Any
 
 
-class IIIInvocationError(Exception):
+class InvocationError(Exception):
     """Raised when an invocation dispatched by the SDK fails.
 
     Inspect ``err.code`` to react to a specific category (e.g.
     ``'FORBIDDEN'`` for RBAC denials, ``'TIMEOUT'`` for timeouts). Catch
     this class to handle every rejection. ``except Exception`` continues to
-    work because ``IIIInvocationError`` inherits from ``Exception``.
+    work because ``InvocationError`` inherits from ``Exception``.
 
     Attributes are read-only after construction. ``stacktrace`` is the
     engine-side trace when the remote handler raised; it may include
@@ -38,8 +38,8 @@ def _wrap_wire_error(
     *,
     function_id: str | None,
     invocation_id: str | None,
-) -> IIIInvocationError:
-    """Convert a wire ``ErrorBody``-shaped dict into an ``IIIInvocationError``.
+) -> InvocationError:
+    """Convert a wire ``ErrorBody``-shaped dict into an ``InvocationError``.
 
     The ``code`` field distinguishes categories (e.g. ``'FORBIDDEN'``,
     ``'TIMEOUT'``). Malformed shapes (non-dict, missing fields, non-string
@@ -56,7 +56,7 @@ def _wrap_wire_error(
         raw_stacktrace = error.get("stacktrace")
         stacktrace = raw_stacktrace if isinstance(raw_stacktrace, str) else None
 
-        return IIIInvocationError(
+        return InvocationError(
             code=code,
             message=message,
             function_id=function_id,
@@ -64,9 +64,13 @@ def _wrap_wire_error(
             invocation_id=invocation_id,
         )
 
-    return IIIInvocationError(
+    return InvocationError(
         code="UNKNOWN",
         message=str(error),
         function_id=function_id,
         invocation_id=invocation_id,
     )
+
+
+# Back-compat alias; renamed to InvocationError in Stage 1. Deprecated.
+IIIInvocationError = InvocationError

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -18,7 +18,7 @@ from iii_observability import OtelConfig
 from websockets.asyncio.client import ClientConnection
 
 from .channels import ChannelReader, ChannelWriter
-from .errors import IIIInvocationError, _wrap_wire_error
+from .errors import InvocationError, _wrap_wire_error
 from .format_utils import extract_request_format, extract_response_format
 from .iii_constants import (
     DEFAULT_RECONNECTION_CONFIG,
@@ -265,7 +265,7 @@ class III:
         for invocation_id, pending in list(self._pending.items()):
             if not pending.future.done():
                 pending.future.set_exception(
-                    IIIInvocationError(
+                    InvocationError(
                         code="SHUTDOWN",
                         message="iii is shutting down",
                         function_id=pending.function_id,
@@ -1081,7 +1081,7 @@ class III:
             actions.
 
         Raises:
-            IIIInvocationError: For any engine rejection. Inspect ``code``:
+            InvocationError: For any engine rejection. Inspect ``code``:
                 ``'TIMEOUT'`` if the invocation timed out, ``'FORBIDDEN'`` if
                 RBAC denied it.
 
@@ -1108,7 +1108,7 @@ class III:
             The result of the function invocation, or ``None`` for void calls.
 
         Raises:
-            IIIInvocationError: For any engine rejection. Inspect ``code``:
+            InvocationError: For any engine rejection. Inspect ``code``:
                 ``'TIMEOUT'`` if the invocation timed out, ``'FORBIDDEN'`` if
                 RBAC denied it.
 
@@ -1171,7 +1171,7 @@ class III:
             return await asyncio.wait_for(future, timeout=timeout_secs)
         except asyncio.TimeoutError:
             self._pending.pop(invocation_id, None)
-            raise IIIInvocationError(
+            raise InvocationError(
                 code="TIMEOUT",
                 message=f"invocation timed out after {timeout_ms}ms",
                 function_id=function_id,

--- a/sdk/packages/python/iii/src/iii/runtime.py
+++ b/sdk/packages/python/iii/src/iii/runtime.py
@@ -1,0 +1,6 @@
+"""Public runtime types."""
+
+from .iii_constants import FunctionRef
+from .triggers import TriggerTypeRef
+
+__all__ = ["FunctionRef", "TriggerTypeRef"]

--- a/sdk/packages/python/iii/src/iii/trigger.py
+++ b/sdk/packages/python/iii/src/iii/trigger.py
@@ -1,0 +1,5 @@
+"""Public trigger types."""
+
+from .triggers import Trigger, TriggerConfig, TriggerHandler
+
+__all__ = ["Trigger", "TriggerConfig", "TriggerHandler"]

--- a/sdk/packages/python/iii/tests/test_channel_submodule.py
+++ b/sdk/packages/python/iii/tests/test_channel_submodule.py
@@ -1,0 +1,14 @@
+"""The iii.channel submodule exposes the channel types; the root keeps the shims."""
+
+
+def test_channel_subpath() -> None:
+    from iii.channel import Channel, ChannelReader, ChannelWriter, StreamChannelRef
+
+    assert all(x is not None for x in (ChannelReader, ChannelWriter, StreamChannelRef, Channel))
+
+
+def test_channel_root_shim() -> None:
+    import iii
+    from iii.channel import ChannelReader as SubReader
+
+    assert iii.ChannelReader is SubReader

--- a/sdk/packages/python/iii/tests/test_errors.py
+++ b/sdk/packages/python/iii/tests/test_errors.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import pytest
 
-from iii import IIIInvocationError
+from iii import InvocationError
 from iii.errors import _wrap_wire_error
 
 
-class TestIIIInvocationError:
+class TestInvocationError:
     def test_exposes_all_fields(self) -> None:
-        err = IIIInvocationError(
+        err = InvocationError(
             code="FORBIDDEN",
             message="function 'engine::functions::list' not allowed",
             function_id="engine::functions::list",
@@ -18,7 +18,7 @@ class TestIIIInvocationError:
             invocation_id="inv-123",
         )
         assert isinstance(err, Exception)
-        assert isinstance(err, IIIInvocationError)
+        assert isinstance(err, InvocationError)
         assert err.code == "FORBIDDEN"
         assert err.message == "function 'engine::functions::list' not allowed"
         assert err.function_id == "engine::functions::list"
@@ -26,7 +26,7 @@ class TestIIIInvocationError:
         assert err.invocation_id == "inv-123"
 
     def test_str_is_code_colon_message(self) -> None:
-        err = IIIInvocationError(
+        err = InvocationError(
             code="FORBIDDEN",
             message="function 'X' not allowed (add to rbac.expose_functions)",
             function_id="X",
@@ -35,13 +35,13 @@ class TestIIIInvocationError:
 
     def test_str_never_looks_like_raw_dict_repr(self) -> None:
         """Guards against the original Node [object Object] equivalent."""
-        err = IIIInvocationError(code="FORBIDDEN", message="nope")
+        err = InvocationError(code="FORBIDDEN", message="nope")
         assert str(err) != "{'code': 'FORBIDDEN', 'message': 'nope'}"
         assert str(err) != repr({"code": "FORBIDDEN", "message": "nope"})
 
     def test_str_does_not_leak_stacktrace(self) -> None:
         """Stacktrace is opt-in via .stacktrace attribute; str/repr must not include it."""
-        err = IIIInvocationError(
+        err = InvocationError(
             code="HANDLER",
             message="boom",
             stacktrace="/internal/path/secrets.py:line 42",
@@ -50,7 +50,7 @@ class TestIIIInvocationError:
         assert "/internal/path/secrets.py" not in repr(err)
 
     def test_supports_optional_fields(self) -> None:
-        err = IIIInvocationError(code="TIMEOUT", message="gone")
+        err = InvocationError(code="TIMEOUT", message="gone")
         assert err.function_id is None
         assert err.stacktrace is None
         assert err.invocation_id is None
@@ -61,28 +61,28 @@ class TestCodeDiscrimination:
     def test_categories_discriminated_by_code(self) -> None:
         """Categories are distinguished by ``code``, not by subclass."""
         for code in ("FORBIDDEN", "TIMEOUT", "UNKNOWN"):
-            err = IIIInvocationError(code=code, message="x")
-            assert isinstance(err, IIIInvocationError)
+            err = InvocationError(code=code, message="x")
+            assert isinstance(err, InvocationError)
             assert isinstance(err, Exception)
             assert err.code == code
 
     def test_base_catches_every_category(self) -> None:
         for err in (
-            IIIInvocationError(code="FORBIDDEN", message="x"),
-            IIIInvocationError(code="TIMEOUT", message="x"),
-            IIIInvocationError(code="UNKNOWN", message="x"),
+            InvocationError(code="FORBIDDEN", message="x"),
+            InvocationError(code="TIMEOUT", message="x"),
+            InvocationError(code="UNKNOWN", message="x"),
         ):
             try:
                 raise err
-            except IIIInvocationError as got:
+            except InvocationError as got:
                 assert got.code in {"FORBIDDEN", "TIMEOUT", "UNKNOWN"}
 
     def test_except_exception_still_works(self) -> None:
         """Migration guarantee: existing `except Exception:` handlers still catch."""
         try:
-            raise IIIInvocationError(code="FORBIDDEN", message="x")
+            raise InvocationError(code="FORBIDDEN", message="x")
         except Exception as got:
-            assert isinstance(got, IIIInvocationError)
+            assert isinstance(got, InvocationError)
 
 
 class TestWrapWireError:
@@ -92,7 +92,7 @@ class TestWrapWireError:
             function_id="engine::functions::list",
             invocation_id="inv-1",
         )
-        assert type(err) is IIIInvocationError
+        assert type(err) is InvocationError
         assert err.code == "FORBIDDEN"
         assert err.function_id == "engine::functions::list"
         assert err.invocation_id == "inv-1"
@@ -103,7 +103,7 @@ class TestWrapWireError:
             function_id="api::slow",
             invocation_id=None,
         )
-        assert type(err) is IIIInvocationError
+        assert type(err) is InvocationError
         assert err.code == "TIMEOUT"
 
     def test_unknown_code_falls_back_to_base(self) -> None:
@@ -112,7 +112,7 @@ class TestWrapWireError:
             function_id=None,
             invocation_id=None,
         )
-        assert type(err) is IIIInvocationError
+        assert type(err) is InvocationError
         assert err.code == "BUSINESS_RULE"
 
     def test_stacktrace_propagated_when_string(self) -> None:
@@ -139,7 +139,7 @@ class TestWrapWireError:
     def test_malformed_wire_errors_never_produce_raw_repr(self, bad_error: object) -> None:
         """Guards against stringified-dict regression for every pathological shape."""
         err = _wrap_wire_error(bad_error, function_id="fn", invocation_id=None)
-        assert isinstance(err, IIIInvocationError)
+        assert isinstance(err, InvocationError)
         assert str(err).startswith(("UNKNOWN:", "X:", "123:"))
         assert "{'" not in str(err), f"dict repr leaked into message: {err!s}"
         assert "': " not in str(err), f"dict repr leaked into message: {err!s}"
@@ -151,3 +151,20 @@ class TestWrapWireError:
             invocation_id=None,
         )
         assert err.stacktrace is None
+
+
+class TestErrorsSubmoduleAndBackCompat:
+    def test_subpath_import(self) -> None:
+        from iii.errors import InvocationError as FromErrors
+
+        assert FromErrors is InvocationError
+
+    def test_deprecated_alias_warns(self) -> None:
+        import warnings
+
+        import iii
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            assert iii.IIIInvocationError is InvocationError
+        assert any(issubclass(w.category, DeprecationWarning) for w in caught)

--- a/sdk/packages/python/iii/tests/test_rbac_workers.py
+++ b/sdk/packages/python/iii/tests/test_rbac_workers.py
@@ -8,8 +8,8 @@ import pytest
 from iii import (
     AuthInput,
     AuthResult,
-    IIIInvocationError,
     InitOptions,
+    InvocationError,
     MiddlewareFunctionInput,
     OnFunctionRegistrationInput,
     OnFunctionRegistrationResult,
@@ -349,7 +349,7 @@ class TestRbacWorkers:
             iii_client.shutdown()
 
     def test_forbidden_wrapped_as_typed_error(self, iii_server):
-        """FORBIDDEN rejections surface as IIIInvocationError (code='FORBIDDEN')
+        """FORBIDDEN rejections surface as InvocationError (code='FORBIDDEN')
         with function_id set and the engine's remediation phrase in the message."""
         iii_client = register_worker(
             EW_URL,
@@ -357,7 +357,7 @@ class TestRbacWorkers:
         )
 
         try:
-            with pytest.raises(IIIInvocationError) as excinfo:
+            with pytest.raises(InvocationError) as excinfo:
                 iii_client.trigger({
                     "function_id": "test::ew::private",
                     "payload": {},
@@ -430,7 +430,7 @@ class TestRbacWorkers:
         try:
             def handler(data: dict) -> dict:
                 # If the carve-out regresses, this nested trigger surfaces
-                # IIIInvocationError (code='FORBIDDEN') and the handler propagates it as a failure.
+                # InvocationError (code='FORBIDDEN') and the handler propagates it as a failure.
                 iii_client.trigger({
                     "function_id": "engine::log::info",
                     "payload": {
@@ -471,7 +471,7 @@ class TestRbacWorkers:
 
         try:
             # No exception == carve-out is working. If this raises
-            # IIIInvocationError (code='FORBIDDEN'), the carve-out regressed.
+            # InvocationError (code='FORBIDDEN'), the carve-out regressed.
             iii_client.trigger({
                 "function_id": "engine::log::info",
                 "payload": {"message": "carve-out direct invocation"},

--- a/sdk/packages/python/iii/tests/test_runtime_submodule.py
+++ b/sdk/packages/python/iii/tests/test_runtime_submodule.py
@@ -1,0 +1,15 @@
+"""The iii.runtime submodule exposes the runtime types; the root keeps the shims."""
+
+
+def test_runtime_subpath() -> None:
+    from iii.runtime import FunctionRef, TriggerTypeRef
+
+    assert FunctionRef is not None
+    assert TriggerTypeRef is not None
+
+
+def test_runtime_root_shim() -> None:
+    import iii
+    from iii.runtime import FunctionRef as SubFunctionRef
+
+    assert iii.FunctionRef is SubFunctionRef

--- a/sdk/packages/python/iii/tests/test_trigger_submodule.py
+++ b/sdk/packages/python/iii/tests/test_trigger_submodule.py
@@ -1,0 +1,14 @@
+"""The iii.trigger submodule exposes the trigger types; the root keeps the shims."""
+
+
+def test_trigger_subpath() -> None:
+    from iii.trigger import Trigger, TriggerConfig, TriggerHandler
+
+    assert all(x is not None for x in (Trigger, TriggerConfig, TriggerHandler))
+
+
+def test_trigger_root_shim() -> None:
+    import iii
+    from iii.trigger import Trigger as SubTrigger
+
+    assert iii.Trigger is SubTrigger

--- a/sdk/packages/rust/iii-example/src/cron_trigger_example.rs
+++ b/sdk/packages/rust/iii-example/src/cron_trigger_example.rs
@@ -1,5 +1,6 @@
 use iii_sdk::builtin_triggers::*;
-use iii_sdk::{Error, III, IIITrigger, RegisterFunction};
+use iii_sdk::trigger::IIITrigger;
+use iii_sdk::{Error, III, RegisterFunction};
 use serde_json::json;
 
 /// Examples using built-in trigger types with the typed `IIITrigger` enum.

--- a/sdk/packages/rust/iii-example/src/cron_trigger_example.rs
+++ b/sdk/packages/rust/iii-example/src/cron_trigger_example.rs
@@ -1,5 +1,5 @@
 use iii_sdk::builtin_triggers::*;
-use iii_sdk::{III, IIIError, IIITrigger, RegisterFunction};
+use iii_sdk::{Error, III, IIITrigger, RegisterFunction};
 use serde_json::json;
 
 /// Examples using built-in trigger types with the typed `IIITrigger` enum.
@@ -97,7 +97,7 @@ struct CronEvent {
     job_id: String,
 }
 
-fn scheduled_cleanup(input: CronEvent) -> Result<serde_json::Value, IIIError> {
+fn scheduled_cleanup(input: CronEvent) -> Result<serde_json::Value, Error> {
     Ok(json!({ "cleaned": true, "trigger": input.trigger, "job_id": input.job_id }))
 }
 
@@ -110,19 +110,19 @@ struct StateEvent {
     new_value: serde_json::Value,
 }
 
-fn on_user_updated(input: StateEvent) -> Result<serde_json::Value, IIIError> {
+fn on_user_updated(input: StateEvent) -> Result<serde_json::Value, Error> {
     Ok(json!({ "event": input.event_type, "scope": input.scope, "key": input.key }))
 }
 
-fn health_check(_input: serde_json::Value) -> Result<serde_json::Value, IIIError> {
+fn health_check(_input: serde_json::Value) -> Result<serde_json::Value, Error> {
     Ok(json!({ "status": "ok" }))
 }
 
-fn on_order_created(input: serde_json::Value) -> Result<serde_json::Value, IIIError> {
+fn on_order_created(input: serde_json::Value) -> Result<serde_json::Value, Error> {
     Ok(json!({ "processed": true, "order": input }))
 }
 
-fn process_email(input: serde_json::Value) -> Result<serde_json::Value, IIIError> {
+fn process_email(input: serde_json::Value) -> Result<serde_json::Value, Error> {
     Ok(json!({ "sent": true, "email": input }))
 }
 
@@ -132,10 +132,10 @@ struct LogEvent {
     body: String,
 }
 
-fn on_error_log(input: LogEvent) -> Result<serde_json::Value, IIIError> {
+fn on_error_log(input: LogEvent) -> Result<serde_json::Value, Error> {
     Ok(json!({ "alerted": true, "severity": input.severity_text, "message": input.body }))
 }
 
-fn on_chat_message(input: serde_json::Value) -> Result<serde_json::Value, IIIError> {
+fn on_chat_message(input: serde_json::Value) -> Result<serde_json::Value, Error> {
     Ok(json!({ "received": true, "event": input }))
 }

--- a/sdk/packages/rust/iii-example/src/custom_trigger_example.rs
+++ b/sdk/packages/rust/iii-example/src/custom_trigger_example.rs
@@ -1,4 +1,5 @@
-use iii_sdk::{Error, III, RegisterTriggerType, TriggerConfig, TriggerHandler};
+use iii_sdk::trigger::{TriggerConfig, TriggerHandler};
+use iii_sdk::{Error, III, RegisterTriggerType};
 use serde_json::json;
 
 // ── Example 1: Typed trigger with full config ───────────────────────────

--- a/sdk/packages/rust/iii-example/src/custom_trigger_example.rs
+++ b/sdk/packages/rust/iii-example/src/custom_trigger_example.rs
@@ -1,4 +1,4 @@
-use iii_sdk::{III, IIIError, RegisterTriggerType, TriggerConfig, TriggerHandler};
+use iii_sdk::{Error, III, RegisterTriggerType, TriggerConfig, TriggerHandler};
 use serde_json::json;
 
 // ── Example 1: Typed trigger with full config ───────────────────────────
@@ -27,11 +27,11 @@ struct ScheduleHandler;
 
 #[async_trait::async_trait]
 impl TriggerHandler for ScheduleHandler {
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         println!("[schedule] Registered: {}", config.config);
         Ok(())
     }
-    async fn unregister_trigger(&self, _config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, _config: TriggerConfig) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -67,11 +67,11 @@ struct FileWatchHandler;
 
 #[async_trait::async_trait]
 impl TriggerHandler for FileWatchHandler {
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         println!("[file-watch] Watching: {}", config.config);
         Ok(())
     }
-    async fn unregister_trigger(&self, _config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, _config: TriggerConfig) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -82,10 +82,10 @@ struct NoopHandler;
 
 #[async_trait::async_trait]
 impl TriggerHandler for NoopHandler {
-    async fn register_trigger(&self, _config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, _config: TriggerConfig) -> Result<(), Error> {
         Ok(())
     }
-    async fn unregister_trigger(&self, _config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, _config: TriggerConfig) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -106,7 +106,7 @@ pub fn setup(iii: &III) {
 
     // register_function on the handle: enforces Fn(ScheduleCallRequest) -> ...
     schedule.register_function("example::send_report", |_input: ScheduleCallRequest| {
-        Ok::<_, IIIError>(json!({ "sent": true }))
+        Ok::<_, Error>(json!({ "sent": true }))
     });
 
     // register_trigger on the handle: enforces ScheduleTriggerConfig
@@ -134,7 +134,7 @@ pub fn setup(iii: &III) {
 
     // Compile-time safe: function input must be FileWatchCallRequest
     file_watch.register_function("example::process_csv", |input: FileWatchCallRequest| {
-        Ok::<_, IIIError>(json!({ "processed": true, "path": input.path }))
+        Ok::<_, Error>(json!({ "processed": true, "path": input.path }))
     });
 
     // Compile-time safe: config must be FileWatchConfig
@@ -157,7 +157,7 @@ pub fn setup(iii: &III) {
     ));
 
     custom.register_function("example::on_custom_event", |input: serde_json::Value| {
-        Ok::<_, IIIError>(json!({ "received": input }))
+        Ok::<_, Error>(json!({ "received": input }))
     });
 
     custom

--- a/sdk/packages/rust/iii-example/src/http_example.rs
+++ b/sdk/packages/rust/iii-example/src/http_example.rs
@@ -1,6 +1,7 @@
 use iii_observability::{Logger, execute_traced_request};
 use iii_sdk::builtin_triggers::{HttpMethod, HttpTriggerConfig};
-use iii_sdk::{ApiRequest, ApiResponse, Error, III, IIITrigger, RegisterFunction};
+use iii_sdk::trigger::IIITrigger;
+use iii_sdk::{ApiRequest, ApiResponse, Error, III, RegisterFunction};
 use serde_json::json;
 
 pub fn setup(iii: &III) {

--- a/sdk/packages/rust/iii-example/src/http_example.rs
+++ b/sdk/packages/rust/iii-example/src/http_example.rs
@@ -1,6 +1,6 @@
 use iii_observability::{Logger, execute_traced_request};
 use iii_sdk::builtin_triggers::{HttpMethod, HttpTriggerConfig};
-use iii_sdk::{ApiRequest, ApiResponse, III, IIIError, IIITrigger, RegisterFunction};
+use iii_sdk::{ApiRequest, ApiResponse, Error, III, IIITrigger, RegisterFunction};
 use serde_json::json;
 
 pub fn setup(iii: &III) {
@@ -19,11 +19,11 @@ pub fn setup(iii: &III) {
                 let request = client
                     .get("https://jsonplaceholder.typicode.com/todos/1")
                     .build()
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let response = execute_traced_request(&client, request)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let status = response.status().as_u16();
                 logger.info(
@@ -34,7 +34,7 @@ pub fn setup(iii: &III) {
                 let data: serde_json::Value = response
                     .json::<serde_json::Value>()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let api_response = ApiResponse {
                     status_code: 200,
@@ -76,11 +76,11 @@ pub fn setup(iii: &III) {
                     .header("Content-Type", "application/json")
                     .json(&payload)
                     .build()
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let response = execute_traced_request(&client, request)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let status = response.status().as_u16();
                 logger.info("Post completed", Some(json!({ "status": status })));
@@ -88,7 +88,7 @@ pub fn setup(iii: &III) {
                 let data: serde_json::Value = response
                     .json::<serde_json::Value>()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let api_response = ApiResponse {
                     status_code: status,

--- a/sdk/packages/rust/iii-example/src/logger_example.rs
+++ b/sdk/packages/rust/iii-example/src/logger_example.rs
@@ -1,5 +1,5 @@
 use iii_observability::Logger;
-use iii_sdk::{III, IIIError, RegisterFunction};
+use iii_sdk::{Error, III, RegisterFunction};
 use serde_json::{Value, json};
 
 pub fn setup(iii: &III) {
@@ -22,7 +22,7 @@ pub fn setup(iii: &III) {
 
             logger.info("Request processed successfully", None);
 
-            Ok::<Value, IIIError>(json!({ "status": "ok" }))
+            Ok::<Value, Error>(json!({ "status": "ok" }))
         })
         .description("Demonstrates Logger with all log levels"),
     );

--- a/sdk/packages/rust/iii-example/src/main.rs
+++ b/sdk/packages/rust/iii-example/src/main.rs
@@ -1,7 +1,7 @@
 use std::{thread::sleep, time::Duration};
 
 use iii_observability::OtelConfig;
-use iii_sdk::{IIIError, InitOptions, RegisterFunction, TriggerRequest, UpdateOp, register_worker};
+use iii_sdk::{Error, InitOptions, RegisterFunction, TriggerRequest, UpdateOp, register_worker};
 use serde_json::json;
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
@@ -12,7 +12,7 @@ struct EchoInput {
     prefix: String,
 }
 
-fn echo_message(input: EchoInput) -> Result<serde_json::Value, IIIError> {
+fn echo_message(input: EchoInput) -> Result<serde_json::Value, Error> {
     let mut result = input.message.repeat(input.repeat as usize);
     if input.uppercase {
         result = result.to_uppercase();
@@ -27,7 +27,7 @@ struct DelayEchoInput {
     suffix: String,
 }
 
-async fn delay_echo(input: DelayEchoInput) -> Result<serde_json::Value, IIIError> {
+async fn delay_echo(input: DelayEchoInput) -> Result<serde_json::Value, Error> {
     tokio::time::sleep(Duration::from_millis(input.delay_ms)).await;
     Ok(
         json!({ "echo": format!("{}{}", input.message, input.suffix), "delayed_ms": input.delay_ms }),

--- a/sdk/packages/rust/iii-example/src/trigger_type_example.rs
+++ b/sdk/packages/rust/iii-example/src/trigger_type_example.rs
@@ -1,4 +1,5 @@
-use iii_sdk::{Error, III, RegisterTriggerType, TriggerConfig, TriggerHandler, TriggerRequest};
+use iii_sdk::trigger::{TriggerConfig, TriggerHandler};
+use iii_sdk::{Error, III, RegisterTriggerType, TriggerRequest};
 use serde::Deserialize;
 
 /// Minimal deserialization target for `engine::triggers::list` rows used

--- a/sdk/packages/rust/iii-example/src/trigger_type_example.rs
+++ b/sdk/packages/rust/iii-example/src/trigger_type_example.rs
@@ -1,4 +1,4 @@
-use iii_sdk::{III, IIIError, RegisterTriggerType, TriggerConfig, TriggerHandler, TriggerRequest};
+use iii_sdk::{Error, III, RegisterTriggerType, TriggerConfig, TriggerHandler, TriggerRequest};
 use serde::Deserialize;
 
 /// Minimal deserialization target for `engine::triggers::list` rows used
@@ -41,7 +41,7 @@ struct WebhookHandler;
 
 #[async_trait::async_trait]
 impl TriggerHandler for WebhookHandler {
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         println!(
             "[webhook] Registered trigger {} for function {} with config: {}",
             config.id, config.function_id, config.config
@@ -49,7 +49,7 @@ impl TriggerHandler for WebhookHandler {
         Ok(())
     }
 
-    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         println!("[webhook] Unregistered trigger {}", config.id);
         Ok(())
     }
@@ -81,7 +81,7 @@ pub fn setup(iii: &III) {
         .expect("failed to register webhook trigger");
 }
 
-fn handle_webhook(input: WebhookCallRequest) -> Result<serde_json::Value, IIIError> {
+fn handle_webhook(input: WebhookCallRequest) -> Result<serde_json::Value, Error> {
     Ok(serde_json::json!({
         "processed": true,
         "method": input.method,

--- a/sdk/packages/rust/iii/src/channels.rs
+++ b/sdk/packages/rust/iii/src/channels.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use tokio::sync::Mutex;
 use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
 
-use crate::error::IIIError;
+use crate::error::Error;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
@@ -85,7 +85,7 @@ impl ChannelWriter {
         }
     }
 
-    async fn ensure_connected(&self) -> Result<(), IIIError> {
+    async fn ensure_connected(&self) -> Result<(), Error> {
         let mut guard = self.ws.lock().await;
         if guard.is_some() {
             return Ok(());
@@ -98,25 +98,25 @@ impl ChannelWriter {
 
     const MAX_FRAME_SIZE: usize = 64 * 1024;
 
-    pub async fn write(&self, data: &[u8]) -> Result<(), IIIError> {
+    pub async fn write(&self, data: &[u8]) -> Result<(), Error> {
         self.ensure_connected().await?;
         let mut guard = self.ws.lock().await;
-        let ws = guard.as_mut().ok_or(IIIError::NotConnected)?;
+        let ws = guard.as_mut().ok_or(Error::NotConnected)?;
         for chunk in data.chunks(Self::MAX_FRAME_SIZE) {
             ws.send(WsMessage::Binary(chunk.to_vec().into())).await?;
         }
         Ok(())
     }
 
-    pub async fn send_message(&self, msg: &str) -> Result<(), IIIError> {
+    pub async fn send_message(&self, msg: &str) -> Result<(), Error> {
         self.ensure_connected().await?;
         let mut guard = self.ws.lock().await;
-        let ws = guard.as_mut().ok_or(IIIError::NotConnected)?;
+        let ws = guard.as_mut().ok_or(Error::NotConnected)?;
         ws.send(WsMessage::Text(msg.to_string().into())).await?;
         Ok(())
     }
 
-    pub async fn close(&self) -> Result<(), IIIError> {
+    pub async fn close(&self) -> Result<(), Error> {
         // Delay the close frame slightly to allow the TCP stack to flush
         // all buffered send() data. Without this, the close frame can arrive
         // at the engine before all data frames, causing data truncation.
@@ -154,7 +154,7 @@ impl ChannelReader {
         }
     }
 
-    async fn ensure_connected(&self) -> Result<(), IIIError> {
+    async fn ensure_connected(&self) -> Result<(), Error> {
         let mut guard = self.ws.lock().await;
         if guard.is_some() {
             return Ok(());
@@ -176,12 +176,12 @@ impl ChannelReader {
     /// Read the next binary chunk from the channel.
     /// Text messages are dispatched to registered callbacks.
     /// Returns `None` when the stream is closed.
-    pub async fn next_binary(&self) -> Result<Option<Vec<u8>>, IIIError> {
+    pub async fn next_binary(&self) -> Result<Option<Vec<u8>>, Error> {
         self.ensure_connected().await?;
 
         loop {
             let mut guard = self.ws.lock().await;
-            let mut reader = guard.take().ok_or(IIIError::NotConnected)?;
+            let mut reader = guard.take().ok_or(Error::NotConnected)?;
             drop(guard);
 
             let msg = reader.next().await;
@@ -200,13 +200,13 @@ impl ChannelReader {
                 }
                 Some(Ok(WsMessage::Close(_))) | None => return Ok(None),
                 Some(Ok(_)) => continue,
-                Some(Err(e)) => return Err(IIIError::WebSocket(e.to_string())),
+                Some(Err(e)) => return Err(Error::WebSocket(e.to_string())),
             }
         }
     }
 
     /// Read the entire stream into a single `Vec<u8>`.
-    pub async fn read_all(&self) -> Result<Vec<u8>, IIIError> {
+    pub async fn read_all(&self) -> Result<Vec<u8>, Error> {
         let mut buffer = Vec::new();
         while let Some(chunk) = self.next_binary().await? {
             buffer.extend_from_slice(&chunk);
@@ -214,7 +214,7 @@ impl ChannelReader {
         Ok(buffer)
     }
 
-    pub async fn close(&self) -> Result<(), IIIError> {
+    pub async fn close(&self) -> Result<(), Error> {
         let mut guard = self.ws.lock().await;
         *guard = None;
         Ok(())

--- a/sdk/packages/rust/iii/src/error.rs
+++ b/sdk/packages/rust/iii/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 /// Errors returned by the III SDK.
 #[derive(Debug, Error, Clone, Serialize, JsonSchema)]
-pub enum IIIError {
+pub enum Error {
     #[error("iii is not connected")]
     NotConnected,
     #[error("invocation timed out")]
@@ -25,26 +25,26 @@ pub enum IIIError {
     WebSocket(String),
 }
 
-impl From<serde_json::Error> for IIIError {
+impl From<serde_json::Error> for Error {
     fn from(err: serde_json::Error) -> Self {
-        IIIError::Serde(err.to_string())
+        Error::Serde(err.to_string())
     }
 }
 
-impl From<String> for IIIError {
+impl From<String> for Error {
     fn from(msg: String) -> Self {
-        IIIError::Handler(msg)
+        Error::Handler(msg)
     }
 }
 
-impl From<&str> for IIIError {
+impl From<&str> for Error {
     fn from(msg: &str) -> Self {
-        IIIError::Handler(msg.to_string())
+        Error::Handler(msg.to_string())
     }
 }
 
-impl From<tokio_tungstenite::tungstenite::Error> for IIIError {
+impl From<tokio_tungstenite::tungstenite::Error> for Error {
     fn from(err: tokio_tungstenite::tungstenite::Error) -> Self {
-        IIIError::WebSocket(err.to_string())
+        Error::WebSocket(err.to_string())
     }
 }

--- a/sdk/packages/rust/iii/src/helpers.rs
+++ b/sdk/packages/rust/iii/src/helpers.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use serde_json::Value;
 
-use crate::error::IIIError;
+use crate::error::Error;
 use crate::iii::{III, RegisterFunction};
 use crate::stream_provider::IStream;
 use crate::types::{
@@ -21,7 +21,7 @@ use crate::types::{
 /// Create a streaming channel pair for worker-to-worker data transfer.
 ///
 /// Free-function form of `III`'s former `create_channel` instance method.
-pub async fn create_channel(iii: &III, buffer_size: Option<usize>) -> Result<Channel, IIIError> {
+pub async fn create_channel(iii: &III, buffer_size: Option<usize>) -> Result<Channel, Error> {
     crate::iii::internal_create_channel(iii, buffer_size).await
 }
 
@@ -44,7 +44,7 @@ where
             let s = s.clone();
             async move {
                 let typed: StreamGetInput =
-                    serde_json::from_value(input).map_err(|e| IIIError::Serde(e.to_string()))?;
+                    serde_json::from_value(input).map_err(|e| Error::Serde(e.to_string()))?;
                 let out = s.get(typed).await?;
                 Ok(serde_json::to_value(out).unwrap_or_default())
             }
@@ -58,7 +58,7 @@ where
             let s = s.clone();
             async move {
                 let typed: StreamSetInput =
-                    serde_json::from_value(input).map_err(|e| IIIError::Serde(e.to_string()))?;
+                    serde_json::from_value(input).map_err(|e| Error::Serde(e.to_string()))?;
                 let out = s.set(typed).await?;
                 Ok(serde_json::to_value(out).unwrap_or_default())
             }
@@ -72,7 +72,7 @@ where
             let s = s.clone();
             async move {
                 let typed: StreamDeleteInput =
-                    serde_json::from_value(input).map_err(|e| IIIError::Serde(e.to_string()))?;
+                    serde_json::from_value(input).map_err(|e| Error::Serde(e.to_string()))?;
                 let out = s.delete(typed).await?;
                 Ok(serde_json::to_value(out).unwrap_or_default())
             }
@@ -86,7 +86,7 @@ where
             let s = s.clone();
             async move {
                 let typed: StreamListInput =
-                    serde_json::from_value(input).map_err(|e| IIIError::Serde(e.to_string()))?;
+                    serde_json::from_value(input).map_err(|e| Error::Serde(e.to_string()))?;
                 let out = s.list(typed).await?;
                 Ok(serde_json::to_value(out).unwrap_or_default())
             }
@@ -100,7 +100,7 @@ where
             let s = s.clone();
             async move {
                 let typed: StreamListGroupsInput =
-                    serde_json::from_value(input).map_err(|e| IIIError::Serde(e.to_string()))?;
+                    serde_json::from_value(input).map_err(|e| Error::Serde(e.to_string()))?;
                 let out = s.list_groups(typed).await?;
                 Ok(serde_json::to_value(out).unwrap_or_default())
             }

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -33,7 +33,7 @@ const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 use crate::{
     channels::{ChannelReader, ChannelWriter, StreamChannelRef},
-    error::IIIError,
+    error::Error,
     protocol::{
         ErrorBody, HttpInvocationConfig, Message, RegisterFunctionMessage, RegisterTriggerInput,
         RegisterTriggerMessage, RegisterTriggerTypeMessage, TriggerAction, TriggerRequest,
@@ -168,7 +168,7 @@ impl<C: Serialize, R> TriggerTypeRef<C, R> {
         &self,
         function_id: impl Into<String>,
         config: C,
-    ) -> Result<Trigger, IIIError> {
+    ) -> Result<Trigger, Error> {
         self.register_trigger_with_metadata(function_id, config, None)
     }
 
@@ -178,11 +178,11 @@ impl<C: Serialize, R> TriggerTypeRef<C, R> {
         function_id: impl Into<String>,
         config: C,
         metadata: Option<Value>,
-    ) -> Result<Trigger, IIIError> {
+    ) -> Result<Trigger, Error> {
         self.iii.register_trigger(RegisterTriggerInput {
             trigger_type: self.trigger_type_id.clone(),
             function_id: function_id.into(),
-            config: serde_json::to_value(config).map_err(|e| IIIError::Handler(e.to_string()))?,
+            config: serde_json::to_value(config).map_err(|e| Error::Handler(e.to_string()))?,
             metadata,
         })
     }
@@ -197,7 +197,7 @@ where
     pub fn register_function<O, F>(&self, id: impl Into<String>, f: F) -> FunctionRef
     where
         O: Serialize + schemars::JsonSchema + Send + 'static,
-        F: Fn(R) -> Result<O, IIIError> + Send + Sync + 'static,
+        F: Fn(R) -> Result<O, Error> + Send + Sync + 'static,
     {
         self.iii.register_function(id, RegisterFunction::new(f))
     }
@@ -208,7 +208,7 @@ where
     where
         O: Serialize + schemars::JsonSchema + Send + 'static,
         F: Fn(R) -> Fut + Send + Sync + 'static,
-        Fut: std::future::Future<Output = Result<O, IIIError>> + Send + 'static,
+        Fut: std::future::Future<Output = Result<O, Error>> + Send + 'static,
     {
         self.iii
             .register_function(id, RegisterFunction::new_async(f))
@@ -341,7 +341,7 @@ enum Outbound {
     Shutdown,
 }
 
-type PendingInvocation = oneshot::Sender<Result<Value, IIIError>>;
+type PendingInvocation = oneshot::Sender<Result<Value, Error>>;
 
 // WebSocket transmitter type alias
 type WsTx = futures_util::stream::SplitSink<
@@ -401,24 +401,24 @@ pub trait IntoSyncHandler<Marker>: Send + Sync + 'static {
 
 // 1-arg sync — deserializes the entire JSON input as T.
 //
-// Error type is fixed to [`IIIError`] (instead of generic `E: Display`) so
+// Error type is fixed to [`Error`] (instead of generic `E: Display`) so
 // closures using bare `Ok(...)` infer cleanly without explicit error
 // annotations — required for ergonomic registration of `Fn(Value) -> ...`
-// handlers. Other error types convert via `From<E> for IIIError` (impls
+// handlers. Other error types convert via `From<E> for Error` (impls
 // for `String` / `&str` / `serde_json::Error` ship with the SDK).
 impl<F, T, R> IntoSyncHandler<(T, R)> for F
 where
-    F: Fn(T) -> Result<R, IIIError> + Send + Sync + 'static,
+    F: Fn(T) -> Result<R, Error> + Send + Sync + 'static,
     T: serde::de::DeserializeOwned + schemars::JsonSchema + Send + 'static,
     R: serde::Serialize + schemars::JsonSchema + Send + 'static,
 {
     fn into_handler(self) -> RemoteFunctionHandler {
         Arc::new(move |input: Value| {
             let output = serde_json::from_value::<T>(input)
-                .map_err(|e| IIIError::Serde(e.to_string()))
+                .map_err(|e| Error::Serde(e.to_string()))
                 .and_then(&self)
                 .and_then(|val| {
-                    serde_json::to_value(&val).map_err(|e| IIIError::Serde(e.to_string()))
+                    serde_json::to_value(&val).map_err(|e| Error::Serde(e.to_string()))
                 });
             Box::pin(async move { output })
         })
@@ -452,32 +452,31 @@ pub trait IntoAsyncHandler<Marker>: Send + Sync + 'static {
 
 // 1-arg async — deserializes the entire JSON input as T.
 //
-// Error type is fixed to [`IIIError`] (see [`IntoSyncHandler`] for the
-// rationale). Use `From<E> for IIIError` to lift custom error types,
+// Error type is fixed to [`Error`] (see [`IntoSyncHandler`] for the
+// rationale). Use `From<E> for Error` to lift custom error types,
 // or `?` propagation in the closure body.
 impl<F, T, Fut, R> IntoAsyncHandler<(T, Fut, R)> for F
 where
     F: Fn(T) -> Fut + Send + Sync + 'static,
     T: serde::de::DeserializeOwned + schemars::JsonSchema + Send + 'static,
-    Fut: std::future::Future<Output = Result<R, IIIError>> + Send + 'static,
+    Fut: std::future::Future<Output = Result<R, Error>> + Send + 'static,
     R: serde::Serialize + schemars::JsonSchema + Send + 'static,
 {
     fn into_handler(self) -> RemoteFunctionHandler {
         Arc::new(
             move |input: Value| -> std::pin::Pin<
-                Box<dyn std::future::Future<Output = Result<Value, IIIError>> + Send>,
+                Box<dyn std::future::Future<Output = Result<Value, Error>> + Send>,
             > {
                 match serde_json::from_value::<T>(input) {
                     Ok(arg) => {
                         let fut = (self)(arg);
                         Box::pin(async move {
                             fut.await.and_then(|val| {
-                                serde_json::to_value(&val)
-                                    .map_err(|e| IIIError::Serde(e.to_string()))
+                                serde_json::to_value(&val).map_err(|e| Error::Serde(e.to_string()))
                             })
                         })
                     }
-                    Err(e) => Box::pin(async move { Err(IIIError::Serde(e.to_string())) }),
+                    Err(e) => Box::pin(async move { Err(Error::Serde(e.to_string())) }),
                 }
             },
         )
@@ -515,7 +514,7 @@ fn empty_message() -> RegisterFunctionMessage {
 ///
 /// Constructors:
 /// - [`RegisterFunction::new`] — sync function. Accepts both typed handlers
-///   (schemas auto-extracted via `schemars`) and `Fn(Value) -> Result<Value, IIIError>`
+///   (schemas auto-extracted via `schemars`) and `Fn(Value) -> Result<Value, Error>`
 ///   closures (permissive `AnyValue` schema, since `Value: JsonSchema`).
 /// - [`RegisterFunction::new_async`] — async equivalent of `new`.
 /// - [`RegisterFunction::http`] — function invoked over HTTP (Lambda,
@@ -820,7 +819,7 @@ impl III {
     ///
     /// # Examples
     /// ```rust,no_run
-    /// use iii_sdk::{register_worker, InitOptions, IIIError, RegisterFunction};
+    /// use iii_sdk::{register_worker, InitOptions, Error, RegisterFunction};
     /// use serde::{Deserialize, Serialize};
     /// use schemars::JsonSchema;
     ///
@@ -829,7 +828,7 @@ impl III {
     /// #[derive(Serialize, JsonSchema)]
     /// struct Output { message: String }
     ///
-    /// async fn greet(input: Input) -> Result<Output, IIIError> {
+    /// async fn greet(input: Input) -> Result<Output, Error> {
     ///     Ok(Output { message: format!("Hello, {}!", input.name) })
     /// }
     ///
@@ -886,8 +885,8 @@ impl III {
     /// # struct MyHandler;
     /// # #[async_trait::async_trait]
     /// # impl iii_sdk::TriggerHandler for MyHandler {
-    /// #     async fn register_trigger(&self, _: iii_sdk::TriggerConfig) -> Result<(), iii_sdk::IIIError> { Ok(()) }
-    /// #     async fn unregister_trigger(&self, _: iii_sdk::TriggerConfig) -> Result<(), iii_sdk::IIIError> { Ok(()) }
+    /// #     async fn register_trigger(&self, _: iii_sdk::TriggerConfig) -> Result<(), iii_sdk::Error> { Ok(()) }
+    /// #     async fn unregister_trigger(&self, _: iii_sdk::TriggerConfig) -> Result<(), iii_sdk::Error> { Ok(()) }
     /// # }
     /// # #[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)] struct MyConfig { url: String }
     /// # #[derive(serde::Deserialize, schemars::JsonSchema)] struct MyRequest { data: String }
@@ -899,7 +898,7 @@ impl III {
     /// );
     ///
     /// // Compile-time safe: config must be MyConfig, function input must be MyRequest
-    /// my_trigger.register_function("my::handler", |req: MyRequest| -> Result<serde_json::Value, iii_sdk::IIIError> {
+    /// my_trigger.register_function("my::handler", |req: MyRequest| -> Result<serde_json::Value, iii_sdk::Error> {
     ///     Ok(serde_json::json!({ "data": req.data }))
     /// });
     /// my_trigger.register_trigger("my::handler", MyConfig { url: "/hook".into() });
@@ -963,9 +962,9 @@ impl III {
     /// })?;
     /// // Later...
     /// trigger.unregister();
-    /// # Ok::<(), iii_sdk::IIIError>(())
+    /// # Ok::<(), iii_sdk::Error>(())
     /// ```
-    pub fn register_trigger(&self, input: RegisterTriggerInput) -> Result<Trigger, IIIError> {
+    pub fn register_trigger(&self, input: RegisterTriggerInput) -> Result<Trigger, Error> {
         let id = Uuid::new_v4().to_string();
         let message = RegisterTriggerMessage {
             id: id.clone(),
@@ -1007,7 +1006,7 @@ impl III {
     /// ```rust
     /// # use iii_sdk::{III, TriggerRequest, TriggerAction};
     /// # use serde_json::json;
-    /// # async fn example(iii: &III) -> Result<(), iii_sdk::IIIError> {
+    /// # async fn example(iii: &III) -> Result<(), iii_sdk::Error> {
     /// // Synchronous
     /// let result = iii.trigger(TriggerRequest {
     ///     function_id: "greet".to_string(),
@@ -1038,7 +1037,7 @@ impl III {
     pub async fn trigger(
         &self,
         request: impl Into<crate::protocol::TriggerRequest>,
-    ) -> Result<Value, IIIError> {
+    ) -> Result<Value, Error> {
         let req = request.into();
         let (tp, bg) = inject_trace_headers();
 
@@ -1076,10 +1075,10 @@ impl III {
 
         match tokio::time::timeout(timeout, rx).await {
             Ok(Ok(result)) => result,
-            Ok(Err(_)) => Err(IIIError::NotConnected),
+            Ok(Err(_)) => Err(Error::NotConnected),
             Err(_) => {
                 self.inner.pending.lock_or_recover().remove(&invocation_id);
-                Err(IIIError::Timeout)
+                Err(Error::Timeout)
             }
         }
     }
@@ -1122,7 +1121,7 @@ impl III {
         }
     }
 
-    fn send_message(&self, message: Message) -> Result<(), IIIError> {
+    fn send_message(&self, message: Message) -> Result<(), Error> {
         if !self.inner.running.load(Ordering::SeqCst) {
             return Ok(());
         }
@@ -1130,7 +1129,7 @@ impl III {
         self.inner
             .outbound
             .send(Outbound::Message(message))
-            .map_err(|_| IIIError::NotConnected)
+            .map_err(|_| Error::NotConnected)
     }
 
     async fn run_connection(&self, mut rx: mpsc::UnboundedReceiver<Outbound>) {
@@ -1354,11 +1353,7 @@ impl III {
         *queue = deduped_rev;
     }
 
-    async fn flush_queue(
-        &self,
-        ws_tx: &mut WsTx,
-        queue: &mut Vec<Message>,
-    ) -> Result<(), IIIError> {
+    async fn flush_queue(&self, ws_tx: &mut WsTx, queue: &mut Vec<Message>) -> Result<(), Error> {
         let mut drained = Vec::new();
         std::mem::swap(queue, &mut drained);
 
@@ -1374,13 +1369,13 @@ impl III {
         Ok(())
     }
 
-    async fn send_ws(&self, ws_tx: &mut WsTx, message: &Message) -> Result<(), IIIError> {
+    async fn send_ws(&self, ws_tx: &mut WsTx, message: &Message) -> Result<(), Error> {
         let payload = serde_json::to_string(message)?;
         ws_tx.send(WsMessage::Text(payload.into())).await?;
         Ok(())
     }
 
-    fn handle_frame(&self, frame: WsMessage) -> Result<(), IIIError> {
+    fn handle_frame(&self, frame: WsMessage) -> Result<(), Error> {
         match frame {
             WsMessage::Text(text) => self.handle_message(&text),
             WsMessage::Binary(bytes) => {
@@ -1391,7 +1386,7 @@ impl III {
         }
     }
 
-    fn handle_message(&self, payload: &str) -> Result<(), IIIError> {
+    fn handle_message(&self, payload: &str) -> Result<(), Error> {
         let message: Message = serde_json::from_str(payload)?;
 
         match message {
@@ -1461,7 +1456,7 @@ impl III {
         let sender = self.inner.pending.lock_or_recover().remove(&invocation_id);
         if let Some(sender) = sender {
             let result = match error {
-                Some(error) => Err(IIIError::Remote {
+                Some(error) => Err(Error::Remote {
                     code: error.code,
                     message: error.message,
                     stacktrace: error.stacktrace,
@@ -1620,7 +1615,7 @@ impl III {
                     Ok(_) => span.set_status(Status::Ok),
                     Err(err) => {
                         let (exc_type, exc_message, stacktrace) = match err {
-                            IIIError::Remote {
+                            Error::Remote {
                                 code,
                                 message,
                                 stacktrace,
@@ -1671,7 +1666,7 @@ impl III {
                     },
                     Err(err) => {
                         let error_body = match err {
-                            IIIError::Remote {
+                            Error::Remote {
                                 code,
                                 message,
                                 stacktrace,
@@ -1805,7 +1800,7 @@ impl III {
 pub(crate) async fn internal_create_channel(
     iii: &III,
     buffer_size: Option<usize>,
-) -> Result<Channel, IIIError> {
+) -> Result<Channel, Error> {
     let result = iii
         .trigger(TriggerRequest {
             function_id: "engine::channels::create".to_string(),
@@ -1819,17 +1814,17 @@ pub(crate) async fn internal_create_channel(
         result
             .get("writer")
             .cloned()
-            .ok_or_else(|| IIIError::Serde("missing 'writer' in channel response".into()))?,
+            .ok_or_else(|| Error::Serde("missing 'writer' in channel response".into()))?,
     )
-    .map_err(|e| IIIError::Serde(e.to_string()))?;
+    .map_err(|e| Error::Serde(e.to_string()))?;
 
     let reader_ref: StreamChannelRef = serde_json::from_value(
         result
             .get("reader")
             .cloned()
-            .ok_or_else(|| IIIError::Serde("missing 'reader' in channel response".into()))?,
+            .ok_or_else(|| Error::Serde("missing 'reader' in channel response".into()))?,
     )
-    .map_err(|e| IIIError::Serde(e.to_string()))?;
+    .map_err(|e| Error::Serde(e.to_string()))?;
 
     Ok(Channel {
         writer: ChannelWriter::new(&iii.inner.address, &writer_ref),
@@ -1960,7 +1955,7 @@ mod tests {
         struct Out {
             message: String,
         }
-        async fn greet(input: In) -> Result<Out, IIIError> {
+        async fn greet(input: In) -> Result<Out, Error> {
             Ok(Out {
                 message: format!("Hello, {}!", input.name),
             })
@@ -1982,7 +1977,7 @@ mod tests {
         struct In {
             name: String,
         }
-        async fn handler(input: In) -> Result<String, IIIError> {
+        async fn handler(input: In) -> Result<String, Error> {
             Ok(input.name)
         }
 
@@ -2019,7 +2014,7 @@ mod tests {
             })
             .await;
 
-        assert!(matches!(result, Err(IIIError::Timeout)));
+        assert!(matches!(result, Err(Error::Timeout)));
         assert!(iii.inner.pending.lock().unwrap().is_empty());
     }
 

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -9,6 +9,12 @@ pub mod structs;
 pub mod triggers;
 pub mod types;
 
+/// Public trigger types. (Stage 1 submodule grouping.)
+pub mod trigger {
+    pub use crate::builtin_triggers::IIITrigger;
+    pub use crate::triggers::{Trigger, TriggerConfig, TriggerHandler};
+}
+
 /// Public channel types. (Stage 1 submodule grouping.)
 pub mod channel {
     pub use crate::channels::{ChannelReader, ChannelWriter, StreamChannelRef};
@@ -20,8 +26,10 @@ pub mod errors {
     pub use crate::error::Error;
 }
 
+#[deprecated(since = "0.19.0", note = "import from iii_sdk::trigger")]
+pub use builtin_triggers::IIITrigger;
 pub use builtin_triggers::{
-    IIITrigger, StreamCallRequest, StreamEventDetail, StreamEventType, StreamJoinLeaveCallRequest,
+    StreamCallRequest, StreamEventDetail, StreamEventType, StreamJoinLeaveCallRequest,
     StreamJoinLeaveTriggerConfig, StreamTriggerConfig,
 };
 #[deprecated(since = "0.19.0", note = "import from iii_sdk::channel")]
@@ -47,6 +55,7 @@ pub use structs::{
     OnFunctionRegistrationResult, OnTriggerRegistrationInput, OnTriggerRegistrationResult,
     OnTriggerTypeRegistrationInput, OnTriggerTypeRegistrationResult,
 };
+#[deprecated(since = "0.19.0", note = "import from iii_sdk::trigger")]
 pub use triggers::{Trigger, TriggerConfig, TriggerHandler};
 #[deprecated(since = "0.19.0", note = "import from iii_sdk::channel")]
 pub use types::Channel;
@@ -162,6 +171,17 @@ fn _ensure_is_channel_ref_not_top_level() {}
 /// ```
 #[allow(dead_code)]
 fn _ensure_create_channel_not_on_instance() {}
+
+// ---------------------------------------------------------------------------
+// Stage 1 trigger submodule: trigger types are reachable at their new
+// canonical path `iii_sdk::trigger`.
+// ---------------------------------------------------------------------------
+
+/// ```rust,no_run
+/// use iii_sdk::trigger::{IIITrigger, Trigger, TriggerConfig, TriggerHandler};
+/// ```
+#[allow(dead_code)]
+fn _ensure_trigger_submodule_path() {}
 
 // ---------------------------------------------------------------------------
 // Stage 1 channel submodule: channel types are reachable at their new

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -9,6 +9,12 @@ pub mod structs;
 pub mod triggers;
 pub mod types;
 
+/// Public channel types. (Stage 1 submodule grouping.)
+pub mod channel {
+    pub use crate::channels::{ChannelReader, ChannelWriter, StreamChannelRef};
+    pub use crate::types::Channel;
+}
+
 /// Public error types. (Stage 1 submodule grouping.)
 pub mod errors {
     pub use crate::error::Error;
@@ -18,6 +24,7 @@ pub use builtin_triggers::{
     IIITrigger, StreamCallRequest, StreamEventDetail, StreamEventType, StreamJoinLeaveCallRequest,
     StreamJoinLeaveTriggerConfig, StreamTriggerConfig,
 };
+#[deprecated(since = "0.19.0", note = "import from iii_sdk::channel")]
 pub use channels::{ChannelReader, ChannelWriter, StreamChannelRef};
 pub use error::Error;
 #[deprecated(
@@ -41,8 +48,10 @@ pub use structs::{
     OnTriggerTypeRegistrationInput, OnTriggerTypeRegistrationResult,
 };
 pub use triggers::{Trigger, TriggerConfig, TriggerHandler};
+#[deprecated(since = "0.19.0", note = "import from iii_sdk::channel")]
+pub use types::Channel;
 pub use types::{
-    ApiRequest, ApiResponse, Channel, DeleteResult, SetResult, StreamAuthInput, StreamAuthResult,
+    ApiRequest, ApiResponse, DeleteResult, SetResult, StreamAuthInput, StreamAuthResult,
     StreamDeleteInput, StreamGetInput, StreamJoinResult, StreamListGroupsInput, StreamListInput,
     StreamSetInput, StreamUpdateInput, UpdateOp, UpdateOpError, UpdateResult,
 };
@@ -153,6 +162,17 @@ fn _ensure_is_channel_ref_not_top_level() {}
 /// ```
 #[allow(dead_code)]
 fn _ensure_create_channel_not_on_instance() {}
+
+// ---------------------------------------------------------------------------
+// Stage 1 channel submodule: channel types are reachable at their new
+// canonical path `iii_sdk::channel`.
+// ---------------------------------------------------------------------------
+
+/// ```rust,no_run
+/// use iii_sdk::channel::{Channel, ChannelReader, ChannelWriter, StreamChannelRef};
+/// ```
+#[allow(dead_code)]
+fn _ensure_channel_submodule_path() {}
 
 // ---------------------------------------------------------------------------
 // Stage 1 errors submodule: the renamed error type is reachable at its new

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -9,12 +9,22 @@ pub mod structs;
 pub mod triggers;
 pub mod types;
 
+/// Public error types. (Stage 1 submodule grouping.)
+pub mod errors {
+    pub use crate::error::Error;
+}
+
 pub use builtin_triggers::{
     IIITrigger, StreamCallRequest, StreamEventDetail, StreamEventType, StreamJoinLeaveCallRequest,
     StreamJoinLeaveTriggerConfig, StreamTriggerConfig,
 };
 pub use channels::{ChannelReader, ChannelWriter, StreamChannelRef};
-pub use error::IIIError;
+pub use error::Error;
+#[deprecated(
+    since = "0.19.0",
+    note = "renamed to Error; import from iii_sdk::errors"
+)]
+pub use error::Error as IIIError;
 pub use iii::{
     FunctionInfo, FunctionRef, III, IIIConnectionState, RegisterFunction, RegisterTriggerType,
     TriggerInfo, TriggerTypeRef, WorkerInfo, WorkerMetadata,
@@ -143,3 +153,15 @@ fn _ensure_is_channel_ref_not_top_level() {}
 /// ```
 #[allow(dead_code)]
 fn _ensure_create_channel_not_on_instance() {}
+
+// ---------------------------------------------------------------------------
+// Stage 1 errors submodule: the renamed error type is reachable at its new
+// canonical path `iii_sdk::errors::Error`.
+// ---------------------------------------------------------------------------
+
+/// ```rust,no_run
+/// use iii_sdk::errors::Error;
+/// fn _takes(_e: Error) {}
+/// ```
+#[allow(dead_code)]
+fn _ensure_errors_submodule_path() {}

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -9,6 +9,14 @@ pub mod structs;
 pub mod triggers;
 pub mod types;
 
+/// Public runtime/worker types. (Stage 1 submodule grouping.)
+pub mod runtime {
+    pub use crate::iii::{
+        FunctionInfo, FunctionRef, IIIConnectionState, TriggerInfo, TriggerTypeRef, WorkerInfo,
+        WorkerMetadata,
+    };
+}
+
 /// Public trigger types. (Stage 1 submodule grouping.)
 pub mod trigger {
     pub use crate::builtin_triggers::IIITrigger;
@@ -40,10 +48,12 @@ pub use error::Error;
     note = "renamed to Error; import from iii_sdk::errors"
 )]
 pub use error::Error as IIIError;
+#[deprecated(since = "0.19.0", note = "import from iii_sdk::runtime")]
 pub use iii::{
-    FunctionInfo, FunctionRef, III, IIIConnectionState, RegisterFunction, RegisterTriggerType,
-    TriggerInfo, TriggerTypeRef, WorkerInfo, WorkerMetadata,
+    FunctionInfo, FunctionRef, IIIConnectionState, TriggerInfo, TriggerTypeRef, WorkerInfo,
+    WorkerMetadata,
 };
+pub use iii::{III, RegisterFunction, RegisterTriggerType};
 pub use protocol::{
     EnqueueResult, ErrorBody, FunctionMessage, HttpAuthConfig, HttpInvocationConfig, HttpMethod,
     Message, RegisterFunctionMessage, RegisterTriggerInput, RegisterTriggerMessage,
@@ -76,7 +86,7 @@ pub use types::{
 #[derive(Debug, Clone, Default)]
 pub struct InitOptions {
     /// Custom worker metadata. Auto-detected if `None`.
-    pub metadata: Option<WorkerMetadata>,
+    pub metadata: Option<iii::WorkerMetadata>,
     /// Custom HTTP headers sent during the WebSocket handshake.
     pub headers: Option<std::collections::HashMap<String, String>>,
     /// OpenTelemetry configuration.
@@ -171,6 +181,20 @@ fn _ensure_is_channel_ref_not_top_level() {}
 /// ```
 #[allow(dead_code)]
 fn _ensure_create_channel_not_on_instance() {}
+
+// ---------------------------------------------------------------------------
+// Stage 1 runtime submodule: runtime/worker types are reachable at their new
+// canonical path `iii_sdk::runtime`.
+// ---------------------------------------------------------------------------
+
+/// ```rust,no_run
+/// use iii_sdk::runtime::{
+///     FunctionInfo, FunctionRef, IIIConnectionState, TriggerInfo, TriggerTypeRef, WorkerInfo,
+///     WorkerMetadata,
+/// };
+/// ```
+#[allow(dead_code)]
+fn _ensure_runtime_submodule_path() {}
 
 // ---------------------------------------------------------------------------
 // Stage 1 trigger submodule: trigger types are reachable at their new

--- a/sdk/packages/rust/iii/src/stream_provider.rs
+++ b/sdk/packages/rust/iii/src/stream_provider.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use serde_json::Value;
 
-use crate::error::IIIError;
+use crate::error::Error;
 use crate::types::{
     DeleteResult, SetResult, StreamDeleteInput, StreamGetInput, StreamListGroupsInput,
     StreamListInput, StreamSetInput, StreamUpdateInput, UpdateResult,
@@ -12,10 +12,10 @@ use crate::types::{
 /// `create_stream` in the `helpers` submodule.
 #[async_trait]
 pub trait IStream: Send + Sync + 'static {
-    async fn get(&self, input: StreamGetInput) -> Result<Option<Value>, IIIError>;
-    async fn set(&self, input: StreamSetInput) -> Result<Option<SetResult>, IIIError>;
-    async fn delete(&self, input: StreamDeleteInput) -> Result<DeleteResult, IIIError>;
-    async fn list(&self, input: StreamListInput) -> Result<Vec<Value>, IIIError>;
-    async fn list_groups(&self, input: StreamListGroupsInput) -> Result<Vec<String>, IIIError>;
-    async fn update(&self, input: StreamUpdateInput) -> Result<Option<UpdateResult>, IIIError>;
+    async fn get(&self, input: StreamGetInput) -> Result<Option<Value>, Error>;
+    async fn set(&self, input: StreamSetInput) -> Result<Option<SetResult>, Error>;
+    async fn delete(&self, input: StreamDeleteInput) -> Result<DeleteResult, Error>;
+    async fn list(&self, input: StreamListInput) -> Result<Vec<Value>, Error>;
+    async fn list_groups(&self, input: StreamListGroupsInput) -> Result<Vec<String>, Error>;
+    async fn update(&self, input: StreamUpdateInput) -> Result<Option<UpdateResult>, Error>;
 }

--- a/sdk/packages/rust/iii/src/triggers.rs
+++ b/sdk/packages/rust/iii/src/triggers.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::Value;
 
-use crate::error::IIIError;
+use crate::error::Error;
 
 /// Configuration passed to a [`TriggerHandler`] when a trigger instance is
 /// registered or unregistered.
@@ -24,9 +24,9 @@ pub struct TriggerConfig {
 #[async_trait]
 pub trait TriggerHandler: Send + Sync {
     /// Called when a trigger instance is registered.
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError>;
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error>;
     /// Called when a trigger instance is unregistered.
-    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), IIIError>;
+    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), Error>;
 }
 
 /// Handle returned by [`III::register_trigger`](crate::III::register_trigger).

--- a/sdk/packages/rust/iii/src/types.rs
+++ b/sdk/packages/rust/iii/src/types.rs
@@ -7,13 +7,13 @@ use serde_json::Value;
 
 use crate::{
     channels::{ChannelReader, ChannelWriter, StreamChannelRef},
-    error::IIIError,
+    error::Error,
     protocol::{RegisterFunctionMessage, RegisterTriggerTypeMessage},
     triggers::TriggerHandler,
 };
 
 pub type RemoteFunctionHandler =
-    Arc<dyn Fn(Value) -> BoxFuture<'static, Result<Value, IIIError>> + Send + Sync>;
+    Arc<dyn Fn(Value) -> BoxFuture<'static, Result<Value, Error>> + Send + Sync>;
 
 // ============================================================================
 // Stream Update Types

--- a/sdk/packages/rust/iii/tests/api_triggers.rs
+++ b/sdk/packages/rust/iii/tests/api_triggers.rs
@@ -12,7 +12,7 @@ use serde_json::{Value, json};
 use serial_test::serial;
 use tokio::sync::Mutex;
 
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput};
+use iii_sdk::{Error, RegisterFunction, RegisterTriggerInput};
 use tokio::time::sleep;
 
 fn test_pdf_path() -> PathBuf {
@@ -146,7 +146,7 @@ async fn raw_json_request_body() {
                 let raw = reader
                     .read_all()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .send_message(
@@ -156,7 +156,7 @@ async fn raw_json_request_body() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .send_message(
@@ -166,23 +166,23 @@ async fn raw_json_request_body() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let response_body = serde_json::to_vec(&json!({
                     "parsed_body": parsed_body,
                     "raw_body": String::from_utf8(raw)
-                        .map_err(|e| IIIError::Handler(e.to_string()))?,
+                        .map_err(|e| Error::Handler(e.to_string()))?,
                 }))
-                .map_err(|e| IIIError::Handler(e.to_string()))?;
+                .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .write(&response_body)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 writer
                     .close()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 Ok(Value::Null)
             }
@@ -437,7 +437,7 @@ async fn download_pdf_streaming() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .send_message(
@@ -447,16 +447,16 @@ async fn download_pdf_streaming() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .write(&pdf_data)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 writer
                     .close()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 Ok(Value::Null)
             }
@@ -552,7 +552,7 @@ async fn upload_pdf_streaming() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .send_message(
@@ -562,25 +562,25 @@ async fn upload_pdf_streaming() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let data = reader
                     .read_all()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 let len = data.len();
                 *received.lock().await = data;
 
                 let body = serde_json::to_vec(&json!({"received_size": len}))
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 writer
                     .write(&body)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 writer
                     .close()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 Ok(Value::Null)
             }
@@ -656,7 +656,7 @@ async fn sse_streaming() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .send_message(
@@ -670,7 +670,7 @@ async fn sse_streaming() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 for event in &events {
                     let mut frame = String::new();
@@ -684,14 +684,14 @@ async fn sse_streaming() {
                     writer
                         .write(frame.as_bytes())
                         .await
-                        .map_err(|e| IIIError::Handler(e.to_string()))?;
+                        .map_err(|e| Error::Handler(e.to_string()))?;
                     tokio::time::sleep(Duration::from_millis(50)).await;
                 }
 
                 writer
                     .close()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 Ok(Value::Null)
             }
         }),
@@ -792,7 +792,7 @@ async fn urlencoded_form_data() {
                 let raw = reader
                     .read_all()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 let body = String::from_utf8_lossy(&raw);
 
                 let params: std::collections::HashMap<String, String> = body
@@ -815,7 +815,7 @@ async fn urlencoded_form_data() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .send_message(
@@ -825,23 +825,23 @@ async fn urlencoded_form_data() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let result = serde_json::to_vec(&json!({
                     "name": params.get("name"),
                     "email": params.get("email"),
                     "age": params.get("age"),
                 }))
-                .map_err(|e| IIIError::Handler(e.to_string()))?;
+                .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .write(&result)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 writer
                     .close()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 Ok(Value::Null)
             }
@@ -943,7 +943,7 @@ async fn multipart_form_data() {
                 let raw = reader
                     .read_all()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let content_type = input
                     .get("headers")
@@ -968,7 +968,7 @@ async fn multipart_form_data() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .send_message(
@@ -978,7 +978,7 @@ async fn multipart_form_data() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let result = serde_json::to_vec(&json!({
                     "has_boundary": has_boundary,
@@ -987,16 +987,16 @@ async fn multipart_form_data() {
                     "has_filename": has_filename,
                     "body_size": raw.len(),
                 }))
-                .map_err(|e| IIIError::Handler(e.to_string()))?;
+                .map_err(|e| Error::Handler(e.to_string()))?;
 
                 writer
                     .write(&result)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 writer
                     .close()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 Ok(Value::Null)
             }

--- a/sdk/packages/rust/iii/tests/api_triggers.rs
+++ b/sdk/packages/rust/iii/tests/api_triggers.rs
@@ -141,8 +141,8 @@ async fn raw_json_request_body() {
                     .map(|(_, r)| r.clone())
                     .expect("missing reader ref");
 
-                let writer = iii_sdk::ChannelWriter::new(iii.address(), &writer_ref);
-                let reader = iii_sdk::ChannelReader::new(iii.address(), &reader_ref);
+                let writer = iii_sdk::channel::ChannelWriter::new(iii.address(), &writer_ref);
+                let reader = iii_sdk::channel::ChannelReader::new(iii.address(), &reader_ref);
                 let raw = reader
                     .read_all()
                     .await
@@ -427,7 +427,7 @@ async fn download_pdf_streaming() {
                     .map(|(_, r)| r.clone())
                     .expect("missing writer ref");
 
-                let writer = iii_sdk::ChannelWriter::new(iii.address(), &writer_ref);
+                let writer = iii_sdk::channel::ChannelWriter::new(iii.address(), &writer_ref);
 
                 writer
                     .send_message(
@@ -541,8 +541,8 @@ async fn upload_pdf_streaming() {
                     .map(|(_, r)| r.clone())
                     .expect("missing reader ref");
 
-                let writer = iii_sdk::ChannelWriter::new(iii.address(), &writer_ref);
-                let reader = iii_sdk::ChannelReader::new(iii.address(), &reader_ref);
+                let writer = iii_sdk::channel::ChannelWriter::new(iii.address(), &writer_ref);
+                let reader = iii_sdk::channel::ChannelReader::new(iii.address(), &reader_ref);
 
                 writer
                     .send_message(
@@ -646,7 +646,7 @@ async fn sse_streaming() {
                     .map(|(_, r)| r.clone())
                     .expect("missing writer ref");
 
-                let writer = iii_sdk::ChannelWriter::new(iii.address(), &writer_ref);
+                let writer = iii_sdk::channel::ChannelWriter::new(iii.address(), &writer_ref);
 
                 writer
                     .send_message(
@@ -786,8 +786,8 @@ async fn urlencoded_form_data() {
                     .map(|(_, r)| r.clone())
                     .expect("missing reader ref");
 
-                let writer = iii_sdk::ChannelWriter::new(iii.address(), &writer_ref);
-                let reader = iii_sdk::ChannelReader::new(iii.address(), &reader_ref);
+                let writer = iii_sdk::channel::ChannelWriter::new(iii.address(), &writer_ref);
+                let reader = iii_sdk::channel::ChannelReader::new(iii.address(), &reader_ref);
 
                 let raw = reader
                     .read_all()
@@ -937,8 +937,8 @@ async fn multipart_form_data() {
                     .map(|(_, r)| r.clone())
                     .expect("missing reader ref");
 
-                let writer = iii_sdk::ChannelWriter::new(iii.address(), &writer_ref);
-                let reader = iii_sdk::ChannelReader::new(iii.address(), &reader_ref);
+                let writer = iii_sdk::channel::ChannelWriter::new(iii.address(), &writer_ref);
+                let reader = iii_sdk::channel::ChannelReader::new(iii.address(), &reader_ref);
 
                 let raw = reader
                     .read_all()

--- a/sdk/packages/rust/iii/tests/bridge.rs
+++ b/sdk/packages/rust/iii/tests/bridge.rs
@@ -10,7 +10,8 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
 
-use iii_sdk::{FunctionInfo, RegisterFunction, TriggerAction, TriggerRequest};
+use iii_sdk::runtime::FunctionInfo;
+use iii_sdk::{RegisterFunction, TriggerAction, TriggerRequest};
 
 #[tokio::test]
 async fn connect_successfully() {

--- a/sdk/packages/rust/iii/tests/data_channels.rs
+++ b/sdk/packages/rust/iii/tests/data_channels.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
 
-use iii_sdk::{IIIError, RegisterFunction, TriggerRequest};
+use iii_sdk::{Error, RegisterFunction, TriggerRequest};
 
 #[tokio::test]
 async fn stream_data_from_sender_to_processor() {
@@ -32,9 +32,9 @@ async fn stream_data_from_sender_to_processor() {
                     .expect("missing reader channel ref");
 
                 let reader = iii_sdk::ChannelReader::new(iii.address(), &reader_ref);
-                let raw = reader.read_all().await.map_err(|e| IIIError::Handler(e.to_string()))?;
+                let raw = reader.read_all().await.map_err(|e| Error::Handler(e.to_string()))?;
                 let records: Vec<Value> = serde_json::from_slice(&raw)
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let values: Vec<f64> = records
                     .iter()
@@ -69,20 +69,20 @@ async fn stream_data_from_sender_to_processor() {
                 let records = input["records"].clone();
                 let channel = iii_sdk::helpers::create_channel(&iii, None)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let payload =
-                    serde_json::to_vec(&records).map_err(|e| IIIError::Handler(e.to_string()))?;
+                    serde_json::to_vec(&records).map_err(|e| Error::Handler(e.to_string()))?;
                 channel
                     .writer
                     .write(&payload)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 channel
                     .writer
                     .close()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let result = iii
                     .trigger(TriggerRequest {
@@ -95,7 +95,7 @@ async fn stream_data_from_sender_to_processor() {
                         timeout_ms: None,
                     })
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 Ok(result)
             }
@@ -185,7 +185,7 @@ async fn bidirectional_streaming() {
                 while let Some(chunk) = reader
                     .next_binary()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?
+                    .map_err(|e| Error::Handler(e.to_string()))?
                 {
                     chunks.push(chunk);
                     chunk_count += 1;
@@ -198,7 +198,7 @@ async fn bidirectional_streaming() {
                             .unwrap(),
                         )
                         .await
-                        .map_err(|e| IIIError::Handler(e.to_string()))?;
+                        .map_err(|e| Error::Handler(e.to_string()))?;
                 }
 
                 let full_data: Vec<u8> = chunks.iter().flatten().copied().collect();
@@ -215,21 +215,21 @@ async fn bidirectional_streaming() {
                         .unwrap(),
                     )
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let result_json = serde_json::to_vec(&json!({
                     "words": &words[..5.min(words.len())],
                     "total": words.len(),
                 }))
-                .map_err(|e| IIIError::Handler(e.to_string()))?;
+                .map_err(|e| Error::Handler(e.to_string()))?;
                 writer
                     .write(&result_json)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 writer
                     .close()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 Ok(json!({"status": "done"}))
             }
@@ -247,10 +247,10 @@ async fn bidirectional_streaming() {
 
                 let input_channel = iii_sdk::helpers::create_channel(&iii, None)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 let output_channel = iii_sdk::helpers::create_channel(&iii, None)
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let messages: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
                 let msgs_clone = messages.clone();
@@ -303,18 +303,18 @@ async fn bidirectional_streaming() {
                     .reader
                     .read_all()
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 write_handle
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 let worker_result = call_handle
                     .await
-                    .map_err(|e| IIIError::Handler(e.to_string()))?
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 let binary_result: Value = serde_json::from_slice(&result_data)
-                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
 
                 // Give a moment for async message callbacks to settle
                 tokio::time::sleep(Duration::from_millis(100)).await;

--- a/sdk/packages/rust/iii/tests/data_channels.rs
+++ b/sdk/packages/rust/iii/tests/data_channels.rs
@@ -31,7 +31,7 @@ async fn stream_data_from_sender_to_processor() {
                     .map(|(_, r)| r.clone())
                     .expect("missing reader channel ref");
 
-                let reader = iii_sdk::ChannelReader::new(iii.address(), &reader_ref);
+                let reader = iii_sdk::channel::ChannelReader::new(iii.address(), &reader_ref);
                 let raw = reader.read_all().await.map_err(|e| Error::Handler(e.to_string()))?;
                 let records: Vec<Value> = serde_json::from_slice(&raw)
                     .map_err(|e| Error::Handler(e.to_string()))?;
@@ -176,8 +176,8 @@ async fn bidirectional_streaming() {
                     .map(|(_, r)| r.clone())
                     .expect("missing writer");
 
-                let reader = iii_sdk::ChannelReader::new(iii.address(), &reader_ref);
-                let writer = iii_sdk::ChannelWriter::new(iii.address(), &writer_ref);
+                let reader = iii_sdk::channel::ChannelReader::new(iii.address(), &reader_ref);
+                let writer = iii_sdk::channel::ChannelWriter::new(iii.address(), &writer_ref);
 
                 let mut chunks: Vec<Vec<u8>> = Vec::new();
                 let mut chunk_count = 0;

--- a/sdk/packages/rust/iii/tests/hold_process.rs
+++ b/sdk/packages/rust/iii/tests/hold_process.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
-use iii_sdk::{IIIConnectionState, InitOptions, register_worker};
+use iii_sdk::runtime::IIIConnectionState;
+use iii_sdk::{InitOptions, register_worker};
 
 #[test]
 fn shutdown_stops_connection_thread() {

--- a/sdk/packages/rust/iii/tests/http_external_functions.rs
+++ b/sdk/packages/rust/iii/tests/http_external_functions.rs
@@ -11,9 +11,9 @@ use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
+use iii_sdk::runtime::FunctionInfo;
 use iii_sdk::{
-    FunctionInfo, HttpInvocationConfig, HttpMethod, RegisterFunction, RegisterTriggerInput,
-    TriggerRequest,
+    HttpInvocationConfig, HttpMethod, RegisterFunction, RegisterTriggerInput, TriggerRequest,
 };
 
 fn unique_function_id(prefix: &str) -> String {

--- a/sdk/packages/rust/iii/tests/queue_integration.rs
+++ b/sdk/packages/rust/iii/tests/queue_integration.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
 
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput, TriggerAction, TriggerRequest};
+use iii_sdk::{Error, RegisterFunction, RegisterTriggerInput, TriggerAction, TriggerRequest};
 
 fn unique_topic(prefix: &str) -> String {
     let ts = std::time::SystemTime::now()
@@ -79,14 +79,14 @@ async fn enqueue_to_unknown_queue_returns_error() {
         .await;
 
     match result {
-        Err(IIIError::Remote { code, message, .. }) => {
+        Err(Error::Remote { code, message, .. }) => {
             assert_eq!(
                 code, "enqueue_error",
                 "expected enqueue_error code, got: {code}"
             );
             assert!(!message.is_empty(), "error message should not be empty");
         }
-        Err(other) => panic!("expected IIIError::Remote with enqueue_error code, got: {other:?}"),
+        Err(other) => panic!("expected Error::Remote with enqueue_error code, got: {other:?}"),
         Ok(val) => panic!("expected error, got success: {val}"),
     }
 }
@@ -155,7 +155,7 @@ async fn enqueue_fifo_missing_group_field_returns_error() {
         .await;
 
     match result {
-        Err(IIIError::Remote { code, message, .. }) => {
+        Err(Error::Remote { code, message, .. }) => {
             assert_eq!(
                 code, "enqueue_error",
                 "expected enqueue_error code, got: {code}"
@@ -165,7 +165,7 @@ async fn enqueue_fifo_missing_group_field_returns_error() {
                 "error message should mention the missing field 'transaction_id', got: {message}"
             );
         }
-        Err(other) => panic!("expected IIIError::Remote with enqueue_error code, got: {other:?}"),
+        Err(other) => panic!("expected Error::Remote with enqueue_error code, got: {other:?}"),
         Ok(val) => panic!("expected error for missing group field, got success: {val}"),
     }
 }
@@ -298,7 +298,7 @@ async fn chained_enqueue() {
                     timeout_ms: None,
                 })
                 .await
-                .map_err(|e| IIIError::Handler(e.to_string()))?;
+                .map_err(|e| Error::Handler(e.to_string()))?;
 
                 Ok(json!({ "step": "a_done" }))
             }

--- a/sdk/packages/rust/iii/tests/rbac_workers.rs
+++ b/sdk/packages/rust/iii/tests/rbac_workers.rs
@@ -142,7 +142,7 @@ fn ensure_functions_registered() {
                             context: json!({ "role": "prefixed", "user_id": "user-prefix" }),
                             function_registration_prefix: Some("test-prefix".to_string()),
                         }),
-                        _ => Err(iii_sdk::IIIError::Handler("invalid token".to_string())),
+                        _ => Err(iii_sdk::Error::Handler("invalid token".to_string())),
                     }
                 }
             }),
@@ -181,11 +181,11 @@ fn ensure_functions_registered() {
             "test::rbac-worker::on-function-reg",
             RegisterFunction::new_async(|input: OnFunctionRegistrationInput| async move {
                 if input.function_id.starts_with("denied::") {
-                    return Err(iii_sdk::IIIError::Handler(
+                    return Err(iii_sdk::Error::Handler(
                         "denied function registration".into(),
                     ));
                 }
-                Ok::<_, iii_sdk::IIIError>(OnFunctionRegistrationResult {
+                Ok::<_, iii_sdk::Error>(OnFunctionRegistrationResult {
                     function_id: Some(input.function_id),
                     ..Default::default()
                 })
@@ -201,11 +201,11 @@ fn ensure_functions_registered() {
                     let denied = input.trigger_type_id.starts_with("denied-tt::");
                     tt_reg_calls.lock().unwrap().push(input);
                     if denied {
-                        return Err(iii_sdk::IIIError::Handler(
+                        return Err(iii_sdk::Error::Handler(
                             "denied trigger type registration".into(),
                         ));
                     }
-                    Ok::<_, iii_sdk::IIIError>(OnTriggerTypeRegistrationResult::default())
+                    Ok::<_, iii_sdk::Error>(OnTriggerTypeRegistrationResult::default())
                 }
             }),
         ));
@@ -219,11 +219,11 @@ fn ensure_functions_registered() {
                     let denied = input.function_id.starts_with("denied-trig::");
                     trig_reg_calls.lock().unwrap().push(input);
                     if denied {
-                        return Err(iii_sdk::IIIError::Handler(
+                        return Err(iii_sdk::Error::Handler(
                             "denied trigger registration".into(),
                         ));
                     }
-                    Ok::<_, iii_sdk::IIIError>(OnTriggerRegistrationResult::default())
+                    Ok::<_, iii_sdk::Error>(OnTriggerRegistrationResult::default())
                 }
             }),
         ));
@@ -235,13 +235,13 @@ fn ensure_functions_registered() {
                 async fn register_trigger(
                     &self,
                     _config: iii_sdk::TriggerConfig,
-                ) -> Result<(), iii_sdk::IIIError> {
+                ) -> Result<(), iii_sdk::Error> {
                     Ok(())
                 }
                 async fn unregister_trigger(
                     &self,
                     _config: iii_sdk::TriggerConfig,
-                ) -> Result<(), iii_sdk::IIIError> {
+                ) -> Result<(), iii_sdk::Error> {
                     Ok(())
                 }
             }
@@ -479,13 +479,13 @@ async fn should_deny_trigger_type_registration_via_hook() {
             async fn register_trigger(
                 &self,
                 _config: iii_sdk::TriggerConfig,
-            ) -> Result<(), iii_sdk::IIIError> {
+            ) -> Result<(), iii_sdk::Error> {
                 Ok(())
             }
             async fn unregister_trigger(
                 &self,
                 _config: iii_sdk::TriggerConfig,
-            ) -> Result<(), iii_sdk::IIIError> {
+            ) -> Result<(), iii_sdk::Error> {
                 Ok(())
             }
         }
@@ -808,13 +808,13 @@ async fn infrastructure_logger_callable_from_user_handler_under_restricted_expos
                     })
                     .await
                     .map_err(|e| {
-                        iii_sdk::IIIError::Handler(format!(
+                        iii_sdk::Error::Handler(format!(
                             "engine::log::info must be allowed via \
                              INFRASTRUCTURE_FUNCTIONS carve-out under a \
                              restricted expose; got: {e}"
                         ))
                     })?;
-                Ok::<_, iii_sdk::IIIError>(json!({ "logged": true }))
+                Ok::<_, iii_sdk::Error>(json!({ "logged": true }))
             }
         }),
     );

--- a/sdk/packages/rust/iii/tests/rbac_workers.rs
+++ b/sdk/packages/rust/iii/tests/rbac_workers.rs
@@ -231,16 +231,16 @@ fn ensure_functions_registered() {
         {
             struct NoopHandler;
             #[async_trait::async_trait]
-            impl iii_sdk::TriggerHandler for NoopHandler {
+            impl iii_sdk::trigger::TriggerHandler for NoopHandler {
                 async fn register_trigger(
                     &self,
-                    _config: iii_sdk::TriggerConfig,
+                    _config: iii_sdk::trigger::TriggerConfig,
                 ) -> Result<(), iii_sdk::Error> {
                     Ok(())
                 }
                 async fn unregister_trigger(
                     &self,
-                    _config: iii_sdk::TriggerConfig,
+                    _config: iii_sdk::trigger::TriggerConfig,
                 ) -> Result<(), iii_sdk::Error> {
                     Ok(())
                 }
@@ -475,16 +475,16 @@ async fn should_deny_trigger_type_registration_via_hook() {
     {
         struct DeniedHandler;
         #[async_trait::async_trait]
-        impl iii_sdk::TriggerHandler for DeniedHandler {
+        impl iii_sdk::trigger::TriggerHandler for DeniedHandler {
             async fn register_trigger(
                 &self,
-                _config: iii_sdk::TriggerConfig,
+                _config: iii_sdk::trigger::TriggerConfig,
             ) -> Result<(), iii_sdk::Error> {
                 Ok(())
             }
             async fn unregister_trigger(
                 &self,
-                _config: iii_sdk::TriggerConfig,
+                _config: iii_sdk::trigger::TriggerConfig,
             ) -> Result<(), iii_sdk::Error> {
                 Ok(())
             }

--- a/sdk/packages/rust/iii/tests/rbac_workers.rs
+++ b/sdk/packages/rust/iii/tests/rbac_workers.rs
@@ -11,11 +11,12 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use serial_test::serial;
 
+use iii_sdk::runtime::IIIConnectionState;
 use iii_sdk::{
-    AuthInput, AuthResult, IIIConnectionState, InitOptions, MiddlewareFunctionInput,
-    OnFunctionRegistrationInput, OnFunctionRegistrationResult, OnTriggerRegistrationInput,
-    OnTriggerRegistrationResult, OnTriggerTypeRegistrationInput, OnTriggerTypeRegistrationResult,
-    RegisterFunction, TriggerRequest, register_worker,
+    AuthInput, AuthResult, InitOptions, MiddlewareFunctionInput, OnFunctionRegistrationInput,
+    OnFunctionRegistrationResult, OnTriggerRegistrationInput, OnTriggerRegistrationResult,
+    OnTriggerTypeRegistrationInput, OnTriggerTypeRegistrationResult, RegisterFunction,
+    TriggerRequest, register_worker,
 };
 use serde::Deserialize;
 

--- a/sdk/packages/rust/iii/tests/registration_dedup.rs
+++ b/sdk/packages/rust/iii/tests/registration_dedup.rs
@@ -20,7 +20,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use iii_sdk::{
-    III, IIIConnectionState, IIIError, InitOptions, RegisterFunction, RegisterTriggerInput,
+    Error, III, IIIConnectionState, InitOptions, RegisterFunction, RegisterTriggerInput,
     RegisterTriggerType, TriggerConfig, TriggerHandler, register_worker,
 };
 
@@ -31,7 +31,7 @@ struct GreetInput {
     name: String,
 }
 
-fn greet(input: GreetInput) -> Result<String, IIIError> {
+fn greet(input: GreetInput) -> Result<String, Error> {
     Ok(format!("Hello, {}", input.name))
 }
 
@@ -40,7 +40,7 @@ struct EchoInput {
     payload: Value,
 }
 
-fn echo(input: EchoInput) -> Result<Value, IIIError> {
+fn echo(input: EchoInput) -> Result<Value, Error> {
     Ok(input.payload)
 }
 
@@ -48,10 +48,10 @@ struct NoopHandler;
 
 #[async_trait::async_trait]
 impl TriggerHandler for NoopHandler {
-    async fn register_trigger(&self, _: TriggerConfig) -> Result<(), iii_sdk::IIIError> {
+    async fn register_trigger(&self, _: TriggerConfig) -> Result<(), iii_sdk::Error> {
         Ok(())
     }
-    async fn unregister_trigger(&self, _: TriggerConfig) -> Result<(), iii_sdk::IIIError> {
+    async fn unregister_trigger(&self, _: TriggerConfig) -> Result<(), iii_sdk::Error> {
         Ok(())
     }
 }

--- a/sdk/packages/rust/iii/tests/registration_dedup.rs
+++ b/sdk/packages/rust/iii/tests/registration_dedup.rs
@@ -19,9 +19,10 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
+use iii_sdk::runtime::IIIConnectionState;
 use iii_sdk::{
-    Error, III, IIIConnectionState, InitOptions, RegisterFunction, RegisterTriggerInput,
-    RegisterTriggerType, TriggerConfig, TriggerHandler, register_worker,
+    Error, III, InitOptions, RegisterFunction, RegisterTriggerInput, RegisterTriggerType,
+    TriggerConfig, TriggerHandler, register_worker,
 };
 
 use common::mock_engine::{MockEngine, count_register, count_type};

--- a/sdk/packages/rust/iii/tests/stream_provider_trait.rs
+++ b/sdk/packages/rust/iii/tests/stream_provider_trait.rs
@@ -9,28 +9,22 @@ struct DummyStream;
 
 #[async_trait]
 impl IStream for DummyStream {
-    async fn get(&self, _: StreamGetInput) -> Result<Option<Value>, iii_sdk::IIIError> {
+    async fn get(&self, _: StreamGetInput) -> Result<Option<Value>, iii_sdk::Error> {
         Ok(None)
     }
-    async fn set(&self, _: StreamSetInput) -> Result<Option<SetResult>, iii_sdk::IIIError> {
+    async fn set(&self, _: StreamSetInput) -> Result<Option<SetResult>, iii_sdk::Error> {
         Ok(None)
     }
-    async fn delete(&self, _: StreamDeleteInput) -> Result<DeleteResult, iii_sdk::IIIError> {
+    async fn delete(&self, _: StreamDeleteInput) -> Result<DeleteResult, iii_sdk::Error> {
         Ok(DeleteResult::default())
     }
-    async fn list(&self, _: StreamListInput) -> Result<Vec<Value>, iii_sdk::IIIError> {
+    async fn list(&self, _: StreamListInput) -> Result<Vec<Value>, iii_sdk::Error> {
         Ok(vec![])
     }
-    async fn list_groups(
-        &self,
-        _: StreamListGroupsInput,
-    ) -> Result<Vec<String>, iii_sdk::IIIError> {
+    async fn list_groups(&self, _: StreamListGroupsInput) -> Result<Vec<String>, iii_sdk::Error> {
         Ok(vec![])
     }
-    async fn update(
-        &self,
-        _: StreamUpdateInput,
-    ) -> Result<Option<UpdateResult>, iii_sdk::IIIError> {
+    async fn update(&self, _: StreamUpdateInput) -> Result<Option<UpdateResult>, iii_sdk::Error> {
         Ok(None)
     }
 }

--- a/sdk/packages/rust/iii/tests/trigger_type_lifecycle.rs
+++ b/sdk/packages/rust/iii/tests/trigger_type_lifecycle.rs
@@ -8,8 +8,8 @@ use serial_test::serial;
 
 use async_trait::async_trait;
 use iii_sdk::{
-    IIIConnectionState, IIIError, InitOptions, RegisterFunction, RegisterTriggerInput,
-    TriggerConfig, TriggerHandler, TriggerRequest, register_worker,
+    Error, IIIConnectionState, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerConfig,
+    TriggerHandler, TriggerRequest, register_worker,
 };
 use serde_json::{Value, json};
 use tokio::time::Duration;
@@ -32,13 +32,13 @@ struct LifecycleTriggerHandler {
 
 #[async_trait]
 impl TriggerHandler for LifecycleTriggerHandler {
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         self.state.bindings.lock().unwrap().push(config.clone());
         self.state.register_calls.lock().unwrap().push(config);
         Ok(())
     }
 
-    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         let stored = {
             let mut bindings = self.state.bindings.lock().unwrap();
             let idx = bindings.iter().position(|b| b.id == config.id);

--- a/sdk/packages/rust/iii/tests/trigger_type_lifecycle.rs
+++ b/sdk/packages/rust/iii/tests/trigger_type_lifecycle.rs
@@ -7,9 +7,10 @@ use std::sync::{Arc, Mutex};
 use serial_test::serial;
 
 use async_trait::async_trait;
+use iii_sdk::runtime::IIIConnectionState;
 use iii_sdk::{
-    Error, IIIConnectionState, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerConfig,
-    TriggerHandler, TriggerRequest, register_worker,
+    Error, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerConfig, TriggerHandler,
+    TriggerRequest, register_worker,
 };
 use serde_json::{Value, json};
 use tokio::time::Duration;


### PR DESCRIPTION
## Stage 1: SDK submodule reorg (slice 1a-1d)

Groups the flat root exports of the Node, Python, and Rust SDKs into named submodules. Every old root path stays exported as a **deprecated alias**, so this is backward compatible at runtime.

| Group | Node | Python | Rust |
|---|---|---|---|
| errors | `iii-sdk/errors` | `iii.errors` | `iii_sdk::errors` |
| channel | `iii-sdk/channel` | `iii.channel` | `iii_sdk::channel` |
| trigger | `iii-sdk/trigger` | `iii.trigger` | `iii_sdk::trigger` |
| runtime | `iii-sdk/runtime` | `iii.runtime` | `iii_sdk::runtime` |

**Errors renamed** (drop `III` prefix): Node/Python `IIIInvocationError` -> `InvocationError`; Rust `IIIError` -> `Error`. Old names kept as deprecated aliases (Python warns via `__getattr__`).

**Scope:** moves only symbols each SDK already exports (runtime is Rust-7 / Node-2 / Python-2). Cross-language parity is tracked separately. `TriggerActionVoid` excluded pending dev-sync decision.

**Includes:** updated `sdk-reference` docs (.mdx + .skill.md) for all 3 langs, and a `0.20.0` changelog entry with migration guide.

No behavior change beyond the error renames. Deprecated root re-exports will be removed in a future breaking release.