### PR TITLE
refactor(rust-sdk)!: rename WorkerTelemetryMeta to TelemetryOptions

### DIFF
--- a/docs/next/sdk-reference/rust-sdk.mdx
+++ b/docs/next/sdk-reference/rust-sdk.mdx
@@ -209,10 +209,11 @@ The SDK re-exports the engine's structured introspection types:
 - `WorkerInfo`. `id`, `name`, runtime / version / OS fields, IP, `status`, `connected_at_ms`,
   `function_count`, registered `functions`, `active_invocations`, optional `isolation`.
 - `WorkerMetadata`. The structured metadata a worker reports about itself: `runtime`, `version`,
-  `name`, `os`, `pid`, `telemetry` (an optional `WorkerTelemetryMeta` carrying language /
+  `name`, `os`, `pid`, `telemetry` (an optional `TelemetryOptions` carrying language /
   framework / project labels plus an Amplitude key, used by iii-telemetry for anonymous usage
   reporting; distinct from the OpenTelemetry observability surfaces owned by iii-observability),
-  `isolation`. Rust is the only SDK that surfaces this as a distinct type today.
+  `isolation`. `TelemetryOptions` is exported at the crate root (matching Node and Python);
+  the former name `WorkerTelemetryMeta` stays as a deprecated alias.
 
 ## `MessageType`
 

--- a/docs/next/sdk-reference/rust-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/rust-sdk.mdx.skill.md
@@ -207,10 +207,11 @@ The SDK re-exports the engine's structured introspection types:
 - `WorkerInfo`. `id`, `name`, runtime / version / OS fields, IP, `status`, `connected_at_ms`,
   `function_count`, registered `functions`, `active_invocations`, optional `isolation`.
 - `WorkerMetadata`. The structured metadata a worker reports about itself: `runtime`, `version`,
-  `name`, `os`, `pid`, `telemetry` (an optional `WorkerTelemetryMeta` carrying language /
+  `name`, `os`, `pid`, `telemetry` (an optional `TelemetryOptions` carrying language /
   framework / project labels plus an Amplitude key, used by iii-telemetry for anonymous usage
   reporting; distinct from the OpenTelemetry observability surfaces owned by iii-observability),
-  `isolation`. Rust is the only SDK that surfaces this as a distinct type today.
+  `isolation`. `TelemetryOptions` is exported at the crate root (matching Node and Python);
+  the former name `WorkerTelemetryMeta` stays as a deprecated alias.
 
 ## `MessageType`
 

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -217,7 +217,7 @@ where
 
 /// Telemetry metadata provided by the SDK to the engine.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct WorkerTelemetryMeta {
+pub struct TelemetryOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -238,7 +238,7 @@ pub struct WorkerMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pid: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub telemetry: Option<WorkerTelemetryMeta>,
+    pub telemetry: Option<TelemetryOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub isolation: Option<String>,
 }
@@ -270,7 +270,7 @@ impl Default for WorkerMetadata {
             name: format!("{}:{}", hostname, pid),
             os: os_info,
             pid: Some(pid),
-            telemetry: Some(WorkerTelemetryMeta {
+            telemetry: Some(TelemetryOptions {
                 language,
                 project_name,
                 ..Default::default()

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -48,6 +48,9 @@ pub use error::Error;
     note = "renamed to Error; import from iii_sdk::errors"
 )]
 pub use error::Error as IIIError;
+pub use iii::TelemetryOptions;
+#[deprecated(since = "0.20.0", note = "renamed to TelemetryOptions")]
+pub use iii::TelemetryOptions as WorkerTelemetryMeta;
 #[deprecated(since = "0.19.0", note = "import from iii_sdk::runtime")]
 pub use iii::{
     FunctionInfo, FunctionRef, IIIConnectionState, TriggerInfo, TriggerTypeRef, WorkerInfo,


### PR DESCRIPTION
Renames the Rust `WorkerTelemetryMeta` struct to `TelemetryOptions`, matching the Node and Python SDKs, and exports it at the crate root (it was not root-exported before).

- New public name: `TelemetryOptions`, re-exported as `iii_sdk::TelemetryOptions`.
- `WorkerTelemetryMeta` kept as a `#[deprecated]` crate-root alias.
- `WorkerMetadata.telemetry` now typed `Option<TelemetryOptions>`.
- Updated the SDK-reference doc and its skill sibling.

Verified: `cargo fmt --check`, build, `test --doc` (5), `test --lib` (53), `clippy --all-targets -D warnings` all pass.