### PR TITLE
enhance(build): add full make build target with PATH instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,15 @@ build-console:
 	pnpm --filter console-frontend build
 	cargo build -p iii-console --release
 
-build: build-sdk-node build-console
+build: sandbox build-console ## Build everything: init + engine + worker + console
+	@echo ""
+	@echo "Build complete. Binaries:"
+	@echo "  engine:   $(CURDIR)/target/release/iii"
+	@echo "  console:  $(CURDIR)/target/release/iii-console"
+	@echo "  worker:   $(CURDIR)/target/$(WORKER_TARGET)/release/iii-worker"
+	@echo ""
+	@echo "Add them to your PATH:"
+	@echo '  export PATH="$(CURDIR)/target/release:$(CURDIR)/target/$(WORKER_TARGET)/release:$$PATH"'
 
 # ── CI Jobs (mirror ci.yml) ──────────────────────────────────────────────────
 
@@ -204,6 +212,6 @@ fix-lint:
 	cargo clippy -p iii-sdk --all-targets --all-features --fix --allow-dirty --allow-staged -- -D warnings
 	pnpm --filter console-frontend run lint:fix
 
-check: lint fmt-check-all typecheck build
+check: lint fmt-check-all typecheck build-sdk-node build-console
 
 ci-local: ci-engine ci-sdk-node ci-sdk-python ci-sdk-rust ci-console


### PR DESCRIPTION
## Summary
- Redefine `make build` to run the full release build (`sandbox` + `build-console`): init, engine, worker, and console.
- Print binary locations and a copy-paste `export PATH=...` line at the end of the build (shows literal `$PATH`, not the expanded value).
- Keep `make check` on the lightweight path (`build-sdk-node` + `build-console`) so it does not trigger the heavy release/musl build.

## Test plan
- [x] `make build` completes and prints PATH instructions with literal `$PATH`
- [x] `make check -n` still runs `build-sdk-node` and `build-console`, not `sandbox`