### PR TITLE
refactor(rust-sdk)!: rename stream call-request types to events

### DIFF
--- a/sdk/packages/rust/iii/src/builtin_triggers.rs
+++ b/sdk/packages/rust/iii/src/builtin_triggers.rs
@@ -350,7 +350,7 @@ pub struct StateCallRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct StreamJoinLeaveCallRequest {
+pub struct StreamJoinLeaveEvent {
     pub subscription_id: String,
     pub stream_name: String,
     pub group_id: String,
@@ -380,7 +380,7 @@ pub struct StreamEventDetail {
 /// Handler input for `stream` triggers, fired when an item changes
 /// via `stream::set`, `stream::update`, or `stream::delete`.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct StreamCallRequest {
+pub struct StreamChangeEvent {
     /// Always `"stream"`.
     #[serde(rename = "type")]
     pub event_type: String,
@@ -520,7 +520,7 @@ mod tests {
 
     #[test]
     fn stream_call_request_deserializes_typed_event() {
-        let request: StreamCallRequest = serde_json::from_value(json!({
+        let request: StreamChangeEvent = serde_json::from_value(json!({
             "type": "stream",
             "timestamp": 1700000000000_i64,
             "streamName": "chat",

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -36,8 +36,12 @@ pub mod errors {
 
 #[deprecated(since = "0.19.0", note = "import from iii_sdk::trigger")]
 pub use builtin_triggers::IIITrigger;
+#[deprecated(since = "0.20.0", note = "renamed to StreamChangeEvent")]
+pub use builtin_triggers::StreamChangeEvent as StreamCallRequest;
+#[deprecated(since = "0.20.0", note = "renamed to StreamJoinLeaveEvent")]
+pub use builtin_triggers::StreamJoinLeaveEvent as StreamJoinLeaveCallRequest;
 pub use builtin_triggers::{
-    StreamCallRequest, StreamEventDetail, StreamEventType, StreamJoinLeaveCallRequest,
+    StreamChangeEvent, StreamEventDetail, StreamEventType, StreamJoinLeaveEvent,
     StreamJoinLeaveTriggerConfig, StreamTriggerConfig,
 };
 #[deprecated(since = "0.19.0", note = "import from iii_sdk::channel")]
@@ -229,3 +233,10 @@ fn _ensure_channel_submodule_path() {}
 /// ```
 #[allow(dead_code)]
 fn _ensure_errors_submodule_path() {}
+
+/// ```rust,no_run
+/// use iii_sdk::{StreamChangeEvent, StreamJoinLeaveEvent};
+/// fn _takes(_a: StreamChangeEvent, _b: StreamJoinLeaveEvent) {}
+/// ```
+#[allow(dead_code)]
+fn _ensure_stream_event_names() {}


### PR DESCRIPTION
Renames the Rust stream-event types to match the Node and Python SDKs (which already use the new names).

- `StreamCallRequest` -> `StreamChangeEvent`
- `StreamJoinLeaveCallRequest` -> `StreamJoinLeaveEvent`
- Both old names kept as `#[deprecated]` crate-root aliases.
- A doctest pins the new public names.

Note: these types are not referenced in the SDK-reference doc, so no doc change was needed.

Verified: `cargo fmt --check`, build, `test --doc` (5), `test --lib` (53), `clippy --all-targets -D warnings` all pass.