### PR TITLE
feat(python-sdk): add EngineFunctions/EngineTriggers

### DIFF
--- a/docs/next/sdk-reference/python-sdk.mdx
+++ b/docs/next/sdk-reference/python-sdk.mdx
@@ -191,6 +191,16 @@ middleware; rarely needed by callers.
 The Python-only helper for declaring a function's request or response schema in a structured way.
 Accepts either a JSON Schema dict directly or constructed values; both forms reach `register_function`.
 
+## `EngineFunctions` / `EngineTriggers`
+
+Engine function and trigger ids for internal operations, with string values matching the Node SDK.
+Both are exported from the package root.
+
+- `EngineFunctions`: `LIST_FUNCTIONS`, `INFO_FUNCTIONS`, `LIST_WORKERS`, `INFO_WORKERS`,
+  `LIST_TRIGGERS`, `INFO_TRIGGERS`, `LIST_REGISTERED_TRIGGERS`, `INFO_REGISTERED_TRIGGERS`,
+  `REGISTER_WORKER`.
+- `EngineTriggers`: `FUNCTIONS_AVAILABLE`, `LOG`.
+
 ## Connection state
 
 `IIIConnectionState` is the literal-type alias `"disconnected" | "connecting" | "connected" |

--- a/docs/next/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/python-sdk.mdx.skill.md
@@ -189,6 +189,16 @@ middleware; rarely needed by callers.
 The Python-only helper for declaring a function's request or response schema in a structured way.
 Accepts either a JSON Schema dict directly or constructed values; both forms reach `register_function`.
 
+## `EngineFunctions` / `EngineTriggers`
+
+Engine function and trigger ids for internal operations, with string values matching the Node SDK.
+Both are exported from the package root.
+
+- `EngineFunctions`: `LIST_FUNCTIONS`, `INFO_FUNCTIONS`, `LIST_WORKERS`, `INFO_WORKERS`,
+  `LIST_TRIGGERS`, `INFO_TRIGGERS`, `LIST_REGISTERED_TRIGGERS`, `INFO_REGISTERED_TRIGGERS`,
+  `REGISTER_WORKER`.
+- `EngineTriggers`: `FUNCTIONS_AVAILABLE`, `LOG`.
+
 ## Connection state
 
 `IIIConnectionState` is the literal-type alias `"disconnected" | "connecting" | "connected" |

--- a/sdk/packages/python/iii/src/iii/__init__.py
+++ b/sdk/packages/python/iii/src/iii/__init__.py
@@ -6,7 +6,13 @@ from .channels import ChannelReader, ChannelWriter
 from .errors import InvocationError
 from .format_utils import extract_request_format, extract_response_format, python_type_to_format
 from .iii import TriggerAction, register_worker
-from .iii_constants import FunctionRef, InitOptions, TelemetryOptions
+from .iii_constants import (
+    EngineFunctions,
+    EngineTriggers,
+    FunctionRef,
+    InitOptions,
+    TelemetryOptions,
+)
 from .iii_types import (
     AuthInput,
     AuthResult,
@@ -66,6 +72,9 @@ __all__ = [
     "register_worker",
     "TelemetryOptions",
     "TriggerAction",
+    # Engine
+    "EngineFunctions",
+    "EngineTriggers",
     # RBAC types
     "AuthInput",
     "AuthResult",

--- a/sdk/packages/python/iii/src/iii/iii_constants.py
+++ b/sdk/packages/python/iii/src/iii/iii_constants.py
@@ -1,7 +1,7 @@
 """Constants and configuration types for the III SDK (mirrors iii-constants.ts)."""
 
 from dataclasses import dataclass
-from typing import Any, Callable, Literal
+from typing import Any, Callable, Final, Literal
 
 from iii_observability import OtelConfig, ReconnectionConfig
 
@@ -62,3 +62,24 @@ class InitOptions:
     otel: OtelConfig | dict[str, Any] | None = None
     headers: dict[str, str] | None = None
     telemetry: TelemetryOptions | None = None
+
+
+class EngineFunctions:
+    """Engine function ids for internal operations (parity with the Node SDK)."""
+
+    LIST_FUNCTIONS: Final[str] = "engine::functions::list"
+    INFO_FUNCTIONS: Final[str] = "engine::functions::info"
+    LIST_WORKERS: Final[str] = "engine::workers::list"
+    INFO_WORKERS: Final[str] = "engine::workers::info"
+    LIST_TRIGGERS: Final[str] = "engine::triggers::list"
+    INFO_TRIGGERS: Final[str] = "engine::triggers::info"
+    LIST_REGISTERED_TRIGGERS: Final[str] = "engine::registered-triggers::list"
+    INFO_REGISTERED_TRIGGERS: Final[str] = "engine::registered-triggers::info"
+    REGISTER_WORKER: Final[str] = "engine::workers::register"
+
+
+class EngineTriggers:
+    """Engine trigger ids (parity with the Node SDK)."""
+
+    FUNCTIONS_AVAILABLE: Final[str] = "engine::functions-available"
+    LOG: Final[str] = "log"

--- a/sdk/packages/python/iii/tests/test_engine_constants.py
+++ b/sdk/packages/python/iii/tests/test_engine_constants.py
@@ -1,0 +1,20 @@
+"""EngineFunctions / EngineTriggers parity with the Node SDK."""
+
+from iii import EngineFunctions, EngineTriggers
+
+
+def test_engine_function_ids() -> None:
+    assert EngineFunctions.LIST_FUNCTIONS == "engine::functions::list"
+    assert EngineFunctions.INFO_FUNCTIONS == "engine::functions::info"
+    assert EngineFunctions.LIST_WORKERS == "engine::workers::list"
+    assert EngineFunctions.INFO_WORKERS == "engine::workers::info"
+    assert EngineFunctions.LIST_TRIGGERS == "engine::triggers::list"
+    assert EngineFunctions.INFO_TRIGGERS == "engine::triggers::info"
+    assert EngineFunctions.LIST_REGISTERED_TRIGGERS == "engine::registered-triggers::list"
+    assert EngineFunctions.INFO_REGISTERED_TRIGGERS == "engine::registered-triggers::info"
+    assert EngineFunctions.REGISTER_WORKER == "engine::workers::register"
+
+
+def test_engine_trigger_ids() -> None:
+    assert EngineTriggers.FUNCTIONS_AVAILABLE == "engine::functions-available"
+    assert EngineTriggers.LOG == "log"


### PR DESCRIPTION
Adds `EngineFunctions` and `EngineTriggers` to the Python SDK, mirroring the Node SDK constants with byte-identical string values. Additive.

- `EngineFunctions`: nine engine function ids (`engine::functions::list`, `engine::workers::register`, etc.).
- `EngineTriggers`: `FUNCTIONS_AVAILABLE`, `LOG`.
- Exported from the package root; added to `__all__`.
- New parity test `test_engine_constants.py` asserts every value against the Node strings.
- Updated the SDK-reference doc and its skill sibling.

Verified: `pytest` (2 passed), `mypy src` (clean), `ruff check` (clean).