### PR TITLE
fix(iii-worker): stop daemon EPIPE panic when engine dies with broken stdio

### DIFF
--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -7,6 +7,37 @@
 use clap::{CommandFactory, FromArgMatches};
 use iii_worker::{Cli, Commands};
 
+/// A `stdout` tracing writer that never reports I/O errors back to the fmt
+/// layer. The fmt layer's sole error path is an `eprintln!`, which PANICS
+/// when stderr is *also* a broken pipe — precisely the engine-death case for
+/// the spawned daemons (`worker-manager-daemon`, `sandbox-daemon`): the engine
+/// consumed both fds 1 and 2, so when it dies the connection thread's very
+/// next reconnect log would panic the process (exit 101) before the
+/// engine-gone reaper runs. Swallowing the write error keeps the daemon alive;
+/// it then dup2's fds 1/2 onto its durable exit log
+/// (`daemon_exit::redirect_stdio_to_exit_log`) and these same writes land there
+/// as forensics. For one-shot CLI use it just turns a `… | head` EPIPE into a
+/// silent drop instead of a panic — strictly better either way.
+struct ResilientStdout;
+
+impl std::io::Write for ResilientStdout {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let _ = std::io::Write::write_all(&mut std::io::stdout(), buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        let _ = std::io::Write::flush(&mut std::io::stdout());
+        Ok(())
+    }
+}
+
+impl tracing_subscriber::fmt::MakeWriter<'_> for ResilientStdout {
+    type Writer = ResilientStdout;
+    fn make_writer(&self) -> Self::Writer {
+        ResilientStdout
+    }
+}
+
 fn main() -> anyhow::Result<()> {
     // FIRST, before the tokio runtime spawns worker threads: capture (and
     // scrub from the env) any inherited lifeline facts. The capture mutates
@@ -22,6 +53,7 @@ fn main() -> anyhow::Result<()> {
 
 async fn async_main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(ResilientStdout)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),


### PR DESCRIPTION
## Problem

CI `Engine Tests` is red on `main`. The flaky test `daemon_survives_its_stdio_dying_with_the_engine` (`crates/iii-worker/tests/engine_death_cascade_integration.rs`) intermittently fails with the daemon exiting **101** (panic) instead of **0**.

## Root cause

The engine-spawned daemons (`worker-manager-daemon`, `sandbox-daemon`) write stdout/stderr into pipes the engine consumes. When the engine dies abnormally, **both** fds become broken pipes.

The SDK connection thread (`iii-connection`) keeps logging reconnect attempts (`failed to connect; retrying`). The tracing fmt layer's only write-error path is an `eprintln!` fallback — which **panics** (`failed printing to stderr: Broken pipe (os error 32)`) when stderr is also a broken pipe. That kills the daemon before its engine-gone reaper runs.

`daemon_exit::redirect_stdio_to_exit_log` only repoints fds 1/2 onto the durable exit log **after** engine-death is detected, leaving a race window that the connection thread's logging can land in. Under CI load the window widens → flake. (PR #1825's CI passed by luck.)

## Fix

Wrap the tracing writer in `ResilientStdout`, which swallows write errors so the fmt layer never reaches its panicking `eprintln!` fallback. The exit-log redirect stays for durable forensics; the reaper output still lands there. For one-shot CLI use it turns a `… | head` EPIPE into a silent drop instead of a panic — strictly better either way.

## Verification

Reproduced by widening the redirect race window to 800ms (temporary):
- **old writer:** panics on the `iii-connection` thread in ~17% of runs (5/30)
- **`ResilientStdout`:** **0 panics / 0 fails in 30 runs**

Final run (window restored): both daemon integration files green (16/16). `cargo fmt --check` clean. Diff is `main.rs` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logging robustness by ensuring I/O errors are handled gracefully without affecting log output or application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->