### PR TITLE
refactor(sdk)!: rename streaming Http types to Stream (PR 2.8)

### DIFF
--- a/sdk/packages/node/iii/src/index.ts
+++ b/sdk/packages/node/iii/src/index.ts
@@ -37,8 +37,6 @@ export type { Trigger, TriggerConfig, TriggerHandler } from './trigger'
 export type {
   ApiRequest,
   ApiResponse,
-  HttpRequest,
-  HttpResponse,
   IIIClient,
   InternalHttpRequest,
   RegisterFunctionInput,
@@ -46,10 +44,15 @@ export type {
   RegisterTriggerInput,
   RegisterTriggerTypeInput,
   RemoteFunctionHandler,
+  StreamRequest,
+  StreamResponse,
 } from './types'
 
 /** @deprecated Renamed to `IIIClient`. */
 export type { ISdk } from './types'
+
+/** @deprecated `HttpRequest`/`HttpResponse` renamed to `StreamRequest`/`StreamResponse`. */
+export type { HttpRequest, HttpResponse } from './types'
 
 /** @deprecated Import runtime types from `iii-sdk/runtime`. */
 export type { FunctionRef, TriggerTypeRef } from './runtime'

--- a/sdk/packages/node/iii/src/types.ts
+++ b/sdk/packages/node/iii/src/types.ts
@@ -323,11 +323,11 @@ export type InternalHttpRequest<TBody = unknown> = {
 }
 
 /**
- * Response object passed to HTTP function handlers. Use `status()` and
+ * Response object passed to streaming function handlers. Use `status()` and
  * `headers()` to set response metadata, write to `stream` for streaming
  * responses, and call `close()` when done.
  */
-export type HttpResponse = {
+export type StreamResponse = {
   /** Set the HTTP status code. */
   status: (statusCode: number) => void
   /** Set response headers. */
@@ -338,19 +338,25 @@ export type HttpResponse = {
   close: () => void
 }
 
-/**
- * Incoming HTTP request received by a function registered with an HTTP trigger.
- *
- * @typeParam TBody - Type of the parsed request body.
- */
-export type HttpRequest<TBody = unknown> = Omit<InternalHttpRequest<TBody>, 'response'>
+/** @deprecated Renamed to `StreamResponse`. */
+export type HttpResponse = StreamResponse
 
 /**
- * Alias for {@link HttpRequest}. Represents an incoming API request.
+ * Incoming streaming request received by a function registered with a stream trigger.
  *
  * @typeParam TBody - Type of the parsed request body.
  */
-export type ApiRequest<TBody = unknown> = HttpRequest<TBody>
+export type StreamRequest<TBody = unknown> = Omit<InternalHttpRequest<TBody>, 'response'>
+
+/** @deprecated Renamed to `StreamRequest`. */
+export type HttpRequest<TBody = unknown> = StreamRequest<TBody>
+
+/**
+ * Alias for {@link StreamRequest}. Represents an incoming API request.
+ *
+ * @typeParam TBody - Type of the parsed request body.
+ */
+export type ApiRequest<TBody = unknown> = StreamRequest<TBody>
 
 /**
  * Structured API response returned from HTTP function handlers.

--- a/sdk/packages/node/iii/src/utils.ts
+++ b/sdk/packages/node/iii/src/utils.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import type { StreamChannelRef } from './iii-types'
-import type { ApiResponse, HttpRequest, HttpResponse, InternalHttpRequest } from './types'
+import type { ApiResponse, InternalHttpRequest, StreamRequest, StreamResponse } from './types'
 
 /**
  * Returns a project identifier for telemetry, derived from the current working
@@ -34,8 +34,8 @@ export function detectProjectName(cwd: string = process.cwd()): string | undefin
  * Helper that wraps an HTTP-style handler (with separate `req`/`res` arguments)
  * into the function handler format expected by the SDK.
  *
- * @param callback - Async handler receiving an {@link HttpRequest} and {@link HttpResponse}.
- * @returns A function handler compatible with {@link ISdk.registerFunction}.
+ * @param callback - Async handler receiving a {@link StreamRequest} and {@link StreamResponse}.
+ * @returns A function handler compatible with {@link IIIClient.registerFunction}.
  *
  * @example
  * ```typescript
@@ -54,12 +54,12 @@ export function detectProjectName(cwd: string = process.cwd()): string | undefin
  */
 export const http = (
   // biome-ignore lint/suspicious/noConfusingVoidType: void is necessary here
-  callback: (req: HttpRequest, res: HttpResponse) => Promise<void | ApiResponse>,
+  callback: (req: StreamRequest, res: StreamResponse) => Promise<void | ApiResponse>,
 ) => {
   return async (req: InternalHttpRequest) => {
     const { response, ...request } = req
 
-    const httpResponse: HttpResponse = {
+    const httpResponse: StreamResponse = {
       status: (status_code: number) =>
         response.sendMessage(JSON.stringify({ type: 'set_status', status_code })),
       headers: (headers: Record<string, string>) =>

--- a/sdk/packages/python/iii/src/iii/__init__.py
+++ b/sdk/packages/python/iii/src/iii/__init__.py
@@ -57,6 +57,8 @@ from .types import (
     IIIClient,
     InternalHttpRequest,
     RemoteFunctionHandler,
+    StreamRequest,
+    StreamResponse,
 )
 from .utils import http
 
@@ -114,6 +116,8 @@ __all__ = [
     "IIIClient",
     "InternalHttpRequest",
     "RemoteFunctionHandler",
+    "StreamRequest",
+    "StreamResponse",
     # Stream
     "IStream",
     "StreamChangeEvent",

--- a/sdk/packages/python/iii/src/iii/types.py
+++ b/sdk/packages/python/iii/src/iii/types.py
@@ -157,8 +157,8 @@ class InternalHttpRequest:
     request_body: ChannelReader
 
 
-class HttpResponse:
-    """Streaming HTTP response built on top of a ChannelWriter."""
+class StreamResponse:
+    """Streaming response built on top of a ChannelWriter."""
 
     def __init__(self, writer: ChannelWriter) -> None:
         self._writer = writer
@@ -182,8 +182,8 @@ class HttpResponse:
 
 
 @dataclass
-class HttpRequest:
-    """HTTP request without the response writer."""
+class StreamRequest:
+    """Streaming request without the response writer."""
 
     path_params: dict[str, str]
     query_params: dict[str, str | list[str]]
@@ -191,6 +191,11 @@ class HttpRequest:
     headers: dict[str, str | list[str]]
     method: str
     request_body: ChannelReader
+
+
+# Back-compat aliases; renamed to StreamRequest / StreamResponse. Deprecated.
+HttpRequest = StreamRequest
+HttpResponse = StreamResponse
 
 
 class StreamChannelRefDict(TypedDict):

--- a/sdk/packages/python/iii/src/iii/utils.py
+++ b/sdk/packages/python/iii/src/iii/utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
-from .types import HttpRequest, HttpResponse, InternalHttpRequest
+from .types import InternalHttpRequest, StreamRequest, StreamResponse
 from .types import is_channel_ref as is_channel_ref  # noqa: F401 - re-exported from types
 
 if TYPE_CHECKING:
@@ -13,14 +13,14 @@ if TYPE_CHECKING:
 
 
 def http(
-    callback: Callable[[HttpRequest, HttpResponse], Awaitable[ApiResponse[Any] | None]],
+    callback: Callable[[StreamRequest, StreamResponse], Awaitable[ApiResponse[Any] | None]],
 ) -> Callable[[Any], Awaitable[ApiResponse[Any] | None]]:
-    """Wrap an HTTP handler so it receives typed HttpRequest and HttpResponse.
+    """Wrap a streaming handler so it receives typed StreamRequest and StreamResponse.
 
     Takes a callback ``(req, res) -> ApiResponse | None`` and returns a
     function the iii engine can invoke directly.  The wrapper converts the
     raw dict (or ``InternalHttpRequest``) delivered by the engine into the
-    typed ``HttpRequest`` / ``HttpResponse`` pair that the callback expects.
+    typed ``StreamRequest`` / ``StreamResponse`` pair that the callback expects.
     """
 
     async def wrapper(req: Any) -> ApiResponse[Any] | None:
@@ -39,8 +39,8 @@ def http(
         else:
             internal = req
 
-        http_response = HttpResponse(internal.response)
-        http_request = HttpRequest(
+        http_response = StreamResponse(internal.response)
+        http_request = StreamRequest(
             path_params=internal.path_params,
             query_params=internal.query_params,
             body=internal.body,

--- a/sdk/packages/python/iii/tests/test_stream_types.py
+++ b/sdk/packages/python/iii/tests/test_stream_types.py
@@ -1,0 +1,13 @@
+"""StreamRequest / StreamResponse rename, with Http* back-compat aliases."""
+
+from iii import HttpRequest, HttpResponse, StreamRequest, StreamResponse
+
+
+def test_stream_types_exported() -> None:
+    assert StreamRequest is not None
+    assert StreamResponse is not None
+
+
+def test_http_names_alias_stream_types() -> None:
+    assert HttpRequest is StreamRequest
+    assert HttpResponse is StreamResponse

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -83,7 +83,8 @@ pub use types::Channel;
 pub use types::{
     ApiRequest, ApiResponse, DeleteResult, SetResult, StreamAuthInput, StreamAuthResult,
     StreamDeleteInput, StreamGetInput, StreamJoinResult, StreamListGroupsInput, StreamListInput,
-    StreamSetInput, StreamUpdateInput, UpdateOp, UpdateOpError, UpdateResult,
+    StreamRequest, StreamResponse, StreamSetInput, StreamUpdateInput, UpdateOp, UpdateOpError,
+    UpdateResult,
 };
 
 /// Configuration options passed to [`register_worker`].
@@ -261,3 +262,10 @@ fn _ensure_engine_constants_path() {}
 /// ```
 #[allow(dead_code)]
 fn _ensure_invocation_error_path() {}
+
+/// ```rust,no_run
+/// use iii_sdk::{StreamRequest, StreamResponse};
+/// fn _takes(_req: StreamRequest, _res: StreamResponse) {}
+/// ```
+#[allow(dead_code)]
+fn _ensure_stream_request_response_path() {}

--- a/sdk/packages/rust/iii/src/types.rs
+++ b/sdk/packages/rust/iii/src/types.rs
@@ -356,6 +356,16 @@ pub struct ApiResponse<T = Value> {
     pub body: T,
 }
 
+/// Streaming request type, mirroring the Node and Python `StreamRequest`.
+///
+/// Alias of [`ApiRequest`]; added for cross-language parity.
+pub type StreamRequest<T = Value> = ApiRequest<T>;
+
+/// Streaming response type, mirroring the Node and Python `StreamResponse`.
+///
+/// Alias of [`ApiResponse`]; added for cross-language parity.
+pub type StreamResponse<T = Value> = ApiResponse<T>;
+
 /// A streaming channel pair for worker-to-worker data transfer.
 pub struct Channel {
     pub writer: ChannelWriter,


### PR DESCRIPTION
Renames the streaming request/response types to `Stream*` across the SDKs, freeing the `Http*` name for the upcoming HTTP work (Stage 3a).

- **Node**: `HttpRequest`/`HttpResponse` -> `StreamRequest`/`StreamResponse` (`types.ts`); old names kept as `@deprecated` aliases and re-exported from the barrel. `ApiRequest` now aliases `StreamRequest`.
- **Python**: `HttpRequest`/`HttpResponse` -> `StreamRequest`/`StreamResponse` (`types.py`); old names kept as back-compat aliases, exported from the package root.
- **Rust**: adds `StreamRequest`/`StreamResponse` type aliases over `ApiRequest`/`ApiResponse` (Rust had no `Http*` streaming types). Exported at the crate root.
- Internal `http()` helpers repointed to the canonical `Stream*` names in Node and Python.

Stacked on `sdk-refactor-parity` (Stage 2). Note: these types were not present in the SDK-reference docs, so no doc change was needed.

Verified: Node `tsc --noEmit` clean (api-trigger/middleware runtime failures are pre-existing integration tests needing a live engine); Python `pytest` (new parity test) + `mypy` + `ruff` clean; Rust `fmt`/build/`test --doc`/`test --lib` (57)/`clippy -D warnings` all pass.