### PR TITLE
refactor(sdk): add TriggerActionEnqueue to the queue lib

### DIFF
--- a/docs/next/sdk-reference/queue-lib.mdx
+++ b/docs/next/sdk-reference/queue-lib.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Queue library"
-description: "The iii queue library and its EnqueueResult type, shared across the Node, Python, and Rust SDKs."
+description: "The iii queue library and its EnqueueResult and TriggerActionEnqueue types, shared across the Node, Python, and Rust SDKs."
 owner: "engineering"
 type: "reference"
 ---
 
 The queue library is a small, standalone package shared across the iii SDKs. It holds queue
-primitives that several SDKs need to agree on. As of this version it exports a single type,
-`EnqueueResult`.
+primitives that several SDKs need to agree on. It exports `EnqueueResult` and, in the Node and
+Python packages, `TriggerActionEnqueue`.
 
 ## Packages
 
@@ -58,13 +58,70 @@ let result = EnqueueResult { message_receipt_id: "...".to_string() };
 `EnqueueResult` is a struct with a single field, `message_receipt_id` (String), serialized as
 `messageReceiptId` on the wire.
 
+## TriggerActionEnqueue
+
+`TriggerActionEnqueue` describes the enqueue trigger action: it routes an invocation through a named
+queue for async processing. The wire shape is a tagged object with `type` set to `enqueue` and a
+`queue` string naming the target queue.
+
+The Node and Python queue packages export `TriggerActionEnqueue` as a named type. Rust is
+asymmetric here: the queue crate does not export it. In Rust the enqueue action is defined in the
+core SDK as the `TriggerAction::Enqueue { queue }` variant, which is the wire enum used by `trigger()`.
+See the table at the end of this section for the per-language surface.
+
+### Node
+
+```ts
+import type { TriggerActionEnqueue } from '@iii-dev/queue'
+
+const action: TriggerActionEnqueue = { type: 'enqueue', queue: 'payments' }
+```
+
+`TriggerActionEnqueue` is a type with two fields: `type` (the literal `'enqueue'`) and `queue`
+(string). It mirrors the `{ type: 'enqueue'; queue: string }` member of the core `TriggerAction`
+union. The queue package type is an additive parity surface: the core union is unchanged and does
+not depend on the queue package.
+
+### Python
+
+```python
+from iii_queue import TriggerActionEnqueue
+
+action = TriggerActionEnqueue(queue="payments")
+```
+
+`TriggerActionEnqueue` is a Pydantic model with two fields: `type` (the literal `"enqueue"`,
+defaulting to `"enqueue"`) and `queue` (str). The core `TriggerAction` union references this model
+by importing it from `iii_queue`, so the public union is unchanged.
+
+### Rust
+
+Rust does not export `TriggerActionEnqueue` from the queue crate. The enqueue action is the
+`TriggerAction::Enqueue { queue }` variant in the core SDK (`iii_sdk`), serialized as
+`{ "type": "enqueue", "queue": "..." }` on the wire.
+
+```rust
+use iii_sdk::TriggerAction;
+
+let action = TriggerAction::Enqueue { queue: "payments".to_string() };
+```
+
+### Per-language surface
+
+| Language | Symbol | Where it is defined |
+| -------- | ------ | -------------- |
+| Node | `TriggerActionEnqueue` type | `@iii-dev/queue` (additive; core keeps its inline union) |
+| Python | `TriggerActionEnqueue` model | `iii_queue` (core union imports it from here) |
+| Rust | `TriggerAction::Enqueue { queue }` variant | `iii_sdk` core (the queue crate does not export it) |
+
 ## Deprecated root re-exports
 
-For backward compatibility, the root SDK still resolves `EnqueueResult` at its old path. These paths
-are deprecated and emit a deprecation notice. Prefer the queue library import shown above.
+For backward compatibility, the root SDK still resolves these symbols at their old paths. These
+paths are deprecated and emit a deprecation notice. Prefer the queue library import shown above.
 
 | Language | Deprecated path | Replacement |
 | -------- | --------------- | ----------- |
 | Node | `EnqueueResult` from `iii-sdk` root | `EnqueueResult` from `@iii-dev/queue` |
 | Python | `from iii import EnqueueResult` | `from iii_queue import EnqueueResult` |
 | Rust | `iii_sdk::EnqueueResult` | `iii_queue::EnqueueResult` |
+| Python | `from iii import TriggerActionEnqueue` | `from iii_queue import TriggerActionEnqueue` |

--- a/docs/next/sdk-reference/queue-lib.mdx.skill.md
+++ b/docs/next/sdk-reference/queue-lib.mdx.skill.md
@@ -4,8 +4,8 @@
 
 
 The queue library is a small, standalone package shared across the iii SDKs. It holds queue
-primitives that several SDKs need to agree on. As of this version it exports a single type,
-`EnqueueResult`.
+primitives that several SDKs need to agree on. It exports `EnqueueResult` and, in the Node and
+Python packages, `TriggerActionEnqueue`.
 
 ## Packages
 
@@ -56,13 +56,70 @@ let result = EnqueueResult { message_receipt_id: "...".to_string() };
 `EnqueueResult` is a struct with a single field, `message_receipt_id` (String), serialized as
 `messageReceiptId` on the wire.
 
+## TriggerActionEnqueue
+
+`TriggerActionEnqueue` describes the enqueue trigger action: it routes an invocation through a named
+queue for async processing. The wire shape is a tagged object with `type` set to `enqueue` and a
+`queue` string naming the target queue.
+
+The Node and Python queue packages export `TriggerActionEnqueue` as a named type. Rust is
+asymmetric here: the queue crate does not export it. In Rust the enqueue action is defined in the
+core SDK as the `TriggerAction::Enqueue { queue }` variant, which is the wire enum used by `trigger()`.
+See the table at the end of this section for the per-language surface.
+
+### Node
+
+```ts
+import type { TriggerActionEnqueue } from '@iii-dev/queue'
+
+const action: TriggerActionEnqueue = { type: 'enqueue', queue: 'payments' }
+```
+
+`TriggerActionEnqueue` is a type with two fields: `type` (the literal `'enqueue'`) and `queue`
+(string). It mirrors the `{ type: 'enqueue'; queue: string }` member of the core `TriggerAction`
+union. The queue package type is an additive parity surface: the core union is unchanged and does
+not depend on the queue package.
+
+### Python
+
+```python
+from iii_queue import TriggerActionEnqueue
+
+action = TriggerActionEnqueue(queue="payments")
+```
+
+`TriggerActionEnqueue` is a Pydantic model with two fields: `type` (the literal `"enqueue"`,
+defaulting to `"enqueue"`) and `queue` (str). The core `TriggerAction` union references this model
+by importing it from `iii_queue`, so the public union is unchanged.
+
+### Rust
+
+Rust does not export `TriggerActionEnqueue` from the queue crate. The enqueue action is the
+`TriggerAction::Enqueue { queue }` variant in the core SDK (`iii_sdk`), serialized as
+`{ "type": "enqueue", "queue": "..." }` on the wire.
+
+```rust
+use iii_sdk::TriggerAction;
+
+let action = TriggerAction::Enqueue { queue: "payments".to_string() };
+```
+
+### Per-language surface
+
+| Language | Symbol | Where it is defined |
+| -------- | ------ | -------------- |
+| Node | `TriggerActionEnqueue` type | `@iii-dev/queue` (additive; core keeps its inline union) |
+| Python | `TriggerActionEnqueue` model | `iii_queue` (core union imports it from here) |
+| Rust | `TriggerAction::Enqueue { queue }` variant | `iii_sdk` core (the queue crate does not export it) |
+
 ## Deprecated root re-exports
 
-For backward compatibility, the root SDK still resolves `EnqueueResult` at its old path. These paths
-are deprecated and emit a deprecation notice. Prefer the queue library import shown above.
+For backward compatibility, the root SDK still resolves these symbols at their old paths. These
+paths are deprecated and emit a deprecation notice. Prefer the queue library import shown above.
 
 | Language | Deprecated path | Replacement |
 | -------- | --------------- | ----------- |
 | Node | `EnqueueResult` from `iii-sdk` root | `EnqueueResult` from `@iii-dev/queue` |
 | Python | `from iii import EnqueueResult` | `from iii_queue import EnqueueResult` |
 | Rust | `iii_sdk::EnqueueResult` | `iii_queue::EnqueueResult` |
+| Python | `from iii import TriggerActionEnqueue` | `from iii_queue import TriggerActionEnqueue` |

--- a/sdk/packages/node/queue/src/index.ts
+++ b/sdk/packages/node/queue/src/index.ts
@@ -5,3 +5,8 @@ export type EnqueueResult = {
   /** Unique receipt ID for the enqueued message. */
   messageReceiptId: string
 }
+
+/**
+ * Routes the invocation through a named queue for async processing.
+ */
+export type TriggerActionEnqueue = { type: 'enqueue'; queue: string }

--- a/sdk/packages/python/iii/src/iii/__init__.py
+++ b/sdk/packages/python/iii/src/iii/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from iii_queue import EnqueueResult
+from iii_queue import EnqueueResult, TriggerActionEnqueue
 
 from .channels import ChannelReader, ChannelWriter
 from .errors import InvocationError
@@ -35,7 +35,6 @@ from .iii_types import (
     RegisterTriggerTypeInput,
     RegisterTriggerTypeMessage,
     StreamChannelRef,
-    TriggerActionEnqueue,
     TriggerActionVoid,
     TriggerRequest,
 )

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -15,6 +15,7 @@ from typing import Any, Awaitable, Callable, Coroutine, TypeVar, cast
 
 import websockets
 from iii_observability import OtelConfig
+from iii_queue import TriggerActionEnqueue
 from websockets.asyncio.client import ClientConnection
 
 from .channels import ChannelReader, ChannelWriter
@@ -40,7 +41,6 @@ from .iii_types import (
     RegisterTriggerTypeInput,
     RegisterTriggerTypeMessage,
     StreamChannelRef,
-    TriggerActionEnqueue,
     TriggerActionVoid,
     TriggerRequest,
     UnregisterFunctionMessage,

--- a/sdk/packages/python/iii/src/iii/iii_types.py
+++ b/sdk/packages/python/iii/src/iii/iii_types.py
@@ -3,6 +3,7 @@
 from enum import Enum
 from typing import Any, Literal
 
+from iii_queue import TriggerActionEnqueue
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -216,18 +217,6 @@ class RegisterFunctionMessage(BaseModel):
     metadata: dict[str, Any] | None = None
     invocation: HttpInvocationConfig | None = None
     message_type: MessageType = Field(default=MessageType.REGISTER_FUNCTION, alias="type")
-
-
-class TriggerActionEnqueue(BaseModel):
-    """Routes the invocation through a named queue for async processing.
-
-    Attributes:
-        type: Always ``'enqueue'``.
-        queue: Name of the target queue.
-    """
-
-    type: Literal["enqueue"] = "enqueue"
-    queue: str
 
 
 class TriggerActionVoid(BaseModel):

--- a/sdk/packages/python/queue/src/iii_queue/__init__.py
+++ b/sdk/packages/python/queue/src/iii_queue/__init__.py
@@ -1,5 +1,7 @@
 """iii queue types."""
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 
@@ -13,4 +15,16 @@ class EnqueueResult(BaseModel):
     messageReceiptId: str = Field(description="UUID assigned by the engine to the enqueued job.")
 
 
-__all__ = ["EnqueueResult"]
+class TriggerActionEnqueue(BaseModel):
+    """Routes the invocation through a named queue for async processing.
+
+    Attributes:
+        type: Always ``'enqueue'``.
+        queue: Name of the target queue.
+    """
+
+    type: Literal["enqueue"] = "enqueue"
+    queue: str
+
+
+__all__ = ["EnqueueResult", "TriggerActionEnqueue"]


### PR DESCRIPTION
## What

Adds `TriggerActionEnqueue` to `@iii-dev/queue` / `iii-queue`, per the locked per-language asymmetry (decision 5):

- **Python**: MOVES the `TriggerActionEnqueue(BaseModel)` class into `iii_queue`; core `iii` re-imports it (still in `__all__`, `from iii import TriggerActionEnqueue` resolves). The public `TriggerAction` union composes the same class object, unchanged.
- **Node**: INTRODUCES a named `export type TriggerActionEnqueue = { type: 'enqueue'; queue: string }` in the queue lib. Core inline `TriggerAction` union left untouched (no core to queue type dep) — additive parity surface.
- **Rust**: untouched. `TriggerAction::Enqueue { queue }` stays a core enum variant (it is the wire enum used by `trigger()`); the queue crate does not export it. Documented asymmetry.
- **Docs**: `queue-lib.mdx` updated with the `TriggerActionEnqueue` section + Rust-asymmetry note; `.skill.md` regenerated via `iii-skill-render`.

## Verification (local)

Node build + `tsc --noEmit`, Python mypy + ruff (iii + queue) clean. Full pytest run against a live engine: 318 passed; the single failure (`test_invoke_function_fire_and_forget`, TimeoutError) is flaky (passes in isolation, unrelated to this type relocation). `from iii import TriggerActionEnqueue` resolves; public `TriggerAction` union unchanged.

## Stacking

Stacked on #1823 (3b.2); base auto-retargets up the stack as each merges.