### PR TITLE
feat(telemetry): enhance worker telemetry to include CI environment detection

### DIFF
--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -4108,8 +4108,11 @@ mod tests {
                         .split_whitespace();
                     let method = parts.next().unwrap_or_default();
                     let path = parts.next().unwrap_or("/");
-                    let keyed = format!("{method} {path}");
-                    let response = routes.get(&keyed).or_else(|| routes.get(path));
+                    // Strip query string so routes keyed as `GET /download/foo`
+                    // still match when the client appends `?version=…&ci=true`.
+                    let path_only = path.split('?').next().unwrap_or(path);
+                    let keyed = format!("{method} {path_only}");
+                    let response = routes.get(&keyed).or_else(|| routes.get(path_only));
 
                     let (status, content_type, body) = match response {
                         Some(response) => (

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -43,10 +43,12 @@ pub use super::local_worker::{handle_local_add, is_local_path, start_local_worke
 /// its telemetry counters. Used for every worker type installed via `/resolve`
 /// (engine workers have no artifact; binary/image/bundle workers fetch their
 /// artifacts from external URLs the registry never sees, so this is the only
-/// install signal it gets). The endpoint returns 204 (no artifact); errors are
-/// logged as warnings and never block the install.
+/// install signal it gets). When a CI environment is detected, `ci=true` is
+/// also sent so the registry increments parallel `ci_count` columns. The
+/// endpoint returns 204 (no artifact); errors are logged as warnings and never
+/// block the install.
 async fn fire_worker_telemetry(name: &str, version: &str) {
-    use super::registry::HTTP_CLIENT;
+    use super::registry::{HTTP_CLIENT, with_download_query};
 
     let api_url =
         std::env::var("III_API_URL").unwrap_or_else(|_| "https://api.workers.iii.dev".to_string());
@@ -55,7 +57,7 @@ async fn fire_worker_telemetry(name: &str, version: &str) {
 
     match tokio::time::timeout(
         timeout,
-        HTTP_CLIENT.get(&url).query(&[("version", version)]).send(),
+        with_download_query(HTTP_CLIENT.get(&url), version).send(),
     )
     .await
     {
@@ -5018,6 +5020,8 @@ workers:
             .unwrap_or_else(|e| e.into_inner());
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+        crate::cli::registry::clear_ci_env_vars_for_test();
+
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind test server");
@@ -5045,6 +5049,53 @@ workers:
 
         let path = rx.await.expect("request captured");
         assert_eq!(path, "/download/iii-http?version=1.2.3%2Bbuild.5");
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn fire_worker_telemetry_appends_ci_true_in_ci_environment() {
+        let _env_guard = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        crate::cli::registry::clear_ci_env_vars_for_test();
+        let _ci_guard = set_env_var_for_test("CI", "true");
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let _api_guard = set_env_var_for_test("III_API_URL", &base_url);
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept request");
+            let mut buf = [0_u8; 4096];
+            let n = stream.read(&mut buf).await.expect("read request");
+            let request = String::from_utf8_lossy(&buf[..n]);
+            let path = request
+                .lines()
+                .next()
+                .and_then(|line| line.split_whitespace().nth(1))
+                .unwrap_or_default()
+                .to_string();
+            let _ = tx.send(path);
+            let _ = stream
+                .write_all(b"HTTP/1.1 204 No Content\r\ncontent-length: 0\r\n\r\n")
+                .await;
+        });
+
+        fire_worker_telemetry("iii-http", "1.0.0").await;
+
+        let path = rx.await.expect("request captured");
+        assert!(
+            path.contains("ci=true"),
+            "expected ci=true in download telemetry request, got: {path}"
+        );
+        assert!(
+            path.contains("version=1.0.0"),
+            "expected version=1.0.0 in download telemetry request, got: {path}"
+        );
         server.abort();
     }
 

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -5206,10 +5206,16 @@ workers:
                 "binary worker should be installed on disk"
             );
             let hits = recorded.lock().unwrap().clone();
-            let expected = format!("/download/{worker_name}?version=1.0.0");
+            // `with_download_query` appends `ci=true` when a CI env var (CI,
+            // GITHUB_ACTIONS, ...) is present, so match on path + version and
+            // tolerate extra query params instead of full-string equality.
+            let expected_path = format!("/download/{worker_name}");
             assert!(
-                hits.iter().any(|p| p == &expected),
-                "expected GET {expected} telemetry hit, got: {hits:?}"
+                hits.iter().any(|hit| {
+                    let (path, query) = hit.split_once('?').unwrap_or((hit.as_str(), ""));
+                    path == expected_path && query.split('&').any(|pair| pair == "version=1.0.0")
+                }),
+                "expected GET {expected_path}?version=1.0.0 telemetry hit, got: {hits:?}"
             );
             server.abort();
         })

--- a/crates/iii-worker/src/cli/registry.rs
+++ b/crates/iii-worker/src/cli/registry.rs
@@ -23,6 +23,39 @@ pub(crate) static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
         .expect("Failed to create HTTP client")
 });
 
+/// Returns true when any standard CI environment variable is present.
+/// Matches the list used by engine telemetry and scaffolder-core.
+pub(crate) fn is_ci_environment() -> bool {
+    const CI_ENV_VARS: &[&str] = &[
+        "CI",
+        "GITHUB_ACTIONS",
+        "GITLAB_CI",
+        "CIRCLECI",
+        "JENKINS_URL",
+        "TRAVIS",
+        "BUILDKITE",
+        "TF_BUILD",
+        "CODEBUILD_BUILD_ID",
+        "BITBUCKET_BUILD_NUMBER",
+        "DRONE",
+        "TEAMCITY_VERSION",
+    ];
+
+    CI_ENV_VARS.iter().any(|var| std::env::var(var).is_ok())
+}
+
+/// Append `version` and, when in CI, `ci=true` to a `GET /download/{slug}` request.
+pub(crate) fn with_download_query(
+    request: reqwest::RequestBuilder,
+    version: &str,
+) -> reqwest::RequestBuilder {
+    let mut request = request.query(&[("version", version)]);
+    if is_ci_environment() {
+        request = request.query(&[("ci", "true")]);
+    }
+    request
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct BinaryInfo {
     pub url: String,
@@ -196,7 +229,9 @@ pub async fn fetch_worker_info(
 
         let mut request = HTTP_CLIENT.get(&url);
         if let Some(v) = version {
-            request = request.query(&[("version", v)]);
+            request = with_download_query(request, v);
+        } else if is_ci_environment() {
+            request = request.query(&[("ci", "true")]);
         }
 
         let resp = request
@@ -369,8 +404,119 @@ pub fn enforce_dep_graph_bounds(
 }
 
 #[cfg(test)]
+pub(crate) fn clear_ci_env_vars_for_test() {
+    const CI_ENV_VARS: &[&str] = &[
+        "CI",
+        "GITHUB_ACTIONS",
+        "GITLAB_CI",
+        "CIRCLECI",
+        "JENKINS_URL",
+        "TRAVIS",
+        "BUILDKITE",
+        "TF_BUILD",
+        "CODEBUILD_BUILD_ID",
+        "BITBUCKET_BUILD_NUMBER",
+        "DRONE",
+        "TEAMCITY_VERSION",
+    ];
+    for var in CI_ENV_VARS {
+        // SAFETY: test-only; serialized by TEST_ENV_LOCK in callers.
+        unsafe { std::env::remove_var(var) };
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn is_ci_environment_false_when_no_ci_vars() {
+        let _guard = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_ci_env_vars_for_test();
+        assert!(!is_ci_environment());
+    }
+
+    #[test]
+    fn is_ci_environment_detects_ci_var() {
+        let _guard = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_ci_env_vars_for_test();
+        // SAFETY: test-only; serialized by TEST_ENV_LOCK.
+        unsafe { std::env::set_var("CI", "true") };
+        assert!(is_ci_environment());
+        unsafe { std::env::remove_var("CI") };
+    }
+
+    #[test]
+    fn is_ci_environment_detects_github_actions() {
+        let _guard = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_ci_env_vars_for_test();
+        // SAFETY: test-only; serialized by TEST_ENV_LOCK.
+        unsafe { std::env::set_var("GITHUB_ACTIONS", "true") };
+        assert!(is_ci_environment());
+        unsafe { std::env::remove_var("GITHUB_ACTIONS") };
+    }
+
+    #[tokio::test]
+    async fn fetch_worker_info_appends_ci_true_in_ci_environment() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let _guard = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_ci_env_vars_for_test();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept request");
+            let mut buf = [0_u8; 4096];
+            let n = stream.read(&mut buf).await.expect("read request");
+            let request = String::from_utf8_lossy(&buf[..n]);
+            let path = request
+                .lines()
+                .next()
+                .and_then(|line| line.split_whitespace().nth(1))
+                .unwrap_or_default()
+                .to_string();
+            let _ = tx.send(path);
+            let _ = stream
+                .write_all(b"HTTP/1.1 204 No Content\r\ncontent-length: 0\r\n\r\n")
+                .await;
+        });
+
+        // SAFETY: test-only; serialized by TEST_ENV_LOCK.
+        unsafe { std::env::set_var("III_API_URL", &base_url) };
+        unsafe { std::env::set_var("CI", "true") };
+
+        let result = fetch_worker_info("iii-exec", Some("latest")).await;
+
+        unsafe { std::env::remove_var("III_API_URL") };
+        unsafe { std::env::remove_var("CI") };
+
+        assert!(
+            result.is_ok(),
+            "fetch_worker_info should succeed: {result:?}"
+        );
+        let path = rx.await.expect("request captured");
+        assert!(
+            path.contains("ci=true"),
+            "expected ci=true in download request, got: {path}"
+        );
+        assert!(
+            path.contains("version=latest"),
+            "expected version=latest in download request, got: {path}"
+        );
+        server.abort();
+    }
 
     #[tokio::test]
     async fn fetch_worker_info_binary_via_file() {


### PR DESCRIPTION
## Summary

Fix registry install telemetry for `iii worker add` and tag CI-origin downloads.

- Fire `GET /download/{name}` for every successfully-installed `/resolve` node (binary, image, bundle, engine), not just engine workers
- Rename `fire_engine_telemetry` → `fire_worker_telemetry`
- When a CI environment is detected (`CI`, `GITHUB_ACTIONS`, etc.), append `ci=true` on all `GET /download/{slug}` calls (`fire_worker_telemetry` + `fetch_worker_info`)

## Problem

Most installs go through `POST /resolve` and fetch artifacts from external URLs. The registry only counted installs via `GET /download/{name}`, which previously ran for engine/builtin workers only — so binary/image/bundle adds were invisible to per-worker counters. CI downloads also weren't tagged for separate `ci_count` tracking.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace`
- [x] `cargo test -p iii-worker fire_worker_telemetry`
- [x] `cargo test -p iii-worker is_ci_environment`
- [x] `cargo test -p iii-worker fetch_worker_info_appends_ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects CI environments and appends a CI flag to download/telemetry requests when present.
  * Download requests now always include version as a query parameter.

* **Bug Fixes**
  * Test HTTP server routing now ignores query strings to prevent false mismatches.

* **Tests**
  * Added tests for CI detection and for telemetry including ci=true when CI is set.
  * Added test tooling to clear CI env vars to validate exact version encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->