### PR TITLE
fix(website): true-parabola hero complexity chart

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -4700,10 +4700,10 @@
           <svg class="hv-complex-chart" viewBox="22 0 186 118" preserveAspectRatio="none" aria-hidden="true">
             <line class="hv-cc-axis" x1="22" y1="94" x2="208" y2="94"/>
             <line class="hv-cc-axis" x1="22" y1="94" x2="22" y2="14"/>
-            <!-- n(n-1)/2: full pairwise growth -->
-            <path class="hv-cc-q" d="M 22 94 Q 118 18 208 20"/>
-            <!-- (n(n-1)/2) / tolerance: proportionally damped curve -->
-            <path class="hv-cc-l" d="M 22 94 Q 118 60 208 61"/>
+            <!-- n(n-1)/2: full pairwise growth. True parabola y = 94 - 74((x-22)/186)^2. -->
+            <path class="hv-cc-q" d="M 22 94 L 45.3 92.8 L 68.5 89.4 L 91.8 83.6 L 115 75.5 L 138.3 65.1 L 161.5 52.4 L 184.8 37.3 L 208 20"/>
+            <!-- (n(n-1)/2) / tolerance: same parabola, proportionally damped (k=34). -->
+            <path class="hv-cc-l" d="M 22 94 L 45.3 93.5 L 68.5 91.9 L 91.8 89.2 L 115 85.5 L 138.3 80.7 L 161.5 74.9 L 184.8 67.9 L 208 60"/>
             <!-- 0: constant on the axis -->
             <path class="hv-cc-f" d="M 22 94 L 208 94"/>
           </svg>


### PR DESCRIPTION
Replaces the two crude `Q`-bezier curve approximations in the hero complexity chart with sampled true-parabola polylines (`y = 94 - k*((x-22)/186)^2`, k=74 full pairwise / k=34 damped), so the curve shows accurate n^2 growth.

Geometry-only change to two `d` attributes. CSS is untouched: transitions stay opacity + stroke-width (compositable). No `transform:scaleY`, area fill, or curve-wrapper animation is reintroduced, so the previous Chrome repaint lag does not return.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the algorithm complexity chart: curve drawings revised to more explicit polyline-style segments for clearer, more accurate visuals.
  * Explanatory labels and descriptions rewritten to match the new curve representations; overall chart layout and baseline remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->