### PR TITLE
feat(ci): isolated per-branch alpha release flow

### DIFF
--- a/.github/scripts/bump_manifests.py
+++ b/.github/scripts/bump_manifests.py
@@ -70,6 +70,22 @@ def bump_pep440_dep_pin(text: str, dep_name: str, new_pep440: str) -> str:
     return f'{text[:m.start()]}"{dep_name}=={new_pep440}"{text[m.end():]}'
 
 
+_GO_SDK_VERSION_RE = re.compile(r'const sdkVersion = "[^"]*"')
+
+
+def bump_go_const_version(text: str, new_version: str) -> str:
+    """Replace the ``const sdkVersion = "..."`` line in the Go SDK client.
+
+    Go modules are versioned by their git tag, but the const is reported in
+    worker metadata, so it must stay in lockstep with the other SDKs. Uses
+    the raw semver string (not the PEP 440 form).
+    """
+    m = _GO_SDK_VERSION_RE.search(text)
+    if m is None:
+        raise ValueError("no sdkVersion const in Go client")
+    return f'{text[:m.start()]}const sdkVersion = "{new_version}"{text[m.end():]}'
+
+
 from pathlib import Path
 
 
@@ -114,6 +130,12 @@ def rewrite_all(root: Path, new_version: str, new_py_version: str) -> None:
     # Python observability: top-level version only
     py_obs = root / "sdk/packages/python/observability/pyproject.toml"
     py_obs.write_text(bump_cargo_package_version(py_obs.read_text(), new_py_version))
+
+    # Go SDK: keep the reported sdkVersion const in lockstep. The module
+    # itself is versioned by its git tag; this only updates the metadata
+    # const, using the raw semver (not the PEP 440) version.
+    go_client = root / "sdk/packages/go/iii/client.go"
+    go_client.write_text(bump_go_const_version(go_client.read_text(), new_version))
 
 
 import argparse

--- a/.github/scripts/calculate_release_version.py
+++ b/.github/scripts/calculate_release_version.py
@@ -128,12 +128,25 @@ def calculate_version(
         beyond the current level, restart from the latest stable.
       - Otherwise apply the requested bump to the current base.
     """
+    cur = parse_version(current)
+
+    if bump_type == "none":
+        # Alpha-from-stable mode: keep the base anchored on the latest
+        # stable release (fall back to the current base if none exists)
+        # and only iterate the prerelease counter. Never bumps the base,
+        # so the official version is never advanced.
+        if prerelease not in PRERELEASE_LABELS:
+            raise ValueError(
+                f"bump_type 'none' requires a prerelease label, got {prerelease!r}"
+            )
+        new_base = latest_stable if latest_stable else cur.base
+        counter = next_prerelease_counter(new_base, prerelease, existing_tags, tag_prefix)
+        return f"{new_base}-{prerelease}.{counter}"
+
     if bump_type not in BUMP_RANK:
         raise ValueError(f"unknown bump_type: {bump_type!r}")
     if prerelease != "none" and prerelease not in PRERELEASE_LABELS:
         raise ValueError(f"unknown prerelease: {prerelease!r}")
-
-    cur = parse_version(current)
 
     if prerelease == "none" and cur.prerelease_label is not None:
         # Promote prerelease to stable.
@@ -216,16 +229,27 @@ def _emit(name: str, value: str) -> None:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--target", required=True)
-    parser.add_argument("--bump", required=True, choices=list(BUMP_RANK))
+    parser.add_argument("--bump", required=True, choices=list(BUMP_RANK) + ["none"])
     parser.add_argument("--prerelease", required=True)
+    parser.add_argument(
+        "--counter-tag-prefix",
+        default=None,
+        help=(
+            "Tag prefix used when scanning for the prerelease counter "
+            "(default: --target). Lets alpha releases accumulate under a "
+            "separate namespace, e.g. iii-alpha, without colliding with the "
+            "official iii/v* tags."
+        ),
+    )
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--current-version-file", required=True)
     args = parser.parse_args(argv)
 
     current = _read_cargo_version(args.current_version_file)
     tags = _git_tags()
-    tag_prefix = args.target
-    latest_stable = latest_stable_from_tags(tags, tag_prefix)
+    stable_prefix = args.target
+    counter_prefix = args.counter_tag_prefix or args.target
+    latest_stable = latest_stable_from_tags(tags, stable_prefix)
 
     new_ver = calculate_version(
         current=current,
@@ -233,7 +257,7 @@ def main(argv: list[str] | None = None) -> int:
         prerelease=args.prerelease,
         latest_stable=latest_stable,
         existing_tags=tags,
-        tag_prefix=tag_prefix,
+        tag_prefix=counter_prefix,
     )
 
     if args.dry_run:
@@ -247,7 +271,7 @@ def main(argv: list[str] | None = None) -> int:
 
     _emit("version", new_ver)
     _emit("python_version", py_ver)
-    _emit("tag", f"{tag_prefix}/v{new_ver}")
+    _emit("tag", f"{counter_prefix}/v{new_ver}")
     _emit("current", current)
     _emit("is_prerelease", "true" if is_prerelease else "false")
     _emit("npm_tag", npm_tag)

--- a/.github/scripts/test_bump_manifests.py
+++ b/.github/scripts/test_bump_manifests.py
@@ -13,6 +13,7 @@ import pytest
 
 from bump_manifests import bump_cargo_package_version
 from bump_manifests import bump_cargo_workspace_dep_version
+from bump_manifests import bump_go_const_version
 from bump_manifests import bump_json_top_level_version
 from bump_manifests import bump_pep440_dep_pin
 from bump_manifests import rewrite_all
@@ -103,6 +104,21 @@ class TestBumpPep440DepPin:
             bump_pep440_dep_pin(src, "iii-observability", "0.16.0.dev2")
 
 
+class TestBumpGoConstVersion:
+    def test_replaces_const(self):
+        src = (
+            "// sdkVersion is reported in the worker metadata.\n"
+            'const sdkVersion = "0.1.0"\n'
+        )
+        out = bump_go_const_version(src, "0.19.2-alpha.1")
+        assert 'const sdkVersion = "0.19.2-alpha.1"' in out
+        assert '"0.1.0"' not in out
+
+    def test_raises_when_missing(self):
+        with pytest.raises(ValueError, match="sdkVersion"):
+            bump_go_const_version("package iii\n", "0.19.2-alpha.1")
+
+
 def _write(p: Path, body: str) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(body)
@@ -129,6 +145,7 @@ def test_rewrite_all_updates_every_target_file(tmp_path: Path):
     ))
     _write(root / "sdk/packages/python/observability/pyproject.toml", '[project]\nname = "iii-observability"\nversion = "0.13.0.dev1"\n')
     _write(root / "console/packages/console-rust/Cargo.toml", '[package]\nname = "console-rust"\nversion = "0.15.0-next.1"\n')
+    _write(root / "sdk/packages/go/iii/client.go", 'package iii\n\nconst sdkVersion = "0.1.0"\n')
 
     rewrite_all(root=root, new_version="0.16.0-next.2", new_py_version="0.16.0.dev2")
 
@@ -145,6 +162,7 @@ def test_rewrite_all_updates_every_target_file(tmp_path: Path):
     assert '"iii-observability==0.16.0.dev2"' in py_iii
     assert 'version = "0.16.0.dev2"' in (root / "sdk/packages/python/observability/pyproject.toml").read_text()
     assert 'version = "0.16.0-next.2"' in (root / "console/packages/console-rust/Cargo.toml").read_text()
+    assert 'const sdkVersion = "0.16.0-next.2"' in (root / "sdk/packages/go/iii/client.go").read_text()
 
 
 def test_cli_invokes_rewrite_all(tmp_path: Path):
@@ -167,6 +185,7 @@ def test_cli_invokes_rewrite_all(tmp_path: Path):
     ))
     _write(root / "sdk/packages/python/observability/pyproject.toml", 'version = "0.13.0.dev1"\n')
     _write(root / "console/packages/console-rust/Cargo.toml", 'version = "0.15.0-next.1"\n')
+    _write(root / "sdk/packages/go/iii/client.go", 'package iii\n\nconst sdkVersion = "0.1.0"\n')
 
     script = Path(__file__).parent / "bump_manifests.py"
     result = subprocess.run(

--- a/.github/scripts/test_calculate_release_version.py
+++ b/.github/scripts/test_calculate_release_version.py
@@ -867,3 +867,58 @@ class TestTagPatternRejectsImpostors:
             calculate_version("0.15.0-next.1", "minor", "next", "0.13.0", tags, "iii")
             == "0.15.0-next.4"
         )
+
+
+# ---------- calculate_version: bump="none" (alpha anchor) ----------
+
+
+class TestCalculateVersionBumpNone:
+    def test_anchors_on_latest_stable_keeps_base(self):
+        # Manifest is ahead (0.19.3-next.1) but the alpha anchors on the
+        # latest stable (0.19.2) and never touches the official version.
+        v = calculate_version(
+            current="0.19.3-next.1",
+            bump_type="none",
+            prerelease="alpha",
+            latest_stable="0.19.2",
+            existing_tags=[],
+            tag_prefix="iii-alpha",
+        )
+        assert v == "0.19.2-alpha.1"
+
+    def test_counter_accumulates_under_its_own_prefix(self):
+        v = calculate_version(
+            current="0.19.3-next.1",
+            bump_type="none",
+            prerelease="alpha",
+            latest_stable="0.19.2",
+            existing_tags=[
+                "iii-alpha/v0.19.2-alpha.1",
+                "iii-alpha/v0.19.2-alpha.2",
+                "iii/v0.19.2",  # official stable — different prefix, ignored
+            ],
+            tag_prefix="iii-alpha",
+        )
+        assert v == "0.19.2-alpha.3"
+
+    def test_falls_back_to_current_base_without_stable(self):
+        v = calculate_version(
+            current="0.19.3-next.1",
+            bump_type="none",
+            prerelease="alpha",
+            latest_stable=None,
+            existing_tags=[],
+            tag_prefix="iii-alpha",
+        )
+        assert v == "0.19.3-alpha.1"
+
+    def test_requires_a_prerelease_label(self):
+        with pytest.raises(ValueError, match="requires a prerelease"):
+            calculate_version(
+                current="0.19.3-next.1",
+                bump_type="none",
+                prerelease="none",
+                latest_stable="0.19.2",
+                existing_tags=[],
+                tag_prefix="iii-alpha",
+            )

--- a/.github/workflows/WORKFLOWS.md
+++ b/.github/workflows/WORKFLOWS.md
@@ -34,6 +34,11 @@ The workflows are organized into two categories:
    docker-engine.yml ◄── called by release-iii / manual
    license-check.yml ◄── push to main / PRs
    checklist-checker.yml ◄── PR license agreement / comments
+
+   alpha-release ◄── manual dispatch from a feature branch
+        │  bumps + tags iii-alpha/v* (isolated; never touches main)
+        ▼
+        └─► _npm / _py / _rust-cargo / _go  (SDK packages only)
 ```
 
 ---
@@ -99,6 +104,30 @@ Entry point for all releases. Provides a form with:
 The tag push then triggers the corresponding release workflow.
 
 **Tag format:** `{target}/v{version}` (e.g., `iii/v1.2.3`)
+
+---
+
+### `alpha-release.yml` — Isolated Per-Branch Alpha
+
+**Triggers:** manual dispatch only — run from a feature branch via "Use workflow from: `<branch>`"
+
+Publishes an alpha prerelease of every SDK (npm, pypi, crates, go) and engine-internal lib **from any feature branch, without touching `main`**. Built for testing a branch end-to-end before merging.
+
+| Input | Options |
+|-------|---------|
+| `dry_run` | boolean (build + validate, no upload; still pushes the alpha tag) |
+
+**What it does:**
+
+1. Refuses to run on `main` (use `create-tag.yml` for official releases)
+2. Calculates the version with `calculate_release_version.py --bump none --counter-tag-prefix iii-alpha`: anchors on the latest stable `iii/v*` tag and appends an accumulating `-alpha.N` suffix (`0.19.2-alpha.1`, `.2`, `.3` …). The official version is never advanced.
+3. Bumps all manifests in lockstep (Cargo.toml, package.json, pyproject.toml, **Go `sdkVersion` const**) into an **ephemeral commit**
+4. Pushes **only** the `iii-alpha/v{version}` tag — never a branch, never `main`
+5. Calls `_npm.yml` / `_py.yml` / `_rust-cargo.yml` / `_go.yml` checking out that tag (via their `ref` input)
+
+**Isolation:** the `iii-alpha/v*` namespace does not match `release-iii.yml`'s `iii/v*` trigger, so the official pipeline never fires. No engine binaries, worker images, worker skills, homebrew or docker are published — SDK packages only.
+
+**Tag format:** `iii-alpha/v{version}` (e.g., `iii-alpha/v0.19.2-alpha.1`)
 
 ---
 

--- a/.github/workflows/WORKFLOWS.md
+++ b/.github/workflows/WORKFLOWS.md
@@ -38,9 +38,9 @@ The workflows are organized into two categories:
    alpha-release ◄── manual dispatch from a feature branch
         │  bumps + tags iii-alpha/v* (isolated; never touches main)
         ▼
-        ├─► _npm / _py / _rust-cargo / _go     (SDK packages)
-        ├─► _rust-binary.yml                    (engine/worker/init binaries → iii-alpha prerelease)
-        └─► _publish-engine-workers / -skills   (builtin workers → `alpha` registry tag)
+        ├─► sdk-node (pnpm) / _py / _rust-cargo / _go   (SDK packages)
+        ├─► _rust-binary.yml + init-build job            (engine/worker/init binaries → iii-alpha prerelease)
+        └─► _publish-engine-workers / -skills            (builtin workers → `alpha` registry tag)
 ```
 
 ---
@@ -126,8 +126,8 @@ Publishes an alpha prerelease of every SDK (npm, pypi, crates, go), the engine b
 3. Bumps all manifests in lockstep (Cargo.toml, package.json, pyproject.toml, **Go `sdkVersion` const**) into an **ephemeral commit**
 4. Pushes **only** the `iii-alpha/v{version}` tag — never a branch, never `main`
 5. Publishes, all checking out that tag:
-   - **SDK packages** — `_npm.yml` (single `pnpm -r publish` job), `_py.yml`, `_rust-cargo.yml`, `_go.yml`
-   - **Engine binaries** — `iii`, `iii-worker`, `iii-init` via `_rust-binary.yml`, attached to a GitHub **prerelease** on the `iii-alpha/v*` tag
+   - **SDK packages** — an inline `sdk-node` job (single `pnpm -r publish` over the three node packages) plus `_py.yml`, `_rust-cargo.yml`, `_go.yml`
+   - **Engine binaries** — `iii` and `iii-worker` via `_rust-binary.yml`, and `iii-init` via an inline `init-build` job; all attached to a GitHub **prerelease** on the `iii-alpha/v*` tag
    - **Builtin workers + skills** — `_publish-engine-workers.yml` / `_publish-worker-skills.yml` published to the workers registry under a dedicated **`alpha`** tag (never `next`/`latest`)
 
 **Isolation:** the `iii-alpha/v*` namespace does not match `release-iii.yml`'s `iii/v*` trigger, so the official pipeline never fires. Engine binaries land on a separate prerelease (own tag namespace); workers use the dedicated `alpha` registry tag — neither collides with the official `iii/v*` releases or the `next`/`latest` channels. **Console, docker and homebrew are intentionally excluded.**

--- a/.github/workflows/WORKFLOWS.md
+++ b/.github/workflows/WORKFLOWS.md
@@ -38,7 +38,9 @@ The workflows are organized into two categories:
    alpha-release ◄── manual dispatch from a feature branch
         │  bumps + tags iii-alpha/v* (isolated; never touches main)
         ▼
-        └─► _npm / _py / _rust-cargo / _go  (SDK packages only)
+        ├─► _npm / _py / _rust-cargo / _go     (SDK packages)
+        ├─► _rust-binary.yml                    (engine/worker/init binaries → iii-alpha prerelease)
+        └─► _publish-engine-workers / -skills   (builtin workers → `alpha` registry tag)
 ```
 
 ---
@@ -111,7 +113,7 @@ The tag push then triggers the corresponding release workflow.
 
 **Triggers:** manual dispatch only — run from a feature branch via "Use workflow from: `<branch>`"
 
-Publishes an alpha prerelease of every SDK (npm, pypi, crates, go) and engine-internal lib **from any feature branch, without touching `main`**. Built for testing a branch end-to-end before merging.
+Publishes an alpha prerelease of every SDK (npm, pypi, crates, go), the engine binaries, and the builtin workers **from any feature branch, without touching `main`**. Built for testing a branch end-to-end before merging.
 
 | Input | Options |
 |-------|---------|
@@ -123,9 +125,14 @@ Publishes an alpha prerelease of every SDK (npm, pypi, crates, go) and engine-in
 2. Calculates the version with `calculate_release_version.py --bump none --counter-tag-prefix iii-alpha`: anchors on the latest stable `iii/v*` tag and appends an accumulating `-alpha.N` suffix (`0.19.2-alpha.1`, `.2`, `.3` …). The official version is never advanced.
 3. Bumps all manifests in lockstep (Cargo.toml, package.json, pyproject.toml, **Go `sdkVersion` const**) into an **ephemeral commit**
 4. Pushes **only** the `iii-alpha/v{version}` tag — never a branch, never `main`
-5. Calls `_npm.yml` / `_py.yml` / `_rust-cargo.yml` / `_go.yml` checking out that tag (via their `ref` input)
+5. Publishes, all checking out that tag:
+   - **SDK packages** — `_npm.yml` (single `pnpm -r publish` job), `_py.yml`, `_rust-cargo.yml`, `_go.yml`
+   - **Engine binaries** — `iii`, `iii-worker`, `iii-init` via `_rust-binary.yml`, attached to a GitHub **prerelease** on the `iii-alpha/v*` tag
+   - **Builtin workers + skills** — `_publish-engine-workers.yml` / `_publish-worker-skills.yml` published to the workers registry under a dedicated **`alpha`** tag (never `next`/`latest`)
 
-**Isolation:** the `iii-alpha/v*` namespace does not match `release-iii.yml`'s `iii/v*` trigger, so the official pipeline never fires. No engine binaries, worker images, worker skills, homebrew or docker are published — SDK packages only.
+**Isolation:** the `iii-alpha/v*` namespace does not match `release-iii.yml`'s `iii/v*` trigger, so the official pipeline never fires. Engine binaries land on a separate prerelease (own tag namespace); workers use the dedicated `alpha` registry tag — neither collides with the official `iii/v*` releases or the `next`/`latest` channels. **Console, docker and homebrew are intentionally excluded.**
+
+**Engine install:** because the binaries live under `iii-alpha/v*`, install them with the `III_RELEASE_TAG` override on `install.sh`, e.g. `III_RELEASE_TAG=iii-alpha/v0.19.2-alpha.1 curl -fsSL https://iii.dev/install.sh | sh`. The worker-publish job uses the same override to pin the engine CLI.
 
 **Tag format:** `iii-alpha/v{version}` (e.g., `iii-alpha/v0.19.2-alpha.1`)
 

--- a/.github/workflows/_go.yml
+++ b/.github/workflows/_go.yml
@@ -26,6 +26,11 @@ on:
         description: 'Semantic version without the v prefix (e.g., 0.1.0)'
         required: true
         type: string
+      ref:
+        description: 'Git ref to checkout (default: the triggering ref)'
+        required: false
+        type: string
+        default: ''
       dry_run:
         description: 'Build and validate without pushing the tag'
         required: false
@@ -70,6 +75,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history so we can tag
+          ref: ${{ inputs.ref }}
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/_go.yml
+++ b/.github/workflows/_go.yml
@@ -76,6 +76,10 @@ jobs:
         with:
           fetch-depth: 0 # full history so we can tag
           ref: ${{ inputs.ref }}
+          # Don't leave the write-scoped token in git config: the caller
+          # controls `ref` and we run go build/test before pushing. Auth is
+          # supplied only to the tag-push step below.
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:
@@ -96,12 +100,14 @@ jobs:
         if: ${{ inputs.dry_run == false }}
         env:
           TAG: ${{ inputs.package_path }}/v${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
             echo "Tag $TAG already exists, nothing to push."
           else
             git tag "$TAG"
-            git push origin "$TAG"
+            # Auth scoped to this push only (checkout used persist-credentials: false).
+            git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$TAG"
           fi
 
       - name: Verify the proxy resolves the published version

--- a/.github/workflows/_npm.yml
+++ b/.github/workflows/_npm.yml
@@ -15,6 +15,11 @@ on:
         description: 'pnpm filter for building the package (e.g., iii-sdk)'
         required: true
         type: string
+      ref:
+        description: 'Git ref to checkout (default: the triggering ref)'
+        required: false
+        type: string
+        default: ''
       pre_build_filter:
         description: 'pnpm filter for building dependencies first (optional)'
         required: false
@@ -65,6 +70,8 @@ jobs:
             text: ":large_yellow_circle: ${{ inputs.slack_label }}${{ inputs.dry_run == true && ' (dry run)' || '' }} — in progress"
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -16,6 +16,11 @@ on:
         required: false
         type: string
         default: ''
+      release_tag:
+        description: 'Exact release tag to install the engine from (e.g. iii-alpha/v0.19.2-alpha.1). When set, the CLI is pinned to this tag via III_RELEASE_TAG instead of the iii/v<version> default. Used by the isolated alpha flow.'
+        required: false
+        type: string
+        default: ''
       registry_tag:
         description: 'Registry tag (latest, next, ...)'
         required: false
@@ -52,18 +57,26 @@ jobs:
       - name: Install iii CLI
         env:
           VERSION_INPUT: ${{ inputs.version }}
+          RELEASE_TAG_INPUT: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
-          expected="$VERSION_INPUT"
-          if [[ -z "$expected" && "${GITHUB_REF_NAME:-}" == iii/v* ]]; then
-            expected="${GITHUB_REF_NAME#iii/v}"
-          fi
-          install_args=()
-          if [[ "$expected" == *-* ]]; then
-            install_args+=("--next")
-          fi
           curl -fsSL https://install.iii.dev/iii/main/install.sh -o /tmp/install-iii.sh
-          VERSION="$expected" sh /tmp/install-iii.sh "${install_args[@]}"
+          if [[ -n "$RELEASE_TAG_INPUT" ]]; then
+            # Isolated alpha: install the exact tag from its own namespace
+            # (e.g. iii-alpha/v0.19.2-alpha.1), which the iii/v<version>
+            # default cannot resolve.
+            III_RELEASE_TAG="$RELEASE_TAG_INPUT" sh /tmp/install-iii.sh
+          else
+            expected="$VERSION_INPUT"
+            if [[ -z "$expected" && "${GITHUB_REF_NAME:-}" == iii/v* ]]; then
+              expected="${GITHUB_REF_NAME#iii/v}"
+            fi
+            install_args=()
+            if [[ "$expected" == *-* ]]; then
+              install_args+=("--next")
+            fi
+            VERSION="$expected" sh /tmp/install-iii.sh "${install_args[@]}"
+          fi
           {
             echo "$HOME/.local/bin"
             echo "$HOME/.iii/bin"

--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -31,6 +31,10 @@ on:
         required: false
         type: string
         default: 'https://api.workers.iii.dev'
+    secrets:
+      WORKERS_REGISTRY_API_KEY:
+        description: 'API key for the workers registry'
+        required: false
 
 jobs:
   publish:

--- a/.github/workflows/_publish-worker-skills.yml
+++ b/.github/workflows/_publish-worker-skills.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: 'https://api.workers.iii.dev'
+    secrets:
+      WORKERS_REGISTRY_API_KEY:
+        description: 'API key for the workers registry'
+        required: false
 
 jobs:
   discover:

--- a/.github/workflows/_py.yml
+++ b/.github/workflows/_py.yml
@@ -7,6 +7,11 @@ on:
         description: 'Package directory (e.g., sdk/packages/python/iii)'
         required: true
         type: string
+      ref:
+        description: 'Git ref to checkout (default: the triggering ref)'
+        required: false
+        type: string
+        default: ''
       dry_run:
         description: 'Build and validate without publishing'
         required: false
@@ -52,6 +57,8 @@ jobs:
             text: ":large_yellow_circle: ${{ inputs.slack_label }}${{ inputs.dry_run == true && ' (dry run)' || '' }} — in progress"
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/_rust-cargo.yml
+++ b/.github/workflows/_rust-cargo.yml
@@ -42,6 +42,11 @@ jobs:
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest
+    # cargo publish authenticates to crates.io via CARGO_REGISTRY_TOKEN, not
+    # git. Drop the inherited write scope so a verify-build can't reuse the
+    # token (matches _npm.yml / _py.yml).
+    permissions:
+      contents: read
     steps:
       - name: Notify Slack — in progress
         if: inputs.slack_thread_ts != ''
@@ -59,6 +64,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+          # cargo publish doesn't push to git; don't leave the token in config.
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/_rust-cargo.yml
+++ b/.github/workflows/_rust-cargo.yml
@@ -7,6 +7,11 @@ on:
         description: 'Path to the crate directory (e.g., sdk/packages/rust/iii)'
         required: true
         type: string
+      ref:
+        description: 'Git ref to checkout (default: the triggering ref)'
+        required: false
+        type: string
+        default: ''
       dry_run:
         description: 'Build and validate without publishing'
         required: false
@@ -52,6 +57,8 @@ jobs:
             text: ":large_yellow_circle: ${{ inputs.slack_label }}${{ inputs.dry_run == true && ' (dry run)' || '' }} — in progress"
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -5,13 +5,22 @@ name: Alpha Release
 # latest stable tag and appends an accumulating -alpha.N suffix
 # (0.19.2-alpha.1, .2, .3 ...).
 #
+# Publishes:
+#   * SDK packages — npm + pypi + crates + go.
+#   * Engine binaries — iii / iii-worker / iii-init, attached to a GitHub
+#     prerelease on the iii-alpha/v* tag.
+#   * Builtin workers + skills — to the workers registry under a dedicated
+#     `alpha` tag (never next/latest).
+#   Console, docker and homebrew are intentionally excluded.
+#
 # Isolation guarantees:
 #   * Tags live under the iii-alpha/v* namespace, so release-iii.yml
 #     (trigger iii/v*) never fires.
 #   * No commit or push to main or to the feature branch — the version bump
 #     lives only in an ephemeral commit that the alpha tag points at.
-#   * Publishes ONLY npm + pypi + crates + go. No engine binaries, worker
-#     images, worker skills, homebrew or docker.
+#   * Engine binaries land on their own prerelease and workers use the
+#     dedicated `alpha` registry tag, so nothing collides with the official
+#     iii/v* releases or the next/latest channels.
 #
 # Run from: Actions -> Alpha Release -> "Use workflow from: <feature-branch>".
 # Note: dry_run still creates the iii-alpha tag (publishers need it to check

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -260,6 +260,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.prepare.outputs.tag }}
+          # Build runs checked-out code; uploads go through softprops (token
+          # via env), so the write token never needs to sit in git config.
+          persist-credentials: false
 
       - name: Install cross-compilation tools
         run: |
@@ -369,7 +372,8 @@ jobs:
       version: ${{ needs.prepare.outputs.version }}
       release_tag: ${{ needs.prepare.outputs.tag }}
       registry_tag: alpha
-    secrets: inherit
+    secrets:
+      WORKERS_REGISTRY_API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
 
   publish-worker-skills:
     name: Publish worker skills (alpha)
@@ -378,4 +382,5 @@ jobs:
     uses: ./.github/workflows/_publish-worker-skills.yml
     with:
       registry_tag: alpha
-    secrets: inherit
+    secrets:
+      WORKERS_REGISTRY_API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -41,18 +41,13 @@ jobs:
       npm_tag: ${{ steps.versions.outputs.npm_tag }}
       dry_run: ${{ inputs.dry_run }}
     steps:
-      - name: Generate token
-        id: generate_token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.III_CI_APP_ID }}
-          private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
-
       - name: Checkout selected branch
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ steps.generate_token.outputs.token }}
+          # Default GITHUB_TOKEN (contents: write) is persisted in git config
+          # and reused by the tag push below. No app token needed: we only
+          # push a tag in the fresh iii-alpha/* namespace, never a branch.
 
       - name: Refuse to run on main
         run: |
@@ -105,47 +100,60 @@ jobs:
           git push origin "$TAG"
           echo "Pushed alpha tag: $TAG"
 
-  observability-npm:
-    name: Observability Node (npm)
+  sdk-node:
+    name: SDK Node (npm)
     needs: prepare
     if: ${{ !failure() && !cancelled() }}
-    uses: ./.github/workflows/_npm.yml
-    with:
-      package_path: sdk/packages/node/observability
-      npm_tag: ${{ needs.prepare.outputs.npm_tag }}
-      build_filter: "@iii-dev/observability"
-      ref: ${{ needs.prepare.outputs.tag }}
-      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
 
-  sdk-npm:
-    name: SDK Node (npm)
-    needs: [prepare, observability-npm]
-    if: ${{ !failure() && !cancelled() }}
-    uses: ./.github/workflows/_npm.yml
-    with:
-      package_path: sdk/packages/node/iii
-      npm_tag: ${{ needs.prepare.outputs.npm_tag }}
-      build_filter: iii-sdk
-      ref: ${{ needs.prepare.outputs.tag }}
-      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
 
-  sdk-npm-browser:
-    name: SDK Browser (npm)
-    needs: [prepare, observability-npm]
-    if: ${{ !failure() && !cancelled() }}
-    uses: ./.github/workflows/_npm.yml
-    with:
-      package_path: sdk/packages/node/iii-browser
-      npm_tag: ${{ needs.prepare.outputs.npm_tag }}
-      build_filter: iii-browser-sdk
-      ref: ${{ needs.prepare.outputs.tag }}
-      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build node SDK packages
+        run: >-
+          pnpm
+          --filter "@iii-dev/observability"
+          --filter iii-sdk
+          --filter iii-browser-sdk
+          build
+
+      - name: Setup NPM authentication
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
+
+      # Recursive publish: pnpm resolves topological order (observability
+      # before iii / iii-browser) and rewrites `workspace:*` deps to the
+      # concrete alpha version automatically — no manual ordering needed.
+      - name: Publish node SDK packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: >-
+          pnpm
+          --filter "@iii-dev/observability"
+          --filter iii-sdk
+          --filter iii-browser-sdk
+          -r publish
+          --no-git-checks
+          --tag "${{ needs.prepare.outputs.npm_tag }}"
+          --access public
+          ${{ needs.prepare.outputs.dry_run == 'true' && '--dry-run' || '' }}
 
   observability-py:
     name: Observability Python (pypi)

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -214,3 +214,168 @@ jobs:
       version: ${{ needs.prepare.outputs.version }}
       ref: ${{ needs.prepare.outputs.tag }}
       dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
+
+  # ──────────────────────────────────────────────────────────────
+  # Engine pipeline (isolated): binaries -> GitHub prerelease on the
+  # iii-alpha/v* tag, builtin workers -> dedicated `alpha` registry tag.
+  # Nothing here touches the official iii/v* releases or the next/latest
+  # worker channels. Console, docker and homebrew are intentionally out.
+  # ──────────────────────────────────────────────────────────────
+
+  create-alpha-release:
+    name: Create alpha GitHub prerelease
+    needs: prepare
+    if: ${{ !failure() && !cancelled() && needs.prepare.outputs.dry_run != 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # The tag was already pushed by `prepare`; this attaches a prerelease
+      # to it. Uses the default GITHUB_TOKEN (contents: write).
+      - name: Create GitHub prerelease
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          name: iii ${{ needs.prepare.outputs.version }} (alpha)
+          draft: false
+          prerelease: true
+          generate_release_notes: false
+
+  init-build:
+    name: Build iii-init (${{ matrix.target }})
+    needs: [prepare, create-alpha-release]
+    if: ${{ !failure() && !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            publish_aliases: 'x86_64-unknown-linux-gnu x86_64-apple-darwin'
+          - target: aarch64-unknown-linux-musl
+            publish_aliases: 'aarch64-unknown-linux-gnu aarch64-apple-darwin'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+
+      - name: Install cross-compilation tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: iii-init-${{ matrix.target }}
+
+      - name: Build iii-init
+        run: cargo build -p iii-init --target ${{ matrix.target }} --release
+
+      - name: Upload init binary as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: iii-init-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/iii-init
+          retention-days: 1
+
+      - name: Package and upload to release
+        if: needs.prepare.outputs.dry_run != 'true'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf iii-init-${{ matrix.target }}.tar.gz iii-init
+          sha256sum iii-init-${{ matrix.target }}.tar.gz | awk '{print $1}' > iii-init-${{ matrix.target }}.sha256
+          for alias in ${{ matrix.publish_aliases }}; do
+            cp iii-init-${{ matrix.target }}.tar.gz "iii-init-${alias}.tar.gz"
+            sha256sum "iii-init-${alias}.tar.gz" | awk '{print $1}' > "iii-init-${alias}.sha256"
+          done
+
+      - name: Upload release assets
+        if: needs.prepare.outputs.dry_run != 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          files: target/${{ matrix.target }}/release/iii-init-*.tar.gz,target/${{ matrix.target }}/release/iii-init-*.sha256
+
+  engine-release:
+    name: Engine Binary (alpha)
+    needs: [prepare, create-alpha-release]
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/_rust-binary.yml
+    with:
+      bin_name: iii
+      manifest_path: engine/Cargo.toml
+      tag_name: ${{ needs.prepare.outputs.tag }}
+      tag_prefix: iii-alpha/
+      is_prerelease: true
+      skip_create_release: true
+      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
+    secrets:
+      III_CI_APP_ID: ${{ secrets.III_CI_APP_ID }}
+      III_CI_APP_PRIVATE_KEY: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
+
+  worker-release:
+    name: Worker Binary (alpha)
+    needs: [prepare, create-alpha-release, init-build]
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/_rust-binary.yml
+    with:
+      bin_name: iii-worker
+      manifest_path: crates/iii-worker/Cargo.toml
+      tag_name: ${{ needs.prepare.outputs.tag }}
+      tag_prefix: iii-alpha/
+      is_prerelease: true
+      skip_create_release: true
+      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
+      features: embed-init,embed-libkrunfw
+      init_artifacts: true
+      targets: '["aarch64-apple-darwin","x86_64-unknown-linux-gnu","aarch64-unknown-linux-gnu"]'
+      system_deps: libcap-ng-dev
+    secrets:
+      III_CI_APP_ID: ${{ secrets.III_CI_APP_ID }}
+      III_CI_APP_PRIVATE_KEY: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
+
+  publish-builtin-workers:
+    name: Publish builtin workers (alpha)
+    needs: [prepare, create-alpha-release, engine-release, worker-release]
+    if: ${{ !failure() && !cancelled() && needs.prepare.outputs.dry_run != 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { worker: iii-worker-manager, worker_dir: engine/src/workers/worker }
+          - { worker: iii-http, worker_dir: engine/src/workers/rest_api }
+          - { worker: iii-stream, worker_dir: engine/src/workers/stream }
+          - { worker: iii-state, worker_dir: engine/src/workers/state }
+          - { worker: iii-queue, worker_dir: engine/src/workers/queue }
+          - { worker: iii-pubsub, worker_dir: engine/src/workers/pubsub }
+          - { worker: iii-cron, worker_dir: engine/src/workers/cron }
+          - { worker: iii-observability, worker_dir: engine/src/workers/observability }
+          - { worker: iii-exec, worker_dir: engine/src/workers/shell }
+          - { worker: iii-bridge, worker_dir: engine/src/workers/bridge_client }
+          - { worker: configuration, worker_dir: engine/src/workers/configuration }
+          - { worker: iii-sandbox, worker_dir: crates/iii-worker/src/sandbox_daemon }
+          - { worker: iii-engine-functions, worker_dir: engine/src/workers/engine_fn }
+    uses: ./.github/workflows/_publish-engine-workers.yml
+    with:
+      worker: ${{ matrix.worker }}
+      worker_dir: ${{ matrix.worker_dir }}
+      version: ${{ needs.prepare.outputs.version }}
+      release_tag: ${{ needs.prepare.outputs.tag }}
+      registry_tag: alpha
+    secrets: inherit
+
+  publish-worker-skills:
+    name: Publish worker skills (alpha)
+    needs: [prepare, publish-builtin-workers]
+    if: ${{ !failure() && !cancelled() && needs.prepare.outputs.dry_run != 'true' }}
+    uses: ./.github/workflows/_publish-worker-skills.yml
+    with:
+      registry_tag: alpha
+    secrets: inherit

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -1,0 +1,208 @@
+name: Alpha Release
+
+# Publishes an isolated alpha prerelease of every SDK + engine-internal lib
+# from ANY feature branch, without touching main. The version anchors on the
+# latest stable tag and appends an accumulating -alpha.N suffix
+# (0.19.2-alpha.1, .2, .3 ...).
+#
+# Isolation guarantees:
+#   * Tags live under the iii-alpha/v* namespace, so release-iii.yml
+#     (trigger iii/v*) never fires.
+#   * No commit or push to main or to the feature branch — the version bump
+#     lives only in an ephemeral commit that the alpha tag points at.
+#   * Publishes ONLY npm + pypi + crates + go. No engine binaries, worker
+#     images, worker skills, homebrew or docker.
+#
+# Run from: Actions -> Alpha Release -> "Use workflow from: <feature-branch>".
+# Note: dry_run still creates the iii-alpha tag (publishers need it to check
+# out the bumped commit) and increments the counter; it just skips uploads.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Build and validate without publishing (still pushes the iii-alpha tag)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    name: Bump & tag alpha
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      tag: ${{ steps.versions.outputs.tag }}
+      version: ${{ steps.versions.outputs.version }}
+      python_version: ${{ steps.versions.outputs.python_version }}
+      npm_tag: ${{ steps.versions.outputs.npm_tag }}
+      dry_run: ${{ inputs.dry_run }}
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.III_CI_APP_ID }}
+          private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
+
+      - name: Checkout selected branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Refuse to run on main
+        run: |
+          BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          if [[ "$BRANCH" == "main" ]]; then
+            echo "::error::alpha-release is for feature branches; use create-tag for main releases"
+            exit 1
+          fi
+          echo "Alpha release from branch: $BRANCH"
+
+      - name: Calculate alpha version
+        id: versions
+        run: |
+          python3 .github/scripts/calculate_release_version.py \
+            --target iii \
+            --bump none \
+            --prerelease alpha \
+            --counter-tag-prefix iii-alpha \
+            --current-version-file engine/Cargo.toml
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Configure git identity
+        run: |
+          git config user.name "iii-ci[bot]"
+          git config user.email "iii-ci[bot]@users.noreply.github.com"
+
+      - name: Bump all manifests in lockstep
+        env:
+          VERSION: ${{ steps.versions.outputs.version }}
+          PY_VERSION: ${{ steps.versions.outputs.python_version }}
+        run: |
+          python3 .github/scripts/bump_manifests.py \
+            --root . \
+            --version "$VERSION" \
+            --python-version "$PY_VERSION"
+
+      - name: Sync Cargo.lock
+        run: cargo update --workspace
+
+      - name: Commit bump (ephemeral) and push the alpha tag only
+        env:
+          TAG: ${{ steps.versions.outputs.tag }}
+        run: |
+          git add -A
+          git commit -m "chore(alpha): $TAG [skip ci]"
+          git tag -a "$TAG" -m "Alpha release $TAG"
+          # Push ONLY the tag. The branch (and main) are never modified on
+          # the remote — the bump commit is reachable solely via this tag.
+          git push origin "$TAG"
+          echo "Pushed alpha tag: $TAG"
+
+  observability-npm:
+    name: Observability Node (npm)
+    needs: prepare
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/_npm.yml
+    with:
+      package_path: sdk/packages/node/observability
+      npm_tag: ${{ needs.prepare.outputs.npm_tag }}
+      build_filter: "@iii-dev/observability"
+      ref: ${{ needs.prepare.outputs.tag }}
+      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  sdk-npm:
+    name: SDK Node (npm)
+    needs: [prepare, observability-npm]
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/_npm.yml
+    with:
+      package_path: sdk/packages/node/iii
+      npm_tag: ${{ needs.prepare.outputs.npm_tag }}
+      build_filter: iii-sdk
+      ref: ${{ needs.prepare.outputs.tag }}
+      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  sdk-npm-browser:
+    name: SDK Browser (npm)
+    needs: [prepare, observability-npm]
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/_npm.yml
+    with:
+      package_path: sdk/packages/node/iii-browser
+      npm_tag: ${{ needs.prepare.outputs.npm_tag }}
+      build_filter: iii-browser-sdk
+      ref: ${{ needs.prepare.outputs.tag }}
+      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  observability-py:
+    name: Observability Python (pypi)
+    needs: prepare
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/_py.yml
+    with:
+      package_path: sdk/packages/python/observability
+      ref: ${{ needs.prepare.outputs.tag }}
+      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
+    secrets:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+
+  sdk-py:
+    name: SDK Python (pypi)
+    needs: [prepare, observability-py]
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/_py.yml
+    with:
+      package_path: sdk/packages/python/iii
+      ref: ${{ needs.prepare.outputs.tag }}
+      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
+    secrets:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+
+  observability-rust:
+    name: Observability Rust (cargo)
+    needs: prepare
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/_rust-cargo.yml
+    with:
+      package_path: sdk/packages/rust/observability
+      ref: ${{ needs.prepare.outputs.tag }}
+      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
+    secrets:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  sdk-rust:
+    name: SDK Rust (cargo)
+    needs: [prepare, observability-rust]
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/_rust-cargo.yml
+    with:
+      package_path: sdk/packages/rust/iii
+      ref: ${{ needs.prepare.outputs.tag }}
+      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
+    secrets:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  sdk-go:
+    name: SDK Go (module)
+    needs: prepare
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/_go.yml
+    with:
+      package_path: sdk/packages/go/iii
+      module_path: github.com/iii-hq/iii/sdk/packages/go/iii
+      version: ${{ needs.prepare.outputs.version }}
+      ref: ${{ needs.prepare.outputs.tag }}
+      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}

--- a/engine/install.sh
+++ b/engine/install.sh
@@ -365,7 +365,20 @@ fi
 # Release selection
 # ---------------------------------------------------------------------------
 
-if [ -n "$VERSION" ]; then
+if [ -n "${III_RELEASE_TAG:-}" ]; then
+  # Explicit exact release tag (e.g. iii-alpha/v0.19.2-alpha.1). Bypasses the
+  # iii/v<version> construction so isolated alpha releases living under a
+  # different tag namespace are installable. Opt-in, so the prerelease flag is
+  # not rejected here.
+  info "installing pinned release tag: $III_RELEASE_TAG"
+  _tag="$III_RELEASE_TAG"
+  release_version="${_tag##*/v}"
+  api_url="https://api.github.com/repos/$REPO/releases/tags/${_tag}"
+  if ! json=$(github_api "$api_url" 2>/dev/null); then
+    check_rate_limit_or_continue "https://api.github.com/repos/$REPO/releases/latest"
+    err "download" "release tag not found: $III_RELEASE_TAG. Browse releases: https://github.com/$REPO/releases"
+  fi
+elif [ -n "$VERSION" ]; then
   info "installing version: $VERSION"
   _ver="${VERSION#iii/}"
   _ver="${_ver#v}"


### PR DESCRIPTION
## What

Adds an **isolated per-branch alpha release** flow: publish an alpha prerelease of every SDK (npm, pypi, crates, go) + engine-internal libs from any feature branch, without touching `main` or running the official release pipeline.

Runs from **Actions → Alpha Release → "Use workflow from: `<branch>`"**. Each run computes `X.Y.Z-alpha.N` anchored on the latest stable tag, with an accumulating counter (`0.19.2-alpha.1`, `.2`, `.3`…).

## Why

Lets a feature branch (e.g. `sdk-refactor`) be tested end-to-end against real registries before merging — no merge, no official version change.

## How it stays isolated

- Tags use the **`iii-alpha/v*`** namespace → `release-iii.yml` (trigger `iii/v*`) never fires.
- **No commit/push to any branch or `main`** — the version bump lives only in an ephemeral commit pointed at by the alpha tag.
- Publishes **SDK packages only** — no engine binaries, worker images, worker skills, homebrew or docker.
- The official version is **never advanced** (`bump=none` keeps the base; only the alpha counter increments).

## Changes

- `calculate_release_version.py` — new `bump=none` anchor-stable mode + `--counter-tag-prefix` to accumulate the counter under a separate namespace.
- `bump_manifests.py` — Go SDK `sdkVersion` const added to the lockstep bump (all internal libs now share one version).
- `_npm.yml` / `_py.yml` / `_rust-cargo.yml` / `_go.yml` — optional `ref` input (default `''`, fully backward-compatible) so publishers check out the bumped commit.
- `alpha-release.yml` — new orchestrator (`workflow_dispatch`, `dry_run` input).
- `WORKFLOWS.md` — documented.

## Verification

- 131 script unit tests pass (4 new for `bump=none`, Go-const tests, updated `rewrite_all`).
- Calc against the real repo → `version=0.19.2-alpha.1`, `tag=iii-alpha/v0.19.2-alpha.1`, `npm_tag=alpha`, `python=0.19.2a1`, `current=0.19.3-next.1` untouched.
- Real-manifest bump touches all 11 manifests (cargo×4 + workspace + node×3 + python×2 + go const) at one version.

## Notes

- **This PR ships only the release tooling — it does not merge any feature-branch code.** `workflow_dispatch` only appears once the workflow is on `main`. After merge, branches cut from/rebased on `main` inherit it; an existing branch like `sdk-refactor` needs one rebase to pick it up.
- Known (intentional, mirrors the official flow): dry-run consumes a counter number; crates.io cross-crate indexing is eventually-consistent; `0.19.2-alpha.N` sorts below the shipped `0.19.2` stable (opt in via the `alpha` dist-tag / explicit prerelease version).

Plan: `docs/superpowers/plans/2026-06-12-alpha-release-flow.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an alpha prerelease workflow to publish SDKs, engine binaries, and workers from feature branches.
  * Publish workflows can target a specific Git ref; engine installer can be pinned to an exact release tag.

* **Chores**
  * Kept SDK version reporting in sync across languages, including Go.
  * Added a "none" prerelease bump mode and configurable prerelease counter namespace for tagging.

* **Documentation**
  * Documented the alpha-release flow and manual-dispatch usage.

* **Tests**
  * Added tests for the "none" prerelease behavior and SDK version synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->