### PR TITLE
feat(worker-api): typed iii.worker.yaml manifest, worker::validate/status, and LLM-operable worker::* surfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2955,7 +2955,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "serde_yml",
  "serial_test",
  "sha2",
  "shlex",
@@ -3402,16 +3401,6 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.5",
-]
-
-[[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
 ]
 
 [[package]]
@@ -5640,21 +5629,6 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
 ]
 
 [[package]]

--- a/crates/iii-network/src/udp_relay.rs
+++ b/crates/iii-network/src/udp_relay.rs
@@ -397,7 +397,10 @@ mod tests {
             EthernetAddress([0; 6]),
             EthernetAddress([0; 6]),
         );
-        assert_eq!(frame.len(), ETH_HDR_LEN + IPV4_HDR_LEN + UDP_HDR_LEN + max.len());
+        assert_eq!(
+            frame.len(),
+            ETH_HDR_LEN + IPV4_HDR_LEN + UDP_HDR_LEN + max.len()
+        );
         assert_eq!(extract_udp_payload(&frame).unwrap(), &max[..]);
     }
 
@@ -424,10 +427,7 @@ mod tests {
             guest_mac,
         ));
 
-        outbound_tx
-            .send(Bytes::from_static(b"ping"))
-            .await
-            .unwrap();
+        outbound_tx.send(Bytes::from_static(b"ping")).await.unwrap();
         let mut buf = [0u8; 64];
         let (n, peer) = server.recv_from(&mut buf).await.unwrap();
         assert_eq!(&buf[..n], b"ping");
@@ -479,10 +479,7 @@ mod tests {
             EthernetAddress([0x02, 0, 0, 0, 0, 2]),
         ));
 
-        outbound_tx
-            .send(Bytes::from_static(b"ping"))
-            .await
-            .unwrap();
+        outbound_tx.send(Bytes::from_static(b"ping")).await.unwrap();
         let mut buf = [0u8; 64];
         let (_, peer) = server.recv_from(&mut buf).await.unwrap();
         server.send_to(b"pong", peer).await.unwrap();

--- a/crates/iii-network/src/udp_relay.rs
+++ b/crates/iii-network/src/udp_relay.rs
@@ -11,8 +11,8 @@ use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use smoltcp::wire::{
-    EthernetAddress, EthernetFrame, EthernetProtocol, EthernetRepr, IpProtocol, Ipv4Packet,
-    UdpPacket,
+    EthernetAddress, EthernetFrame, EthernetProtocol, EthernetRepr, IpAddress, IpProtocol,
+    Ipv4Packet, UdpPacket,
 };
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
@@ -25,6 +25,10 @@ const RECV_BUF_SIZE: usize = 4096;
 const ETH_HDR_LEN: usize = 14;
 const IPV4_HDR_LEN: usize = 20;
 const UDP_HDR_LEN: usize = 8;
+/// Largest UDP payload an IPv4 datagram can carry: the IP total-length
+/// field is 16-bit, minus the IP and UDP headers. Anything bigger would
+/// silently truncate in the `as u16` header writes below.
+const MAX_UDP_PAYLOAD: usize = u16::MAX as usize - IPV4_HDR_LEN - UDP_HDR_LEN;
 
 /// Relays non-DNS UDP traffic between the guest and the real network.
 ///
@@ -168,8 +172,13 @@ async fn udp_relay_task(
                             gateway_mac,
                             guest_mac,
                         );
-                        let _ = shared.rx_ring.push(frame);
-                        shared.rx_wake.wake();
+                        // Empty = construction refused (non-IPv4 addrs or
+                        // oversized payload); don't inject a zero-length
+                        // frame into the guest's rx ring.
+                        if !frame.is_empty() {
+                            let _ = shared.rx_ring.push(frame);
+                            shared.rx_wake.wake();
+                        }
                     }
                     Err(e) => {
                         tracing::debug!(error = %e, "UDP relay recv failed");
@@ -202,6 +211,9 @@ fn construct_udp_response_v4(
         std::net::IpAddr::V4(v4) => v4,
         _ => return Vec::new(),
     };
+    if payload.len() > MAX_UDP_PAYLOAD {
+        return Vec::new();
+    }
 
     let udp_len = UDP_HDR_LEN + payload.len();
     let ip_total_len = IPV4_HDR_LEN + udp_len;
@@ -234,8 +246,12 @@ fn construct_udp_response_v4(
     udp_pkt.set_src_port(src.port());
     udp_pkt.set_dst_port(dst.port());
     udp_pkt.set_len(udp_len as u16);
-    udp_pkt.set_checksum(0);
     udp_pkt.payload_mut()[..payload.len()].copy_from_slice(payload);
+    // Real checksum, not the "no checksum" zero sentinel: strict guest
+    // stacks drop zero-checksum UDP, and the pseudo-header sum catches
+    // corruption between the relay and the guest. Must run AFTER the
+    // payload write — the sum covers it.
+    udp_pkt.fill_checksum(&IpAddress::from(src_ip), &IpAddress::from(dst_ip));
 
     buf
 }
@@ -305,5 +321,64 @@ mod tests {
         );
         let payload = extract_udp_payload(&frame).unwrap();
         assert_eq!(payload, b"test data");
+    }
+
+    /// Injected response frames must carry a REAL UDP checksum, not the
+    /// "no checksum" zero sentinel — guests with strict UDP validation
+    /// drop zero-checksum datagrams, and a real checksum catches
+    /// corruption between the relay and the guest stack.
+    #[test]
+    fn construct_v4_response_fills_udp_checksum() {
+        let src_ip = Ipv4Addr::new(8, 8, 8, 8);
+        let dst_ip = Ipv4Addr::new(100, 96, 0, 2);
+        let src: SocketAddr = (src_ip, 53).into();
+        let dst: SocketAddr = (dst_ip, 12345).into();
+        let frame = construct_udp_response_v4(
+            src,
+            dst,
+            b"checksummed payload",
+            EthernetAddress([0x02, 0, 0, 0, 0, 1]),
+            EthernetAddress([0x02, 0, 0, 0, 0, 2]),
+        );
+
+        let eth = EthernetFrame::new_checked(&frame).unwrap();
+        let ipv4 = Ipv4Packet::new_checked(eth.payload()).unwrap();
+        assert!(ipv4.verify_checksum(), "IPv4 header checksum invalid");
+
+        let udp = UdpPacket::new_checked(ipv4.payload()).unwrap();
+        assert_ne!(udp.checksum(), 0, "UDP checksum left as the zero sentinel");
+        assert!(
+            udp.verify_checksum(&IpAddress::from(src_ip), &IpAddress::from(dst_ip)),
+            "UDP checksum does not verify against the pseudo-header"
+        );
+    }
+
+    /// A payload that would overflow the 16-bit IP/UDP length fields must
+    /// be rejected, not silently truncated into a corrupt header.
+    #[test]
+    fn construct_v4_response_rejects_oversized_payload() {
+        let src: SocketAddr = (Ipv4Addr::new(8, 8, 8, 8), 53).into();
+        let dst: SocketAddr = (Ipv4Addr::new(100, 96, 0, 2), 12345).into();
+        let oversized = vec![0u8; MAX_UDP_PAYLOAD + 1];
+        let frame = construct_udp_response_v4(
+            src,
+            dst,
+            &oversized,
+            EthernetAddress([0; 6]),
+            EthernetAddress([0; 6]),
+        );
+        assert!(frame.is_empty(), "oversized payload must yield no frame");
+
+        // The largest legal payload still produces a well-formed frame.
+        let max = vec![0u8; MAX_UDP_PAYLOAD];
+        let frame = construct_udp_response_v4(
+            src,
+            dst,
+            &max,
+            EthernetAddress([0; 6]),
+            EthernetAddress([0; 6]),
+        );
+        assert_eq!(frame.len(), ETH_HDR_LEN + IPV4_HDR_LEN + UDP_HDR_LEN + max.len());
+        assert_eq!(extract_udp_payload(&frame).unwrap(), &max[..]);
     }
 }

--- a/crates/iii-network/src/udp_relay.rs
+++ b/crates/iii-network/src/udp_relay.rs
@@ -271,6 +271,28 @@ fn extract_udp_payload(frame: &[u8]) -> Option<&[u8]> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::Ipv6Addr;
+
+    fn wake_signaled(pipe: &crate::wake_pipe::WakePipe) -> bool {
+        let mut buf = [0u8; 16];
+        // SAFETY: as_raw_fd() is a valid non-blocking pipe read end; reading
+        // into a local stack buffer of matching length is sound.
+        let n = unsafe { libc::read(pipe.as_raw_fd(), buf.as_mut_ptr().cast(), buf.len()) };
+        n > 0
+    }
+
+    async fn wait_for_rx_frame(shared: &SharedState) -> Vec<u8> {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if let Some(frame) = shared.rx_ring.pop() {
+                    return frame;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("relay task never injected a response frame into rx_ring")
+    }
 
     #[test]
     fn construct_v4_response_has_correct_structure() {
@@ -295,11 +317,8 @@ mod tests {
         );
 
         let ipv4 = Ipv4Packet::new_checked(eth.payload()).unwrap();
-        assert_eq!(Ipv4Addr::from(ipv4.src_addr()), Ipv4Addr::new(8, 8, 8, 8));
-        assert_eq!(
-            Ipv4Addr::from(ipv4.dst_addr()),
-            Ipv4Addr::new(100, 96, 0, 2)
-        );
+        assert_eq!(ipv4.src_addr(), Ipv4Addr::new(8, 8, 8, 8));
+        assert_eq!(ipv4.dst_addr(), Ipv4Addr::new(100, 96, 0, 2));
         assert_eq!(ipv4.next_header(), IpProtocol::Udp);
 
         let udp = UdpPacket::new_checked(ipv4.payload()).unwrap();
@@ -380,5 +399,104 @@ mod tests {
         );
         assert_eq!(frame.len(), ETH_HDR_LEN + IPV4_HDR_LEN + UDP_HDR_LEN + max.len());
         assert_eq!(extract_udp_payload(&frame).unwrap(), &max[..]);
+    }
+
+    /// A response received on the relay socket must be injected into
+    /// `rx_ring` as a well-formed frame and signal `rx_wake` so the
+    /// NetWorker delivers it to the guest.
+    #[tokio::test]
+    async fn relay_task_injects_response_frame_into_rx_ring_and_wakes() {
+        let server = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let server_addr = server.local_addr().unwrap();
+        let guest_src: SocketAddr = (Ipv4Addr::new(100, 96, 0, 2), 40000).into();
+        let gateway_mac = EthernetAddress([0x02, 0, 0, 0, 0, 1]);
+        let guest_mac = EthernetAddress([0x02, 0, 0, 0, 0, 2]);
+        let shared = Arc::new(SharedState::new(64));
+        shared.rx_wake.drain();
+        let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_CHANNEL_CAPACITY);
+
+        let task = tokio::spawn(udp_relay_task(
+            outbound_rx,
+            guest_src,
+            server_addr,
+            shared.clone(),
+            gateway_mac,
+            guest_mac,
+        ));
+
+        outbound_tx
+            .send(Bytes::from_static(b"ping"))
+            .await
+            .unwrap();
+        let mut buf = [0u8; 64];
+        let (n, peer) = server.recv_from(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"ping");
+        server.send_to(b"pong", peer).await.unwrap();
+
+        let frame = wait_for_rx_frame(&shared).await;
+
+        assert!(
+            wake_signaled(&shared.rx_wake),
+            "rx_wake must be signaled after injecting a frame"
+        );
+        let eth = EthernetFrame::new_checked(&frame).unwrap();
+        assert_eq!(eth.src_addr(), gateway_mac);
+        assert_eq!(eth.dst_addr(), guest_mac);
+        let ipv4 = Ipv4Packet::new_checked(eth.payload()).unwrap();
+        assert_eq!(ipv4.src_addr(), Ipv4Addr::LOCALHOST);
+        assert_eq!(ipv4.dst_addr(), Ipv4Addr::new(100, 96, 0, 2));
+        let udp = UdpPacket::new_checked(ipv4.payload()).unwrap();
+        assert_eq!(udp.src_port(), server_addr.port());
+        assert_eq!(udp.dst_port(), 40000);
+        assert_eq!(udp.payload(), b"pong");
+
+        drop(outbound_tx);
+        tokio::time::timeout(Duration::from_secs(5), task)
+            .await
+            .expect("relay task must exit once the outbound channel closes")
+            .unwrap()
+            .unwrap();
+    }
+
+    /// When frame construction refuses (here: non-IPv4 guest address), no
+    /// zero-length frame may be injected into `rx_ring` and `rx_wake` must
+    /// stay silent.
+    #[tokio::test]
+    async fn relay_task_skips_injection_when_frame_construction_refuses() {
+        let server = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let server_addr = server.local_addr().unwrap();
+        let guest_src: SocketAddr = (Ipv6Addr::LOCALHOST, 40000).into();
+        let shared = Arc::new(SharedState::new(64));
+        shared.rx_wake.drain();
+        let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_CHANNEL_CAPACITY);
+
+        let _task = tokio::spawn(udp_relay_task(
+            outbound_rx,
+            guest_src,
+            server_addr,
+            shared.clone(),
+            EthernetAddress([0x02, 0, 0, 0, 0, 1]),
+            EthernetAddress([0x02, 0, 0, 0, 0, 2]),
+        ));
+
+        outbound_tx
+            .send(Bytes::from_static(b"ping"))
+            .await
+            .unwrap();
+        let mut buf = [0u8; 64];
+        let (_, peer) = server.recv_from(&mut buf).await.unwrap();
+        server.send_to(b"pong", peer).await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(250)).await;
+
+        assert!(
+            shared.rx_ring.pop().is_none(),
+            "refused frame must not be injected into rx_ring"
+        );
+        assert!(
+            !wake_signaled(&shared.rx_wake),
+            "rx_wake must not fire when no frame was injected"
+        );
+        drop(outbound_tx);
     }
 }

--- a/crates/iii-shell-client/src/lib.rs
+++ b/crates/iii-shell-client/src/lib.rs
@@ -947,8 +947,7 @@ where
             "frame length {frame_len} out of range"
         )));
     }
-    let mut body: Vec<u8> = Vec::with_capacity(frame_len);
-    unsafe { body.set_len(frame_len) };
+    let mut body = vec![0u8; frame_len];
     reader
         .read_exact(&mut body)
         .await
@@ -1001,10 +1000,9 @@ async fn read_one_frame(
             "frame length {frame_len} out of range"
         )));
     }
-    // read_exact overwrites every byte, so uninit is fine — same
-    // SAFETY rationale as shell_relay::read_frame.
-    let mut body: Vec<u8> = Vec::with_capacity(frame_len);
-    unsafe { body.set_len(frame_len) };
+    // Zero-init then overwrite via read_exact — memset is noise next to
+    // the socket read (clippy::uninit_vec is deny-by-default).
+    let mut body = vec![0u8; frame_len];
     reader
         .read_exact(&mut body)
         .await

--- a/crates/iii-shell-client/src/lib.rs
+++ b/crates/iii-shell-client/src/lib.rs
@@ -1152,4 +1152,144 @@ mod tests {
         assert_eq!(s.on_stdout(b"x"), Flow::StopAppending);
         assert_eq!(s.on_stderr(b"y"), Flow::StopAppending);
     }
+
+    #[tokio::test]
+    async fn read_frame_async_round_trips_valid_frame() {
+        let (mut client, mut server) = tokio::io::duplex(1024);
+        let msg = ShellMessage::Exited { code: 7 };
+        let frame = encode_frame(11, FLAG_TERMINAL, &msg).expect("encode");
+        server.write_all(&frame).await.expect("write frame");
+
+        let got = read_frame_async(&mut client)
+            .await
+            .expect("read ok")
+            .expect("frame present");
+
+        assert_eq!(got, (11, FLAG_TERMINAL, msg));
+    }
+
+    #[tokio::test]
+    async fn read_frame_async_returns_none_on_eof_at_frame_boundary() {
+        let (mut client, server) = tokio::io::duplex(64);
+        drop(server);
+
+        let got = read_frame_async(&mut client).await.expect("clean eof");
+
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_frame_async_rejects_frame_length_above_max() {
+        let (mut client, mut server) = tokio::io::duplex(64);
+        let oversized = (MAX_FRAME_SIZE as u32) + 1;
+        server
+            .write_all(&oversized.to_be_bytes())
+            .await
+            .expect("write prefix");
+        drop(server);
+
+        let err = read_frame_async(&mut client).await.unwrap_err();
+
+        assert!(matches!(err, VmClientError::ProtocolViolation(_)));
+    }
+
+    #[tokio::test]
+    async fn read_frame_async_rejects_frame_length_below_header_size() {
+        let (mut client, mut server) = tokio::io::duplex(64);
+        let undersized = (FRAME_HEADER_SIZE as u32) - 1;
+        server
+            .write_all(&undersized.to_be_bytes())
+            .await
+            .expect("write prefix");
+        drop(server);
+
+        let err = read_frame_async(&mut client).await.unwrap_err();
+
+        assert!(matches!(err, VmClientError::ProtocolViolation(_)));
+    }
+
+    #[tokio::test]
+    async fn read_frame_async_rejects_partial_length_prefix() {
+        let (mut client, mut server) = tokio::io::duplex(64);
+        server.write_all(&[0u8, 0]).await.expect("write 2 bytes");
+        drop(server);
+
+        let err = read_frame_async(&mut client).await.unwrap_err();
+
+        assert!(matches!(err, VmClientError::ProtocolViolation(_)));
+    }
+
+    #[tokio::test]
+    async fn read_frame_async_errors_on_truncated_body() {
+        let (mut client, mut server) = tokio::io::duplex(1024);
+        let frame =
+            encode_frame(3, 0, &ShellMessage::Exited { code: 0 }).expect("encode");
+        server
+            .write_all(&frame[..frame.len() - 1])
+            .await
+            .expect("write truncated");
+        drop(server);
+
+        let err = read_frame_async(&mut client).await.unwrap_err();
+
+        assert!(matches!(err, VmClientError::Io(_)));
+    }
+
+    #[tokio::test]
+    async fn read_one_frame_round_trips_valid_frame_over_unix_socket() {
+        let (a, mut b) = UnixStream::pair().expect("socketpair");
+        let (mut read_half, _keep_write) = a.into_split();
+        let msg = ShellMessage::Exited { code: 42 };
+        let frame = encode_frame(9, 0, &msg).expect("encode");
+        b.write_all(&frame).await.expect("write frame");
+
+        let got = read_one_frame(&mut read_half)
+            .await
+            .expect("read ok")
+            .expect("frame present");
+
+        assert_eq!(got, (9, 0, msg));
+    }
+
+    #[tokio::test]
+    async fn read_one_frame_returns_none_on_eof_at_frame_boundary() {
+        let (a, b) = UnixStream::pair().expect("socketpair");
+        let (mut read_half, _keep_write) = a.into_split();
+        drop(b);
+
+        let got = read_one_frame(&mut read_half).await.expect("clean eof");
+
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_one_frame_rejects_frame_length_above_max() {
+        let (a, mut b) = UnixStream::pair().expect("socketpair");
+        let (mut read_half, _keep_write) = a.into_split();
+        let oversized = (MAX_FRAME_SIZE as u32) + 1;
+        b.write_all(&oversized.to_be_bytes())
+            .await
+            .expect("write prefix");
+        drop(b);
+
+        let err = read_one_frame(&mut read_half).await.unwrap_err();
+
+        assert!(matches!(err, VmClientError::ProtocolViolation(_)));
+    }
+
+    #[tokio::test]
+    async fn read_one_frame_errors_on_truncated_body() {
+        let (a, mut b) = UnixStream::pair().expect("socketpair");
+        let (mut read_half, _keep_write) = a.into_split();
+        let frame =
+            encode_frame(5, 0, &ShellMessage::Exited { code: 1 }).expect("encode");
+        b.write_all(&frame[..frame.len() - 1])
+            .await
+            .expect("write truncated");
+        drop(b);
+
+        let err = read_one_frame(&mut read_half).await.unwrap_err();
+
+        assert!(matches!(err, VmClientError::Io(_)));
+    }
 }

--- a/crates/iii-shell-client/src/lib.rs
+++ b/crates/iii-shell-client/src/lib.rs
@@ -1222,8 +1222,7 @@ mod tests {
     #[tokio::test]
     async fn read_frame_async_errors_on_truncated_body() {
         let (mut client, mut server) = tokio::io::duplex(1024);
-        let frame =
-            encode_frame(3, 0, &ShellMessage::Exited { code: 0 }).expect("encode");
+        let frame = encode_frame(3, 0, &ShellMessage::Exited { code: 0 }).expect("encode");
         server
             .write_all(&frame[..frame.len() - 1])
             .await
@@ -1281,8 +1280,7 @@ mod tests {
     async fn read_one_frame_errors_on_truncated_body() {
         let (a, mut b) = UnixStream::pair().expect("socketpair");
         let (mut read_half, _keep_write) = a.into_split();
-        let frame =
-            encode_frame(5, 0, &ShellMessage::Exited { code: 1 }).expect("encode");
+        let frame = encode_frame(5, 0, &ShellMessage::Exited { code: 1 }).expect("encode");
         b.write_all(&frame[..frame.len() - 1])
             .await
             .expect("write truncated");

--- a/crates/iii-shell-proto/src/lib.rs
+++ b/crates/iii-shell-proto/src/lib.rs
@@ -490,15 +490,12 @@ pub fn read_frame_blocking<R: std::io::Read>(
     let frame_len = validate_frame_len(frame_len)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
 
-    // SAFETY: read_exact fills every byte of the uninit body before
-    // decode_frame_body sees it; on error we truncate + drop. u8 has
-    // no invalid bit patterns. Matches shell_relay::read_frame.
-    let mut body: Vec<u8> = Vec::with_capacity(frame_len);
-    unsafe { body.set_len(frame_len) };
-    if let Err(e) = reader.read_exact(&mut body) {
-        body.truncate(0);
-        return Err(e);
-    }
+    // Zero-init then overwrite via read_exact. The memset is noise next
+    // to the socket read, and it keeps the buffer free of uninit bytes
+    // (clippy::uninit_vec is deny-by-default). Matches
+    // shell_relay::read_frame.
+    let mut body = vec![0u8; frame_len];
+    reader.read_exact(&mut body)?;
     let parsed = decode_frame_body(&body)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
     Ok(Some(parsed))

--- a/crates/iii-worker/Cargo.toml
+++ b/crates/iii-worker/Cargo.toml
@@ -44,7 +44,6 @@ scaffolder-core = { workspace = true }
 serde_json = "1"
 serde_yaml = "0.9"
 semver = { workspace = true }
-serde_yml = "0.0.12"
 anyhow = "1.0.100"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 async-trait = "0.1.89"

--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -13,8 +13,10 @@ pub const DEFAULT_PORT: u16 = 49134;
 /// Shared arguments for `add` and `reinstall` commands.
 #[derive(Args, Debug)]
 pub struct AddArgs {
-    /// Worker names or OCI image references (e.g., "pdfkit", "pdfkit@1.0.0", "ghcr.io/org/worker:tag")
-    #[arg(value_name = "WORKER[@VERSION]", required = true, num_args = 1..)]
+    /// Worker names, OCI image references, or local project paths — e.g.
+    /// "pdfkit", "pdfkit@1.0.0", "ghcr.io/org/worker:tag", or "./my-worker"
+    /// (a directory containing iii.worker.yaml).
+    #[arg(value_name = "WORKER[@VERSION]|PATH", required = true, num_args = 1..)]
     pub worker_names: Vec<String>,
 
     /// Reset config: also remove config.yaml entry before re-adding (requires --force on add)
@@ -36,8 +38,10 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
-    /// Install an EXISTING worker from the registry or by OCI image reference.
-    /// To create a NEW worker from scratch, use `iii worker init`.
+    /// Install an EXISTING worker from the registry, an OCI image reference, or
+    /// a local project directory (a path starting with `./`, `/`, or `~` that
+    /// contains an `iii.worker.yaml`). To create a NEW worker from scratch, use
+    /// `iii worker init`.
     Add {
         #[command(flatten)]
         args: AddArgs,

--- a/crates/iii-worker/src/cli/host_shim.rs
+++ b/crates/iii-worker/src/cli/host_shim.rs
@@ -1081,4 +1081,23 @@ mod tests {
             "worker name must be a single path segment, got {name}"
         );
     }
+
+    /// OCI re-adds have no manifest dir or registry slug to resolve a name
+    /// from, so the only safe answer is the raw reference label (the
+    /// lockfile version lookup returns None cleanly for it).
+    #[test]
+    fn post_install_worker_name_oci_readd_falls_back_to_reference_label() {
+        let reference = "ghcr.io/iii-hq/node:latest";
+        let source = crate::core::WorkerSource::Oci {
+            reference: reference.to_string(),
+        };
+        let pre: std::collections::HashSet<String> =
+            crate::cli::config_file::list_worker_names().into_iter().collect();
+
+        let name = post_install_worker_name(&source, &pre, reference);
+        assert_eq!(
+            name, reference,
+            "OCI re-add must fall back to the reference label"
+        );
+    }
 }

--- a/crates/iii-worker/src/cli/host_shim.rs
+++ b/crates/iii-worker/src/cli/host_shim.rs
@@ -1045,8 +1045,9 @@ mod tests {
         };
         // Snapshot the CURRENT config names as `pre` so the diff finds
         // nothing new — the forced re-add shape.
-        let pre: std::collections::HashSet<String> =
-            crate::cli::config_file::list_worker_names().into_iter().collect();
+        let pre: std::collections::HashSet<String> = crate::cli::config_file::list_worker_names()
+            .into_iter()
+            .collect();
         let label = dir.path().display().to_string();
 
         let name = post_install_worker_name(&source, &pre, &label);
@@ -1064,8 +1065,9 @@ mod tests {
         let source = crate::core::WorkerSource::Local {
             path: dir.path().to_path_buf(),
         };
-        let pre: std::collections::HashSet<String> =
-            crate::cli::config_file::list_worker_names().into_iter().collect();
+        let pre: std::collections::HashSet<String> = crate::cli::config_file::list_worker_names()
+            .into_iter()
+            .collect();
         let label = dir.path().display().to_string();
 
         let name = post_install_worker_name(&source, &pre, &label);
@@ -1091,8 +1093,9 @@ mod tests {
         let source = crate::core::WorkerSource::Oci {
             reference: reference.to_string(),
         };
-        let pre: std::collections::HashSet<String> =
-            crate::cli::config_file::list_worker_names().into_iter().collect();
+        let pre: std::collections::HashSet<String> = crate::cli::config_file::list_worker_names()
+            .into_iter()
+            .collect();
 
         let name = post_install_worker_name(&source, &pre, reference);
         assert_eq!(

--- a/crates/iii-worker/src/cli/host_shim.rs
+++ b/crates/iii-worker/src/cli/host_shim.rs
@@ -248,6 +248,22 @@ pub fn classify_handler_error(rc: i32, captured: &str, op: &str, name_hint: &str
     WorkerOpError::Internal { message: msg }
 }
 
+/// True when `e` is the bare rc-only wrapper from [`classify_handler_error`]
+/// — produced when the handler ran UNCAPTURED (TTY or log-file stderr), i.e.
+/// its real, colored error already reached the user directly. CLI callers
+/// should exit nonzero without re-printing it: the wrapper carries nothing
+/// the user hasn't seen, and "[W900] internal" mislabels what is usually a
+/// plain user error (caught by the live DX audit). Daemon trigger callers
+/// still receive it over the bus as a last-resort envelope when stderr
+/// capture itself failed.
+pub fn is_bare_rc_wrapper(e: &WorkerOpError) -> bool {
+    matches!(
+        e,
+        WorkerOpError::Internal { message }
+            if message.starts_with("iii worker ") && message.contains(" exited with rc ")
+    )
+}
+
 /// Strip a leading `internal: ` from handler output before re-wrapping into
 /// a typed validation error. The handler emits a self-describing message
 /// already; the prefix is misleading once we route to W100.
@@ -315,11 +331,12 @@ impl WorkerHostShim for CliHostShim {
         let reset_config = opts.reset_config;
         let wait = opts.wait;
         // Snapshot config workers BEFORE the install so we can diff and
-        // recover the canonical worker name on success. For OCI / local
-        // installs `source_label_name` returns a raw reference/path, which
-        // lockfile lookups miss and clients can't feed back into other
-        // worker::* triggers. The canonical name is whatever the installer
-        // actually wrote to config.yaml.
+        // recover the canonical worker name on success. For OCI installs
+        // `source_label_name` returns a raw reference, which lockfile
+        // lookups miss and clients can't feed back into other worker::*
+        // triggers. The canonical name is whatever the installer actually
+        // wrote to config.yaml; local re-adds (no diff) resolve it from
+        // the manifest instead.
         let pre_config_names: std::collections::HashSet<String> =
             crate::cli::config_file::list_worker_names()
                 .into_iter()
@@ -350,10 +367,10 @@ impl WorkerHostShim for CliHostShim {
         if rc == 0 {
             let label = source_label_name(&opts.source);
             // First post-install canonical name we didn't see beforehand.
-            // Falls back to the raw label for idempotent re-adds where the
-            // entry already existed (in which case the label IS the name
-            // for the registry path, and the lockfile lookup at least
-            // returns None cleanly for OCI / local sources).
+            // For idempotent re-adds where the entry already existed:
+            // registry sources use the slug, local sources resolve the
+            // manifest name, and only OCI falls back to the raw label
+            // (the lockfile lookup returns None cleanly there).
             let name = post_install_worker_name(&opts.source, &pre_config_names, &label);
             let version = read_locked_version(&name);
             Ok(AddOutcome {
@@ -626,12 +643,6 @@ impl WorkerHostShim for CliHostShim {
 // on-disk worker dirs; safe to call concurrently.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Resolve the canonical worker name after a successful add by diffing
-/// config.yaml entries. Returns the first name that appears post-install
-/// but didn't exist beforehand. Falls back to:
-///   - the registry name (for `Registry` sources, which is already canonical)
-///   - the raw label otherwise (OCI ref / local path), preserving the prior
-///     behavior for idempotent re-adds where the diff is empty.
 fn post_install_worker_name(
     source: &crate::core::WorkerSource,
     pre: &std::collections::HashSet<String>,
@@ -645,7 +656,14 @@ fn post_install_worker_name(
     }
     match source {
         crate::core::WorkerSource::Registry { name, .. } => name.clone(),
-        _ => fallback_label.to_string(),
+        // Re-adds (force: true) leave the config.yaml entry in place, so the
+        // pre/post diff finds nothing new. Resolve from the manifest (falling
+        // back to the directory name) — the raw path label is not a worker
+        // name and no other worker::* trigger accepts it.
+        crate::core::WorkerSource::Local { path } => {
+            crate::cli::local_worker::resolve_worker_name(path)
+        }
+        crate::core::WorkerSource::Oci { .. } => fallback_label.to_string(),
     }
 }
 
@@ -990,5 +1008,77 @@ mod tests {
         };
         let err = resolve_clear_targets(&opts).unwrap_err();
         assert_eq!(err.kind(), WorkerOpErrorKind::MissingTarget);
+    }
+
+    #[test]
+    fn bare_rc_wrapper_detected_only_for_uncaptured_failures() {
+        // Empty capture (CLI TTY / log-file stderr) → the bare wrapper the
+        // CLI must NOT re-print: the handler already showed the real error.
+        let bare = classify_handler_error(1, "", "add", "w");
+        assert!(is_bare_rc_wrapper(&bare));
+
+        // Captured detail → a real message the CLI/daemon caller needs.
+        let detailed = classify_handler_error(1, "error: HTTP 422 from registry", "add", "w");
+        assert!(!is_bare_rc_wrapper(&detailed));
+
+        // Other typed errors never match.
+        let not_found = classify_handler_error(1, "Worker 'w' not found", "add", "w");
+        assert!(!is_bare_rc_wrapper(&not_found));
+    }
+
+    /// Regression: a forced re-add of a local worker found no NEW name in
+    /// the config.yaml pre/post diff (the entry already existed) and fell
+    /// back to the raw path label — `worker::add` returned
+    /// `name: "/tmp/hello-world"`, which no other worker::* trigger
+    /// accepts. Local sources must resolve the name from the manifest.
+    #[test]
+    fn post_install_worker_name_local_readd_resolves_manifest_name() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("iii.worker.yaml"),
+            "name: hello-world\nscripts:\n  start: \"node src/index.js\"\n",
+        )
+        .expect("write manifest");
+
+        let source = crate::core::WorkerSource::Local {
+            path: dir.path().to_path_buf(),
+        };
+        // Snapshot the CURRENT config names as `pre` so the diff finds
+        // nothing new — the forced re-add shape.
+        let pre: std::collections::HashSet<String> =
+            crate::cli::config_file::list_worker_names().into_iter().collect();
+        let label = dir.path().display().to_string();
+
+        let name = post_install_worker_name(&source, &pre, &label);
+        assert_eq!(
+            name, "hello-world",
+            "local re-add must return the manifest name, not the path"
+        );
+    }
+
+    /// Without a manifest name, the local fallback is the directory name —
+    /// still a valid single-segment worker id, never the full path.
+    #[test]
+    fn post_install_worker_name_local_readd_without_manifest_uses_dir_name() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source = crate::core::WorkerSource::Local {
+            path: dir.path().to_path_buf(),
+        };
+        let pre: std::collections::HashSet<String> =
+            crate::cli::config_file::list_worker_names().into_iter().collect();
+        let label = dir.path().display().to_string();
+
+        let name = post_install_worker_name(&source, &pre, &label);
+        let dir_name = dir
+            .path()
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap()
+            .to_string();
+        assert_eq!(name, dir_name);
+        assert!(
+            !name.contains('/'),
+            "worker name must be a single path segment, got {name}"
+        );
     }
 }

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -1480,6 +1480,133 @@ resources:
         assert_eq!(memory, 4096);
     }
 
+    #[test]
+    fn parse_manifest_resources_defaults_when_shape_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join(WORKER_MANIFEST);
+        // Valid YAML, but `resources` is a scalar where the typed manifest
+        // requires a mapping — WorkerManifest::from_value fails and the
+        // lenient sizing probe must fall back to defaults.
+        std::fs::write(&manifest_path, "name: w\nresources: lots\n").unwrap();
+
+        let (cpus, memory) = parse_manifest_resources(&manifest_path);
+
+        assert_eq!(cpus, 2);
+        assert_eq!(memory, 2048);
+    }
+
+    #[tokio::test]
+    async fn local_add_rejects_invalid_dependency_semver_range() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = "name: iii-cov-test-dep-range\n\
+                    scripts:\n  install: \"npm install\"\n  start: \"node server.js\"\n\
+                    dependencies:\n  other-worker: \"not a semver range\"\n";
+        std::fs::write(dir.path().join(WORKER_MANIFEST), yaml).unwrap();
+
+        let code = handle_local_add(
+            dir.path().to_str().unwrap(),
+            /*force=*/ false,
+            /*reset_config=*/ false,
+            /*brief=*/ false,
+            /*wait=*/ false,
+        )
+        .await;
+
+        // Fails at dependency resolution, BEFORE config.yaml is touched.
+        assert_eq!(code, 1);
+    }
+
+    #[tokio::test]
+    async fn start_rejects_manifest_with_unknown_keys_before_boot() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = "name: w\nscripts:\n  start: \"node server.js\"\ntypo_key: 1\n";
+        std::fs::write(dir.path().join(WORKER_MANIFEST), yaml).unwrap();
+
+        let code = start_local_worker(
+            "iii-cov-test-start-unknown-key",
+            dir.path().to_str().unwrap(),
+            49134,
+        )
+        .await;
+
+        assert_eq!(code, 1);
+    }
+
+    #[tokio::test]
+    async fn start_rejects_oversized_manifest_before_boot() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut yaml = String::from("name: w\nscripts:\n  start: \"node server.js\"\n");
+        let cap = super::super::project::MAX_LOCAL_MANIFEST_BYTES as usize;
+        yaml.push_str(&"# pad\n".repeat(cap / 6 + 16));
+        assert!(yaml.len() as u64 > super::super::project::MAX_LOCAL_MANIFEST_BYTES);
+        std::fs::write(dir.path().join(WORKER_MANIFEST), yaml).unwrap();
+
+        let code = start_local_worker(
+            "iii-cov-test-start-oversize",
+            dir.path().to_str().unwrap(),
+            49134,
+        )
+        .await;
+
+        assert_eq!(code, 1);
+    }
+
+    #[tokio::test]
+    async fn start_skips_manifest_validation_when_manifest_absent() {
+        // Empty dir: read_manifest_doc returns Ok(None) (nothing to validate),
+        // then start fails at project detection — never at the validator.
+        let dir = tempfile::tempdir().unwrap();
+
+        let code = start_local_worker(
+            "iii-cov-test-start-no-manifest",
+            dir.path().to_str().unwrap(),
+            49134,
+        )
+        .await;
+
+        assert_eq!(code, 1);
+    }
+
+    #[tokio::test]
+    async fn start_passes_key_validation_then_rejects_unrecognized_kind() {
+        // Keys are all known (runtime.kind is deprecated, not unknown), so the
+        // strict start-time validator falls through; the run then fails at
+        // ProjectInfo::validate on the unsupported kind — still pre-boot.
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = "name: w\nruntime:\n  kind: cobol\n\
+                    scripts:\n  install: \"true\"\n  start: \"node server.js\"\n";
+        std::fs::write(dir.path().join(WORKER_MANIFEST), yaml).unwrap();
+
+        let code = start_local_worker(
+            "iii-cov-test-start-bad-kind",
+            dir.path().to_str().unwrap(),
+            49134,
+        )
+        .await;
+
+        assert_eq!(code, 1);
+    }
+
+    #[tokio::test]
+    async fn bundle_start_skips_local_validation_then_rejects_unrecognized_kind() {
+        // is_bundle=true takes validate_bundle_manifest (which allows the
+        // deprecated runtime.kind) and skips the local strict-validation
+        // block; the run then fails pre-boot at ProjectInfo::validate.
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = "name: iii-cov-test-bundle-kind\nruntime:\n  kind: cobol\n\
+                    scripts:\n  start: \"node bundle.js\"\n";
+        std::fs::write(dir.path().join(WORKER_MANIFEST), yaml).unwrap();
+
+        let code = start_bundle_worker(
+            "iii-cov-test-bundle-kind",
+            dir.path().to_str().unwrap(),
+            49134,
+        )
+        .await;
+
+        assert_eq!(code, 1);
+    }
+
     // Symlink-defense + 0o600 mode tests moved to super::pidfile where
     // the shared implementation lives.
 

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -84,27 +84,23 @@ pub fn restore_terminal_cooked_mode() {
     }
 }
 
+/// Best-effort read of `resources.cpus`/`resources.memory` for VM sizing.
+/// Lenient by design: any read/parse/shape failure falls back to the defaults
+/// (2 vCPUs, 2048 MiB) — strictness lives in the add/start validation and
+/// `worker::validate`, not in this sizing probe. Backed by the typed
+/// [`super::worker_manifest::WorkerManifest`] so add, start, and validate all
+/// read resources through one schema (previously this used the `serde_yml`
+/// fork while everything else used `serde_yaml`).
 pub fn parse_manifest_resources(manifest_path: &Path) -> (u32, u32) {
     let default = (2, 2048);
-    let content = match std::fs::read_to_string(manifest_path) {
-        Ok(c) => c,
-        Err(_) => return default,
+    let Ok(Some(doc)) = super::project::read_manifest_doc(manifest_path) else {
+        return default;
     };
-    let yaml: serde_yml::Value = match serde_yml::from_str(&content) {
-        Ok(v) => v,
-        Err(_) => return default,
+    let Ok(manifest) = super::worker_manifest::WorkerManifest::from_value(&doc) else {
+        return default;
     };
-    let cpus = yaml
-        .get("resources")
-        .and_then(|r| r.get("cpus"))
-        .and_then(|v| v.as_u64())
-        .unwrap_or(2) as u32;
-    let memory = yaml
-        .get("resources")
-        .and_then(|r| r.get("memory"))
-        .and_then(|v| v.as_u64())
-        .unwrap_or(2048) as u32;
-    (cpus, memory)
+    let r = manifest.resources.unwrap_or_default();
+    (r.cpus.unwrap_or(2), r.memory.unwrap_or(2048))
 }
 
 /// Remove workspace contents except installed dependency directories.
@@ -397,6 +393,56 @@ pub async fn handle_local_add(
         return 1;
     }
 
+    // 3a. Read the manifest ONCE, size-capped. The parsed doc is threaded
+    //     through key validation, dependency resolution, and config extraction
+    //     below so the file is read a single time, an oversize manifest can't
+    //     be slurped whole into memory, and a malformed one fails fast instead
+    //     of being silently skipped.
+    let manifest_path = project_path.join(WORKER_MANIFEST);
+    let manifest_doc = match super::project::read_manifest_doc(&manifest_path) {
+        Ok(doc) => doc,
+        Err(e) => {
+            eprintln!(
+                "{} {}\n  \
+                 Fix: ensure iii.worker.yaml is valid YAML and within the size limit.",
+                "error:".red(),
+                e
+            );
+            return 1;
+        }
+    };
+
+    // 3b. Strict manifest key/shape validation + deprecation warnings, BEFORE
+    //     project detection so a typo'd or malformed manifest gets the precise
+    //     validator error instead of a misleading "No project manifest
+    //     detected". Unknown keys fail the add before anything is persisted;
+    //     deprecated keys warn but proceed. Skipped when there's no
+    //     iii.worker.yaml (auto-detected workers have nothing to validate).
+    if let Some(doc) = &manifest_doc {
+        if let Err(msg) = super::project::validate_manifest_keys(doc, &manifest_path) {
+            eprintln!(
+                "{} {}\n  \
+                 Fix: remove or correct the offending key(s). Dry-run with \
+                 `worker::validate`, or see \
+                 https://motia.dev/docs/iii/worker-manifest for the supported schema.",
+                "error:".red(),
+                msg
+            );
+            return 1;
+        }
+        if let Err(msg) = super::project::require_manifest_name(doc, &manifest_path) {
+            eprintln!(
+                "{} {}\n  \
+                 Fix: add `name: <worker-name>` to iii.worker.yaml — it becomes \
+                 the config.yaml entry and the artifact directory name.",
+                "error:".red(),
+                msg
+            );
+            return 1;
+        }
+        super::project::warn_deprecated_manifest_keys(doc, &manifest_path);
+    }
+
     // 3. Detect language / project type
     let project = match load_project_info(&project_path) {
         Some(p) => p,
@@ -406,9 +452,8 @@ pub async fn handle_local_add(
                  Looked for: iii.worker.yaml, package.json, Cargo.toml, pyproject.toml.\n  \
                  Fix: run from inside your worker project, or create iii.worker.yaml:\n      \
                      name: my-worker\n      \
-                     runtime:\n        \
-                       kind: typescript\n      \
-                     command: [\"node\", \"src/index.js\"]",
+                     scripts:\n        \
+                       start: \"node src/index.js\"",
                 "error:".red(),
                 project_path.display()
             );
@@ -426,8 +471,25 @@ pub async fn handle_local_add(
         return 1;
     }
 
-    // 4. Resolve worker name
-    let worker_name = resolve_worker_name(&project_path);
+    // 4. Resolve worker name from the already-parsed manifest doc (no
+    //    re-read); fall back to the directory name like resolve_worker_name.
+    //    Trimmed to match `worker::validate`, which reports the trimmed name
+    //    as valid — without it `name: " w "` validated clean but failed here
+    //    on the embedded space.
+    let worker_name = manifest_doc
+        .as_ref()
+        .and_then(|d| d.get("name"))
+        .and_then(|n| n.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .unwrap_or_else(|| {
+            project_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("worker")
+                .to_string()
+        });
 
     // Defense in depth: the manifest's `name:` field is attacker-
     // reachable via a hand-edited or copy-pasted iii.worker.yaml, and
@@ -480,27 +542,29 @@ pub async fn handle_local_add(
         }
     }
 
-    let manifest_path = project_path.join(WORKER_MANIFEST);
-
     // 5b. Resolve + install declared manifest dependencies BEFORE we touch
     //     config.yaml. A failure here leaves the local worker NOT in
     //     config.yaml and iii.lock unchanged — retry is just retry, no
     //     `--force` dance required. This is load-bearing: reversing this
     //     order recreates the "already in config.yaml" rerun trap.
-    let declared_deps = match super::project::load_manifest_dependencies(&manifest_path) {
-        Ok(deps) => deps,
-        Err(e) => {
-            eprintln!(
-                "{} {} in {}\n  \
-                 Fix: correct the `dependencies:` block and rerun \
-                 `iii worker add {}`.",
-                "error:".red(),
-                e,
-                manifest_path.display(),
-                path,
-            );
-            return 1;
-        }
+    //     Parsed from the single manifest doc read in step 3a.
+    let declared_deps = match manifest_doc.as_ref() {
+        Some(doc) => match super::project::manifest_dependencies_from_doc(doc) {
+            Ok(deps) => deps,
+            Err(e) => {
+                eprintln!(
+                    "{} {} in {}\n  \
+                     Fix: correct the `dependencies:` block and rerun \
+                     `iii worker add {}`.",
+                    "error:".red(),
+                    e,
+                    manifest_path.display(),
+                    path,
+                );
+                return 1;
+            }
+        },
+        None => std::collections::BTreeMap::new(),
     };
     if !declared_deps.is_empty()
         && let Err(e) = super::managed::install_manifest_dependencies(&declared_deps, brief).await
@@ -516,16 +580,12 @@ pub async fn handle_local_add(
         return 1;
     }
 
-    // 6. Extract default config from iii.worker.yaml
-    let config_yaml = if manifest_path.exists() {
-        std::fs::read_to_string(&manifest_path)
-            .ok()
-            .and_then(|content| serde_yaml::from_str::<serde_yaml::Value>(&content).ok())
-            .and_then(|doc| doc.get("config").cloned())
-            .and_then(|v| serde_yaml::to_string(&v).ok())
-    } else {
-        None
-    };
+    // 6. Extract default config from the single manifest doc read in step 3a
+    //     (no re-read — also closes the read-then-write window for `config:`).
+    let config_yaml = manifest_doc
+        .as_ref()
+        .and_then(|doc| doc.get("config").cloned())
+        .and_then(|v| serde_yaml::to_string(&v).ok());
 
     // 7. Append to config.yaml with worker_path
     let abs_path_str = project_path.to_string_lossy();
@@ -763,6 +823,29 @@ async fn start_worker_impl(
             e,
         );
         return 1;
+    }
+
+    // 1b. Local (non-bundle) workers: strict key validation at start too, so a
+    // manifest hand-edited or swapped after `add` can't smuggle unknown keys
+    // (or an oversize/billion-laughs YAML) past the engine via the permissive
+    // load_project_info path below. Deprecation warnings are intentionally NOT
+    // re-emitted here — they fired at add time; repeating them on every engine
+    // boot would be noise.
+    if !is_bundle {
+        let manifest_path = project_path.join(WORKER_MANIFEST);
+        match super::project::read_manifest_doc(&manifest_path) {
+            Ok(Some(doc)) => {
+                if let Err(e) = super::project::validate_manifest_keys(&doc, &manifest_path) {
+                    eprintln!("{} manifest validation failed at start: {}", "error:".red(), e);
+                    return 1;
+                }
+            }
+            Ok(None) => {} // auto-detected worker, no manifest to validate
+            Err(e) => {
+                eprintln!("{} {}", "error:".red(), e);
+                return 1;
+            }
+        }
     }
 
     // 2. Detect language

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -836,7 +836,11 @@ async fn start_worker_impl(
         match super::project::read_manifest_doc(&manifest_path) {
             Ok(Some(doc)) => {
                 if let Err(e) = super::project::validate_manifest_keys(&doc, &manifest_path) {
-                    eprintln!("{} manifest validation failed at start: {}", "error:".red(), e);
+                    eprintln!(
+                        "{} manifest validation failed at start: {}",
+                        "error:".red(),
+                        e
+                    );
                     return 1;
                 }
             }

--- a/crates/iii-worker/src/cli/mod.rs
+++ b/crates/iii-worker/src/cli/mod.rs
@@ -38,5 +38,6 @@ pub(crate) mod test_support;
 pub mod vm_boot;
 pub mod worker_manager;
 pub mod worker_manager_daemon;
+pub mod worker_manifest;
 pub mod worker_manifest_deps;
 pub mod worker_trigger;

--- a/crates/iii-worker/src/cli/project.rs
+++ b/crates/iii-worker/src/cli/project.rs
@@ -353,11 +353,7 @@ pub fn load_from_manifest(manifest_path: &std::path::Path) -> Option<ProjectInfo
     // Prefer `runtime.kind`; fall back to the legacy `runtime.language` so
     // older manifests keep working. Deprecation warnings come from
     // `warn_deprecated_manifest_keys` on the `worker add` path.
-    let kind = rt
-        .kind
-        .as_deref()
-        .or(rt.language.as_deref())
-        .unwrap_or("");
+    let kind = rt.kind.as_deref().or(rt.language.as_deref()).unwrap_or("");
     let package_manager = rt.package_manager.as_deref().unwrap_or("");
     let entry = rt.entry.as_deref().unwrap_or("");
     let base_image = rt
@@ -404,7 +400,11 @@ pub fn load_from_manifest(manifest_path: &std::path::Path) -> Option<ProjectInfo
                 "error:".red(),
                 kind,
                 manifest_path.display(),
-                if entry.is_empty() { "src/index.ts" } else { entry },
+                if entry.is_empty() {
+                    "src/index.ts"
+                } else {
+                    entry
+                },
             );
             return None;
         }
@@ -570,7 +570,10 @@ scripts:
             serde_yaml::from_str(yaml).unwrap()
         }
 
-        assert_eq!(resolve_install(&scripts("start: run")), (String::new(), true));
+        assert_eq!(
+            resolve_install(&scripts("start: run")),
+            (String::new(), true)
+        );
         assert_eq!(
             resolve_install(&scripts("install: \"\"")),
             (String::new(), false)
@@ -989,8 +992,7 @@ dependencies:
 
     #[test]
     fn validate_keys_accepts_fully_documented_manifest() {
-        let d = doc(
-            r#"
+        let d = doc(r#"
 name: my-worker
 description: A worker that does things.
 runtime:
@@ -1006,8 +1008,7 @@ dependencies:
 resources:
   cpus: 2
   memory: 2048
-"#,
-        );
+"#);
         assert!(validate_manifest_keys(&d, &dummy_manifest_path()).is_ok());
     }
 
@@ -1019,7 +1020,10 @@ resources:
         assert!(validate_manifest_keys(&d, &dummy_manifest_path()).is_ok());
         let m = super::super::worker_manifest::WorkerManifest::from_value(&d).unwrap();
         let (unknown, deprecated) = m.classify_keys();
-        assert!(unknown.is_empty(), "description must not be unknown: {unknown:?}");
+        assert!(
+            unknown.is_empty(),
+            "description must not be unknown: {unknown:?}"
+        );
         assert!(
             !deprecated.iter().any(|d| d == "description"),
             "description must not be deprecated: {deprecated:?}"
@@ -1067,9 +1071,18 @@ resources:
         // concern (warn_deprecated_manifest_keys).
         for (manifest, expect_dep) in [
             ("name: w\nruntime:\n  kind: bun\n", "runtime.kind"),
-            ("name: w\nruntime:\n  package_manager: npm\n", "runtime.package_manager"),
-            ("name: w\nruntime:\n  entry: src/index.ts\n", "runtime.entry"),
-            ("name: w\nruntime:\n  language: typescript\n", "runtime.language"),
+            (
+                "name: w\nruntime:\n  package_manager: npm\n",
+                "runtime.package_manager",
+            ),
+            (
+                "name: w\nruntime:\n  entry: src/index.ts\n",
+                "runtime.entry",
+            ),
+            (
+                "name: w\nruntime:\n  language: typescript\n",
+                "runtime.language",
+            ),
             ("name: w\nconfig:\n  port: 3000\n", "config"),
             ("name: w\nlanguage: typescript\n", "language"),
             ("name: w\nentry: src/index.ts\n", "entry"),
@@ -1081,7 +1094,10 @@ resources:
             );
             let m = super::super::worker_manifest::WorkerManifest::from_value(&d).unwrap();
             let (unknown, deprecated) = m.classify_keys();
-            assert!(unknown.is_empty(), "no unknowns expected for {manifest}: {unknown:?}");
+            assert!(
+                unknown.is_empty(),
+                "no unknowns expected for {manifest}: {unknown:?}"
+            );
             assert!(
                 deprecated.iter().any(|x| x == expect_dep),
                 "expected `{expect_dep}` deprecated for {manifest}: {deprecated:?}"
@@ -1093,10 +1109,8 @@ resources:
 
     #[test]
     fn validate_keys_treats_env_and_dependencies_as_opaque() {
-        let d = doc(
-            "name: w\nenv:\n  MY_WEIRD_KEY: v\n  ANYTHING_GOES: w\n\
-             dependencies:\n  some-worker: \"^1\"\n  another-one: \"~2\"\n",
-        );
+        let d = doc("name: w\nenv:\n  MY_WEIRD_KEY: v\n  ANYTHING_GOES: w\n\
+             dependencies:\n  some-worker: \"^1\"\n  another-one: \"~2\"\n");
         assert!(validate_manifest_keys(&d, &dummy_manifest_path()).is_ok());
     }
 
@@ -1134,8 +1148,8 @@ resources:
         // silently waved through to a confusing downstream failure.
         let err = validate_manifest_keys(&doc("- a\n- b\n"), &dummy_manifest_path()).unwrap_err();
         assert!(err.contains("mapping"), "got: {err}");
-        let err = validate_manifest_keys(&doc("\"just a string\""), &dummy_manifest_path())
-            .unwrap_err();
+        let err =
+            validate_manifest_keys(&doc("\"just a string\""), &dummy_manifest_path()).unwrap_err();
         assert!(err.contains("mapping"), "got: {err}");
     }
 
@@ -1175,7 +1189,10 @@ resources:
         unsafe { std::env::set_var("III_NO_DEPRECATION_WARN", "1") };
         // warn path is a no-op under the gate (can't observe stderr in-process,
         // but it must run without panicking).
-        warn_deprecated_manifest_keys(&doc("name: w\nconfig:\n  port: 1\n"), &dummy_manifest_path());
+        warn_deprecated_manifest_keys(
+            &doc("name: w\nconfig:\n  port: 1\n"),
+            &dummy_manifest_path(),
+        );
         // The hard error is independent of the env var.
         let unknown_err =
             validate_manifest_keys(&doc("name: w\nruntimee:\n  x: 1\n"), &dummy_manifest_path())
@@ -1213,7 +1230,10 @@ resources:
         // through an unknown key name. Build the key programmatically so the
         // ESC byte is exact regardless of YAML escaping rules.
         let mut m = serde_yaml::Mapping::new();
-        m.insert(serde_yaml::Value::from("name"), serde_yaml::Value::from("w"));
+        m.insert(
+            serde_yaml::Value::from("name"),
+            serde_yaml::Value::from("w"),
+        );
         m.insert(
             serde_yaml::Value::from("ev\u{1b}\u{7}il"),
             serde_yaml::Value::from(1),
@@ -1260,7 +1280,10 @@ resources:
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(WORKER_MANIFEST);
         // Valid YAML, but larger than the cap.
-        let big = format!("name: w\nbloat: \"{}\"\n", "a".repeat(MAX_LOCAL_MANIFEST_BYTES as usize));
+        let big = format!(
+            "name: w\nbloat: \"{}\"\n",
+            "a".repeat(MAX_LOCAL_MANIFEST_BYTES as usize)
+        );
         std::fs::write(&path, big).unwrap();
         let err = read_manifest_doc(&path).unwrap_err();
         assert!(err.contains("capped at"), "got: {err}");

--- a/crates/iii-worker/src/cli/project.rs
+++ b/crates/iii-worker/src/cli/project.rs
@@ -1189,6 +1189,25 @@ resources:
     }
 
     #[test]
+    fn warn_returns_silently_when_manifest_shape_is_invalid() {
+        let _g = DEPRECATION_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialized via DEPRECATION_ENV_LOCK; the env gate must be
+        // open or the function returns before reaching the typed-parse branch.
+        unsafe { std::env::remove_var("III_NO_DEPRECATION_WARN") };
+        let d = doc("name: w\nruntime: node\n");
+        assert!(
+            crate::cli::worker_manifest::WorkerManifest::from_value(&d).is_err(),
+            "precondition: `runtime: node` must fail the typed parse"
+        );
+
+        // Shape errors are validate_manifest_keys' job: the warn helper must
+        // bail out of the let-else without panicking or classifying keys.
+        warn_deprecated_manifest_keys(&d, &dummy_manifest_path());
+    }
+
+    #[test]
     fn validate_keys_sanitizes_control_chars_in_echoed_keys() {
         // A hostile third-party manifest must not inject terminal escapes
         // through an unknown key name. Build the key programmatically so the

--- a/crates/iii-worker/src/cli/project.rs
+++ b/crates/iii-worker/src/cli/project.rs
@@ -14,7 +14,7 @@ pub const WORKER_MANIFEST: &str = "iii.worker.yaml";
 /// First-gate check on `runtime.base_image` — rejects shell
 /// metacharacters, whitespace, NUL, etc. Does not replace
 /// `Reference::parse`'s own grammar check.
-fn is_plausible_image_ref(s: &str) -> bool {
+pub(crate) fn is_plausible_image_ref(s: &str) -> bool {
     if s.is_empty() || s.len() > 512 {
         return false;
     }
@@ -32,6 +32,23 @@ fn is_plausible_image_ref(s: &str) -> bool {
 /// Keep in sync with the match arms in `infer_scripts()` and
 /// `oci::oci_image_for_kind()`.
 const SUPPORTED_KINDS: &[&str] = &["typescript", "javascript", "bun", "python", "rust"];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Manifest schema source of truth: `cli::worker_manifest::WorkerManifest`.
+// The typed struct defines the supported fields (mirroring the formal sections
+// in docs/creating-workers/worker-manifest.mdx), carries the deprecated legacy
+// fields (runtime.kind/package_manager/entry/language, top-level config/
+// language/entry — warned, still honored), and catches unknown keys via
+// `#[serde(flatten)]` maps. `validate_manifest_keys` / `warn_deprecated_
+// manifest_keys` below are thin wrappers over it for the add/start paths.
+// `env` and `dependencies` are arbitrary user-defined maps — their inner keys
+// are never allowlist-checked.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Max size of a local `iii.worker.yaml` we will read, mirroring the bundle
+/// path's `MAX_BUNDLE_MANIFEST_BYTES`. Guards against a hostile or accidental
+/// multi-GB manifest in a cloned worker dir being slurped into host memory.
+pub const MAX_LOCAL_MANIFEST_BYTES: u64 = 64 * 1024;
 
 pub struct ProjectInfo {
     pub name: String,
@@ -141,14 +158,14 @@ pub fn load_project_info(path: &std::path::Path) -> Option<ProjectInfo> {
     auto_detect_project(path)
 }
 
-/// Resolve `scripts.install` from a manifest's `scripts` block. Returns
+/// Resolve `scripts.install` from a manifest's `scripts` section. Returns
 /// the install command plus whether the key was *omitted* entirely.
 /// An omitted key yields `("", true)` so the caller can warn that the
 /// dependency install will be skipped; an explicit `install: ""`
 /// is an intentional opt-out and reports `("", false)`.
-fn resolve_install(scripts: Option<&serde_yaml::Value>) -> (String, bool) {
-    match scripts.and_then(|s| s.get("install")) {
-        Some(v) => (v.as_str().unwrap_or("").trim().to_string(), false),
+fn resolve_install(scripts: &super::worker_manifest::ScriptsSection) -> (String, bool) {
+    match &scripts.install {
+        Some(v) => (v.trim().to_string(), false),
         None => (String::new(), true),
     }
 }
@@ -165,47 +182,187 @@ fn install_skipped_warning(manifest_path: &std::path::Path) -> String {
     )
 }
 
+/// Read, size-cap, and parse an `iii.worker.yaml` exactly once.
+///
+/// Returns `Ok(None)` when the manifest is absent (the auto-detect path), so
+/// callers can branch without a second `exists()` check. Returns `Err` when
+/// the file exceeds [`MAX_LOCAL_MANIFEST_BYTES`] or fails to read/parse — the
+/// size cap mirrors the bundle path and bounds every downstream read, since
+/// callers thread the returned `Value` instead of re-reading.
+pub fn read_manifest_doc(
+    manifest_path: &std::path::Path,
+) -> Result<Option<serde_yaml::Value>, String> {
+    if !manifest_path.exists() {
+        return Ok(None);
+    }
+    let len = std::fs::metadata(manifest_path)
+        .map_err(|e| format!("cannot stat {}: {e}", manifest_path.display()))?
+        .len();
+    if len > MAX_LOCAL_MANIFEST_BYTES {
+        return Err(format!(
+            "{} is {len} bytes; iii.worker.yaml is capped at {MAX_LOCAL_MANIFEST_BYTES} bytes",
+            manifest_path.display(),
+        ));
+    }
+    let content = std::fs::read_to_string(manifest_path)
+        .map_err(|e| format!("cannot read {}: {e}", manifest_path.display()))?;
+    let doc = serde_yaml::from_str(&content)
+        .map_err(|e| format!("invalid YAML in {}: {e}", manifest_path.display()))?;
+    Ok(Some(doc))
+}
+
+/// Strict key/shape validation, delegating to the typed
+/// [`super::worker_manifest::WorkerManifest`] (the schema's single source of
+/// truth). Returns `Err` listing every UNKNOWN key (typo / unsupported),
+/// collected and sorted so a manifest with several mistakes surfaces them all
+/// in one run, or an `invalid manifest shape` error when a section has the
+/// wrong type (e.g. `runtime: node` where a mapping is required). Pure — emits
+/// NO warnings — so it can run on both the `add` and the `start` paths (start
+/// would otherwise re-warn about deprecated keys on every engine boot).
+///
+/// An empty manifest (`null`) or empty mapping returns `Ok(())`: there are no
+/// keys to police. Missing `name` is a separate required-field rule —
+/// [`require_manifest_name`], enforced on the add path. A non-mapping top
+/// level (a list, a bare scalar) is a shape error.
+pub fn validate_manifest_keys(
+    doc: &serde_yaml::Value,
+    manifest_path: &std::path::Path,
+) -> Result<(), String> {
+    if matches!(doc, serde_yaml::Value::Null) {
+        return Ok(());
+    }
+    if doc.as_mapping().is_none() {
+        return Err(format!(
+            "{}: manifest top level must be a YAML mapping of fields, e.g. `name: my-worker`",
+            manifest_path.display(),
+        ));
+    }
+    let manifest = super::worker_manifest::WorkerManifest::from_value(doc)
+        .map_err(|e| format!("{}: {e}", manifest_path.display()))?;
+    let (unknown, _deprecated) = manifest.classify_keys();
+    if unknown.is_empty() {
+        return Ok(());
+    }
+    Err(format!(
+        "unknown key(s) in {}: [{}]. Supported fields are: name, description, \
+         runtime.base_image, scripts.(setup|install|start), env, dependencies, \
+         resources.(cpus|memory).",
+        manifest_path.display(),
+        unknown.join(", "),
+    ))
+}
+
+/// Require a non-empty `name` on a parsed `iii.worker.yaml`. Add-path gate,
+/// run right after [`validate_manifest_keys`] (which stays pure key/shape
+/// policing). Without this, a nameless manifest fell through
+/// `load_from_manifest → None` and was misreported as "No project manifest
+/// detected" — a false diagnosis when the file plainly exists (caught by the
+/// live DX audit). Deliberately NOT enforced on the start path: workers
+/// added via auto-detect before this rule may sit next to a nameless
+/// placeholder manifest, and start must not brick them.
+pub fn require_manifest_name(
+    doc: &serde_yaml::Value,
+    manifest_path: &std::path::Path,
+) -> Result<(), String> {
+    if matches!(doc, serde_yaml::Value::Null) {
+        return Err(format!(
+            "{} is empty; at least `name` and `scripts.start` are required",
+            manifest_path.display(),
+        ));
+    }
+    let has_name = doc
+        .get("name")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .is_some_and(|s| !s.is_empty());
+    if has_name {
+        return Ok(());
+    }
+    Err(format!(
+        "{}: missing required field `name` (a single path segment, e.g. `name: my-worker`)",
+        manifest_path.display(),
+    ))
+}
+
+/// Emit a single batched DEPRECATION warning (gated by
+/// `III_NO_DEPRECATION_WARN`) for keys the parser still honors but the docs no
+/// longer define. Add-path only — the start path stays silent so engine boots
+/// don't spam the warning. Side-effect only; never fails (shape errors are
+/// `validate_manifest_keys`' job and have already gated the add by the time
+/// this runs).
+pub fn warn_deprecated_manifest_keys(doc: &serde_yaml::Value, manifest_path: &std::path::Path) {
+    if std::env::var_os("III_NO_DEPRECATION_WARN").is_some() {
+        return;
+    }
+    let Ok(manifest) = super::worker_manifest::WorkerManifest::from_value(doc) else {
+        return;
+    };
+    let (_unknown, deprecated) = manifest.classify_keys();
+    if deprecated.is_empty() {
+        return;
+    }
+    // Only print the remediation bullet for a group that is actually present,
+    // so a `config:`-only manifest isn't told how to migrate keys it lacks.
+    let has_inference = deprecated.iter().any(|d| {
+        matches!(
+            d.as_str(),
+            "runtime.kind"
+                | "runtime.package_manager"
+                | "runtime.entry"
+                | "runtime.language"
+                | "language"
+                | "entry"
+        )
+    });
+    let has_config = deprecated.iter().any(|d| d == "config");
+    let mut bullets = String::new();
+    if has_inference {
+        bullets.push_str(
+            "\n  - `runtime.kind`/`package_manager`/`entry`/`language` (and the legacy \
+             top-level `language`/`entry`): define `scripts.setup`/`install`/`start` \
+             explicitly instead.",
+        );
+    }
+    if has_config {
+        bullets.push_str(
+            "\n  - `config`: set per-worker config directly in your project's \
+             `config.yaml` entry for this worker.",
+        );
+    }
+    eprintln!(
+        "{} {}: deprecated manifest key(s) [{}]. Still honored for now but no \
+         longer part of the documented schema; they will be removed in a \
+         future version.{}\n  (set III_NO_DEPRECATION_WARN=1 to silence.)",
+        "warning:".yellow(),
+        manifest_path.display(),
+        deprecated.join(", "),
+        bullets,
+    );
+}
+
 pub fn load_from_manifest(manifest_path: &std::path::Path) -> Option<ProjectInfo> {
     let content = std::fs::read_to_string(manifest_path).ok()?;
     let doc: serde_yaml::Value = serde_yaml::from_str(&content).ok()?;
-    let name = doc.get("name")?.as_str()?.to_string();
+    // Typed view — the manifest schema's single source of truth. A shape
+    // mismatch (e.g. `runtime: node`) yields None here; on the add/start
+    // paths `validate_manifest_keys` has already surfaced the precise error.
+    let manifest = super::worker_manifest::WorkerManifest::from_value(&doc).ok()?;
+    let name = manifest.name.clone()?;
 
-    let runtime = doc.get("runtime");
-    // Prefer `runtime.kind`; fall back to the legacy `runtime.language`
-    // so older manifests keep working. When only `language` is set,
-    // print a one-line deprecation note so the user knows to migrate.
-    let kind_str = runtime.and_then(|r| r.get("kind")).and_then(|v| v.as_str());
-    let legacy_language = runtime
-        .and_then(|r| r.get("language"))
-        .and_then(|v| v.as_str());
-    let kind = match (kind_str, legacy_language) {
-        (Some(k), _) => k,
-        (None, Some(l)) => {
-            if std::env::var_os("III_NO_DEPRECATION_WARN").is_none() {
-                eprintln!(
-                    "{} {}: `runtime.language` is deprecated; rename to \
-                     `runtime.kind`. Still accepted in v0.11.x; scheduled \
-                     for removal in v0.13 (set III_NO_DEPRECATION_WARN=1 \
-                     to silence).",
-                    "warning:".yellow(),
-                    manifest_path.display()
-                );
-            }
-            l
-        }
-        (None, None) => "",
-    };
-    let package_manager = runtime
-        .and_then(|r| r.get("package_manager"))
-        .and_then(|v| v.as_str())
+    let rt = manifest.runtime.clone().unwrap_or_default();
+    // Prefer `runtime.kind`; fall back to the legacy `runtime.language` so
+    // older manifests keep working. Deprecation warnings come from
+    // `warn_deprecated_manifest_keys` on the `worker add` path.
+    let kind = rt
+        .kind
+        .as_deref()
+        .or(rt.language.as_deref())
         .unwrap_or("");
-    let entry = runtime
-        .and_then(|r| r.get("entry"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let base_image = runtime
-        .and_then(|r| r.get("base_image"))
-        .and_then(|v| v.as_str())
+    let package_manager = rt.package_manager.as_deref().unwrap_or("");
+    let entry = rt.entry.as_deref().unwrap_or("");
+    let base_image = rt
+        .base_image
+        .as_deref()
         .filter(|s| !s.trim().is_empty())
         .and_then(|s| {
             let trimmed = s.trim();
@@ -224,14 +381,8 @@ pub fn load_from_manifest(manifest_path: &std::path::Path) -> Option<ProjectInfo
             }
         });
 
-    let scripts = doc.get("scripts");
-    let (setup_cmd, install_cmd, run_cmd) = if scripts.is_some() {
-        let setup = scripts
-            .and_then(|s| s.get("setup"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .trim()
-            .to_string();
+    let (setup_cmd, install_cmd, run_cmd) = if let Some(scripts) = &manifest.scripts {
+        let setup = scripts.setup.as_deref().unwrap_or("").trim().to_string();
         // `scripts.install` omitted means no dependency install runs.
         // That silently breaks workers whose code imports those deps
         // (e.g. ModuleNotFoundError at boot), so warn loudly.
@@ -240,12 +391,7 @@ pub fn load_from_manifest(manifest_path: &std::path::Path) -> Option<ProjectInfo
         if install_omitted {
             eprintln!("{}", install_skipped_warning(manifest_path));
         }
-        let start = scripts
-            .and_then(|s| s.get("start"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .trim()
-            .to_string();
+        let start = scripts.start.as_deref().unwrap_or("").trim().to_string();
         (setup, install, start)
     } else {
         // `package_manager` is required for typescript/javascript
@@ -254,11 +400,11 @@ pub fn load_from_manifest(manifest_path: &std::path::Path) -> Option<ProjectInfo
         let needs_pm = matches!(kind, "typescript" | "javascript");
         if needs_pm && package_manager.is_empty() {
             eprintln!(
-                "{} missing `package_manager` in {}\n\n  runtime:\n    kind: {}\n    package_manager: npm    <-- add this line\n    entry: {}\n\nhint: valid options are: npm, yarn, pnpm, bun. Or use `kind: bun` directly and drop `package_manager`.",
+                "{} cannot infer install/start for `{}` in {} without `runtime.package_manager`.\n\nhint: prefer defining explicit lifecycle scripts (these are the documented, supported fields):\n\n  scripts:\n    install: \"npm install\"\n    start: \"npx tsx {}\"\n\n(the legacy inference path via `runtime.package_manager: npm|yarn|pnpm|bun` is deprecated.)",
                 "error:".red(),
-                manifest_path.display(),
                 kind,
-                entry
+                manifest_path.display(),
+                if entry.is_empty() { "src/index.ts" } else { entry },
             );
             return None;
         }
@@ -266,13 +412,10 @@ pub fn load_from_manifest(manifest_path: &std::path::Path) -> Option<ProjectInfo
     };
 
     let mut env = HashMap::new();
-    if let Some(env_map) = doc.get("env").and_then(|e| e.as_mapping()) {
-        for (k, v) in env_map {
-            if let (Some(key), Some(val)) = (k.as_str(), v.as_str())
-                && key != "III_URL"
-                && key != "III_ENGINE_URL"
-            {
-                env.insert(key.to_string(), val.to_string());
+    if let Some(env_map) = &manifest.env {
+        for (key, val) in env_map {
+            if key != "III_URL" && key != "III_ENGINE_URL" {
+                env.insert(key.clone(), val.clone());
             }
         }
     }
@@ -304,6 +447,16 @@ pub fn load_manifest_dependencies(
         .map_err(|e| format!("failed to parse {}: {e}", manifest_path.display()))?;
     let self_name = doc.get("name").and_then(|v| v.as_str());
     super::worker_manifest_deps::parse_dependencies(&doc, self_name)
+}
+
+/// Same as [`load_manifest_dependencies`] but operates on an already-parsed
+/// document, so callers that read the manifest once can thread it through
+/// instead of re-reading from disk.
+pub fn manifest_dependencies_from_doc(
+    doc: &serde_yaml::Value,
+) -> Result<BTreeMap<String, String>, String> {
+    let self_name = doc.get("name").and_then(|v| v.as_str());
+    super::worker_manifest_deps::parse_dependencies(doc, self_name)
 }
 
 pub fn auto_detect_project(path: &std::path::Path) -> Option<ProjectInfo> {
@@ -412,19 +565,20 @@ scripts:
     // The omitted/opt-out/explicit decision that drives the warning.
     #[test]
     fn resolve_install_reports_omission() {
-        let omitted: serde_yaml::Value = serde_yaml::from_str("start: run").unwrap();
-        assert_eq!(resolve_install(Some(&omitted)), (String::new(), true));
+        use super::super::worker_manifest::ScriptsSection;
+        fn scripts(yaml: &str) -> ScriptsSection {
+            serde_yaml::from_str(yaml).unwrap()
+        }
 
-        let opt_out: serde_yaml::Value = serde_yaml::from_str("install: \"\"").unwrap();
-        assert_eq!(resolve_install(Some(&opt_out)), (String::new(), false));
-
-        let explicit: serde_yaml::Value = serde_yaml::from_str("install: npm install").unwrap();
+        assert_eq!(resolve_install(&scripts("start: run")), (String::new(), true));
         assert_eq!(
-            resolve_install(Some(&explicit)),
+            resolve_install(&scripts("install: \"\"")),
+            (String::new(), false)
+        );
+        assert_eq!(
+            resolve_install(&scripts("install: npm install")),
             ("npm install".to_string(), false)
         );
-
-        assert_eq!(resolve_install(None), (String::new(), true));
     }
 
     // The skipped-install warning text is generic (not python-specific)
@@ -554,8 +708,9 @@ env:
     #[test]
     fn load_manifest_accepts_legacy_language_field() {
         // Backwards compat: old manifests with `runtime.language`
-        // keep working. Emits a deprecation warning to stderr but
-        // parses equivalently.
+        // keep working and parse equivalently. The deprecation warning
+        // now comes from `validate_manifest_keys` on the `worker add`
+        // path, not from `load_from_manifest`.
         let dir = tempfile::tempdir().unwrap();
         let manifest_path = dir.path().join("iii.worker.yaml");
         let yaml = r#"
@@ -820,5 +975,275 @@ dependencies:
         let manifest_path = dir.path().join("iii.worker.yaml");
         let deps = super::load_manifest_dependencies(&manifest_path).unwrap();
         assert!(deps.is_empty());
+    }
+
+    // ── validate_manifest_keys ──────────────────────────────────────────────
+
+    fn doc(s: &str) -> serde_yaml::Value {
+        serde_yaml::from_str(s).unwrap()
+    }
+
+    fn dummy_manifest_path() -> std::path::PathBuf {
+        std::path::PathBuf::from("/tmp/iii.worker.yaml")
+    }
+
+    #[test]
+    fn validate_keys_accepts_fully_documented_manifest() {
+        let d = doc(
+            r#"
+name: my-worker
+description: A worker that does things.
+runtime:
+  base_image: oven/bun:1
+scripts:
+  setup: "apt-get update"
+  install: "npm install"
+  start: "node server.js"
+env:
+  FOO: bar
+dependencies:
+  iii-http: "^0.19"
+resources:
+  cpus: 2
+  memory: 2048
+"#,
+        );
+        assert!(validate_manifest_keys(&d, &dummy_manifest_path()).is_ok());
+    }
+
+    #[test]
+    fn validate_keys_supports_description() {
+        // `description` is read by managed.rs and documented in workers.mdx;
+        // it must be a supported top-level field, not an unknown key.
+        let d = doc("name: w\ndescription: does things\n");
+        assert!(validate_manifest_keys(&d, &dummy_manifest_path()).is_ok());
+        let m = super::super::worker_manifest::WorkerManifest::from_value(&d).unwrap();
+        let (unknown, deprecated) = m.classify_keys();
+        assert!(unknown.is_empty(), "description must not be unknown: {unknown:?}");
+        assert!(
+            !deprecated.iter().any(|d| d == "description"),
+            "description must not be deprecated: {deprecated:?}"
+        );
+    }
+
+    #[test]
+    fn validate_keys_rejects_unknown_top_level() {
+        let d = doc("name: w\nruntimee:\n  kind: bun\n");
+        let err = validate_manifest_keys(&d, &dummy_manifest_path()).unwrap_err();
+        assert!(err.contains("runtimee"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_keys_rejects_unknown_nested_keys() {
+        let scripts = doc("name: w\nscripts:\n  instal: \"npm i\"\n  start: \"x\"\n");
+        let err = validate_manifest_keys(&scripts, &dummy_manifest_path()).unwrap_err();
+        assert!(err.contains("scripts.instal"), "got: {err}");
+
+        let runtime = doc("name: w\nruntime:\n  foo: bar\n");
+        let err = validate_manifest_keys(&runtime, &dummy_manifest_path()).unwrap_err();
+        assert!(err.contains("runtime.foo"), "got: {err}");
+
+        let resources = doc("name: w\nresources:\n  disk: 10\n");
+        let err = validate_manifest_keys(&resources, &dummy_manifest_path()).unwrap_err();
+        assert!(err.contains("resources.disk"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_keys_collects_multiple_unknowns_sorted() {
+        // Document order is zzz_bad then aaa_bad; the error must list BOTH and
+        // sort them (aaa_bad before zzz_bad), proving collect-all + sort.
+        let d = doc("name: w\nzzz_bad:\n  x: 1\naaa_bad:\n  y: 2\n");
+        let err = validate_manifest_keys(&d, &dummy_manifest_path()).unwrap_err();
+        let first = err.find("aaa_bad").expect("aaa_bad listed");
+        let second = err.find("zzz_bad").expect("zzz_bad listed");
+        assert!(first < second, "expected sorted order, got: {err}");
+    }
+
+    #[test]
+    fn validate_keys_deprecated_keys_are_not_errors() {
+        // Deprecated keys (runtime.* inference keys, top-level config, and the
+        // legacy top-level language/entry) classify as deprecated, never
+        // unknown, so strict validation passes. The warning is a separate
+        // concern (warn_deprecated_manifest_keys).
+        for (manifest, expect_dep) in [
+            ("name: w\nruntime:\n  kind: bun\n", "runtime.kind"),
+            ("name: w\nruntime:\n  package_manager: npm\n", "runtime.package_manager"),
+            ("name: w\nruntime:\n  entry: src/index.ts\n", "runtime.entry"),
+            ("name: w\nruntime:\n  language: typescript\n", "runtime.language"),
+            ("name: w\nconfig:\n  port: 3000\n", "config"),
+            ("name: w\nlanguage: typescript\n", "language"),
+            ("name: w\nentry: src/index.ts\n", "entry"),
+        ] {
+            let d = doc(manifest);
+            assert!(
+                validate_manifest_keys(&d, &dummy_manifest_path()).is_ok(),
+                "deprecated key must not error: {manifest}"
+            );
+            let m = super::super::worker_manifest::WorkerManifest::from_value(&d).unwrap();
+            let (unknown, deprecated) = m.classify_keys();
+            assert!(unknown.is_empty(), "no unknowns expected for {manifest}: {unknown:?}");
+            assert!(
+                deprecated.iter().any(|x| x == expect_dep),
+                "expected `{expect_dep}` deprecated for {manifest}: {deprecated:?}"
+            );
+            // warn path must not panic regardless of which keys are present.
+            warn_deprecated_manifest_keys(&d, &dummy_manifest_path());
+        }
+    }
+
+    #[test]
+    fn validate_keys_treats_env_and_dependencies_as_opaque() {
+        let d = doc(
+            "name: w\nenv:\n  MY_WEIRD_KEY: v\n  ANYTHING_GOES: w\n\
+             dependencies:\n  some-worker: \"^1\"\n  another-one: \"~2\"\n",
+        );
+        assert!(validate_manifest_keys(&d, &dummy_manifest_path()).is_ok());
+    }
+
+    #[test]
+    fn require_manifest_name_enforces_the_required_field() {
+        let path = dummy_manifest_path();
+        assert!(require_manifest_name(&doc("name: w\n"), &path).is_ok());
+
+        for (manifest, label) in [
+            ("scripts:\n  start: x\n", "missing name"),
+            ("name: \"\"\nscripts:\n  start: x\n", "empty name"),
+            ("name: \"   \"\n", "whitespace name"),
+        ] {
+            let err = require_manifest_name(&doc(manifest), &path).unwrap_err();
+            assert!(
+                err.contains("missing required field `name`"),
+                "{label}: got {err}"
+            );
+        }
+
+        // Empty file: the message says the manifest is empty rather than
+        // pretending the file was never found.
+        let err = require_manifest_name(&doc(""), &path).unwrap_err();
+        assert!(err.contains("is empty"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_keys_empty_is_ok_non_mapping_is_shape_error() {
+        // Empty file (null) and empty mapping: nothing to police; missing
+        // `name` is require_manifest_name's job on the add path.
+        assert!(validate_manifest_keys(&doc("{}"), &dummy_manifest_path()).is_ok());
+        assert!(validate_manifest_keys(&doc(""), &dummy_manifest_path()).is_ok());
+        // A list or bare scalar was never a functional manifest — with the
+        // typed WorkerManifest it is now a clear shape error instead of being
+        // silently waved through to a confusing downstream failure.
+        let err = validate_manifest_keys(&doc("- a\n- b\n"), &dummy_manifest_path()).unwrap_err();
+        assert!(err.contains("mapping"), "got: {err}");
+        let err = validate_manifest_keys(&doc("\"just a string\""), &dummy_manifest_path())
+            .unwrap_err();
+        assert!(err.contains("mapping"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_keys_runtime_scalar_is_shape_error() {
+        // `runtime: node` used to be silently skipped (the old key-walker
+        // couldn't express type errors). The typed manifest reports it as a
+        // clear shape error instead of letting the add fail later with the
+        // confusing "no run command could be determined".
+        let d = doc("name: w\nruntime: node\n");
+        let err = validate_manifest_keys(&d, &dummy_manifest_path()).unwrap_err();
+        assert!(err.contains("invalid manifest shape"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_keys_unknown_errors_even_with_deprecated_present() {
+        // The deprecation-collection path must not swallow the hard error when
+        // both a deprecated and an unknown key are present. (The interaction
+        // with III_NO_DEPRECATION_WARN is covered separately below.)
+        let d = doc("name: w\nconfig:\n  port: 3000\nruntimee:\n  kind: bun\n");
+        let err = validate_manifest_keys(&d, &dummy_manifest_path()).unwrap_err();
+        assert!(err.contains("runtimee"), "got: {err}");
+    }
+
+    /// Serializes the two tests that mutate the process-global
+    /// `III_NO_DEPRECATION_WARN` env var so they don't race each other (or
+    /// other tests that read it) under cargo's parallel test runner.
+    static DEPRECATION_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn env_gate_silences_warning_but_validation_still_errors() {
+        let _g = DEPRECATION_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialized via DEPRECATION_ENV_LOCK and restored before any
+        // assertion (so a panic can't leak the var into other tests).
+        unsafe { std::env::set_var("III_NO_DEPRECATION_WARN", "1") };
+        // warn path is a no-op under the gate (can't observe stderr in-process,
+        // but it must run without panicking).
+        warn_deprecated_manifest_keys(&doc("name: w\nconfig:\n  port: 1\n"), &dummy_manifest_path());
+        // The hard error is independent of the env var.
+        let unknown_err =
+            validate_manifest_keys(&doc("name: w\nruntimee:\n  x: 1\n"), &dummy_manifest_path())
+                .is_err();
+        unsafe { std::env::remove_var("III_NO_DEPRECATION_WARN") };
+
+        assert!(
+            unknown_err,
+            "III_NO_DEPRECATION_WARN must never suppress the unknown-key error"
+        );
+    }
+
+    #[test]
+    fn validate_keys_sanitizes_control_chars_in_echoed_keys() {
+        // A hostile third-party manifest must not inject terminal escapes
+        // through an unknown key name. Build the key programmatically so the
+        // ESC byte is exact regardless of YAML escaping rules.
+        let mut m = serde_yaml::Mapping::new();
+        m.insert(serde_yaml::Value::from("name"), serde_yaml::Value::from("w"));
+        m.insert(
+            serde_yaml::Value::from("ev\u{1b}\u{7}il"),
+            serde_yaml::Value::from(1),
+        );
+        let d = serde_yaml::Value::Mapping(m);
+        let err = validate_manifest_keys(&d, &dummy_manifest_path()).unwrap_err();
+        assert!(
+            !err.contains('\u{1b}') && !err.contains('\u{7}'),
+            "control bytes must be stripped from echoed key: {err:?}"
+        );
+        assert!(
+            err.contains("evil"),
+            "printable key text should survive sanitization: {err}"
+        );
+    }
+
+    #[test]
+    fn read_manifest_doc_absent_is_ok_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(WORKER_MANIFEST);
+        assert!(matches!(read_manifest_doc(&path), Ok(None)));
+    }
+
+    #[test]
+    fn read_manifest_doc_valid_parses() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(WORKER_MANIFEST);
+        std::fs::write(&path, "name: w\nscripts:\n  start: x\n").unwrap();
+        let doc = read_manifest_doc(&path).unwrap().expect("Some");
+        assert_eq!(doc.get("name").and_then(|v| v.as_str()), Some("w"));
+    }
+
+    #[test]
+    fn read_manifest_doc_malformed_is_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(WORKER_MANIFEST);
+        std::fs::write(&path, "name: w\n  : : bad\n:\n").unwrap();
+        let err = read_manifest_doc(&path).unwrap_err();
+        assert!(err.contains("invalid YAML"), "got: {err}");
+    }
+
+    #[test]
+    fn read_manifest_doc_oversize_is_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(WORKER_MANIFEST);
+        // Valid YAML, but larger than the cap.
+        let big = format!("name: w\nbloat: \"{}\"\n", "a".repeat(MAX_LOCAL_MANIFEST_BYTES as usize));
+        std::fs::write(&path, big).unwrap();
+        let err = read_manifest_doc(&path).unwrap_err();
+        assert!(err.contains("capped at"), "got: {err}");
     }
 }

--- a/crates/iii-worker/src/cli/shell_relay.rs
+++ b/crates/iii-worker/src/cli/shell_relay.rs
@@ -723,8 +723,7 @@ async fn client_session(
 
 /// Read one full frame (length prefix + body). `Ok(None)` on EOF at
 /// a frame boundary. Returned buffer includes the 4-byte length
-/// prefix so callers forward verbatim. Skips zero-fill of the body
-/// via `set_len` + `read_exact` (SAFETY below).
+/// prefix so callers forward verbatim.
 async fn read_frame<R: AsyncReadExt + Unpin>(
     reader: &mut R,
 ) -> std::io::Result<Option<FrameBytes>> {
@@ -740,16 +739,12 @@ async fn read_frame<R: AsyncReadExt + Unpin>(
         ));
     }
     let total = 4 + frame_len;
-    let mut buf: FrameBytes = Vec::with_capacity(total);
-    // SAFETY: `u8` has no invalid bit patterns. The uninit capacity
-    // is fully overwritten by `copy_from_slice` + `read_exact` before
-    // any read; on error we truncate + drop without observing.
-    unsafe { buf.set_len(total) };
+    // Zero-init then overwrite via copy_from_slice + read_exact. The
+    // memset is noise next to the socket read, and it keeps the buffer
+    // free of uninit bytes (clippy::uninit_vec is deny-by-default).
+    let mut buf: FrameBytes = vec![0u8; total];
     buf[..4].copy_from_slice(&len_buf);
-    if let Err(e) = reader.read_exact(&mut buf[4..]).await {
-        buf.truncate(0);
-        return Err(e);
-    }
+    reader.read_exact(&mut buf[4..]).await?;
     Ok(Some(buf))
 }
 

--- a/crates/iii-worker/src/cli/worker_manager_daemon.rs
+++ b/crates/iii-worker/src/cli/worker_manager_daemon.rs
@@ -772,3 +772,289 @@ fn register_clear(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
         ),
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::lock_home;
+    use super::*;
+
+    #[test]
+    fn op_description_documents_the_manifest_pseudo_id() {
+        let desc = op_description("iii.worker.yaml");
+
+        assert!(desc.contains("JSON Schema"));
+        assert!(desc.contains("worker::schema"));
+        assert!(desc.contains("worker::validate"));
+    }
+
+    fn schema_entry(id: &str) -> &'static (&'static str, Option<Value>, Option<Value>) {
+        schema_table()
+            .iter()
+            .find(|(entry_id, _, _)| *entry_id == id)
+            .unwrap_or_else(|| panic!("schema_table is missing {id}"))
+    }
+
+    #[test]
+    fn schema_table_serves_status_and_validate_entries() {
+        let (_, status_req, status_resp) = schema_entry("worker::status");
+        let (_, validate_req, validate_resp) = schema_entry("worker::validate");
+
+        let status_props = status_req.as_ref().unwrap()["properties"]
+            .as_object()
+            .unwrap();
+        assert!(status_props.contains_key("name"));
+        assert!(status_resp.as_ref().unwrap()["properties"]["hint"].is_object());
+
+        let validate_props = validate_req.as_ref().unwrap()["properties"]
+            .as_object()
+            .unwrap();
+        assert!(validate_props.contains_key("manifest"));
+        assert!(validate_props.contains_key("path"));
+        assert!(validate_resp.as_ref().unwrap()["properties"]["errors"].is_object());
+    }
+
+    #[test]
+    fn schema_table_manifest_pseudo_entry_carries_schema_and_example() {
+        let (_, req, resp) = schema_entry("iii.worker.yaml");
+
+        assert_eq!(req.as_ref().unwrap(), &manifest_schema_json());
+        assert_eq!(resp.as_ref().unwrap(), &hello_world_example_json());
+    }
+
+    // `III` exposes no registry listing, so the duplicate-registration
+    // panic is the only externally observable proof that `register_all`
+    // claimed a function id.
+    fn offline_iii_with_sink() -> (III, Arc<IIIEventSink>) {
+        let iii = III::new("ws://127.0.0.1:9");
+        let subs: Subscriptions = Arc::new(Mutex::new(HashMap::new()));
+        let sink = Arc::new(IIIEventSink::new(iii.clone(), subs, CallerMode::Trigger));
+        (iii, sink)
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "function id 'worker::status' already registered")]
+    async fn register_all_claims_the_worker_status_id() {
+        let (iii, sink) = offline_iii_with_sink();
+        register_all(&iii, PathBuf::from("."), sink);
+
+        iii.register_function(
+            "worker::status",
+            RegisterFunction::new_async(|input: Value| async move { Ok::<_, IIIError>(input) }),
+        );
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "function id 'worker::validate' already registered")]
+    async fn register_all_claims_the_worker_validate_id() {
+        let (iii, sink) = offline_iii_with_sink();
+        register_all(&iii, PathBuf::from("."), sink);
+
+        iii.register_function(
+            "worker::validate",
+            RegisterFunction::new_async(|input: Value| async move { Ok::<_, IIIError>(input) }),
+        );
+    }
+
+    struct EnvGuard {
+        home: Option<std::ffi::OsString>,
+        cwd: Option<PathBuf>,
+    }
+
+    impl EnvGuard {
+        fn new(home: &std::path::Path) -> Self {
+            let original_home = std::env::var_os("HOME");
+            let original_cwd = std::env::current_dir().ok();
+            // SAFETY: test-only, serialized via test_support::lock_home.
+            unsafe { std::env::set_var("HOME", home) };
+            std::env::set_current_dir(home).unwrap();
+            Self {
+                home: original_home,
+                cwd: original_cwd,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            if let Some(cwd) = &self.cwd {
+                let _ = std::env::set_current_dir(cwd);
+            }
+            // SAFETY: test-only, serialized via test_support::lock_home.
+            unsafe {
+                match &self.home {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn build_status_rejects_traversal_worker_name() {
+        let err = build_status("../evil").await.unwrap_err();
+
+        assert_eq!(err.kind(), WorkerOpErrorKind::BadRequest);
+        assert!(matches!(
+            err,
+            WorkerOpError::BadRequest { ref function_id, .. }
+                if function_id == "worker::status"
+        ));
+    }
+
+    #[tokio::test]
+    async fn build_status_reports_not_installed_worker() {
+        let _g = lock_home();
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new(tmp.path());
+
+        let s = build_status("wmd-ghost").await.unwrap();
+
+        assert!(!s.installed);
+        assert_eq!(s.worker_type, "not-installed");
+        assert!(!s.running);
+        assert!(s.pid.is_none());
+        assert!(s.version.is_none());
+        assert!(s.logs_dir.is_none());
+        assert!(s.hint.contains("worker::add"));
+    }
+
+    #[tokio::test]
+    async fn build_status_reports_running_binary_worker() {
+        let _g = lock_home();
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new(tmp.path());
+
+        let name = "wmd-bin";
+        std::fs::write(
+            tmp.path().join("config.yaml"),
+            format!("workers:\n  - name: {name}\n"),
+        )
+        .unwrap();
+        let workers_dir = tmp.path().join(".iii/workers");
+        std::fs::create_dir_all(&workers_dir).unwrap();
+        std::fs::write(workers_dir.join(name), b"").unwrap();
+        let pids = tmp.path().join(".iii/pids");
+        std::fs::create_dir_all(&pids).unwrap();
+        // Our own pid makes the kill(pid, 0) liveness check succeed.
+        std::fs::write(
+            pids.join(format!("{name}.pid")),
+            std::process::id().to_string(),
+        )
+        .unwrap();
+
+        let s = build_status(name).await.unwrap();
+
+        assert!(s.installed);
+        assert_eq!(s.worker_type, "binary");
+        assert!(s.running);
+        assert!(s.hint.contains("engine::functions::list"));
+    }
+
+    #[tokio::test]
+    async fn build_status_hints_provisioning_for_local_worker_without_logs() {
+        let _g = lock_home();
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new(tmp.path());
+
+        let name = "wmd-local";
+        std::fs::write(
+            tmp.path().join("config.yaml"),
+            format!("workers:\n  - name: {name}\n    worker_path: /tmp/{name}\n"),
+        )
+        .unwrap();
+
+        let s = build_status(name).await.unwrap();
+
+        assert!(s.installed);
+        assert_eq!(s.worker_type, "local");
+        assert!(!s.running);
+        assert!(s.hint.contains("still provisioning"));
+    }
+
+    #[tokio::test]
+    async fn build_status_surfaces_stderr_tail_and_version_for_failed_oci_worker() {
+        let _g = lock_home();
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new(tmp.path());
+
+        let name = "wmd-oci";
+        std::fs::write(
+            tmp.path().join("config.yaml"),
+            format!("workers:\n  - name: {name}\n    image: ghcr.io/acme/{name}:1\n"),
+        )
+        .unwrap();
+        let logs = tmp.path().join(".iii/logs").join(name);
+        std::fs::create_dir_all(&logs).unwrap();
+        std::fs::write(logs.join("stderr.log"), "npm ERR! boom\n").unwrap();
+        let digest = "a".repeat(64);
+        std::fs::write(
+            tmp.path().join("iii.lock"),
+            format!(
+                "version: 1\nworkers:\n  {name}:\n    version: 9.9.9\n    type: image\n    \
+                 source:\n      kind: image\n      image: ghcr.io/acme/{name}@sha256:{digest}\n"
+            ),
+        )
+        .unwrap();
+
+        let s = build_status(name).await.unwrap();
+
+        assert!(s.installed);
+        assert_eq!(s.worker_type, "oci");
+        assert!(!s.running);
+        assert_eq!(s.version.as_deref(), Some("9.9.9"));
+        assert!(s.logs_dir.is_some());
+        assert_eq!(s.stderr_tail, vec!["npm ERR! boom".to_string()]);
+        assert!(s.hint.contains("stderr_tail"));
+    }
+
+    #[tokio::test]
+    async fn build_status_classifies_bundle_worker() {
+        let _g = lock_home();
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new(tmp.path());
+
+        let name = "wmd-bundle";
+        std::fs::write(
+            tmp.path().join("config.yaml"),
+            format!("workers:\n  - name: {name}\n"),
+        )
+        .unwrap();
+        let bundle = tmp.path().join(".iii/workers-bundle").join(name);
+        std::fs::create_dir_all(&bundle).unwrap();
+        std::fs::write(bundle.join("iii.worker.yaml"), format!("name: {name}\n")).unwrap();
+
+        let s = build_status(name).await.unwrap();
+
+        assert!(s.installed);
+        assert_eq!(s.worker_type, "bundle");
+        assert!(!s.running);
+    }
+
+    #[tokio::test]
+    async fn build_status_counts_builtin_as_running_when_engine_port_listens() {
+        let _g = lock_home();
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new(tmp.path());
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let name = "wmd-builtin";
+        std::fs::write(
+            tmp.path().join("config.yaml"),
+            format!(
+                "workers:\n  - name: iii-worker-manager\n    config:\n      port: {port}\n  - name: {name}\n"
+            ),
+        )
+        .unwrap();
+
+        let s = build_status(name).await.unwrap();
+
+        assert!(s.installed);
+        assert_eq!(s.worker_type, "builtin");
+        assert!(
+            s.running,
+            "builtin worker must count as running while the engine port is up"
+        );
+        drop(listener);
+    }
+}

--- a/crates/iii-worker/src/cli/worker_manager_daemon.rs
+++ b/crates/iii-worker/src/cli/worker_manager_daemon.rs
@@ -466,11 +466,9 @@ async fn build_status(name: &str) -> Result<StatusOutcome, WorkerOpError> {
     use crate::cli::config_file::{self, ResolvedWorkerType};
     use crate::cli::managed::{find_worker_pid_from_ps, is_engine_running, is_worker_running};
 
-    crate::core::types::validate_worker_name(name).map_err(|reason| {
-        WorkerOpError::BadRequest {
-            function_id: "worker::status".into(),
-            reason,
-        }
+    crate::core::types::validate_worker_name(name).map_err(|reason| WorkerOpError::BadRequest {
+        function_id: "worker::status".into(),
+        reason,
     })?;
 
     let installed = config_file::worker_exists(name);
@@ -489,14 +487,12 @@ async fn build_status(name: &str) -> Result<StatusOutcome, WorkerOpError> {
     let worker_running = is_worker_running(name);
     // Engine builtins run inside the engine process; count them as running
     // when the engine is up (mirrors CliHostShim::list / `iii worker list`).
-    let running =
-        worker_running || (installed && worker_type == "builtin" && is_engine_running());
+    let running = worker_running || (installed && worker_type == "builtin" && is_engine_running());
     let pid = find_worker_pid_from_ps(name);
-    let version = crate::cli::lockfile::WorkerLockfile::read_from(
-        crate::cli::lockfile::lockfile_path(),
-    )
-    .ok()
-    .and_then(|lf| lf.workers.get(name).map(|w| w.version.clone()));
+    let version =
+        crate::cli::lockfile::WorkerLockfile::read_from(crate::cli::lockfile::lockfile_path())
+            .ok()
+            .and_then(|lf| lf.workers.get(name).map(|w| w.version.clone()));
 
     let logs = core_logs::run(LogsOptions {
         name: name.to_string(),
@@ -510,9 +506,7 @@ async fn build_status(name: &str) -> Result<StatusOutcome, WorkerOpError> {
          with worker::validate)"
             .to_string()
     } else if running {
-        format!(
-            "running; see its functions with engine::functions::list {{ search: {name:?} }}"
-        )
+        format!("running; see its functions with engine::functions::list {{ search: {name:?} }}")
     } else if logs.stderr.is_empty() && logs.stdout.is_empty() {
         "installed but not running and no logs yet — likely still provisioning; \
          poll again shortly, or worker::start to boot it"
@@ -540,9 +534,7 @@ async fn build_status(name: &str) -> Result<StatusOutcome, WorkerOpError> {
 
 fn register_status(iii: &III) {
     let rf = RegisterFunction::new_async_with_bad_request(
-        |opts: StatusOptions| async move {
-            build_status(&opts.name).await.map_err(|e| op_error(&e))
-        },
+        |opts: StatusOptions| async move { build_status(&opts.name).await.map_err(|e| op_error(&e)) },
         |e| bad_request_error("worker::status", &e),
     );
     let _ = iii.register_function("worker::status", describe_op(rf, "worker::status"));
@@ -567,7 +559,11 @@ fn register_validate(iii: &III) {
                 }
                 (Some(text), None) => report_from_str(&text),
                 (None, Some(p)) => {
-                    let file = if p.is_dir() { p.join(WORKER_MANIFEST) } else { p };
+                    let file = if p.is_dir() {
+                        p.join(WORKER_MANIFEST)
+                    } else {
+                        p
+                    };
                     // Stat-first so a huge file is rejected without reading it
                     // into memory (same cap the add path enforces).
                     match std::fs::metadata(&file) {
@@ -585,7 +581,8 @@ fn register_validate(iii: &III) {
                             Ok(content) => report_from_str(&content),
                             Err(e) => {
                                 let mut r = ManifestReport::default();
-                                r.errors.push(format!("cannot read {}: {e}", file.display()));
+                                r.errors
+                                    .push(format!("cannot read {}: {e}", file.display()));
                                 r
                             }
                         },

--- a/crates/iii-worker/src/cli/worker_manager_daemon.rs
+++ b/crates/iii-worker/src/cli/worker_manager_daemon.rs
@@ -19,9 +19,10 @@ use std::sync::{Arc, Mutex};
 use crate::core::{
     AddOptions, AddOutcome, ClearOptions, ClearOutcome, EventSink, ListOptions, ListOutcome,
     LogsOptions, LogsOutcome, NullSink, ProjectCtx, RemoveOptions, RemoveOutcome, StartOptions,
-    StartOutcome, StopOptions, StopOutcome, UpdateOptions, UpdateOutcome, WorkerOpError,
-    WorkerOpErrorKind, add as core_add, clear as core_clear, list as core_list, logs as core_logs,
-    remove as core_remove, start as core_start, stop as core_stop, update as core_update,
+    StartOutcome, StatusOptions, StatusOutcome, StopOptions, StopOutcome, UpdateOptions,
+    UpdateOutcome, WorkerOpError, WorkerOpErrorKind, add as core_add, clear as core_clear,
+    list as core_list, logs as core_logs, remove as core_remove, start as core_start,
+    stop as core_stop, update as core_update,
 };
 use iii_observability::OtelConfig;
 use iii_sdk::{
@@ -33,6 +34,11 @@ use serde_json::{Value, json};
 
 use crate::cli::app::WorkerManagerDaemonArgs;
 use crate::cli::host_shim::CliHostShim;
+use crate::cli::project::{MAX_LOCAL_MANIFEST_BYTES, WORKER_MANIFEST};
+use crate::cli::worker_manifest::{
+    ManifestReport, ValidateOptions, hello_world_example_json, manifest_schema_json,
+    report_from_str,
+};
 use crate::cli::worker_trigger::{
     IIIEventSink, Subscriptions, WorkerCallRequest, WorkerTriggerConfig, WorkerTriggerHandler,
 };
@@ -61,8 +67,9 @@ pub async fn run(args: WorkerManagerDaemonArgs) -> i32 {
                 name: "iii-worker-ops".to_string(),
                 description: Some(
                     "Manages installed workers: add/remove/update/start/stop/list/clear/logs, \
-                     plus worker::schema introspection and the `worker` lifecycle \
-                     trigger type."
+                     plus worker::schema introspection (including the iii.worker.yaml \
+                     manifest schema), worker::validate manifest dry-runs, and the \
+                     `worker` lifecycle trigger type."
                         .to_string(),
                 ),
                 ..Default::default()
@@ -183,12 +190,37 @@ fn schema_for_value<T: JsonSchema>() -> Option<Value> {
 #[doc(hidden)]
 pub fn op_description(function_id: &str) -> &'static str {
     match function_id {
-        "worker::add" => "Install a worker from registry name or OCI ref",
+        "worker::add" => {
+            "Install a worker from a registry slug, an OCI image ref, or a LOCAL \
+             project directory (one containing an iii.worker.yaml). Call \
+             worker::schema to see each source shape, and worker::validate to \
+             dry-run an iii.worker.yaml before installing. LOCAL installs run \
+             the project directory LIVE and start a source watcher: code edits \
+             auto-restart the worker, so do NOT re-add after changing source \
+             files — re-add (force: true) only when iii.worker.yaml itself \
+             changes. Installs can outlive a bus invocation timeout and \
+             CONTINUE server-side — on timeout, poll worker::status instead of \
+             re-issuing (the project lock stays held until the in-flight \
+             install finishes)."
+        }
         "worker::remove" => "Uninstall workers and clear their artifacts",
-        "worker::update" => "Reinstall workers preserving config",
+        "worker::update" => {
+            "Reinstall REGISTRY-installed workers preserving config (re-resolves \
+             iii.lock pins). LOCAL-path workers are NOT touched by this: their \
+             source watcher already auto-restarts them on code edits; only an \
+             iii.worker.yaml change needs worker::add with force: true. Like \
+             worker::add, updates can outlive a bus timeout and continue \
+             server-side — poll worker::status."
+        }
         "worker::start" => "Start a configured worker",
         "worker::stop" => "Stop a running worker",
         "worker::list" => "List installed workers",
+        "worker::status" => {
+            "Install/runtime status for ONE worker: installed?, running?, pid, \
+             version, a sanitized recent log tail, and a next-step hint. THE poll \
+             target after worker::add { wait: false } or after an add/update call \
+             hit a bus timeout (the install keeps running server-side)."
+        }
         "worker::clear" => "Wipe worker artifacts",
         "worker::logs" => {
             "Read a worker's recent stdout/stderr log lines from the engine host. \
@@ -196,7 +228,23 @@ pub fn op_description(function_id: &str) -> &'static str {
         }
         "worker::schema" => {
             "Introspect request/response schemas for worker::* triggers. \
-             Optional `function_id` filters to a single trigger."
+             Optional `function_id` filters to a single trigger. Also serves \
+             the iii.worker.yaml manifest schema under the pseudo-id \
+             \"iii.worker.yaml\"."
+        }
+        "worker::validate" => {
+            "Dry-run validation of an iii.worker.yaml WITHOUT installing \
+             anything. Pass `manifest` (inline YAML text) or `path` (host \
+             file/dir). Returns errors, unknown keys, deprecated keys, and \
+             warnings — author, validate, then worker::add."
+        }
+        "iii.worker.yaml" => {
+            "JSON Schema for the iii.worker.yaml manifest file (not a callable \
+             trigger). Fetch via worker::schema { function_id: \
+             \"iii.worker.yaml\" }: `request` = the manifest schema, `response` \
+             = a complete minimal Node hello-world worker as { path: file \
+             contents } ready to write to disk (uses the `iii-sdk` npm \
+             package). Check a concrete manifest with worker::validate."
         }
         _ => "",
     }
@@ -226,6 +274,8 @@ fn register_all(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     register_clear(iii, project_root, sink);
     register_logs(iii);
     register_schema(iii);
+    register_status(iii);
+    register_validate(iii);
 }
 
 #[derive(serde::Deserialize, JsonSchema)]
@@ -269,6 +319,11 @@ pub fn op_metadata(function_id: &str) -> (u64, bool) {
         "worker::clear" => (30_000, true),
         "worker::logs" => (10_000, true),
         "worker::schema" => (10_000, true),
+        "worker::status" => (10_000, true),
+        "worker::validate" => (10_000, true),
+        // Pseudo-id for the manifest schema served by worker::schema; not a
+        // callable trigger, but the SchemaEntry row still carries metadata.
+        "iii.worker.yaml" => (10_000, true),
         _ => (30_000, false),
     }
 }
@@ -278,9 +333,11 @@ struct SchemaResponse {
     schemas: Vec<SchemaEntry>,
 }
 
-/// The 9 worker::* (function_id, request, response) schema triples, built
-/// once via schemars reflection and reused on every `worker::schema` call.
-/// Regenerating all 16 schemas per invocation was wasted CPU/allocation on
+/// The 10 worker::* (function_id, request, response) schema triples plus the
+/// `iii.worker.yaml` pseudo-entry (the manifest file's own JSON Schema, so
+/// LLMs can author a manifest from the real contract), built once via
+/// schemars reflection and reused on every `worker::schema` call.
+/// Regenerating every schema per invocation was wasted CPU/allocation on
 /// an endpoint LLM/automation callers hit repeatedly; only the matched
 /// entries are cloned per request.
 fn schema_table() -> &'static [(&'static str, Option<Value>, Option<Value>)] {
@@ -332,6 +389,26 @@ fn schema_table() -> &'static [(&'static str, Option<Value>, Option<Value>)] {
                     schema_for_value::<SchemaRequest>(),
                     schema_for_value::<SchemaResponse>(),
                 ),
+                (
+                    "worker::status",
+                    schema_for_value::<StatusOptions>(),
+                    schema_for_value::<StatusOutcome>(),
+                ),
+                (
+                    "worker::validate",
+                    schema_for_value::<ValidateOptions>(),
+                    schema_for_value::<ManifestReport>(),
+                ),
+                // Pseudo-entry: the iii.worker.yaml authoring contract.
+                // request = the manifest's own JSON Schema; response = a
+                // complete minimal Node hello-world worker as { path → file
+                // contents }, ready to write to disk. Fetch via
+                // worker::schema { function_id: "iii.worker.yaml" }.
+                (
+                    "iii.worker.yaml",
+                    Some(manifest_schema_json()),
+                    Some(hello_world_example_json()),
+                ),
             ]
         });
     &TABLE
@@ -377,6 +454,157 @@ fn register_schema(iii: &III) {
         |e| bad_request_error("worker::schema", &e),
     );
     let _ = iii.register_function("worker::schema", describe_op(rf, "worker::schema"));
+}
+
+/// Compose one worker's status from host-side observables: config.yaml
+/// declaration, process liveness, lockfile version, and a sanitized log
+/// tail. Born from a harness session where, after `worker::add` timed out at
+/// the bus gate, the caller had NO way to tell "still installing" from
+/// "crashed" (worker::list only says running:false) and went spelunking with
+/// shell commands instead.
+async fn build_status(name: &str) -> Result<StatusOutcome, WorkerOpError> {
+    use crate::cli::config_file::{self, ResolvedWorkerType};
+    use crate::cli::managed::{find_worker_pid_from_ps, is_engine_running, is_worker_running};
+
+    crate::core::types::validate_worker_name(name).map_err(|reason| {
+        WorkerOpError::BadRequest {
+            function_id: "worker::status".into(),
+            reason,
+        }
+    })?;
+
+    let installed = config_file::worker_exists(name);
+    let worker_type = if !installed {
+        "not-installed".to_string()
+    } else {
+        match config_file::resolve_worker_type(name) {
+            ResolvedWorkerType::Oci { .. } => "oci".to_string(),
+            ResolvedWorkerType::Local { .. } => "local".to_string(),
+            ResolvedWorkerType::Binary { .. } => "binary".to_string(),
+            ResolvedWorkerType::Bundle { .. } => "bundle".to_string(),
+            ResolvedWorkerType::Config => "builtin".to_string(),
+        }
+    };
+
+    let worker_running = is_worker_running(name);
+    // Engine builtins run inside the engine process; count them as running
+    // when the engine is up (mirrors CliHostShim::list / `iii worker list`).
+    let running =
+        worker_running || (installed && worker_type == "builtin" && is_engine_running());
+    let pid = find_worker_pid_from_ps(name);
+    let version = crate::cli::lockfile::WorkerLockfile::read_from(
+        crate::cli::lockfile::lockfile_path(),
+    )
+    .ok()
+    .and_then(|lf| lf.workers.get(name).map(|w| w.version.clone()));
+
+    let logs = core_logs::run(LogsOptions {
+        name: name.to_string(),
+        tail: 20,
+        raw: false,
+    })
+    .await?;
+
+    let hint = if !installed {
+        "not in config.yaml — install with worker::add (dry-run the manifest first \
+         with worker::validate)"
+            .to_string()
+    } else if running {
+        format!(
+            "running; see its functions with engine::functions::list {{ search: {name:?} }}"
+        )
+    } else if logs.stderr.is_empty() && logs.stdout.is_empty() {
+        "installed but not running and no logs yet — likely still provisioning; \
+         poll again shortly, or worker::start to boot it"
+            .to_string()
+    } else {
+        "installed but not running — check stderr_tail/stdout_tail for the failure \
+         (e.g. a dependency install error), fix the worker source, then \
+         worker::add { force: true } to reinstall or worker::start to retry"
+            .to_string()
+    };
+
+    Ok(StatusOutcome {
+        name: name.to_string(),
+        installed,
+        worker_type,
+        running,
+        pid,
+        version,
+        logs_dir: logs.logs_dir,
+        stderr_tail: logs.stderr,
+        stdout_tail: logs.stdout,
+        hint,
+    })
+}
+
+fn register_status(iii: &III) {
+    let rf = RegisterFunction::new_async_with_bad_request(
+        |opts: StatusOptions| async move {
+            build_status(&opts.name).await.map_err(|e| op_error(&e))
+        },
+        |e| bad_request_error("worker::status", &e),
+    );
+    let _ = iii.register_function("worker::status", describe_op(rf, "worker::status"));
+}
+
+/// `worker::validate` — dry-run an `iii.worker.yaml` without installing.
+/// Read-only and side-effect free: the LLM/automation loop is author →
+/// validate → fix → `worker::add`. Accepts exactly one of `manifest` (inline
+/// YAML text, preferred for authoring) or `path` (host file or worker dir,
+/// resolved like `worker::add { kind: "local" }`).
+fn register_validate(iii: &III) {
+    let rf = RegisterFunction::new_async_with_bad_request(
+        |opts: ValidateOptions| async move {
+            let report: ManifestReport = match (opts.manifest, opts.path) {
+                (Some(_), Some(_)) | (None, None) => {
+                    return Err(op_error(&WorkerOpError::BadRequest {
+                        function_id: "worker::validate".into(),
+                        reason: "pass exactly one of `manifest` (inline YAML) or `path` \
+                                 (host file or worker directory)"
+                            .into(),
+                    }));
+                }
+                (Some(text), None) => report_from_str(&text),
+                (None, Some(p)) => {
+                    let file = if p.is_dir() { p.join(WORKER_MANIFEST) } else { p };
+                    // Stat-first so a huge file is rejected without reading it
+                    // into memory (same cap the add path enforces).
+                    match std::fs::metadata(&file) {
+                        Ok(meta) if meta.len() > MAX_LOCAL_MANIFEST_BYTES => {
+                            let mut r = ManifestReport::default();
+                            r.errors.push(format!(
+                                "{} is {} bytes; iii.worker.yaml is capped at \
+                                 {MAX_LOCAL_MANIFEST_BYTES} bytes",
+                                file.display(),
+                                meta.len(),
+                            ));
+                            r
+                        }
+                        Ok(_) => match std::fs::read_to_string(&file) {
+                            Ok(content) => report_from_str(&content),
+                            Err(e) => {
+                                let mut r = ManifestReport::default();
+                                r.errors.push(format!("cannot read {}: {e}", file.display()));
+                                r
+                            }
+                        },
+                        Err(e) => {
+                            let mut r = ManifestReport::default();
+                            r.errors.push(format!(
+                                "cannot stat {} on the engine/daemon host: {e}",
+                                file.display(),
+                            ));
+                            r
+                        }
+                    }
+                }
+            };
+            Ok::<_, IIIError>(report)
+        },
+        |e| bad_request_error("worker::validate", &e),
+    );
+    let _ = iii.register_function("worker::validate", describe_op(rf, "worker::validate"));
 }
 
 fn sink_ref<'a>(sink: &'a Arc<IIIEventSink>) -> &'a dyn EventSink {

--- a/crates/iii-worker/src/cli/worker_manifest.rs
+++ b/crates/iii-worker/src/cli/worker_manifest.rs
@@ -844,6 +844,91 @@ mod tests {
     }
 
     #[test]
+    fn shape_errors_describe_bool_mapping_and_tagged_values() {
+        let r = report("name: true\nscripts:\n  start: x\n");
+        assert!(
+            r.errors.iter().any(|e| e.contains("`name` must be a string, got the boolean true")),
+            "got: {r:?}"
+        );
+
+        let r = report("name:\n  nested: 1\nscripts:\n  start: x\n");
+        assert!(
+            r.errors.iter().any(|e| e.contains("`name` must be a string, got a mapping")),
+            "got: {r:?}"
+        );
+
+        // serde_yaml accessors untag, so a tagged STRING still reads as a
+        // string; only a tagged non-string reaches the Tagged description.
+        let r = report("name: !custom [w]\nscripts:\n  start: x\n");
+        assert!(
+            r.errors.iter().any(|e| e.contains("`name` must be a string, got a tagged value")),
+            "got: {r:?}"
+        );
+    }
+
+    #[test]
+    fn shape_errors_flag_non_string_top_level_keys() {
+        let r = report("name: w\nscripts:\n  start: x\n1: y\n");
+        assert!(!r.valid);
+        assert!(
+            r.errors
+                .iter()
+                .any(|e| e.contains("manifest keys must be strings, got the number 1")),
+            "got: {r:?}"
+        );
+    }
+
+    #[test]
+    fn scripts_scalar_shape_error_omits_list_hint() {
+        let r = report("name: w\nscripts:\n  start: 5\n");
+        assert!(!r.valid);
+        let err = r.errors.iter().find(|e| e.contains("`scripts.start`")).expect("scripts error");
+        assert!(err.contains("must be a command string, got the number 5"), "got: {err}");
+        assert!(!err.contains("use one command string"), "list hint only fits lists: {err}");
+    }
+
+    #[test]
+    fn env_list_value_shape_error_omits_quoting_hint() {
+        let r = report("name: w\nscripts:\n  start: x\nenv:\n  FOO:\n    - a\n");
+        assert!(!r.valid);
+        let err = r.errors.iter().find(|e| e.contains("`env.FOO`")).expect("env error");
+        assert!(err.contains("must be a string, got a list"), "got: {err}");
+        assert!(
+            !err.contains("quote it") && !err.contains("write `"),
+            "scalar hints must not apply to lists: {err}"
+        );
+    }
+
+    #[test]
+    fn report_rejects_manifest_over_size_cap() {
+        let content = "x".repeat(MAX_LOCAL_MANIFEST_BYTES as usize + 1);
+        let r = report(&content);
+        assert!(!r.valid);
+        assert_eq!(r.errors.len(), 1, "size cap short-circuits all other checks");
+        assert!(
+            r.errors[0]
+                .contains(&format!("capped at {MAX_LOCAL_MANIFEST_BYTES} bytes")),
+            "got: {:?}",
+            r.errors
+        );
+    }
+
+    #[test]
+    fn report_rejects_path_escaping_name() {
+        let r = report("name: \"../escape\"\nscripts:\n  start: x\n");
+        assert!(!r.valid);
+        assert_eq!(r.name.as_deref(), Some("../escape"));
+        assert!(r.errors.iter().any(|e| e.contains("'..'")), "got: {r:?}");
+    }
+
+    #[test]
+    fn from_value_rejects_non_mapping_document_via_serde_backstop() {
+        let doc: YamlValue = serde_yaml::from_str("just-a-string").unwrap();
+        let err = WorkerManifest::from_value(&doc).expect_err("non-mapping must fail");
+        assert!(err.starts_with("invalid manifest shape:"), "got: {err}");
+    }
+
+    #[test]
     fn classify_keys_matches_legacy_validator_semantics() {
         let doc: YamlValue =
             serde_yaml::from_str("name: w\nruntime:\n  kind: bun\n  foo: 1\nconfig: {}\nbad: 2\n")

--- a/crates/iii-worker/src/cli/worker_manifest.rs
+++ b/crates/iii-worker/src/cli/worker_manifest.rs
@@ -1,0 +1,856 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+//! Typed `iii.worker.yaml` manifest.
+//!
+//! Single source of truth for the manifest schema: the [`WorkerManifest`]
+//! struct drives (a) key classification for `worker add` validation
+//! (`project::validate_manifest_keys` / `warn_deprecated_manifest_keys`
+//! delegate here), (b) the machine-readable JSON Schema served by
+//! `worker::schema { function_id: "iii.worker.yaml" }`, and (c) the dry-run
+//! `worker::validate` trigger so an LLM can author → check → `worker::add`
+//! without a failed install.
+//!
+//! Design notes:
+//! - Deprecated fields are REAL typed fields (so readers stay clean and the
+//!   schema can describe them) while every section carries a
+//!   `#[serde(flatten)]` catch-all map — non-empty catch-all = unknown keys =
+//!   hard error at add time. This preserves the warn-vs-reject split that
+//!   `#[serde(deny_unknown_fields)]` cannot express.
+//! - Parsing goes Value-first then `from_value`: serde_yaml 0.9 detects
+//!   duplicate mapping keys only at the `Value` layer (typed maps silently
+//!   last-win), so the two-step keeps duplicate keys a hard error.
+
+use std::collections::BTreeMap;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value as JsonValue;
+use serde_yaml::Value as YamlValue;
+
+use super::project::{MAX_LOCAL_MANIFEST_BYTES, is_plausible_image_ref};
+
+/// Strip control characters from a manifest key before it is echoed into a
+/// terminal-bound error or warning. Manifest keys are third-party (users run
+/// `iii worker add ./cloned-worker`), so an unknown key like `"\x1b]2;…\x07"`
+/// must not reach the user's terminal raw. Mirrors the established
+/// terminal-sanitization pattern in `engine/src/cli_trigger/help.rs`.
+/// `is_control` covers only Cc, so the invisible Cf-category spoofing chars
+/// (bidi overrides, zero-widths) are filtered explicitly — U+202E alone can
+/// visually reverse an echoed key and disguise what the error points at.
+pub(crate) fn sanitize_key(s: &str) -> String {
+    fn is_invisible_format_char(c: char) -> bool {
+        matches!(c,
+            '\u{200b}'..='\u{200f}' // zero-widths + LRM/RLM
+            | '\u{202a}'..='\u{202e}' // bidi embeddings/overrides
+            | '\u{2066}'..='\u{2069}' // bidi isolates
+            | '\u{061c}' // Arabic letter mark
+            | '\u{feff}' // BOM / zero-width no-break space
+        )
+    }
+    s.chars()
+        .filter(|c| !c.is_control() && !is_invisible_format_char(*c))
+        .collect()
+}
+
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+#[schemars(
+    description = "The `iii.worker.yaml` manifest at a worker project's root. Tells iii how to provision, install, and start the worker. Required for local-path `worker::add`. Unknown keys are rejected at add time; deprecated keys warn but still work."
+)]
+pub struct WorkerManifest {
+    /// Required. Worker id; a single path segment (alphanumerics, '-', '_', '.').
+    #[schemars(
+        description = "Required. Worker id; must be a single path segment (alphanumerics, '-', '_', '.')."
+    )]
+    pub name: Option<String>,
+
+    #[schemars(
+        description = "Optional one-line human/LLM-readable summary; shown when installing or inspecting the worker."
+    )]
+    pub description: Option<String>,
+
+    #[schemars(
+        description = "Optional runtime details. The only supported sub-field is `base_image`; the rest are deprecated legacy inference knobs."
+    )]
+    pub runtime: Option<RuntimeSection>,
+
+    #[schemars(
+        description = "Lifecycle scripts: `start` runs the worker (required in practice), `install` installs dependencies, `setup` provisions the sandbox once."
+    )]
+    pub scripts: Option<ScriptsSection>,
+
+    #[schemars(
+        description = "Optional string->string env vars injected into the worker process. III_URL / III_ENGINE_URL are set by the engine and ignored here."
+    )]
+    pub env: Option<BTreeMap<String, String>>,
+
+    #[schemars(
+        description = "Optional map of other-worker-name -> semver range, resolved against the registry and installed before this worker, e.g. { iii-state: \"^0.19\" }. No self-references."
+    )]
+    pub dependencies: Option<BTreeMap<String, String>>,
+
+    #[schemars(
+        description = "Optional sandbox sizing: `cpus` (default 2) and `memory` in MiB (default 2048)."
+    )]
+    pub resources: Option<ResourcesSection>,
+
+    #[schemars(
+        with = "Option<JsonValue>",
+        description = "DEPRECATED — set per-worker config directly in your project's config.yaml entry instead. Copied verbatim into config.yaml at add time."
+    )]
+    pub config: Option<YamlValue>,
+
+    #[schemars(
+        description = "DEPRECATED legacy scaffolder field — use explicit `scripts.start` instead."
+    )]
+    pub language: Option<String>,
+
+    #[schemars(
+        description = "DEPRECATED legacy scaffolder field — use explicit `scripts.start` instead."
+    )]
+    pub entry: Option<String>,
+
+    #[serde(flatten)]
+    #[schemars(skip)]
+    pub unknown: BTreeMap<String, YamlValue>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+#[schemars(description = "Runtime environment details.")]
+pub struct RuntimeSection {
+    #[schemars(
+        description = "Optional OCI rootfs override, e.g. \"oven/bun:1\" or \"ghcr.io/astral-sh/uv:bookworm-slim\". Alphanumerics plus `._-/:@+`, max 512 chars."
+    )]
+    pub base_image: Option<String>,
+
+    #[schemars(
+        description = "DEPRECATED — define `scripts.setup`/`install`/`start` explicitly instead. Legacy script inference: typescript|javascript|bun|python|rust."
+    )]
+    pub kind: Option<String>,
+
+    #[schemars(
+        description = "DEPRECATED — define explicit `scripts` instead. Legacy inference: npm|yarn|pnpm|bun (only meaningful with kind typescript/javascript)."
+    )]
+    pub package_manager: Option<String>,
+
+    #[schemars(
+        description = "DEPRECATED — put the entrypoint in `scripts.start` instead (e.g. start: \"npx tsx src/index.ts\")."
+    )]
+    pub entry: Option<String>,
+
+    #[schemars(description = "DEPRECATED — rename to `runtime.kind` (itself deprecated; prefer explicit `scripts`).")]
+    pub language: Option<String>,
+
+    #[serde(flatten)]
+    #[schemars(skip)]
+    pub unknown: BTreeMap<String, YamlValue>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+#[schemars(
+    description = "Explicit lifecycle scripts (the documented, supported way to run a worker). When omitted, legacy inference from runtime.kind/package_manager applies (deprecated)."
+)]
+pub struct ScriptsSection {
+    #[schemars(
+        description = "Optional one-time sandbox provisioning, e.g. \"apt-get update && apt-get install -y build-essential\". Runs once when the sandbox is created."
+    )]
+    pub setup: Option<String>,
+
+    #[schemars(
+        description = "Optional dependency install, e.g. \"npm install\". Omitting it skips dependency install (warned); an explicit \"\" opts out silently."
+    )]
+    pub install: Option<String>,
+
+    #[schemars(
+        description = "Command that runs the worker process, e.g. \"node src/index.js\" or \"npx tsx watch src/index.ts\". Required unless legacy runtime.kind inference applies."
+    )]
+    pub start: Option<String>,
+
+    #[serde(flatten)]
+    #[schemars(skip)]
+    pub unknown: BTreeMap<String, YamlValue>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+#[schemars(description = "Optional CPU/memory requests for the worker's sandbox.")]
+pub struct ResourcesSection {
+    #[schemars(description = "Optional integer vCPUs. Default 2; bundle workers are capped at 4.")]
+    pub cpus: Option<u32>,
+
+    #[schemars(description = "Optional memory in MiB. Default 2048; bundle workers are capped at 4096.")]
+    pub memory: Option<u32>,
+
+    #[serde(flatten)]
+    #[schemars(skip)]
+    pub unknown: BTreeMap<String, YamlValue>,
+}
+
+/// Human-readable YAML type label for shape-error messages. Numbers echo
+/// their value (safe — serde_yaml renders them numerically); everything else
+/// gets a type name so hostile string content never reaches the terminal.
+fn yaml_value_desc(v: &YamlValue) -> String {
+    match v {
+        YamlValue::Null => "null".into(),
+        YamlValue::Bool(b) => format!("the boolean {b}"),
+        YamlValue::Number(n) => format!("the number {n}"),
+        YamlValue::String(_) => "a string".into(),
+        YamlValue::Sequence(_) => "a list".into(),
+        YamlValue::Mapping(_) => "a mapping".into(),
+        YamlValue::Tagged(_) => "a tagged value".into(),
+    }
+}
+
+/// Treat YAML `null` like an absent field (serde maps it to `None`), so the
+/// shape checks below only fire on values serde would actually reject.
+fn present(v: Option<&YamlValue>) -> Option<&YamlValue> {
+    v.filter(|v| !v.is_null())
+}
+
+/// Value-layer shape checks for every documented field, collected with dotted
+/// paths so type mistakes read as "`runtime` must be a mapping ..., got a
+/// string" instead of serde's "invalid type: string \"node\", expected struct
+/// RuntimeSection" (Rust internals were leaking into user errors — caught by
+/// the live DX audit). Must stay consistent with the typed struct: flag only
+/// what serde would reject anyway; serde remains the backstop for anything
+/// not covered here.
+fn shape_problems(doc: &YamlValue) -> Vec<String> {
+    let mut problems = Vec::new();
+    let Some(map) = doc.as_mapping() else {
+        return problems;
+    };
+
+    for key in map.keys() {
+        if key.as_str().is_none() {
+            problems.push(format!(
+                "manifest keys must be strings, got {}",
+                yaml_value_desc(key)
+            ));
+        }
+    }
+
+    for field in ["name", "description", "language", "entry"] {
+        if let Some(v) = present(doc.get(field))
+            && v.as_str().is_none()
+        {
+            problems.push(format!("`{field}` must be a string, got {}", yaml_value_desc(v)));
+        }
+    }
+
+    for section in ["runtime", "scripts", "resources"] {
+        if let Some(v) = present(doc.get(section))
+            && v.as_mapping().is_none()
+        {
+            problems.push(format!(
+                "`{section}` must be a mapping of indented `key: value` fields, got {}",
+                yaml_value_desc(v)
+            ));
+        }
+    }
+
+    if let Some(rt) = doc.get("runtime").and_then(YamlValue::as_mapping) {
+        for field in ["base_image", "kind", "package_manager", "entry", "language"] {
+            if let Some(v) = present(rt.get(field))
+                && v.as_str().is_none()
+            {
+                problems.push(format!(
+                    "`runtime.{field}` must be a string, got {}",
+                    yaml_value_desc(v)
+                ));
+            }
+        }
+    }
+
+    if let Some(scripts) = doc.get("scripts").and_then(YamlValue::as_mapping) {
+        for field in ["setup", "install", "start"] {
+            if let Some(v) = present(scripts.get(field))
+                && v.as_str().is_none()
+            {
+                let hint = if v.is_sequence() {
+                    " — use one command string, chaining with `&&` if needed"
+                } else {
+                    ""
+                };
+                problems.push(format!(
+                    "`scripts.{field}` must be a command string, got {}{hint}",
+                    yaml_value_desc(v)
+                ));
+            }
+        }
+    }
+
+    if let Some(res) = doc.get("resources").and_then(YamlValue::as_mapping) {
+        for field in ["cpus", "memory"] {
+            if let Some(v) = present(res.get(field)) {
+                match v.as_u64() {
+                    Some(n) if n <= u64::from(u32::MAX) => {}
+                    // A non-negative integer that's just too big needs the
+                    // bound named, not a self-contradictory "must be a
+                    // non-negative integer, got 4294967296".
+                    Some(n) => problems.push(format!(
+                        "`resources.{field}` must be at most {}, got {n}",
+                        u32::MAX
+                    )),
+                    None => problems.push(format!(
+                        "`resources.{field}` must be a non-negative integer, got {}",
+                        yaml_value_desc(v)
+                    )),
+                }
+            }
+        }
+    }
+
+    // env/dependencies are opaque maps key-wise, but their VALUES must be
+    // strings — the classic trap is `PORT: 8080` (a YAML number), so the
+    // message says how to quote it.
+    for section in ["env", "dependencies"] {
+        let Some(v) = present(doc.get(section)) else {
+            continue;
+        };
+        let Some(entries) = v.as_mapping() else {
+            problems.push(format!(
+                "`{section}` must be a mapping of string values, got {}",
+                yaml_value_desc(v)
+            ));
+            continue;
+        };
+        for (key, val) in entries {
+            let Some(key_name) = key.as_str().map(sanitize_key) else {
+                problems.push(format!(
+                    "`{section}` keys must be strings, got {}",
+                    yaml_value_desc(key)
+                ));
+                continue;
+            };
+            if val.as_str().is_none() {
+                let hint = match val {
+                    YamlValue::Null => format!(" — write `{key_name}: \"\"` for an empty value"),
+                    YamlValue::Bool(_) | YamlValue::Number(_) => {
+                        format!(" — quote it (`{key_name}: \"...\"`)")
+                    }
+                    _ => String::new(),
+                };
+                problems.push(format!(
+                    "`{section}.{key_name}` must be a string, got {}{hint}",
+                    yaml_value_desc(val)
+                ));
+            }
+        }
+    }
+
+    problems
+}
+
+impl WorkerManifest {
+    /// Deserialize from an already-parsed YAML document. Returns `Err` with a
+    /// human-readable message when the document's shape doesn't match (e.g.
+    /// `runtime: node` where a mapping is required, or `resources.cpus: "four"`).
+    /// Friendly [`shape_problems`] run first so the common type mistakes get
+    /// dotted-path messages; raw serde errors are the backstop only.
+    pub fn from_value(doc: &YamlValue) -> Result<Self, String> {
+        let problems = shape_problems(doc);
+        if !problems.is_empty() {
+            return Err(format!("invalid manifest shape: {}", problems.join("; ")));
+        }
+        serde_yaml::from_value(doc.clone()).map_err(|e| format!("invalid manifest shape: {e}"))
+    }
+
+    /// Classify every manifest key into `(unknown, deprecated)` dotted paths,
+    /// sanitized for terminal display and sorted. The single source of truth
+    /// for add-time key validation and the `worker::validate` report.
+    pub fn classify_keys(&self) -> (Vec<String>, Vec<String>) {
+        let mut unknown: Vec<String> = Vec::new();
+        let mut deprecated: Vec<String> = Vec::new();
+
+        for k in self.unknown.keys() {
+            unknown.push(sanitize_key(k));
+        }
+        if self.config.is_some() {
+            deprecated.push("config".into());
+        }
+        if self.language.is_some() {
+            deprecated.push("language".into());
+        }
+        if self.entry.is_some() {
+            deprecated.push("entry".into());
+        }
+        if let Some(rt) = &self.runtime {
+            for k in rt.unknown.keys() {
+                unknown.push(format!("runtime.{}", sanitize_key(k)));
+            }
+            if rt.kind.is_some() {
+                deprecated.push("runtime.kind".into());
+            }
+            if rt.package_manager.is_some() {
+                deprecated.push("runtime.package_manager".into());
+            }
+            if rt.entry.is_some() {
+                deprecated.push("runtime.entry".into());
+            }
+            if rt.language.is_some() {
+                deprecated.push("runtime.language".into());
+            }
+        }
+        if let Some(s) = &self.scripts {
+            for k in s.unknown.keys() {
+                unknown.push(format!("scripts.{}", sanitize_key(k)));
+            }
+        }
+        if let Some(r) = &self.resources {
+            for k in r.unknown.keys() {
+                unknown.push(format!("resources.{}", sanitize_key(k)));
+            }
+        }
+        unknown.sort();
+        deprecated.sort();
+        (unknown, deprecated)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// worker::validate — dry-run manifest validation for LLM/automation callers.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[schemars(
+    description = "Validate an iii.worker.yaml WITHOUT installing anything. Pass exactly one of `manifest` (inline YAML text — preferred for authoring) or `path` (a file or worker directory on the engine/daemon host)."
+)]
+pub struct ValidateOptions {
+    #[serde(default)]
+    #[schemars(
+        description = "Inline iii.worker.yaml content to validate. Preferred: lets a caller check a manifest before writing it anywhere."
+    )]
+    pub manifest: Option<String>,
+    #[serde(default)]
+    #[schemars(
+        description = "Host path to an iii.worker.yaml, or to a worker project directory containing one (same resolution as worker::add kind=local; resolved on the engine/daemon host, not the caller)."
+    )]
+    pub path: Option<std::path::PathBuf>,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, JsonSchema)]
+#[schemars(
+    description = "Dry-run validation result. `valid: true` means worker::add would accept this manifest's keys and required fields. Fetch the full manifest schema via worker::schema { function_id: \"iii.worker.yaml\" }."
+)]
+pub struct ManifestReport {
+    #[schemars(
+        description = "True when there are no errors and no unknown keys — worker::add would accept the manifest."
+    )]
+    pub valid: bool,
+    #[schemars(description = "Worker name parsed from the manifest, when present.")]
+    pub name: Option<String>,
+    #[schemars(
+        description = "Blocking problems: YAML syntax/shape errors, missing required fields, invalid dependencies. Fix all of these."
+    )]
+    pub errors: Vec<String>,
+    #[schemars(
+        description = "Keys not in the documented schema (typos or unsupported). worker::add rejects the manifest while any are present."
+    )]
+    pub unknown_keys: Vec<String>,
+    #[schemars(
+        description = "Deprecated keys: still honored, warned at add time, scheduled for removal in a future version. Prefer migrating to explicit `scripts`."
+    )]
+    pub deprecated_keys: Vec<String>,
+    #[schemars(description = "Non-blocking advice (e.g. omitted scripts.install, implausible base_image).")]
+    pub warnings: Vec<String>,
+}
+
+/// Build a full validation report from raw manifest text. Never panics; every
+/// failure mode lands in `errors`. This is the `worker::validate` engine and
+/// mirrors what the `worker add` gate enforces (size cap, YAML/duplicate
+/// keys, shape, unknown keys, required `name`). Known gaps where `add` is
+/// stricter, all on the deprecated legacy-inference path: it rejects
+/// `runtime.kind` values outside its allowlist and ts/js kinds without
+/// `runtime.package_manager` — checks that live in script inference, which a
+/// dry run can't execute. Manifests on the documented schema (explicit
+/// `scripts.*`) have no known divergence.
+pub fn report_from_str(content: &str) -> ManifestReport {
+    let mut report = ManifestReport::default();
+
+    if content.len() as u64 > MAX_LOCAL_MANIFEST_BYTES {
+        report.errors.push(format!(
+            "manifest is {} bytes; iii.worker.yaml is capped at {MAX_LOCAL_MANIFEST_BYTES} bytes",
+            content.len()
+        ));
+        return report;
+    }
+
+    // Value-first: catches YAML syntax errors AND duplicate mapping keys.
+    let doc: YamlValue = match serde_yaml::from_str(content) {
+        Ok(d) => d,
+        Err(e) => {
+            report.errors.push(format!("invalid YAML: {e}"));
+            return report;
+        }
+    };
+
+    if matches!(doc, YamlValue::Null) {
+        report.errors.push("manifest is empty; at least `name` and `scripts.start` are required".into());
+        return report;
+    }
+    if doc.as_mapping().is_none() {
+        report
+            .errors
+            .push("manifest top level must be a YAML mapping of fields, e.g. `name: my-worker`".into());
+        return report;
+    }
+
+    // Dependency rules run on the Value (better messages than serde's), and
+    // independently of typed-shape success.
+    let self_name = doc.get("name").and_then(|v| v.as_str());
+    if let Err(e) = super::worker_manifest_deps::parse_dependencies(&doc, self_name) {
+        report.errors.push(e);
+    }
+
+    let manifest = match WorkerManifest::from_value(&doc) {
+        Ok(m) => m,
+        Err(e) => {
+            report.errors.push(e);
+            // Without the typed view we can still report the name.
+            report.name = self_name.map(String::from);
+            return report;
+        }
+    };
+
+    let (unknown, deprecated) = manifest.classify_keys();
+    report.unknown_keys = unknown;
+    report.deprecated_keys = deprecated;
+
+    match manifest.name.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        Some(name) => {
+            report.name = Some(name.to_string());
+            if let Err(e) = crate::core::types::validate_worker_name(name) {
+                report.errors.push(e);
+            }
+        }
+        None => report
+            .errors
+            .push("missing required field `name` (a single path segment, e.g. `name: my-worker`)".into()),
+    }
+
+    let has_explicit_start = manifest
+        .scripts
+        .as_ref()
+        .and_then(|s| s.start.as_deref())
+        .map(str::trim)
+        .is_some_and(|s| !s.is_empty());
+    let has_legacy_inference = manifest.runtime.as_ref().is_some_and(|r| {
+        r.kind.as_deref().is_some_and(|k| !k.trim().is_empty())
+            || r.language.as_deref().is_some_and(|l| !l.trim().is_empty())
+    });
+    if !has_explicit_start && !has_legacy_inference {
+        report.errors.push(
+            "no way to start the worker: add `scripts.start` (e.g. start: \"node src/index.js\")"
+                .into(),
+        );
+    }
+
+    if let Some(s) = &manifest.scripts
+        && s.start.is_some()
+        && s.install.is_none()
+    {
+        report.warnings.push(
+            "`scripts.install` omitted; dependency install will be skipped at provision time"
+                .into(),
+        );
+    }
+    if let Some(img) = manifest.runtime.as_ref().and_then(|r| r.base_image.as_deref())
+        && !is_plausible_image_ref(img.trim())
+    {
+        report.warnings.push(format!(
+            "`runtime.base_image` {:?} does not look like an OCI reference (allowed: alphanumerics and `._-/:@+`); the default image would be used",
+            sanitize_key(img),
+        ));
+    }
+    if !report.deprecated_keys.is_empty() {
+        report.warnings.push(
+            "deprecated key(s) present — still honored but will be removed in a future version; \
+             migrate to explicit `scripts.*` (and move `config` into the project config.yaml entry)"
+                .into(),
+        );
+    }
+
+    report.valid = report.errors.is_empty() && report.unknown_keys.is_empty();
+    report
+}
+
+/// JSON Schema for `iii.worker.yaml`, post-processed so machines see the real
+/// contract: unknown keys rejected (`additionalProperties: false` on every
+/// section) and `name` required. schemars can't express either directly here —
+/// the flatten catch-all forbids `deny_unknown_fields`, and `name` is `Option`
+/// in Rust only so partial manifests still classify during validation.
+pub fn manifest_schema_json() -> JsonValue {
+    let schema = schemars::schema_for!(WorkerManifest);
+    let mut v = serde_json::to_value(schema).unwrap_or(JsonValue::Null);
+
+    if let Some(root) = v.as_object_mut() {
+        root.insert("additionalProperties".into(), JsonValue::Bool(false));
+        root.insert("required".into(), serde_json::json!(["name"]));
+        if let Some(defs) = root.get_mut("definitions").and_then(|d| d.as_object_mut()) {
+            for section in ["RuntimeSection", "ScriptsSection", "ResourcesSection"] {
+                if let Some(s) = defs.get_mut(section).and_then(|s| s.as_object_mut()) {
+                    s.insert("additionalProperties".into(), JsonValue::Bool(false));
+                }
+            }
+        }
+    }
+    v
+}
+
+/// A complete, ready-to-write minimal Node worker as `{ path → contents }`,
+/// served as the `iii.worker.yaml` pseudo-entry's response in
+/// `worker::schema`. Exists because a real harness session showed an LLM
+/// hallucinating the SDK package name (`@iii-hq/sdk` — npm 404) and then
+/// reverse-engineering `registerWorker` out of `node_modules`: the manifest
+/// schema alone doesn't teach what the worker CODE must look like. Contents
+/// mirror docs/next/creating-workers/workers.mdx (the canonical example).
+pub fn hello_world_example_json() -> JsonValue {
+    serde_json::json!({
+        "iii.worker.yaml": "name: hello-world\ndescription: Minimal Node worker exposing hello-world::greet.\nscripts:\n  install: \"npm install\"\n  start: \"node src/index.js\"\n",
+        "package.json": "{\n  \"name\": \"hello-world\",\n  \"type\": \"module\",\n  \"private\": true,\n  \"dependencies\": {\n    \"iii-sdk\": \"latest\"\n  }\n}\n",
+        "src/index.js": "import { registerWorker } from \"iii-sdk\";\n\nconst url = process.env.III_URL;\nif (!url) throw new Error(\"III_URL must be set\");\nconst worker = registerWorker(url, { workerName: \"hello-world\" });\n\nworker.registerFunction(\"hello-world::greet\", async (payload) => {\n  const name = payload?.name ?? \"World\";\n  return { message: `Hello, ${name}!` };\n});\n",
+        "_usage": "Write these files into a directory on the engine/daemon host, then worker::add { source: { kind: \"local\", path: \"<dir>\" }, wait: false } and poll worker::status. The npm package is `iii-sdk` (NOT @iii-hq/sdk). The engine sets III_URL/III_ENGINE_URL automatically."
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(s: &str) -> ManifestReport {
+        report_from_str(s)
+    }
+
+    #[test]
+    fn report_accepts_fully_documented_manifest() {
+        let r = report(
+            "name: my-worker\ndescription: does things\nruntime:\n  base_image: oven/bun:1\n\
+             scripts:\n  setup: \"apt-get update\"\n  install: \"npm install\"\n  start: \"node server.js\"\n\
+             env:\n  FOO: bar\ndependencies:\n  iii-http: \"^0.19\"\nresources:\n  cpus: 2\n  memory: 2048\n",
+        );
+        assert!(r.valid, "expected valid, got: {r:?}");
+        assert_eq!(r.name.as_deref(), Some("my-worker"));
+        assert!(r.errors.is_empty() && r.unknown_keys.is_empty());
+    }
+
+    #[test]
+    fn report_minimal_manifest_is_valid() {
+        let r = report("name: w\nscripts:\n  start: \"node i.js\"\n");
+        assert!(r.valid, "got: {r:?}");
+        // install omitted → warned, not an error
+        assert!(r.warnings.iter().any(|w| w.contains("scripts.install")));
+    }
+
+    #[test]
+    fn report_flags_unknown_keys_sorted() {
+        let r = report("name: w\nscripts:\n  start: x\n  instal: y\nzzz_bad: 1\naaa_bad: 2\n");
+        assert!(!r.valid);
+        assert_eq!(r.unknown_keys, vec!["aaa_bad", "scripts.instal", "zzz_bad"]);
+    }
+
+    #[test]
+    fn report_flags_deprecated_keys_but_stays_valid() {
+        let r = report("name: w\nruntime:\n  kind: bun\n  entry: src/i.ts\nconfig:\n  port: 1\n");
+        assert!(r.valid, "deprecated keys must not invalidate: {r:?}");
+        assert_eq!(
+            r.deprecated_keys,
+            vec!["config", "runtime.entry", "runtime.kind"]
+        );
+        assert!(r.warnings.iter().any(|w| w.contains("deprecated")));
+    }
+
+    #[test]
+    fn report_requires_name_and_start() {
+        let r = report("scripts:\n  setup: \"true\"\n");
+        assert!(!r.valid);
+        assert!(r.errors.iter().any(|e| e.contains("missing required field `name`")));
+        assert!(r.errors.iter().any(|e| e.contains("scripts.start")));
+    }
+
+    #[test]
+    fn report_rejects_bad_dependencies() {
+        let r = report("name: w\nscripts:\n  start: x\ndependencies:\n  w: \"^1\"\n");
+        assert!(r.errors.iter().any(|e| e.contains("itself")), "got: {r:?}");
+
+        let r = report("name: w\nscripts:\n  start: x\ndependencies:\n  other: \"not-a-range\"\n");
+        assert!(r.errors.iter().any(|e| e.contains("semver")), "got: {r:?}");
+    }
+
+    #[test]
+    fn report_rejects_duplicate_keys() {
+        let r = report("name: w\nname: x\nscripts:\n  start: y\n");
+        assert!(!r.valid);
+        assert!(r.errors.iter().any(|e| e.contains("invalid YAML")), "got: {r:?}");
+    }
+
+    #[test]
+    fn report_rejects_wrong_shapes_with_clear_error() {
+        // The messages must name the field and the expected type in plain
+        // English — never serde's "expected struct RuntimeSection".
+        let r = report("name: w\nruntime: node\nscripts:\n  start: x\n");
+        assert!(!r.valid);
+        let err = r.errors.iter().find(|e| e.contains("invalid manifest shape")).expect("shape error");
+        assert!(err.contains("`runtime` must be a mapping"), "got: {err}");
+        assert!(!err.contains("RuntimeSection"), "Rust internals must not leak: {err}");
+
+        let r = report("name: w\nscripts:\n  start: x\nresources:\n  cpus: \"four\"\n");
+        assert!(!r.valid, "non-integer cpus must be a shape error: {r:?}");
+        assert!(
+            r.errors.iter().any(|e| e.contains("`resources.cpus` must be a non-negative integer")),
+            "got: {r:?}"
+        );
+    }
+
+    #[test]
+    fn shape_errors_cover_common_type_mistakes() {
+        // Every problem in one manifest, all reported together with dotted paths.
+        let r = report(
+            "name: 7\nruntime:\n  base_image: 1\nscripts:\n  start:\n    - npm i\n    - npm start\n\
+             env:\n  PORT: 8080\n  EMPTY:\ndependencies:\n  other: 1.0\n",
+        );
+        assert!(!r.valid);
+        let shape = r
+            .errors
+            .iter()
+            .find(|e| e.contains("invalid manifest shape"))
+            .expect("shape error present");
+        for needle in [
+            "`name` must be a string, got the number 7",
+            "`runtime.base_image` must be a string",
+            "`scripts.start` must be a command string, got a list — use one command string",
+            "`env.PORT` must be a string, got the number 8080 — quote it",
+            "`env.EMPTY` must be a string, got null — write `EMPTY: \"\"`",
+            "`dependencies.other` must be a string",
+        ] {
+            assert!(shape.contains(needle), "missing {needle:?} in: {shape}");
+        }
+    }
+
+    #[test]
+    fn shape_error_names_the_u32_bound_for_oversized_resources() {
+        // 4294967296 IS a non-negative integer; the message must name the
+        // actual violated constraint instead of contradicting itself.
+        let r = report("name: w\nscripts:\n  start: x\nresources:\n  memory: 4294967296\n");
+        assert!(!r.valid);
+        assert!(
+            r.errors
+                .iter()
+                .any(|e| e.contains("`resources.memory` must be at most 4294967295, got 4294967296")),
+            "got: {r:?}"
+        );
+    }
+
+    #[test]
+    fn sanitize_key_strips_bidi_and_zero_width_format_chars() {
+        // U+202E (RLO) visually reverses everything after it; U+200B is an
+        // invisible zero-width space. Neither is Cc, so is_control() alone
+        // passes them through — they must still never reach the terminal.
+        assert_eq!(sanitize_key("ev\u{202e}il"), "evil");
+        assert_eq!(sanitize_key("a\u{200b}b\u{feff}c\u{2066}d"), "abcd");
+
+        // End-to-end through the env-key echo path in shape_problems.
+        let r = report("name: w\nscripts:\n  start: x\nenv:\n  \"P\u{202e}ORT\": 1\n");
+        let err = r.errors.iter().find(|e| e.contains("must be a string")).expect("env error");
+        assert!(!err.contains('\u{202e}'), "bidi override must be stripped: {err:?}");
+        assert!(err.contains("PORT"), "printable key text survives: {err}");
+    }
+
+    #[test]
+    fn report_trims_padded_name_like_the_add_path() {
+        let r = report("name: \" w \"\nscripts:\n  start: x\n");
+        assert!(r.valid, "padded name trims to a valid one: {r:?}");
+        assert_eq!(r.name.as_deref(), Some("w"));
+    }
+
+    #[test]
+    fn shape_errors_for_scalar_env_and_non_string_keys() {
+        let r = report("name: w\nscripts:\n  start: x\nenv: production\n");
+        assert!(
+            r.errors.iter().any(|e| e.contains("`env` must be a mapping of string values")),
+            "got: {r:?}"
+        );
+
+        let r = report("name: w\nscripts:\n  start: x\nenv:\n  1: x\n");
+        assert!(
+            r.errors.iter().any(|e| e.contains("`env` keys must be strings")),
+            "got: {r:?}"
+        );
+    }
+
+    #[test]
+    fn report_empty_and_non_mapping() {
+        assert!(!report("").valid);
+        assert!(!report("- a\n- b\n").valid);
+        assert!(report("- a\n").errors[0].contains("mapping"));
+    }
+
+    #[test]
+    fn report_warns_on_implausible_base_image() {
+        let r = report("name: w\nscripts:\n  start: x\nruntime:\n  base_image: \"bad image!\"\n");
+        assert!(r.valid, "implausible base_image is a warning, not an error");
+        assert!(r.warnings.iter().any(|w| w.contains("base_image")));
+    }
+
+    #[test]
+    fn report_sanitizes_unknown_key_names() {
+        let mut m = serde_yaml::Mapping::new();
+        m.insert("name".into(), "w".into());
+        m.insert(
+            serde_yaml::Value::from("ev\u{1b}\u{7}il"),
+            serde_yaml::Value::from(1),
+        );
+        let yaml = serde_yaml::to_string(&serde_yaml::Value::Mapping(m)).unwrap();
+        let r = report(&yaml);
+        assert!(
+            r.unknown_keys.iter().any(|k| k == "evil"),
+            "control bytes stripped: {:?}",
+            r.unknown_keys
+        );
+    }
+
+    #[test]
+    fn schema_enforces_closed_world_and_required_name() {
+        let s = manifest_schema_json();
+        assert_eq!(s["additionalProperties"], serde_json::json!(false));
+        assert_eq!(s["required"], serde_json::json!(["name"]));
+        for section in ["RuntimeSection", "ScriptsSection", "ResourcesSection"] {
+            assert_eq!(
+                s["definitions"][section]["additionalProperties"],
+                serde_json::json!(false),
+                "{section} must reject unknown keys in the schema"
+            );
+        }
+        // Deprecation is conveyed via descriptions the LLM reads.
+        let runtime_kind_desc = s["definitions"]["RuntimeSection"]["properties"]["kind"]
+            ["description"]
+            .as_str()
+            .unwrap_or("");
+        assert!(runtime_kind_desc.contains("DEPRECATED"));
+    }
+
+    #[test]
+    fn hello_world_example_passes_our_own_validation() {
+        // The example we hand to LLMs must be valid by our own rules — if the
+        // schema or validator drifts, this test forces the example to follow.
+        let bundle = hello_world_example_json();
+        let manifest = bundle["iii.worker.yaml"].as_str().expect("manifest text");
+        let r = report_from_str(manifest);
+        assert!(r.valid, "example manifest must validate: {r:?}");
+        assert!(r.deprecated_keys.is_empty(), "example must not use deprecated keys");
+        // And the code example must name the real npm package.
+        let code = bundle["src/index.js"].as_str().unwrap();
+        assert!(code.contains("from \"iii-sdk\""));
+        let pkg = bundle["package.json"].as_str().unwrap();
+        assert!(pkg.contains("\"iii-sdk\""));
+    }
+
+    #[test]
+    fn classify_keys_matches_legacy_validator_semantics() {
+        let doc: YamlValue =
+            serde_yaml::from_str("name: w\nruntime:\n  kind: bun\n  foo: 1\nconfig: {}\nbad: 2\n")
+                .unwrap();
+        let m = WorkerManifest::from_value(&doc).unwrap();
+        let (unknown, deprecated) = m.classify_keys();
+        assert_eq!(unknown, vec!["bad", "runtime.foo"]);
+        assert_eq!(deprecated, vec!["config", "runtime.kind"]);
+    }
+}

--- a/crates/iii-worker/src/cli/worker_manifest.rs
+++ b/crates/iii-worker/src/cli/worker_manifest.rs
@@ -138,7 +138,9 @@ pub struct RuntimeSection {
     )]
     pub entry: Option<String>,
 
-    #[schemars(description = "DEPRECATED — rename to `runtime.kind` (itself deprecated; prefer explicit `scripts`).")]
+    #[schemars(
+        description = "DEPRECATED — rename to `runtime.kind` (itself deprecated; prefer explicit `scripts`)."
+    )]
     pub language: Option<String>,
 
     #[serde(flatten)]
@@ -177,7 +179,9 @@ pub struct ResourcesSection {
     #[schemars(description = "Optional integer vCPUs. Default 2; bundle workers are capped at 4.")]
     pub cpus: Option<u32>,
 
-    #[schemars(description = "Optional memory in MiB. Default 2048; bundle workers are capped at 4096.")]
+    #[schemars(
+        description = "Optional memory in MiB. Default 2048; bundle workers are capped at 4096."
+    )]
     pub memory: Option<u32>,
 
     #[serde(flatten)]
@@ -232,7 +236,10 @@ fn shape_problems(doc: &YamlValue) -> Vec<String> {
         if let Some(v) = present(doc.get(field))
             && v.as_str().is_none()
         {
-            problems.push(format!("`{field}` must be a string, got {}", yaml_value_desc(v)));
+            problems.push(format!(
+                "`{field}` must be a string, got {}",
+                yaml_value_desc(v)
+            ));
         }
     }
 
@@ -450,7 +457,9 @@ pub struct ManifestReport {
         description = "Deprecated keys: still honored, warned at add time, scheduled for removal in a future version. Prefer migrating to explicit `scripts`."
     )]
     pub deprecated_keys: Vec<String>,
-    #[schemars(description = "Non-blocking advice (e.g. omitted scripts.install, implausible base_image).")]
+    #[schemars(
+        description = "Non-blocking advice (e.g. omitted scripts.install, implausible base_image)."
+    )]
     pub warnings: Vec<String>,
 }
 
@@ -484,13 +493,15 @@ pub fn report_from_str(content: &str) -> ManifestReport {
     };
 
     if matches!(doc, YamlValue::Null) {
-        report.errors.push("manifest is empty; at least `name` and `scripts.start` are required".into());
+        report
+            .errors
+            .push("manifest is empty; at least `name` and `scripts.start` are required".into());
         return report;
     }
     if doc.as_mapping().is_none() {
-        report
-            .errors
-            .push("manifest top level must be a YAML mapping of fields, e.g. `name: my-worker`".into());
+        report.errors.push(
+            "manifest top level must be a YAML mapping of fields, e.g. `name: my-worker`".into(),
+        );
         return report;
     }
 
@@ -515,16 +526,21 @@ pub fn report_from_str(content: &str) -> ManifestReport {
     report.unknown_keys = unknown;
     report.deprecated_keys = deprecated;
 
-    match manifest.name.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+    match manifest
+        .name
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
         Some(name) => {
             report.name = Some(name.to_string());
             if let Err(e) = crate::core::types::validate_worker_name(name) {
                 report.errors.push(e);
             }
         }
-        None => report
-            .errors
-            .push("missing required field `name` (a single path segment, e.g. `name: my-worker`)".into()),
+        None => report.errors.push(
+            "missing required field `name` (a single path segment, e.g. `name: my-worker`)".into(),
+        ),
     }
 
     let has_explicit_start = manifest
@@ -553,7 +569,10 @@ pub fn report_from_str(content: &str) -> ManifestReport {
                 .into(),
         );
     }
-    if let Some(img) = manifest.runtime.as_ref().and_then(|r| r.base_image.as_deref())
+    if let Some(img) = manifest
+        .runtime
+        .as_ref()
+        .and_then(|r| r.base_image.as_deref())
         && !is_plausible_image_ref(img.trim())
     {
         report.warnings.push(format!(
@@ -662,7 +681,11 @@ mod tests {
     fn report_requires_name_and_start() {
         let r = report("scripts:\n  setup: \"true\"\n");
         assert!(!r.valid);
-        assert!(r.errors.iter().any(|e| e.contains("missing required field `name`")));
+        assert!(
+            r.errors
+                .iter()
+                .any(|e| e.contains("missing required field `name`"))
+        );
         assert!(r.errors.iter().any(|e| e.contains("scripts.start")));
     }
 
@@ -679,7 +702,10 @@ mod tests {
     fn report_rejects_duplicate_keys() {
         let r = report("name: w\nname: x\nscripts:\n  start: y\n");
         assert!(!r.valid);
-        assert!(r.errors.iter().any(|e| e.contains("invalid YAML")), "got: {r:?}");
+        assert!(
+            r.errors.iter().any(|e| e.contains("invalid YAML")),
+            "got: {r:?}"
+        );
     }
 
     #[test]
@@ -688,14 +714,23 @@ mod tests {
         // English — never serde's "expected struct RuntimeSection".
         let r = report("name: w\nruntime: node\nscripts:\n  start: x\n");
         assert!(!r.valid);
-        let err = r.errors.iter().find(|e| e.contains("invalid manifest shape")).expect("shape error");
+        let err = r
+            .errors
+            .iter()
+            .find(|e| e.contains("invalid manifest shape"))
+            .expect("shape error");
         assert!(err.contains("`runtime` must be a mapping"), "got: {err}");
-        assert!(!err.contains("RuntimeSection"), "Rust internals must not leak: {err}");
+        assert!(
+            !err.contains("RuntimeSection"),
+            "Rust internals must not leak: {err}"
+        );
 
         let r = report("name: w\nscripts:\n  start: x\nresources:\n  cpus: \"four\"\n");
         assert!(!r.valid, "non-integer cpus must be a shape error: {r:?}");
         assert!(
-            r.errors.iter().any(|e| e.contains("`resources.cpus` must be a non-negative integer")),
+            r.errors
+                .iter()
+                .any(|e| e.contains("`resources.cpus` must be a non-negative integer")),
             "got: {r:?}"
         );
     }
@@ -732,9 +767,9 @@ mod tests {
         let r = report("name: w\nscripts:\n  start: x\nresources:\n  memory: 4294967296\n");
         assert!(!r.valid);
         assert!(
-            r.errors
-                .iter()
-                .any(|e| e.contains("`resources.memory` must be at most 4294967295, got 4294967296")),
+            r.errors.iter().any(
+                |e| e.contains("`resources.memory` must be at most 4294967295, got 4294967296")
+            ),
             "got: {r:?}"
         );
     }
@@ -749,8 +784,15 @@ mod tests {
 
         // End-to-end through the env-key echo path in shape_problems.
         let r = report("name: w\nscripts:\n  start: x\nenv:\n  \"P\u{202e}ORT\": 1\n");
-        let err = r.errors.iter().find(|e| e.contains("must be a string")).expect("env error");
-        assert!(!err.contains('\u{202e}'), "bidi override must be stripped: {err:?}");
+        let err = r
+            .errors
+            .iter()
+            .find(|e| e.contains("must be a string"))
+            .expect("env error");
+        assert!(
+            !err.contains('\u{202e}'),
+            "bidi override must be stripped: {err:?}"
+        );
         assert!(err.contains("PORT"), "printable key text survives: {err}");
     }
 
@@ -765,13 +807,17 @@ mod tests {
     fn shape_errors_for_scalar_env_and_non_string_keys() {
         let r = report("name: w\nscripts:\n  start: x\nenv: production\n");
         assert!(
-            r.errors.iter().any(|e| e.contains("`env` must be a mapping of string values")),
+            r.errors
+                .iter()
+                .any(|e| e.contains("`env` must be a mapping of string values")),
             "got: {r:?}"
         );
 
         let r = report("name: w\nscripts:\n  start: x\nenv:\n  1: x\n");
         assert!(
-            r.errors.iter().any(|e| e.contains("`env` keys must be strings")),
+            r.errors
+                .iter()
+                .any(|e| e.contains("`env` keys must be strings")),
             "got: {r:?}"
         );
     }
@@ -820,10 +866,10 @@ mod tests {
             );
         }
         // Deprecation is conveyed via descriptions the LLM reads.
-        let runtime_kind_desc = s["definitions"]["RuntimeSection"]["properties"]["kind"]
-            ["description"]
-            .as_str()
-            .unwrap_or("");
+        let runtime_kind_desc =
+            s["definitions"]["RuntimeSection"]["properties"]["kind"]["description"]
+                .as_str()
+                .unwrap_or("");
         assert!(runtime_kind_desc.contains("DEPRECATED"));
     }
 
@@ -835,7 +881,10 @@ mod tests {
         let manifest = bundle["iii.worker.yaml"].as_str().expect("manifest text");
         let r = report_from_str(manifest);
         assert!(r.valid, "example manifest must validate: {r:?}");
-        assert!(r.deprecated_keys.is_empty(), "example must not use deprecated keys");
+        assert!(
+            r.deprecated_keys.is_empty(),
+            "example must not use deprecated keys"
+        );
         // And the code example must name the real npm package.
         let code = bundle["src/index.js"].as_str().unwrap();
         assert!(code.contains("from \"iii-sdk\""));
@@ -847,13 +896,17 @@ mod tests {
     fn shape_errors_describe_bool_mapping_and_tagged_values() {
         let r = report("name: true\nscripts:\n  start: x\n");
         assert!(
-            r.errors.iter().any(|e| e.contains("`name` must be a string, got the boolean true")),
+            r.errors
+                .iter()
+                .any(|e| e.contains("`name` must be a string, got the boolean true")),
             "got: {r:?}"
         );
 
         let r = report("name:\n  nested: 1\nscripts:\n  start: x\n");
         assert!(
-            r.errors.iter().any(|e| e.contains("`name` must be a string, got a mapping")),
+            r.errors
+                .iter()
+                .any(|e| e.contains("`name` must be a string, got a mapping")),
             "got: {r:?}"
         );
 
@@ -861,7 +914,9 @@ mod tests {
         // string; only a tagged non-string reaches the Tagged description.
         let r = report("name: !custom [w]\nscripts:\n  start: x\n");
         assert!(
-            r.errors.iter().any(|e| e.contains("`name` must be a string, got a tagged value")),
+            r.errors
+                .iter()
+                .any(|e| e.contains("`name` must be a string, got a tagged value")),
             "got: {r:?}"
         );
     }
@@ -882,16 +937,30 @@ mod tests {
     fn scripts_scalar_shape_error_omits_list_hint() {
         let r = report("name: w\nscripts:\n  start: 5\n");
         assert!(!r.valid);
-        let err = r.errors.iter().find(|e| e.contains("`scripts.start`")).expect("scripts error");
-        assert!(err.contains("must be a command string, got the number 5"), "got: {err}");
-        assert!(!err.contains("use one command string"), "list hint only fits lists: {err}");
+        let err = r
+            .errors
+            .iter()
+            .find(|e| e.contains("`scripts.start`"))
+            .expect("scripts error");
+        assert!(
+            err.contains("must be a command string, got the number 5"),
+            "got: {err}"
+        );
+        assert!(
+            !err.contains("use one command string"),
+            "list hint only fits lists: {err}"
+        );
     }
 
     #[test]
     fn env_list_value_shape_error_omits_quoting_hint() {
         let r = report("name: w\nscripts:\n  start: x\nenv:\n  FOO:\n    - a\n");
         assert!(!r.valid);
-        let err = r.errors.iter().find(|e| e.contains("`env.FOO`")).expect("env error");
+        let err = r
+            .errors
+            .iter()
+            .find(|e| e.contains("`env.FOO`"))
+            .expect("env error");
         assert!(err.contains("must be a string, got a list"), "got: {err}");
         assert!(
             !err.contains("quote it") && !err.contains("write `"),
@@ -904,10 +973,13 @@ mod tests {
         let content = "x".repeat(MAX_LOCAL_MANIFEST_BYTES as usize + 1);
         let r = report(&content);
         assert!(!r.valid);
-        assert_eq!(r.errors.len(), 1, "size cap short-circuits all other checks");
+        assert_eq!(
+            r.errors.len(),
+            1,
+            "size cap short-circuits all other checks"
+        );
         assert!(
-            r.errors[0]
-                .contains(&format!("capped at {MAX_LOCAL_MANIFEST_BYTES} bytes")),
+            r.errors[0].contains(&format!("capped at {MAX_LOCAL_MANIFEST_BYTES} bytes")),
             "got: {:?}",
             r.errors
         );

--- a/crates/iii-worker/src/core/error.rs
+++ b/crates/iii-worker/src/core/error.rs
@@ -116,8 +116,15 @@ pub enum WorkerOpError {
     #[error("worker {name:?} is already running (pid {pid})")]
     AlreadyRunning { name: String, pid: u32 },
 
-    #[error("project lock busy{}", match holder_pid { Some(p) => format!(" (held by pid {})", p), None => String::new() })]
-    LockBusy { holder_pid: Option<u32> },
+    #[error("{}", lock_busy_message(holder_pid, *holder_is_self))]
+    LockBusy {
+        holder_pid: Option<u32>,
+        /// True when the lock holder is THIS process — i.e. another worker
+        /// operation is already running in the same worker-ops daemon.
+        /// Surfaced so callers (especially LLMs) don't "fix" a busy lock by
+        /// killing the holder pid, which kills the daemon serving worker::*.
+        holder_is_self: bool,
+    },
 
     #[error("lock I/O failed at {path:?}: {source}")]
     LockIo {
@@ -194,6 +201,30 @@ pub enum WorkerOpError {
     Internal { message: String },
 }
 
+/// W120 message, written for the caller who has to decide what to do next —
+/// including LLM callers whose instinct on "lock held by pid N" is to kill
+/// pid N. In a real session that pid was the worker-ops daemon itself (an
+/// in-flight `worker::add` held the project flock), and killing it took the
+/// whole worker::* API down. Say what the holder is and forbid the footgun.
+fn lock_busy_message(holder_pid: &Option<u32>, holder_is_self: bool) -> String {
+    match (holder_pid, holder_is_self) {
+        (Some(p), true) => format!(
+            "project lock busy: another worker operation is already running in this \
+             worker-ops daemon (pid {p}). The lock clears when that operation finishes — \
+             retry shortly, or poll worker::status / worker::list. Do NOT kill pid {p}: \
+             it is the daemon serving the worker::* API."
+        ),
+        (Some(p), false) => format!(
+            "project lock busy (held by pid {p}, likely an in-flight worker operation). \
+             The lock dies with that process, so a crashed holder never strands it — \
+             just retry shortly. Do NOT kill pid {p} to free the lock."
+        ),
+        (None, _) => "project lock busy; an in-flight worker operation holds it. \
+             Retry shortly."
+            .to_string(),
+    }
+}
+
 impl WorkerOpError {
     pub fn kind(&self) -> WorkerOpErrorKind {
         use WorkerOpErrorKind as K;
@@ -260,7 +291,10 @@ impl WorkerOpError {
             | Self::NotInstalled { name }
             | Self::NotRunning { name } => json!({ "name": name }),
             Self::AlreadyRunning { name, pid } => json!({ "name": name, "pid": pid }),
-            Self::LockBusy { holder_pid } => json!({ "holder_pid": holder_pid }),
+            Self::LockBusy {
+                holder_pid,
+                holder_is_self,
+            } => json!({ "holder_pid": holder_pid, "holder_is_self": holder_is_self }),
             Self::LockIo { path, .. } => json!({ "path": path.display().to_string() }),
             Self::ConfigIo { path, .. } => json!({ "path": path.display().to_string() }),
             Self::ConfigParse { path, message } => {
@@ -353,6 +387,46 @@ mod tests {
     fn local_path_not_allowed_via_trigger_is_w102() {
         let err = WorkerOpError::local_path_not_allowed_via_trigger("./my-worker");
         assert_eq!(err.to_payload()["code"], "W102");
+    }
+
+    // W120 messages must steer the caller away from killing the lock holder
+    // — a real LLM session killed the worker-ops daemon to "free" the lock,
+    // taking the whole worker::* API down.
+    #[test]
+    fn lock_busy_self_holder_names_the_daemon_and_forbids_kill() {
+        let err = WorkerOpError::LockBusy {
+            holder_pid: Some(4242),
+            holder_is_self: true,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("worker-ops daemon"), "got: {msg}");
+        assert!(msg.contains("Do NOT kill pid 4242"), "got: {msg}");
+        assert!(msg.contains("worker::status"), "got: {msg}");
+        let payload = err.to_payload();
+        assert_eq!(payload["code"], "W120");
+        assert_eq!(payload["details"]["holder_pid"], 4242);
+        assert_eq!(payload["details"]["holder_is_self"], true);
+    }
+
+    #[test]
+    fn lock_busy_foreign_holder_still_warns_against_kill() {
+        let err = WorkerOpError::LockBusy {
+            holder_pid: Some(99),
+            holder_is_self: false,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("Do NOT kill pid 99"), "got: {msg}");
+        assert!(msg.contains("retry"), "got: {msg}");
+        assert_eq!(err.to_payload()["details"]["holder_is_self"], false);
+    }
+
+    #[test]
+    fn lock_busy_unknown_holder_has_guidance() {
+        let err = WorkerOpError::LockBusy {
+            holder_pid: None,
+            holder_is_self: false,
+        };
+        assert!(err.to_string().contains("Retry shortly"));
     }
 
     #[test]

--- a/crates/iii-worker/src/core/logs.rs
+++ b/crates/iii-worker/src/core/logs.rs
@@ -277,6 +277,27 @@ mod tests {
     }
 
     #[test]
+    fn strip_terminal_controls_terminates_osc_on_st_terminator() {
+        assert_eq!(
+            strip_terminal_controls("\u{1b}]0;set title\u{1b}\\visible"),
+            "visible"
+        );
+    }
+
+    #[test]
+    fn strip_terminal_controls_consumes_single_char_escapes() {
+        // ESC M (reverse index) and ESC 7 (save cursor): the char after
+        // ESC is swallowed, surrounding text survives.
+        assert_eq!(strip_terminal_controls("\u{1b}Mup"), "up");
+        assert_eq!(strip_terminal_controls("a\u{1b}7b"), "ab");
+    }
+
+    #[test]
+    fn strip_terminal_controls_drops_trailing_escape() {
+        assert_eq!(strip_terminal_controls("tail\u{1b}"), "tail");
+    }
+
+    #[test]
     fn sanitize_lines_drops_spinner_residue_and_blanks() {
         let lines = vec![
             "⠙\u{1b}[1G\u{1b}[0K⠹\u{1b}[1G\u{1b}[0K".to_string(), // pure spinner
@@ -301,5 +322,95 @@ mod tests {
         assert!(outcome.logs_dir.is_none());
         assert!(outcome.stdout.is_empty());
         assert!(outcome.stderr.is_empty());
+    }
+
+    /// Restores the original `HOME` on drop so the override can't leak
+    /// into sibling tests. Mirrors `cli::status::tests::ProbeEnvGuard`;
+    /// callers must hold `test_support::lock_home` for the whole body.
+    struct HomeGuard {
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl HomeGuard {
+        fn set(home: &Path) -> Self {
+            let original = std::env::var_os("HOME");
+            // SAFETY: test-only, serialized via test_support::lock_home.
+            unsafe { std::env::set_var("HOME", home) };
+            Self { original }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: test-only, serialized via test_support::lock_home.
+            unsafe {
+                match &self.original {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+        }
+    }
+
+    // lock_home is intentionally held across run().await: it serializes the
+    // process-global HOME mutation against sibling tests.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn run_sanitizes_logs_from_best_dir_by_default() {
+        let _g = crate::cli::test_support::lock_home();
+        let tmp = TempDir::new().unwrap();
+        let _home = HomeGuard::set(tmp.path());
+        let logs_dir = tmp.path().join(".iii/logs/sanitize-target");
+        write(
+            &logs_dir,
+            "stdout.log",
+            "\u{1b}[32mready\u{1b}[0m\n⠙\u{1b}[1G\u{1b}[0K\n",
+        );
+        write(&logs_dir, "stderr.log", "\u{1b}[31moops\u{1b}[39m\n");
+
+        let outcome = run(LogsOptions {
+            name: "sanitize-target".to_string(),
+            tail: 10,
+            raw: false,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.stdout, vec!["ready".to_string()]);
+        assert_eq!(outcome.stderr, vec!["oops".to_string()]);
+        assert_eq!(outcome.logs_dir, Some(logs_dir.display().to_string()));
+        assert_eq!(outcome.name, "sanitize-target");
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn run_raw_preserves_escapes_and_spinner_frames() {
+        let _g = crate::cli::test_support::lock_home();
+        let tmp = TempDir::new().unwrap();
+        let _home = HomeGuard::set(tmp.path());
+        let logs_dir = tmp.path().join(".iii/logs/raw-target");
+        write(
+            &logs_dir,
+            "stdout.log",
+            "\u{1b}[32mready\u{1b}[0m\n⠙\u{1b}[1G\u{1b}[0K\n",
+        );
+
+        let outcome = run(LogsOptions {
+            name: "raw-target".to_string(),
+            tail: 10,
+            raw: true,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outcome.stdout,
+            vec![
+                "\u{1b}[32mready\u{1b}[0m".to_string(),
+                "⠙\u{1b}[1G\u{1b}[0K".to_string(),
+            ]
+        );
+        assert!(outcome.stderr.is_empty());
+        assert_eq!(outcome.logs_dir, Some(logs_dir.display().to_string()));
     }
 }

--- a/crates/iii-worker/src/core/logs.rs
+++ b/crates/iii-worker/src/core/logs.rs
@@ -58,6 +58,72 @@ pub fn pick_best_logs_dir(candidates: &[PathBuf]) -> Option<PathBuf> {
     best.map(|(dir, _)| dir)
 }
 
+/// Strip terminal escape sequences (CSI `ESC[…m`-style, OSC `ESC]…BEL/ST`,
+/// single-char escapes) and remaining control bytes (tabs survive) from one
+/// log line. Worker logs are written by tools that assume a TTY (npm's
+/// colored output, braille spinners, cursor-rewrite frames); over the bus
+/// they reach LLM/automation callers where the escapes are pure token noise
+/// and can even rewrite the reader's terminal when echoed.
+pub fn strip_terminal_controls(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' {
+            match chars.peek() {
+                // CSI: ESC [ … final byte in @..=~
+                Some('[') => {
+                    chars.next();
+                    for c2 in chars.by_ref() {
+                        if ('\u{40}'..='\u{7e}').contains(&c2) {
+                            break;
+                        }
+                    }
+                }
+                // OSC: ESC ] … terminated by BEL or ST (ESC \)
+                Some(']') => {
+                    chars.next();
+                    while let Some(c2) = chars.next() {
+                        if c2 == '\u{7}' {
+                            break;
+                        }
+                        if c2 == '\u{1b}' && chars.peek() == Some(&'\\') {
+                            chars.next();
+                            break;
+                        }
+                    }
+                }
+                // Single-char escape (ESC X)
+                Some(_) => {
+                    chars.next();
+                }
+                None => {}
+            }
+        } else if !c.is_control() || c == '\t' {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// True when a stripped line carries no information for a non-TTY reader:
+/// blank, or nothing but braille spinner glyphs (U+2800..=U+28FF) and
+/// whitespace — the residue of progress-spinner redraw frames.
+fn is_spinner_noise(stripped: &str) -> bool {
+    stripped
+        .chars()
+        .all(|c| c.is_whitespace() || ('\u{2800}'..='\u{28ff}').contains(&c))
+}
+
+/// Default (non-`raw`) presentation: strip terminal controls and drop
+/// spinner-residue frames.
+pub fn sanitize_lines(lines: Vec<String>) -> Vec<String> {
+    lines
+        .into_iter()
+        .map(|l| strip_terminal_controls(&l))
+        .filter(|l| !is_spinner_noise(l))
+        .collect()
+}
+
 /// Last `tail` lines of `path`, scanning at most the trailing
 /// [`LOGS_READ_BYTES_MAX`] bytes. Missing/unreadable files yield no lines.
 fn tail_lines(path: &Path, tail: usize) -> Vec<String> {
@@ -100,9 +166,17 @@ pub async fn run(opts: LogsOptions) -> Result<LogsOutcome, WorkerOpError> {
         });
     };
 
+    let stdout = tail_lines(&dir.join("stdout.log"), tail);
+    let stderr = tail_lines(&dir.join("stderr.log"), tail);
+    let (stdout, stderr) = if opts.raw {
+        (stdout, stderr)
+    } else {
+        (sanitize_lines(stdout), sanitize_lines(stderr))
+    };
+
     Ok(LogsOutcome {
-        stdout: tail_lines(&dir.join("stdout.log"), tail),
-        stderr: tail_lines(&dir.join("stderr.log"), tail),
+        stdout,
+        stderr,
         logs_dir: Some(dir.display().to_string()),
         name: opts.name,
     })
@@ -175,6 +249,7 @@ mod tests {
             let err = run(LogsOptions {
                 name: name.to_string(),
                 tail: 10,
+                raw: false,
             })
             .await
             .unwrap_err();
@@ -186,6 +261,31 @@ mod tests {
         }
     }
 
+    #[test]
+    fn strip_terminal_controls_removes_csi_osc_and_controls() {
+        // npm-style colored line
+        assert_eq!(
+            strip_terminal_controls("\u{1b}[1mnpm\u{1b}[22m \u{1b}[31merror\u{1b}[39m 404"),
+            "npm error 404"
+        );
+        // OSC title-set terminated by BEL, then text
+        assert_eq!(strip_terminal_controls("\u{1b}]2;evil\u{7}ok"), "ok");
+        // cursor-rewrite spinner frame residue
+        assert_eq!(strip_terminal_controls("⠼\u{1b}[1G\u{1b}[0K"), "⠼");
+        // tabs survive, other C0 controls don't
+        assert_eq!(strip_terminal_controls("a\tb\u{8}c"), "a\tbc");
+    }
+
+    #[test]
+    fn sanitize_lines_drops_spinner_residue_and_blanks() {
+        let lines = vec![
+            "⠙\u{1b}[1G\u{1b}[0K⠹\u{1b}[1G\u{1b}[0K".to_string(), // pure spinner
+            "".to_string(),
+            "\u{1b}[32mreal output\u{1b}[0m".to_string(),
+        ];
+        assert_eq!(sanitize_lines(lines), vec!["real output".to_string()]);
+    }
+
     #[tokio::test]
     async fn run_caps_tail_at_max() {
         // Unknown-but-valid worker: empty outcome, no error — the cap and
@@ -194,6 +294,7 @@ mod tests {
         let outcome = run(LogsOptions {
             name: "definitely-not-a-real-worker-name-xyz".to_string(),
             tail: usize::MAX,
+            raw: false,
         })
         .await
         .unwrap();

--- a/crates/iii-worker/src/core/project.rs
+++ b/crates/iii-worker/src/core/project.rs
@@ -55,7 +55,15 @@ impl ProjectOperationLock {
                         .find_map(|l| l.strip_prefix("pid="))
                         .and_then(|p| p.trim().parse::<u32>().ok())
                 });
-                Err(WorkerOpError::LockBusy { holder_pid })
+                // flock ownership is per open-file-description, so a second
+                // acquire in the SAME process (a concurrent op in this daemon)
+                // also lands here — flag it so the error can tell the caller
+                // the holder is the daemon itself, not a stale process.
+                let holder_is_self = holder_pid == Some(std::process::id());
+                Err(WorkerOpError::LockBusy {
+                    holder_pid,
+                    holder_is_self,
+                })
             }
             Err((_, errno)) => Err(WorkerOpError::LockIo {
                 path,

--- a/crates/iii-worker/src/core/types.rs
+++ b/crates/iii-worker/src/core/types.rs
@@ -27,14 +27,14 @@ pub enum WorkerSource {
     },
     Local {
         #[schemars(
-            description = "Filesystem path on the engine/daemon host (NOT the caller's machine). Installs run the manifest's setup/install/start scripts on the host. Works over the trigger as well as the CLI."
+            description = "Path to a worker PROJECT DIRECTORY on the engine/daemon host (NOT the caller's machine), e.g. \"/srv/workers/my-worker\". The directory MUST contain an `iii.worker.yaml` manifest.\n\nMinimal manifest (just name + how to start):\n  name: my-worker\n  scripts:\n    start: \"node src/index.js\"\n\nAll iii.worker.yaml fields:\n  name        (required) worker id; must be a single path segment (alphanumerics, '-', '_', '.').\n  description (optional) one-line human/LLM-readable summary.\n  scripts.start   (required unless inferred) command that runs the worker process.\n  scripts.setup   (optional) one-time host provisioning, e.g. \"apt-get install -y build-essential\".\n  scripts.install (optional) dependency install, e.g. \"npm install\".\n  dependencies    (optional) map of other-worker-name -> semver range, e.g. { iii-state: \"^0.19\" }.\n  resources.cpus   (optional) integer vCPUs, default 2.\n  resources.memory (optional) MiB, default 2048.\n  env             (optional) string->string vars injected into the worker (III_URL/III_ENGINE_URL are set by the engine and ignored here).\n  runtime.base_image (optional) OCI rootfs override, e.g. \"oven/bun:1\".\n\nUnknown keys are rejected at add time. The setup/install/start scripts run on the host. Works over the trigger as well as the CLI. Dry-run a manifest with `worker::validate`; fetch the full manifest JSON Schema via `worker::schema { function_id: \"iii.worker.yaml\" }`."
         )]
         path: PathBuf,
     },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(example = "add_options_example")]
+#[schemars(example = "add_options_example", example = "add_options_local_example")]
 pub struct AddOptions {
     #[schemars(description = "Where the worker comes from (registry/oci/local).")]
     pub source: WorkerSource,
@@ -50,7 +50,7 @@ pub struct AddOptions {
     pub reset_config: bool,
     #[serde(default = "default_wait")]
     #[schemars(
-        description = "Block until the worker reports ready. Default true. Set false to return immediately after install."
+        description = "Block until the worker reports ready. Default true. Over the trigger surface installs routinely exceed bus invocation timeouts (npm install etc.) — prefer wait:false and poll worker::status. If a wait:true call times out, the install KEEPS RUNNING server-side: do not re-issue blindly (the project lock will be busy, W120); poll worker::status instead."
     )]
     pub wait: bool,
 }
@@ -60,6 +60,16 @@ fn add_options_example() -> serde_json::Value {
         "source": {"kind": "registry", "name": "pdfkit", "version": "1.0.0"},
         "force": false,
         "reset_config": false,
+        "wait": true
+    })
+}
+
+/// Second example so introspecting LLMs see the local-path shape, not just
+/// the registry one — the directory must hold an iii.worker.yaml (see the
+/// `WorkerSource::Local` field description for the manifest fields).
+fn add_options_local_example() -> serde_json::Value {
+    serde_json::json!({
+        "source": {"kind": "local", "path": "/srv/workers/my-worker"},
         "wait": true
     })
 }
@@ -224,6 +234,11 @@ pub struct LogsOptions {
         description = "Trailing lines to return per stream. Default 100, capped at 1000. Only the last 1 MiB of each log file is scanned."
     )]
     pub tail: usize,
+    #[serde(default)]
+    #[schemars(
+        description = "Return raw log lines including ANSI color codes and spinner redraw frames. Default false: terminal escape sequences are stripped and spinner-only frames dropped, which is what automation/LLM callers want."
+    )]
+    pub raw: bool,
 }
 
 fn default_logs_tail() -> usize {
@@ -248,6 +263,56 @@ pub struct LogsOutcome {
         description = "Trailing stderr lines — host-side boot/runtime messages; during startup these chronologically precede stdout."
     )]
     pub stderr: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(example = "status_options_example")]
+pub struct StatusOptions {
+    #[schemars(
+        description = "Worker to inspect, e.g. \"pdfkit\". Use worker::list for the full roster."
+    )]
+    pub name: String,
+}
+
+fn status_options_example() -> serde_json::Value {
+    serde_json::json!({"name": "pdfkit"})
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(
+    description = "One worker's install/runtime status plus a recent sanitized log tail and a next-step hint. The poll target after worker::add { wait: false } (or after a wait:true call hit a bus timeout — the install continues server-side)."
+)]
+pub struct StatusOutcome {
+    #[schemars(description = "Worker name inspected.")]
+    pub name: String,
+    #[schemars(
+        description = "True when the worker is declared in the project config.yaml (i.e. worker::add completed its config write)."
+    )]
+    pub installed: bool,
+    #[schemars(
+        description = "How the worker is provisioned: \"oci\" | \"local\" | \"binary\" | \"bundle\" | \"builtin\" (config-only/engine builtin) | \"not-installed\"."
+    )]
+    pub worker_type: String,
+    #[schemars(
+        description = "True when the worker's process is alive (or, for engine builtins, when the engine itself is running). False during install/boot AND after a crash — check stderr_tail to tell which."
+    )]
+    pub running: bool,
+    #[schemars(description = "Worker process pid when one is observable; null for engine builtins.")]
+    pub pid: Option<u32>,
+    #[schemars(description = "Installed version from iii.lock; null when not lockfile-tracked.")]
+    pub version: Option<String>,
+    #[schemars(description = "Host log directory, when any logs exist yet.")]
+    pub logs_dir: Option<String>,
+    #[schemars(
+        description = "Last stderr lines (terminal escapes stripped) — host-side boot/install progress and errors live here (e.g. npm install failures)."
+    )]
+    pub stderr_tail: Vec<String>,
+    #[schemars(description = "Last stdout lines (terminal escapes stripped) — the worker/guest console.")]
+    pub stdout_tail: Vec<String>,
+    #[schemars(
+        description = "Suggested next step derived from the state above (e.g. retry guidance, which trigger to call). Advisory, not machine-stable."
+    )]
+    pub hint: String,
 }
 
 /// Reject names that could escape the per-worker directories these names

--- a/crates/iii-worker/src/core/types.rs
+++ b/crates/iii-worker/src/core/types.rs
@@ -297,7 +297,9 @@ pub struct StatusOutcome {
         description = "True when the worker's process is alive (or, for engine builtins, when the engine itself is running). False during install/boot AND after a crash — check stderr_tail to tell which."
     )]
     pub running: bool,
-    #[schemars(description = "Worker process pid when one is observable; null for engine builtins.")]
+    #[schemars(
+        description = "Worker process pid when one is observable; null for engine builtins."
+    )]
     pub pid: Option<u32>,
     #[schemars(description = "Installed version from iii.lock; null when not lockfile-tracked.")]
     pub version: Option<String>,
@@ -307,7 +309,9 @@ pub struct StatusOutcome {
         description = "Last stderr lines (terminal escapes stripped) — host-side boot/install progress and errors live here (e.g. npm install failures)."
     )]
     pub stderr_tail: Vec<String>,
-    #[schemars(description = "Last stdout lines (terminal escapes stripped) — the worker/guest console.")]
+    #[schemars(
+        description = "Last stdout lines (terminal escapes stripped) — the worker/guest console."
+    )]
     pub stdout_tail: Vec<String>,
     #[schemars(
         description = "Suggested next step derived from the state above (e.g. retry guidance, which trigger to call). Advisory, not machine-stable."

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -38,6 +38,21 @@ impl tracing_subscriber::fmt::MakeWriter<'_> for ResilientStdout {
     }
 }
 
+/// Print a failed worker op's error — unless it is the bare rc wrapper, in
+/// which case the underlying handler already wrote its real, colored error
+/// to this terminal (or to the tailed log file) and a second "[W900]
+/// internal: iii worker X exited with rc N" line would only mislabel a user
+/// error as internal. The suppression assumes handlers always print before
+/// returning nonzero (true today for every shim-reachable path); the debug
+/// line keeps a silent-failure regression diagnosable via RUST_LOG=debug.
+fn report_op_error(e: &iii_worker::core::WorkerOpError) {
+    if iii_worker::cli::host_shim::is_bare_rc_wrapper(e) {
+        tracing::debug!(error = %e, "suppressed bare rc wrapper (handler reported directly)");
+        return;
+    }
+    eprintln!("error: [{}] {}", e.kind().code(), e);
+}
+
 fn main() -> anyhow::Result<()> {
     // FIRST, before the tokio runtime spawns worker threads: capture (and
     // scrub from the env) any inherited lifeline facts. The capture mutates
@@ -134,7 +149,7 @@ async fn async_main() -> anyhow::Result<()> {
                 let result = core_add::run(opts, &ctx, &sink, &CliHostShim).await;
 
                 if let Err(e) = result {
-                    eprintln!("error: [{}] {}", e.kind().code(), e);
+                    report_op_error(&e);
                     fail_count += 1;
                 }
             }
@@ -184,7 +199,7 @@ async fn async_main() -> anyhow::Result<()> {
             match core_remove::run(opts, &ctx, &sink, &CliHostShim).await {
                 Ok(_) => 0,
                 Err(e) => {
-                    eprintln!("error: [{}] {}", e.kind().code(), e);
+                    report_op_error(&e);
                     1
                 }
             }
@@ -217,7 +232,7 @@ async fn async_main() -> anyhow::Result<()> {
                 // the inner handler's progress output.
                 let sink = StderrSink::new(true);
                 if let Err(e) = core_add::run(opts, &ctx, &sink, &CliHostShim).await {
-                    eprintln!("error: [{}] {}", e.kind().code(), e);
+                    report_op_error(&e);
                     fail_count += 1;
                 }
             }
@@ -240,7 +255,7 @@ async fn async_main() -> anyhow::Result<()> {
             match core_update::run(opts, &ctx, &sink, &CliHostShim).await {
                 Ok(_) => 0,
                 Err(e) => {
-                    eprintln!("error: [{}] {}", e.kind().code(), e);
+                    report_op_error(&e);
                     1
                 }
             }
@@ -297,7 +312,7 @@ async fn async_main() -> anyhow::Result<()> {
             match core_clear::run(opts, &ctx, &sink, &CliHostShim).await {
                 Ok(_) => 0,
                 Err(e) => {
-                    eprintln!("error: [{}] {}", e.kind().code(), e);
+                    report_op_error(&e);
                     1
                 }
             }
@@ -328,7 +343,7 @@ async fn async_main() -> anyhow::Result<()> {
             match core_start::run(opts, &ctx, &sink, &CliHostShim).await {
                 Ok(_) => 0,
                 Err(e) => {
-                    eprintln!("error: [{}] {}", e.kind().code(), e);
+                    report_op_error(&e);
                     1
                 }
             }
@@ -360,7 +375,7 @@ async fn async_main() -> anyhow::Result<()> {
             match core_stop::run(opts, &ctx, &sink, &CliHostShim).await {
                 Ok(_) => 0,
                 Err(e) => {
-                    eprintln!("error: [{}] {}", e.kind().code(), e);
+                    report_op_error(&e);
                     1
                 }
             }
@@ -436,7 +451,7 @@ async fn async_main() -> anyhow::Result<()> {
                     0
                 }
                 Err(e) => {
-                    eprintln!("error: [{}] {}", e.kind().code(), e);
+                    report_op_error(&e);
                     1
                 }
             }

--- a/crates/iii-worker/tests/local_add_manifest_validation_integration.rs
+++ b/crates/iii-worker/tests/local_add_manifest_validation_integration.rs
@@ -1,0 +1,230 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! End-to-end coverage for `iii worker add <local-path>` manifest key
+//! validation. Mirrors the harness in `local_add_dependencies_integration.rs`:
+//! a CWD + `III_API_URL` mutex, a temp project dir, and a real
+//! `handle_managed_add` call that asserts disk state afterwards. The manifests
+//! here declare no `dependencies`, so the deps stage is a no-op and never hits
+//! the network.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+/// Serializes tests in this file that mutate CWD and `III_API_URL`.
+static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+async fn in_temp_dir<F, Fut, R>(f: F) -> R
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = R>,
+{
+    let _guard = TEST_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let prev = std::env::current_dir().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+    let result = f().await;
+    std::env::set_current_dir(prev).unwrap();
+    result
+}
+
+fn write_manifest(dir: &Path, body: &str) {
+    std::fs::write(dir.join("iii.worker.yaml"), body).unwrap();
+}
+
+async fn add_local(worker_dir: &Path) -> i32 {
+    let prev_api = std::env::var("III_API_URL").ok();
+    unsafe { std::env::set_var("III_API_URL", "http://127.0.0.1:1") };
+
+    let rc = iii_worker::cli::managed::handle_managed_add(
+        worker_dir.to_str().unwrap(),
+        true,
+        false,
+        false,
+        false,
+    )
+    .await;
+
+    match prev_api {
+        Some(v) => unsafe { std::env::set_var("III_API_URL", v) },
+        None => unsafe { std::env::remove_var("III_API_URL") },
+    }
+    rc
+}
+
+/// An unknown manifest key (typo / unsupported) must FAIL the add before any
+/// state is written — proving the validation gate runs ahead of the
+/// config.yaml/iii.lock mutations.
+#[tokio::test]
+async fn local_add_unknown_key_fails_and_writes_nothing() {
+    in_temp_dir(|| async {
+        let worker_dir: PathBuf = std::env::current_dir().unwrap().join("bad-worker");
+        std::fs::create_dir(&worker_dir).unwrap();
+        // `runtimee` is an unknown top-level key; `scripts.start` keeps the
+        // manifest otherwise loadable so we reach the key validator.
+        write_manifest(
+            &worker_dir,
+            "name: bad-worker\nscripts:\n  start: \"node index.js\"\nruntimee:\n  foo: bar\n",
+        );
+
+        let rc = add_local(&worker_dir).await;
+
+        assert_ne!(rc, 0, "unknown manifest key must fail the add");
+        let cwd = std::env::current_dir().unwrap();
+        assert!(
+            !cwd.join("config.yaml").exists(),
+            "config.yaml must not exist — validation fails before append"
+        );
+        assert!(
+            !cwd.join("iii.lock").exists(),
+            "iii.lock must not exist — validation fails before install"
+        );
+    })
+    .await;
+}
+
+/// Deprecated keys (`runtime.kind`, `config`, legacy top-level `language`/
+/// `entry`) must WARN but still allow the add to succeed and write the worker
+/// to config.yaml — so existing/scaffolded workers keep installing.
+#[tokio::test]
+async fn local_add_deprecated_keys_succeed_and_add_worker() {
+    in_temp_dir(|| async {
+        let worker_dir: PathBuf = std::env::current_dir().unwrap().join("dep-worker");
+        std::fs::create_dir(&worker_dir).unwrap();
+        write_manifest(
+            &worker_dir,
+            "name: dep-worker\n\
+             language: typescript\n\
+             entry: src/index.ts\n\
+             runtime:\n  kind: bun\n\
+             config:\n  port: 3000\n",
+        );
+
+        let rc = add_local(&worker_dir).await;
+
+        assert_eq!(rc, 0, "deprecated-only manifest must still add (rc 0)");
+        let config = std::fs::read_to_string(std::env::current_dir().unwrap().join("config.yaml"))
+            .unwrap_or_default();
+        assert!(
+            config.contains("dep-worker"),
+            "config.yaml must contain the added worker; got:\n{config}"
+        );
+    })
+    .await;
+}
+
+/// `description` is a supported field (read by managed.rs, documented in
+/// workers.mdx); a manifest using it must add cleanly, not hard-fail.
+#[tokio::test]
+async fn local_add_description_field_succeeds() {
+    in_temp_dir(|| async {
+        let worker_dir: PathBuf = std::env::current_dir().unwrap().join("desc-worker");
+        std::fs::create_dir(&worker_dir).unwrap();
+        write_manifest(
+            &worker_dir,
+            "name: desc-worker\n\
+             description: Evaluate things over iii functions.\n\
+             scripts:\n  start: \"node index.js\"\n",
+        );
+
+        let rc = add_local(&worker_dir).await;
+
+        assert_eq!(rc, 0, "manifest with `description` must add (rc 0)");
+        assert!(
+            std::fs::read_to_string(std::env::current_dir().unwrap().join("config.yaml"))
+                .unwrap_or_default()
+                .contains("desc-worker"),
+            "config.yaml must contain the added worker"
+        );
+    })
+    .await;
+}
+
+/// A manifest that exists but lacks `name` must fail at the validation gate
+/// with the required-field error — NOT fall through to auto-detection and the
+/// false "No project manifest detected" diagnosis (the file plainly exists).
+/// Nothing may be written.
+#[tokio::test]
+async fn local_add_nameless_manifest_fails_and_writes_nothing() {
+    in_temp_dir(|| async {
+        let worker_dir: PathBuf = std::env::current_dir().unwrap().join("nameless-worker");
+        std::fs::create_dir(&worker_dir).unwrap();
+        // Even with a package.json present (the old auto-detect fallback), an
+        // existing iii.worker.yaml is authoritative and must carry `name`.
+        write_manifest(&worker_dir, "scripts:\n  start: \"node index.js\"\n");
+        std::fs::write(
+            worker_dir.join("package.json"),
+            "{ \"name\": \"nameless-worker\" }",
+        )
+        .unwrap();
+
+        let rc = add_local(&worker_dir).await;
+
+        assert_ne!(rc, 0, "nameless manifest must fail the add");
+        let cwd = std::env::current_dir().unwrap();
+        assert!(
+            !cwd.join("config.yaml").exists(),
+            "config.yaml must not exist — name gate fails before append"
+        );
+    })
+    .await;
+}
+
+/// A whitespace-padded `name` must add cleanly under the trimmed name —
+/// `worker::validate` reports the trimmed name as valid, so the add path must
+/// agree instead of failing on the embedded space.
+#[tokio::test]
+async fn local_add_padded_name_trims_and_succeeds() {
+    in_temp_dir(|| async {
+        let worker_dir: PathBuf = std::env::current_dir().unwrap().join("padded-worker");
+        std::fs::create_dir(&worker_dir).unwrap();
+        write_manifest(
+            &worker_dir,
+            "name: \" padded-worker \"\nscripts:\n  start: \"node index.js\"\n",
+        );
+
+        let rc = add_local(&worker_dir).await;
+
+        assert_eq!(rc, 0, "padded name must trim and add (rc 0)");
+        let config = std::fs::read_to_string(std::env::current_dir().unwrap().join("config.yaml"))
+            .unwrap_or_default();
+        assert!(
+            config.contains("padded-worker"),
+            "config.yaml must contain the trimmed worker name; got:\n{config}"
+        );
+    })
+    .await;
+}
+
+/// An oversize manifest is rejected (memory-DoS guard) before any state is
+/// written, with nothing persisted.
+#[tokio::test]
+async fn local_add_oversize_manifest_fails_and_writes_nothing() {
+    in_temp_dir(|| async {
+        let worker_dir: PathBuf = std::env::current_dir().unwrap().join("big-worker");
+        std::fs::create_dir(&worker_dir).unwrap();
+        // Valid YAML, but past the 64 KiB cap.
+        write_manifest(
+            &worker_dir,
+            &format!(
+                "name: big-worker\nscripts:\n  start: x\nbloat: \"{}\"\n",
+                "a".repeat(70 * 1024)
+            ),
+        );
+
+        let rc = add_local(&worker_dir).await;
+
+        assert_ne!(rc, 0, "oversize manifest must fail the add");
+        let cwd = std::env::current_dir().unwrap();
+        assert!(
+            !cwd.join("config.yaml").exists(),
+            "config.yaml must not exist — oversize manifest rejected before append"
+        );
+    })
+    .await;
+}

--- a/crates/iii-worker/tests/worker_manager_integration.rs
+++ b/crates/iii-worker/tests/worker_manager_integration.rs
@@ -91,9 +91,7 @@ async fn create_adapter_with_unknown_runtime() {
 /// The actual value depends on whether firmware is present on the test host.
 #[test]
 fn libkrun_available_returns_bool() {
-    let available: bool = iii_worker::cli::worker_manager::libkrun::libkrun_available();
-    // Assert it is a valid bool (this is mainly a smoke test for no panic).
-    assert!(available || !available);
+    let _available: bool = iii_worker::cli::worker_manager::libkrun::libkrun_available();
 }
 
 // ===========================================================================

--- a/crates/iii-worker/tests/worker_trigger_integration.rs
+++ b/crates/iii-worker/tests/worker_trigger_integration.rs
@@ -546,9 +546,10 @@ fn status_outcome_every_field_has_description() {
 
 #[test]
 fn validate_options_every_field_has_description() {
-    let schema =
-        serde_json::to_value(schema_for!(iii_worker::cli::worker_manifest::ValidateOptions))
-            .unwrap();
+    let schema = serde_json::to_value(schema_for!(
+        iii_worker::cli::worker_manifest::ValidateOptions
+    ))
+    .unwrap();
     let missing = fields_missing_description(&schema);
     assert!(
         missing.is_empty(),
@@ -558,9 +559,10 @@ fn validate_options_every_field_has_description() {
 
 #[test]
 fn manifest_report_every_field_has_description() {
-    let schema =
-        serde_json::to_value(schema_for!(iii_worker::cli::worker_manifest::ManifestReport))
-            .unwrap();
+    let schema = serde_json::to_value(schema_for!(
+        iii_worker::cli::worker_manifest::ManifestReport
+    ))
+    .unwrap();
     let missing = fields_missing_description(&schema);
     assert!(
         missing.is_empty(),

--- a/crates/iii-worker/tests/worker_trigger_integration.rs
+++ b/crates/iii-worker/tests/worker_trigger_integration.rs
@@ -525,6 +525,65 @@ fn logs_outcome_every_field_has_description() {
 }
 
 #[test]
+fn status_options_every_field_has_description() {
+    let schema = serde_json::to_value(schema_for!(iii_worker::core::StatusOptions)).unwrap();
+    let missing = fields_missing_description(&schema);
+    assert!(
+        missing.is_empty(),
+        "StatusOptions fields missing description: {missing:?}"
+    );
+}
+
+#[test]
+fn status_outcome_every_field_has_description() {
+    let schema = serde_json::to_value(schema_for!(iii_worker::core::StatusOutcome)).unwrap();
+    let missing = fields_missing_description(&schema);
+    assert!(
+        missing.is_empty(),
+        "StatusOutcome fields missing description: {missing:?}"
+    );
+}
+
+#[test]
+fn validate_options_every_field_has_description() {
+    let schema =
+        serde_json::to_value(schema_for!(iii_worker::cli::worker_manifest::ValidateOptions))
+            .unwrap();
+    let missing = fields_missing_description(&schema);
+    assert!(
+        missing.is_empty(),
+        "ValidateOptions fields missing description: {missing:?}"
+    );
+}
+
+#[test]
+fn manifest_report_every_field_has_description() {
+    let schema =
+        serde_json::to_value(schema_for!(iii_worker::cli::worker_manifest::ManifestReport))
+            .unwrap();
+    let missing = fields_missing_description(&schema);
+    assert!(
+        missing.is_empty(),
+        "ManifestReport fields missing description: {missing:?}"
+    );
+}
+
+#[test]
+fn worker_manifest_schema_is_closed_world_with_descriptions() {
+    // The iii.worker.yaml schema served via worker::schema must reject
+    // unknown keys, require `name`, and describe every field — it is the
+    // authoring contract LLMs build manifests from.
+    let schema = iii_worker::cli::worker_manifest::manifest_schema_json();
+    assert_eq!(schema["additionalProperties"], serde_json::json!(false));
+    assert_eq!(schema["required"], serde_json::json!(["name"]));
+    let missing = fields_missing_description(&schema);
+    assert!(
+        missing.is_empty(),
+        "WorkerManifest fields missing description: {missing:?}"
+    );
+}
+
+#[test]
 fn clear_options_every_field_has_description() {
     let schema = serde_json::to_value(schema_for!(ClearOptions)).unwrap();
     let missing = fields_missing_description(&schema);
@@ -619,6 +678,8 @@ const ALL_OPS: &[&str] = &[
     "worker::clear",
     "worker::logs",
     "worker::schema",
+    "worker::status",
+    "worker::validate",
 ];
 
 #[test]
@@ -667,6 +728,8 @@ fn read_only_ops_are_idempotent() {
         "worker::schema",
         "worker::clear",
         "worker::logs",
+        "worker::status",
+        "worker::validate",
     ] {
         let (_, idempotent) = op_metadata(op);
         assert!(idempotent, "{op} should be declared idempotent");

--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -5,6 +5,56 @@ owner: "devrel"
 type: "reference"
 ---
 
+<Update label="0.20.0" description="June 2026">
+  ## `iii.worker.yaml` is validated before anything is installed
+
+  Local `worker add` (CLI and `worker::add` trigger) now validates the manifest **before any artifact is written**. A typed schema is the single source of truth, and it is strict where it matters:
+
+  - **Unknown keys are rejected** — collected and sorted, so a manifest with several typos surfaces them all in one run:
+
+    ```
+    unknown key(s) in ./my-worker/iii.worker.yaml: [runtimee, scrpits].
+    Supported fields are: name, description, runtime.base_image,
+    scripts.(setup|install|start), env, dependencies, resources.(cpus|memory).
+    ```
+
+  - **Deprecated keys warn but still work** (`runtime.kind` / `package_manager` / `entry` / `language`, top-level `config` / `language` / `entry`) — honored for now, scheduled for removal in a future version, with migration hints per key. Silence with `III_NO_DEPRECATION_WARN=1`.
+  - **Shape errors read in plain English** — `runtime: node` reports "`runtime` must be a mapping", not serde's "expected struct RuntimeSection". A manifest missing `name` says so precisely instead of the false "No project manifest detected".
+  - The same strict validation re-runs at `start`, with a 64 KiB size cap that defuses hostile (billion-laughs) or accidental multi-GB manifests before they are slurped into host memory.
+
+  **Breaking:** a local manifest with unknown keys that previously installed silently now fails `worker::add`. Fix the typo or remove the key — `worker::validate` (below) tells you exactly which.
+
+  ## Author → check → add: `worker::validate` and the manifest contract
+
+  Two new ops close the authoring loop for LLMs and automation:
+
+  - **`worker::validate`** dry-runs a manifest — inline string or host path — and returns `{ valid, name, errors, unknown_keys, deprecated_keys, warnings }` without touching anything. `valid: true` means `worker::add` would accept it.
+  - **`worker::schema { function_id: "iii.worker.yaml" }`** serves the manifest's JSON Schema (closed-world: every field described, unknown keys rejected) plus a ready-to-write hello-world bundle using the correct `iii-sdk` package — self-tested against our own validator so the example can never drift from the rules.
+
+  ## `worker::status`: one worker, full picture
+
+  `worker::status { name }` reports a single worker's config entry, sandbox state, process liveness, and recent logs in one call, with actionable hints — a local worker without logs yet reports that it is still provisioning rather than implying failure. Like every `worker::*` op it carries schemars-generated request/response schemas via `engine::functions::info`.
+
+  ## Local-path workers: stop re-adding after code edits
+
+  Local workers run their project directory live and get a host-side source watcher: editing a source file auto-restarts the worker, and editing a dependency manifest (`package.json`, `Cargo.toml`, …) forces a full restart. Re-running `worker::add` after a code change is pure waste — it re-registers triggers and re-runs install scripts. The `worker::add` / `worker::update` descriptions now say this to LLM callers directly: re-add with `force: true` only when `iii.worker.yaml` itself changes, and `worker::update` never touches local-path workers (it re-resolves registry workers pinned in `iii.lock`).
+
+  Also fixed: a forced local re-add returned the raw path (`/tmp/hello-world`) as the worker name instead of the manifest name (`hello-world`) — no other `worker::*` op accepts the path form, so the response was a dead end.
+
+  ## W120 tells you when the lock holder is the daemon itself
+
+  When the worker lock is held by the `iii-worker-ops` daemon — the process serving the `worker::*` API — the W120 `LockBusy` error now says so and tells the caller **not** to kill that pid. From a real harness session: an LLM saw "lock held by pid N", killed N, and took down the entire worker management API it was using.
+
+  ## `worker::logs` output is terminal-sanitized
+
+  Logs fetched over the bus are stripped of ANSI/OSC escapes and spinner residue — raw escape bytes are token noise for LLM consumers and can rewrite the reader's terminal. Pass `raw: true` to opt out.
+
+  ## Hardening
+
+  - The VM UDP relay now writes a real pseudo-header checksum on response packets (strict guest stacks drop zero-checksum UDP), bounds payloads to the 16-bit IP length limit instead of silently truncating, and no longer injects empty frames into the guest's rx ring.
+  - Shell frame readers (proto, client, relay) zero-initialize their buffers instead of using uninitialized memory before the socket read.
+</Update>
+
 <Update label="0.19.2" description="June 2026">
   ## Conflicting HTTP routes are rejected instead of crashing the worker
 


### PR DESCRIPTION
## Summary

Makes the documented `iii.worker.yaml` schema authoritative for local `worker add` and gives the `worker::*` bus API the self-description an LLM needs to author a worker, check it, and operate it without guessing — plus a coverage pass that puts the branch at **96.8% diff coverage**.

### Manifest validation & deprecation
- New typed `WorkerManifest` is the single source of truth: it drives add-time key validation, the `worker::schema` JSON Schema, and the `worker::validate` dry-run. Deprecated fields are real typed fields with per-section `#[serde(flatten)]` catch-alls, preserving warn-vs-reject semantics `deny_unknown_fields` can't express; Value-first parse keeps duplicate keys a hard error.
- Local `worker add` validates the manifest **before anything is persisted**: unknown keys hard-fail (collected + sorted), deprecated keys warn but proceed, shape errors read in plain English instead of leaking serde internals, and a manifest missing `name` fails precisely instead of the false "No project manifest detected". The same strict validation re-runs at start (size cap defuses billion-laughs YAML).
- All deprecation messages say "a future version" — no version numbers are tagged.

### Self-describing `worker::*` API
- `worker::validate` dry-runs a manifest (inline or path); `worker::status` reports config/sandbox/process/logs for one worker; both carry schemars-generated request/response schemas. `worker::schema` serves the manifest schema plus a ready-to-write hello-world bundle, self-tested against our own validator.
- W120 `LockBusy` now distinguishes a self-held flock and tells callers NOT to kill that pid — from a real harness session where an LLM killed the daemon.
- `worker::logs` output is terminal-sanitized (ANSI/OSC stripping, spinner residue dropped) for bus consumers, with a raw opt-out.

### Worker-add DX (from a real LLM session transcript)
- Local workers run their project dir live (virtiofs) with a host-side source watcher, so re-running `worker::add` after a code edit is pure waste. `worker::add`/`worker::update` descriptions now say so; a forced local re-add resolves the worker name from the manifest instead of echoing the raw path (was returning `/tmp/hello-world` instead of `hello-world`).

### Reliability hardening
- Frame readers (iii-shell-proto, iii-shell-client, worker shell_relay) zero-init buffers instead of `Vec::with_capacity` + `set_len` (UB-adjacent; `clippy::uninit_vec` is deny-by-default and the proto failure was masking downstream crates from clippy entirely).
- UDP relay response construction fills a real pseudo-header checksum after the payload write, bounds payloads to `MAX_UDP_PAYLOAD` so `as u16` casts can't silently truncate, and no longer injects empty frames into the rx ring.

### Test coverage (second commit)
45 targeted tests for branch-added lines no test executed, measured with `cargo llvm-cov` against `main` — diff coverage **83.6% → 96.8%** (1766/1824 added lines), no production code changes:

| Area | Before → After |
|---|---|
| `worker_manager_daemon` (`build_status` all 5 worker-type arms + 4 hint branches) | 21.5% → 88.8% |
| `local_worker` start-path re-validation early-exits | 71.2% → 100% |
| `udp_relay` (real relay task driven via localhost UDP echo) | 91.7% → 100% |
| `shell-client` frame readers (first tests ever) | 0% → 100% of added lines |
| `logs` escape-stripping branches + full `run()` paths | 79.7% → 99.2% |
| `worker_manifest` error arms (exact-message assertions) | 96.2% → 99.6% |

Remaining uncovered: bus-dispatch closure bodies (need a live WS engine), daemon startup metadata, `main.rs` subprocess dispatch (exercised live by integration tests, invisible to the profiler), and two provably-dead defensive else-branches.

## Test plan
- [x] `cargo test -p iii-worker --lib` — 889 passed
- [x] `cargo test -p iii-network --lib` / `-p iii-shell-client --lib` / `-p iii-shell-proto --lib` — 66 / 17 / 35 passed
- [x] Integration: `local_add_manifest_validation_integration`, `worker_trigger_integration` (71), `worker_manager_integration` — all green, every error path retested live against the built binary
- [x] `cargo clippy --all-targets` on all four touched crates — 0 errors; new code warning-free
- [x] Diff coverage measured with `cargo llvm-cov` (96.8%)
- [ ] CI green on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `worker::status` and `worker::validate`, plus a published manifest contract schema with a hello-world example, including better status hints.
  * Added `raw` option for worker logs (default now sanitizes terminal control/spinner noise).
* **Bug Fixes**
  * Hardened UDP relay to prevent invalid/empty frame injection, enforce safe UDP payload sizing, and generate correct UDP checksums.
  * Improved frame readers to use safe zero-initialized buffers (eliminating unsafe length handling).
  * Enhanced lock-busy messaging to indicate when the daemon itself holds the lock.
* **Documentation**
  * Updated CLI help for worker install with `WORKER[`@VERSION`]|PATH` and clarified local directory behavior.
* **Tests**
  * Expanded coverage for framing, UDP construction, manifest validation, schema contracts, and signaling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->