### PR TITLE
refactor(node-sdk)!: rename ISdk to IIIClient

### DIFF
--- a/docs/next/sdk-reference/node-sdk.mdx
+++ b/docs/next/sdk-reference/node-sdk.mdx
@@ -25,12 +25,12 @@ npm install iii-sdk
 Connect a worker to a running iii engine and return its handle.
 
 ```typescript
-function registerWorker(address: string, options?: InitOptions): ISdk;
+function registerWorker(address: string, options?: InitOptions): IIIClient;
 ```
 
 Pass the engine's SDK WebSocket URL (e.g. `process.env.III_URL`) as `address`. `options` configures
-worker identity, timeouts, reconnection, and OpenTelemetry. The returned `ISdk` carries every
-method below.
+worker identity, timeouts, reconnection, and OpenTelemetry. The returned `IIIClient` carries every
+method below. (`ISdk` remains as a deprecated alias for `IIIClient`.)
 
 ### `registerFunction`
 

--- a/docs/next/sdk-reference/node-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/node-sdk.mdx.skill.md
@@ -23,12 +23,12 @@ npm install iii-sdk
 Connect a worker to a running iii engine and return its handle.
 
 ```typescript
-function registerWorker(address: string, options?: InitOptions): ISdk;
+function registerWorker(address: string, options?: InitOptions): IIIClient;
 ```
 
 Pass the engine's SDK WebSocket URL (e.g. `process.env.III_URL`) as `address`. `options` configures
-worker identity, timeouts, reconnection, and OpenTelemetry. The returned `ISdk` carries every
-method below.
+worker identity, timeouts, reconnection, and OpenTelemetry. The returned `IIIClient` carries every
+method below. (`ISdk` remains as a deprecated alias for `IIIClient`.)
 
 ### `registerFunction`
 

--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -47,8 +47,8 @@ import {
 import type { TriggerHandler } from './triggers'
 import type {
   FunctionRef,
+  IIIClient,
   Invocation,
-  ISdk,
   RegisterFunctionOptions,
   RemoteFunctionData,
   RemoteFunctionHandler,
@@ -114,7 +114,7 @@ export type InitOptions = {
   telemetry?: TelemetryOptions
 }
 
-class Sdk implements ISdk {
+class Sdk implements IIIClient {
   private ws?: WebSocket
   private functions = new Map<string, RemoteFunctionData>()
   private invocations = new Map<string, Invocation & { timeout?: NodeJS.Timeout }>()
@@ -396,7 +396,7 @@ class Sdk implements ISdk {
 
   /**
    * @internal Implementation backing the `createChannel` helper in the
-   * `iii-sdk/helpers` submodule. Not part of the public `ISdk` surface.
+   * `iii-sdk/helpers` submodule. Not part of the public `IIIClient` surface.
    *
    * Creates a streaming channel pair for worker-to-worker data transfer.
    * Returns a {@link Channel} with a local writer/reader and serializable refs
@@ -543,7 +543,7 @@ class Sdk implements ISdk {
 
   /**
    * @internal Implementation backing the `createStream` helper in the
-   * `iii-sdk/helpers` submodule. Not part of the public `ISdk` surface.
+   * `iii-sdk/helpers` submodule. Not part of the public `IIIClient` surface.
    *
    * Registers a custom stream implementation, overriding the engine default
    * for the given stream name. Registers 5 of the 6 `IStream` methods
@@ -1031,7 +1031,7 @@ class Sdk implements ISdk {
 }
 
 /**
- * Factory object that constructs routing actions for {@link ISdk.trigger}.
+ * Factory object that constructs routing actions for {@link IIIClient.trigger}.
  *
  * @example
  * ```typescript
@@ -1075,7 +1075,7 @@ export const TriggerAction = {
  *
  * @param address - WebSocket URL of the III engine (e.g. `ws://localhost:49134`).
  * @param options - Optional {@link InitOptions} for worker name, timeouts, reconnection, and OTel.
- * @returns A connected {@link ISdk} instance.
+ * @returns A connected {@link IIIClient} instance.
  *
  * @example
  * ```typescript
@@ -1086,4 +1086,4 @@ export const TriggerAction = {
  * })
  * ```
  */
-export const registerWorker = (address: string, options?: InitOptions): ISdk => new Sdk(address, options)
+export const registerWorker = (address: string, options?: InitOptions): IIIClient => new Sdk(address, options)

--- a/sdk/packages/node/iii/src/index.ts
+++ b/sdk/packages/node/iii/src/index.ts
@@ -39,14 +39,17 @@ export type {
   ApiResponse,
   HttpRequest,
   HttpResponse,
+  IIIClient,
   InternalHttpRequest,
-  ISdk,
   RegisterFunctionInput,
   RegisterFunctionOptions,
   RegisterTriggerInput,
   RegisterTriggerTypeInput,
   RemoteFunctionHandler,
 } from './types'
+
+/** @deprecated Renamed to `IIIClient`. */
+export type { ISdk } from './types'
 
 /** @deprecated Import runtime types from `iii-sdk/runtime`. */
 export type { FunctionRef, TriggerTypeRef } from './runtime'

--- a/sdk/packages/node/iii/src/types.ts
+++ b/sdk/packages/node/iii/src/types.ts
@@ -67,7 +67,7 @@ export type RegisterFunctionInput = Omit<RegisterFunctionMessage, 'message_type'
 export type RegisterFunctionOptions = Omit<RegisterFunctionMessage, 'message_type' | 'id'>
 export type RegisterTriggerTypeInput = Omit<RegisterTriggerTypeMessage, 'message_type'>
 
-export interface ISdk {
+export interface IIIClient {
   /**
    * Registers a new trigger. A trigger is a way to invoke a function when a certain event occurs.
    * @param trigger - The trigger to register
@@ -213,8 +213,11 @@ export interface ISdk {
   shutdown(): Promise<void>
 }
 
+/** @deprecated Renamed to `IIIClient`. */
+export type ISdk = IIIClient
+
 /**
- * Handle returned by {@link ISdk.registerTrigger}. Use `unregister()` to
+ * Handle returned by {@link IIIClient.registerTrigger}. Use `unregister()` to
  * remove the trigger from the engine.
  */
 export type Trigger = {
@@ -223,7 +226,7 @@ export type Trigger = {
 }
 
 /**
- * Handle returned by {@link ISdk.registerFunction}. Contains the function's
+ * Handle returned by {@link IIIClient.registerFunction}. Contains the function's
  * `id` and an `unregister()` method.
  */
 export type FunctionRef = {
@@ -234,7 +237,7 @@ export type FunctionRef = {
 }
 
 /**
- * Typed handle returned by {@link ISdk.registerTriggerType}.
+ * Typed handle returned by {@link IIIClient.registerTriggerType}.
  *
  * Provides convenience methods to register triggers and functions scoped
  * to this trigger type, so callers don't need to repeat the `type` field.

--- a/sdk/packages/node/iii/tests/exports.test.ts
+++ b/sdk/packages/node/iii/tests/exports.test.ts
@@ -12,6 +12,12 @@ describe('Package Exports', () => {
     expect(typeof registerWorker).toBe('function')
   })
 
+  it('registerWorker returns an IIIClient-shaped object', () => {
+    expect(typeof iii.registerFunction).toBe('function')
+    expect(typeof iii.trigger).toBe('function')
+    void iii.shutdown()
+  })
+
   it('should import stream module', async () => {
     await expect(import('../src/stream')).resolves.toBeDefined()
   })


### PR DESCRIPTION
Renames the public Node client interface `ISdk` to `IIIClient`, matching the Python SDK (already `IIIClient`) and the renamed Rust client.

- New public name: `IIIClient` (interface in `types.ts`, exported from the barrel).
- `ISdk` stays as a `@deprecated` type alias for back-compat (re-exported from `index.ts`).
- `registerWorker` now returns `IIIClient`.
- Updated the SDK-reference doc and its skill sibling.

Type-only change; runtime surface is unchanged.