### PR TITLE
refactor(rust-sdk)!: rename III to IIIClient

### DIFF
--- a/docs/next/sdk-reference/rust-sdk.mdx
+++ b/docs/next/sdk-reference/rust-sdk.mdx
@@ -27,11 +27,11 @@ Imported as `iii_sdk`.
 Connect a worker to a running iii engine and return its handle.
 
 ```rust
-pub fn register_worker(address: &str, options: InitOptions) -> III;
+pub fn register_worker(address: &str, options: InitOptions) -> IIIClient;
 ```
 
-The returned `III` carries every method below. Spawned async tasks are driven on the SDK's
-internal tokio runtime.
+The returned `IIIClient` carries every method below. Spawned async tasks are driven on the SDK's
+internal tokio runtime. (`III` remains as a deprecated alias for `IIIClient`.)
 
 ### `register_function`
 

--- a/docs/next/sdk-reference/rust-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/rust-sdk.mdx.skill.md
@@ -25,11 +25,11 @@ Imported as `iii_sdk`.
 Connect a worker to a running iii engine and return its handle.
 
 ```rust
-pub fn register_worker(address: &str, options: InitOptions) -> III;
+pub fn register_worker(address: &str, options: InitOptions) -> IIIClient;
 ```
 
-The returned `III` carries every method below. Spawned async tasks are driven on the SDK's
-internal tokio runtime.
+The returned `IIIClient` carries every method below. Spawned async tasks are driven on the SDK's
+internal tokio runtime. (`III` remains as a deprecated alias for `IIIClient`.)
 
 ### `register_function`
 

--- a/sdk/packages/rust/iii-example/src/cron_trigger_example.rs
+++ b/sdk/packages/rust/iii-example/src/cron_trigger_example.rs
@@ -1,10 +1,10 @@
 use iii_sdk::builtin_triggers::*;
 use iii_sdk::trigger::IIITrigger;
-use iii_sdk::{Error, III, RegisterFunction};
+use iii_sdk::{Error, IIIClient, RegisterFunction};
 use serde_json::json;
 
 /// Examples using built-in trigger types with the typed `IIITrigger` enum.
-pub fn setup(iii: &III) {
+pub fn setup(iii: &IIIClient) {
     // ── Cron trigger ────────────────────────────────────────────────
     iii.register_function(
         "example::scheduled_cleanup",

--- a/sdk/packages/rust/iii-example/src/custom_trigger_example.rs
+++ b/sdk/packages/rust/iii-example/src/custom_trigger_example.rs
@@ -1,5 +1,5 @@
 use iii_sdk::trigger::{TriggerConfig, TriggerHandler};
-use iii_sdk::{Error, III, RegisterTriggerType};
+use iii_sdk::{Error, IIIClient, RegisterTriggerType};
 use serde_json::json;
 
 // ── Example 1: Typed trigger with full config ───────────────────────────
@@ -93,7 +93,7 @@ impl TriggerHandler for NoopHandler {
 
 // ── Setup ───────────────────────────────────────────────────────────────
 
-pub fn setup(iii: &III) {
+pub fn setup(iii: &IIIClient) {
     // ── Example 1: Schedule trigger (fully typed) ───────────────────
     let schedule = iii.register_trigger_type(
         RegisterTriggerType::new(

--- a/sdk/packages/rust/iii-example/src/http_example.rs
+++ b/sdk/packages/rust/iii-example/src/http_example.rs
@@ -1,10 +1,10 @@
 use iii_observability::{Logger, execute_traced_request};
 use iii_sdk::builtin_triggers::{HttpMethod, HttpTriggerConfig};
 use iii_sdk::trigger::IIITrigger;
-use iii_sdk::{ApiRequest, ApiResponse, Error, III, RegisterFunction};
+use iii_sdk::{ApiRequest, ApiResponse, Error, IIIClient, RegisterFunction};
 use serde_json::json;
 
-pub fn setup(iii: &III) {
+pub fn setup(iii: &IIIClient) {
     let client = reqwest::Client::new();
 
     let get_client = client.clone();

--- a/sdk/packages/rust/iii-example/src/logger_example.rs
+++ b/sdk/packages/rust/iii-example/src/logger_example.rs
@@ -1,8 +1,8 @@
 use iii_observability::Logger;
-use iii_sdk::{Error, III, RegisterFunction};
+use iii_sdk::{Error, IIIClient, RegisterFunction};
 use serde_json::{Value, json};
 
-pub fn setup(iii: &III) {
+pub fn setup(iii: &IIIClient) {
     iii.register_function(
         "example::logger_demo",
         RegisterFunction::new_async(|input: Value| async move {

--- a/sdk/packages/rust/iii-example/src/trigger_type_example.rs
+++ b/sdk/packages/rust/iii-example/src/trigger_type_example.rs
@@ -1,5 +1,5 @@
 use iii_sdk::trigger::{TriggerConfig, TriggerHandler};
-use iii_sdk::{Error, III, RegisterTriggerType, TriggerRequest};
+use iii_sdk::{Error, IIIClient, RegisterTriggerType, TriggerRequest};
 use serde::Deserialize;
 
 /// Minimal deserialization target for `engine::triggers::list` rows used
@@ -58,7 +58,7 @@ impl TriggerHandler for WebhookHandler {
 
 // ── Setup ───────────────────────────────────────────────────────────────
 
-pub fn setup(iii: &III) {
+pub fn setup(iii: &IIIClient) {
     // Register trigger type — returns a typed handle
     let webhook = iii.register_trigger_type(
         RegisterTriggerType::new("webhook", "Incoming webhook trigger", WebhookHandler)
@@ -92,7 +92,7 @@ fn handle_webhook(input: WebhookCallRequest) -> Result<serde_json::Value, Error>
 
 // ── List trigger types example ──────────────────────────────────────────
 
-pub async fn print_trigger_type_catalog(iii: &III) {
+pub async fn print_trigger_type_catalog(iii: &IIIClient) {
     println!("\n--- Listing all trigger types ---");
 
     // `engine::trigger-types::list` was retired in favor of

--- a/sdk/packages/rust/iii/src/helpers.rs
+++ b/sdk/packages/rust/iii/src/helpers.rs
@@ -1,7 +1,7 @@
-//! Helper free functions that operate on an [`III`] instance.
+//! Helper free functions that operate on an [`IIIClient`] instance.
 //!
-//! These were previously instance methods on `III`. They take `&III` as the
-//! first argument so the public API surface of `III` stays focused on the
+//! These were previously instance methods on `IIIClient`. They take `&IIIClient` as the
+//! first argument so the public API surface of `IIIClient` stays focused on the
 //! core lifecycle and registration methods.
 
 pub use crate::channels::{ChannelDirection, ChannelItem, extract_channel_refs, is_channel_ref};
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use serde_json::Value;
 
 use crate::error::Error;
-use crate::iii::{III, RegisterFunction};
+use crate::iii::{IIIClient, RegisterFunction};
 use crate::stream_provider::IStream;
 use crate::types::{
     Channel, StreamDeleteInput, StreamGetInput, StreamListGroupsInput, StreamListInput,
@@ -20,8 +20,8 @@ use crate::types::{
 
 /// Create a streaming channel pair for worker-to-worker data transfer.
 ///
-/// Free-function form of `III`'s former `create_channel` instance method.
-pub async fn create_channel(iii: &III, buffer_size: Option<usize>) -> Result<Channel, Error> {
+/// Free-function form of `IIIClient`'s former `create_channel` instance method.
+pub async fn create_channel(iii: &IIIClient, buffer_size: Option<usize>) -> Result<Channel, Error> {
     crate::iii::internal_create_channel(iii, buffer_size).await
 }
 
@@ -30,7 +30,7 @@ pub async fn create_channel(iii: &III, buffer_size: Option<usize>) -> Result<Cha
 /// Wires the 5 callable `stream::*` functions (`get`, `set`, `delete`, `list`,
 /// `list_groups`) on the engine through the supplied [`IStream`] implementor.
 /// `update` is **not** registered — atomic updates remain engine-side.
-pub fn create_stream<S>(iii: &III, stream_name: impl Into<String>, stream: S)
+pub fn create_stream<S>(iii: &IIIClient, stream_name: impl Into<String>, stream: S)
 where
     S: IStream,
 {

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -93,7 +93,7 @@ pub struct TriggerInfo {
 /// - `R` tracks the call request type (set via `.call_request_format::<T>()`)
 ///
 /// Both default to `Value` (untyped) and change when the respective builder
-/// method is called. This allows [`III::register_trigger_type`] to return a
+/// method is called. This allows [`IIIClient::register_trigger_type`] to return a
 /// [`TriggerTypeRef<C, R>`] with compile-time safety for both config and
 /// function input types.
 pub struct RegisterTriggerType<H, C = Value, R = Value> {
@@ -150,14 +150,14 @@ impl<H: TriggerHandler, C, R> RegisterTriggerType<H, C, R> {
     }
 }
 
-/// Typed handle returned by [`III::register_trigger_type`].
+/// Typed handle returned by [`IIIClient::register_trigger_type`].
 ///
 /// Type parameters:
 /// - `C` — trigger registration type for [`register_trigger`](Self::register_trigger)
 /// - `R` — call request type for [`register_function`](Self::register_function)
 #[derive(Clone)]
 pub struct TriggerTypeRef<C = Value, R = Value> {
-    iii: III,
+    iii: IIIClient,
     trigger_type_id: String,
     _phantom: std::marker::PhantomData<(C, R)>,
 }
@@ -509,7 +509,7 @@ fn empty_message() -> RegisterFunctionMessage {
 /// Function registration builder.
 ///
 /// The function ID is supplied separately at registration time via
-/// [`III::register_function`] — `RegisterFunction` only carries the handler
+/// [`IIIClient::register_function`] — `RegisterFunction` only carries the handler
 /// and optional metadata.
 ///
 /// Constructors:
@@ -626,11 +626,11 @@ struct IIIInner {
 ///
 /// Create with [`register_worker`](crate::register_worker).
 #[derive(Clone)]
-pub struct III {
+pub struct IIIClient {
     inner: Arc<IIIInner>,
 }
 
-impl III {
+impl IIIClient {
     /// Create a new III with default worker metadata (auto-detected runtime, os, hostname)
     pub fn new(address: &str) -> Self {
         Self::with_metadata(address, WorkerMetadata::default())
@@ -881,7 +881,7 @@ impl III {
     ///
     /// # Examples
     /// ```rust,no_run
-    /// # use iii_sdk::{III, RegisterTriggerType};
+    /// # use iii_sdk::{IIIClient, RegisterTriggerType};
     /// # struct MyHandler;
     /// # #[async_trait::async_trait]
     /// # impl iii_sdk::TriggerHandler for MyHandler {
@@ -890,7 +890,7 @@ impl III {
     /// # }
     /// # #[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)] struct MyConfig { url: String }
     /// # #[derive(serde::Deserialize, schemars::JsonSchema)] struct MyRequest { data: String }
-    /// # let iii = III::new("ws://localhost:49134");
+    /// # let iii = IIIClient::new("ws://localhost:49134");
     /// let my_trigger = iii.register_trigger_type(
     ///     RegisterTriggerType::new("my-trigger", "My custom trigger", MyHandler)
     ///         .trigger_request_format::<MyConfig>()
@@ -951,9 +951,9 @@ impl III {
     ///
     /// # Examples
     /// ```rust
-    /// # use iii_sdk::{III, RegisterTriggerInput};
+    /// # use iii_sdk::{IIIClient, RegisterTriggerInput};
     /// # use serde_json::json;
-    /// # let iii = III::new("ws://localhost:49134");
+    /// # let iii = IIIClient::new("ws://localhost:49134");
     /// let trigger = iii.register_trigger(RegisterTriggerInput {
     ///     trigger_type: "http".to_string(),
     ///     function_id: "greet".to_string(),
@@ -1004,9 +1004,9 @@ impl III {
     ///
     /// # Examples
     /// ```rust
-    /// # use iii_sdk::{III, TriggerRequest, TriggerAction};
+    /// # use iii_sdk::{IIIClient, TriggerRequest, TriggerAction};
     /// # use serde_json::json;
-    /// # async fn example(iii: &III) -> Result<(), iii_sdk::Error> {
+    /// # async fn example(iii: &IIIClient) -> Result<(), iii_sdk::Error> {
     /// // Synchronous
     /// let result = iii.trigger(TriggerRequest {
     ///     function_id: "greet".to_string(),
@@ -1798,7 +1798,7 @@ impl III {
 // ---------------------------------------------------------------------------
 
 pub(crate) async fn internal_create_channel(
-    iii: &III,
+    iii: &IIIClient,
     buffer_size: Option<usize>,
 ) -> Result<Channel, Error> {
     let result = iii
@@ -2156,26 +2156,26 @@ mod tests {
     #[test]
     fn registration_key_returns_typed_keys_for_register_messages() {
         assert_eq!(
-            III::registration_key(&make_register_function("greet")),
+            IIIClient::registration_key(&make_register_function("greet")),
             Some("function:greet".to_string())
         );
         assert_eq!(
-            III::registration_key(&make_register_trigger("t1")),
+            IIIClient::registration_key(&make_register_trigger("t1")),
             Some("trigger:t1".to_string())
         );
         assert_eq!(
-            III::registration_key(&make_register_trigger_type("tt1")),
+            IIIClient::registration_key(&make_register_trigger_type("tt1")),
             Some("trigger_type:tt1".to_string())
         );
     }
 
     #[test]
     fn registration_key_returns_none_for_non_register_messages() {
-        assert_eq!(III::registration_key(&make_invoke("f")), None);
-        assert_eq!(III::registration_key(&Message::Ping), None);
-        assert_eq!(III::registration_key(&Message::Pong), None);
+        assert_eq!(IIIClient::registration_key(&make_invoke("f")), None);
+        assert_eq!(IIIClient::registration_key(&Message::Ping), None);
+        assert_eq!(IIIClient::registration_key(&Message::Pong), None);
         assert_eq!(
-            III::registration_key(&Message::WorkerRegistered {
+            IIIClient::registration_key(&Message::WorkerRegistered {
                 worker_id: "w".to_string()
             }),
             None
@@ -2205,10 +2205,11 @@ mod tests {
         .collect();
 
         let mut queue: Vec<Message> = Vec::new();
-        let shutdown = III::drain_pre_connect_duplicates(&mut rx, &mut queue, &snapshot_ids);
+        let shutdown = IIIClient::drain_pre_connect_duplicates(&mut rx, &mut queue, &snapshot_ids);
 
         assert!(!shutdown);
-        let kept_keys: Vec<Option<String>> = queue.iter().map(III::registration_key).collect();
+        let kept_keys: Vec<Option<String>> =
+            queue.iter().map(IIIClient::registration_key).collect();
         assert_eq!(
             kept_keys,
             vec![
@@ -2233,7 +2234,7 @@ mod tests {
 
         let snapshot_ids: HashSet<String> = ["function:a".to_string()].into_iter().collect();
         let mut queue: Vec<Message> = Vec::new();
-        let shutdown = III::drain_pre_connect_duplicates(&mut rx, &mut queue, &snapshot_ids);
+        let shutdown = IIIClient::drain_pre_connect_duplicates(&mut rx, &mut queue, &snapshot_ids);
 
         assert!(shutdown, "expected shutdown signal to be reported");
         assert!(
@@ -2248,7 +2249,7 @@ mod tests {
         let snapshot_ids: HashSet<String> = HashSet::new();
         let mut queue: Vec<Message> = Vec::new();
 
-        let shutdown = III::drain_pre_connect_duplicates(&mut rx, &mut queue, &snapshot_ids);
+        let shutdown = IIIClient::drain_pre_connect_duplicates(&mut rx, &mut queue, &snapshot_ids);
 
         assert!(!shutdown);
         assert!(queue.is_empty());

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -48,12 +48,14 @@ pub use error::Error;
     note = "renamed to Error; import from iii_sdk::errors"
 )]
 pub use error::Error as IIIError;
+#[deprecated(since = "0.20.0", note = "renamed to IIIClient")]
+pub use iii::IIIClient as III;
 #[deprecated(since = "0.19.0", note = "import from iii_sdk::runtime")]
 pub use iii::{
     FunctionInfo, FunctionRef, IIIConnectionState, TriggerInfo, TriggerTypeRef, WorkerInfo,
     WorkerMetadata,
 };
-pub use iii::{III, RegisterFunction, RegisterTriggerType};
+pub use iii::{IIIClient, RegisterFunction, RegisterTriggerType};
 pub use protocol::{
     EnqueueResult, ErrorBody, FunctionMessage, HttpAuthConfig, HttpInvocationConfig, HttpMethod,
     Message, RegisterFunctionMessage, RegisterTriggerInput, RegisterTriggerMessage,
@@ -97,7 +99,7 @@ pub struct InitOptions {
 /// established automatically in a dedicated background thread with its own
 /// tokio runtime.
 ///
-/// Call [`III::shutdown`] before the end of `main` to cleanly stop the
+/// Call [`IIIClient::shutdown`] before the end of `main` to cleanly stop the
 /// connection and join the background thread. In Rust the process exits
 /// when `main` returns, terminating all threads — so `shutdown()` must be
 /// called while `main` is still running.
@@ -114,7 +116,7 @@ pub struct InitOptions {
 /// // register functions, handle events, etc.
 /// iii.shutdown(); // cleanly stops the connection thread
 /// ```
-pub fn register_worker(address: &str, options: InitOptions) -> III {
+pub fn register_worker(address: &str, options: InitOptions) -> IIIClient {
     let InitOptions {
         metadata,
         headers,
@@ -122,9 +124,9 @@ pub fn register_worker(address: &str, options: InitOptions) -> III {
     } = options;
 
     let iii = if let Some(metadata) = metadata {
-        III::with_metadata(address, metadata)
+        IIIClient::with_metadata(address, metadata)
     } else {
-        III::new(address)
+        IIIClient::new(address)
     };
 
     if let Some(h) = headers {
@@ -172,11 +174,11 @@ fn _ensure_is_channel_ref_not_top_level() {}
 
 // ---------------------------------------------------------------------------
 // Compile-fail doctest: enforces that `create_channel` (relocated to
-// `helpers`) is no longer callable on `III`.
+// `helpers`) is no longer callable on `IIIClient`.
 // ---------------------------------------------------------------------------
 
 /// ```compile_fail
-/// let iii = iii_sdk::III::new("ws://x");
+/// let iii = iii_sdk::IIIClient::new("ws://x");
 /// iii.create_channel(None);
 /// ```
 #[allow(dead_code)]

--- a/sdk/packages/rust/iii/src/protocol.rs
+++ b/sdk/packages/rust/iii/src/protocol.rs
@@ -206,7 +206,7 @@ impl RegisterTriggerTypeMessage {
     }
 }
 
-/// Input for [`III::register_trigger`](crate::III::register_trigger).
+/// Input for [`IIIClient::register_trigger`](crate::IIIClient::register_trigger).
 /// The `id` is auto-generated internally.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegisterTriggerInput {

--- a/sdk/packages/rust/iii/src/triggers.rs
+++ b/sdk/packages/rust/iii/src/triggers.rs
@@ -20,7 +20,7 @@ pub struct TriggerConfig {
 }
 
 /// Handler trait for custom trigger types. Implement this and pass to
-/// [`III::register_trigger_type`](crate::III::register_trigger_type).
+/// [`IIIClient::register_trigger_type`](crate::IIIClient::register_trigger_type).
 #[async_trait]
 pub trait TriggerHandler: Send + Sync {
     /// Called when a trigger instance is registered.
@@ -29,7 +29,7 @@ pub trait TriggerHandler: Send + Sync {
     async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), Error>;
 }
 
-/// Handle returned by [`III::register_trigger`](crate::III::register_trigger).
+/// Handle returned by [`IIIClient::register_trigger`](crate::IIIClient::register_trigger).
 /// Call [`unregister`](Trigger::unregister) to remove the trigger from the engine.
 #[derive(Clone)]
 pub struct Trigger {

--- a/sdk/packages/rust/iii/tests/common/mod.rs
+++ b/sdk/packages/rust/iii/tests/common/mod.rs
@@ -5,10 +5,10 @@ pub mod mock_engine;
 use std::sync::OnceLock;
 use std::time::Duration;
 
-use iii_sdk::{III, InitOptions, register_worker};
+use iii_sdk::{IIIClient, InitOptions, register_worker};
 
 static SHARED_RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
-static SHARED_III: OnceLock<III> = OnceLock::new();
+static SHARED_III: OnceLock<IIIClient> = OnceLock::new();
 
 #[ctor::dtor]
 fn shutdown() {
@@ -32,7 +32,7 @@ pub fn http_client() -> reqwest::Client {
     reqwest::Client::new()
 }
 
-pub fn shared_iii() -> &'static III {
+pub fn shared_iii() -> &'static IIIClient {
     SHARED_III.get_or_init(|| {
         let rt = SHARED_RT.get_or_init(|| {
             tokio::runtime::Builder::new_multi_thread()

--- a/sdk/packages/rust/iii/tests/registration_dedup.rs
+++ b/sdk/packages/rust/iii/tests/registration_dedup.rs
@@ -21,7 +21,7 @@ use serde_json::{Value, json};
 
 use iii_sdk::runtime::IIIConnectionState;
 use iii_sdk::{
-    Error, III, InitOptions, RegisterFunction, RegisterTriggerInput, RegisterTriggerType,
+    Error, IIIClient, InitOptions, RegisterFunction, RegisterTriggerInput, RegisterTriggerType,
     TriggerConfig, TriggerHandler, register_worker,
 };
 
@@ -75,7 +75,7 @@ async fn assert_stable(
     snap
 }
 
-async fn shutdown(iii: &III) {
+async fn shutdown(iii: &IIIClient) {
     iii.shutdown_async().await;
 }
 

--- a/sdk/packages/rust/iii/tests/state.rs
+++ b/sdk/packages/rust/iii/tests/state.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
 
-use iii_sdk::{III, RegisterFunction, RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{IIIClient, RegisterFunction, RegisterTriggerInput, TriggerRequest};
 
 const SCOPE: &str = "test-scope-rs";
 
@@ -22,7 +22,7 @@ fn unique_key(test_name: &str) -> String {
     format!("{test_name}-{ts}")
 }
 
-async fn delete_state(iii: &III, key: &str) {
+async fn delete_state(iii: &IIIClient, key: &str) {
     let _ = iii
         .trigger(TriggerRequest {
             function_id: "state::delete".to_string(),

--- a/sdk/packages/rust/iii/tests/trigger_type_lifecycle.rs
+++ b/sdk/packages/rust/iii/tests/trigger_type_lifecycle.rs
@@ -54,7 +54,7 @@ impl TriggerHandler for LifecycleTriggerHandler {
     }
 }
 
-async fn wait_connected(iii: &iii_sdk::III) {
+async fn wait_connected(iii: &iii_sdk::IIIClient) {
     for _ in 0..50 {
         if iii.get_connection_state() == IIIConnectionState::Connected {
             tokio::time::sleep(Duration::from_millis(100)).await;
@@ -85,7 +85,7 @@ async fn wait_handler_calls(state: &LifecycleState, at_least: usize) {
     panic!("timed out waiting for handler invocations");
 }
 
-async fn create_provider(state: &LifecycleState) -> iii_sdk::III {
+async fn create_provider(state: &LifecycleState) -> iii_sdk::IIIClient {
     let handler_state = state.clone();
     let iii = register_worker(&common::engine_ws_url(), InitOptions::default());
     wait_connected(&iii).await;
@@ -126,7 +126,7 @@ async fn create_provider(state: &LifecycleState) -> iii_sdk::III {
     iii
 }
 
-async fn create_consumer(state: &LifecycleState) -> iii_sdk::III {
+async fn create_consumer(state: &LifecycleState) -> iii_sdk::IIIClient {
     let handler_state = state.clone();
     let iii = register_worker(&common::engine_ws_url(), InitOptions::default());
     wait_connected(&iii).await;


### PR DESCRIPTION
Renames the Rust client struct `III` to `IIIClient`, matching the Python and Node SDKs.

- New public name: `IIIClient` (struct + impl in `iii.rs`); `register_worker` returns `IIIClient`.
- `III` kept as a `#[deprecated]` crate-root alias (`pub use iii::IIIClient as III`) for back-compat.
- Internal modules, doctests, the `iii-example` crate, and integration `tests/` repointed to `IIIClient`.
- Product/engine prose references ("iii engine", "III SDK") left untouched; only the type symbol was renamed.
- Updated the SDK-reference doc and its skill sibling.

Verified: `cargo fmt --check`, `build`, `test --doc` (5), `test --lib` (53), `clippy --all-targets -D warnings` all pass.