### PR TITLE
feat(node-sdk): export TelemetryOptions

### DIFF
--- a/docs/next/sdk-reference/node-sdk.mdx
+++ b/docs/next/sdk-reference/node-sdk.mdx
@@ -32,6 +32,9 @@ Pass the engine's SDK WebSocket URL (e.g. `process.env.III_URL`) as `address`. `
 worker identity, timeouts, reconnection, and OpenTelemetry. The returned `ISdk` carries every
 method below.
 
+`TelemetryOptions` is the public type for the worker's telemetry labels (`language`, `project_name`,
+`framework`, `amplitude_api_key`), exported from `iii-sdk` to match the Python and Rust SDKs.
+
 ### `registerFunction`
 
 Register a callable function on this worker.

--- a/docs/next/sdk-reference/node-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/node-sdk.mdx.skill.md
@@ -30,6 +30,9 @@ Pass the engine's SDK WebSocket URL (e.g. `process.env.III_URL`) as `address`. `
 worker identity, timeouts, reconnection, and OpenTelemetry. The returned `ISdk` carries every
 method below.
 
+`TelemetryOptions` is the public type for the worker's telemetry labels (`language`, `project_name`,
+`framework`, `amplitude_api_key`), exported from `iii-sdk` to match the Python and Rust SDKs.
+
 ### `registerFunction`
 
 Register a callable function on this worker.

--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -69,7 +69,7 @@ function getDefaultWorkerName(): string {
   return `${os.hostname()}:${process.pid}`
 }
 
-/** @internal */
+/** Telemetry labels reported by the worker (language, framework, project). */
 export type TelemetryOptions = {
   language?: string
   project_name?: string

--- a/sdk/packages/node/iii/src/index.ts
+++ b/sdk/packages/node/iii/src/index.ts
@@ -7,7 +7,7 @@ export { InvocationError, type InvocationErrorInit } from './errors'
 /** @deprecated Renamed; import `InvocationError` / `InvocationErrorInit` from `iii-sdk/errors`. */
 export { IIIInvocationError, type IIIInvocationErrorInit } from './errors'
 
-export { type InitOptions, registerWorker, TriggerAction } from './iii'
+export { type InitOptions, registerWorker, type TelemetryOptions, TriggerAction } from './iii'
 
 export { EngineFunctions, EngineTriggers } from './iii-constants'
 

--- a/sdk/packages/node/iii/tests/exports.test.ts
+++ b/sdk/packages/node/iii/tests/exports.test.ts
@@ -39,4 +39,9 @@ describe('Package Exports', () => {
   it('should import the runtime subpath module', async () => {
     await expect(import('../src/runtime')).resolves.toBeDefined()
   })
+
+  it('exposes the TelemetryOptions type via the barrel', async () => {
+    // Type-only; presence is enforced by tsc. This asserts the module resolves.
+    await expect(import('../src/index')).resolves.toBeDefined()
+  })
 })


### PR DESCRIPTION
Makes the Node `TelemetryOptions` type public. It was defined but marked `@internal` and not exported from the barrel.

- Dropped `@internal`; `TelemetryOptions` (`language`, `project_name`, `framework`, `amplitude_api_key`) is now exported from `iii-sdk`.
- Matches the Python and Rust SDKs, which already surface this type.
- Additive; no rename, no alias needed.
- Updated the SDK-reference doc and its skill sibling.

Verified: `pnpm build`, `tsc --noEmit`, `vitest run tests/exports.test.ts` (7 passed).