### PR TITLE
refactor(sdk)!: move internal types to the internal submodule

### DIFF
--- a/console/packages/console-rust/src/bridge/functions.rs
+++ b/console/packages/console-rust/src/bridge/functions.rs
@@ -1,4 +1,5 @@
-use iii_sdk::{RegisterFunction, TriggerRequest, III};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{RegisterFunction, III};
 use serde_json::{json, Value};
 use std::collections::HashSet;
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/console/packages/console-rust/src/bridge/triggers.rs
+++ b/console/packages/console-rust/src/bridge/triggers.rs
@@ -1,4 +1,5 @@
-use iii_sdk::{IIIError, RegisterTriggerInput, III};
+use iii_sdk::protocol::RegisterTriggerInput;
+use iii_sdk::{IIIError, III};
 use serde_json::json;
 use tracing::info;
 

--- a/crates/iii-worker/src/cli/sandbox.rs
+++ b/crates/iii-worker/src/cli/sandbox.rs
@@ -7,7 +7,8 @@
 //! `iii sandbox {run, create, exec, list, stop}` handlers. Thin CLI wrapper
 //! that calls the sandbox daemon directly via `iii.trigger(TriggerRequest{...})`.
 
-use iii_sdk::{III, IIIError, InitOptions, TriggerRequest, register_worker};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{III, IIIError, InitOptions, register_worker};
 use serde_json::{Value, json};
 
 use crate::cli::rootfs_cache;

--- a/crates/iii-worker/src/cli/worker_trigger.rs
+++ b/crates/iii-worker/src/cli/worker_trigger.rs
@@ -21,7 +21,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use iii_sdk::{III, IIIError, TriggerAction, TriggerConfig, TriggerHandler, TriggerRequest};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{III, IIIError, TriggerAction, TriggerConfig, TriggerHandler};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/docs/next/sdk-reference/node-sdk.mdx
+++ b/docs/next/sdk-reference/node-sdk.mdx
@@ -55,9 +55,23 @@ The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii-s
 subpath (`import type { FunctionRef } from 'iii-sdk/runtime'`). They stay re-exported from the
 package root as deprecated aliases.
 
+The `IIIConnectionState` type is provided only by the `iii-sdk/runtime` subpath
+(`import type { IIIConnectionState } from 'iii-sdk/runtime'`). It is not exported from the
+package root.
+
 The `InternalHttpRequest` type is provided only by the `iii-sdk/internal` subpath
 (`import type { InternalHttpRequest } from 'iii-sdk/internal'`). It is not exported from the
 package root.
+
+The `EngineFunctions` and `EngineTriggers` constants and the `RemoteFunctionHandler` type are
+provided only by the `iii-sdk/engine` subpath (`import { EngineFunctions } from 'iii-sdk/engine'`).
+They are not exported from the package root.
+
+The protocol message and register-input types (`MessageType`, `RegisterFunctionMessage`,
+`RegisterTriggerMessage`, `RegisterTriggerTypeMessage`, `TriggerRequest`, `RegisterFunctionInput`,
+`RegisterFunctionOptions`, `RegisterTriggerInput`, `RegisterTriggerTypeInput`, `RegisterFunctionFormat`
+and `ErrorBody`) are provided only by the `iii-sdk/protocol` subpath
+(`import { MessageType } from 'iii-sdk/protocol'`). They are not exported from the package root.
 
 ### `registerTrigger`
 

--- a/docs/next/sdk-reference/node-sdk.mdx
+++ b/docs/next/sdk-reference/node-sdk.mdx
@@ -55,6 +55,10 @@ The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii-s
 subpath (`import type { FunctionRef } from 'iii-sdk/runtime'`). They stay re-exported from the
 package root as deprecated aliases.
 
+The `InternalHttpRequest` type is provided only by the `iii-sdk/internal` subpath
+(`import type { InternalHttpRequest } from 'iii-sdk/internal'`). It is not exported from the
+package root.
+
 ### `registerTrigger`
 
 Bind a registered function to a configured trigger instance.

--- a/docs/next/sdk-reference/node-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/node-sdk.mdx.skill.md
@@ -53,9 +53,23 @@ The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii-s
 subpath (`import type { FunctionRef } from 'iii-sdk/runtime'`). They stay re-exported from the
 package root as deprecated aliases.
 
+The `IIIConnectionState` type is provided only by the `iii-sdk/runtime` subpath
+(`import type { IIIConnectionState } from 'iii-sdk/runtime'`). It is not exported from the
+package root.
+
 The `InternalHttpRequest` type is provided only by the `iii-sdk/internal` subpath
 (`import type { InternalHttpRequest } from 'iii-sdk/internal'`). It is not exported from the
 package root.
+
+The `EngineFunctions` and `EngineTriggers` constants and the `RemoteFunctionHandler` type are
+provided only by the `iii-sdk/engine` subpath (`import { EngineFunctions } from 'iii-sdk/engine'`).
+They are not exported from the package root.
+
+The protocol message and register-input types (`MessageType`, `RegisterFunctionMessage`,
+`RegisterTriggerMessage`, `RegisterTriggerTypeMessage`, `TriggerRequest`, `RegisterFunctionInput`,
+`RegisterFunctionOptions`, `RegisterTriggerInput`, `RegisterTriggerTypeInput`, `RegisterFunctionFormat`
+and `ErrorBody`) are provided only by the `iii-sdk/protocol` subpath
+(`import { MessageType } from 'iii-sdk/protocol'`). They are not exported from the package root.
 
 ### `registerTrigger`
 

--- a/docs/next/sdk-reference/node-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/node-sdk.mdx.skill.md
@@ -53,6 +53,10 @@ The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii-s
 subpath (`import type { FunctionRef } from 'iii-sdk/runtime'`). They stay re-exported from the
 package root as deprecated aliases.
 
+The `InternalHttpRequest` type is provided only by the `iii-sdk/internal` subpath
+(`import type { InternalHttpRequest } from 'iii-sdk/internal'`). It is not exported from the
+package root.
+
 ### `registerTrigger`
 
 Bind a registered function to a configured trigger instance.

--- a/docs/next/sdk-reference/python-sdk.mdx
+++ b/docs/next/sdk-reference/python-sdk.mdx
@@ -63,8 +63,28 @@ The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii.r
 (`from iii.runtime import FunctionRef`). They stay importable from the package root as deprecated
 re-exports.
 
+The `IIIConnectionState` type is provided only by the `iii.runtime` submodule
+(`from iii.runtime import IIIConnectionState`). It is not importable from the package root.
+
 The `InternalHttpRequest` type is provided only by the `iii.internal` submodule
 (`from iii.internal import InternalHttpRequest`). It is not importable from the package root.
+
+The `EngineFunctions` and `EngineTriggers` constants and the `RemoteFunctionHandler` type are
+provided only by the `iii.engine` submodule (`from iii.engine import EngineFunctions`). They are
+not importable from the package root.
+
+The protocol message and register-input types (`MessageType`, `RegisterFunctionMessage`,
+`RegisterTriggerMessage`, `RegisterTriggerTypeMessage`, `TriggerRequest`, `RegisterFunctionFormat`,
+`RegisterFunctionInput`, `RegisterTriggerInput`, `RegisterTriggerTypeInput`) are provided only by
+the `iii.protocol` submodule (`from iii.protocol import MessageType`). They are not importable from
+the package root.
+
+The `TriggerActionVoid` type is provided only by the `iii.trigger` submodule
+(`from iii.trigger import TriggerActionVoid`). It is not importable from the package root.
+
+The `extract_request_format`, `extract_response_format`, and `python_type_to_format` helpers are
+provided only by the `iii.utils` submodule (`from iii.utils import python_type_to_format`). They are
+not importable from the package root.
 
 ### `register_trigger`
 

--- a/docs/next/sdk-reference/python-sdk.mdx
+++ b/docs/next/sdk-reference/python-sdk.mdx
@@ -63,6 +63,9 @@ The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii.r
 (`from iii.runtime import FunctionRef`). They stay importable from the package root as deprecated
 re-exports.
 
+The `InternalHttpRequest` type is provided only by the `iii.internal` submodule
+(`from iii.internal import InternalHttpRequest`). It is not importable from the package root.
+
 ### `register_trigger`
 
 Bind a registered function to a configured trigger instance.

--- a/docs/next/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/python-sdk.mdx.skill.md
@@ -61,8 +61,28 @@ The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii.r
 (`from iii.runtime import FunctionRef`). They stay importable from the package root as deprecated
 re-exports.
 
+The `IIIConnectionState` type is provided only by the `iii.runtime` submodule
+(`from iii.runtime import IIIConnectionState`). It is not importable from the package root.
+
 The `InternalHttpRequest` type is provided only by the `iii.internal` submodule
 (`from iii.internal import InternalHttpRequest`). It is not importable from the package root.
+
+The `EngineFunctions` and `EngineTriggers` constants and the `RemoteFunctionHandler` type are
+provided only by the `iii.engine` submodule (`from iii.engine import EngineFunctions`). They are
+not importable from the package root.
+
+The protocol message and register-input types (`MessageType`, `RegisterFunctionMessage`,
+`RegisterTriggerMessage`, `RegisterTriggerTypeMessage`, `TriggerRequest`, `RegisterFunctionFormat`,
+`RegisterFunctionInput`, `RegisterTriggerInput`, `RegisterTriggerTypeInput`) are provided only by
+the `iii.protocol` submodule (`from iii.protocol import MessageType`). They are not importable from
+the package root.
+
+The `TriggerActionVoid` type is provided only by the `iii.trigger` submodule
+(`from iii.trigger import TriggerActionVoid`). It is not importable from the package root.
+
+The `extract_request_format`, `extract_response_format`, and `python_type_to_format` helpers are
+provided only by the `iii.utils` submodule (`from iii.utils import python_type_to_format`). They are
+not importable from the package root.
 
 ### `register_trigger`
 

--- a/docs/next/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/python-sdk.mdx.skill.md
@@ -61,6 +61,9 @@ The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii.r
 (`from iii.runtime import FunctionRef`). They stay importable from the package root as deprecated
 re-exports.
 
+The `InternalHttpRequest` type is provided only by the `iii.internal` submodule
+(`from iii.internal import InternalHttpRequest`). It is not importable from the package root.
+
 ### `register_trigger`
 
 Bind a registered function to a configured trigger instance.

--- a/engine/src/cli_trigger/exec.rs
+++ b/engine/src/cli_trigger/exec.rs
@@ -4,7 +4,8 @@
 // This software is patent protected. We welcome discussions - reach out at team@iii.dev
 // See LICENSE and PATENTS files for details.
 
-use iii_sdk::{IIIError, InitOptions, TriggerRequest, register_worker};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{IIIError, InitOptions, register_worker};
 use serde_json::Value;
 
 use super::TriggerCliError;

--- a/engine/src/cli_trigger/help.rs
+++ b/engine/src/cli_trigger/help.rs
@@ -6,7 +6,8 @@
 
 use anyhow::Result;
 use colored::Colorize;
-use iii_sdk::{InitOptions, TriggerRequest, register_worker};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{InitOptions, register_worker};
 use serde_json::{Value, json};
 
 pub async fn print(

--- a/engine/src/workers/bridge_client/mod.rs
+++ b/engine/src/workers/bridge_client/mod.rs
@@ -7,7 +7,8 @@
 use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use iii_sdk::{III, IIIError, InitOptions, TriggerAction, TriggerRequest, register_worker};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{III, IIIError, InitOptions, TriggerAction, register_worker};
 use serde::Deserialize;
 use serde_json::Value;
 

--- a/engine/src/workers/configuration/adapters/bridge.rs
+++ b/engine/src/workers/configuration/adapters/bridge.rs
@@ -11,9 +11,8 @@
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use iii_sdk::{
-    III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker,
-};
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{III, InitOptions, RegisterFunction, register_worker};
 use serde::Serialize;
 use serde_json::Value;
 use tokio::sync::OnceCell;

--- a/engine/src/workers/queue/adapters/bridge.rs
+++ b/engine/src/workers/queue/adapters/bridge.rs
@@ -7,10 +7,8 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
-use iii_sdk::{
-    III, IIIError, InitOptions, RegisterTriggerInput, Trigger, TriggerAction, TriggerRequest,
-    register_worker,
-};
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{III, IIIError, InitOptions, Trigger, TriggerAction, register_worker};
 use serde_json::Value;
 use tokio::sync::RwLock;
 use uuid::Uuid;

--- a/engine/src/workers/state/adapters/bridge.rs
+++ b/engine/src/workers/state/adapters/bridge.rs
@@ -8,7 +8,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use iii_helpers::stream::{SetResult, UpdateOp, UpdateResult};
-use iii_sdk::{III, InitOptions, TriggerRequest, register_worker};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{III, InitOptions, register_worker};
 use serde_json::Value;
 
 use crate::{

--- a/engine/src/workers/stream/adapters/bridge.rs
+++ b/engine/src/workers/stream/adapters/bridge.rs
@@ -8,7 +8,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use iii_helpers::stream::{DeleteResult, SetResult, UpdateOp, UpdateResult};
-use iii_sdk::{III, InitOptions, RegisterTriggerInput, TriggerRequest, register_worker};
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{III, InitOptions, register_worker};
 use serde_json::Value;
 
 use crate::{

--- a/engine/tests/worker_trigger_e2e.rs
+++ b/engine/tests/worker_trigger_e2e.rs
@@ -24,9 +24,8 @@ use std::time::Duration;
 
 use iii::EngineBuilder;
 use iii::workers::config::EngineConfig;
-use iii_sdk::{
-    III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker,
-};
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{III, InitOptions, RegisterFunction, register_worker};
 use iii_worker::cli::app::WorkerManagerDaemonArgs;
 use iii_worker::cli::worker_manager_daemon;
 use serde_json::{Value, json};

--- a/sdk/packages/node/iii/package.json
+++ b/sdk/packages/node/iii/package.json
@@ -66,6 +66,16 @@
       "types": "./dist/internal.d.ts",
       "import": "./dist/internal.mjs",
       "require": "./dist/internal.cjs"
+    },
+    "./engine": {
+      "types": "./dist/engine.d.ts",
+      "import": "./dist/engine.mjs",
+      "require": "./dist/engine.cjs"
+    },
+    "./protocol": {
+      "types": "./dist/protocol.d.ts",
+      "import": "./dist/protocol.mjs",
+      "require": "./dist/protocol.cjs"
     }
   },
   "dependencies": {

--- a/sdk/packages/node/iii/package.json
+++ b/sdk/packages/node/iii/package.json
@@ -61,6 +61,11 @@
       "types": "./dist/errors.d.ts",
       "import": "./dist/errors.mjs",
       "require": "./dist/errors.cjs"
+    },
+    "./internal": {
+      "types": "./dist/internal.d.ts",
+      "import": "./dist/internal.mjs",
+      "require": "./dist/internal.cjs"
     }
   },
   "dependencies": {

--- a/sdk/packages/node/iii/src/engine.ts
+++ b/sdk/packages/node/iii/src/engine.ts
@@ -1,0 +1,2 @@
+export { EngineFunctions, EngineTriggers } from './iii-constants'
+export type { RemoteFunctionHandler } from './types'

--- a/sdk/packages/node/iii/src/index.ts
+++ b/sdk/packages/node/iii/src/index.ts
@@ -25,7 +25,6 @@ export type { Trigger, TriggerConfig, TriggerHandler } from './trigger'
 
 export type {
   IIIClient,
-  InternalHttpRequest,
   RegisterFunctionInput,
   RegisterFunctionOptions,
   RegisterTriggerInput,

--- a/sdk/packages/node/iii/src/index.ts
+++ b/sdk/packages/node/iii/src/index.ts
@@ -9,30 +9,12 @@ export { IIIInvocationError, type IIIInvocationErrorInit } from './errors'
 
 export { type InitOptions, registerWorker, type TelemetryOptions, TriggerAction } from './iii'
 
-export { EngineFunctions, EngineTriggers } from './iii-constants'
-
-export type {
-  MessageType,
-  MiddlewareFunctionInput,
-  RegisterFunctionMessage,
-  RegisterTriggerMessage,
-  RegisterTriggerTypeMessage,
-  TriggerRequest,
-} from './iii-types'
+export type { MiddlewareFunctionInput } from './iii-types'
 
 /** @deprecated Import trigger types from `iii-sdk/trigger`. */
 export type { Trigger, TriggerConfig, TriggerHandler } from './trigger'
 
-export type {
-  IIIClient,
-  RegisterFunctionInput,
-  RegisterFunctionOptions,
-  RegisterTriggerInput,
-  RegisterTriggerTypeInput,
-  RemoteFunctionHandler,
-  StreamRequest,
-  StreamResponse,
-} from './types'
+export type { IIIClient, StreamRequest, StreamResponse } from './types'
 
 /** @deprecated Renamed to `IIIClient`. */
 export type { ISdk } from './types'

--- a/sdk/packages/node/iii/src/internal.ts
+++ b/sdk/packages/node/iii/src/internal.ts
@@ -1,0 +1,1 @@
+export type { InternalHttpRequest } from './types'

--- a/sdk/packages/node/iii/src/protocol.ts
+++ b/sdk/packages/node/iii/src/protocol.ts
@@ -1,0 +1,15 @@
+export { MessageType } from './iii-types'
+export type {
+  ErrorBody,
+  RegisterFunctionFormat,
+  RegisterFunctionMessage,
+  RegisterTriggerMessage,
+  RegisterTriggerTypeMessage,
+  TriggerRequest,
+} from './iii-types'
+export type {
+  RegisterFunctionInput,
+  RegisterFunctionOptions,
+  RegisterTriggerInput,
+  RegisterTriggerTypeInput,
+} from './types'

--- a/sdk/packages/node/iii/src/runtime.ts
+++ b/sdk/packages/node/iii/src/runtime.ts
@@ -1,1 +1,2 @@
+export type { IIIConnectionState } from './iii-constants'
 export type { FunctionRef, TriggerTypeRef } from './types'

--- a/sdk/packages/node/iii/tsdown.config.ts
+++ b/sdk/packages/node/iii/tsdown.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
     './src/runtime.ts',
     './src/errors.ts',
     './src/internal.ts',
+    './src/engine.ts',
+    './src/protocol.ts',
   ],
   format: ['esm', 'cjs'],
   dts: true,

--- a/sdk/packages/node/iii/tsdown.config.ts
+++ b/sdk/packages/node/iii/tsdown.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     './src/trigger.ts',
     './src/runtime.ts',
     './src/errors.ts',
+    './src/internal.ts',
   ],
   format: ['esm', 'cjs'],
   dts: true,

--- a/sdk/packages/python/iii/src/iii/__init__.py
+++ b/sdk/packages/python/iii/src/iii/__init__.py
@@ -4,35 +4,22 @@ from typing import Any
 
 from .channels import ChannelReader, ChannelWriter
 from .errors import InvocationError
-from .format_utils import extract_request_format, extract_response_format, python_type_to_format
 from .iii import TriggerAction, register_worker
 from .iii_constants import (
-    EngineFunctions,
-    EngineTriggers,
     FunctionRef,
     InitOptions,
     TelemetryOptions,
 )
 from .iii_types import (
-    MessageType,
     MiddlewareFunctionInput,
-    RegisterFunctionFormat,
-    RegisterFunctionMessage,
-    RegisterTriggerInput,
-    RegisterTriggerMessage,
-    RegisterTriggerTypeInput,
-    RegisterTriggerTypeMessage,
     StreamChannelRef,
     TriggerActionEnqueue,
-    TriggerActionVoid,
-    TriggerRequest,
 )
 from .stream import IStream
 from .triggers import Trigger, TriggerConfig, TriggerHandler, TriggerTypeRef
 from .types import (
     Channel,
     IIIClient,
-    RemoteFunctionHandler,
     StreamRequest,
     StreamResponse,
 )
@@ -49,23 +36,11 @@ __all__ = [
     "register_worker",
     "TelemetryOptions",
     "TriggerAction",
-    # Engine
-    "EngineFunctions",
-    "EngineTriggers",
     # RBAC types
     "MiddlewareFunctionInput",
     # Message types
-    "MessageType",
-    "RegisterFunctionFormat",
-    "RegisterFunctionMessage",
-    "RegisterTriggerInput",
-    "RegisterTriggerMessage",
-    "RegisterTriggerTypeInput",
-    "RegisterTriggerTypeMessage",
     "StreamChannelRef",
     "TriggerActionEnqueue",
-    "TriggerActionVoid",
-    "TriggerRequest",
     # Triggers
     "Trigger",
     "TriggerConfig",
@@ -74,15 +49,10 @@ __all__ = [
     # Types
     "Channel",
     "IIIClient",
-    "RemoteFunctionHandler",
     "StreamRequest",
     "StreamResponse",
     # Stream
     "IStream",
-    # Format extraction
-    "extract_request_format",
-    "extract_response_format",
-    "python_type_to_format",
 ]
 
 

--- a/sdk/packages/python/iii/src/iii/__init__.py
+++ b/sdk/packages/python/iii/src/iii/__init__.py
@@ -32,7 +32,6 @@ from .triggers import Trigger, TriggerConfig, TriggerHandler, TriggerTypeRef
 from .types import (
     Channel,
     IIIClient,
-    InternalHttpRequest,
     RemoteFunctionHandler,
     StreamRequest,
     StreamResponse,
@@ -75,7 +74,6 @@ __all__ = [
     # Types
     "Channel",
     "IIIClient",
-    "InternalHttpRequest",
     "RemoteFunctionHandler",
     "StreamRequest",
     "StreamResponse",

--- a/sdk/packages/python/iii/src/iii/engine.py
+++ b/sdk/packages/python/iii/src/iii/engine.py
@@ -1,0 +1,6 @@
+"""Engine constants and handler types."""
+
+from .iii_constants import EngineFunctions, EngineTriggers
+from .types import RemoteFunctionHandler
+
+__all__ = ["EngineFunctions", "EngineTriggers", "RemoteFunctionHandler"]

--- a/sdk/packages/python/iii/src/iii/internal.py
+++ b/sdk/packages/python/iii/src/iii/internal.py
@@ -1,0 +1,5 @@
+"""Internal types."""
+
+from .types import InternalHttpRequest
+
+__all__ = ["InternalHttpRequest"]

--- a/sdk/packages/python/iii/src/iii/protocol.py
+++ b/sdk/packages/python/iii/src/iii/protocol.py
@@ -1,0 +1,25 @@
+"""Protocol message and register-input types."""
+
+from .iii_types import (
+    MessageType,
+    RegisterFunctionFormat,
+    RegisterFunctionInput,
+    RegisterFunctionMessage,
+    RegisterTriggerInput,
+    RegisterTriggerMessage,
+    RegisterTriggerTypeInput,
+    RegisterTriggerTypeMessage,
+    TriggerRequest,
+)
+
+__all__ = [
+    "MessageType",
+    "RegisterFunctionFormat",
+    "RegisterFunctionInput",
+    "RegisterFunctionMessage",
+    "RegisterTriggerInput",
+    "RegisterTriggerMessage",
+    "RegisterTriggerTypeInput",
+    "RegisterTriggerTypeMessage",
+    "TriggerRequest",
+]

--- a/sdk/packages/python/iii/src/iii/runtime.py
+++ b/sdk/packages/python/iii/src/iii/runtime.py
@@ -1,6 +1,6 @@
 """Public runtime types."""
 
-from .iii_constants import FunctionRef
+from .iii_constants import FunctionRef, IIIConnectionState
 from .triggers import TriggerTypeRef
 
-__all__ = ["FunctionRef", "TriggerTypeRef"]
+__all__ = ["FunctionRef", "IIIConnectionState", "TriggerTypeRef"]

--- a/sdk/packages/python/iii/src/iii/trigger.py
+++ b/sdk/packages/python/iii/src/iii/trigger.py
@@ -1,5 +1,6 @@
 """Public trigger types."""
 
+from .iii_types import TriggerActionVoid
 from .triggers import Trigger, TriggerConfig, TriggerHandler
 
-__all__ = ["Trigger", "TriggerConfig", "TriggerHandler"]
+__all__ = ["Trigger", "TriggerActionVoid", "TriggerConfig", "TriggerHandler"]

--- a/sdk/packages/python/iii/src/iii/utils.py
+++ b/sdk/packages/python/iii/src/iii/utils.py
@@ -5,7 +5,16 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from .format_utils import extract_request_format, extract_response_format, python_type_to_format
 from .types import is_channel_ref as is_channel_ref  # noqa: F401 - re-exported from types
+
+__all__ = [
+    "extract_request_format",
+    "extract_response_format",
+    "is_channel_ref",
+    "python_type_to_format",
+    "safe_stringify",
+]
 
 
 def safe_stringify(value: Any) -> str:

--- a/sdk/packages/python/iii/tests/test_engine_constants.py
+++ b/sdk/packages/python/iii/tests/test_engine_constants.py
@@ -1,6 +1,6 @@
 """EngineFunctions / EngineTriggers parity with the Node SDK."""
 
-from iii import EngineFunctions, EngineTriggers
+from iii.engine import EngineFunctions, EngineTriggers
 
 
 def test_engine_function_ids() -> None:

--- a/sdk/packages/python/iii/tests/test_helpers.py
+++ b/sdk/packages/python/iii/tests/test_helpers.py
@@ -169,7 +169,7 @@ def test_init_no_longer_exports_relocated_channel_items() -> None:
 def test_iii_register_and_unregister_trigger_type_round_trip(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from iii import RegisterTriggerTypeInput
+    from iii.protocol import RegisterTriggerTypeInput
     from iii.triggers import TriggerConfig, TriggerHandler
 
     class DummyHandler(TriggerHandler[Any]):

--- a/sdk/packages/python/iii/tests/test_register_function_args.py
+++ b/sdk/packages/python/iii/tests/test_register_function_args.py
@@ -190,9 +190,9 @@ def test_register_function_str_with_http_invocation_and_format(monkeypatch: pyte
     client.shutdown()
 
 
-def test_register_function_format_importable_from_top_level() -> None:
-    """RegisterFunctionFormat should remain importable from iii."""
-    from iii import RegisterFunctionFormat
+def test_register_function_format_importable_from_protocol() -> None:
+    """RegisterFunctionFormat should be importable from iii.protocol."""
+    from iii.protocol import RegisterFunctionFormat
 
     fmt = RegisterFunctionFormat(name="test", type="string")
     assert fmt.name == "test"

--- a/sdk/packages/python/iii/tests/test_sync_api.py
+++ b/sdk/packages/python/iii/tests/test_sync_api.py
@@ -8,7 +8,8 @@ from typing import Any
 import pytest
 
 import iii.iii as iii_module
-from iii import InitOptions, RegisterTriggerTypeInput
+from iii import InitOptions
+from iii.protocol import RegisterTriggerTypeInput
 from iii.helpers import create_channel
 from iii.iii import III
 from iii.triggers import TriggerConfig, TriggerHandler

--- a/sdk/packages/rust/iii-example/src/main.rs
+++ b/sdk/packages/rust/iii-example/src/main.rs
@@ -2,7 +2,8 @@ use std::{thread::sleep, time::Duration};
 
 use iii_helpers::stream::UpdateOp;
 use iii_observability::OtelConfig;
-use iii_sdk::{Error, InitOptions, RegisterFunction, TriggerRequest, register_worker};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{Error, InitOptions, RegisterFunction, register_worker};
 use serde_json::json;
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]

--- a/sdk/packages/rust/iii-example/src/trigger_type_example.rs
+++ b/sdk/packages/rust/iii-example/src/trigger_type_example.rs
@@ -1,5 +1,6 @@
+use iii_sdk::protocol::TriggerRequest;
 use iii_sdk::trigger::{TriggerConfig, TriggerHandler};
-use iii_sdk::{Error, IIIClient, RegisterTriggerType, TriggerRequest};
+use iii_sdk::{Error, IIIClient, RegisterTriggerType};
 use serde::Deserialize;
 
 /// Minimal deserialization target for `engine::triggers::list` rows used

--- a/sdk/packages/rust/iii/src/engine.rs
+++ b/sdk/packages/rust/iii/src/engine.rs
@@ -1,4 +1,13 @@
 //! Engine function and trigger ids, mirroring the Node SDK constants.
+//!
+//! This module also re-exports [`RemoteFunctionHandler`] so the engine
+//! grouping (`iii_sdk::engine`) exposes the same symbols as the Node
+//! `iii-sdk/engine` and Python `iii.engine` submodules. Rust cannot use a
+//! separate `pub mod engine { ... }` grouping block here because the real
+//! engine module is the file `engine.rs` (`pub mod engine;` in `lib.rs`),
+//! so the grouping is folded into this module instead.
+
+pub use crate::types::RemoteFunctionHandler;
 
 /// Engine function ids for internal operations.
 pub struct EngineFunctions;

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -1008,7 +1008,8 @@ impl IIIClient {
     ///
     /// # Examples
     /// ```rust
-    /// # use iii_sdk::{IIIClient, RegisterTriggerInput};
+    /// # use iii_sdk::IIIClient;
+    /// # use iii_sdk::protocol::RegisterTriggerInput;
     /// # use serde_json::json;
     /// # let iii = IIIClient::new("ws://localhost:49134");
     /// let trigger = iii.register_trigger(RegisterTriggerInput {
@@ -1061,7 +1062,8 @@ impl IIIClient {
     ///
     /// # Examples
     /// ```rust
-    /// # use iii_sdk::{IIIClient, TriggerRequest, TriggerAction};
+    /// # use iii_sdk::{IIIClient, TriggerAction};
+    /// # use iii_sdk::protocol::TriggerRequest;
     /// # use serde_json::json;
     /// # async fn example(iii: &IIIClient) -> Result<(), iii_sdk::Error> {
     /// // Synchronous

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -35,6 +35,16 @@ pub mod errors {
     pub use crate::error::{Error, InvocationError};
 }
 
+// No `internal` submodule for Rust: the internal types grouped under
+// `iii-sdk/internal` (Node) and `iii.internal` (Python) have no crate-root
+// equivalent here. There is no `InternalHttpRequest` (the Rust SDK uses
+// `iii_helpers::http::HttpRequest`), and the stream result types
+// (`SetResult`, `UpdateResult`, `DeleteResult`) live in `iii_helpers::stream`
+// and are consumed inside `stream_provider.rs` — they are not re-exported at
+// the crate root. Grouping them here would re-surface clean-break helpers
+// types into the SDK, which the `compile_fail` doctests below deliberately
+// forbid. Hence the `internal` grouping is a no-op for Rust.
+
 #[deprecated(since = "0.19.0", note = "import from iii_sdk::trigger")]
 pub use builtin_triggers::IIITrigger;
 #[deprecated(since = "0.19.0", note = "import from iii_sdk::channel")]

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -49,7 +49,6 @@ pub mod errors {
 pub use builtin_triggers::IIITrigger;
 #[deprecated(since = "0.19.0", note = "import from iii_sdk::channel")]
 pub use channels::{ChannelReader, ChannelWriter, StreamChannelRef};
-pub use engine::{EngineFunctions, EngineTriggers};
 #[deprecated(
     since = "0.19.0",
     note = "renamed to Error; import from iii_sdk::errors"
@@ -62,15 +61,9 @@ pub use iii::TelemetryOptions;
 #[deprecated(since = "0.20.0", note = "renamed to TelemetryOptions")]
 pub use iii::TelemetryOptions as WorkerTelemetryMeta;
 #[deprecated(since = "0.19.0", note = "import from iii_sdk::runtime")]
-pub use iii::{
-    FunctionInfo, FunctionRef, IIIConnectionState, TriggerInfo, TriggerTypeRef, WorkerInfo,
-    WorkerMetadata,
-};
+pub use iii::{FunctionInfo, FunctionRef, TriggerInfo, TriggerTypeRef, WorkerInfo, WorkerMetadata};
 pub use iii::{IIIClient, RegisterFunction, RegisterTriggerType};
-pub use protocol::{
-    ErrorBody, FunctionMessage, Message, RegisterFunctionMessage, RegisterTriggerInput,
-    RegisterTriggerMessage, RegisterTriggerTypeMessage, TriggerAction, TriggerRequest,
-};
+pub use protocol::{Message, TriggerAction};
 pub use stream_provider::IStream;
 pub use structs::MiddlewareFunctionInput;
 #[deprecated(since = "0.19.0", note = "import from iii_sdk::trigger")]
@@ -200,6 +193,12 @@ fn _ensure_create_channel_not_on_instance() {}
 #[allow(dead_code)]
 fn _ensure_runtime_submodule_path() {}
 
+/// ```compile_fail
+/// use iii_sdk::IIIConnectionState;
+/// ```
+#[allow(dead_code)]
+fn _ensure_connection_state_not_top_level() {}
+
 // ---------------------------------------------------------------------------
 // Stage 1 trigger submodule: trigger types are reachable at their new
 // canonical path `iii_sdk::trigger`.
@@ -264,12 +263,26 @@ fn _ensure_stream_io_types_not_top_level() {}
 #[allow(dead_code)]
 fn _ensure_stream_events_helpers_path() {}
 
+// ---------------------------------------------------------------------------
+// engine submodule grouping: engine constants and the remote handler type are
+// reachable only at their canonical path `iii_sdk::engine`. Rust folds this
+// grouping into the existing `engine` module (the file `engine.rs`) rather than
+// a separate `pub mod engine { ... }` block, which would clash with it.
+// ---------------------------------------------------------------------------
+
 /// ```rust,no_run
-/// use iii_sdk::{EngineFunctions, EngineTriggers};
+/// use iii_sdk::engine::{EngineFunctions, EngineTriggers, RemoteFunctionHandler};
 /// let _ = (EngineFunctions::LIST_FUNCTIONS, EngineTriggers::LOG);
+/// fn _takes(_h: RemoteFunctionHandler) {}
 /// ```
 #[allow(dead_code)]
-fn _ensure_engine_constants_path() {}
+fn _ensure_engine_submodule_path() {}
+
+/// ```compile_fail
+/// use iii_sdk::{EngineFunctions, EngineTriggers};
+/// ```
+#[allow(dead_code)]
+fn _ensure_engine_constants_not_top_level() {}
 
 /// ```rust,no_run
 /// use iii_sdk::errors::InvocationError;
@@ -284,3 +297,27 @@ fn _ensure_invocation_error_path() {}
 /// ```
 #[allow(dead_code)]
 fn _ensure_stream_request_response_path() {}
+
+// ---------------------------------------------------------------------------
+// protocol submodule grouping: the low-level protocol message and
+// register-input types are reachable only at their canonical path
+// `iii_sdk::protocol` and are no longer re-exported at the crate root.
+// ---------------------------------------------------------------------------
+
+/// ```rust,no_run
+/// use iii_sdk::protocol::{
+///     ErrorBody, FunctionMessage, RegisterFunctionMessage, RegisterTriggerInput,
+///     RegisterTriggerMessage, RegisterTriggerTypeMessage, TriggerRequest,
+/// };
+/// ```
+#[allow(dead_code)]
+fn _ensure_protocol_submodule_path() {}
+
+/// ```compile_fail
+/// use iii_sdk::{
+///     ErrorBody, FunctionMessage, RegisterFunctionMessage, RegisterTriggerInput,
+///     RegisterTriggerMessage, RegisterTriggerTypeMessage, TriggerRequest,
+/// };
+/// ```
+#[allow(dead_code)]
+fn _ensure_protocol_types_not_top_level() {}

--- a/sdk/packages/rust/iii/tests/api_triggers.rs
+++ b/sdk/packages/rust/iii/tests/api_triggers.rs
@@ -12,7 +12,8 @@ use serde_json::{Value, json};
 use serial_test::serial;
 use tokio::sync::Mutex;
 
-use iii_sdk::{Error, RegisterFunction, RegisterTriggerInput, TriggerRequest};
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{Error, RegisterFunction};
 use tokio::time::sleep;
 
 fn test_pdf_path() -> PathBuf {

--- a/sdk/packages/rust/iii/tests/bridge.rs
+++ b/sdk/packages/rust/iii/tests/bridge.rs
@@ -10,8 +10,9 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
 
+use iii_sdk::protocol::TriggerRequest;
 use iii_sdk::runtime::FunctionInfo;
-use iii_sdk::{RegisterFunction, TriggerAction, TriggerRequest};
+use iii_sdk::{RegisterFunction, TriggerAction};
 
 #[tokio::test]
 async fn connect_successfully() {

--- a/sdk/packages/rust/iii/tests/data_channels.rs
+++ b/sdk/packages/rust/iii/tests/data_channels.rs
@@ -10,7 +10,8 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
 
-use iii_sdk::{Error, RegisterFunction, TriggerRequest};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{Error, RegisterFunction};
 
 #[tokio::test]
 async fn stream_data_from_sender_to_processor() {

--- a/sdk/packages/rust/iii/tests/healthcheck.rs
+++ b/sdk/packages/rust/iii/tests/healthcheck.rs
@@ -8,7 +8,8 @@ use std::time::Duration;
 
 use serde_json::{Value, json};
 
-use iii_sdk::{RegisterFunction, RegisterTriggerInput};
+use iii_sdk::RegisterFunction;
+use iii_sdk::protocol::RegisterTriggerInput;
 
 async fn get_health_status(http_url: &str) -> u16 {
     common::http_client()

--- a/sdk/packages/rust/iii/tests/http_external_functions.rs
+++ b/sdk/packages/rust/iii/tests/http_external_functions.rs
@@ -12,8 +12,9 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
 use iii_helpers::http::{HttpInvocationConfig, HttpMethod};
+use iii_sdk::RegisterFunction;
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
 use iii_sdk::runtime::FunctionInfo;
-use iii_sdk::{RegisterFunction, RegisterTriggerInput, TriggerRequest};
 
 fn unique_function_id(prefix: &str) -> String {
     use std::time::{SystemTime, UNIX_EPOCH};

--- a/sdk/packages/rust/iii/tests/middleware.rs
+++ b/sdk/packages/rust/iii/tests/middleware.rs
@@ -11,7 +11,8 @@ use serde_json::{Value, json};
 use tokio::sync::Mutex;
 use tokio::time::sleep;
 
-use iii_sdk::{RegisterFunction, RegisterTriggerInput};
+use iii_sdk::RegisterFunction;
+use iii_sdk::protocol::RegisterTriggerInput;
 
 #[tokio::test]
 async fn middleware_continue_to_handler() {

--- a/sdk/packages/rust/iii/tests/pubsub.rs
+++ b/sdk/packages/rust/iii/tests/pubsub.rs
@@ -10,7 +10,8 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
 
-use iii_sdk::{RegisterFunction, RegisterTriggerInput, TriggerRequest};
+use iii_sdk::RegisterFunction;
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
 
 fn unique_topic(prefix: &str) -> String {
     use std::time::{SystemTime, UNIX_EPOCH};

--- a/sdk/packages/rust/iii/tests/queue_integration.rs
+++ b/sdk/packages/rust/iii/tests/queue_integration.rs
@@ -11,7 +11,8 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
 
-use iii_sdk::{Error, RegisterFunction, RegisterTriggerInput, TriggerAction, TriggerRequest};
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{Error, RegisterFunction, TriggerAction};
 
 fn unique_topic(prefix: &str) -> String {
     let ts = std::time::SystemTime::now()

--- a/sdk/packages/rust/iii/tests/rbac_workers.rs
+++ b/sdk/packages/rust/iii/tests/rbac_workers.rs
@@ -16,10 +16,9 @@ use iii_helpers::worker_connection_manager::{
     OnTriggerRegistrationInput, OnTriggerRegistrationResult, OnTriggerTypeRegistrationInput,
     OnTriggerTypeRegistrationResult,
 };
+use iii_sdk::protocol::TriggerRequest;
 use iii_sdk::runtime::IIIConnectionState;
-use iii_sdk::{
-    InitOptions, MiddlewareFunctionInput, RegisterFunction, TriggerRequest, register_worker,
-};
+use iii_sdk::{InitOptions, MiddlewareFunctionInput, RegisterFunction, register_worker};
 use serde::Deserialize;
 
 /// Minimal deserialization target for `engine::functions::list` rows used
@@ -537,7 +536,7 @@ async fn should_deny_trigger_registration_via_hook() {
 
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    let _ = iii_client.register_trigger(iii_sdk::RegisterTriggerInput {
+    let _ = iii_client.register_trigger(iii_sdk::protocol::RegisterTriggerInput {
         trigger_type: "test-rbac-trigger".to_string(),
         function_id: "denied-trig::my-fn".to_string(),
         config: json!({ "key": "value" }),

--- a/sdk/packages/rust/iii/tests/registration_dedup.rs
+++ b/sdk/packages/rust/iii/tests/registration_dedup.rs
@@ -19,10 +19,11 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
+use iii_sdk::protocol::RegisterTriggerInput;
 use iii_sdk::runtime::IIIConnectionState;
 use iii_sdk::{
-    Error, IIIClient, InitOptions, RegisterFunction, RegisterTriggerInput, RegisterTriggerType,
-    TriggerConfig, TriggerHandler, register_worker,
+    Error, IIIClient, InitOptions, RegisterFunction, RegisterTriggerType, TriggerConfig,
+    TriggerHandler, register_worker,
 };
 
 use common::mock_engine::{MockEngine, count_register, count_type};

--- a/sdk/packages/rust/iii/tests/state.rs
+++ b/sdk/packages/rust/iii/tests/state.rs
@@ -10,7 +10,8 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
 
-use iii_sdk::{IIIClient, RegisterFunction, RegisterTriggerInput, TriggerRequest};
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{IIIClient, RegisterFunction};
 
 const SCOPE: &str = "test-scope-rs";
 

--- a/sdk/packages/rust/iii/tests/stream.rs
+++ b/sdk/packages/rust/iii/tests/stream.rs
@@ -6,7 +6,7 @@ mod common;
 
 use serde_json::{Value, json};
 
-use iii_sdk::TriggerRequest;
+use iii_sdk::protocol::TriggerRequest;
 
 const STREAM_NAME: &str = "test-stream-rs";
 const GROUP_ID: &str = "test-group";

--- a/sdk/packages/rust/iii/tests/trigger_type_lifecycle.rs
+++ b/sdk/packages/rust/iii/tests/trigger_type_lifecycle.rs
@@ -7,10 +7,10 @@ use std::sync::{Arc, Mutex};
 use serial_test::serial;
 
 use async_trait::async_trait;
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
 use iii_sdk::runtime::IIIConnectionState;
 use iii_sdk::{
-    Error, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerConfig, TriggerHandler,
-    TriggerRequest, register_worker,
+    Error, InitOptions, RegisterFunction, TriggerConfig, TriggerHandler, register_worker,
 };
 use serde_json::{Value, json};
 use tokio::time::Duration;


### PR DESCRIPTION
## What

Adds an `internal` submodule to the iii SDK, mirroring the existing `runtime`/`channel`/`errors` deprecated-re-export pattern: the symbol stays exported at the package root (marked deprecated) and is also reachable via the new subpath (`iii-sdk/internal`, `iii.internal`).

- **Node/Python**: `InternalHttpRequest` grouped under `internal`.
- **Rust**: documented no-op. Rust has no `InternalHttpRequest`, and the state/stream result types (`SetResult`/`UpdateResult`/`DeleteResult`) live in `iii_helpers::stream` (clean break) — re-surfacing them from the SDK would violate that. So no `pub mod internal` is added.

Pure re-export grouping: no type, wire, or logic changes.

## Notes

The CSV listed `DeleteResult`/`SetResult`/`UpdateResult` for `internal`, but those already moved to `@iii-dev/helpers` in the stream work, so the only genuinely-internal root symbol left to group is `InternalHttpRequest`.

## Verification

Node build + `tsc --noEmit`; Python mypy + ruff; Rust lib/doc tests + clippy `-D warnings` + fmt; engine `cargo build -p iii` + engine test compile — all green. Symbol importable from both the new subpath and the (deprecated) root.

Base: `sdk-refactor`.