### PR TITLE
feat(rust-sdk): add EngineFunctions/EngineTriggers

### DIFF
--- a/docs/next/sdk-reference/rust-sdk.mdx
+++ b/docs/next/sdk-reference/rust-sdk.mdx
@@ -218,3 +218,14 @@ The SDK re-exports the engine's structured introspection types:
 
 Not part of this SDK. Wire frames are typed via the protocol module's `Message` enum, which is
 internal to the SDK.
+
+## `EngineFunctions` / `EngineTriggers`
+
+Engine function and trigger ids for internal operations, with string values matching the Node SDK.
+Both are exported at the crate root (`iii_sdk::EngineFunctions`, `iii_sdk::EngineTriggers`) as unit
+structs carrying associated `&'static str` constants.
+
+- `EngineFunctions`: `LIST_FUNCTIONS`, `INFO_FUNCTIONS`, `LIST_WORKERS`, `INFO_WORKERS`,
+  `LIST_TRIGGERS`, `INFO_TRIGGERS`, `LIST_REGISTERED_TRIGGERS`, `INFO_REGISTERED_TRIGGERS`,
+  `REGISTER_WORKER`.
+- `EngineTriggers`: `FUNCTIONS_AVAILABLE`, `LOG`.

--- a/docs/next/sdk-reference/rust-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/rust-sdk.mdx.skill.md
@@ -216,3 +216,14 @@ The SDK re-exports the engine's structured introspection types:
 
 Not part of this SDK. Wire frames are typed via the protocol module's `Message` enum, which is
 internal to the SDK.
+
+## `EngineFunctions` / `EngineTriggers`
+
+Engine function and trigger ids for internal operations, with string values matching the Node SDK.
+Both are exported at the crate root (`iii_sdk::EngineFunctions`, `iii_sdk::EngineTriggers`) as unit
+structs carrying associated `&'static str` constants.
+
+- `EngineFunctions`: `LIST_FUNCTIONS`, `INFO_FUNCTIONS`, `LIST_WORKERS`, `INFO_WORKERS`,
+  `LIST_TRIGGERS`, `INFO_TRIGGERS`, `LIST_REGISTERED_TRIGGERS`, `INFO_REGISTERED_TRIGGERS`,
+  `REGISTER_WORKER`.
+- `EngineTriggers`: `FUNCTIONS_AVAILABLE`, `LOG`.

--- a/sdk/packages/rust/iii/src/engine.rs
+++ b/sdk/packages/rust/iii/src/engine.rs
@@ -1,0 +1,51 @@
+//! Engine function and trigger ids, mirroring the Node SDK constants.
+
+/// Engine function ids for internal operations.
+pub struct EngineFunctions;
+
+impl EngineFunctions {
+    pub const LIST_FUNCTIONS: &'static str = "engine::functions::list";
+    pub const INFO_FUNCTIONS: &'static str = "engine::functions::info";
+    pub const LIST_WORKERS: &'static str = "engine::workers::list";
+    pub const INFO_WORKERS: &'static str = "engine::workers::info";
+    pub const LIST_TRIGGERS: &'static str = "engine::triggers::list";
+    pub const INFO_TRIGGERS: &'static str = "engine::triggers::info";
+    pub const LIST_REGISTERED_TRIGGERS: &'static str = "engine::registered-triggers::list";
+    pub const INFO_REGISTERED_TRIGGERS: &'static str = "engine::registered-triggers::info";
+    pub const REGISTER_WORKER: &'static str = "engine::workers::register";
+}
+
+/// Engine trigger ids.
+pub struct EngineTriggers;
+
+impl EngineTriggers {
+    pub const FUNCTIONS_AVAILABLE: &'static str = "engine::functions-available";
+    pub const LOG: &'static str = "log";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn engine_function_ids_match_node() {
+        assert_eq!(EngineFunctions::LIST_FUNCTIONS, "engine::functions::list");
+        assert_eq!(
+            EngineFunctions::REGISTER_WORKER,
+            "engine::workers::register"
+        );
+        assert_eq!(
+            EngineFunctions::LIST_REGISTERED_TRIGGERS,
+            "engine::registered-triggers::list"
+        );
+    }
+
+    #[test]
+    fn engine_trigger_ids_match_node() {
+        assert_eq!(
+            EngineTriggers::FUNCTIONS_AVAILABLE,
+            "engine::functions-available"
+        );
+        assert_eq!(EngineTriggers::LOG, "log");
+    }
+}

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod builtin_triggers;
 pub mod channels;
+pub mod engine;
 pub mod error;
 pub mod helpers;
 pub mod iii;
@@ -42,6 +43,7 @@ pub use builtin_triggers::{
 };
 #[deprecated(since = "0.19.0", note = "import from iii_sdk::channel")]
 pub use channels::{ChannelReader, ChannelWriter, StreamChannelRef};
+pub use engine::{EngineFunctions, EngineTriggers};
 pub use error::Error;
 #[deprecated(
     since = "0.19.0",
@@ -229,3 +231,10 @@ fn _ensure_channel_submodule_path() {}
 /// ```
 #[allow(dead_code)]
 fn _ensure_errors_submodule_path() {}
+
+/// ```rust,no_run
+/// use iii_sdk::{EngineFunctions, EngineTriggers};
+/// let _ = (EngineFunctions::LIST_FUNCTIONS, EngineTriggers::LOG);
+/// ```
+#[allow(dead_code)]
+fn _ensure_engine_constants_path() {}


### PR DESCRIPTION
Adds `EngineFunctions` and `EngineTriggers` to the Rust SDK, mirroring the Node SDK constants with byte-identical string values. Additive.

- New `src/engine.rs` with two unit structs exposing associated `&'static str` constants.
- `EngineFunctions`: nine engine function ids; `EngineTriggers`: `FUNCTIONS_AVAILABLE`, `LOG`.
- Exported at the crate root (`iii_sdk::EngineFunctions`, `iii_sdk::EngineTriggers`).
- Unit tests assert values against the Node strings; a doctest pins the public path.
- Updated the SDK-reference doc and its skill sibling.

Verified: `cargo fmt --check`, build, `test --doc` (5), `test --lib` (55, incl. 2 new), `clippy --all-targets -D warnings` all pass.