### PR TITLE
fix(observability): tree-correct trace detail stream and cut span flush latency

### DIFF
--- a/console/packages/console-frontend/src/hooks/useTraceData.ts
+++ b/console/packages/console-frontend/src/hooks/useTraceData.ts
@@ -58,7 +58,10 @@ export function useTraceData({
         limit: DEFAULT_TRACE_LIMIT,
         include_internal: showSystem,
       }),
-    refetchInterval: isPaused ? false : 3000,
+    // Interim: poll every 1s (was 3s) so freshly emitted spans surface sooner.
+    // The real fix is to subscribe to the engine's reactive trace-rows feed
+    // over the existing streams WebSocket instead of polling at all.
+    refetchInterval: isPaused ? false : 1000,
     staleTime: 1000,
   })
 

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -447,6 +447,19 @@ fn prune_empty_trigger_spans(mut spans: Vec<otel::StoredSpan>) -> Vec<otel::Stor
     spans
 }
 
+/// Compiled collapse rules for the global config, cached after first use.
+/// `GLOBAL_OTEL_CONFIG` is a set-once `OnceLock`, so the compiled form never
+/// changes; callers on the hot path (one per coalesce tick / REST request)
+/// must not recompile the regexes each time. Returns an empty slice — without
+/// poisoning the cache — if the config is not set yet.
+fn cached_collapse_rules() -> &'static [CompiledCollapseRule] {
+    static RULES: std::sync::OnceLock<Vec<CompiledCollapseRule>> = std::sync::OnceLock::new();
+    match otel::get_otel_config() {
+        Some(config) => RULES.get_or_init(|| compile_collapse_rules(&config.collapse_spans)),
+        None => &[],
+    }
+}
+
 /// Compile the configured collapse rules, skipping any with invalid patterns.
 fn compile_collapse_rules(rules: &[config::SpanCollapseRule]) -> Vec<CompiledCollapseRule> {
     rules
@@ -549,17 +562,13 @@ fn detail_stream_spans(
             continue;
         }
         let mut cursor: Option<&str> = Some(span.span_id.as_str());
-        let mut guard = 0usize;
         while let Some(id) = cursor {
             // Already walked this id (and therefore its ancestors) — stop.
+            // This also terminates parent cycles: a cycle must revisit an id.
             if !emit_ids.insert(id.to_string()) {
                 break;
             }
             cursor = parent_of.get(id).copied().flatten();
-            guard += 1;
-            if guard > 100_000 {
-                break; // cycle guard, mirrors collapse_spans
-            }
         }
     }
 
@@ -570,9 +579,23 @@ fn detail_stream_spans(
         .collect()
 }
 
-/// Build the detail-stream payload for one trace: run the same prune+collapse
-/// pipeline `traces::tree` uses over the FULL raw trace, then keep each arrived
-/// span and its corrected ancestor chain (see [`detail_stream_spans`]).
+/// Shared trace-correction pipeline: drop no-op trigger fan-out wrappers
+/// (childless state_triggers/stream_triggers — wrappers that actually invoked
+/// a handler are kept so trigger→handler causality stays visible), then
+/// collapse user-configured pass-through spans, reparenting children to the
+/// nearest survivor. Both `traces::tree` and the live detail stream go through
+/// this one function so the live feed can never disagree with the REST tree.
+fn correct_trace_spans(
+    spans: Vec<otel::StoredSpan>,
+    rules: &[CompiledCollapseRule],
+) -> Vec<otel::StoredSpan> {
+    collapse_spans(prune_empty_trigger_spans(spans), rules)
+}
+
+/// Build the detail-stream payload for one trace: run the same
+/// [`correct_trace_spans`] pipeline `traces::tree` uses over the FULL raw
+/// trace, then keep each arrived span and its corrected ancestor chain (see
+/// [`detail_stream_spans`]).
 ///
 /// The full trace — not just the window — is required because the surviving
 /// ancestor a span must reparent to may have arrived in an earlier window.
@@ -582,8 +605,7 @@ fn corrected_detail_spans(
     arrived_ids: &HashSet<String>,
     rules: &[CompiledCollapseRule],
 ) -> Vec<otel::StoredSpan> {
-    let pruned = prune_empty_trigger_spans(full_trace);
-    let corrected = collapse_spans(pruned, rules);
+    let corrected = correct_trace_spans(full_trace, rules);
     detail_stream_spans(&corrected, arrived_ids)
 }
 
@@ -1008,9 +1030,7 @@ impl ObservabilityWorker {
         let Some(storage) = otel::get_span_storage() else {
             return; // No in-memory store → nothing to correct against.
         };
-        let collapse_rules = otel::get_otel_config()
-            .map(|c| compile_collapse_rules(&c.collapse_spans))
-            .unwrap_or_default();
+        let collapse_rules = cached_collapse_rules();
 
         let mut arrived_by_trace: HashMap<&str, HashSet<String>> = HashMap::new();
         for span in batch {
@@ -1022,7 +1042,7 @@ impl ObservabilityWorker {
 
         for (trace_id, arrived_ids) in arrived_by_trace {
             let full_trace = storage.get_spans_by_trace_id(trace_id);
-            let to_send = corrected_detail_spans(full_trace, &arrived_ids, &collapse_rules);
+            let to_send = corrected_detail_spans(full_trace, &arrived_ids, collapse_rules);
             if !to_send.is_empty()
                 && let Ok(spans) = serde_json::to_value(&to_send)
             {
@@ -1251,17 +1271,7 @@ impl ObservabilityWorker {
                     })));
                 }
 
-                // Drop no-op trigger fan-out wrappers (childless
-                // state_triggers/stream_triggers); wrappers that actually invoked
-                // a handler are kept so the trigger→handler causality stays visible.
-                let all_spans = prune_empty_trigger_spans(all_spans);
-
-                // Collapse user-configured pass-through wrapper spans before
-                // building the tree (children reparent to the nearest survivor).
-                let collapse_rules = otel::get_otel_config()
-                    .map(|c| compile_collapse_rules(&c.collapse_spans))
-                    .unwrap_or_default();
-                let all_spans = collapse_spans(all_spans, &collapse_rules);
+                let all_spans = correct_trace_spans(all_spans, cached_collapse_rules());
 
                 let roots = build_span_tree(all_spans);
 

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -518,6 +518,75 @@ fn collapse_spans(
         .collect()
 }
 
+/// From a trace's corrected (post prune+collapse) spans and the ids that just
+/// arrived in this coalesce window, select the spans to push on the detail
+/// stream: each arrived survivor plus its corrected ancestor chain, walked to
+/// the root.
+///
+/// Including the chain is what re-attaches a span whose nearest real parent is a
+/// KEPT internal wrapper (e.g. `stream_triggers`) that the raw window omitted —
+/// without it the consumer treats the span's absent parent as a new depth-0 root
+/// (the console/web "phantom root" bug). Walking to the root keeps every frame
+/// self-contained, so it survives a dropped earlier frame the same way the feed
+/// already self-heals on reconnect; the cost is re-emitting ancestors, which is
+/// safe because the detail feed is upsert-by-`span_id`. Returned spans carry
+/// their CORRECTED `parent_span_id`, so the consumer's `buildSpanTree` nests
+/// them identically to `traces::tree` instead of re-rooting.
+fn detail_stream_spans(
+    corrected: &[otel::StoredSpan],
+    arrived_ids: &HashSet<String>,
+) -> Vec<otel::StoredSpan> {
+    let parent_of: HashMap<&str, Option<&str>> = corrected
+        .iter()
+        .map(|s| (s.span_id.as_str(), s.parent_span_id.as_deref()))
+        .collect();
+
+    let mut emit_ids: HashSet<String> = HashSet::new();
+    for span in corrected {
+        // Start only from spans that actually arrived this window AND survived
+        // the pipeline; a collapsed/pruned arrival simply contributes nothing.
+        if !arrived_ids.contains(&span.span_id) {
+            continue;
+        }
+        let mut cursor: Option<&str> = Some(span.span_id.as_str());
+        let mut guard = 0usize;
+        while let Some(id) = cursor {
+            // Already walked this id (and therefore its ancestors) — stop.
+            if !emit_ids.insert(id.to_string()) {
+                break;
+            }
+            cursor = parent_of.get(id).copied().flatten();
+            guard += 1;
+            if guard > 100_000 {
+                break; // cycle guard, mirrors collapse_spans
+            }
+        }
+    }
+
+    corrected
+        .iter()
+        .filter(|s| emit_ids.contains(&s.span_id))
+        .cloned()
+        .collect()
+}
+
+/// Build the detail-stream payload for one trace: run the same prune+collapse
+/// pipeline `traces::tree` uses over the FULL raw trace, then keep each arrived
+/// span and its corrected ancestor chain (see [`detail_stream_spans`]).
+///
+/// The full trace — not just the window — is required because the surviving
+/// ancestor a span must reparent to may have arrived in an earlier window.
+/// Pure over its inputs so the correction is unit-testable without span storage.
+fn corrected_detail_spans(
+    full_trace: Vec<otel::StoredSpan>,
+    arrived_ids: &HashSet<String>,
+    rules: &[CompiledCollapseRule],
+) -> Vec<otel::StoredSpan> {
+    let pruned = prune_empty_trigger_spans(full_trace);
+    let corrected = collapse_spans(pruned, rules);
+    detail_stream_spans(&corrected, arrived_ids)
+}
+
 fn build_span_tree(spans: Vec<otel::StoredSpan>) -> Vec<SpanTreeNode> {
     let mut children_map: HashMap<String, Vec<otel::StoredSpan>> = HashMap::new();
     let mut roots: Vec<otel::StoredSpan> = Vec::new();
@@ -873,13 +942,20 @@ impl ObservabilityWorker {
 
     /// Push the coalesce window's spans onto the live trace streams via
     /// ephemeral `stream::send`: root rows (internal/plumbing excluded) to the
-    /// global list stream, and every span grouped by `trace_id` to that trace's
-    /// detail stream. Fire-and-forget — the in-memory store stays authoritative
-    /// (re-read once on reconnect), so a dropped frame self-heals rather than
-    /// corrupting client state.
+    /// global list stream, and — per trace touched this window — tree-corrected
+    /// spans to that trace's detail stream. The detail payload is rebuilt from
+    /// the FULL trace in storage with the same prune+collapse pipeline as
+    /// `traces::tree` (see `corrected_detail_spans`), so the live feed is
+    /// directly appendable and never re-orphans a span whose real parent was an
+    /// internal wrapper the window filtered out. Fire-and-forget — the in-memory
+    /// store stays authoritative (re-read once on reconnect), so a dropped frame
+    /// self-heals rather than corrupting client state.
     ///
-    /// Loop-safe by construction: the `batch` is the post-filter window, which
-    /// already excludes engine-internal spans (`is_internal_span`) — and
+    /// Loop-safe by construction: spans only ENTER the feed through the
+    /// subscriber's post-filter window, which already excludes engine-internal
+    /// spans (`is_internal_span`) and the trigger's own delivery spans. The
+    /// detail payload may re-read KEPT internal wrappers from storage to repair
+    /// causality, but those are existing stored spans, not new ones — and
     /// `stream::send` plus the `iii::console::*` consumer handlers are all
     /// builtins (`iii.function.kind=internal`), so neither delivery re-enters
     /// the feed (see the subscriber loop's loop-break + consumer contract).
@@ -914,16 +990,42 @@ impl ObservabilityWorker {
             );
         }
 
-        // Detail: every (non-internal) span grouped by trace_id, to that
-        // trace's group. Only a subscriber that joined this `trace_id` receives
-        // it (engine-side fan-out filter), so a trace nobody is viewing costs
-        // just the no-match early-out in `stream::invoke_triggers`.
-        let mut by_trace: HashMap<&str, Vec<&otel::StoredSpan>> = HashMap::new();
+        // Detail: tree-corrected spans grouped by trace_id, to that trace's
+        // group. The raw window is structurally lossy — its spans' parents point
+        // at engine-internal wrappers (`stream_triggers` etc.) the subscriber
+        // already filtered out, so a naive push re-orphans every span whose real
+        // parent was such a wrapper. Instead, per touched trace, recompute
+        // structure from the FULL trace in storage with the SAME pipeline as
+        // `traces::tree`, then push each arrived span with its corrected ancestor
+        // chain. Only a subscriber that joined this `trace_id` receives it
+        // (engine-side fan-out filter), so a trace nobody is viewing costs just
+        // the no-match early-out in `stream::invoke_triggers`.
+        //
+        // Cost: one in-memory `get_spans_by_trace_id` + prune/collapse per
+        // distinct trace per coalesce tick (bounded by the 300ms window and the
+        // set of traces actively streaming). Acceptable; a future optimization
+        // could memoize the corrected parent map per trace.
+        let Some(storage) = otel::get_span_storage() else {
+            return; // No in-memory store → nothing to correct against.
+        };
+        let collapse_rules = otel::get_otel_config()
+            .map(|c| compile_collapse_rules(&c.collapse_spans))
+            .unwrap_or_default();
+
+        let mut arrived_by_trace: HashMap<&str, HashSet<String>> = HashMap::new();
         for span in batch {
-            by_trace.entry(&span.trace_id).or_default().push(span);
+            arrived_by_trace
+                .entry(&span.trace_id)
+                .or_default()
+                .insert(span.span_id.clone());
         }
-        for (trace_id, spans) in by_trace {
-            if let Ok(spans) = serde_json::to_value(&spans) {
+
+        for (trace_id, arrived_ids) in arrived_by_trace {
+            let full_trace = storage.get_spans_by_trace_id(trace_id);
+            let to_send = corrected_detail_spans(full_trace, &arrived_ids, &collapse_rules);
+            if !to_send.is_empty()
+                && let Ok(spans) = serde_json::to_value(&to_send)
+            {
                 send(engine, TRACE_SPANS_STREAM, trace_id.to_string(), spans);
             }
         }
@@ -2364,7 +2466,7 @@ crate::register_worker!("iii-observability", ObservabilityWorker, mandatory);
 mod tests {
     use super::*;
     use serial_test::serial;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     // =========================================================================
     // Helper: create a StoredSpan with configurable fields
@@ -2584,6 +2686,191 @@ mod tests {
         assert_eq!(tree[0].span.span_id, "call");
         assert_eq!(tree[0].children.len(), 1);
         assert_eq!(tree[0].children[0].span.span_id, "leaf");
+    }
+
+    // =========================================================================
+    // detail stream correction tests (corrected_detail_spans)
+    // =========================================================================
+
+    #[test]
+    fn test_corrected_detail_spans_reattaches_under_kept_wrapper() {
+        // turn -> steering_check -> stream_triggers (internal wrapper) -> leaf.
+        // Only `leaf` arrives this window — the wrapper is internal, so the span
+        // subscriber filtered it out of the batch. The OLD feed pushed just
+        // `leaf` pointing at the absent wrapper → phantom depth-0 root. The
+        // corrected payload must KEEP the wrapper (it has a child) and emit the
+        // whole chain so `leaf` nests under it, matching `traces::tree`.
+        let turn = make_span("t", "turn", None, "turn", "harness", 100, 900, "ok", vec![]);
+        let steering = make_span(
+            "t",
+            "steer",
+            Some("turn"),
+            "steering_check",
+            "harness",
+            110,
+            880,
+            "ok",
+            vec![],
+        );
+        let wrapper = make_span(
+            "t",
+            "wrap",
+            Some("steer"),
+            "stream_triggers",
+            "harness",
+            120,
+            870,
+            "ok",
+            vec![("iii.function.kind", "internal")],
+        );
+        let leaf = make_span(
+            "t",
+            "leaf",
+            Some("wrap"),
+            "context-compaction::on_agent_event",
+            "ctx",
+            130,
+            860,
+            "ok",
+            vec![],
+        );
+
+        let full = vec![turn, steering, wrapper, leaf];
+        let arrived: HashSet<String> = ["leaf".to_string()].into_iter().collect();
+
+        let sent = corrected_detail_spans(full, &arrived, &[]);
+        let ids: HashSet<&str> = sent.iter().map(|s| s.span_id.as_str()).collect();
+
+        // Kept internal wrapper + the spine are emitted so nothing re-roots.
+        assert!(
+            ids.contains("wrap"),
+            "kept internal wrapper must be streamed so the leaf has a present parent"
+        );
+        assert!(ids.contains("leaf"));
+        assert!(ids.contains("steer"));
+        assert!(ids.contains("turn"));
+
+        // The leaf still parents to the wrapper, not to a phantom root.
+        let leaf = sent.iter().find(|s| s.span_id == "leaf").unwrap();
+        assert_eq!(leaf.parent_span_id.as_deref(), Some("wrap"));
+
+        // The chain is intact: building the tree yields a single root.
+        let tree = build_span_tree(sent);
+        assert_eq!(tree.len(), 1);
+        assert_eq!(tree[0].span.span_id, "turn");
+    }
+
+    #[test]
+    fn test_corrected_detail_spans_drops_childless_wrapper() {
+        // steering_check has a childless `stream_triggers` (no-op fan-out) plus a
+        // real `leaf`. The childless wrapper is pruned and never streamed; the
+        // leaf streams under the surviving `steering_check`.
+        let steering = make_span(
+            "t",
+            "steer",
+            None,
+            "steering_check",
+            "harness",
+            100,
+            500,
+            "ok",
+            vec![],
+        );
+        let empty_wrapper = make_span(
+            "t",
+            "wrap",
+            Some("steer"),
+            "stream_triggers",
+            "harness",
+            110,
+            200,
+            "ok",
+            vec![("iii.function.kind", "internal")],
+        );
+        let leaf = make_span(
+            "t",
+            "leaf",
+            Some("steer"),
+            "models::get",
+            "models",
+            120,
+            480,
+            "ok",
+            vec![],
+        );
+
+        let full = vec![steering, empty_wrapper, leaf];
+        let arrived: HashSet<String> = ["leaf".to_string()].into_iter().collect();
+
+        let sent = corrected_detail_spans(full, &arrived, &[]);
+        let ids: HashSet<&str> = sent.iter().map(|s| s.span_id.as_str()).collect();
+
+        assert!(
+            !ids.contains("wrap"),
+            "childless trigger wrapper must be pruned, not streamed"
+        );
+        assert!(ids.contains("leaf"));
+        assert!(ids.contains("steer"));
+        let leaf = sent.iter().find(|s| s.span_id == "leaf").unwrap();
+        assert_eq!(leaf.parent_span_id.as_deref(), Some("steer"));
+    }
+
+    #[test]
+    fn test_corrected_detail_spans_applies_collapse_reparent() {
+        // call -> trigger (collapse rule) -> leaf. The collapsed wrapper is
+        // removed and the leaf reparents to `call` on the stream, just as in
+        // `traces::tree`.
+        let call = make_span(
+            "t",
+            "call",
+            None,
+            "call h::trigger",
+            "iii-test",
+            100,
+            500,
+            "ok",
+            vec![],
+        );
+        let wrapper = make_span(
+            "t",
+            "trig",
+            Some("call"),
+            "trigger h::trigger",
+            "harness",
+            110,
+            480,
+            "ok",
+            vec![],
+        );
+        let leaf = make_span(
+            "t",
+            "leaf",
+            Some("trig"),
+            "harness.h::trigger",
+            "harness",
+            120,
+            470,
+            "ok",
+            vec![],
+        );
+
+        let rules = compile_collapse_rules(&[config::SpanCollapseRule {
+            name: "trigger *".to_string(),
+            service: Some("harness".to_string()),
+        }]);
+        let full = vec![call, wrapper, leaf];
+        let arrived: HashSet<String> = ["leaf".to_string()].into_iter().collect();
+
+        let sent = corrected_detail_spans(full, &arrived, &rules);
+        let ids: HashSet<&str> = sent.iter().map(|s| s.span_id.as_str()).collect();
+
+        assert!(
+            !ids.contains("trig"),
+            "collapsed wrapper must not be streamed"
+        );
+        assert!(ids.contains("call"));
+        let leaf = sent.iter().find(|s| s.span_id == "leaf").unwrap();
+        assert_eq!(leaf.parent_span_id.as_deref(), Some("call"));
     }
 
     #[test]

--- a/sdk/packages/node/observability/src/telemetry-system/index.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/index.ts
@@ -131,13 +131,10 @@ export function initOtel(config: OtelConfig = {}): void {
   // seconds after the action that produced them. Mirror the logs path
   // (BatchLogRecordProcessor below) with a small flush delay. maxExportBatchSize
   // stays at the OTel default so a burst of spans from one turn still coalesces
-  // into a single frame rather than one frame per span. The standard
-  // OTEL_BSP_SCHEDULE_DELAY stays in the fallback chain because the OTel SDK
-  // ignores it once an explicit value is passed.
+  // into a single frame rather than one frame per span.
   const spansScheduledDelayMillis = resolveFlushIntervalMs(
     config.spansFlushIntervalMs,
     process.env.OTEL_SPANS_FLUSH_INTERVAL_MS,
-    process.env.OTEL_BSP_SCHEDULE_DELAY,
     DEFAULT_OTEL_CONFIG.spansFlushIntervalMs,
   )
   tracerProvider = new NodeTracerProvider({
@@ -208,7 +205,6 @@ export function initOtel(config: OtelConfig = {}): void {
   const logsScheduledDelayMillis = resolveFlushIntervalMs(
     config.logsFlushIntervalMs,
     process.env.OTEL_LOGS_FLUSH_INTERVAL_MS,
-    process.env.OTEL_BLRP_SCHEDULE_DELAY,
     DEFAULT_OTEL_CONFIG.logsFlushIntervalMs,
   )
   const logsMaxExportBatchSize =

--- a/sdk/packages/node/observability/src/telemetry-system/index.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/index.ts
@@ -125,9 +125,23 @@ export function initOtel(config: OtelConfig = {}): void {
   // registration order, so baggage entries are materialized as span
   // attributes before the batch exporter reads them.
   const spanExporter = new EngineSpanExporter(sharedConnection)
+  // Without an explicit scheduledDelayMillis, BatchSpanProcessor inherits the
+  // OpenTelemetry default of 5000ms, so an ended span sits in the buffer up to
+  // 5s before it is flushed to the engine — the dominant reason traces show up
+  // seconds after the action that produced them. Mirror the logs path
+  // (BatchLogRecordProcessor below) with a small flush delay. maxExportBatchSize
+  // stays at the OTel default so a burst of spans from one turn still coalesces
+  // into a single frame rather than one frame per span.
+  const spansScheduledDelayMillis =
+    config.spansFlushIntervalMs ??
+    parseNumberEnv(process.env.OTEL_SPANS_FLUSH_INTERVAL_MS, 0) ??
+    DEFAULT_OTEL_CONFIG.spansFlushIntervalMs
   tracerProvider = new NodeTracerProvider({
     resource,
-    spanProcessors: [new BaggageSpanProcessor(), new BatchSpanProcessor(spanExporter)],
+    spanProcessors: [
+      new BaggageSpanProcessor(),
+      new BatchSpanProcessor(spanExporter, { scheduledDelayMillis: spansScheduledDelayMillis }),
+    ],
   })
 
   // Register W3C Trace Context and Baggage propagators

--- a/sdk/packages/node/observability/src/telemetry-system/index.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/index.ts
@@ -41,7 +41,7 @@ import { SharedEngineConnection } from './connection'
 import { EngineSpanExporter, EngineMetricsExporter, EngineLogExporter } from './exporters'
 import { extractTraceparent } from './context'
 import { patchGlobalFetch, unpatchGlobalFetch } from './fetch-instrumentation'
-import { parseIntegerEnv, parseNumberEnv } from './utils'
+import { parseIntegerEnv, resolveFlushIntervalMs } from './utils'
 
 // Re-export everything from submodules
 export * from './types'
@@ -131,11 +131,15 @@ export function initOtel(config: OtelConfig = {}): void {
   // seconds after the action that produced them. Mirror the logs path
   // (BatchLogRecordProcessor below) with a small flush delay. maxExportBatchSize
   // stays at the OTel default so a burst of spans from one turn still coalesces
-  // into a single frame rather than one frame per span.
-  const spansScheduledDelayMillis =
-    config.spansFlushIntervalMs ??
-    parseNumberEnv(process.env.OTEL_SPANS_FLUSH_INTERVAL_MS, 0) ??
-    DEFAULT_OTEL_CONFIG.spansFlushIntervalMs
+  // into a single frame rather than one frame per span. The standard
+  // OTEL_BSP_SCHEDULE_DELAY stays in the fallback chain because the OTel SDK
+  // ignores it once an explicit value is passed.
+  const spansScheduledDelayMillis = resolveFlushIntervalMs(
+    config.spansFlushIntervalMs,
+    process.env.OTEL_SPANS_FLUSH_INTERVAL_MS,
+    process.env.OTEL_BSP_SCHEDULE_DELAY,
+    DEFAULT_OTEL_CONFIG.spansFlushIntervalMs,
+  )
   tracerProvider = new NodeTracerProvider({
     resource,
     spanProcessors: [
@@ -201,10 +205,12 @@ export function initOtel(config: OtelConfig = {}): void {
 
   // Initialize logs (always enabled when OTEL is enabled)
   const logExporter = new EngineLogExporter(sharedConnection)
-  const logsScheduledDelayMillis =
-    config.logsFlushIntervalMs ??
-    parseNumberEnv(process.env.OTEL_LOGS_FLUSH_INTERVAL_MS, 0) ??
-    DEFAULT_OTEL_CONFIG.logsFlushIntervalMs
+  const logsScheduledDelayMillis = resolveFlushIntervalMs(
+    config.logsFlushIntervalMs,
+    process.env.OTEL_LOGS_FLUSH_INTERVAL_MS,
+    process.env.OTEL_BLRP_SCHEDULE_DELAY,
+    DEFAULT_OTEL_CONFIG.logsFlushIntervalMs,
+  )
   const logsMaxExportBatchSize =
     config.logsBatchSize ?? parseIntegerEnv(process.env.OTEL_LOGS_BATCH_SIZE, 1) ?? DEFAULT_OTEL_CONFIG.logsBatchSize
 

--- a/sdk/packages/node/observability/src/telemetry-system/types.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/types.ts
@@ -64,10 +64,15 @@ export interface OtelConfig {
    * Span processor flush delay in milliseconds. Defaults to 100ms. This is how
    * long an ended span waits in the batch buffer before it is flushed to the
    * engine — the OpenTelemetry default of 5000ms is what makes traces appear
-   * seconds after the action. Env override: OTEL_SPANS_FLUSH_INTERVAL_MS.
+   * seconds after the action. Env overrides: OTEL_SPANS_FLUSH_INTERVAL_MS,
+   * then the standard OTEL_BSP_SCHEDULE_DELAY.
    */
   spansFlushIntervalMs?: number
-  /** Log processor flush delay in milliseconds. Defaults to 100ms. */
+  /**
+   * Log processor flush delay in milliseconds. Defaults to 100ms. Env
+   * overrides: OTEL_LOGS_FLUSH_INTERVAL_MS, then the standard
+   * OTEL_BLRP_SCHEDULE_DELAY.
+   */
   logsFlushIntervalMs?: number
   /** Maximum number of log records exported per batch. Defaults to 1. */
   logsBatchSize?: number

--- a/sdk/packages/node/observability/src/telemetry-system/types.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/types.ts
@@ -64,15 +64,10 @@ export interface OtelConfig {
    * Span processor flush delay in milliseconds. Defaults to 100ms. This is how
    * long an ended span waits in the batch buffer before it is flushed to the
    * engine — the OpenTelemetry default of 5000ms is what makes traces appear
-   * seconds after the action. Env overrides: OTEL_SPANS_FLUSH_INTERVAL_MS,
-   * then the standard OTEL_BSP_SCHEDULE_DELAY.
+   * seconds after the action. Env override: OTEL_SPANS_FLUSH_INTERVAL_MS.
    */
   spansFlushIntervalMs?: number
-  /**
-   * Log processor flush delay in milliseconds. Defaults to 100ms. Env
-   * overrides: OTEL_LOGS_FLUSH_INTERVAL_MS, then the standard
-   * OTEL_BLRP_SCHEDULE_DELAY.
-   */
+  /** Log processor flush delay in milliseconds. Defaults to 100ms. Env override: OTEL_LOGS_FLUSH_INTERVAL_MS. */
   logsFlushIntervalMs?: number
   /** Maximum number of log records exported per batch. Defaults to 1. */
   logsBatchSize?: number

--- a/sdk/packages/node/observability/src/telemetry-system/types.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/types.ts
@@ -60,6 +60,13 @@ export interface OtelConfig {
   metricsEnabled?: boolean
   /** Metrics export interval in milliseconds. Defaults to 60000 (60 seconds). */
   metricsExportIntervalMs?: number
+  /**
+   * Span processor flush delay in milliseconds. Defaults to 100ms. This is how
+   * long an ended span waits in the batch buffer before it is flushed to the
+   * engine — the OpenTelemetry default of 5000ms is what makes traces appear
+   * seconds after the action. Env override: OTEL_SPANS_FLUSH_INTERVAL_MS.
+   */
+  spansFlushIntervalMs?: number
   /** Log processor flush delay in milliseconds. Defaults to 100ms. */
   logsFlushIntervalMs?: number
   /** Maximum number of log records exported per batch. Defaults to 1. */
@@ -78,6 +85,7 @@ export const DEFAULT_OTEL_CONFIG = {
   engineWsUrl: 'ws://localhost:49134',
   metricsEnabled: true,
   metricsExportIntervalMs: 60000,
+  spansFlushIntervalMs: 100,
   logsFlushIntervalMs: 100,
   logsBatchSize: 1,
   fetchInstrumentationEnabled: true,

--- a/sdk/packages/node/observability/src/telemetry-system/utils.test.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/utils.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseIntegerEnv, parseNumberEnv, resolveFlushIntervalMs } from './utils'
+
+describe('parseNumberEnv', () => {
+  it('returns undefined when the variable is unset', () => {
+    expect(parseNumberEnv(undefined, 0)).toBeUndefined()
+  })
+
+  it('parses a plain number', () => {
+    expect(parseNumberEnv('250', 0)).toBe(250)
+  })
+
+  it('allows an explicit zero when the minimum permits it', () => {
+    expect(parseNumberEnv('0', 0)).toBe(0)
+  })
+
+  it('treats an empty string as unset instead of coercing to 0', () => {
+    expect(parseNumberEnv('', 0)).toBeUndefined()
+  })
+
+  it('treats a whitespace-only string as unset instead of coercing to 0', () => {
+    expect(parseNumberEnv('   ', 0)).toBeUndefined()
+  })
+
+  it('rejects values below the minimum', () => {
+    expect(parseNumberEnv('-5', 0)).toBeUndefined()
+    expect(parseNumberEnv('0', 1)).toBeUndefined()
+  })
+
+  it('rejects non-numeric values', () => {
+    expect(parseNumberEnv('abc', 0)).toBeUndefined()
+    expect(parseNumberEnv('NaN', 0)).toBeUndefined()
+    expect(parseNumberEnv('Infinity', 0)).toBeUndefined()
+  })
+})
+
+describe('parseIntegerEnv', () => {
+  it('parses integers and rejects fractions', () => {
+    expect(parseIntegerEnv('3', 1)).toBe(3)
+    expect(parseIntegerEnv('2.5', 1)).toBeUndefined()
+  })
+
+  it('treats an empty string as unset', () => {
+    expect(parseIntegerEnv('', 0)).toBeUndefined()
+  })
+})
+
+describe('resolveFlushIntervalMs', () => {
+  it('prefers the explicit config value over everything', () => {
+    expect(resolveFlushIntervalMs(50, '200', '300', 100)).toBe(50)
+  })
+
+  it('respects an explicit config value of 0', () => {
+    expect(resolveFlushIntervalMs(0, '200', '300', 100)).toBe(0)
+  })
+
+  it('falls back to the III-specific env var next', () => {
+    expect(resolveFlushIntervalMs(undefined, '200', '300', 100)).toBe(200)
+  })
+
+  it('falls back to the standard OTel env var when the III one is unset', () => {
+    expect(resolveFlushIntervalMs(undefined, undefined, '300', 100)).toBe(300)
+  })
+
+  it('uses the default when nothing else is set', () => {
+    expect(resolveFlushIntervalMs(undefined, undefined, undefined, 100)).toBe(100)
+  })
+
+  it('falls through past empty or invalid env values to the default', () => {
+    expect(resolveFlushIntervalMs(undefined, '', 'abc', 100)).toBe(100)
+  })
+})

--- a/sdk/packages/node/observability/src/telemetry-system/utils.test.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/utils.test.ts
@@ -48,26 +48,23 @@ describe('parseIntegerEnv', () => {
 
 describe('resolveFlushIntervalMs', () => {
   it('prefers the explicit config value over everything', () => {
-    expect(resolveFlushIntervalMs(50, '200', '300', 100)).toBe(50)
+    expect(resolveFlushIntervalMs(50, '200', 100)).toBe(50)
   })
 
   it('respects an explicit config value of 0', () => {
-    expect(resolveFlushIntervalMs(0, '200', '300', 100)).toBe(0)
+    expect(resolveFlushIntervalMs(0, '200', 100)).toBe(0)
   })
 
   it('falls back to the III-specific env var next', () => {
-    expect(resolveFlushIntervalMs(undefined, '200', '300', 100)).toBe(200)
+    expect(resolveFlushIntervalMs(undefined, '200', 100)).toBe(200)
   })
 
-  it('falls back to the standard OTel env var when the III one is unset', () => {
-    expect(resolveFlushIntervalMs(undefined, undefined, '300', 100)).toBe(300)
-  })
-
-  it('uses the default when nothing else is set', () => {
-    expect(resolveFlushIntervalMs(undefined, undefined, undefined, 100)).toBe(100)
+  it('uses the default when config and env are unset', () => {
+    expect(resolveFlushIntervalMs(undefined, undefined, 100)).toBe(100)
   })
 
   it('falls through past empty or invalid env values to the default', () => {
-    expect(resolveFlushIntervalMs(undefined, '', 'abc', 100)).toBe(100)
+    expect(resolveFlushIntervalMs(undefined, '', 100)).toBe(100)
+    expect(resolveFlushIntervalMs(undefined, 'abc', 100)).toBe(100)
   })
 })

--- a/sdk/packages/node/observability/src/telemetry-system/utils.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/utils.ts
@@ -26,15 +26,18 @@ export function parseIntegerEnv(
 
 /**
  * Resolve a batch-processor flush delay: explicit config wins, then the
- * III-specific env var, then the standard OTel env var (which the OTel SDK
- * stops honoring once we pass an explicit `scheduledDelayMillis`), then the
- * III default.
+ * III-specific env var, then the III default.
+ *
+ * III SDKs deliberately expose a single OTEL_*_FLUSH_INTERVAL_MS knob and do
+ * NOT honor the standard OTel OTEL_BSP_SCHEDULE_DELAY / OTEL_BLRP_SCHEDULE_DELAY
+ * vars, for cross-SDK consistency (the Node, Python, and Rust SDKs all resolve
+ * the same way). Passing an explicit `scheduledDelayMillis` to the processor
+ * already makes the OTel SDK ignore those standard vars regardless.
  */
 export function resolveFlushIntervalMs(
   configValue: number | undefined,
-  iiiEnvValue: string | undefined,
-  otelEnvValue: string | undefined,
+  envValue: string | undefined,
   defaultValue: number,
 ): number {
-  return configValue ?? parseNumberEnv(iiiEnvValue, 0) ?? parseNumberEnv(otelEnvValue, 0) ?? defaultValue
+  return configValue ?? parseNumberEnv(envValue, 0) ?? defaultValue
 }

--- a/sdk/packages/node/observability/src/telemetry-system/utils.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/utils.ts
@@ -1,8 +1,12 @@
 /**
  * Parse a numeric environment variable with optional minimum bound.
+ *
+ * An empty or whitespace-only string is treated as unset: `Number('')` is 0,
+ * so without this check a variable set-but-blank (common in .env files) would
+ * silently resolve to 0 instead of falling through to the default.
  */
 export function parseNumberEnv(value: string | undefined, minimum: number = 0): number | undefined {
-  if (value === undefined) return undefined
+  if (value === undefined || value.trim() === '') return undefined
   const parsed = Number(value)
   if (!Number.isFinite(parsed) || parsed < minimum) return undefined
   return parsed
@@ -18,4 +22,19 @@ export function parseIntegerEnv(
   const parsed = parseNumberEnv(value, minimum)
   if (parsed === undefined || !Number.isInteger(parsed)) return undefined
   return parsed
+}
+
+/**
+ * Resolve a batch-processor flush delay: explicit config wins, then the
+ * III-specific env var, then the standard OTel env var (which the OTel SDK
+ * stops honoring once we pass an explicit `scheduledDelayMillis`), then the
+ * III default.
+ */
+export function resolveFlushIntervalMs(
+  configValue: number | undefined,
+  iiiEnvValue: string | undefined,
+  otelEnvValue: string | undefined,
+  defaultValue: number,
+): number {
+  return configValue ?? parseNumberEnv(iiiEnvValue, 0) ?? parseNumberEnv(otelEnvValue, 0) ?? defaultValue
 }

--- a/sdk/packages/python/observability/src/iii_observability/telemetry.py
+++ b/sdk/packages/python/observability/src/iii_observability/telemetry.py
@@ -115,7 +115,21 @@ def init_otel(
     from .baggage_span_processor import BaggageSpanProcessor
 
     provider.add_span_processor(BaggageSpanProcessor())
-    provider.add_span_processor(BatchSpanProcessor(span_exporter))  # type: ignore[arg-type]
+    # Without an explicit schedule_delay_millis, BatchSpanProcessor inherits the
+    # OpenTelemetry default of 5000ms, so an ended span sits in the buffer up to
+    # 5s before reaching the engine — the dominant reason traces appear seconds
+    # late. Mirror the logs path with a small flush delay.
+    spans_flush_interval_ms = _resolve_int(
+        cfg.spans_flush_interval_ms,
+        "OTEL_SPANS_FLUSH_INTERVAL_MS",
+        default=100,
+    )
+    provider.add_span_processor(
+        BatchSpanProcessor(
+            span_exporter,  # type: ignore[arg-type]
+            schedule_delay_millis=spans_flush_interval_ms,
+        )
+    )
     trace.set_tracer_provider(provider)
     _tracer = trace.get_tracer("iii-python-sdk")
 

--- a/sdk/packages/python/observability/src/iii_observability/telemetry_types.py
+++ b/sdk/packages/python/observability/src/iii_observability/telemetry_types.py
@@ -30,6 +30,13 @@ class OtelConfig:
     fetch_instrumentation_enabled: bool = True
     """Auto-instrument urllib HTTP calls via URLLibInstrumentor. Defaults to True."""
 
+    spans_flush_interval_ms: int | None = None
+    """Span processor flush delay in milliseconds. Defaults to 100ms when not set.
+
+    The OpenTelemetry default of 5000ms is what makes traces appear seconds
+    after the action. Env override: OTEL_SPANS_FLUSH_INTERVAL_MS.
+    """
+
     logs_enabled: bool | None = None
     """Enable OTel log export via EngineLogExporter. Defaults to True when OTel is enabled."""
 

--- a/sdk/packages/rust/observability/src/telemetry/mod.rs
+++ b/sdk/packages/rust/observability/src/telemetry/mod.rs
@@ -23,7 +23,9 @@ use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::logs::{BatchConfigBuilder, BatchLogProcessor, SdkLoggerProvider};
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::propagation::{BaggagePropagator, TraceContextPropagator};
-use opentelemetry_sdk::trace::SdkTracerProvider;
+use opentelemetry_sdk::trace::{
+    BatchConfigBuilder as SpanBatchConfigBuilder, BatchSpanProcessor, SdkTracerProvider,
+};
 use tokio::sync::Mutex;
 
 use self::connection::SharedEngineConnection;
@@ -289,11 +291,37 @@ pub async fn init_otel(config: OtelConfig) -> bool {
     // registration order, so baggage entries are materialized as span
     // attributes before the batch exporter reads them.
     let span_exporter = EngineSpanExporter::new(connection.clone());
+
+    // Without an explicit scheduled delay, the batch span processor inherits the
+    // OpenTelemetry default of ~5000ms, so an ended span sits in the buffer up to
+    // 5s before reaching the engine — the dominant reason traces appear seconds
+    // late. Mirror the logs path: resolve config > custom env var > 100ms default.
+    let spans_flush_ms = config
+        .spans_flush_interval_ms
+        .or_else(|| {
+            std::env::var("OTEL_SPANS_FLUSH_INTERVAL_MS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+        })
+        .unwrap_or(100);
+
+    let span_batch_config = SpanBatchConfigBuilder::default()
+        .with_scheduled_delay(std::time::Duration::from_millis(spans_flush_ms))
+        .build();
+    let span_processor = BatchSpanProcessor::builder(span_exporter)
+        .with_batch_config(span_batch_config)
+        .build();
+
     let tracer_provider = SdkTracerProvider::builder()
         .with_resource(resource.clone())
         .with_span_processor(baggage_span_processor::BaggageSpanProcessor::default())
-        .with_batch_exporter(span_exporter)
+        .with_span_processor(span_processor)
         .build();
+
+    tracing::debug!(
+        flush_interval_ms = spans_flush_ms,
+        "Span provider configured"
+    );
 
     opentelemetry::global::set_tracer_provider(tracer_provider.clone());
 

--- a/sdk/packages/rust/observability/src/telemetry/types.rs
+++ b/sdk/packages/rust/observability/src/telemetry/types.rs
@@ -68,6 +68,10 @@ pub struct OtelConfig {
     /// `ReconnectionConfig::max_pending_messages` to absorb bursts during
     /// normal operation while limiting stale data across reconnects.
     pub channel_capacity: Option<usize>,
+    /// Span processor flush delay in milliseconds. Defaults to 100ms when not
+    /// set. The OpenTelemetry default of 5000ms is what makes traces appear
+    /// seconds after the action. Env override: OTEL_SPANS_FLUSH_INTERVAL_MS.
+    pub spans_flush_interval_ms: Option<u64>,
     /// Whether to enable the log exporter (default: true)
     pub logs_enabled: Option<bool>,
     /// Log processor flush delay in milliseconds. Defaults to 100ms when not set.


### PR DESCRIPTION
## Summary

Traces were showing up in the console seconds after the action that produced them, and spans whose real parent was an engine-internal wrapper rendered as detached "phantom roots" in the live detail view. This fixes both the latency and the structural correctness of the live trace feed.

### Engine — tree-correct the detail stream
The live detail stream pushed the raw coalesce window, whose spans point at engine-internal wrappers (`stream_triggers`, etc.) the subscriber already filtered out — so a naive push re-orphaned every span whose real parent was such a wrapper, and the console treated it as a new depth-0 root.

Per touched trace, the payload is now rebuilt from the **full** stored trace with the same prune+collapse pipeline `traces::tree` uses, emitting each arrived span plus its corrected ancestor chain (walked to the root). Returned spans carry their corrected `parent_span_id`, so the consumer nests them identically to the REST tree instead of re-rooting. The feed is upsert-by-`span_id`, so re-emitting ancestors is safe and each frame stays self-contained (survives a dropped frame the same way reconnect already self-heals).

### SDK (Node) — cut span flush latency
`BatchSpanProcessor` inherited OpenTelemetry's default 5000ms flush delay, so an ended span sat in the buffer up to 5s before reaching the engine — the dominant source of the lag. Spans now flush at 100ms by default (mirroring the logs path), configurable via `spansFlushIntervalMs`. `maxExportBatchSize` stays at the OTel default so a burst from one turn still coalesces into a single frame.

### Console — interim poll bump
Trace list polling drops from 3s to 1s so freshly emitted spans surface sooner. This is interim — the real fix is subscribing to the reactive trace-rows feed over the existing streams WebSocket instead of polling, which is left as follow-up.

## Review fixes folded in
- **Blank env vars no longer force a 0ms flush.** `parseNumberEnv` treated a set-but-empty `OTEL_*_FLUSH_INTERVAL_MS` as `0` (busy flush loop); it now treats empty/whitespace as unset and falls back to the default. An explicit `"0"` is still honored.
- **Standard OTel env vars kept working.** Passing an explicit `scheduledDelayMillis` makes the OTel SDK ignore `OTEL_BSP_SCHEDULE_DELAY` / `OTEL_BLRP_SCHEDULE_DELAY`; both are now folded into the fallback chain. The spans and logs paths share one `resolveFlushIntervalMs` helper.
- **Collapse rules compiled once.** Regexes were recompiled on every coalesce tick and every REST request; they're now cached in a `OnceLock` (config is set-once).
- **Single shared correction pipeline.** Extracted `correct_trace_spans` so `traces::tree` and the live detail stream can't drift apart.
- **Removed an unreachable cycle-guard counter** in `detail_stream_spans` (the visited-set break already terminates cycles).

## Test plan
- [x] `cargo test --lib workers::observability` — 343 passed (includes new detail-stream correction tests)
- [x] SDK observability suite — 18 passed, incl. new `utils.test.ts` covering the env-parsing and fallback-chain edge cases
- [x] `tsc --noEmit` clean; no new clippy warnings
- [ ] Manual: confirm in the console that spans nest correctly on the live feed (no phantom roots) and surface within ~1s of the action


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable span flush interval for trace collection (default 100ms).

* **Bug Fixes**
  * Fixed orphaned spans in trace detail streams so traces display with correct parent-child relationships.
  * Increased trace polling frequency to 1s when active for more responsive real-time updates.

* **Tests**
  * Added tests validating telemetry flush-interval resolution and corrected trace streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->