### PR TITLE
fix(engine): reject conflicting HTTP routes instead of panicking

### DIFF
--- a/engine/src/workers/rest_api/api_core.rs
+++ b/engine/src/workers/rest_api/api_core.rs
@@ -217,6 +217,29 @@ impl HttpWorker {
         format!("{}:{}", method, path)
     }
 
+    /// Structural signature of a route, used to detect axum matcher conflicts.
+    ///
+    /// Axum matches routes by position, not by parameter name, so
+    /// `/sessions/{listId}/{userId}` and `/sessions/{userId}/{listId}` are the
+    /// same route to its matcher and inserting both panics. Two routes share
+    /// this signature exactly when they would collide: same method and same
+    /// shape with every path parameter collapsed to a positional placeholder.
+    fn route_signature(http_method: &str, http_path: &str) -> String {
+        let axum_path = Self::build_router_for_axum(&http_path.to_string());
+        let shape = axum_path
+            .split('/')
+            .map(|segment| {
+                if segment.starts_with('{') && segment.ends_with('}') {
+                    "{}".to_string()
+                } else {
+                    segment.to_string()
+                }
+            })
+            .collect::<Vec<String>>()
+            .join("/");
+        format!("{}:{}", http_method.to_uppercase(), shape)
+    }
+
     /// Updates the router with all routes from the registry and configurations
     async fn update_routes(&self) -> anyhow::Result<()> {
         // Build CORS layer
@@ -292,10 +315,25 @@ impl HttpWorker {
 
         let mut router = Router::new();
 
-        for entry in routers_registry.iter() {
-            let path = Self::build_router_for_axum(&entry.http_path);
+        // Defense in depth: `register_router` already rejects conflicting
+        // routes, but skip any colliding signature here too so a stray
+        // duplicate can never panic axum and crash the HTTP worker thread.
+        let mut seen_signatures = std::collections::HashSet::new();
 
+        for entry in routers_registry.iter() {
             let method = entry.http_method.to_ascii_uppercase();
+
+            let signature = Self::route_signature(&method, &entry.http_path);
+            if !seen_signatures.insert(signature) {
+                tracing::warn!(
+                    "Skipping route {} {} — conflicts with a previously registered route of the same structure",
+                    method.purple(),
+                    entry.http_path.purple()
+                );
+                continue;
+            }
+
+            let path = Self::build_router_for_axum(&entry.http_path);
             let path_for_extension = entry.http_path.clone();
             router = match method.as_str() {
                 "GET" => router.route(
@@ -398,6 +436,32 @@ impl HttpWorker {
         let http_path = router.http_path.clone();
         let method = router.http_method.to_uppercase();
         let key = Self::build_router_key(&method, &router.http_path);
+
+        // Reject routes that collide with an already-registered route of the
+        // same shape but different path-parameter names. Axum's matcher would
+        // panic on such an insert, taking down the whole HTTP worker thread, so
+        // we fail this single registration gracefully instead.
+        let signature = Self::route_signature(&method, &http_path);
+        let conflict = self
+            .routers_registry
+            .iter()
+            .find(|entry| {
+                entry.key() != &key
+                    && Self::route_signature(&entry.http_method, &entry.http_path) == signature
+            })
+            .map(|entry| entry.http_path.clone());
+        if let Some(existing_path) = conflict {
+            anyhow::bail!(
+                "Route '{} {}' conflicts with already-registered route '{} {}': \
+                 routes with identical structure but different path-parameter \
+                 names are not supported",
+                method,
+                http_path,
+                method,
+                existing_path
+            );
+        }
+
         tracing::debug!("Registering router {}", key.purple());
         self.routers_registry.insert(key, router);
 
@@ -635,6 +699,38 @@ mod tests {
     fn build_router_key_root_with_different_methods() {
         assert_eq!(HttpWorker::build_router_key("GET", "/"), "GET:/");
         assert_eq!(HttpWorker::build_router_key("POST", "/"), "POST:/");
+    }
+
+    // ---- route_signature tests ----
+
+    #[test]
+    fn route_signature_collapses_param_names() {
+        // Same shape, swapped param names -> identical signature (would collide).
+        let a = HttpWorker::route_signature("GET", "sessions/:listId/:userId/calls/:contactId");
+        let b = HttpWorker::route_signature("GET", "sessions/:userId/:listId/calls/:contactId");
+        assert_eq!(a, b);
+        assert_eq!(a, "GET:/sessions/{}/{}/calls/{}");
+    }
+
+    #[test]
+    fn route_signature_distinguishes_method() {
+        let get = HttpWorker::route_signature("GET", "items/:id");
+        let post = HttpWorker::route_signature("POST", "items/:id");
+        assert_ne!(get, post);
+    }
+
+    #[test]
+    fn route_signature_distinguishes_literal_segments() {
+        let a = HttpWorker::route_signature("GET", "sessions/:id/calls");
+        let b = HttpWorker::route_signature("GET", "sessions/:id/messages");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn route_signature_distinguishes_param_vs_literal() {
+        let param = HttpWorker::route_signature("GET", "users/:id");
+        let literal = HttpWorker::route_signature("GET", "users/me");
+        assert_ne!(param, literal);
     }
 
     // ---- build_router_for_axum tests ----

--- a/sdk/packages/go/iii/tests/api_triggers_test.go
+++ b/sdk/packages/go/iii/tests/api_triggers_test.go
@@ -9,6 +9,9 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
+
+	iii "github.com/iii-hq/iii/sdk/packages/go/iii"
 )
 
 // Mirrors sdk/packages/rust/iii/tests/api_triggers.rs: register an HTTP trigger and
@@ -75,5 +78,95 @@ func TestHTTPTriggerRoundtrip(t *testing.T) {
 	}
 	if out.Greeting != "hi world" {
 		t.Errorf("greeting = %q, want %q", out.Greeting, "hi world")
+	}
+}
+
+// TestConflictingRouteStructureIsRejected mirrors the Python/Rust suites: two HTTP routes
+// with identical structure but swapped path-param names must not crash the engine. The
+// first route keeps serving and the second is rejected (never becomes an active registered
+// trigger).
+func TestConflictingRouteStructureIsRejected(t *testing.T) {
+	c := connect(t)
+
+	handler := func(_ context.Context, _ json.RawMessage) (any, error) {
+		return map[string]any{"status_code": 200, "body": map[string]bool{"ok": true}}, nil
+	}
+	if err := c.RegisterFunction("test::api::conflict::a::go", handler); err != nil {
+		t.Fatalf("RegisterFunction A: %v", err)
+	}
+	if err := c.RegisterFunction("test::api::conflict::b::go", handler); err != nil {
+		t.Fatalf("RegisterFunction B: %v", err)
+	}
+
+	// Shared literal prefix (unique per run) so A and B collide structurally without
+	// clashing with other runs against the engine-global registry.
+	suffix := uniqueSuffix(t)
+	base := "test/go/conflict-" + suffix
+
+	if err := c.RegisterTrigger(
+		"test-go-conflict-a-"+suffix,
+		"http",
+		"test::api::conflict::a::go",
+		json.RawMessage(`{"api_path":"`+base+`/:listId/:userId","http_method":"GET"}`),
+		nil,
+	); err != nil {
+		t.Fatalf("RegisterTrigger A: %v", err)
+	}
+	// Second route has the same axum shape with swapped param names -> conflict.
+	if err := c.RegisterTrigger(
+		"test-go-conflict-b-"+suffix,
+		"http",
+		"test::api::conflict::b::go",
+		json.RawMessage(`{"api_path":"`+base+`/:userId/:listId","http_method":"GET"}`),
+		nil,
+	); err != nil {
+		t.Fatalf("RegisterTrigger B: %v", err)
+	}
+	settle()
+
+	// Engine stayed alive and the first route still serves — no panic.
+	resp, err := httpClient().Get(engineHTTPURL() + "/" + base + "/list1/user1")
+	if err != nil {
+		t.Fatalf("HTTP GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	var out struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode response: %v\nraw: %s", err, body)
+	}
+	if !out.OK {
+		t.Errorf("ok = false, want true; raw: %s", body)
+	}
+
+	// Exactly one of the two routes survives: the engine rejects whichever conflicting
+	// registration it processes second (wire order is not guaranteed), so the loser
+	// never becomes an active registered trigger.
+	registered := 0
+	for _, fid := range []string{"test::api::conflict::a::go", "test::api::conflict::b::go"} {
+		res, err := c.Trigger(ctxFor(t, 5*time.Second), iii.TriggerRequest{
+			FunctionID: iii.FnListRegisteredTriggers,
+			Data:       json.RawMessage(`{"function_id":"` + fid + `"}`),
+		})
+		if err != nil {
+			t.Fatalf("engine::registered-triggers::list (%s): %v", fid, err)
+		}
+		var out struct {
+			RegisteredTriggers []struct {
+				ID string `json:"id"`
+			} `json:"registered_triggers"`
+		}
+		if err := json.Unmarshal(res, &out); err != nil {
+			t.Fatalf("decode registered-triggers list: %v\nraw: %s", err, res)
+		}
+		registered += len(out.RegisteredTriggers)
+	}
+	if registered != 1 {
+		t.Errorf("exactly one conflicting route must be registered, found %d", registered)
 	}
 }

--- a/sdk/packages/node/iii/tests/api-triggers.test.ts
+++ b/sdk/packages/node/iii/tests/api-triggers.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { pipeline } from 'node:stream/promises'
 import { fileURLToPath } from 'node:url'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { http, type ApiResponse, type HttpRequest } from '../src'
 import type { HttpResponse } from '../src/types'
 import { engineHttpUrl, execute, httpRequest, iii, sleep } from './utils'
@@ -547,5 +547,55 @@ describe('API Triggers', () => {
 
     fn.unregister()
     trigger.unregister()
+  })
+
+  it('should reject a conflicting route structure without crashing the engine', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const handler = async (_req: HttpRequest): Promise<ApiResponse> => ({
+      status_code: 200,
+      body: { ok: true },
+    })
+
+    // First route registers normally.
+    const fnA = iii.registerFunction('test.api.conflict.a', handler)
+    const triggerA = iii.registerTrigger({
+      type: 'http',
+      function_id: fnA.id,
+      config: {
+        api_path: 'test/node/conflict/:listId/:userId',
+        http_method: 'GET',
+      },
+    })
+
+    // Second route has the same axum shape with swapped param names -> conflict.
+    const fnB = iii.registerFunction('test.api.conflict.b', handler)
+    const triggerB = iii.registerTrigger({
+      type: 'http',
+      function_id: fnB.id,
+      config: {
+        api_path: 'test/node/conflict/:userId/:listId',
+        http_method: 'GET',
+      },
+    })
+
+    await sleep(500)
+
+    // Engine stayed alive and the first route still serves — no panic.
+    const response = await execute(async () =>
+      httpRequest('GET', '/test/node/conflict/list1/user1'),
+    )
+    expect(response.status).toBe(200)
+    expect(response.data).toEqual({ ok: true })
+
+    // The conflicting registration was surfaced as an error.
+    const formatted = errorSpy.mock.calls.map((args) => args.join(' ')).join('\n')
+    expect(formatted.toLowerCase()).toContain('conflict')
+    errorSpy.mockRestore()
+
+    fnA.unregister()
+    triggerA.unregister()
+    fnB.unregister()
+    triggerB.unregister()
   })
 })

--- a/sdk/packages/python/iii/tests/test_api_triggers.py
+++ b/sdk/packages/python/iii/tests/test_api_triggers.py
@@ -137,6 +137,64 @@ async def test_raw_json_request_body(engine_http_url, iii_client: III):
 
 
 @pytest.mark.asyncio
+async def test_conflicting_route_structure_is_rejected(engine_http_url, iii_client: III, caplog):
+    """Two routes with identical structure but swapped path-param names must not
+    crash the engine: the first keeps serving and the second is rejected with a
+    logged registration error."""
+    caplog.set_level("ERROR", logger="iii")
+
+    def handler(input_data):
+        return {"status_code": 200, "body": {"ok": True}}
+
+    # First route registers normally.
+    fn_a = iii_client.register_function("test.api.conflict.a.py", handler)
+    trig_a = iii_client.register_trigger(
+        {
+            "type": "http",
+            "function_id": "test.api.conflict.a.py",
+            "config": {
+                "api_path": "test/py/conflict/:listId/:userId",
+                "http_method": "GET",
+            },
+        }
+    )
+
+    # Second route has the same axum shape with swapped param names -> conflict.
+    fn_b = iii_client.register_function("test.api.conflict.b.py", handler)
+    trig_b = iii_client.register_trigger(
+        {
+            "type": "http",
+            "function_id": "test.api.conflict.b.py",
+            "config": {
+                "api_path": "test/py/conflict/:userId/:listId",
+                "http_method": "GET",
+            },
+        }
+    )
+
+    # Give the engine time to process both registrations and reply.
+    time.sleep(0.5)
+
+    # Engine stayed alive and the first route still serves — no panic.
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{engine_http_url}/test/py/conflict/list1/user1") as resp:
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["ok"] is True
+
+    # The conflicting registration was surfaced as an error. The engine rejects
+    # whichever route it processes second (wire order is not guaranteed), so assert on
+    # the conflict message rather than a specific route or the random trigger id.
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("conflicts with already-registered route" in m for m in messages), messages
+
+    fn_a.unregister()
+    trig_a.unregister()
+    fn_b.unregister()
+    trig_b.unregister()
+
+
+@pytest.mark.asyncio
 async def test_path_parameters(engine_http_url, iii_client: III):
     """Verify path parameters are extracted correctly."""
 

--- a/sdk/packages/rust/iii/tests/api_triggers.rs
+++ b/sdk/packages/rust/iii/tests/api_triggers.rs
@@ -12,7 +12,7 @@ use serde_json::{Value, json};
 use serial_test::serial;
 use tokio::sync::Mutex;
 
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput};
+use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput, TriggerRequest};
 use tokio::time::sleep;
 
 fn test_pdf_path() -> PathBuf {
@@ -1046,4 +1046,88 @@ async fn multipart_form_data() {
     assert!(data["has_description"].as_bool().unwrap_or(false));
     assert!(data["has_filename"].as_bool().unwrap_or(false));
     assert!(data["body_size"].as_u64().unwrap_or(0) > original_pdf.len() as u64);
+}
+
+#[tokio::test]
+#[serial]
+async fn conflicting_route_structure_is_rejected() {
+    let iii = common::shared_iii();
+
+    // First route registers normally.
+    iii.register_function(
+        "test::api::conflict::a::rs",
+        RegisterFunction::new_async(|_input: Value| async move {
+            Ok(json!({"status_code": 200, "body": {"ok": true}}))
+        }),
+    );
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "test::api::conflict::a::rs".to_string(),
+        config: json!({
+            "api_path": "test/rs/conflict/:listId/:userId",
+            "http_method": "GET",
+        }),
+        metadata: None,
+    })
+    .expect("register trigger a");
+
+    // Second route has the same axum shape with swapped param names -> conflict.
+    iii.register_function(
+        "test::api::conflict::b::rs",
+        RegisterFunction::new_async(|_input: Value| async move {
+            Ok(json!({"status_code": 200, "body": {"ok": true}}))
+        }),
+    );
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "test::api::conflict::b::rs".to_string(),
+        config: json!({
+            "api_path": "test/rs/conflict/:userId/:listId",
+            "http_method": "GET",
+        }),
+        metadata: None,
+    })
+    .expect("register trigger b");
+
+    common::settle().await;
+    sleep(Duration::from_millis(500)).await;
+
+    // Engine stayed alive and the first route still serves — no panic.
+    let resp = common::http_client()
+        .get(format!(
+            "{}/test/rs/conflict/list1/user1",
+            common::engine_http_url()
+        ))
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status().as_u16(), 200);
+    let data: Value = resp.json().await.expect("json parse");
+    assert_eq!(data["ok"], true);
+
+    // Exactly one of the two routes survives: the engine rejects whichever conflicting
+    // registration it processes second (the order over the wire is not guaranteed), so
+    // the loser never becomes an active registered trigger.
+    let mut registered = 0;
+    for function_id in ["test::api::conflict::a::rs", "test::api::conflict::b::rs"] {
+        let listed = iii
+            .trigger(TriggerRequest {
+                function_id: "engine::registered-triggers::list".to_string(),
+                payload: json!({ "function_id": function_id }),
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+            .expect("registered-triggers::list request should succeed");
+        let rows = listed
+            .get("registered_triggers")
+            .and_then(|v| v.as_array())
+            .map(|a| a.len())
+            .unwrap_or(0);
+        registered += rows;
+    }
+    assert_eq!(
+        registered, 1,
+        "exactly one conflicting route must be registered, found {registered}"
+    );
 }


### PR DESCRIPTION
## Demo

![route conflict rejected — engine stays alive](https://vhs.charm.sh/vhs-3xKL5lBWcOqsT5xeRYeZ7v.gif)

## Problem

Two HTTP triggers whose paths share the same axum structure but use **different path-parameter names** collide in axum's matcher and **panic the HTTP worker thread**, bringing the whole engine down:

```
thread 'tokio-rt-worker' panicked at engine/src/workers/rest_api/api_core.rs:
Invalid route "/sessions/{listId}/{userId}/calls/{contactId}": Insertion failed
due to conflict with previously registered route: /sessions/{userId}/{listId}/calls/{contactId}
```

Axum matches by position, not by parameter name, so `/sessions/{listId}/{userId}` and `/sessions/{userId}/{listId}` are the same route to its matcher.

## Fix

- **`route_signature(method, path)`** — structural signature with every path param collapsed to a positional placeholder. Two routes collide ⇔ same signature.
- **`register_router`** — before insert, scans the registry for a same-signature/different-path route and rejects the registration with `anyhow::bail!`, naming the conflicting path. Engine stays alive; only this one registration fails. The error surfaces to the originating worker as a `TriggerRegistrationResult` error (`trigger_registration_failed`).
- **Router build loop** — skips duplicate signatures as defense in depth, so a stray duplicate can never panic axum.

## Tests

Integration test added to all four SDKs (`python` / `node` / `rust` / `go`): register two structurally-conflicting routes, assert the engine stays alive (first route still serves `200`) and the conflict is surfaced.

Note: the engine rejects whichever route it processes **second** (wire order is not guaranteed), so the tests assert order-independently — "conflict logged" (node/python) or "exactly one of the two registered" (rust/go).

Engine unit tests cover `route_signature` (collapse, method, literal-vs-param distinctions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of HTTP routes with identical structure but different path-parameter names. When conflicts are detected, the system registers the first route and emits a warning, preventing service disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->