### PR TITLE
feat(rust-sdk): add InvocationError

### DIFF
--- a/docs/next/sdk-reference/rust-sdk.mdx
+++ b/docs/next/sdk-reference/rust-sdk.mdx
@@ -153,6 +153,12 @@ The former name `IIIError` stays reachable at the crate root as a deprecated ali
 `Error::Remote(body) => body.code.as_str()` to branch on engine error codes
 (`invocation_failed`, `invocation_stopped`, `function_not_found`, `FORBIDDEN`, `TIMEOUT`, etc.).
 
+`InvocationError` is the structured form of a remote invocation failure (`code`, `message`,
+optional `function_id`, optional `stacktrace`), mirroring the Node and Python SDKs. Obtain it from
+an `Error` with `err.invocation_error()`, which returns `Some(InvocationError)` for `Error::Remote`
+and `None` for transport, serde, or handler errors. Exported as `iii_sdk::InvocationError` and
+`iii_sdk::errors::InvocationError`.
+
 ## Channels
 
 Import channel types from the `iii_sdk::channel` submodule

--- a/docs/next/sdk-reference/rust-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/rust-sdk.mdx.skill.md
@@ -151,6 +151,12 @@ The former name `IIIError` stays reachable at the crate root as a deprecated ali
 `Error::Remote(body) => body.code.as_str()` to branch on engine error codes
 (`invocation_failed`, `invocation_stopped`, `function_not_found`, `FORBIDDEN`, `TIMEOUT`, etc.).
 
+`InvocationError` is the structured form of a remote invocation failure (`code`, `message`,
+optional `function_id`, optional `stacktrace`), mirroring the Node and Python SDKs. Obtain it from
+an `Error` with `err.invocation_error()`, which returns `Some(InvocationError)` for `Error::Remote`
+and `None` for transport, serde, or handler errors. Exported as `iii_sdk::InvocationError` and
+`iii_sdk::errors::InvocationError`.
+
 ## Channels
 
 Import channel types from the `iii_sdk::channel` submodule

--- a/sdk/packages/rust/iii/src/error.rs
+++ b/sdk/packages/rust/iii/src/error.rs
@@ -1,5 +1,5 @@
 use schemars::JsonSchema;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Errors returned by the III SDK.
@@ -46,5 +46,72 @@ impl From<&str> for Error {
 impl From<tokio_tungstenite::tungstenite::Error> for Error {
     fn from(err: tokio_tungstenite::tungstenite::Error) -> Self {
         Error::WebSocket(err.to_string())
+    }
+}
+
+/// Structured invocation failure, mirroring the Node and Python `InvocationError`.
+///
+/// Produced from the [`Error::Remote`] variant via [`Error::invocation_error`].
+/// `function_id` is `None` from that accessor because the wire `Remote` payload
+/// does not carry it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct InvocationError {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stacktrace: Option<String>,
+}
+
+impl std::fmt::Display for InvocationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for InvocationError {}
+
+impl Error {
+    /// If this is a remote invocation failure (`Error::Remote`), return its
+    /// structured form. Returns `None` for transport/serde/handler errors.
+    pub fn invocation_error(&self) -> Option<InvocationError> {
+        match self {
+            Error::Remote {
+                code,
+                message,
+                stacktrace,
+            } => Some(InvocationError {
+                code: code.clone(),
+                message: message.clone(),
+                function_id: None,
+                stacktrace: stacktrace.clone(),
+            }),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod invocation_error_tests {
+    use super::*;
+
+    #[test]
+    fn remote_error_yields_invocation_error() {
+        let err = Error::Remote {
+            code: "FORBIDDEN".into(),
+            message: "nope".into(),
+            stacktrace: Some("trace".into()),
+        };
+        let inv = err.invocation_error().expect("remote -> invocation");
+        assert_eq!(inv.code, "FORBIDDEN");
+        assert_eq!(inv.message, "nope");
+        assert_eq!(inv.stacktrace.as_deref(), Some("trace"));
+        assert_eq!(inv.to_string(), "FORBIDDEN: nope");
+    }
+
+    #[test]
+    fn non_remote_error_yields_none() {
+        assert!(Error::Timeout.invocation_error().is_none());
     }
 }

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -31,7 +31,7 @@ pub mod channel {
 
 /// Public error types. (Stage 1 submodule grouping.)
 pub mod errors {
-    pub use crate::error::Error;
+    pub use crate::error::{Error, InvocationError};
 }
 
 #[deprecated(since = "0.19.0", note = "import from iii_sdk::trigger")]
@@ -42,12 +42,12 @@ pub use builtin_triggers::{
 };
 #[deprecated(since = "0.19.0", note = "import from iii_sdk::channel")]
 pub use channels::{ChannelReader, ChannelWriter, StreamChannelRef};
-pub use error::Error;
 #[deprecated(
     since = "0.19.0",
     note = "renamed to Error; import from iii_sdk::errors"
 )]
 pub use error::Error as IIIError;
+pub use error::{Error, InvocationError};
 #[deprecated(since = "0.19.0", note = "import from iii_sdk::runtime")]
 pub use iii::{
     FunctionInfo, FunctionRef, IIIConnectionState, TriggerInfo, TriggerTypeRef, WorkerInfo,
@@ -229,3 +229,10 @@ fn _ensure_channel_submodule_path() {}
 /// ```
 #[allow(dead_code)]
 fn _ensure_errors_submodule_path() {}
+
+/// ```rust,no_run
+/// use iii_sdk::errors::InvocationError;
+/// fn _takes(_e: InvocationError) {}
+/// ```
+#[allow(dead_code)]
+fn _ensure_invocation_error_path() {}


### PR DESCRIPTION
Adds a structured `InvocationError` to the Rust SDK, mirroring the Node and Python `InvocationError`. Additive: no change to the `Error` enum or any `Result` signature.

- New `InvocationError` struct (`code`, `message`, optional `function_id`, optional `stacktrace`) with `Display` + `std::error::Error`.
- `Error::invocation_error()` accessor extracts it from `Error::Remote`; returns `None` for transport/serde/handler errors. `function_id` is `None` from the accessor (the wire `Remote` payload does not carry it).
- Exported as `iii_sdk::InvocationError` and `iii_sdk::errors::InvocationError`.
- Updated the SDK-reference doc and its skill sibling.

Verified: `cargo fmt --check`, build, `test --doc` (5), `test --lib` (55, incl. 2 new), `clippy --all-targets -D warnings` all pass.