### PR TITLE
fix(iii-worker,engine): kill the zombie-worker leak — engine-death cascade for daemons, VMs, watchers, and workers

### DIFF
--- a/crates/iii-worker/src/cli/vm_boot.rs
+++ b/crates/iii-worker/src/cli/vm_boot.rs
@@ -990,6 +990,40 @@ fn boot_vm(args: &VmBootArgs) -> Result<std::convert::Infallible, String> {
         );
     }
 
+    // Lifeline cascade: when the spawner attached a lifeline pipe (the
+    // sandbox daemon does, for every VM it boots), tear the VM down the
+    // instant the spawner dies — ANY death, SIGKILL included. Without this,
+    // VMs are setsid'd session leaders that nothing ever reaps once their
+    // daemon is gone. Routed through the same ExitHandle as SIGTERM/SIGINT
+    // so the on_exit cleanup (pidfile + socket fingerprints) runs instead of
+    // an abrupt process::exit. Plain OS threads, because libkrun owns the
+    // main thread once `enter()` runs; if the spawner died during boot the
+    // first read/poll fires immediately. The spawner-pid poll backstops the
+    // one lifeline failure mode (a write end leaked through the macOS
+    // non-atomic CLOEXEC window delaying EOF). Detached spawners (the
+    // managed-worker start path) attach neither env, preserving their
+    // adopt-orphan semantics.
+    #[cfg(unix)]
+    {
+        if let Some(fd) = crate::daemon_exit::take_early_lifeline() {
+            let handle = vm.exit_handle();
+            std::thread::spawn(move || {
+                if crate::daemon_exit::blocking_wait_lifeline_eof(fd) {
+                    eprintln!("vm-boot: spawner lifeline closed; shutting down VM");
+                    handle.trigger();
+                }
+            });
+        }
+        if let Some(pid) = crate::daemon_exit::early_spawner_pid() {
+            let handle = vm.exit_handle();
+            std::thread::spawn(move || {
+                crate::daemon_exit::blocking_wait_pid_gone(pid);
+                eprintln!("vm-boot: spawner pid {pid} exited; shutting down VM");
+                handle.trigger();
+            });
+        }
+    }
+
     let vcpu_label = if args.vcpus == 1 { "vCPU" } else { "vCPUs" };
     eprintln!(
         "  Booting VM ({} {}, {} MiB RAM)...",

--- a/crates/iii-worker/src/cli/vm_boot.rs
+++ b/crates/iii-worker/src/cli/vm_boot.rs
@@ -1022,6 +1022,19 @@ fn boot_vm(args: &VmBootArgs) -> Result<std::convert::Infallible, String> {
                 handle.trigger();
             });
         }
+        // Engine anchor: managed-worker VMs are detached from their
+        // (transient) spawner by design, but nothing the engine started may
+        // outlive the engine — a real `killall -9 iii` left worker VMs
+        // running. III_ENGINE_PID flows down the whole spawn tree env, so
+        // watch it directly; hand-run VMs (no engine env) stay unwatched.
+        if let Some(pid) = crate::daemon_exit::engine_pid_from_env() {
+            let handle = vm.exit_handle();
+            std::thread::spawn(move || {
+                crate::daemon_exit::blocking_wait_pid_gone(pid);
+                eprintln!("vm-boot: engine pid {pid} exited; shutting down VM");
+                handle.trigger();
+            });
+        }
     }
 
     let vcpu_label = if args.vcpus == 1 { "vCPU" } else { "vCPUs" };

--- a/crates/iii-worker/src/cli/worker_manager/libkrun.rs
+++ b/crates/iii-worker/src/cli/worker_manager/libkrun.rs
@@ -129,6 +129,11 @@ pub async fn run_dev(
 
     let mut cmd = tokio::process::Command::new(&self_exe);
     cmd.arg("__vm-boot");
+    // Managed-worker VMs are DETACHED by design (adopt-orphan semantics);
+    // scrub any ambient lifeline inheritance so a VM spawned by a process
+    // that itself carries a lifeline can never wrongly die with it.
+    cmd.env_remove(crate::daemon_exit::LIFELINE_FD_ENV);
+    cmd.env_remove(crate::daemon_exit::LIFELINE_SPAWNER_PID_ENV);
     for boot_arg in vm_boot_args_dev(
         &rootfs,
         exec_path,
@@ -696,6 +701,9 @@ This image likely does not publish arm64. Rebuild/push a multi-arch image (linux
 
         let mut cmd = std::process::Command::new(&self_exe);
         cmd.arg("__vm-boot");
+        // Detached by design — see the matching scrub in run_dev above.
+        cmd.env_remove(crate::daemon_exit::LIFELINE_FD_ENV);
+        cmd.env_remove(crate::daemon_exit::LIFELINE_SPAWNER_PID_ENV);
         for boot_arg in vm_boot_args_oci(
             &worker_rootfs,
             &exec_path,

--- a/crates/iii-worker/src/cli/worker_manager_daemon.rs
+++ b/crates/iii-worker/src/cli/worker_manager_daemon.rs
@@ -544,4 +544,3 @@ fn register_clear(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
         ),
     );
 }
-

--- a/crates/iii-worker/src/cli/worker_manager_daemon.rs
+++ b/crates/iii-worker/src/cli/worker_manager_daemon.rs
@@ -39,6 +39,12 @@ use crate::cli::worker_trigger::{
 use crate::core::add::CallerMode;
 
 pub async fn run(args: WorkerManagerDaemonArgs) -> i32 {
+    // FIRST statement, before any await: snapshot spawn-time facts (current
+    // ppid + III_ENGINE_PID). The exit-watch is polled only after SDK init +
+    // ~10 registrations; if the engine died in that window we'd baseline
+    // against the ADOPTER and never notice (cross-model review finding).
+    let exit_watch = crate::daemon_exit::ExitWatch::arm_at_startup();
+
     let project_root = args
         .project_root
         .or_else(|| std::env::var_os("IIIWORKER_PROJECT_ROOT").map(Into::into))
@@ -85,12 +91,13 @@ pub async fn run(args: WorkerManagerDaemonArgs) -> i32 {
     register_all(&iii, project_root, event_sink);
 
     tracing::info!("worker-manager-daemon ready");
-    if let Err(e) = tokio::signal::ctrl_c().await {
-        tracing::error!(error = %e, "ctrl_c handler failed");
-        iii.shutdown_async().await;
-        return 1;
-    }
-    tracing::info!("worker-manager-daemon shutting down");
+
+    // Exit on SIGINT/SIGTERM/SIGHUP or engine death — see crate::daemon_exit
+    // for the full design (PID handshake + hardened reparent fallback).
+    // shutdown_async is a best-effort flush; the connection thread is not
+    // joined before exit.
+    let reason = exit_watch.wait("worker-manager-daemon").await;
+    tracing::info!(reason, "worker-manager-daemon shutting down");
     iii.shutdown_async().await;
     0
 }
@@ -503,3 +510,4 @@ fn register_clear(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
         ),
     );
 }
+

--- a/crates/iii-worker/src/cli/worker_manager_daemon.rs
+++ b/crates/iii-worker/src/cli/worker_manager_daemon.rs
@@ -93,13 +93,47 @@ pub async fn run(args: WorkerManagerDaemonArgs) -> i32 {
     tracing::info!("worker-manager-daemon ready");
 
     // Exit on SIGINT/SIGTERM/SIGHUP or engine death — see crate::daemon_exit
-    // for the full design (PID handshake + hardened reparent fallback).
-    // shutdown_async is a best-effort flush; the connection thread is not
-    // joined before exit.
+    // for the full design (lifeline pipe + PID handshake + hardened reparent
+    // fallback). shutdown_async is a best-effort flush; the connection
+    // thread is not joined before exit.
     let reason = exit_watch.wait("worker-manager-daemon").await;
     tracing::info!(reason, "worker-manager-daemon shutting down");
+    if reason == "engine-gone" {
+        // Session reaper: nothing the engine started may outlive it. The
+        // engine cannot kill its tree post-mortem (no macOS PDEATHSIG, and
+        // workers are setsid'd session leaders), but THIS daemon notices
+        // engine death and still has the full host-side stop machinery —
+        // handle_managed_stop kills the VM (or binary worker process) AND
+        // its source-watcher sidecar per worker, no engine required. VMs
+        // also self-watch the engine pid as defense for the case where this
+        // daemon was killed first.
+        reap_managed_workers().await;
+    }
     iii.shutdown_async().await;
     0
+}
+
+/// Stop every config.yaml worker, each bounded so one wedged stop can't
+/// stall the daemon's own exit. Best-effort by design: the daemon is going
+/// down either way, and per-worker failures are logged, not fatal.
+async fn reap_managed_workers() {
+    let names = crate::cli::config_file::list_worker_names();
+    tracing::warn!(
+        count = names.len(),
+        "engine gone — reaping managed workers before exit"
+    );
+    for name in names {
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            crate::cli::managed::handle_managed_stop(&name),
+        )
+        .await
+        {
+            Ok(rc) if rc == 0 => tracing::info!(worker = %name, "reaped"),
+            Ok(rc) => tracing::warn!(worker = %name, rc, "reap stop returned nonzero"),
+            Err(_) => tracing::warn!(worker = %name, "reap stop timed out after 10s"),
+        }
+    }
 }
 
 #[doc(hidden)]

--- a/crates/iii-worker/src/daemon_exit.rs
+++ b/crates/iii-worker/src/daemon_exit.rs
@@ -419,6 +419,7 @@ impl ExitWatch {
             tokio::select! {
                 eof = tokio::task::spawn_blocking(move || blocking_wait_lifeline_eof(dup)) => {
                     if matches!(eof, Ok(true)) {
+                        redirect_stdio_to_exit_log(daemon);
                         tracing::warn!(daemon, "lifeline closed: spawner gone");
                         return;
                     }
@@ -429,6 +430,49 @@ impl ExitWatch {
             }
         }
         backstop.await;
+    }
+}
+
+/// The engine that consumed this daemon's stdout/stderr just died, so fds
+/// 1/2 are broken pipes. The very next write would panic the daemon: the
+/// fmt layer swallows its own EPIPE, but its internal-error fallback is an
+/// `eprintln!`, which panics when stderr is also broken — unwinding the
+/// main task BETWEEN engine-death detection and the breadcrumb/reaper. A
+/// real `killall -9 iii` left every managed worker running because the
+/// reaper died to exactly this before stopping anything.
+///
+/// Re-point fds 1/2 at the durable exit log (same file as the breadcrumb)
+/// so post-mortem writes succeed AND the reap pass becomes visible
+/// forensics; fall back to /dev/null. Must run BEFORE the first
+/// engine-is-gone log line. Best-effort: on total failure the panic risk
+/// simply remains, which is no worse than before.
+#[cfg(unix)]
+fn redirect_stdio_to_exit_log(daemon: &str) {
+    use std::os::fd::IntoRawFd;
+    let log = exit_log_path(daemon)
+        .and_then(|p| {
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(p)
+                .ok()
+        })
+        .or_else(|| {
+            std::fs::OpenOptions::new()
+                .write(true)
+                .open("/dev/null")
+                .ok()
+        });
+    let Some(log) = log else { return };
+    // Leak the fd deliberately: it must outlive this call as the process's
+    // stdout/stderr for the remaining (short) life of the daemon.
+    let fd = log.into_raw_fd();
+    unsafe {
+        libc::dup2(fd, 1);
+        libc::dup2(fd, 2);
+        if fd > 2 {
+            libc::close(fd);
+        }
     }
 }
 
@@ -472,6 +516,7 @@ async fn wait_for_pid_exit(pid: i32, daemon: &'static str) {
     loop {
         tokio::time::sleep(ENGINE_POLL_INTERVAL).await;
         if process_is_gone(pid) {
+            redirect_stdio_to_exit_log(daemon);
             tracing::warn!(engine_pid = pid, daemon, "declared engine pid exited");
             return;
         }
@@ -499,6 +544,7 @@ async fn wait_for_reparent(initial: i32, daemon: &'static str) {
         tokio::time::sleep(ENGINE_POLL_INTERVAL).await;
         let current = nix::unistd::getppid().as_raw();
         if reparented_away(initial, current) && process_is_gone(initial) {
+            redirect_stdio_to_exit_log(daemon);
             tracing::warn!(was = initial, now = current, daemon, "spawn parent exited");
             return;
         }
@@ -528,17 +574,25 @@ fn process_is_gone(pid: i32) -> bool {
     )
 }
 
+/// The durable per-daemon exit log: `~/.iii/logs/<daemon>.log`. Holds the
+/// engine-gone breadcrumb and, post-redirect, the daemon's final output
+/// (the reap pass). Creates the parent directory as a side effect.
+#[cfg(unix)]
+fn exit_log_path(daemon: &str) -> Option<std::path::PathBuf> {
+    let dir = dirs::home_dir()?.join(".iii/logs");
+    std::fs::create_dir_all(&dir).ok()?;
+    Some(dir.join(format!("{daemon}.log")))
+}
+
 /// Best-effort durable trace of an engine-gone self-exit (appends to
 /// `~/.iii/logs/<daemon>.log`). Every failure mode is silently ignored — the
 /// daemon is exiting either way.
 #[cfg(unix)]
 fn write_exit_breadcrumb(daemon: &str, engine_pid: Option<i32>, spawn_parent: i32) {
     use std::io::Write;
-    let Some(home) = dirs::home_dir() else { return };
-    let dir = home.join(".iii/logs");
-    if std::fs::create_dir_all(&dir).is_err() {
+    let Some(path) = exit_log_path(daemon) else {
         return;
-    }
+    };
     let ts = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
@@ -550,7 +604,7 @@ fn write_exit_breadcrumb(daemon: &str, engine_pid: Option<i32>, spawn_parent: i3
     if let Ok(mut f) = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(dir.join(format!("{daemon}.log")))
+        .open(path)
     {
         let _ = f.write_all(line.as_bytes());
     }

--- a/crates/iii-worker/src/daemon_exit.rs
+++ b/crates/iii-worker/src/daemon_exit.rs
@@ -130,6 +130,19 @@ pub fn blocking_wait_pid_gone(pid: i32) {
     }
 }
 
+/// Read-only engine pid from the env. Deliberately NOT scrubbed — unlike the
+/// lifeline fd, [`ENGINE_PID_ENV`] flows down the entire spawn tree so that
+/// detached processes (managed-worker `__vm-boot` VMs, `__watch-source`
+/// sidecars) can anchor to ENGINE lifetime regardless of how many transient
+/// spawners sit in between. Absent (e.g. a hand-run `iii worker start` in a
+/// terminal) means "not engine-rooted": no watch, the process is the user's.
+pub fn engine_pid_from_env() -> Option<i32> {
+    std::env::var(ENGINE_PID_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<i32>().ok())
+        .filter(|p| *p > 1)
+}
+
 /// How often the engine-liveness watch polls. The orphan-exit integration
 /// test's deadline is sized against this value.
 #[cfg(unix)]
@@ -340,10 +353,7 @@ impl ExitWatch {
     pub fn arm_at_startup() -> Self {
         #[cfg(unix)]
         {
-            let engine_pid = std::env::var(ENGINE_PID_ENV)
-                .ok()
-                .and_then(|v| v.trim().parse::<i32>().ok())
-                .filter(|p| *p > 1);
+            let engine_pid = engine_pid_from_env();
             Self {
                 spawn_parent: nix::unistd::getppid().as_raw(),
                 engine_pid,

--- a/crates/iii-worker/src/daemon_exit.rs
+++ b/crates/iii-worker/src/daemon_exit.rs
@@ -1,0 +1,660 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+//! Shared self-exit watch for engine-spawned daemons (`worker-manager-daemon`,
+//! `sandbox-daemon`).
+//!
+//! The engine spawns these daemons in their OWN session (setsid, see
+//! engine/src/workers/external.rs) so it can clean-kill the whole process
+//! group — but that detaches them from parent-death signals (an orphaned
+//! session leader gets no SIGHUP from the kernel). Without a self-exit path,
+//! an engine that dies abnormally (SIGKILL, OOM, crash, dev hard-restart that
+//! skips kill_child) leaves the daemon reconnect-looping forever, and every
+//! engine restart leaks another orphan. A real incident accumulated 19 of
+//! them; an orphaned sandbox-daemon additionally keeps multi-GB libkrun VMs
+//! alive.
+//!
+//! [`ExitWatch::wait`] resolves on ANY of: SIGINT, SIGTERM (what the engine's
+//! kill_child actually sends — previously default-disposition death), SIGHUP
+//! (terminal close on a hand-launched daemon), or engine death. Engine death
+//! is detected two ways, in preference order:
+//!
+//! 1. **PID handshake** — the engine exports [`ENGINE_PID_ENV`] at spawn and
+//!    the daemon polls that pid's existence directly. Immune to whatever sits
+//!    between the engine and the daemon (wrapper scripts, spawn shims,
+//!    debugger reparenting).
+//! 2. **Reparent fallback** (env absent — e.g. version skew with an older
+//!    engine) — the daemon snapshots `getppid()` at startup and exits when
+//!    the ppid CHANGES *and* the original parent no longer exists. Both
+//!    conditions are required: on macOS a debugger attach reparents the
+//!    target to lldb (XNU `proc_reparent`), so a change-only check would kill
+//!    the live daemon API under a debugger while the engine is healthy.
+//!
+//! Either way, a long-lived PID-reuse collision can only cause over-survival
+//! (the old leak, rare and bounded), never a false exit.
+//!
+//! INVARIANT the fallback depends on: the engine must never fork or re-exec
+//! itself after spawning a daemon — a parent that "moves" looks identical to
+//! a parent that died.
+//!
+//! Unix-only: on non-Unix targets only Ctrl-C is watched and the orphan
+//! self-exit does not exist.
+
+#[cfg(unix)]
+use std::time::Duration;
+
+/// Env var the engine sets at daemon spawn (engine/src/workers/external.rs)
+/// declaring its own pid, so daemons watch ENGINE liveness directly instead
+/// of inferring it from `getppid()`.
+pub const ENGINE_PID_ENV: &str = "III_ENGINE_PID";
+
+/// Env var naming the file-descriptor number of an inherited LIFELINE PIPE
+/// read end. The spawner holds the write end and never writes; when the
+/// spawner dies — for ANY reason, SIGKILL included — the kernel closes the
+/// write end and the child's read returns EOF instantly. Strictly stronger
+/// than the PID watch: zero latency, no polling, no PID-reuse caveat, and no
+/// dependence on parent/ppid semantics. Set by the engine for daemons
+/// (engine/src/workers/external.rs — keep the literal there in sync) and by
+/// the sandbox daemon for the `__vm-boot` VMs it launches.
+pub const LIFELINE_FD_ENV: &str = "III_LIFELINE_FD";
+
+/// Env var naming the SPAWNER's pid, set alongside [`LIFELINE_FD_ENV`] by
+/// [`attach_lifeline`]. Children use it as the polling backstop for the one
+/// lifeline failure mode: on macOS `pipe2` doesn't exist, so a concurrent
+/// spawn on another thread can inherit a write end in the window before the
+/// CLOEXEC fcntls land, delaying EOF until that bystander also exits. The
+/// pid poll is immune to leaked fds.
+pub const LIFELINE_SPAWNER_PID_ENV: &str = "III_LIFELINE_SPAWNER_PID";
+
+/// Spawn-time facts captured BEFORE the tokio runtime exists. Reading the
+/// lifeline fd out of the env requires `env::remove_var` (so children never
+/// inherit it), which is only sound while the process is single-threaded —
+/// `#[tokio::main]`-style entrypoints spawn worker threads before any user
+/// code runs, so `main()` must call [`capture_early`] first, pre-runtime.
+struct EarlyCapture {
+    #[cfg(unix)]
+    lifeline: std::sync::Mutex<Option<std::os::fd::OwnedFd>>,
+    #[cfg(unix)]
+    spawner_pid: Option<i32>,
+}
+
+static EARLY: std::sync::OnceLock<EarlyCapture> = std::sync::OnceLock::new();
+
+/// Capture (and scrub from the env) the inherited lifeline facts. MUST be
+/// the first thing `main()` does, before building the tokio runtime — this
+/// is the only point where mutating the process environment is sound.
+/// Idempotent; later calls are no-ops.
+pub fn capture_early() {
+    let _ = EARLY.get_or_init(|| EarlyCapture {
+        #[cfg(unix)]
+        lifeline: std::sync::Mutex::new(lifeline_fd_from_env()),
+        #[cfg(unix)]
+        spawner_pid: {
+            let pid = std::env::var(LIFELINE_SPAWNER_PID_ENV)
+                .ok()
+                .and_then(|v| v.trim().parse::<i32>().ok())
+                .filter(|p| *p > 1);
+            if std::env::var_os(LIFELINE_SPAWNER_PID_ENV).is_some() {
+                // SAFETY: pre-runtime, single-threaded (the contract of this
+                // function); scrubbed so children never inherit it.
+                unsafe { std::env::remove_var(LIFELINE_SPAWNER_PID_ENV) };
+            }
+            pid
+        },
+    });
+}
+
+/// Take the early-captured lifeline read end (None if [`capture_early`]
+/// wasn't called or no valid lifeline was inherited).
+#[cfg(unix)]
+pub fn take_early_lifeline() -> Option<std::os::fd::OwnedFd> {
+    EARLY.get()?.lifeline.lock().ok()?.take()
+}
+
+/// The early-captured spawner pid, for the polling backstop.
+#[cfg(unix)]
+pub fn early_spawner_pid() -> Option<i32> {
+    EARLY.get()?.spawner_pid
+}
+
+/// Polling-backstop companion to [`blocking_wait_lifeline_eof`]: block until
+/// `pid` no longer exists (ESRCH). For plain-thread contexts like
+/// `__vm-boot`; the daemons use the async PID watch in [`ExitWatch`].
+#[cfg(unix)]
+pub fn blocking_wait_pid_gone(pid: i32) {
+    loop {
+        std::thread::sleep(ENGINE_POLL_INTERVAL);
+        if process_is_gone(pid) {
+            return;
+        }
+    }
+}
+
+/// How often the engine-liveness watch polls. The orphan-exit integration
+/// test's deadline is sized against this value.
+#[cfg(unix)]
+pub const ENGINE_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// One end of a spawner→child death-notification pipe. The holder is the
+/// SPAWNER: dropping a `Lifeline` (or the spawner dying, however abruptly)
+/// closes the write end and the child's lifeline watch sees EOF. Created by
+/// [`attach_lifeline`] / [`attach_lifeline_std`].
+#[derive(Debug)]
+pub struct Lifeline {
+    /// Held open, never written. Kernel closes it on process death.
+    #[cfg(unix)]
+    _write: std::os::fd::OwnedFd,
+    /// The parent's copy of the read end. Kept so the raw fd number baked
+    /// into the child's env/pre_exec stays valid until (and after) spawn;
+    /// holding a READ end open never delays the child's EOF (EOF fires when
+    /// all WRITE ends close).
+    #[cfg(unix)]
+    _read: std::os::fd::OwnedFd,
+}
+
+/// Create a lifeline pipe and wire `cmd` so the child inherits the read end:
+/// both ends are CLOEXEC in this process (no leak into other children); a
+/// `pre_exec` hook clears CLOEXEC on the read end for THIS child only, and
+/// [`LIFELINE_FD_ENV`] tells the child which fd number it is.
+///
+/// Keep the returned [`Lifeline`] alive for as long as the child should
+/// live; drop it to tell the child its spawner is gone.
+///
+/// macOS has no `pipe2`, so there is a tiny window between `pipe()` and the
+/// CLOEXEC fcntls where a concurrent spawn on another thread could inherit
+/// both ends, which would delay the child's EOF until that bystander also
+/// exits. The pid-poll backstops cover that case: [`LIFELINE_SPAWNER_PID_ENV`]
+/// is set here and consumed by [`ExitWatch::wait`] (daemons) and `__vm-boot`'s
+/// [`blocking_wait_pid_gone`] thread (VMs).
+#[cfg(unix)]
+pub fn attach_lifeline(cmd: &mut tokio::process::Command) -> std::io::Result<Lifeline> {
+    let (read, write) = new_cloexec_pipe()?;
+    let read_raw = std::os::fd::AsRawFd::as_raw_fd(&read);
+    cmd.env(LIFELINE_FD_ENV, read_raw.to_string());
+    cmd.env(LIFELINE_SPAWNER_PID_ENV, std::process::id().to_string());
+    // SAFETY: fcntl(F_SETFD) is async-signal-safe; runs in the
+    // forked-but-not-yet-execed child to un-CLOEXEC its inherited copy.
+    unsafe {
+        cmd.pre_exec(move || clear_cloexec(read_raw));
+    }
+    Ok(Lifeline {
+        _write: write,
+        _read: read,
+    })
+}
+
+/// [`attach_lifeline`] for `std::process::Command` spawn sites.
+#[cfg(unix)]
+pub fn attach_lifeline_std(cmd: &mut std::process::Command) -> std::io::Result<Lifeline> {
+    use std::os::unix::process::CommandExt;
+    let (read, write) = new_cloexec_pipe()?;
+    let read_raw = std::os::fd::AsRawFd::as_raw_fd(&read);
+    cmd.env(LIFELINE_FD_ENV, read_raw.to_string());
+    cmd.env(LIFELINE_SPAWNER_PID_ENV, std::process::id().to_string());
+    // SAFETY: as in `attach_lifeline`.
+    unsafe {
+        cmd.pre_exec(move || clear_cloexec(read_raw));
+    }
+    Ok(Lifeline {
+        _write: write,
+        _read: read,
+    })
+}
+
+/// Pipe with both ends CLOEXEC: atomically via `pipe2` where it exists,
+/// pipe+fcntl elsewhere (see the race note on [`attach_lifeline`]).
+#[cfg(unix)]
+fn new_cloexec_pipe() -> std::io::Result<(std::os::fd::OwnedFd, std::os::fd::OwnedFd)> {
+    #[cfg(target_os = "linux")]
+    {
+        let (r, w) = nix::unistd::pipe2(nix::fcntl::OFlag::O_CLOEXEC)?;
+        Ok((r, w))
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let (r, w) = nix::unistd::pipe()?;
+        set_cloexec(std::os::fd::AsRawFd::as_raw_fd(&r))?;
+        set_cloexec(std::os::fd::AsRawFd::as_raw_fd(&w))?;
+        Ok((r, w))
+    }
+}
+
+#[cfg(unix)]
+fn set_cloexec(fd: i32) -> std::io::Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn clear_cloexec(fd: i32) -> std::io::Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Child side: take ownership of the lifeline read end named by
+/// [`LIFELINE_FD_ENV`], if any. Validates the fd is a live FIFO before
+/// trusting it (a stale/corrupt env naming, say, stdin would otherwise turn
+/// "read /dev/null EOF" into a false spawner-death). On success the fd gets
+/// CLOEXEC set again and the env var is scrubbed, so OUR children inherit
+/// neither — without that, e.g. a `__vm-boot` launched by the worker start
+/// path would inherit the daemon's ENGINE lifeline and a detached worker VM
+/// would wrongly die with the engine.
+///
+/// Single-call contract: takes ownership of the raw fd, so call at most once
+/// per process (the daemons call it from `arm_at_startup`, `__vm-boot` from
+/// its entrypoint).
+#[cfg(unix)]
+pub fn lifeline_fd_from_env() -> Option<std::os::fd::OwnedFd> {
+    use std::os::fd::FromRawFd;
+    let val = std::env::var(LIFELINE_FD_ENV).ok()?;
+    // Scrub BEFORE validating: every rejection path below must also keep the
+    // var away from our children, not just the success path.
+    // SAFETY: startup-time, before this process spawns anything that could
+    // race the env table (capture_early's pre-runtime contract).
+    unsafe { std::env::remove_var(LIFELINE_FD_ENV) };
+    let Ok(raw) = val.trim().parse::<i32>() else {
+        tracing::warn!(value = ?val, "ignoring unparsable lifeline env");
+        return None;
+    };
+    if raw <= 2 {
+        tracing::warn!(fd = raw, "ignoring lifeline env naming a stdio fd");
+        return None;
+    }
+    // Validate BEFORE taking ownership: if the env lies and names a foreign
+    // fd, we must not adopt (and later close) something that isn't ours.
+    let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+    if unsafe { libc::fstat(raw, &mut stat) } != 0 {
+        tracing::warn!(fd = raw, "ignoring lifeline env: fd is not open");
+        return None;
+    }
+    if stat.st_mode & libc::S_IFMT != libc::S_IFIFO {
+        tracing::warn!(fd = raw, "ignoring lifeline env: fd is not a pipe");
+        return None;
+    }
+    // Ownership BEFORE the final fcntl: a failure there must close the
+    // (genuinely ours, per protocol) fd rather than leak it open and
+    // non-CLOEXEC into every child we spawn.
+    // SAFETY: protocol gives this process sole ownership of the inherited fd.
+    let owned = unsafe { std::os::fd::OwnedFd::from_raw_fd(raw) };
+    if let Err(e) = set_cloexec(raw) {
+        tracing::warn!(fd = raw, error = %e, "ignoring lifeline: cannot re-arm CLOEXEC");
+        return None; // drop(owned) closes it
+    }
+    Some(owned)
+}
+
+/// Block until the lifeline reports the spawner is gone. Returns `true` on
+/// EOF (all write ends closed — the spawner died or dropped its
+/// [`Lifeline`]); `false` on an unrecoverable read error, which is NOT death
+/// evidence (callers fall back to their other watches). Any bytes received
+/// are ignored — the protocol never writes.
+#[cfg(unix)]
+pub fn blocking_wait_lifeline_eof(fd: std::os::fd::OwnedFd) -> bool {
+    use std::io::Read;
+    let mut file = std::fs::File::from(fd);
+    let mut buf = [0u8; 16];
+    loop {
+        match file.read(&mut buf) {
+            Ok(0) => return true,
+            Ok(_) => continue,
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => {
+                tracing::warn!(error = %e, "lifeline read failed; falling back to PID watches");
+                return false;
+            }
+        }
+    }
+}
+
+/// Spawn-time facts needed to detect engine death. Construct with
+/// [`ExitWatch::arm_at_startup`] as the FIRST statement of the daemon's
+/// entrypoint, before any await: the parent right now is whoever launched us;
+/// by the time the watch is polled (after SDK init + registrations) a dead
+/// engine would already have been replaced by the adopter in `getppid()`.
+pub struct ExitWatch {
+    #[cfg(unix)]
+    spawn_parent: i32,
+    #[cfg(unix)]
+    engine_pid: Option<i32>,
+    /// From [`LIFELINE_SPAWNER_PID_ENV`]: pid-poll backstop when no engine
+    /// pid was declared (lifeline-only spawners like [`attach_lifeline`]).
+    #[cfg(unix)]
+    spawner_pid: Option<i32>,
+    #[cfg(unix)]
+    lifeline: Option<std::os::fd::OwnedFd>,
+}
+
+impl ExitWatch {
+    pub fn arm_at_startup() -> Self {
+        #[cfg(unix)]
+        {
+            let engine_pid = std::env::var(ENGINE_PID_ENV)
+                .ok()
+                .and_then(|v| v.trim().parse::<i32>().ok())
+                .filter(|p| *p > 1);
+            Self {
+                spawn_parent: nix::unistd::getppid().as_raw(),
+                engine_pid,
+                spawner_pid: early_spawner_pid(),
+                // Prefer the pre-runtime capture (env already scrubbed,
+                // single-threaded at the time); fall back to a live read for
+                // in-process embedders (tests, the engine e2e harness) that
+                // never go through main().
+                lifeline: take_early_lifeline().or_else(lifeline_fd_from_env),
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            Self {}
+        }
+    }
+
+    /// Block until the daemon should exit; returns a short reason for the
+    /// log ("sigint" | "sigterm" | "sighup" | "engine-gone"). On the
+    /// engine-gone path a one-line breadcrumb is appended to
+    /// `~/.iii/logs/<daemon>.log` first: the daemon's stdout/stderr are pipes
+    /// into the now-dead engine and the OTEL sink WAS that engine, so without
+    /// it the self-exit is invisible in the field.
+    pub async fn wait(&self, daemon: &'static str) -> &'static str {
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::SignalKind;
+            let reason = tokio::select! {
+                _ = wait_for_sigint() => "sigint",
+                _ = wait_for_unix_signal(SignalKind::terminate(), "SIGTERM") => "sigterm",
+                _ = wait_for_unix_signal(SignalKind::hangup(), "SIGHUP") => "sighup",
+                _ = self.wait_for_engine_gone(daemon) => "engine-gone",
+            };
+            if reason == "engine-gone" {
+                write_exit_breadcrumb(daemon, self.engine_pid, self.spawn_parent);
+            }
+            reason
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = daemon;
+            let _ = tokio::signal::ctrl_c().await;
+            "sigint"
+        }
+    }
+
+    #[cfg(unix)]
+    async fn wait_for_engine_gone(&self, daemon: &'static str) {
+        // The PID watch (or reparent fallback) always runs as the backstop;
+        // the lifeline, when present, races it as the primary signal — EOF is
+        // instant and immune to PID semantics, while the backstop covers the
+        // one lifeline failure mode (a leaked write end keeping EOF at bay).
+        let backstop = async {
+            match self.engine_pid.or(self.spawner_pid) {
+                Some(pid) => wait_for_pid_exit(pid, daemon).await,
+                None => wait_for_reparent(self.spawn_parent, daemon).await,
+            }
+        };
+        tokio::pin!(backstop);
+
+        if let Some(dup) = self.lifeline.as_ref().and_then(|fd| fd.try_clone().ok()) {
+            tracing::info!(daemon, "lifeline exit-watch armed");
+            tokio::select! {
+                eof = tokio::task::spawn_blocking(move || blocking_wait_lifeline_eof(dup)) => {
+                    if matches!(eof, Ok(true)) {
+                        tracing::warn!(daemon, "lifeline closed: spawner gone");
+                        return;
+                    }
+                    // Read error or a cancelled blocking task: not death
+                    // evidence — fall through to the backstop.
+                }
+                _ = backstop.as_mut() => return,
+            }
+        }
+        backstop.await;
+    }
+}
+
+/// Resolve on Ctrl-C/SIGINT. If the handler can't be installed, log and park
+/// forever instead of resolving — an installation Err is NOT an exit request,
+/// and the other exit arms still cover shutdown. (An earlier version exited
+/// rc 0 with reason "sigint" on Err, silently taking the daemon down at
+/// startup.)
+#[cfg(unix)]
+async fn wait_for_sigint() {
+    if let Err(e) = tokio::signal::ctrl_c().await {
+        tracing::error!(error = %e, "ctrl_c handler failed; SIGINT exit arm disabled");
+        std::future::pending::<()>().await
+    }
+}
+
+/// Resolve when `kind` is delivered. Installation failure (or stream
+/// exhaustion) logs and parks rather than resolving, for the same reason as
+/// [`wait_for_sigint`].
+#[cfg(unix)]
+async fn wait_for_unix_signal(kind: tokio::signal::unix::SignalKind, name: &'static str) {
+    match tokio::signal::unix::signal(kind) {
+        Ok(mut sig) => {
+            if sig.recv().await.is_none() {
+                tracing::error!(signal = name, "signal stream closed; exit arm disabled");
+                std::future::pending::<()>().await
+            }
+        }
+        Err(e) => {
+            tracing::error!(error = %e, signal = name, "failed to install signal handler; exit arm disabled");
+            std::future::pending::<()>().await
+        }
+    }
+}
+
+/// PID-handshake watch: resolve once the engine's declared pid stops
+/// existing. Immune to who our direct parent is.
+#[cfg(unix)]
+async fn wait_for_pid_exit(pid: i32, daemon: &'static str) {
+    tracing::info!(engine_pid = pid, daemon, "engine exit-watch armed");
+    loop {
+        tokio::time::sleep(ENGINE_POLL_INTERVAL).await;
+        if process_is_gone(pid) {
+            tracing::warn!(engine_pid = pid, daemon, "declared engine pid exited");
+            return;
+        }
+    }
+}
+
+/// Reparent-fallback watch: resolve once the spawn-time parent is gone —
+/// `getppid()` moved away from `initial` AND `initial` no longer exists.
+///
+/// If we were already orphaned at startup (ppid <= 1: init/launchd, or a
+/// container where the engine is PID 1), there is nothing meaningful to
+/// watch — the watch stays disarmed and the signal arms are the exits.
+#[cfg(unix)]
+async fn wait_for_reparent(initial: i32, daemon: &'static str) {
+    if initial <= 1 {
+        tracing::warn!(
+            ppid = initial,
+            daemon,
+            "parent exit-watch disarmed: no watchable spawn parent"
+        );
+        return std::future::pending::<()>().await;
+    }
+    tracing::info!(ppid = initial, daemon, "parent exit-watch armed");
+    loop {
+        tokio::time::sleep(ENGINE_POLL_INTERVAL).await;
+        let current = nix::unistd::getppid().as_raw();
+        if reparented_away(initial, current) && process_is_gone(initial) {
+            tracing::warn!(was = initial, now = current, daemon, "spawn parent exited");
+            return;
+        }
+    }
+}
+
+/// True when a fresh `getppid()` reading means we've been reparented away
+/// from the parent that spawned us. Pure so the subtle parts are pinned by
+/// tests: `initial <= 1` (no real parent at startup) never triggers, and we
+/// key off a CHANGE from the startup parent — NOT `current == 1` — so
+/// adoption by a subreaper rather than init still counts, and a daemon whose
+/// real parent stays alive never false-exits. Callers must additionally
+/// confirm the old parent is actually dead ([`process_is_gone`]) before
+/// acting.
+#[cfg(unix)]
+fn reparented_away(initial: i32, current: i32) -> bool {
+    initial > 1 && current != initial
+}
+
+/// Existence probe via `kill(pid, 0)`: true only on ESRCH (no such process).
+/// EPERM means the process exists but isn't ours — counts as alive.
+#[cfg(unix)]
+fn process_is_gone(pid: i32) -> bool {
+    matches!(
+        nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None),
+        Err(nix::errno::Errno::ESRCH)
+    )
+}
+
+/// Best-effort durable trace of an engine-gone self-exit (appends to
+/// `~/.iii/logs/<daemon>.log`). Every failure mode is silently ignored — the
+/// daemon is exiting either way.
+#[cfg(unix)]
+fn write_exit_breadcrumb(daemon: &str, engine_pid: Option<i32>, spawn_parent: i32) {
+    use std::io::Write;
+    let Some(home) = dirs::home_dir() else { return };
+    let dir = home.join(".iii/logs");
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let line = format!(
+        "ts={ts} daemon={daemon} self-exit reason=engine-gone engine_pid={} spawn_parent={spawn_parent}\n",
+        engine_pid.map_or_else(|| "none".to_string(), |p| p.to_string()),
+    );
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dir.join(format!("{daemon}.log")))
+    {
+        let _ = f.write_all(line.as_bytes());
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::{process_is_gone, reparented_away};
+
+    #[test]
+    fn reparent_detection_keys_on_change_not_pid_one() {
+        // Engine alive: ppid unchanged → keep running.
+        assert!(!reparented_away(12345, 12345));
+        // Engine died, adopted by launchd/init → exit.
+        assert!(reparented_away(12345, 1));
+        // Adopted by a subreaper (not init) → still a reparent → exit.
+        assert!(reparented_away(12345, 999));
+        // Started already orphaned (ppid 1) or unknown (0): nothing to watch,
+        // never exit on this signal — guards the in-process e2e harness and
+        // any daemon launched without a real parent.
+        assert!(!reparented_away(1, 1));
+        assert!(!reparented_away(1, 999));
+        assert!(!reparented_away(0, 1));
+    }
+
+    #[test]
+    fn process_is_gone_only_on_esrch() {
+        // Our own process and our own parent demonstrably exist.
+        assert!(!process_is_gone(std::process::id() as i32));
+        assert!(!process_is_gone(nix::unistd::getppid().as_raw()));
+        // PID 1 (launchd/init) always exists; we can't signal it → EPERM →
+        // counts as alive, never as gone.
+        assert!(!process_is_gone(1));
+        // A child we spawn and fully reap is guaranteed dead at probe time.
+        // (Its pid could in principle be recycled between reap and probe, in
+        // which case the probe correctly says "exists" — so don't assert the
+        // negative; just that the probe never panics.)
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = child.id() as i32;
+        child.wait().unwrap();
+        let _ = process_is_gone(pid);
+    }
+
+    /// Serializes the env-mutating tests below: `arm_at_startup` reads BOTH
+    /// env vars and `lifeline_fd_from_env` takes fd ownership, so unguarded
+    /// parallel runs could double-own an fd or see each other's vars.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn arm_at_startup_parses_engine_pid_env() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        unsafe { std::env::remove_var(super::LIFELINE_FD_ENV) };
+
+        unsafe { std::env::set_var(super::ENGINE_PID_ENV, "  4242 ") };
+        let watch = super::ExitWatch::arm_at_startup();
+        assert_eq!(watch.engine_pid, Some(4242));
+
+        unsafe { std::env::set_var(super::ENGINE_PID_ENV, "1") }; // <= 1 rejected
+        assert_eq!(super::ExitWatch::arm_at_startup().engine_pid, None);
+
+        unsafe { std::env::set_var(super::ENGINE_PID_ENV, "not-a-pid") };
+        assert_eq!(super::ExitWatch::arm_at_startup().engine_pid, None);
+
+        unsafe { std::env::remove_var(super::ENGINE_PID_ENV) };
+        assert_eq!(super::ExitWatch::arm_at_startup().engine_pid, None);
+    }
+
+    #[test]
+    fn lifeline_env_rejects_garbage_and_non_pipes() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        unsafe { std::env::remove_var(super::LIFELINE_FD_ENV) };
+        assert!(super::lifeline_fd_from_env().is_none());
+
+        // Stdio fd numbers are refused outright.
+        unsafe { std::env::set_var(super::LIFELINE_FD_ENV, "0") };
+        assert!(super::lifeline_fd_from_env().is_none());
+
+        // A live fd that is NOT a pipe (a regular file) is refused — a
+        // corrupt env must not turn "EOF on some file" into engine death.
+        let f = std::fs::File::open("/dev/null").unwrap();
+        let raw = std::os::fd::AsRawFd::as_raw_fd(&f);
+        unsafe { std::env::set_var(super::LIFELINE_FD_ENV, raw.to_string()) };
+        assert!(super::lifeline_fd_from_env().is_none());
+
+        // Closed/garbage fd numbers are refused.
+        unsafe { std::env::set_var(super::LIFELINE_FD_ENV, "9999") };
+        assert!(super::lifeline_fd_from_env().is_none());
+        // The var is scrubbed even on rejection (children must not inherit).
+        assert!(std::env::var(super::LIFELINE_FD_ENV).is_err());
+    }
+
+    #[test]
+    fn lifeline_accepts_pipe_and_sees_eof_when_writer_drops() {
+        use std::os::fd::IntoRawFd;
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        let (read, write) = nix::unistd::pipe().unwrap();
+        // Hand the raw number over as "inherited" — lifeline_fd_from_env
+        // takes ownership, so release ours first.
+        let raw = read.into_raw_fd();
+        unsafe { std::env::set_var(super::LIFELINE_FD_ENV, raw.to_string()) };
+        let owned = super::lifeline_fd_from_env().expect("pipe read end accepted");
+        // Env scrubbed so OUR children can't inherit the lifeline.
+        assert!(std::env::var(super::LIFELINE_FD_ENV).is_err());
+
+        // EOF only after the write end drops.
+        let watcher = std::thread::spawn(move || super::blocking_wait_lifeline_eof(owned));
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        assert!(!watcher.is_finished(), "no EOF while the writer is alive");
+        drop(write);
+        assert!(
+            watcher.join().unwrap(),
+            "dropping the write end must read as EOF (spawner gone)"
+        );
+    }
+}

--- a/crates/iii-worker/src/lib.rs
+++ b/crates/iii-worker/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod cli;
 pub mod core;
+pub mod daemon_exit;
 pub mod sandbox_daemon;
 
 pub use cli::app::{

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -532,12 +532,27 @@ async fn async_main() -> anyhow::Result<()> {
         Commands::WatchSource(args) => {
             let project = std::path::PathBuf::from(&args.project);
             let worker = args.worker.clone();
-            iii_worker::cli::source_watcher::watch_and_restart(
+            let watch = iii_worker::cli::source_watcher::watch_and_restart(
                 worker,
                 project,
                 iii_worker::cli::source_watcher::restart_via_cli,
-            )
-            .await?;
+            );
+            // Engine anchor: the watcher sidecar must not outlive the engine
+            // that (transitively) spawned it — `killall -9 iii` previously
+            // left one per dev worker running forever.
+            match iii_worker::daemon_exit::engine_pid_from_env() {
+                Some(pid) => {
+                    tokio::select! {
+                        r = watch => { r?; }
+                        _ = tokio::task::spawn_blocking(move || {
+                            iii_worker::daemon_exit::blocking_wait_pid_gone(pid)
+                        }) => {
+                            eprintln!("watch-source: engine pid {pid} exited; stopping");
+                        }
+                    }
+                }
+                None => watch.await?,
+            }
             0
         }
     };

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -7,8 +7,20 @@
 use clap::{CommandFactory, FromArgMatches};
 use iii_worker::{Cli, Commands};
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
+    // FIRST, before the tokio runtime spawns worker threads: capture (and
+    // scrub from the env) any inherited lifeline facts. The capture mutates
+    // the process environment, which is only sound while single-threaded —
+    // see daemon_exit::capture_early.
+    iii_worker::daemon_exit::capture_early();
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(async_main())
+}
+
+async fn async_main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()

--- a/crates/iii-worker/src/sandbox_daemon/adapters.rs
+++ b/crates/iii-worker/src/sandbox_daemon/adapters.rs
@@ -215,6 +215,13 @@ impl VmLauncher for IiiWorkerLauncher {
             ))
         })?;
 
+        // Lifeline: the registry entry will hold the write end; if this
+        // daemon dies (any way, SIGKILL included) or the sandbox entry is
+        // dropped, the VM's __vm-boot watcher sees EOF and self-terminates —
+        // VMs no longer outlive the daemon as orphaned session leaders.
+        let lifeline = crate::daemon_exit::attach_lifeline(&mut cmd)
+            .map_err(|e| SandboxError::BootFailed(format!("lifeline pipe: {e}")))?;
+
         let t_spawn = Instant::now();
         let child = cmd
             .stdout(std::process::Stdio::null())
@@ -309,7 +316,10 @@ impl VmLauncher for IiiWorkerLauncher {
             "boot_phase: shell_sock_wait (boot total)"
         );
 
-        Ok(BootHandle { vm_pid })
+        Ok(BootHandle {
+            vm_pid,
+            lifeline: Some(std::sync::Arc::new(lifeline)),
+        })
     }
 }
 

--- a/crates/iii-worker/src/sandbox_daemon/create.rs
+++ b/crates/iii-worker/src/sandbox_daemon/create.rs
@@ -81,6 +81,12 @@ pub struct BootParams {
 
 pub struct BootHandle {
     pub vm_pid: u32,
+    /// Spawner-side write end of the VM's lifeline pipe. Held by the
+    /// sandbox's registry entry: if this daemon dies (any way, SIGKILL
+    /// included) or the entry is dropped, the kernel/Drop closes it and the
+    /// `__vm-boot` process self-terminates instead of living on as an
+    /// orphaned session leader holding a multi-GB VM.
+    pub lifeline: Option<std::sync::Arc<crate::daemon_exit::Lifeline>>,
 }
 
 pub async fn handle_create<L: VmLauncher, F: FnMut(SandboxCreateEvent) + Send + 'static>(
@@ -197,6 +203,7 @@ pub async fn handle_create<L: VmLauncher, F: FnMut(SandboxCreateEvent) + Send + 
         workdir,
         shell_sock,
         vm_pid: Some(boot.vm_pid),
+        lifeline: boot.lifeline,
         created_at: Instant::now(),
         last_exec_at: Instant::now(),
         exec_in_progress: false,
@@ -236,6 +243,7 @@ mod tests {
         async fn boot(&self, _p: &BootParams) -> Result<BootHandle, SandboxError> {
             Ok(BootHandle {
                 vm_pid: self.vm_pid,
+                lifeline: None,
             })
         }
     }

--- a/crates/iii-worker/src/sandbox_daemon/exec.rs
+++ b/crates/iii-worker/src/sandbox_daemon/exec.rs
@@ -299,6 +299,7 @@ mod tests {
             workdir: PathBuf::from("/tmp/w"),
             shell_sock: PathBuf::from("/tmp/s"),
             vm_pid: Some(1),
+            lifeline: None,
             created_at: Instant::now(),
             last_exec_at: Instant::now(),
             exec_in_progress: false,

--- a/crates/iii-worker/src/sandbox_daemon/fs/chmod.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/chmod.rs
@@ -160,6 +160,7 @@ mod tests {
             workdir: PathBuf::from("/tmp/w"),
             shell_sock: PathBuf::from("/tmp/s"),
             vm_pid: Some(1),
+            lifeline: None,
             created_at: Instant::now(),
             last_exec_at: Instant::now(),
             exec_in_progress: false,

--- a/crates/iii-worker/src/sandbox_daemon/fs/grep.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/grep.rs
@@ -192,6 +192,7 @@ mod tests {
             workdir: PathBuf::from("/tmp/w"),
             shell_sock: PathBuf::from("/tmp/s"),
             vm_pid: Some(1),
+            lifeline: None,
             created_at: Instant::now(),
             last_exec_at: Instant::now(),
             exec_in_progress: false,

--- a/crates/iii-worker/src/sandbox_daemon/fs/ls.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/ls.rs
@@ -143,6 +143,7 @@ mod tests {
             workdir: PathBuf::from("/tmp/w"),
             shell_sock: PathBuf::from("/tmp/s"),
             vm_pid: Some(1),
+            lifeline: None,
             created_at: Instant::now(),
             last_exec_at: Instant::now(),
             exec_in_progress: false,

--- a/crates/iii-worker/src/sandbox_daemon/fs/mkdir.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/mkdir.rs
@@ -158,6 +158,7 @@ mod tests {
             workdir: PathBuf::from("/tmp/w"),
             shell_sock: PathBuf::from("/tmp/s"),
             vm_pid: Some(1),
+            lifeline: None,
             created_at: Instant::now(),
             last_exec_at: Instant::now(),
             exec_in_progress: false,

--- a/crates/iii-worker/src/sandbox_daemon/fs/mv.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/mv.rs
@@ -153,6 +153,7 @@ mod tests {
             workdir: PathBuf::from("/tmp/w"),
             shell_sock: PathBuf::from("/tmp/s"),
             vm_pid: Some(1),
+            lifeline: None,
             created_at: Instant::now(),
             last_exec_at: Instant::now(),
             exec_in_progress: false,

--- a/crates/iii-worker/src/sandbox_daemon/fs/rm.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/rm.rs
@@ -149,6 +149,7 @@ mod tests {
             workdir: PathBuf::from("/tmp/w"),
             shell_sock: PathBuf::from("/tmp/s"),
             vm_pid: Some(1),
+            lifeline: None,
             created_at: Instant::now(),
             last_exec_at: Instant::now(),
             exec_in_progress: false,

--- a/crates/iii-worker/src/sandbox_daemon/fs/sed.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/sed.rs
@@ -222,6 +222,7 @@ mod tests {
             workdir: PathBuf::from("/tmp/w"),
             shell_sock: PathBuf::from("/tmp/s"),
             vm_pid: Some(1),
+            lifeline: None,
             created_at: Instant::now(),
             last_exec_at: Instant::now(),
             exec_in_progress: false,

--- a/crates/iii-worker/src/sandbox_daemon/fs/stat.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/stat.rs
@@ -161,6 +161,7 @@ mod tests {
             workdir: PathBuf::from("/tmp/w"),
             shell_sock: PathBuf::from("/tmp/s"),
             vm_pid: Some(1),
+            lifeline: None,
             created_at: Instant::now(),
             last_exec_at: Instant::now(),
             exec_in_progress: false,

--- a/crates/iii-worker/src/sandbox_daemon/fs/write.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/write.rs
@@ -397,6 +397,7 @@ mod tests {
             workdir: PathBuf::from("/tmp/w"),
             shell_sock: PathBuf::from("/tmp/s"),
             vm_pid: Some(1),
+            lifeline: None,
             created_at: Instant::now(),
             last_exec_at: Instant::now(),
             exec_in_progress: false,

--- a/crates/iii-worker/src/sandbox_daemon/list.rs
+++ b/crates/iii-worker/src/sandbox_daemon/list.rs
@@ -59,6 +59,7 @@ mod tests {
             workdir: PathBuf::new(),
             shell_sock: PathBuf::new(),
             vm_pid: Some(1),
+            lifeline: None,
             created_at: Instant::now(),
             last_exec_at: Instant::now(),
             exec_in_progress: false,

--- a/crates/iii-worker/src/sandbox_daemon/mod.rs
+++ b/crates/iii-worker/src/sandbox_daemon/mod.rs
@@ -110,6 +110,12 @@ use crate::sandbox_daemon::config::SandboxConfig;
 use crate::sandbox_daemon::errors::SandboxErrorWire;
 
 pub async fn serve(config: SandboxConfig, engine_url: &str) -> anyhow::Result<()> {
+    // FIRST statement, before any await: snapshot spawn-time facts for the
+    // engine-death watch (see crate::daemon_exit). Without it this daemon had
+    // the same orphan leak as worker-manager-daemon — worse, an orphaned
+    // sandbox-daemon keeps live libkrun VMs around.
+    let exit_watch = crate::daemon_exit::ExitWatch::arm_at_startup();
+
     tracing::info!(url = %engine_url, "connecting to III engine");
     // Identify ourselves as `iii-sandbox` so the engine surfaces this
     // worker by its config-yaml name (and not the auto-detected
@@ -178,8 +184,14 @@ pub async fn serve(config: SandboxConfig, engine_url: &str) -> anyhow::Result<()
     }
 
     tracing::info!("sandbox-daemon ready");
-    tokio::signal::ctrl_c().await?;
-    tracing::info!("sandbox-daemon shutting down");
+    // Exit on SIGINT/SIGTERM/SIGHUP or engine death — see crate::daemon_exit.
+    // Previously this parked on bare ctrl_c(): the engine's kill_child SIGTERM
+    // killed it via default disposition, and an abnormal engine exit leaked it
+    // as a reconnect-looping orphan holding live VMs. VM teardown on exit is
+    // unchanged (the reaper/registry semantics are their own concern); this
+    // closes the daemon-leak layer.
+    let reason = exit_watch.wait("sandbox-daemon").await;
+    tracing::info!(reason, "sandbox-daemon shutting down");
     iii.shutdown_async().await;
     Ok(())
 }

--- a/crates/iii-worker/src/sandbox_daemon/reaper.rs
+++ b/crates/iii-worker/src/sandbox_daemon/reaper.rs
@@ -61,6 +61,7 @@ mod tests {
             workdir: PathBuf::new(),
             shell_sock: PathBuf::new(),
             vm_pid: Some(1),
+            lifeline: None,
             created_at: past,
             last_exec_at: past,
             exec_in_progress: false,

--- a/crates/iii-worker/src/sandbox_daemon/registry.rs
+++ b/crates/iii-worker/src/sandbox_daemon/registry.rs
@@ -18,6 +18,11 @@ pub struct SandboxState {
     pub workdir: PathBuf,
     pub shell_sock: PathBuf,
     pub vm_pid: Option<u32>,
+    /// Write end of the VM's lifeline pipe (see `daemon_exit::Lifeline`).
+    /// While any clone of this state is alive the VM keeps running; once the
+    /// entry is dropped — or this whole daemon dies, however abruptly — the
+    /// pipe closes and `__vm-boot` self-terminates.
+    pub lifeline: Option<std::sync::Arc<crate::daemon_exit::Lifeline>>,
     pub created_at: Instant,
     pub last_exec_at: Instant,
     pub exec_in_progress: bool,
@@ -120,6 +125,7 @@ mod tests {
             workdir: PathBuf::from("/tmp/work"),
             shell_sock: PathBuf::from("/tmp/sock"),
             vm_pid: Some(1234),
+            lifeline: None,
             created_at: Instant::now(),
             last_exec_at: Instant::now(),
             exec_in_progress: false,

--- a/crates/iii-worker/src/sandbox_daemon/stop.rs
+++ b/crates/iii-worker/src/sandbox_daemon/stop.rs
@@ -83,6 +83,7 @@ mod tests {
             workdir: PathBuf::from("/tmp/w"),
             shell_sock: PathBuf::from("/tmp/s"),
             vm_pid: Some(1234),
+            lifeline: None,
             created_at: Instant::now(),
             last_exec_at: Instant::now(),
             exec_in_progress: false,

--- a/crates/iii-worker/tests/common/sandbox_fakes.rs
+++ b/crates/iii-worker/tests/common/sandbox_fakes.rs
@@ -287,10 +287,10 @@ impl VmLauncher for FakeVmLauncher {
             )
         });
         match mode {
-            LaunchMode::Ok { vm_pid } => Ok(BootHandle { vm_pid }),
+            LaunchMode::Ok { vm_pid } => Ok(BootHandle { vm_pid, lifeline: None }),
             LaunchMode::Err(e) => Err(e),
             LaunchMode::Block { release } => match release.await {
-                Ok(LaunchMode::Ok { vm_pid }) => Ok(BootHandle { vm_pid }),
+                Ok(LaunchMode::Ok { vm_pid }) => Ok(BootHandle { vm_pid, lifeline: None }),
                 Ok(LaunchMode::Err(e)) => Err(e),
                 Ok(LaunchMode::Block { .. }) => Err(SandboxError::BootFailed(
                     "FakeVmLauncher: nested Block is not supported".into(),

--- a/crates/iii-worker/tests/common/sandbox_fakes.rs
+++ b/crates/iii-worker/tests/common/sandbox_fakes.rs
@@ -287,10 +287,16 @@ impl VmLauncher for FakeVmLauncher {
             )
         });
         match mode {
-            LaunchMode::Ok { vm_pid } => Ok(BootHandle { vm_pid, lifeline: None }),
+            LaunchMode::Ok { vm_pid } => Ok(BootHandle {
+                vm_pid,
+                lifeline: None,
+            }),
             LaunchMode::Err(e) => Err(e),
             LaunchMode::Block { release } => match release.await {
-                Ok(LaunchMode::Ok { vm_pid }) => Ok(BootHandle { vm_pid, lifeline: None }),
+                Ok(LaunchMode::Ok { vm_pid }) => Ok(BootHandle {
+                    vm_pid,
+                    lifeline: None,
+                }),
                 Ok(LaunchMode::Err(e)) => Err(e),
                 Ok(LaunchMode::Block { .. }) => Err(SandboxError::BootFailed(
                     "FakeVmLauncher: nested Block is not supported".into(),

--- a/crates/iii-worker/tests/daemon_orphan_exit_integration.rs
+++ b/crates/iii-worker/tests/daemon_orphan_exit_integration.rs
@@ -359,6 +359,123 @@ fn daemon_survives_orphaning_when_declared_engine_alive() {
     // ProcGuard::drop kills the (intentionally surviving) daemon.
 }
 
+/// Engine anchor for the `__watch-source` sidecar: with III_ENGINE_PID
+/// declared, the watcher must exit when that pid dies — a real
+/// `killall -9 iii` previously left one watcher per dev worker running
+/// forever (their direct spawner is transient, so reparenting tells them
+/// nothing).
+#[test]
+fn watch_source_exits_when_engine_pid_dies() {
+    let bin = env!("CARGO_BIN_EXE_iii-worker");
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("proj");
+    std::fs::create_dir(&project).unwrap();
+
+    let mut fake_engine = Command::new("sleep")
+        .arg("300")
+        .spawn()
+        .expect("spawn fake engine");
+    let engine_pid = fake_engine.id() as i32;
+
+    let logfile = tmp.path().join("watcher.log");
+    let log = std::fs::File::create(&logfile).unwrap();
+    let log_err = log.try_clone().unwrap();
+    let mut watcher = Command::new(bin)
+        .args(["__watch-source", "--worker", "w", "--project"])
+        .arg(&project)
+        .env("RUST_LOG", "info")
+        .env("HOME", tmp.path())
+        .env("III_ENGINE_PID", engine_pid.to_string())
+        .stdout(std::process::Stdio::from(log))
+        .stderr(std::process::Stdio::from(log_err))
+        .spawn()
+        .expect("spawn watcher");
+
+    // Alive while the declared engine is alive.
+    std::thread::sleep(ARMED_SURVIVAL_WINDOW);
+    if watcher.try_wait().expect("try_wait").is_some() {
+        let _ = fake_engine.kill();
+        let log = std::fs::read_to_string(&logfile).unwrap_or_default();
+        panic!("watcher exited while its engine was alive; log:\n{log}");
+    }
+
+    let _ = fake_engine.kill();
+    let _ = fake_engine.wait();
+
+    let deadline = Instant::now() + EXIT_DEADLINE;
+    let status = loop {
+        if let Some(s) = watcher.try_wait().expect("try_wait") {
+            break s;
+        }
+        if Instant::now() >= deadline {
+            let _ = watcher.kill();
+            let log = std::fs::read_to_string(&logfile).unwrap_or_default();
+            panic!("watcher ignored engine death; log:\n{log}");
+        }
+        std::thread::sleep(PROBE_INTERVAL);
+    };
+    assert_eq!(status.code(), Some(0), "engine-gone watcher exit is graceful");
+}
+
+/// Session-reaper wiring: on engine-gone the daemon must run the
+/// reap-managed-workers pass (observable via its log line) before exiting —
+/// this is what kills VMs, watcher sidecars, and binary workers that the
+/// dead engine started.
+#[test]
+fn daemon_reaps_managed_workers_on_engine_gone() {
+    let bin = env!("CARGO_BIN_EXE_iii-worker");
+    let tmp = tempfile::tempdir().unwrap();
+    let logfile = tmp.path().join("daemon.log");
+
+    let mut fake_engine = Command::new("sleep")
+        .arg("300")
+        .spawn()
+        .expect("spawn fake engine");
+    let engine_pid = fake_engine.id() as i32;
+
+    let log = std::fs::File::create(&logfile).unwrap();
+    let log_err = log.try_clone().unwrap();
+    let mut daemon = Command::new(bin)
+        .args(["worker-manager-daemon", "--engine", "ws://127.0.0.1:1"])
+        .current_dir(tmp.path()) // empty project: zero workers to reap
+        .env("RUST_LOG", "info")
+        .env("HOME", tmp.path())
+        .env("III_ENGINE_PID", engine_pid.to_string())
+        .stdout(std::process::Stdio::from(log))
+        .stderr(std::process::Stdio::from(log_err))
+        .spawn()
+        .expect("spawn daemon");
+
+    let (armed, log) =
+        wait_for_log_line(&logfile, "engine exit-watch armed", Duration::from_secs(10));
+    if !armed {
+        let _ = daemon.kill();
+        let _ = fake_engine.kill();
+        panic!("daemon never armed; log:\n{log}");
+    }
+
+    let _ = fake_engine.kill();
+    let _ = fake_engine.wait();
+
+    let deadline = Instant::now() + EXIT_DEADLINE;
+    loop {
+        if daemon.try_wait().expect("try_wait").is_some() {
+            break;
+        }
+        if Instant::now() >= deadline {
+            let _ = daemon.kill();
+            let final_log = std::fs::read_to_string(&logfile).unwrap_or_default();
+            panic!("daemon ignored engine death; log:\n{final_log}");
+        }
+        std::thread::sleep(PROBE_INTERVAL);
+    }
+    let final_log = std::fs::read_to_string(&logfile).unwrap_or_default();
+    assert!(
+        final_log.contains("reaping managed workers"),
+        "engine-gone exit must run the reaper; log:\n{final_log}"
+    );
+}
+
 /// The engine's kill_child sends SIGTERM; SIGINT is the hand-run Ctrl-C path.
 /// Both must exit GRACEFULLY through wait_for_exit (process exits with code
 /// 0). Pre-fix, SIGTERM killed via default disposition: terminated-by-signal,

--- a/crates/iii-worker/tests/daemon_orphan_exit_integration.rs
+++ b/crates/iii-worker/tests/daemon_orphan_exit_integration.rs
@@ -1,0 +1,420 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Regression tests for the orphaned `worker-manager-daemon` leak and its
+//! graceful-exit paths.
+//!
+//! The engine spawns the daemon in its own session (setsid), so an engine that
+//! exits abnormally (SIGKILL, OOM, crash, dev hard-restart) used to leave the
+//! daemon with no signal at all — it reconnect-looped forever as an orphan
+//! (PPID 1), and every engine restart leaked another. The fix makes the daemon
+//! watch for losing the parent that spawned it and exit on its own, and adds
+//! SIGTERM/SIGHUP graceful exits (the engine's kill_child sends SIGTERM, which
+//! previously killed the daemon via default disposition).
+//!
+//! `daemon_exits_when_orphaned_from_engine` reproduces the leak with a real
+//! daemon process: an intermediate `sh` becomes the daemon's parent, then we
+//! kill `sh` to orphan the daemon and assert it exits on its own. Without the
+//! fix it runs forever and this times out. Readiness is gated on the daemon's
+//! own "parent exit-watch armed" log line (not a blind sleep), and the daemon
+//! must demonstrably SURVIVE at least one armed poll while its parent is alive
+//! before we orphan it — so a false-positive exit reads as a failure instead
+//! of being mistaken for the expected one.
+
+#![cfg(unix)]
+
+use std::path::Path;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use nix::sys::signal::{Signal, kill};
+use nix::unistd::Pid;
+
+/// Sized against the daemon's REPARENT_POLL_INTERVAL (2s): generous for
+/// loaded CI runners, far below the suite timeout.
+const EXIT_DEADLINE: Duration = Duration::from_secs(15);
+const PROBE_INTERVAL: Duration = Duration::from_millis(200);
+/// One full daemon poll interval plus slack — long enough that at least one
+/// armed `getppid()` poll completes with the parent alive.
+const ARMED_SURVIVAL_WINDOW: Duration = Duration::from_millis(2500);
+
+/// Liveness probe via `kill(pid, 0)` — no subprocess per poll.
+fn pid_alive(pid: i32) -> bool {
+    kill(Pid::from_raw(pid), None).is_ok()
+}
+
+/// True when `pid` currently belongs to an iii-worker process. Guards the
+/// failure-path SIGKILL (and final diagnostics) against PID reuse hitting an
+/// unrelated same-user process.
+fn pid_is_iii_worker(pid: i32) -> bool {
+    Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "comm="])
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).contains("iii-worker"))
+        .unwrap_or(false)
+}
+
+/// Kills the intermediate `sh` and (identity-checked) the daemon on EVERY
+/// exit path, including assertion panics — `std::process::Child` does not
+/// kill on drop, and a leaked daemon here reconnect-loops forever.
+struct ProcGuard {
+    sh: std::process::Child,
+    daemon_pid: Option<i32>,
+}
+
+impl Drop for ProcGuard {
+    fn drop(&mut self) {
+        if let Some(pid) = self.daemon_pid
+            && pid > 1
+            && pid_is_iii_worker(pid)
+        {
+            let _ = kill(Pid::from_raw(pid), Signal::SIGKILL);
+        }
+        let _ = self.sh.kill();
+        let _ = self.sh.wait();
+    }
+}
+
+/// Poll `logfile` until it contains `needle` or `deadline` passes. Returns
+/// the log contents either way so failures carry diagnostics.
+fn wait_for_log_line(logfile: &Path, needle: &str, deadline: Duration) -> (bool, String) {
+    let end = Instant::now() + deadline;
+    loop {
+        let contents = std::fs::read_to_string(logfile).unwrap_or_default();
+        if contents.contains(needle) {
+            return (true, contents);
+        }
+        if Instant::now() >= end {
+            return (false, contents);
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[test]
+fn daemon_exits_when_orphaned_from_engine() {
+    let bin = env!("CARGO_BIN_EXE_iii-worker");
+    let tmp = tempfile::tempdir().unwrap();
+    let pidfile = tmp.path().join("daemon.pid");
+    let logfile = tmp.path().join("daemon.log");
+
+    // Intermediate `sh` backgrounds the daemon (so the daemon's parent is sh,
+    // not the test runner) and then `wait`s, staying alive until we kill it.
+    // Paths travel via the environment, not string interpolation — no shell
+    // quoting surface, and paths containing quotes or spaces still work. The
+    // engine URL points at a dead port so the daemon just reconnect-loops.
+    // RUST_LOG=info makes the daemon's readiness/armed lines observable in
+    // $DAEMON_LOG (the default filter is warn).
+    // env_remove: this test exercises the REPARENT FALLBACK, which only arms
+    // when no engine pid was declared (a real engine sets III_ENGINE_PID).
+    let sh = Command::new("sh")
+        .arg("-c")
+        .arg(r#""$DAEMON_BIN" worker-manager-daemon --engine ws://127.0.0.1:1 >>"$DAEMON_LOG" 2>&1 & echo $! > "$DAEMON_PIDFILE"; wait"#)
+        .env("DAEMON_BIN", bin)
+        .env("DAEMON_PIDFILE", &pidfile)
+        .env("DAEMON_LOG", &logfile)
+        .env("RUST_LOG", "info")
+        .env("HOME", tmp.path())
+        .env_remove("III_ENGINE_PID")
+        .spawn()
+        .expect("spawn intermediate sh");
+    let mut guard = ProcGuard {
+        sh,
+        daemon_pid: None,
+    };
+
+    // Read the daemon's pid once sh has launched it. Reject pid <= 1 so a
+    // corrupt pidfile can never aim the probes (or the guard's SIGKILL) at
+    // init or the whole session.
+    let daemon_pid = {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Ok(s) = std::fs::read_to_string(&pidfile)
+                && let Ok(pid) = s.trim().parse::<i32>()
+                && pid > 1
+            {
+                break pid;
+            }
+            assert!(Instant::now() < deadline, "daemon never wrote its pid");
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    };
+    guard.daemon_pid = Some(daemon_pid);
+
+    // Deterministic readiness: wait for the daemon's own log line proving it
+    // snapshotted its parent and armed the watch WHILE sh was still alive —
+    // no blind startup sleep, no arming race under CI load.
+    let (armed, log) = wait_for_log_line(&logfile, "parent exit-watch armed", Duration::from_secs(10));
+    assert!(armed, "daemon never armed its exit watch; log:\n{log}");
+
+    // Negative path: with its parent alive, the daemon must SURVIVE at least
+    // one full armed poll interval — a watch that false-fires on the first
+    // poll must fail here, not be mistaken for the expected exit below.
+    std::thread::sleep(ARMED_SURVIVAL_WINDOW);
+    assert!(
+        pid_alive(daemon_pid),
+        "daemon exited while its parent was still alive (false-positive watch)"
+    );
+
+    // Orphan it: SIGKILL only the intermediate sh. The daemon is a separate
+    // child, so it survives and is reparented to init/launchd — exactly the
+    // production scenario where the engine dies without killing the daemon.
+    let _ = guard.sh.kill();
+    let _ = guard.sh.wait();
+
+    // The fix must make the daemon notice the lost parent and exit on its own.
+    let deadline = Instant::now() + EXIT_DEADLINE;
+    let exited = loop {
+        if !pid_alive(daemon_pid) {
+            break true;
+        }
+        if Instant::now() >= deadline {
+            break false;
+        }
+        std::thread::sleep(PROBE_INTERVAL);
+    };
+
+    let final_log = std::fs::read_to_string(&logfile).unwrap_or_default();
+    assert!(
+        exited,
+        "orphaned daemon did not self-exit within {EXIT_DEADLINE:?} — the leak regressed; log:\n{final_log}"
+    );
+    // ProcGuard::drop still runs (identity-checked no-op for the dead daemon).
+}
+
+/// Lifeline path: with a lifeline pipe attached (what the engine actually
+/// does at spawn), dropping the spawner-side handle must make the daemon
+/// exit gracefully — the EOF is instant, no poll interval involved. The
+/// daemon's direct parent (this test) stays alive throughout, so neither
+/// the reparent fallback nor a signal can be the cause.
+#[test]
+fn daemon_exits_when_lifeline_drops() {
+    let bin = env!("CARGO_BIN_EXE_iii-worker");
+    let tmp = tempfile::tempdir().unwrap();
+    let logfile = tmp.path().join("daemon.log");
+
+    let log = std::fs::File::create(&logfile).unwrap();
+    let log_err = log.try_clone().unwrap();
+    let mut cmd = Command::new(bin);
+    cmd.args(["worker-manager-daemon", "--engine", "ws://127.0.0.1:1"])
+        .env("RUST_LOG", "info")
+        .env("HOME", tmp.path())
+        .env_remove("III_ENGINE_PID")
+        .stdout(std::process::Stdio::from(log))
+        .stderr(std::process::Stdio::from(log_err));
+    let lifeline =
+        iii_worker::daemon_exit::attach_lifeline_std(&mut cmd).expect("attach lifeline");
+    let mut daemon = cmd.spawn().expect("spawn daemon");
+
+    let (armed, log) =
+        wait_for_log_line(&logfile, "lifeline exit-watch armed", Duration::from_secs(10));
+    if !armed {
+        let _ = daemon.kill();
+        panic!("daemon never armed the lifeline watch; log:\n{log}");
+    }
+
+    // Held lifeline → daemon must keep running.
+    std::thread::sleep(Duration::from_millis(500));
+    assert!(
+        daemon.try_wait().expect("try_wait").is_none(),
+        "daemon exited while the lifeline was held"
+    );
+
+    // Drop the spawner-side handle: the daemon's read sees EOF instantly.
+    drop(lifeline);
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let status = loop {
+        if let Some(s) = daemon.try_wait().expect("try_wait") {
+            break s;
+        }
+        if Instant::now() >= deadline {
+            let _ = daemon.kill();
+            let final_log = std::fs::read_to_string(&logfile).unwrap_or_default();
+            panic!("daemon ignored lifeline EOF; log:\n{final_log}");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    assert_eq!(status.code(), Some(0), "lifeline exit must be graceful");
+}
+
+/// PID-handshake path: with III_ENGINE_PID declared, the daemon must exit
+/// when THAT pid dies — even though its direct parent (this test) stays
+/// alive. This is the production engine contract (engine/src/workers/
+/// external.rs exports the env), and it is what makes the watch immune to
+/// wrappers/shims sitting between the engine and the daemon.
+#[test]
+fn daemon_exits_when_declared_engine_pid_dies() {
+    let bin = env!("CARGO_BIN_EXE_iii-worker");
+    let tmp = tempfile::tempdir().unwrap();
+    let logfile = tmp.path().join("daemon.log");
+
+    // Fake engine: a sleeper we control. Killed below to simulate engine death.
+    let mut fake_engine = Command::new("sleep")
+        .arg("300")
+        .spawn()
+        .expect("spawn fake engine");
+    let engine_pid = fake_engine.id() as i32;
+
+    let log = std::fs::File::create(&logfile).unwrap();
+    let log_err = log.try_clone().unwrap();
+    let mut daemon = Command::new(bin)
+        .args(["worker-manager-daemon", "--engine", "ws://127.0.0.1:1"])
+        .env("RUST_LOG", "info")
+        .env("HOME", tmp.path())
+        .env("III_ENGINE_PID", engine_pid.to_string())
+        .stdout(std::process::Stdio::from(log))
+        .stderr(std::process::Stdio::from(log_err))
+        .spawn()
+        .expect("spawn daemon");
+
+    let (armed, log) =
+        wait_for_log_line(&logfile, "engine exit-watch armed", Duration::from_secs(10));
+    if !armed {
+        let _ = daemon.kill();
+        let _ = fake_engine.kill();
+        panic!("daemon never armed the engine-pid watch; log:\n{log}");
+    }
+
+    // Kill the declared engine. The daemon's parent (this test) stays alive,
+    // so only the handshake can trigger the exit.
+    let _ = fake_engine.kill();
+    let _ = fake_engine.wait();
+
+    let deadline = Instant::now() + EXIT_DEADLINE;
+    let status = loop {
+        if let Some(s) = daemon.try_wait().expect("try_wait") {
+            break s;
+        }
+        if Instant::now() >= deadline {
+            let _ = daemon.kill();
+            let final_log = std::fs::read_to_string(&logfile).unwrap_or_default();
+            panic!("daemon ignored declared engine death; log:\n{final_log}");
+        }
+        std::thread::sleep(PROBE_INTERVAL);
+    };
+    assert_eq!(status.code(), Some(0), "engine-gone exit must be graceful");
+}
+
+/// Handshake precedence: a daemon whose declared engine is ALIVE must
+/// survive losing its direct parent — a wrapper/shim exiting is not engine
+/// death. (The reparent fallback would have exited here; the handshake must
+/// win.)
+#[test]
+fn daemon_survives_orphaning_when_declared_engine_alive() {
+    let bin = env!("CARGO_BIN_EXE_iii-worker");
+    let tmp = tempfile::tempdir().unwrap();
+    let pidfile = tmp.path().join("daemon.pid");
+    let logfile = tmp.path().join("daemon.log");
+
+    // Declared engine = this test process (alive throughout).
+    let sh = Command::new("sh")
+        .arg("-c")
+        .arg(r#""$DAEMON_BIN" worker-manager-daemon --engine ws://127.0.0.1:1 >>"$DAEMON_LOG" 2>&1 & echo $! > "$DAEMON_PIDFILE"; wait"#)
+        .env("DAEMON_BIN", bin)
+        .env("DAEMON_PIDFILE", &pidfile)
+        .env("DAEMON_LOG", &logfile)
+        .env("RUST_LOG", "info")
+        .env("HOME", tmp.path())
+        .env("III_ENGINE_PID", std::process::id().to_string())
+        .spawn()
+        .expect("spawn intermediate sh");
+    let mut guard = ProcGuard {
+        sh,
+        daemon_pid: None,
+    };
+
+    let daemon_pid = {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Ok(s) = std::fs::read_to_string(&pidfile)
+                && let Ok(pid) = s.trim().parse::<i32>()
+                && pid > 1
+            {
+                break pid;
+            }
+            assert!(Instant::now() < deadline, "daemon never wrote its pid");
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    };
+    guard.daemon_pid = Some(daemon_pid);
+
+    let (armed, log) =
+        wait_for_log_line(&logfile, "engine exit-watch armed", Duration::from_secs(10));
+    assert!(armed, "daemon never armed the engine-pid watch; log:\n{log}");
+
+    // Orphan the daemon (kill its direct parent). The declared engine (us)
+    // is alive, so the daemon must keep running through multiple polls.
+    let _ = guard.sh.kill();
+    let _ = guard.sh.wait();
+
+    std::thread::sleep(ARMED_SURVIVAL_WINDOW);
+    assert!(
+        pid_alive(daemon_pid),
+        "daemon exited on parent loss despite its declared engine being alive"
+    );
+    // ProcGuard::drop kills the (intentionally surviving) daemon.
+}
+
+/// The engine's kill_child sends SIGTERM; SIGINT is the hand-run Ctrl-C path.
+/// Both must exit GRACEFULLY through wait_for_exit (process exits with code
+/// 0). Pre-fix, SIGTERM killed via default disposition: terminated-by-signal,
+/// status.code() == None — which is exactly what this asserts against.
+#[test]
+fn daemon_exits_gracefully_on_sigterm_and_sigint() {
+    for sig in [Signal::SIGTERM, Signal::SIGINT] {
+        let bin = env!("CARGO_BIN_EXE_iii-worker");
+        let tmp = tempfile::tempdir().unwrap();
+        let logfile = tmp.path().join("daemon.log");
+
+        // Direct child: its parent (this test) stays alive, so the reparent
+        // watch arms but must never fire — the signal is the only exit.
+        // tracing_subscriber::fmt() writes to STDOUT, so both streams go to
+        // the logfile.
+        let log = std::fs::File::create(&logfile).unwrap();
+        let log_err = log.try_clone().unwrap();
+        let mut daemon = Command::new(bin)
+            .args(["worker-manager-daemon", "--engine", "ws://127.0.0.1:1"])
+            .env("RUST_LOG", "info")
+            .env("HOME", tmp.path())
+            .env_remove("III_ENGINE_PID")
+            .stdout(std::process::Stdio::from(log))
+            .stderr(std::process::Stdio::from(log_err))
+            .spawn()
+            .expect("spawn daemon");
+        let pid = daemon.id() as i32;
+
+        // Signal only after the handlers are demonstrably installed — the
+        // "armed" line is logged from the same select that owns the signal
+        // arms, so its presence means a too-early default-disposition death
+        // can no longer happen.
+        let (armed, log) =
+            wait_for_log_line(&logfile, "parent exit-watch armed", Duration::from_secs(10));
+        if !armed {
+            let _ = daemon.kill();
+            panic!("daemon never armed its exit watch ({sig}); log:\n{log}");
+        }
+
+        kill(Pid::from_raw(pid), sig).expect("send signal");
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let status = loop {
+            if let Some(s) = daemon.try_wait().expect("try_wait") {
+                break s;
+            }
+            if Instant::now() >= deadline {
+                let _ = daemon.kill();
+                panic!("daemon ignored {sig}");
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        };
+        assert_eq!(
+            status.code(),
+            Some(0),
+            "{sig} must exit gracefully via wait_for_exit (None = killed by default disposition)"
+        );
+    }
+}

--- a/crates/iii-worker/tests/daemon_orphan_exit_integration.rs
+++ b/crates/iii-worker/tests/daemon_orphan_exit_integration.rs
@@ -476,13 +476,14 @@ fn daemon_reaps_managed_workers_on_engine_gone() {
     );
 }
 
-/// The engine's kill_child sends SIGTERM; SIGINT is the hand-run Ctrl-C path.
-/// Both must exit GRACEFULLY through wait_for_exit (process exits with code
-/// 0). Pre-fix, SIGTERM killed via default disposition: terminated-by-signal,
+/// The engine's kill_child sends SIGTERM; SIGINT is the hand-run Ctrl-C
+/// path; SIGHUP is the terminal closing on a hand-launched daemon. All three
+/// must exit GRACEFULLY through wait_for_exit (process exits with code 0).
+/// Pre-fix, each killed via default disposition: terminated-by-signal,
 /// status.code() == None — which is exactly what this asserts against.
 #[test]
 fn daemon_exits_gracefully_on_sigterm_and_sigint() {
-    for sig in [Signal::SIGTERM, Signal::SIGINT] {
+    for sig in [Signal::SIGTERM, Signal::SIGINT, Signal::SIGHUP] {
         let bin = env!("CARGO_BIN_EXE_iii-worker");
         let tmp = tempfile::tempdir().unwrap();
         let logfile = tmp.path().join("daemon.log");
@@ -504,10 +505,13 @@ fn daemon_exits_gracefully_on_sigterm_and_sigint() {
             .expect("spawn daemon");
         let pid = daemon.id() as i32;
 
-        // Signal only after the handlers are demonstrably installed — the
-        // "armed" line is logged from the same select that owns the signal
-        // arms, so its presence means a too-early default-disposition death
-        // can no longer happen.
+        // Signal only after the daemon has demonstrably reached the exit
+        // select: the "armed" line is logged while select polls its arms,
+        // and the signal arms install their handlers in that same first
+        // poll pass. select gives no strict ordering between the arms, so
+        // an instructions-wide pre-handler window remains — but gating on
+        // the armed line shrinks "daemon not ready yet" from whole startup
+        // (SDK init, registrations) to that sliver.
         let (armed, log) =
             wait_for_log_line(&logfile, "parent exit-watch armed", Duration::from_secs(10));
         if !armed {

--- a/crates/iii-worker/tests/daemon_orphan_exit_integration.rs
+++ b/crates/iii-worker/tests/daemon_orphan_exit_integration.rs
@@ -479,10 +479,14 @@ fn daemon_reaps_managed_workers_on_engine_gone() {
         }
         std::thread::sleep(PROBE_INTERVAL);
     }
-    let final_log = std::fs::read_to_string(&logfile).unwrap_or_default();
+    // Post-detection output is redirected to the durable exit log under
+    // $HOME/.iii/logs (the engine that owned stdout is dead), so the reap
+    // pass is asserted there, not in the spawn-time logfile.
+    let exit_log = std::fs::read_to_string(tmp.path().join(".iii/logs/worker-manager-daemon.log"))
+        .unwrap_or_default();
     assert!(
-        final_log.contains("reaping managed workers"),
-        "engine-gone exit must run the reaper; log:\n{final_log}"
+        exit_log.contains("reaping managed workers"),
+        "engine-gone exit must run the reaper (exit log):\n{exit_log}"
     );
 }
 

--- a/crates/iii-worker/tests/daemon_orphan_exit_integration.rs
+++ b/crates/iii-worker/tests/daemon_orphan_exit_integration.rs
@@ -147,7 +147,8 @@ fn daemon_exits_when_orphaned_from_engine() {
     // Deterministic readiness: wait for the daemon's own log line proving it
     // snapshotted its parent and armed the watch WHILE sh was still alive —
     // no blind startup sleep, no arming race under CI load.
-    let (armed, log) = wait_for_log_line(&logfile, "parent exit-watch armed", Duration::from_secs(10));
+    let (armed, log) =
+        wait_for_log_line(&logfile, "parent exit-watch armed", Duration::from_secs(10));
     assert!(armed, "daemon never armed its exit watch; log:\n{log}");
 
     // Negative path: with its parent alive, the daemon must SURVIVE at least
@@ -205,12 +206,14 @@ fn daemon_exits_when_lifeline_drops() {
         .env_remove("III_ENGINE_PID")
         .stdout(std::process::Stdio::from(log))
         .stderr(std::process::Stdio::from(log_err));
-    let lifeline =
-        iii_worker::daemon_exit::attach_lifeline_std(&mut cmd).expect("attach lifeline");
+    let lifeline = iii_worker::daemon_exit::attach_lifeline_std(&mut cmd).expect("attach lifeline");
     let mut daemon = cmd.spawn().expect("spawn daemon");
 
-    let (armed, log) =
-        wait_for_log_line(&logfile, "lifeline exit-watch armed", Duration::from_secs(10));
+    let (armed, log) = wait_for_log_line(
+        &logfile,
+        "lifeline exit-watch armed",
+        Duration::from_secs(10),
+    );
     if !armed {
         let _ = daemon.kill();
         panic!("daemon never armed the lifeline watch; log:\n{log}");
@@ -344,7 +347,10 @@ fn daemon_survives_orphaning_when_declared_engine_alive() {
 
     let (armed, log) =
         wait_for_log_line(&logfile, "engine exit-watch armed", Duration::from_secs(10));
-    assert!(armed, "daemon never armed the engine-pid watch; log:\n{log}");
+    assert!(
+        armed,
+        "daemon never armed the engine-pid watch; log:\n{log}"
+    );
 
     // Orphan the daemon (kill its direct parent). The declared engine (us)
     // is alive, so the daemon must keep running through multiple polls.
@@ -414,7 +420,11 @@ fn watch_source_exits_when_engine_pid_dies() {
         }
         std::thread::sleep(PROBE_INTERVAL);
     };
-    assert_eq!(status.code(), Some(0), "engine-gone watcher exit is graceful");
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "engine-gone watcher exit is graceful"
+    );
 }
 
 /// Session-reaper wiring: on engine-gone the daemon must run the

--- a/crates/iii-worker/tests/engine_death_cascade_integration.rs
+++ b/crates/iii-worker/tests/engine_death_cascade_integration.rs
@@ -520,14 +520,105 @@ fn reaper_kills_running_binary_worker_on_engine_gone() {
         "daemon exit after reap must be graceful"
     );
 
-    let final_log = std::fs::read_to_string(&logfile).unwrap_or_default();
+    // Post-detection output is redirected to the durable exit log (the
+    // engine that owned stdout is dead), so the reap pass is asserted THERE.
+    let exit_log = std::fs::read_to_string(breadcrumb_path(tmp.path(), "worker-manager-daemon"))
+        .unwrap_or_default();
     assert!(
-        final_log.contains("reaping managed workers"),
-        "reaper pass must be observable; log:\n{final_log}"
+        exit_log.contains("reaping managed workers"),
+        "reaper pass must be observable in the exit log; got:\n{exit_log}"
     );
     assert!(
         !worker_pidfile.exists(),
-        "stop path must clean up the worker pidfile; log:\n{final_log}"
+        "stop path must clean up the worker pidfile; exit log:\n{exit_log}"
+    );
+}
+
+/// THE field bug behind "killall -9 iii didn't reap anything": the engine
+/// spawns the daemon with stdout/stderr PIPED INTO ITSELF, so engine death
+/// breaks both fds. The first post-detection log write then EPIPEs, the fmt
+/// layer's internal-error `eprintln!` fallback panics on the equally-broken
+/// stderr, and the main task unwinds BEFORE the breadcrumb and the reaper —
+/// silent exit 101, nothing reaped. The fix re-points fds 1/2 at the
+/// durable exit log the instant engine death is detected, which also makes
+/// the reap pass visible there. File-backed stdio (every other test in
+/// this suite) can never catch this.
+#[test]
+fn daemon_survives_its_stdio_dying_with_the_engine() {
+    use std::io::BufRead;
+
+    let tmp = tempfile::tempdir().unwrap();
+
+    let mut fake_engine = KillOnDrop(spawn_fake_engine());
+    let engine_pid = fake_engine.0.id() as i32;
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_iii-worker"));
+    cmd.args(["worker-manager-daemon", "--engine", "ws://127.0.0.1:1"])
+        .current_dir(tmp.path())
+        .env("RUST_LOG", "info")
+        .env("HOME", tmp.path())
+        .env("III_ENGINE_PID", engine_pid.to_string())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let lifeline = iii_worker::daemon_exit::attach_lifeline_std(&mut cmd).expect("attach lifeline");
+    let mut daemon = KillOnDrop(cmd.spawn().expect("spawn daemon"));
+
+    // Readiness gate: scan the piped stdout for the armed line, then hand
+    // the handle back so this test can break the pipe at "engine death".
+    let stdout = daemon.0.stdout.take().expect("piped stdout");
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut reader = std::io::BufReader::new(stdout);
+        let mut line = String::new();
+        let mut armed = false;
+        while reader.read_line(&mut line).is_ok_and(|n| n > 0) {
+            if line.contains("lifeline exit-watch armed") {
+                armed = true;
+                break;
+            }
+            line.clear();
+        }
+        let _ = tx.send((armed, reader.into_inner()));
+    });
+    let (armed, stdout) = rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("daemon produced no armed line on its piped stdout");
+    assert!(armed, "daemon never armed the lifeline watch");
+
+    // Engine death, production-shaped: the process dies AND every pipe it
+    // held dies with it — lifeline EOF plus broken stdout/stderr.
+    let _ = fake_engine.0.kill();
+    let _ = fake_engine.0.wait();
+    drop(lifeline);
+    drop(stdout);
+    drop(daemon.0.stderr.take());
+
+    let crumb_file = breadcrumb_path(tmp.path(), "worker-manager-daemon");
+    let deadline = Instant::now() + EXIT_DEADLINE;
+    let status = loop {
+        if let Some(s) = daemon.0.try_wait().expect("try_wait") {
+            break s;
+        }
+        if Instant::now() >= deadline {
+            panic!("daemon never exited after engine death with broken stdio");
+        }
+        std::thread::sleep(PROBE_INTERVAL);
+    };
+    let crumb = std::fs::read_to_string(&crumb_file).unwrap_or_default();
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "broken stdio must not panic the daemon (101 = the EPIPE panic regressed); exit log:\n{crumb}"
+    );
+    assert!(
+        crumb.contains("reason=engine-gone"),
+        "breadcrumb must still be written with broken stdio: {crumb}"
+    );
+    // The redirect points the daemon's remaining output at the exit log, so
+    // the reap pass is durable forensics instead of EPIPE fodder.
+    assert!(
+        crumb.contains("reaping managed workers"),
+        "reaper output must land in the exit log after the stdio redirect: {crumb}"
     );
 }
 

--- a/crates/iii-worker/tests/engine_death_cascade_integration.rs
+++ b/crates/iii-worker/tests/engine_death_cascade_integration.rs
@@ -1,0 +1,575 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Engine-death cascade behaviors NOT covered by
+//! `daemon_orphan_exit_integration.rs` (which pins the basic exit paths:
+//! reparent fallback, lifeline EOF, engine-pid handshake, signals).
+//!
+//! This file pins the layered semantics on top of those paths:
+//!
+//! - the durable **breadcrumb** in `~/.iii/logs/<daemon>.log` is written on
+//!   engine-gone exits (with the right fields) and ONLY on engine-gone exits
+//!   — a breadcrumb on every graceful shutdown was a real pre-fix bug;
+//! - **precedence**: lifeline EOF is authoritative even while the declared
+//!   engine pid is alive, and the pid backstop pins the ENGINE pid over the
+//!   spawner pid when both are declared;
+//! - the **spawner-pid backstop** covers the one lifeline failure mode (a
+//!   leaked write end keeping EOF at bay — the macOS no-`pipe2` race);
+//! - garbage `III_ENGINE_PID` degrades to the reparent fallback instead of
+//!   crashing or arming a bogus watch;
+//! - the session reaper actually KILLS a running worker process (the log-line
+//!   test in the sibling file only proves the reaper ran);
+//! - `sandbox-daemon` (the second armed daemon) exits on engine death too.
+//!
+//! Every daemon gets `HOME=<tempdir>` (breadcrumbs and pidfiles are read
+//! under `$HOME/.iii`) and `current_dir(<tempdir>)` (worker discovery reads
+//! `./config.yaml` relative to the daemon's cwd), so tests can neither see
+//! nor touch the developer's real workers.
+
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use nix::sys::signal::{Signal, kill};
+use nix::unistd::Pid;
+
+/// Sized against the daemon's ENGINE_POLL_INTERVAL (2s): generous for loaded
+/// CI runners, far below the suite timeout.
+const EXIT_DEADLINE: Duration = Duration::from_secs(15);
+const PROBE_INTERVAL: Duration = Duration::from_millis(200);
+/// Two full daemon poll intervals plus slack — even on a loaded runner where
+/// a tick lands late, at least one armed poll completes while the
+/// not-to-be-watched process is already dead, so "survived" means the watch
+/// demonstrably ignored that death (a single-interval window can contain
+/// zero completed ticks under load, turning the negative assert vacuous).
+const ARMED_SURVIVAL_WINDOW: Duration = Duration::from_millis(5000);
+
+/// Kills the child on EVERY exit path including assertion panics —
+/// `std::process::Child` does not kill on drop, and a leaked daemon here
+/// reconnect-loops forever.
+struct KillOnDrop(std::process::Child);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Poll `logfile` until it contains `needle` or `deadline` passes. Returns
+/// the log contents either way so failures carry diagnostics.
+fn wait_for_log_line(logfile: &Path, needle: &str, deadline: Duration) -> (bool, String) {
+    let end = Instant::now() + deadline;
+    loop {
+        let contents = std::fs::read_to_string(logfile).unwrap_or_default();
+        if contents.contains(needle) {
+            return (true, contents);
+        }
+        if Instant::now() >= end {
+            return (false, contents);
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Poll the child until it exits, returning its status; panics with the log
+/// contents (and kills the child) on deadline.
+fn wait_for_exit(
+    child: &mut KillOnDrop,
+    deadline: Duration,
+    logfile: &Path,
+    what: &str,
+) -> std::process::ExitStatus {
+    let end = Instant::now() + deadline;
+    loop {
+        if let Some(s) = child.0.try_wait().expect("try_wait") {
+            return s;
+        }
+        if Instant::now() >= end {
+            let log = std::fs::read_to_string(logfile).unwrap_or_default();
+            let _ = child.0.kill();
+            panic!("{what} did not exit within {deadline:?}; log:\n{log}");
+        }
+        std::thread::sleep(PROBE_INTERVAL);
+    }
+}
+
+/// A `worker-manager-daemon` Command with the shared isolation/observability
+/// wiring: tempdir HOME (breadcrumbs + pidfiles), tempdir cwd (worker
+/// discovery), info-level logs into `logfile` (tracing fmt writes to stdout;
+/// readiness gating and failure diagnostics need both streams).
+fn daemon_cmd(tmp: &Path, logfile: &Path) -> Command {
+    let log = std::fs::File::create(logfile).unwrap();
+    let log_err = log.try_clone().unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_iii-worker"));
+    cmd.args(["worker-manager-daemon", "--engine", "ws://127.0.0.1:1"])
+        .current_dir(tmp)
+        .env("RUST_LOG", "info")
+        .env("HOME", tmp)
+        .env_remove("III_ENGINE_PID")
+        .env_remove("III_LIFELINE_FD")
+        .env_remove("III_LIFELINE_SPAWNER_PID")
+        .stdout(std::process::Stdio::from(log))
+        .stderr(std::process::Stdio::from(log_err));
+    cmd
+}
+
+/// The engine-gone breadcrumb the daemon appends under `$HOME/.iii/logs/`.
+fn breadcrumb_path(home: &Path, daemon: &str) -> PathBuf {
+    home.join(".iii/logs").join(format!("{daemon}.log"))
+}
+
+fn spawn_fake_engine() -> std::process::Child {
+    Command::new("sleep")
+        .arg("300")
+        .spawn()
+        .expect("spawn fake engine")
+}
+
+/// Engine-gone via the PID handshake must leave a durable breadcrumb with
+/// the fields a field investigation needs: which daemon, why, which engine
+/// pid was watched, and who the spawn parent was. The daemon's stdout/stderr
+/// are pipes into the (dead) engine in production, so this file is the ONLY
+/// trace of a self-exit.
+#[test]
+fn engine_gone_breadcrumb_records_engine_pid_and_spawn_parent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let logfile = tmp.path().join("daemon.log");
+
+    let mut fake_engine = KillOnDrop(spawn_fake_engine());
+    let engine_pid = fake_engine.0.id() as i32;
+
+    let mut cmd = daemon_cmd(tmp.path(), &logfile);
+    cmd.env("III_ENGINE_PID", engine_pid.to_string());
+    let mut daemon = KillOnDrop(cmd.spawn().expect("spawn daemon"));
+
+    let (armed, log) =
+        wait_for_log_line(&logfile, "engine exit-watch armed", Duration::from_secs(10));
+    assert!(armed, "daemon never armed the engine-pid watch; log:\n{log}");
+
+    let _ = fake_engine.0.kill();
+    let _ = fake_engine.0.wait();
+
+    let status = wait_for_exit(&mut daemon, EXIT_DEADLINE, &logfile, "daemon");
+    assert_eq!(status.code(), Some(0), "engine-gone exit must be graceful");
+
+    let crumb = std::fs::read_to_string(breadcrumb_path(tmp.path(), "worker-manager-daemon"))
+        .expect("engine-gone exit must write a breadcrumb");
+    assert!(
+        crumb.contains("daemon=worker-manager-daemon"),
+        "breadcrumb must name the daemon: {crumb}"
+    );
+    assert!(
+        crumb.contains("reason=engine-gone"),
+        "breadcrumb must carry the reason: {crumb}"
+    );
+    // Trailing delimiters pin the exact field values (engine_pid is always
+    // followed by " spawn_parent=", which terminates the line) — a bare
+    // substring would also match a longer pid sharing the same prefix.
+    assert!(
+        crumb.contains(&format!("engine_pid={engine_pid} ")),
+        "breadcrumb must record the watched engine pid: {crumb}"
+    );
+    // The daemon is our direct child here, so spawn parent == this test
+    // process. The spawn-time-vs-current distinction is pinned by
+    // garbage_engine_pid_falls_back_to_reparent_watch, whose spawn parent
+    // (the sh trampoline) is dead by breadcrumb time.
+    assert!(
+        crumb.contains(&format!("spawn_parent={}\n", std::process::id())),
+        "breadcrumb must record the spawn-time parent: {crumb}"
+    );
+}
+
+/// A graceful SIGNAL exit must NOT write the engine-gone breadcrumb — a
+/// pre-fix bug stamped a false "engine-gone" line on 17 of 20 ordinary
+/// shutdowns, which would poison any future incident investigation that
+/// trusts the file.
+#[test]
+fn signal_exit_writes_no_breadcrumb() {
+    let tmp = tempfile::tempdir().unwrap();
+    let logfile = tmp.path().join("daemon.log");
+
+    let mut daemon = KillOnDrop(daemon_cmd(tmp.path(), &logfile).spawn().expect("spawn daemon"));
+    let pid = daemon.0.id() as i32;
+
+    let (armed, log) =
+        wait_for_log_line(&logfile, "parent exit-watch armed", Duration::from_secs(10));
+    assert!(armed, "daemon never armed its exit watch; log:\n{log}");
+
+    kill(Pid::from_raw(pid), Signal::SIGTERM).expect("send SIGTERM");
+    let status = wait_for_exit(&mut daemon, EXIT_DEADLINE, &logfile, "daemon");
+    assert_eq!(status.code(), Some(0), "SIGTERM exit must be graceful");
+
+    // Nothing else writes this file under the isolated HOME, so its very
+    // existence would mean a breadcrumb was stamped on a signal shutdown.
+    let crumb_file = breadcrumb_path(tmp.path(), "worker-manager-daemon");
+    assert!(
+        !crumb_file.exists(),
+        "signal shutdown must not write any breadcrumb: {}",
+        std::fs::read_to_string(&crumb_file).unwrap_or_default()
+    );
+}
+
+/// Lifeline EOF is AUTHORITATIVE: the daemon must exit on it even while the
+/// declared engine pid is demonstrably alive. In production the engine holds
+/// the write end, so EOF ⇔ engine gone with zero latency; a regression that
+/// demotes the lifeline behind the pid poll (or worse, requires both) would
+/// pass the sibling file's tests and fail only here.
+#[test]
+fn lifeline_eof_exits_daemon_even_while_declared_engine_alive() {
+    let tmp = tempfile::tempdir().unwrap();
+    let logfile = tmp.path().join("daemon.log");
+
+    let fake_engine = KillOnDrop(spawn_fake_engine());
+    let engine_pid = fake_engine.0.id() as i32;
+
+    let mut cmd = daemon_cmd(tmp.path(), &logfile);
+    cmd.env("III_ENGINE_PID", engine_pid.to_string());
+    let lifeline =
+        iii_worker::daemon_exit::attach_lifeline_std(&mut cmd).expect("attach lifeline");
+    let mut daemon = KillOnDrop(cmd.spawn().expect("spawn daemon"));
+
+    let (armed, log) =
+        wait_for_log_line(&logfile, "lifeline exit-watch armed", Duration::from_secs(10));
+    assert!(armed, "daemon never armed the lifeline watch; log:\n{log}");
+
+    // Lifeline held + engine alive → must keep running across at least one
+    // completed pid poll (a watch that fires on its first tick regardless of
+    // liveness must fail HERE, not be mistaken for the EOF exit below).
+    std::thread::sleep(ARMED_SURVIVAL_WINDOW);
+    assert!(
+        daemon.0.try_wait().expect("try_wait").is_none(),
+        "daemon exited while both the lifeline and the engine were alive"
+    );
+
+    drop(lifeline); // EOF — while the engine pid still exists
+
+    let status = wait_for_exit(&mut daemon, Duration::from_secs(5), &logfile, "daemon");
+    assert_eq!(status.code(), Some(0), "lifeline exit must be graceful");
+
+    // It is an engine-gone exit (the spawner IS the engine in production),
+    // so the breadcrumb must be written, recording the still-alive declared
+    // pid — that mismatch is exactly the forensic detail worth keeping.
+    let crumb = std::fs::read_to_string(breadcrumb_path(tmp.path(), "worker-manager-daemon"))
+        .expect("lifeline engine-gone exit must write a breadcrumb");
+    assert!(
+        crumb.contains(&format!("engine_pid={engine_pid} ")),
+        "breadcrumb must record the declared engine pid: {crumb}"
+    );
+}
+
+/// The one lifeline failure mode: on macOS `pipe()` + fcntl is not atomic,
+/// so a write end can leak into an unrelated child and keep EOF from ever
+/// firing. The spawner-pid backstop must cover it — we simulate the leak by
+/// HOLDING the write end open in this test while the declared spawner dies.
+#[test]
+fn spawner_pid_backstop_covers_leaked_lifeline_write_end() {
+    use std::os::fd::AsRawFd;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let logfile = tmp.path().join("daemon.log");
+
+    let mut fake_spawner = KillOnDrop(spawn_fake_engine());
+    let spawner_pid = fake_spawner.0.id() as i32;
+
+    // Hand-rolled lifeline (attach_lifeline_std would pin the spawner pid to
+    // this test process, which we cannot kill): a plain pipe is non-CLOEXEC,
+    // so the child inherits the read end at the same fd number. Both ends
+    // stay open in this test for the whole run — the held write end IS the
+    // simulated leak.
+    let (read_end, _write_end_leak) = nix::unistd::pipe().expect("pipe");
+
+    let mut cmd = daemon_cmd(tmp.path(), &logfile);
+    cmd.env("III_LIFELINE_FD", read_end.as_raw_fd().to_string())
+        .env("III_LIFELINE_SPAWNER_PID", spawner_pid.to_string());
+    let mut daemon = KillOnDrop(cmd.spawn().expect("spawn daemon"));
+
+    // Both watches must be armed before we kill anything: the lifeline (which
+    // will never fire here) and the pid backstop (which must).
+    let (armed, log) =
+        wait_for_log_line(&logfile, "lifeline exit-watch armed", Duration::from_secs(10));
+    assert!(armed, "daemon never armed the lifeline watch; log:\n{log}");
+    let (armed, log) =
+        wait_for_log_line(&logfile, "engine exit-watch armed", Duration::from_secs(10));
+    assert!(armed, "daemon never armed the pid backstop; log:\n{log}");
+
+    // Spawner alive + lifeline open → must keep running across at least one
+    // completed pid poll, so the exit below is attributable to the spawner's
+    // death and not to a first-tick false fire.
+    std::thread::sleep(ARMED_SURVIVAL_WINDOW);
+    assert!(
+        daemon.0.try_wait().expect("try_wait").is_none(),
+        "daemon exited while its spawner was alive"
+    );
+
+    let _ = fake_spawner.0.kill();
+    let _ = fake_spawner.0.wait();
+
+    // The lifeline never reaches EOF (we hold the write end), so only the
+    // pid backstop can produce this exit.
+    let status = wait_for_exit(&mut daemon, EXIT_DEADLINE, &logfile, "daemon");
+    assert_eq!(status.code(), Some(0), "backstop exit must be graceful");
+
+    let crumb = std::fs::read_to_string(breadcrumb_path(tmp.path(), "worker-manager-daemon"))
+        .expect("backstop engine-gone exit must write a breadcrumb");
+    assert!(
+        crumb.contains("engine_pid=none "),
+        "no engine pid was declared, the breadcrumb must say so: {crumb}"
+    );
+}
+
+/// When BOTH pids are declared, the backstop must pin the ENGINE pid: the
+/// spawner dying while the engine lives is a wrapper/shim exiting, not
+/// engine death. A regression flipping `engine_pid.or(spawner_pid)` to
+/// spawner-first passes every other test and fails only here.
+#[test]
+fn engine_pid_outranks_spawner_pid_in_backstop() {
+    let tmp = tempfile::tempdir().unwrap();
+    let logfile = tmp.path().join("daemon.log");
+
+    let mut fake_engine = KillOnDrop(spawn_fake_engine());
+    let mut fake_spawner = KillOnDrop(spawn_fake_engine());
+
+    let mut cmd = daemon_cmd(tmp.path(), &logfile);
+    cmd.env("III_ENGINE_PID", fake_engine.0.id().to_string())
+        .env("III_LIFELINE_SPAWNER_PID", fake_spawner.0.id().to_string());
+    let mut daemon = KillOnDrop(cmd.spawn().expect("spawn daemon"));
+
+    let (armed, log) =
+        wait_for_log_line(&logfile, "engine exit-watch armed", Duration::from_secs(10));
+    assert!(armed, "daemon never armed the pid watch; log:\n{log}");
+
+    // Kill the spawner; the engine lives. The daemon must survive at least
+    // one full poll interval — an exit here means the watch picked the
+    // wrong pid.
+    let _ = fake_spawner.0.kill();
+    let _ = fake_spawner.0.wait();
+    std::thread::sleep(ARMED_SURVIVAL_WINDOW);
+    assert!(
+        daemon.0.try_wait().expect("try_wait").is_none(),
+        "daemon exited on SPAWNER death while the declared engine was alive"
+    );
+
+    // Now the engine dies → the daemon must go.
+    let _ = fake_engine.0.kill();
+    let _ = fake_engine.0.wait();
+    let status = wait_for_exit(&mut daemon, EXIT_DEADLINE, &logfile, "daemon");
+    assert_eq!(status.code(), Some(0), "engine-gone exit must be graceful");
+}
+
+/// A garbage III_ENGINE_PID (version skew, a broken wrapper exporting junk)
+/// must not crash the daemon OR arm a bogus engine watch — it degrades to
+/// the reparent fallback, which still detects orphaning.
+#[test]
+fn garbage_engine_pid_falls_back_to_reparent_watch() {
+    let bin = env!("CARGO_BIN_EXE_iii-worker");
+    let tmp = tempfile::tempdir().unwrap();
+    let pidfile = tmp.path().join("daemon.pid");
+    let logfile = tmp.path().join("daemon.log");
+
+    // Intermediate `sh` so the daemon has a killable parent (same trampoline
+    // as the sibling file's orphan test; paths travel via env, not
+    // interpolation). The cwd is set on `sh` itself and inherited — a
+    // `cd && daemon &` compound would background a SUBSHELL, making `$!` the
+    // subshell pid and the subshell the daemon's parent.
+    let sh = Command::new("sh")
+        .arg("-c")
+        .arg(r#""$DAEMON_BIN" worker-manager-daemon --engine ws://127.0.0.1:1 >>"$DAEMON_LOG" 2>&1 & echo $! > "$DAEMON_PIDFILE"; wait"#)
+        .current_dir(tmp.path())
+        .env("DAEMON_BIN", bin)
+        .env("DAEMON_PIDFILE", &pidfile)
+        .env("DAEMON_LOG", &logfile)
+        .env("RUST_LOG", "info")
+        .env("HOME", tmp.path())
+        .env("III_ENGINE_PID", "not-a-pid")
+        .spawn()
+        .expect("spawn intermediate sh");
+    let mut sh = KillOnDrop(sh);
+
+    let daemon_pid = {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Ok(s) = std::fs::read_to_string(&pidfile)
+                && let Ok(pid) = s.trim().parse::<i32>()
+                && pid > 1
+            {
+                break pid;
+            }
+            assert!(Instant::now() < deadline, "daemon never wrote its pid");
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    };
+
+    // The garbage pid must be REJECTED (reparent watch armed) — not parsed
+    // into an engine watch on a nonsense pid.
+    let (armed, log) =
+        wait_for_log_line(&logfile, "parent exit-watch armed", Duration::from_secs(10));
+    if !armed {
+        let _ = kill(Pid::from_raw(daemon_pid), Signal::SIGKILL);
+        panic!("daemon with garbage engine pid never armed the fallback; log:\n{log}");
+    }
+    assert!(
+        !log.contains("engine exit-watch armed"),
+        "garbage III_ENGINE_PID must not arm an engine watch; log:\n{log}"
+    );
+
+    // And the fallback must still WORK: orphan the daemon, it self-exits.
+    let sh_pid = sh.0.id();
+    let _ = sh.0.kill();
+    let _ = sh.0.wait();
+
+    let deadline = Instant::now() + EXIT_DEADLINE;
+    loop {
+        if kill(Pid::from_raw(daemon_pid), None).is_err() {
+            break; // gone
+        }
+        if Instant::now() >= deadline {
+            let final_log = std::fs::read_to_string(&logfile).unwrap_or_default();
+            let _ = kill(Pid::from_raw(daemon_pid), Signal::SIGKILL);
+            panic!("orphaned daemon (garbage engine pid) never self-exited; log:\n{final_log}");
+        }
+        std::thread::sleep(PROBE_INTERVAL);
+    }
+
+    // The breadcrumb's spawn_parent must be the SPAWN-time parent (the sh
+    // trampoline, dead by now) — the only topology in this suite where
+    // spawn-time and current parent actually differ, so this is what pins
+    // "snapshot at startup" over "whatever getppid() says at exit".
+    let crumb = std::fs::read_to_string(breadcrumb_path(tmp.path(), "worker-manager-daemon"))
+        .expect("reparent engine-gone exit must write a breadcrumb");
+    assert!(
+        crumb.contains("engine_pid=none ") && crumb.contains(&format!("spawn_parent={sh_pid}\n")),
+        "breadcrumb must record no engine pid and the dead spawn-time parent {sh_pid}: {crumb}"
+    );
+}
+
+/// The session reaper must actually KILL a running worker process — the
+/// sibling file only asserts the reaper's log line on an empty project.
+/// Binary-tier worker anatomy (all under the isolated $HOME/cwd):
+/// `./config.yaml` lists the name, `$HOME/.iii/workers/<name>` marks it a
+/// binary worker, `$HOME/.iii/pids/<name>.pid` points at the live process.
+#[test]
+fn reaper_kills_running_binary_worker_on_engine_gone() {
+    let tmp = tempfile::tempdir().unwrap();
+    let logfile = tmp.path().join("daemon.log");
+
+    // The "worker": a sleeper this test owns, registered exactly the way the
+    // managed-stop machinery discovers binary workers.
+    let mut worker = KillOnDrop(spawn_fake_engine());
+    let worker_pid = worker.0.id();
+    std::fs::write(
+        tmp.path().join("config.yaml"),
+        "workers:\n  - name: zwreap\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(tmp.path().join(".iii/workers")).unwrap();
+    std::fs::write(tmp.path().join(".iii/workers/zwreap"), "").unwrap();
+    std::fs::create_dir_all(tmp.path().join(".iii/pids")).unwrap();
+    let worker_pidfile = tmp.path().join(".iii/pids/zwreap.pid");
+    std::fs::write(&worker_pidfile, worker_pid.to_string()).unwrap();
+
+    let mut fake_engine = KillOnDrop(spawn_fake_engine());
+
+    let mut cmd = daemon_cmd(tmp.path(), &logfile);
+    cmd.env("III_ENGINE_PID", fake_engine.0.id().to_string());
+    let mut daemon = KillOnDrop(cmd.spawn().expect("spawn daemon"));
+
+    let (armed, log) =
+        wait_for_log_line(&logfile, "engine exit-watch armed", Duration::from_secs(10));
+    assert!(armed, "daemon never armed; log:\n{log}");
+
+    let _ = fake_engine.0.kill();
+    let _ = fake_engine.0.wait();
+
+    // The worker must die at the daemon's hand (SIGTERM→SIGKILL): observe it
+    // via try_wait on OUR child handle — kill(pid, 0) would still see the
+    // zombie until we reap it here.
+    let deadline = Instant::now() + EXIT_DEADLINE;
+    loop {
+        if worker.0.try_wait().expect("try_wait").is_some() {
+            break;
+        }
+        if Instant::now() >= deadline {
+            let final_log = std::fs::read_to_string(&logfile).unwrap_or_default();
+            panic!("reaper never killed the running worker; log:\n{final_log}");
+        }
+        std::thread::sleep(PROBE_INTERVAL);
+    }
+
+    let status = wait_for_exit(&mut daemon, EXIT_DEADLINE, &logfile, "daemon");
+    assert_eq!(status.code(), Some(0), "daemon exit after reap must be graceful");
+
+    let final_log = std::fs::read_to_string(&logfile).unwrap_or_default();
+    assert!(
+        final_log.contains("reaping managed workers"),
+        "reaper pass must be observable; log:\n{final_log}"
+    );
+    assert!(
+        !worker_pidfile.exists(),
+        "stop path must clean up the worker pidfile; log:\n{final_log}"
+    );
+}
+
+/// `sandbox-daemon` is the OTHER engine-spawned daemon (and the worse leak:
+/// an orphan holds live multi-GB libkrun VMs). It shares ExitWatch with the
+/// worker-manager daemon; this pins that `serve()` actually arms it and
+/// honors engine death, with its own breadcrumb.
+#[test]
+fn sandbox_daemon_exits_when_engine_dies() {
+    let tmp = tempfile::tempdir().unwrap();
+    let logfile = tmp.path().join("sandbox-daemon.out");
+    let config = tmp.path().join("sandbox-config.yaml");
+    // Minimal valid config; an empty allowlist denies creates, which is fine
+    // — this test never creates a sandbox.
+    std::fs::write(&config, "image_allowlist: []\n").unwrap();
+
+    let mut fake_engine = KillOnDrop(spawn_fake_engine());
+    let engine_pid = fake_engine.0.id() as i32;
+
+    let log = std::fs::File::create(&logfile).unwrap();
+    let log_err = log.try_clone().unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_iii-worker"));
+    cmd.arg("sandbox-daemon")
+        .arg("--config")
+        .arg(&config)
+        .args(["--engine", "ws://127.0.0.1:1"])
+        .current_dir(tmp.path())
+        .env("RUST_LOG", "info")
+        .env("HOME", tmp.path())
+        .env("III_ENGINE_PID", engine_pid.to_string())
+        .env_remove("III_LIFELINE_FD")
+        .env_remove("III_LIFELINE_SPAWNER_PID")
+        .stdout(std::process::Stdio::from(log))
+        .stderr(std::process::Stdio::from(log_err));
+    let mut daemon = KillOnDrop(cmd.spawn().expect("spawn sandbox-daemon"));
+
+    let (armed, log) =
+        wait_for_log_line(&logfile, "engine exit-watch armed", Duration::from_secs(10));
+    assert!(armed, "sandbox-daemon never armed the engine watch; log:\n{log}");
+
+    // Engine alive → daemon stays up across at least one completed pid poll
+    // (attributes the exit below to engine death, not a first-tick misfire).
+    std::thread::sleep(ARMED_SURVIVAL_WINDOW);
+    assert!(
+        daemon.0.try_wait().expect("try_wait").is_none(),
+        "sandbox-daemon exited while its engine was alive"
+    );
+
+    let _ = fake_engine.0.kill();
+    let _ = fake_engine.0.wait();
+
+    let status = wait_for_exit(&mut daemon, EXIT_DEADLINE, &logfile, "sandbox-daemon");
+    assert_eq!(status.code(), Some(0), "engine-gone exit must be graceful");
+
+    let crumb = std::fs::read_to_string(breadcrumb_path(tmp.path(), "sandbox-daemon"))
+        .expect("sandbox-daemon engine-gone exit must write a breadcrumb");
+    assert!(
+        crumb.contains("daemon=sandbox-daemon") && crumb.contains("reason=engine-gone"),
+        "breadcrumb must identify the sandbox daemon and reason: {crumb}"
+    );
+}

--- a/crates/iii-worker/tests/engine_death_cascade_integration.rs
+++ b/crates/iii-worker/tests/engine_death_cascade_integration.rs
@@ -150,7 +150,10 @@ fn engine_gone_breadcrumb_records_engine_pid_and_spawn_parent() {
 
     let (armed, log) =
         wait_for_log_line(&logfile, "engine exit-watch armed", Duration::from_secs(10));
-    assert!(armed, "daemon never armed the engine-pid watch; log:\n{log}");
+    assert!(
+        armed,
+        "daemon never armed the engine-pid watch; log:\n{log}"
+    );
 
     let _ = fake_engine.0.kill();
     let _ = fake_engine.0.wait();
@@ -194,7 +197,11 @@ fn signal_exit_writes_no_breadcrumb() {
     let tmp = tempfile::tempdir().unwrap();
     let logfile = tmp.path().join("daemon.log");
 
-    let mut daemon = KillOnDrop(daemon_cmd(tmp.path(), &logfile).spawn().expect("spawn daemon"));
+    let mut daemon = KillOnDrop(
+        daemon_cmd(tmp.path(), &logfile)
+            .spawn()
+            .expect("spawn daemon"),
+    );
     let pid = daemon.0.id() as i32;
 
     let (armed, log) =
@@ -230,12 +237,14 @@ fn lifeline_eof_exits_daemon_even_while_declared_engine_alive() {
 
     let mut cmd = daemon_cmd(tmp.path(), &logfile);
     cmd.env("III_ENGINE_PID", engine_pid.to_string());
-    let lifeline =
-        iii_worker::daemon_exit::attach_lifeline_std(&mut cmd).expect("attach lifeline");
+    let lifeline = iii_worker::daemon_exit::attach_lifeline_std(&mut cmd).expect("attach lifeline");
     let mut daemon = KillOnDrop(cmd.spawn().expect("spawn daemon"));
 
-    let (armed, log) =
-        wait_for_log_line(&logfile, "lifeline exit-watch armed", Duration::from_secs(10));
+    let (armed, log) = wait_for_log_line(
+        &logfile,
+        "lifeline exit-watch armed",
+        Duration::from_secs(10),
+    );
     assert!(armed, "daemon never armed the lifeline watch; log:\n{log}");
 
     // Lifeline held + engine alive → must keep running across at least one
@@ -291,8 +300,11 @@ fn spawner_pid_backstop_covers_leaked_lifeline_write_end() {
 
     // Both watches must be armed before we kill anything: the lifeline (which
     // will never fire here) and the pid backstop (which must).
-    let (armed, log) =
-        wait_for_log_line(&logfile, "lifeline exit-watch armed", Duration::from_secs(10));
+    let (armed, log) = wait_for_log_line(
+        &logfile,
+        "lifeline exit-watch armed",
+        Duration::from_secs(10),
+    );
     assert!(armed, "daemon never armed the lifeline watch; log:\n{log}");
     let (armed, log) =
         wait_for_log_line(&logfile, "engine exit-watch armed", Duration::from_secs(10));
@@ -502,7 +514,11 @@ fn reaper_kills_running_binary_worker_on_engine_gone() {
     }
 
     let status = wait_for_exit(&mut daemon, EXIT_DEADLINE, &logfile, "daemon");
-    assert_eq!(status.code(), Some(0), "daemon exit after reap must be graceful");
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "daemon exit after reap must be graceful"
+    );
 
     let final_log = std::fs::read_to_string(&logfile).unwrap_or_default();
     assert!(
@@ -550,7 +566,10 @@ fn sandbox_daemon_exits_when_engine_dies() {
 
     let (armed, log) =
         wait_for_log_line(&logfile, "engine exit-watch armed", Duration::from_secs(10));
-    assert!(armed, "sandbox-daemon never armed the engine watch; log:\n{log}");
+    assert!(
+        armed,
+        "sandbox-daemon never armed the engine watch; log:\n{log}"
+    );
 
     // Engine alive → daemon stays up across at least one completed pid poll
     // (attributes the exit below to engine death, not a first-tick misfire).

--- a/crates/iii-worker/tests/fake_sandbox_relay.rs
+++ b/crates/iii-worker/tests/fake_sandbox_relay.rs
@@ -27,7 +27,10 @@ struct FakeLauncher {
 impl VmLauncher for FakeLauncher {
     async fn boot(&self, _p: &BootParams) -> Result<BootHandle, SandboxError> {
         let n = self.boot_count.fetch_add(1, Ordering::SeqCst) + 1;
-        Ok(BootHandle { vm_pid: 10_000 + n })
+        Ok(BootHandle {
+            vm_pid: 10_000 + n,
+            lifeline: None,
+        })
     }
 }
 

--- a/crates/iii-worker/tests/sandbox_fs_integration.rs
+++ b/crates/iii-worker/tests/sandbox_fs_integration.rs
@@ -613,6 +613,7 @@ fn fixture_state(id: Uuid) -> SandboxState {
         workdir: PathBuf::from("/tmp/w"),
         shell_sock: PathBuf::from("/tmp/s"),
         vm_pid: Some(1),
+        lifeline: None,
         created_at: Instant::now(),
         last_exec_at: Instant::now(),
         exec_in_progress: false,

--- a/crates/iii-worker/tests/sandbox_fs_read_buffer_boundary.rs
+++ b/crates/iii-worker/tests/sandbox_fs_read_buffer_boundary.rs
@@ -81,6 +81,7 @@ fn make_state(id: Uuid) -> SandboxState {
         workdir: PathBuf::from("/tmp/w"),
         shell_sock: PathBuf::from("/tmp/s"),
         vm_pid: Some(1),
+        lifeline: None,
         created_at: Instant::now(),
         last_exec_at: Instant::now(),
         exec_in_progress: false,

--- a/crates/iii-worker/tests/sandbox_lifecycle_integration.rs
+++ b/crates/iii-worker/tests/sandbox_lifecycle_integration.rs
@@ -55,6 +55,7 @@ fn make_state(id: Uuid) -> SandboxState {
         workdir: std::path::PathBuf::from("/tmp/work"),
         shell_sock: std::path::PathBuf::from("/tmp/shell.sock"),
         vm_pid: Some(4321),
+        lifeline: None,
         created_at: Instant::now(),
         last_exec_at: Instant::now(),
         exec_in_progress: false,

--- a/crates/iii-worker/tests/sandbox_workflow_integration.rs
+++ b/crates/iii-worker/tests/sandbox_workflow_integration.rs
@@ -41,6 +41,7 @@ fn make_state(id: Uuid) -> SandboxState {
         workdir: PathBuf::from("/tmp/work"),
         shell_sock: PathBuf::from("/tmp/shell.sock"),
         vm_pid: Some(7777),
+        lifeline: None,
         created_at: Instant::now(),
         last_exec_at: Instant::now(),
         exec_in_progress: false,

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -136,6 +136,7 @@ inventory = "0.3"
 rand = "0.8"
 rkyv = "0.8.12"
 nix = { version = "0.30.1", features = ["signal", "process", "term"] }
+libc = "0.2"
 winapi = { version = "0.3.9", features = ["minwindef", "wincon", "winbase", "consoleapi"] }
 dirs = "6"
 machineid-rs = "1.2"

--- a/engine/src/workers/external.rs
+++ b/engine/src/workers/external.rs
@@ -183,6 +183,13 @@ pub struct ExternalWorker {
     config: Option<Value>,
     child: Arc<Mutex<Option<Child>>>,
     config_file: Arc<Mutex<Option<PathBuf>>>,
+    /// Write end of the child's lifeline pipe (see the spawn path). Held for
+    /// the child's lifetime; the kernel closes it when THIS engine dies —
+    /// any death, SIGKILL included — and the daemon's lifeline watch sees
+    /// EOF instantly and self-exits. Dropped explicitly on shutdown/destroy
+    /// so graceful teardown signals the child the same way.
+    #[cfg(unix)]
+    lifeline: Arc<Mutex<Option<std::os::fd::OwnedFd>>>,
 }
 
 impl ExternalWorker {
@@ -197,8 +204,51 @@ impl ExternalWorker {
             config,
             child: Arc::new(Mutex::new(None)),
             config_file: Arc::new(Mutex::new(None)),
+            #[cfg(unix)]
+            lifeline: Arc::new(Mutex::new(None)),
         }
     }
+}
+
+/// Pipe with both ends CLOEXEC. macOS has no `pipe2`, so there the CLOEXEC
+/// fcntls leave a tiny window where a concurrent spawn on another thread can
+/// inherit the fds; the daemon's PID-watch backstop covers that case (keep
+/// in sync with iii-worker's `daemon_exit::new_cloexec_pipe`).
+#[cfg(unix)]
+fn new_cloexec_pipe() -> std::io::Result<(std::os::fd::OwnedFd, std::os::fd::OwnedFd)> {
+    use std::os::fd::FromRawFd;
+    let mut fds = [0i32; 2];
+    #[cfg(target_os = "linux")]
+    {
+        if unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) } != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        for fd in fds {
+            let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+            if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) } < 0
+            {
+                let err = std::io::Error::last_os_error();
+                unsafe {
+                    libc::close(fds[0]);
+                    libc::close(fds[1]);
+                }
+                return Err(err);
+            }
+        }
+    }
+    // SAFETY: fresh fds from pipe(2), owned exclusively here.
+    Ok(unsafe {
+        (
+            std::os::fd::OwnedFd::from_raw_fd(fds[0]),
+            std::os::fd::OwnedFd::from_raw_fd(fds[1]),
+        )
+    })
 }
 
 #[async_trait::async_trait]
@@ -275,18 +325,84 @@ impl Worker for ExternalWorker {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
+        // Declare this engine's pid so daemons can watch ENGINE liveness
+        // directly and self-exit when we die without running kill_child
+        // (SIGKILL/OOM/crash). getppid() alone can't prove the parent is the
+        // engine — wrappers and debugger reparenting break it — so iii-worker's
+        // daemon_exit module prefers this handshake when present.
+        cmd.env("III_ENGINE_PID", std::process::id().to_string());
+
+        // Lifeline pipe: we hold the write end (never written) for the
+        // child's lifetime; the kernel closes it the instant this engine
+        // dies — ANY death, SIGKILL included — and the daemon's lifeline
+        // watch sees EOF immediately. Env name + protocol live in
+        // iii-worker's daemon_exit module (III_LIFELINE_FD); keep in sync.
+        #[cfg(unix)]
+        let lifeline_read = match new_cloexec_pipe() {
+            Ok((read, write)) => {
+                use std::os::fd::AsRawFd;
+                cmd.env("III_LIFELINE_FD", read.as_raw_fd().to_string());
+                *self.lifeline.lock().await = Some(write);
+                Some(read)
+            }
+            Err(e) => {
+                // Non-fatal: the daemon's PID handshake still covers engine
+                // death, just with poll latency instead of instant EOF.
+                tracing::warn!("lifeline pipe for '{}' failed: {e}", self.name);
+                None
+            }
+        };
+
         // Detach process group on Unix for clean termination
         #[cfg(unix)]
-        // SAFETY: setsid() is async-signal-safe per POSIX and safe to call in
-        // pre_exec (which runs in the forked-but-not-yet-execed child). We create
-        // a new session so the child process group can be cleanly terminated via
-        // killpg() in kill_child().
-        unsafe {
-            cmd.pre_exec(|| {
-                nix::unistd::setsid()
-                    .map_err(|e| std::io::Error::other(format!("setsid failed: {e}")))?;
-                Ok(())
-            });
+        {
+            use std::os::fd::AsRawFd;
+            let lifeline_raw = lifeline_read.as_ref().map(|fd| fd.as_raw_fd());
+            // Captured pre-fork: in the child, "my parent is still the
+            // engine" must compare against the ENGINE's pid, not against 1 —
+            // in the standard container deployment the engine IS PID 1
+            // (engine/Dockerfile has no init shim), so a `getppid()==1 →
+            // exit` check would deterministically kill every worker spawn.
+            let engine_pid = std::process::id() as i32;
+            // SAFETY: everything in this hook is async-signal-safe per POSIX
+            // (setsid, fcntl, prctl, getppid, _exit) and runs in the
+            // forked-but-not-yet-execed child. setsid() gives the child its
+            // own session so kill_child() can killpg() the whole group.
+            unsafe {
+                cmd.pre_exec(move || {
+                    nix::unistd::setsid()
+                        .map_err(|e| std::io::Error::other(format!("setsid failed: {e}")))?;
+                    // Un-CLOEXEC the lifeline read end for THIS child only
+                    // (the parent-side fds stay CLOEXEC so no other spawn
+                    // inherits them).
+                    if let Some(fd) = lifeline_raw {
+                        let flags = libc::fcntl(fd, libc::F_GETFD);
+                        if flags < 0
+                            || libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) < 0
+                        {
+                            return Err(std::io::Error::last_os_error());
+                        }
+                    }
+                    // Linux belt-and-suspenders: kernel-delivered SIGKILL on
+                    // parent death, covering even a wedged child that never
+                    // polls its watches. Tied to the spawning THREAD — a
+                    // tokio core worker thread, which lives as long as the
+                    // runtime ≈ the engine process. If the engine died
+                    // between fork and prctl, we were already reparented
+                    // (getppid no longer the engine); exit now instead of
+                    // leaking unprotected.
+                    #[cfg(target_os = "linux")]
+                    {
+                        libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL);
+                        if libc::getppid() != engine_pid {
+                            libc::_exit(125);
+                        }
+                    }
+                    #[cfg(not(target_os = "linux"))]
+                    let _ = engine_pid;
+                    Ok(())
+                });
+            }
         }
 
         let mut child = cmd.spawn().map_err(|e| {
@@ -320,13 +436,23 @@ impl Worker for ExternalWorker {
         // Watch for shutdown signal
         let child_for_shutdown = self.child.clone();
         let name_for_shutdown = self.name.clone();
+        #[cfg(unix)]
+        let lifeline_for_shutdown = self.lifeline.clone();
         tokio::spawn(async move {
             let _ = shutdown_rx.changed().await;
             tracing::info!(
                 "External worker '{}' received shutdown signal",
                 name_for_shutdown
             );
+            // SIGTERM first, lifeline-drop after: the daemon races its exit
+            // arms, and an already-pending EOF beats the signal — which
+            // would make every GRACEFUL shutdown take the "engine-gone"
+            // path and write the abnormal-death breadcrumb. Dropping after
+            // kill_child keeps EOF as a true engine-death signal (and is a
+            // no-op for the already-dead child).
             kill_child(&child_for_shutdown).await;
+            #[cfg(unix)]
+            drop(lifeline_for_shutdown.lock().await.take());
         });
 
         Ok(())
@@ -335,6 +461,9 @@ impl Worker for ExternalWorker {
     async fn destroy(&self) -> anyhow::Result<()> {
         tracing::info!("Destroying external worker '{}'", self.name);
         kill_child(&self.child).await;
+        // After kill_child for breadcrumb accuracy — see the shutdown task.
+        #[cfg(unix)]
+        drop(self.lifeline.lock().await.take());
 
         if let Some(path) = self.config_file.lock().await.take()
             && let Err(e) = std::fs::remove_file(&path)
@@ -905,5 +1034,22 @@ mod tests {
             argv.starts_with("first-arg second-arg --config "),
             "expected extra args before --config, got: {argv:?}"
         );
+
+        // Engine-attachment contract: the child must receive this engine's
+        // pid AND an OPEN lifeline pipe fd (the probe checks /dev/fd/N from
+        // inside the child — proving the pre_exec un-CLOEXEC actually made
+        // the fd survive exec).
+        #[cfg(unix)]
+        {
+            let env_line = argv.lines().nth(1).unwrap_or_default();
+            assert!(
+                env_line.contains(&format!("engine_pid={}", std::process::id())),
+                "child must see this engine's pid; got: {env_line:?}"
+            );
+            assert!(
+                env_line.contains("lifeline_open=yes"),
+                "child's lifeline fd must be open after exec; got: {env_line:?}"
+            );
+        }
     }
 }

--- a/engine/src/workers/registry_worker.rs
+++ b/engine/src/workers/registry_worker.rs
@@ -301,6 +301,15 @@ impl ExternalWorkerProcess {
         let args = spawn_args(name, port, config_path.as_deref());
         let mut cmd = tokio::process::Command::new(&worker_binary);
         cmd.args(&args).stdout(stdout_file).stderr(stderr_file);
+        // Anchor the whole spawn tree to THIS engine. `iii-worker start`
+        // detaches the real worker (VM / binary / watcher sidecar) and
+        // exits, so a lifeline pipe can't span the chain — but
+        // III_ENGINE_PID flows down inherited environments (deliberately
+        // unscrubbed; see iii-worker's daemon_exit module) and arms the
+        // VM/watcher engine-death self-watches. Without it a `killall -9
+        // iii` left every managed worker running: this path — not
+        // external.rs — is how production workers are spawned.
+        cmd.env("III_ENGINE_PID", std::process::id().to_string());
 
         let child = cmd
             .spawn()

--- a/engine/tests/fixtures/argv_probe.sh
+++ b/engine/tests/fixtures/argv_probe.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
-# argv probe: writes the args it was called with to the file named by
-# the environment variable ARGV_LOG, then sleeps so the engine's
-# spawn path can inspect the file before the probe exits.
-printf '%s\n' "$*" > "$ARGV_LOG"
+# argv probe: writes the args it was called with (line 1) and the
+# engine-attachment env contract (line 2) to the file named by the
+# environment variable ARGV_LOG, then sleeps so the engine's spawn
+# path can inspect the file before the probe exits.
+{
+  printf '%s\n' "$*"
+  if [ -e "/dev/fd/${III_LIFELINE_FD:-999}" ]; then lifeline_open=yes; else lifeline_open=no; fi
+  printf 'engine_pid=%s lifeline_fd=%s lifeline_open=%s\n' \
+    "${III_ENGINE_PID:-unset}" "${III_LIFELINE_FD:-unset}" "$lifeline_open"
+} > "$ARGV_LOG"
 sleep 30

--- a/engine/tests/worker_trigger_e2e.rs
+++ b/engine/tests/worker_trigger_e2e.rs
@@ -57,6 +57,14 @@ fn set_test_env(project_root: &std::path::Path) {
             // local port so the 2s timeout fails immediately and never
             // touches the network.
             std::env::set_var("III_API_URL", "http://127.0.0.1:1");
+            // The in-process daemon arms its engine-death watch from env at
+            // startup (daemon_exit::ExitWatch). If this TEST process was
+            // itself launched by an iii-managed parent (dogfooding, CI
+            // wrappers), ambient values would make the daemon poll a foreign
+            // pid and self-exit mid-test when it dies. Scrub them.
+            std::env::remove_var("III_ENGINE_PID");
+            std::env::remove_var("III_LIFELINE_FD");
+            std::env::remove_var("III_LIFELINE_SPAWNER_PID");
         }
     });
     // `IIIWORKER_PROJECT_ROOT` is read per-run by the daemon, so we set it


### PR DESCRIPTION
## Problem

`kill -9 iii` (or any abnormal engine death: OOM, crash, dev hard-restart) left the engine's entire spawn tree running forever:

- `worker-manager-daemon` / `sandbox-daemon` are spawned with `setsid()` (so the engine can killpg-clean them), which detaches them from every parent-death signal — they reconnect-loop as orphans. A real incident accumulated **19 of them**; an orphaned sandbox-daemon additionally pins live multi-GB libkrun VMs.
- Managed-worker `__vm-boot` VMs, `__watch-source` sidecars, and binary workers (shell/coder/database/…) all survived a real `killall -9 iii` test.

## Fix: nothing the engine started survives it

**Engine death is detected three ways, strongest first** (`crates/iii-worker/src/daemon_exit.rs`):

1. **Lifeline pipe** — the engine holds a never-written write end (`III_LIFELINE_FD`); the kernel closes it on ANY death including SIGKILL, and the child's read sees EOF instantly. CLOEXEC-armed both sides, fd validated (FIFO, fd>2) and scrubbed from the env before children can inherit it.
2. **PID handshake** — `III_ENGINE_PID` is exported at spawn and deliberately flows down the whole spawn tree, so detached processes (VMs, watchers) anchor to ENGINE lifetime no matter how many transient spawners sit in between. 2s `kill(pid,0)` poll; ESRCH-only counts as gone.
3. **Hardened reparent fallback** (version skew) — exit only when `getppid()` *changed* from the startup snapshot AND the old parent is gone — a change-only check would kill daemons under lldb (XNU reparents to the debugger).

**Cascade wiring:**

- `worker-manager-daemon` and `sandbox-daemon` share the `ExitWatch` (SIGINT/SIGTERM/SIGHUP graceful exits too — the engine's `kill_child` SIGTERM previously killed via default disposition).
- On engine-gone the worker-ops daemon runs a **session reaper**: stops every config.yaml worker host-side via the existing stop machinery (kills the VM or binary-worker process AND its watcher sidecar, 10s bound per worker, no engine needed) — this covers uncooperative binary workers.
- `__vm-boot` VMs and `__watch-source` sidecars also self-watch the engine pid as defense for the daemon-killed-first case; VM teardown goes through the ExitHandle path so `on_exit` cleanup (pidfile, socket fingerprints) still runs.
- Engine side (`engine/src/workers/external.rs`): exports both env vars, adds Linux `PR_SET_PDEATHSIG` with a pre-fork-captured engine-pid guard (safe when the engine is container PID 1 — our own Dockerfile), and drops the lifeline only AFTER `kill_child` so graceful shutdowns never race a false "engine-gone".
- Engine-gone self-exits append a one-line **breadcrumb** to `~/.iii/logs/<daemon>.log` (`ts/daemon/reason/engine_pid/spawn_parent`) — the daemon's stdout was a pipe into the now-dead engine, so without it the exit is invisible in the field.
- The macOS no-`pipe2` CLOEXEC race (a leaked write end delaying EOF) is covered by a spawner-pid poll backstop (`III_LIFELINE_SPAWNER_PID`).
- `capture_early()` runs as the first statement of `main()` before the tokio runtime exists — env scrubbing (`remove_var`) is only sound single-threaded.

**Known residual:** binary workers leak only if the engine AND the worker-ops daemon are SIGKILLed in the same instant; VMs and watchers still self-exit via their own engine anchors. PID-reuse can only cause over-survival (the old, bounded leak), never a false exit.

## Tests

15 integration tests across two suites, plus engine-side coverage:

- `daemon_orphan_exit_integration.rs` (7): reparent orphan exit (with armed-survival negative check), lifeline EOF, engine-pid handshake, survives-orphaning-while-engine-alive, SIGTERM/SIGINT/SIGHUP graceful (code 0, not signal death), watcher engine anchor, reaper pass observable.
- `engine_death_cascade_integration.rs` (8, adversarially reviewed): breadcrumb fields + no-breadcrumb-on-signal, lifeline EOF authoritative over a live declared pid, leaked-write-end backstop, engine-pid-outranks-spawner-pid precedence, garbage `III_ENGINE_PID` degrading to the reparent fallback, **a real running worker killed by the session reaper** (pidfile cleaned up), sandbox-daemon cascade. Survival windows sized at two poll intervals so first-tick-misfire mutations fail every pre-event check.
- Engine: `argv_probe` asserts the child actually sees `engine_pid=<pid>` and an open lifeline fd; e2e green.

## Test plan

- [x] `cargo test -p iii-worker` — full suite green
- [x] `cargo test -p iii` external-worker (32) + `worker_trigger_e2e` green
- [x] New cascade suite: 9 consecutive clean runs (flake check)
- [x] Zero leaked processes after every test run (`pgrep` clean)
- [ ] Real-world re-test after rebuild: `cargo build --release -p iii-worker -p iii`, start a dev session, `killall -9 iii` → `ps aux | grep iii` empty within ~5s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daemons/workers now watch engine/spawner lifelines and self-exit when those lifelines end.
  * VMs launched by the system get an explicit lifeline so spawned VMs self-terminate if their spawner dies.
  * Durable breadcrumb logging records engine-driven exits for post-mortem.

* **Bug Fixes**
  * Managed workers are reaped on engine exit to prevent orphaned processes.
  * Improved graceful shutdown across signals and engine-death scenarios.

* **Tests**
  * New Unix-only integration suites validating lifeline, engine-death, and reaper behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->