### PR TITLE
refactor(sdk)!: move IIIConnectionState/TriggerActionVoid/format helpers to their submodules

### DIFF
--- a/docs/next/sdk-reference/node-sdk.mdx
+++ b/docs/next/sdk-reference/node-sdk.mdx
@@ -55,6 +55,10 @@ The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii-s
 subpath (`import type { FunctionRef } from 'iii-sdk/runtime'`). They stay re-exported from the
 package root as deprecated aliases.
 
+The `IIIConnectionState` type is provided only by the `iii-sdk/runtime` subpath
+(`import type { IIIConnectionState } from 'iii-sdk/runtime'`). It is not exported from the
+package root.
+
 The `InternalHttpRequest` type is provided only by the `iii-sdk/internal` subpath
 (`import type { InternalHttpRequest } from 'iii-sdk/internal'`). It is not exported from the
 package root.

--- a/docs/next/sdk-reference/node-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/node-sdk.mdx.skill.md
@@ -53,6 +53,10 @@ The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii-s
 subpath (`import type { FunctionRef } from 'iii-sdk/runtime'`). They stay re-exported from the
 package root as deprecated aliases.
 
+The `IIIConnectionState` type is provided only by the `iii-sdk/runtime` subpath
+(`import type { IIIConnectionState } from 'iii-sdk/runtime'`). It is not exported from the
+package root.
+
 The `InternalHttpRequest` type is provided only by the `iii-sdk/internal` subpath
 (`import type { InternalHttpRequest } from 'iii-sdk/internal'`). It is not exported from the
 package root.

--- a/docs/next/sdk-reference/python-sdk.mdx
+++ b/docs/next/sdk-reference/python-sdk.mdx
@@ -63,6 +63,9 @@ The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii.r
 (`from iii.runtime import FunctionRef`). They stay importable from the package root as deprecated
 re-exports.
 
+The `IIIConnectionState` type is provided only by the `iii.runtime` submodule
+(`from iii.runtime import IIIConnectionState`). It is not importable from the package root.
+
 The `InternalHttpRequest` type is provided only by the `iii.internal` submodule
 (`from iii.internal import InternalHttpRequest`). It is not importable from the package root.
 
@@ -75,6 +78,13 @@ The protocol message and register-input types (`MessageType`, `RegisterFunctionM
 `RegisterFunctionInput`, `RegisterTriggerInput`, `RegisterTriggerTypeInput`) are provided only by
 the `iii.protocol` submodule (`from iii.protocol import MessageType`). They are not importable from
 the package root.
+
+The `TriggerActionVoid` type is provided only by the `iii.trigger` submodule
+(`from iii.trigger import TriggerActionVoid`). It is not importable from the package root.
+
+The `extract_request_format`, `extract_response_format`, and `python_type_to_format` helpers are
+provided only by the `iii.utils` submodule (`from iii.utils import python_type_to_format`). They are
+not importable from the package root.
 
 ### `register_trigger`
 

--- a/docs/next/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/python-sdk.mdx.skill.md
@@ -61,6 +61,9 @@ The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii.r
 (`from iii.runtime import FunctionRef`). They stay importable from the package root as deprecated
 re-exports.
 
+The `IIIConnectionState` type is provided only by the `iii.runtime` submodule
+(`from iii.runtime import IIIConnectionState`). It is not importable from the package root.
+
 The `InternalHttpRequest` type is provided only by the `iii.internal` submodule
 (`from iii.internal import InternalHttpRequest`). It is not importable from the package root.
 
@@ -73,6 +76,13 @@ The protocol message and register-input types (`MessageType`, `RegisterFunctionM
 `RegisterFunctionInput`, `RegisterTriggerInput`, `RegisterTriggerTypeInput`) are provided only by
 the `iii.protocol` submodule (`from iii.protocol import MessageType`). They are not importable from
 the package root.
+
+The `TriggerActionVoid` type is provided only by the `iii.trigger` submodule
+(`from iii.trigger import TriggerActionVoid`). It is not importable from the package root.
+
+The `extract_request_format`, `extract_response_format`, and `python_type_to_format` helpers are
+provided only by the `iii.utils` submodule (`from iii.utils import python_type_to_format`). They are
+not importable from the package root.
 
 ### `register_trigger`
 

--- a/sdk/packages/node/iii/src/runtime.ts
+++ b/sdk/packages/node/iii/src/runtime.ts
@@ -1,1 +1,2 @@
+export type { IIIConnectionState } from './iii-constants'
 export type { FunctionRef, TriggerTypeRef } from './types'

--- a/sdk/packages/python/iii/src/iii/__init__.py
+++ b/sdk/packages/python/iii/src/iii/__init__.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from .channels import ChannelReader, ChannelWriter
 from .errors import InvocationError
-from .format_utils import extract_request_format, extract_response_format, python_type_to_format
 from .iii import TriggerAction, register_worker
 from .iii_constants import (
     FunctionRef,
@@ -15,7 +14,6 @@ from .iii_types import (
     MiddlewareFunctionInput,
     StreamChannelRef,
     TriggerActionEnqueue,
-    TriggerActionVoid,
 )
 from .stream import IStream
 from .triggers import Trigger, TriggerConfig, TriggerHandler, TriggerTypeRef
@@ -43,7 +41,6 @@ __all__ = [
     # Message types
     "StreamChannelRef",
     "TriggerActionEnqueue",
-    "TriggerActionVoid",
     # Triggers
     "Trigger",
     "TriggerConfig",
@@ -56,10 +53,6 @@ __all__ = [
     "StreamResponse",
     # Stream
     "IStream",
-    # Format extraction
-    "extract_request_format",
-    "extract_response_format",
-    "python_type_to_format",
 ]
 
 

--- a/sdk/packages/python/iii/src/iii/runtime.py
+++ b/sdk/packages/python/iii/src/iii/runtime.py
@@ -1,6 +1,6 @@
 """Public runtime types."""
 
-from .iii_constants import FunctionRef
+from .iii_constants import FunctionRef, IIIConnectionState
 from .triggers import TriggerTypeRef
 
-__all__ = ["FunctionRef", "TriggerTypeRef"]
+__all__ = ["FunctionRef", "IIIConnectionState", "TriggerTypeRef"]

--- a/sdk/packages/python/iii/src/iii/trigger.py
+++ b/sdk/packages/python/iii/src/iii/trigger.py
@@ -1,5 +1,6 @@
 """Public trigger types."""
 
+from .iii_types import TriggerActionVoid
 from .triggers import Trigger, TriggerConfig, TriggerHandler
 
-__all__ = ["Trigger", "TriggerConfig", "TriggerHandler"]
+__all__ = ["Trigger", "TriggerActionVoid", "TriggerConfig", "TriggerHandler"]

--- a/sdk/packages/python/iii/src/iii/utils.py
+++ b/sdk/packages/python/iii/src/iii/utils.py
@@ -5,7 +5,16 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from .format_utils import extract_request_format, extract_response_format, python_type_to_format
 from .types import is_channel_ref as is_channel_ref  # noqa: F401 - re-exported from types
+
+__all__ = [
+    "extract_request_format",
+    "extract_response_format",
+    "is_channel_ref",
+    "python_type_to_format",
+    "safe_stringify",
+]
 
 
 def safe_stringify(value: Any) -> str:

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -61,10 +61,7 @@ pub use iii::TelemetryOptions;
 #[deprecated(since = "0.20.0", note = "renamed to TelemetryOptions")]
 pub use iii::TelemetryOptions as WorkerTelemetryMeta;
 #[deprecated(since = "0.19.0", note = "import from iii_sdk::runtime")]
-pub use iii::{
-    FunctionInfo, FunctionRef, IIIConnectionState, TriggerInfo, TriggerTypeRef, WorkerInfo,
-    WorkerMetadata,
-};
+pub use iii::{FunctionInfo, FunctionRef, TriggerInfo, TriggerTypeRef, WorkerInfo, WorkerMetadata};
 pub use iii::{IIIClient, RegisterFunction, RegisterTriggerType};
 pub use protocol::{Message, TriggerAction};
 pub use stream_provider::IStream;
@@ -195,6 +192,12 @@ fn _ensure_create_channel_not_on_instance() {}
 /// ```
 #[allow(dead_code)]
 fn _ensure_runtime_submodule_path() {}
+
+/// ```compile_fail
+/// use iii_sdk::IIIConnectionState;
+/// ```
+#[allow(dead_code)]
+fn _ensure_connection_state_not_top_level() {}
 
 // ---------------------------------------------------------------------------
 // Stage 1 trigger submodule: trigger types are reachable at their new


### PR DESCRIPTION
Three small submodule-grouping completions mirroring the existing pattern (deprecated re-export, root kept):
- `runtime`: `IIIConnectionState` now reachable via the runtime submodule.
- `trigger` (Python): `TriggerActionVoid` via the trigger submodule (Node uses the inline `{type:'void'}` union arm, Rust `TriggerAction::Void` — no equivalent symbol).
- `utils` (Python): the format helpers (`extract_request_format`/`extract_response_format`/`python_type_to_format`) added to the existing `iii.utils` (existing `safe_stringify`/`is_channel_ref` preserved).

Mostly Python-only (per-lang asymmetry). Engine build + SDK builds/tests green. Stacked on #1852.