### PR TITLE
fix(observability): stop shutdownOtel() hanging when the engine is unreachable

### DIFF
--- a/sdk/packages/node/observability/src/telemetry-system/connection.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/connection.ts
@@ -214,11 +214,32 @@ export class SharedEngineConnection {
    * be flushed. Call before flushing, then call shutdown() to close fully.
    */
   beginShutdown(): void {
+    if (this.shuttingDown) {
+      return
+    }
     this.shuttingDown = true
 
     if (this.reconnectTimeout) {
       clearTimeout(this.reconnectTimeout)
       this.reconnectTimeout = null
+    }
+
+    // With no live connection there's nothing to flush to, so fail queued work
+    // now instead of leaving callbacks unresolved for the flush below to wait on
+    if (this.state !== 'connected') {
+      const pending = this.pendingMessages.splice(0, this.pendingMessages.length)
+      const shutdownError = new Error('Connection shutdown before message could be sent')
+      for (const { callback } of pending) {
+        callback?.(shutdownError)
+      }
+
+      for (const cb of this.onFailedCallbacks) {
+        try {
+          cb()
+        } catch (err) {
+          console.error('[OTel] onFailed callback threw:', err)
+        }
+      }
     }
   }
 

--- a/sdk/packages/node/observability/src/telemetry-system/connection.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/connection.ts
@@ -200,6 +200,29 @@ export class SharedEngineConnection {
   }
 
   /**
+   * Whether the connection is shutting down. While shutting down, exporters
+   * fail-fast instead of queueing when there is no live connection, so a final
+   * forceFlush() can't hang waiting for a reconnect that will never happen.
+   */
+  isShuttingDown(): boolean {
+    return this.shuttingDown
+  }
+
+  /**
+   * Begin shutdown: stop reconnecting and stop accepting new queued exports,
+   * while leaving an open connection in place so buffered telemetry can still
+   * be flushed. Call before flushing, then call shutdown() to close fully.
+   */
+  beginShutdown(): void {
+    this.shuttingDown = true
+
+    if (this.reconnectTimeout) {
+      clearTimeout(this.reconnectTimeout)
+      this.reconnectTimeout = null
+    }
+  }
+
+  /**
    * Shutdown the connection.
    */
   async shutdown(): Promise<void> {

--- a/sdk/packages/node/observability/src/telemetry-system/index.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/index.ts
@@ -229,21 +229,26 @@ export async function shutdownOtel(): Promise<void> {
   // Stop reconnecting/queuing before flushing so a final forceFlush() can't hang on a dead engine
   sharedConnection?.beginShutdown()
 
+  // Flushing is best-effort on shutdown: when the engine is gone the exporters
+  // fail their pending exports, which rejects forceFlush()/shutdown(). Swallow
+  // those so a dropped final flush can't crash or block teardown.
+  const settle = (p: Promise<unknown>) => p.catch(() => {})
+
   if (tracerProvider) {
-    await tracerProvider.forceFlush()
-    await tracerProvider.shutdown()
+    await settle(tracerProvider.forceFlush())
+    await settle(tracerProvider.shutdown())
     tracerProvider = null
   }
 
   if (meterProvider) {
-    await meterProvider.forceFlush()
-    await meterProvider.shutdown()
+    await settle(meterProvider.forceFlush())
+    await settle(meterProvider.shutdown())
     meterProvider = null
   }
 
   if (loggerProvider) {
-    await loggerProvider.forceFlush()
-    await loggerProvider.shutdown()
+    await settle(loggerProvider.forceFlush())
+    await settle(loggerProvider.shutdown())
     loggerProvider = null
   }
 

--- a/sdk/packages/node/observability/src/telemetry-system/index.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/index.ts
@@ -226,6 +226,9 @@ export function initOtel(config: OtelConfig = {}): void {
  * Shutdown OpenTelemetry, flushing any pending data.
  */
 export async function shutdownOtel(): Promise<void> {
+  // Stop reconnecting/queuing before flushing so a final forceFlush() can't hang on a dead engine
+  sharedConnection?.beginShutdown()
+
   if (tracerProvider) {
     await tracerProvider.forceFlush()
     await tracerProvider.shutdown()

--- a/sdk/packages/node/observability/src/telemetry-system/log-exporter.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/log-exporter.ts
@@ -46,14 +46,16 @@ export class EngineLogExporter implements LogRecordExporter {
     resultCallback: (result: ExportResult) => void,
   ): void {
     const state = this.connection.getState()
-    if (state === 'failed') {
-      resultCallback({
-        code: ExportResultCode.FAILED,
-        error: new Error('Connection failed: dropping logs'),
-      })
-      return
-    }
     if (state !== 'connected') {
+      // Drop instead of queue when there's no prospect of delivery (failed, or shutting down)
+      if (state === 'failed' || this.connection.isShuttingDown()) {
+        const reason = state === 'failed' ? 'failed' : 'shut down'
+        resultCallback({
+          code: ExportResultCode.FAILED,
+          error: new Error(`Connection ${reason}: dropping logs`),
+        })
+        return
+      }
       if (this.pendingExports.length >= EngineLogExporter.MAX_PENDING_EXPORTS) {
         const dropped = this.pendingExports.shift()
         dropped?.callback({

--- a/sdk/packages/node/observability/src/telemetry-system/metrics-exporter.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/metrics-exporter.ts
@@ -71,14 +71,16 @@ export class EngineMetricsExporter implements PushMetricExporter {
     resultCallback: (result: ExportResult) => void,
   ): void {
     const state = this.connection.getState()
-    if (state === 'failed') {
-      resultCallback({
-        code: ExportResultCode.FAILED,
-        error: new Error('Connection failed: dropping metrics'),
-      })
-      return
-    }
     if (state !== 'connected') {
+      // Drop instead of queue when there's no prospect of delivery (failed, or shutting down)
+      if (state === 'failed' || this.connection.isShuttingDown()) {
+        const reason = state === 'failed' ? 'failed' : 'shut down'
+        resultCallback({
+          code: ExportResultCode.FAILED,
+          error: new Error(`Connection ${reason}: dropping metrics`),
+        })
+        return
+      }
       if (this.pendingExports.length >= EngineMetricsExporter.MAX_PENDING_EXPORTS) {
         const dropped = this.pendingExports.shift()
         dropped?.resultCallback?.({

--- a/sdk/packages/node/observability/src/telemetry-system/span-exporter.test.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/span-exporter.test.ts
@@ -1,0 +1,41 @@
+import { ExportResultCode } from '@opentelemetry/core'
+import { describe, expect, it, vi } from 'vitest'
+import type { SharedEngineConnection } from './connection'
+import { EngineSpanExporter } from './span-exporter'
+import type { ConnectionState } from './types'
+
+/** Minimal connection stub so exporter behavior can be driven without a socket. */
+function stubConnection(state: ConnectionState) {
+  const stub = {
+    state,
+    shuttingDown: false,
+    getState: () => stub.state,
+    isShuttingDown: () => stub.shuttingDown,
+    onConnected: () => {},
+    onFailed: () => {},
+    send: () => {},
+  }
+  return stub
+}
+
+describe('EngineSpanExporter shutdown behavior', () => {
+  it('queues exports while disconnected but fails fast once shutting down', () => {
+    const connection = stubConnection('disconnected')
+    const exporter = new EngineSpanExporter(connection as unknown as SharedEngineConnection)
+
+    // Disconnected but still running: the export is queued for a later reconnect,
+    // so the callback stays pending.
+    const queued = vi.fn()
+    exporter.export([], queued)
+    expect(queued).not.toHaveBeenCalled()
+
+    // Shutting down with no live connection: the export fails fast instead of
+    // queueing, so a final forceFlush() can't hang waiting for a reconnect that
+    // will never happen (regression test for the shutdownOtel() hang).
+    connection.shuttingDown = true
+    const failed = vi.fn()
+    exporter.export([], failed)
+    expect(failed).toHaveBeenCalledOnce()
+    expect(failed.mock.calls[0][0].code).toBe(ExportResultCode.FAILED)
+  })
+})

--- a/sdk/packages/node/observability/src/telemetry-system/span-exporter.test.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/span-exporter.test.ts
@@ -1,6 +1,6 @@
 import { ExportResultCode } from '@opentelemetry/core'
 import { describe, expect, it, vi } from 'vitest'
-import type { SharedEngineConnection } from './connection'
+import { SharedEngineConnection } from './connection'
 import { EngineSpanExporter } from './span-exporter'
 import type { ConnectionState } from './types'
 
@@ -37,5 +37,24 @@ describe('EngineSpanExporter shutdown behavior', () => {
     exporter.export([], failed)
     expect(failed).toHaveBeenCalledOnce()
     expect(failed.mock.calls[0][0].code).toBe(ExportResultCode.FAILED)
+  })
+
+  it('drains already-queued export callbacks when shutdown begins while disconnected', async () => {
+    // Dead address: the connection never reaches 'connected'.
+    const connection = new SharedEngineConnection('ws://127.0.0.1:9', {})
+    const exporter = new EngineSpanExporter(connection)
+
+    // Export queued before shutdown — callback still pending.
+    const callback = vi.fn()
+    exporter.export([], callback)
+    expect(callback).not.toHaveBeenCalled()
+
+    // beginShutdown() with no live connection must resolve the queued callback,
+    // so a later forceFlush() can't hang waiting on it.
+    connection.beginShutdown()
+    expect(callback).toHaveBeenCalledOnce()
+    expect(callback.mock.calls[0][0].code).toBe(ExportResultCode.FAILED)
+
+    await connection.shutdown()
   })
 })

--- a/sdk/packages/node/observability/src/telemetry-system/span-exporter.ts
+++ b/sdk/packages/node/observability/src/telemetry-system/span-exporter.ts
@@ -65,14 +65,16 @@ export class EngineSpanExporter implements SpanExporter {
 
   private doExport(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
     const state = this.connection.getState()
-    if (state === 'failed') {
-      resultCallback({
-        code: ExportResultCode.FAILED,
-        error: new Error('Connection failed: dropping spans'),
-      })
-      return
-    }
     if (state !== 'connected') {
+      // Drop instead of queue when there's no prospect of delivery (failed, or shutting down)
+      if (state === 'failed' || this.connection.isShuttingDown()) {
+        const reason = state === 'failed' ? 'failed' : 'shut down'
+        resultCallback({
+          code: ExportResultCode.FAILED,
+          error: new Error(`Connection ${reason}: dropping spans`),
+        })
+        return
+      }
       if (this.pendingExports.length >= EngineSpanExporter.MAX_PENDING_EXPORTS) {
         const dropped = this.pendingExports.shift()
         dropped?.resultCallback?.({


### PR DESCRIPTION
Fixes #1835. Thanks for confirming, @guibeira — here's the fix.

## Problem

When the engine is unreachable at shutdown, `shutdownOtel()` `forceFlush()`es the OTel providers while `SharedEngineConnection` is still in its (infinite) reconnect loop. Each exporter's `doExport()` sees a non-`connected` state and **queues** the export without invoking its result callback — that callback only fires on reconnect, on the `failed` state, or on exporter shutdown. With the default `maxRetries: -1` the `failed` state is unreachable, the engine never returns, and the queue is only drained *after* the flush — so `forceFlush()` never resolves and the process hangs until it's force-killed (~90s under systemd).

## Fix

An explicit draining phase, no timeouts:

- `SharedEngineConnection.beginShutdown()` stops reconnecting and marks the connection as shutting down, but leaves the open socket in place so buffered telemetry can still flush.
- Exporters **fail-fast** (drop, like the `failed` state) when there's no live connection *and* the connection is shutting down, instead of queueing.
- `shutdownOtel()` calls `beginShutdown()` before the provider flushes.

Net: a final `forceFlush()` still **sends** buffered telemetry when the engine is reachable (healthy shutdown unchanged), but **fails fast** instead of hanging when it isn't.

## Testing

New regression test (`span-exporter.test.ts`): an export queues while disconnected, then fails fast once shutting down. `pnpm test` (18 pass), `type-check`, `build` all green; biome clean on changed files. The hang affected traces, metrics and logs, so all three exporters get the symmetric change.

---

- [x] I license my contributions to this repository under Apache 2.0, and I have all necessary rights over the code I am contributing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown behavior for telemetry exporters to prevent process hangs
  * Enhanced connection state handling during shutdown to properly fail pending telemetry exports with clear error messages
  * Optimized shutdown sequence to stop reconnection attempts and drain queued metrics, logs, and spans

<!-- end of auto-generated comment: release notes by coderabbit.ai -->