### PR TITLE
refactor(sdk): align stream helper type names across the SDKs

### DIFF
--- a/docs/next/sdk-reference/helpers-lib.mdx
+++ b/docs/next/sdk-reference/helpers-lib.mdx
@@ -602,16 +602,18 @@ or `stream::delete`. The `event` field carries the mutation type and the changed
 <CodeGroup>
 
 ```typescript Node
+export type StreamChangeEventDetail = {
+  type: 'create' | 'update' | 'delete'
+  data: any
+}
+
 export interface StreamChangeEvent {
   type: 'stream'
   timestamp: number
   streamName: string
   groupId: string
   id?: string
-  event: {
-    type: 'create' | 'update' | 'delete'
-    data: any
-  }
+  event: StreamChangeEventDetail
 }
 ```
 
@@ -631,6 +633,12 @@ class StreamChangeEvent(BaseModel):
 ```
 
 ```rust Rust
+pub struct StreamChangeEventDetail {
+    #[serde(rename = "type")]
+    pub event_type: StreamEventType,
+    pub data: Value,
+}
+
 pub struct StreamChangeEvent {
     #[serde(rename = "type")]
     pub event_type: String,
@@ -640,7 +648,7 @@ pub struct StreamChangeEvent {
     #[serde(rename = "groupId")]
     pub group_id: String,
     pub id: Option<String>,
-    pub event: StreamEventDetail,
+    pub event: StreamChangeEventDetail,
 }
 ```
 
@@ -810,7 +818,7 @@ export type StreamUpdateResult<TData> = {
   errors?: UpdateOpError[]
 }
 
-export type DeleteResult = {
+export type StreamDeleteResult = {
   old_value?: any
 }
 
@@ -840,19 +848,19 @@ class StreamJoinResult(BaseModel):
 ```
 
 ```rust Rust
-pub struct SetResult {
+pub struct StreamSetResult {
     pub old_value: Option<Value>,
     pub new_value: Value,
 }
 
-pub struct UpdateResult {
+pub struct StreamUpdateResult {
     pub old_value: Option<Value>,
     pub new_value: Value,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub errors: Vec<UpdateOpError>,
 }
 
-pub struct DeleteResult {
+pub struct StreamDeleteResult {
     pub old_value: Option<Value>,
 }
 
@@ -892,6 +900,8 @@ export type UpdateOpError = {
 ```
 
 ```python Python
+MergePath = str | list[str]
+
 UpdateOp = (
     UpdateSet
     | UpdateIncrement

--- a/docs/next/sdk-reference/helpers-lib.mdx.skill.md
+++ b/docs/next/sdk-reference/helpers-lib.mdx.skill.md
@@ -600,16 +600,18 @@ or `stream::delete`. The `event` field carries the mutation type and the changed
 <CodeGroup>
 
 ```typescript Node
+export type StreamChangeEventDetail = {
+  type: 'create' | 'update' | 'delete'
+  data: any
+}
+
 export interface StreamChangeEvent {
   type: 'stream'
   timestamp: number
   streamName: string
   groupId: string
   id?: string
-  event: {
-    type: 'create' | 'update' | 'delete'
-    data: any
-  }
+  event: StreamChangeEventDetail
 }
 ```
 
@@ -629,6 +631,12 @@ class StreamChangeEvent(BaseModel):
 ```
 
 ```rust Rust
+pub struct StreamChangeEventDetail {
+    #[serde(rename = "type")]
+    pub event_type: StreamEventType,
+    pub data: Value,
+}
+
 pub struct StreamChangeEvent {
     #[serde(rename = "type")]
     pub event_type: String,
@@ -638,7 +646,7 @@ pub struct StreamChangeEvent {
     #[serde(rename = "groupId")]
     pub group_id: String,
     pub id: Option<String>,
-    pub event: StreamEventDetail,
+    pub event: StreamChangeEventDetail,
 }
 ```
 
@@ -808,7 +816,7 @@ export type StreamUpdateResult<TData> = {
   errors?: UpdateOpError[]
 }
 
-export type DeleteResult = {
+export type StreamDeleteResult = {
   old_value?: any
 }
 
@@ -838,19 +846,19 @@ class StreamJoinResult(BaseModel):
 ```
 
 ```rust Rust
-pub struct SetResult {
+pub struct StreamSetResult {
     pub old_value: Option<Value>,
     pub new_value: Value,
 }
 
-pub struct UpdateResult {
+pub struct StreamUpdateResult {
     pub old_value: Option<Value>,
     pub new_value: Value,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub errors: Vec<UpdateOpError>,
 }
 
-pub struct DeleteResult {
+pub struct StreamDeleteResult {
     pub old_value: Option<Value>,
 }
 
@@ -890,6 +898,8 @@ export type UpdateOpError = {
 ```
 
 ```python Python
+MergePath = str | list[str]
+
 UpdateOp = (
     UpdateSet
     | UpdateIncrement

--- a/engine/src/builtins/kv.rs
+++ b/engine/src/builtins/kv.rs
@@ -14,7 +14,7 @@ use std::{
 
 use indexmap::IndexMap;
 
-use iii_helpers::stream::{DeleteResult, SetResult, UpdateOp, UpdateResult};
+use iii_helpers::stream::{StreamDeleteResult, StreamSetResult, StreamUpdateResult, UpdateOp};
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -291,7 +291,7 @@ impl BuiltinKvStore {
         }
     }
 
-    pub async fn set(&self, index: String, key: String, data: Value) -> SetResult {
+    pub async fn set(&self, index: String, key: String, data: Value) -> StreamSetResult {
         let result = {
             let mut store = self.store.write().await;
             let index_map = store.get_mut(&index);
@@ -300,7 +300,7 @@ impl BuiltinKvStore {
                 let old_value = index_map.get(&key).cloned();
                 index_map.insert(key.clone(), data.clone());
 
-                SetResult {
+                StreamSetResult {
                     old_value,
                     new_value: data.clone(),
                 }
@@ -309,7 +309,7 @@ impl BuiltinKvStore {
                 index_map.insert(key, data.clone());
                 store.insert(index.clone(), index_map);
 
-                SetResult {
+                StreamSetResult {
                     old_value: None,
                     new_value: data.clone(),
                 }
@@ -334,7 +334,7 @@ impl BuiltinKvStore {
         None
     }
 
-    pub async fn delete(&self, index: String, key: String) -> DeleteResult {
+    pub async fn delete(&self, index: String, key: String) -> StreamDeleteResult {
         let (removed, dirty_op) = {
             let mut store = self.store.write().await;
             let index_map = store.get_mut(&index);
@@ -350,9 +350,9 @@ impl BuiltinKvStore {
                 } else {
                     None
                 };
-                (DeleteResult { old_value: removed }, dirty_op)
+                (StreamDeleteResult { old_value: removed }, dirty_op)
             } else {
-                (DeleteResult { old_value: None }, None)
+                (StreamDeleteResult { old_value: None }, None)
             }
         };
 
@@ -445,7 +445,12 @@ impl BuiltinKvStore {
         released
     }
 
-    pub async fn update(&self, index: String, key: String, ops: Vec<UpdateOp>) -> UpdateResult {
+    pub async fn update(
+        &self,
+        index: String,
+        key: String,
+        ops: Vec<UpdateOp>,
+    ) -> StreamUpdateResult {
         let mut store = self.store.write().await;
 
         // Automatically create index_map if it doesn't exist
@@ -466,7 +471,7 @@ impl BuiltinKvStore {
                 .insert(index.clone(), DirtyOp::Upsert);
         }
 
-        UpdateResult {
+        StreamUpdateResult {
             old_value,
             new_value: updated_value,
             errors,

--- a/engine/src/workers/state/adapters/bridge.rs
+++ b/engine/src/workers/state/adapters/bridge.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use iii_helpers::stream::{SetResult, UpdateOp, UpdateResult};
+use iii_helpers::stream::{StreamSetResult, StreamUpdateResult, UpdateOp};
 use iii_sdk::protocol::TriggerRequest;
 use iii_sdk::{III, InitOptions, register_worker};
 use serde_json::Value;
@@ -45,7 +45,7 @@ impl StateAdapter for BridgeAdapter {
         scope: &str,
         key: &str,
         ops: Vec<UpdateOp>,
-    ) -> anyhow::Result<UpdateResult> {
+    ) -> anyhow::Result<StreamUpdateResult> {
         let data = StateUpdateInput {
             scope: scope.to_string(),
             key: key.to_string(),
@@ -63,7 +63,7 @@ impl StateAdapter for BridgeAdapter {
             .await
             .map_err(|e| anyhow::anyhow!("Failed to update value via bridge: {}", e))?;
 
-        serde_json::from_value::<UpdateResult>(result)
+        serde_json::from_value::<StreamUpdateResult>(result)
             .map_err(|e| anyhow::anyhow!("Failed to deserialize update result: {}", e))
     }
 
@@ -72,7 +72,7 @@ impl StateAdapter for BridgeAdapter {
         Ok(())
     }
 
-    async fn set(&self, scope: &str, key: &str, value: Value) -> anyhow::Result<SetResult> {
+    async fn set(&self, scope: &str, key: &str, value: Value) -> anyhow::Result<StreamSetResult> {
         let data = StateSetInput {
             scope: scope.to_string(),
             key: key.to_string(),
@@ -89,7 +89,7 @@ impl StateAdapter for BridgeAdapter {
             .await
             .map_err(|e| anyhow::anyhow!("Failed to set value via bridge: {}", e))?;
 
-        serde_json::from_value::<SetResult>(result)
+        serde_json::from_value::<StreamSetResult>(result)
             .map_err(|e| anyhow::anyhow!("Failed to deserialize set result: {}", e))
     }
 

--- a/engine/src/workers/state/adapters/kv_store.rs
+++ b/engine/src/workers/state/adapters/kv_store.rs
@@ -7,7 +7,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
-use iii_helpers::stream::{SetResult, UpdateOp, UpdateResult};
+use iii_helpers::stream::{StreamSetResult, StreamUpdateResult, UpdateOp};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -40,7 +40,7 @@ impl StateAdapter for BuiltinKvStoreAdapter {
         Ok(())
     }
 
-    async fn set(&self, scope: &str, key: &str, value: Value) -> anyhow::Result<SetResult> {
+    async fn set(&self, scope: &str, key: &str, value: Value) -> anyhow::Result<StreamSetResult> {
         Ok(self
             .storage
             .set(scope.to_string(), key.to_string(), value.clone())
@@ -63,7 +63,7 @@ impl StateAdapter for BuiltinKvStoreAdapter {
         scope: &str,
         key: &str,
         ops: Vec<UpdateOp>,
-    ) -> anyhow::Result<UpdateResult> {
+    ) -> anyhow::Result<StreamUpdateResult> {
         Ok(self
             .storage
             .update(scope.to_string(), key.to_string(), ops)

--- a/engine/src/workers/state/adapters/mod.rs
+++ b/engine/src/workers/state/adapters/mod.rs
@@ -9,12 +9,12 @@ pub mod kv_store;
 pub mod redis_adapter;
 
 use async_trait::async_trait;
-use iii_helpers::stream::{SetResult, UpdateOp, UpdateResult};
+use iii_helpers::stream::{StreamSetResult, StreamUpdateResult, UpdateOp};
 use serde_json::Value;
 
 #[async_trait]
 pub trait StateAdapter: Send + Sync {
-    async fn set(&self, scope: &str, key: &str, value: Value) -> anyhow::Result<SetResult>;
+    async fn set(&self, scope: &str, key: &str, value: Value) -> anyhow::Result<StreamSetResult>;
     async fn get(&self, scope: &str, key: &str) -> anyhow::Result<Option<Value>>;
     async fn delete(&self, scope: &str, key: &str) -> anyhow::Result<()>;
     async fn update(
@@ -22,7 +22,7 @@ pub trait StateAdapter: Send + Sync {
         scope: &str,
         key: &str,
         ops: Vec<UpdateOp>,
-    ) -> anyhow::Result<UpdateResult>;
+    ) -> anyhow::Result<StreamUpdateResult>;
     async fn list(&self, scope: &str) -> anyhow::Result<Vec<Value>>;
     async fn list_groups(&self) -> anyhow::Result<Vec<String>>;
     async fn destroy(&self) -> anyhow::Result<()>;

--- a/engine/src/workers/state/adapters/redis_adapter.rs
+++ b/engine/src/workers/state/adapters/redis_adapter.rs
@@ -7,7 +7,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
-use iii_helpers::stream::{SetResult, UpdateOp, UpdateResult};
+use iii_helpers::stream::{StreamSetResult, StreamUpdateResult, UpdateOp};
 use redis::{AsyncCommands, Client, aio::ConnectionManager};
 use serde_json::Value;
 use tokio::{sync::Mutex, time::timeout};
@@ -51,7 +51,7 @@ impl StateRedisAdapter {
 
 #[async_trait]
 impl StateAdapter for StateRedisAdapter {
-    async fn set(&self, scope: &str, key: &str, value: Value) -> anyhow::Result<SetResult> {
+    async fn set(&self, scope: &str, key: &str, value: Value) -> anyhow::Result<StreamSetResult> {
         let scope_key: String = format!("state:{}", scope);
         let mut conn = self.publisher.lock().await;
         let serialized = serde_json::to_string(&value)
@@ -80,7 +80,7 @@ impl StateAdapter for StateRedisAdapter {
                 let old_value = s.map(|s| serde_json::from_str(&s).unwrap_or(Value::Null));
                 let new_value = value.clone();
 
-                Ok(SetResult {
+                Ok(StreamSetResult {
                     old_value,
                     new_value,
                 })
@@ -110,7 +110,7 @@ impl StateAdapter for StateRedisAdapter {
         scope: &str,
         key: &str,
         ops: Vec<UpdateOp>,
-    ) -> anyhow::Result<UpdateResult> {
+    ) -> anyhow::Result<StreamUpdateResult> {
         let mut conn = self.publisher.lock().await;
         let scope_key = format!("state:{}", scope);
 
@@ -158,7 +158,7 @@ impl StateAdapter for StateRedisAdapter {
                         Vec::new()
                     };
 
-                    Ok(UpdateResult {
+                    Ok(StreamUpdateResult {
                         old_value,
                         new_value,
                         errors,

--- a/engine/src/workers/state/state.rs
+++ b/engine/src/workers/state/state.rs
@@ -14,7 +14,7 @@ use once_cell::sync::Lazy;
 use serde_json::Value;
 use tracing::Instrument;
 
-use iii_helpers::stream::{SetResult, UpdateResult};
+use iii_helpers::stream::{StreamSetResult, StreamUpdateResult};
 
 use crate::{
     condition::check_condition,
@@ -259,7 +259,7 @@ impl StateWorker {
 #[service(name = "state")]
 impl StateWorker {
     #[function(id = "state::set", description = "Set a value in state")]
-    pub async fn set(&self, input: StateSetInput) -> FunctionResult<SetResult, ErrorBody> {
+    pub async fn set(&self, input: StateSetInput) -> FunctionResult<StreamSetResult, ErrorBody> {
         crate::workers::telemetry::collector::track_state_set();
         match self
             .adapter
@@ -351,7 +351,10 @@ impl StateWorker {
     }
 
     #[function(id = "state::update", description = "Update a value in state")]
-    pub async fn update(&self, input: StateUpdateInput) -> FunctionResult<UpdateResult, ErrorBody> {
+    pub async fn update(
+        &self,
+        input: StateUpdateInput,
+    ) -> FunctionResult<StreamUpdateResult, ErrorBody> {
         crate::workers::telemetry::collector::track_state_update();
         match self
             .adapter
@@ -502,9 +505,9 @@ mod tests {
         list_error: Option<&'static str>,
         list_groups_error: Option<&'static str>,
         destroy_error: Option<&'static str>,
-        set_result: SetResult,
+        set_result: StreamSetResult,
         get_result: Option<Value>,
-        update_result: UpdateResult,
+        update_result: StreamUpdateResult,
         list_values: Vec<Value>,
         groups: Vec<String>,
         destroy_called: AtomicBool,
@@ -520,12 +523,12 @@ mod tests {
                 list_error: None,
                 list_groups_error: None,
                 destroy_error: None,
-                set_result: SetResult {
+                set_result: StreamSetResult {
                     old_value: None,
                     new_value: serde_json::json!({"ok": true}),
                 },
                 get_result: None,
-                update_result: UpdateResult {
+                update_result: StreamUpdateResult {
                     old_value: None,
                     new_value: serde_json::json!({"ok": true}),
                     errors: Vec::new(),
@@ -539,7 +542,12 @@ mod tests {
 
     #[async_trait::async_trait]
     impl StateAdapter for FakeStateAdapter {
-        async fn set(&self, _scope: &str, _key: &str, _value: Value) -> anyhow::Result<SetResult> {
+        async fn set(
+            &self,
+            _scope: &str,
+            _key: &str,
+            _value: Value,
+        ) -> anyhow::Result<StreamSetResult> {
             match self.set_error {
                 Some(message) => Err(anyhow::anyhow!(message)),
                 None => Ok(self.set_result.clone()),
@@ -565,7 +573,7 @@ mod tests {
             _scope: &str,
             _key: &str,
             _ops: Vec<iii_helpers::stream::UpdateOp>,
-        ) -> anyhow::Result<UpdateResult> {
+        ) -> anyhow::Result<StreamUpdateResult> {
             match self.update_error {
                 Some(message) => Err(anyhow::anyhow!(message)),
                 None => Ok(self.update_result.clone()),
@@ -695,7 +703,7 @@ mod tests {
             assert_eq!(val.old_value, Some(serde_json::json!(1)));
             assert_eq!(val.new_value, serde_json::json!(2));
         } else {
-            panic!("Expected Success with SetResult");
+            panic!("Expected Success with StreamSetResult");
         }
 
         // Verify get returns updated value

--- a/engine/src/workers/state/trigger.rs
+++ b/engine/src/workers/state/trigger.rs
@@ -102,7 +102,7 @@ impl TriggerRegistrator for StateWorker {
 
 #[cfg(test)]
 mod tests {
-    use iii_helpers::stream::{SetResult, UpdateOp, UpdateResult};
+    use iii_helpers::stream::{StreamSetResult, StreamUpdateResult, UpdateOp};
     use serde_json::json;
 
     use super::*;
@@ -120,8 +120,8 @@ mod tests {
             _scope: &str,
             _key: &str,
             _value: serde_json::Value,
-        ) -> anyhow::Result<SetResult> {
-            Ok(SetResult {
+        ) -> anyhow::Result<StreamSetResult> {
+            Ok(StreamSetResult {
                 old_value: None,
                 new_value: serde_json::Value::Null,
             })
@@ -140,8 +140,8 @@ mod tests {
             _scope: &str,
             _key: &str,
             _ops: Vec<UpdateOp>,
-        ) -> anyhow::Result<UpdateResult> {
-            Ok(UpdateResult {
+        ) -> anyhow::Result<StreamUpdateResult> {
+            Ok(StreamUpdateResult {
                 old_value: None,
                 new_value: serde_json::Value::Null,
                 errors: Vec::new(),

--- a/engine/src/workers/stream/adapters/bridge.rs
+++ b/engine/src/workers/stream/adapters/bridge.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use iii_helpers::stream::{DeleteResult, SetResult, UpdateOp, UpdateResult};
+use iii_helpers::stream::{StreamDeleteResult, StreamSetResult, StreamUpdateResult, UpdateOp};
 use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
 use iii_sdk::{III, InitOptions, register_worker};
 use serde_json::Value;
@@ -60,7 +60,7 @@ impl StreamAdapter for BridgeAdapter {
         group_id: &str,
         item_id: &str,
         ops: Vec<UpdateOp>,
-    ) -> anyhow::Result<UpdateResult> {
+    ) -> anyhow::Result<StreamUpdateResult> {
         let data = StreamUpdateInput {
             stream_name: stream_name.to_string(),
             group_id: group_id.to_string(),
@@ -79,7 +79,7 @@ impl StreamAdapter for BridgeAdapter {
             .await
             .map_err(|e| anyhow::anyhow!("Failed to update value via bridge: {}", e))?;
 
-        serde_json::from_value::<UpdateResult>(result)
+        serde_json::from_value::<StreamUpdateResult>(result)
             .map_err(|e| anyhow::anyhow!("Failed to deserialize update result: {}", e))
     }
 
@@ -115,7 +115,7 @@ impl StreamAdapter for BridgeAdapter {
         group_id: &str,
         item_id: &str,
         data: Value,
-    ) -> anyhow::Result<SetResult> {
+    ) -> anyhow::Result<StreamSetResult> {
         let input = StreamSetInput {
             stream_name: stream_name.to_string(),
             group_id: group_id.to_string(),
@@ -133,7 +133,7 @@ impl StreamAdapter for BridgeAdapter {
             .await
             .map_err(|e| anyhow::anyhow!("Failed to set value via bridge: {}", e))?;
 
-        serde_json::from_value::<SetResult>(result)
+        serde_json::from_value::<StreamSetResult>(result)
             .map_err(|e| anyhow::anyhow!("Failed to deserialize set result: {}", e))
     }
 
@@ -168,7 +168,7 @@ impl StreamAdapter for BridgeAdapter {
         stream_name: &str,
         group_id: &str,
         item_id: &str,
-    ) -> anyhow::Result<DeleteResult> {
+    ) -> anyhow::Result<StreamDeleteResult> {
         let data = StreamDeleteInput {
             stream_name: stream_name.to_string(),
             group_id: group_id.to_string(),
@@ -185,7 +185,7 @@ impl StreamAdapter for BridgeAdapter {
             .await
             .map_err(|e| anyhow::anyhow!("Failed to delete value via bridge: {}", e))?;
 
-        serde_json::from_value::<DeleteResult>(result)
+        serde_json::from_value::<StreamDeleteResult>(result)
             .map_err(|e| anyhow::anyhow!("Failed to deserialize delete result: {}", e))
     }
 

--- a/engine/src/workers/stream/adapters/kv_store.rs
+++ b/engine/src/workers/stream/adapters/kv_store.rs
@@ -7,7 +7,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
-use iii_helpers::stream::{DeleteResult, SetResult, UpdateOp, UpdateResult};
+use iii_helpers::stream::{StreamDeleteResult, StreamSetResult, StreamUpdateResult, UpdateOp};
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -60,7 +60,7 @@ impl StreamAdapter for BuiltinKvStoreAdapter {
         group_id: &str,
         item_id: &str,
         ops: Vec<UpdateOp>,
-    ) -> anyhow::Result<UpdateResult> {
+    ) -> anyhow::Result<StreamUpdateResult> {
         Ok(self
             .storage
             .update(
@@ -82,7 +82,7 @@ impl StreamAdapter for BuiltinKvStoreAdapter {
         group_id: &str,
         item_id: &str,
         data: Value,
-    ) -> anyhow::Result<SetResult> {
+    ) -> anyhow::Result<StreamSetResult> {
         let index = self.gen_key(stream_name, group_id);
         let result = self
             .storage
@@ -107,7 +107,7 @@ impl StreamAdapter for BuiltinKvStoreAdapter {
         stream_name: &str,
         group_id: &str,
         item_id: &str,
-    ) -> anyhow::Result<DeleteResult> {
+    ) -> anyhow::Result<StreamDeleteResult> {
         let index = self.gen_key(stream_name, group_id);
         let old_value = self.storage.delete(index, item_id.to_string()).await;
 

--- a/engine/src/workers/stream/adapters/mod.rs
+++ b/engine/src/workers/stream/adapters/mod.rs
@@ -11,7 +11,7 @@ pub mod redis_adapter;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use iii_helpers::stream::{DeleteResult, SetResult, UpdateOp, UpdateResult};
+use iii_helpers::stream::{StreamDeleteResult, StreamSetResult, StreamUpdateResult, UpdateOp};
 use serde_json::Value;
 
 use crate::{
@@ -27,7 +27,7 @@ pub trait StreamAdapter: Send + Sync {
         group_id: &str,
         item_id: &str,
         data: Value,
-    ) -> anyhow::Result<SetResult>;
+    ) -> anyhow::Result<StreamSetResult>;
 
     async fn get(
         &self,
@@ -41,7 +41,7 @@ pub trait StreamAdapter: Send + Sync {
         stream_name: &str,
         group_id: &str,
         item_id: &str,
-    ) -> anyhow::Result<DeleteResult>;
+    ) -> anyhow::Result<StreamDeleteResult>;
 
     async fn get_group(&self, stream_name: &str, group_id: &str) -> anyhow::Result<Vec<Value>>;
 
@@ -70,7 +70,7 @@ pub trait StreamAdapter: Send + Sync {
         group_id: &str,
         item_id: &str,
         ops: Vec<UpdateOp>,
-    ) -> anyhow::Result<UpdateResult>;
+    ) -> anyhow::Result<StreamUpdateResult>;
 }
 
 #[async_trait]

--- a/engine/src/workers/stream/adapters/redis_adapter.rs
+++ b/engine/src/workers/stream/adapters/redis_adapter.rs
@@ -26,7 +26,7 @@ use crate::{
         },
     },
 };
-use iii_helpers::stream::{DeleteResult, SetResult, UpdateOp, UpdateResult};
+use iii_helpers::stream::{StreamDeleteResult, StreamSetResult, StreamUpdateResult, UpdateOp};
 
 const STREAM_TOPIC: &str = "stream::events";
 
@@ -73,7 +73,7 @@ impl StreamAdapter for RedisAdapter {
         group_id: &str,
         item_id: &str,
         ops: Vec<UpdateOp>,
-    ) -> anyhow::Result<UpdateResult> {
+    ) -> anyhow::Result<StreamUpdateResult> {
         let mut conn = self.publisher.lock().await;
         let key = format!("stream:{}:{}", stream_name, group_id);
 
@@ -121,7 +121,7 @@ impl StreamAdapter for RedisAdapter {
                         Vec::new()
                     };
 
-                    Ok(UpdateResult {
+                    Ok(StreamUpdateResult {
                         old_value,
                         new_value,
                         errors,
@@ -161,7 +161,7 @@ impl StreamAdapter for RedisAdapter {
         group_id: &str,
         item_id: &str,
         data: Value,
-    ) -> anyhow::Result<SetResult> {
+    ) -> anyhow::Result<StreamSetResult> {
         let key: String = format!("stream:{}:{}", stream_name, group_id);
         let mut conn = self.publisher.lock().await;
         let value = serde_json::to_string(&data).unwrap_or_default();
@@ -201,7 +201,7 @@ impl StreamAdapter for RedisAdapter {
 
         tracing::debug!(stream_name = %stream_name, group_id = %group_id, item_id = %item_id, "Value set in Redis");
 
-        Ok(SetResult {
+        Ok(StreamSetResult {
             old_value,
             new_value,
         })
@@ -230,7 +230,7 @@ impl StreamAdapter for RedisAdapter {
         stream_name: &str,
         group_id: &str,
         item_id: &str,
-    ) -> anyhow::Result<DeleteResult> {
+    ) -> anyhow::Result<StreamDeleteResult> {
         let stream_name = stream_name.to_string();
         let group_id = group_id.to_string();
         let item_id = item_id.to_string();
@@ -268,7 +268,7 @@ impl StreamAdapter for RedisAdapter {
             }
         };
 
-        Ok(DeleteResult { old_value })
+        Ok(StreamDeleteResult { old_value })
     }
 
     async fn get_group(&self, stream_name: &str, group_id: &str) -> anyhow::Result<Vec<Value>> {

--- a/engine/src/workers/stream/socket.rs
+++ b/engine/src/workers/stream/socket.rs
@@ -158,7 +158,7 @@ mod tests {
         routing::get,
     };
     use futures_util::{SinkExt, StreamExt};
-    use iii_helpers::stream::{DeleteResult, SetResult, UpdateResult};
+    use iii_helpers::stream::{StreamDeleteResult, StreamSetResult, StreamUpdateResult};
     use serde_json::{Value, json};
     use tokio::{
         net::TcpListener,
@@ -226,8 +226,8 @@ mod tests {
             _group_id: &str,
             _item_id: &str,
             data: Value,
-        ) -> anyhow::Result<SetResult> {
-            Ok(SetResult {
+        ) -> anyhow::Result<StreamSetResult> {
+            Ok(StreamSetResult {
                 old_value: None,
                 new_value: data,
             })
@@ -247,8 +247,8 @@ mod tests {
             _stream_name: &str,
             _group_id: &str,
             _item_id: &str,
-        ) -> anyhow::Result<DeleteResult> {
-            Ok(DeleteResult { old_value: None })
+        ) -> anyhow::Result<StreamDeleteResult> {
+            Ok(StreamDeleteResult { old_value: None })
         }
 
         async fn get_group(
@@ -319,8 +319,8 @@ mod tests {
             _group_id: &str,
             _item_id: &str,
             _ops: Vec<iii_helpers::stream::UpdateOp>,
-        ) -> anyhow::Result<UpdateResult> {
-            Ok(UpdateResult {
+        ) -> anyhow::Result<StreamUpdateResult> {
+            Ok(StreamUpdateResult {
                 old_value: None,
                 new_value: json!({}),
                 errors: Vec::new(),

--- a/engine/src/workers/stream/stream.rs
+++ b/engine/src/workers/stream/stream.rs
@@ -20,7 +20,7 @@ use axum::{
 use chrono::Utc;
 use colored::Colorize;
 use function_macros::{function, service};
-use iii_helpers::stream::{DeleteResult, SetResult, UpdateResult};
+use iii_helpers::stream::{StreamDeleteResult, StreamSetResult, StreamUpdateResult};
 use once_cell::sync::Lazy;
 use serde_json::Value;
 use tokio::{net::TcpListener, task::AbortHandle};
@@ -435,7 +435,7 @@ impl StreamWorker {
 #[service(name = "stream")]
 impl StreamWorker {
     #[function(id = "stream::set", description = "Set a value in a stream")]
-    pub async fn set(&self, input: StreamSetInput) -> FunctionResult<SetResult, ErrorBody> {
+    pub async fn set(&self, input: StreamSetInput) -> FunctionResult<StreamSetResult, ErrorBody> {
         let cloned_input = input.clone();
         let stream_name = input.stream_name;
         let group_id = input.group_id;
@@ -446,7 +446,7 @@ impl StreamWorker {
         let function = self.engine.functions.get(&function_id);
         let adapter = self.adapter.clone();
 
-        let result: anyhow::Result<SetResult> = match function {
+        let result: anyhow::Result<StreamSetResult> = match function {
             Some(_) => {
                 tracing::debug!(function_id = %function_id, "Calling custom stream.set function");
 
@@ -463,7 +463,7 @@ impl StreamWorker {
                 let result = self.engine.call(&function_id, input).await;
 
                 match result {
-                    Ok(Some(result)) => match serde_json::from_value::<SetResult>(result) {
+                    Ok(Some(result)) => match serde_json::from_value::<StreamSetResult>(result) {
                         Ok(result) => Ok(result),
                         Err(e) => {
                             return FunctionResult::Failure(ErrorBody {
@@ -574,7 +574,7 @@ impl StreamWorker {
     pub async fn delete(
         &self,
         input: StreamDeleteInput,
-    ) -> FunctionResult<DeleteResult, ErrorBody> {
+    ) -> FunctionResult<StreamDeleteResult, ErrorBody> {
         let cloned_input = input.clone();
         let stream_name = input.stream_name;
         let group_id = input.group_id;
@@ -583,7 +583,7 @@ impl StreamWorker {
         let function = self.engine.functions.get(&function_id);
         let adapter = self.adapter.clone();
 
-        let result: anyhow::Result<DeleteResult> = match function {
+        let result: anyhow::Result<StreamDeleteResult> = match function {
             Some(_) => {
                 tracing::debug!(function_id = %function_id, "Calling custom stream.delete function");
 
@@ -600,7 +600,7 @@ impl StreamWorker {
                 let result = self.engine.call(&function_id, input).await;
                 match result {
                     Ok(Some(result)) => {
-                        let result = match serde_json::from_value::<DeleteResult>(result) {
+                        let result = match serde_json::from_value::<StreamDeleteResult>(result) {
                             Ok(result) => result,
                             Err(e) => {
                                 return FunctionResult::Failure(ErrorBody {
@@ -812,7 +812,7 @@ impl StreamWorker {
     pub async fn update(
         &self,
         input: StreamUpdateInput,
-    ) -> FunctionResult<UpdateResult, ErrorBody> {
+    ) -> FunctionResult<StreamUpdateResult, ErrorBody> {
         let cloned_input = input.clone();
         let stream_name = input.stream_name;
         let group_id = input.group_id;
@@ -825,7 +825,7 @@ impl StreamWorker {
         let function = self.engine.functions.get(&function_id);
         let adapter = self.adapter.clone();
 
-        let result: anyhow::Result<UpdateResult> = match function {
+        let result: anyhow::Result<StreamUpdateResult> = match function {
             Some(_) => {
                 tracing::debug!(function_id = %function_id, "Calling custom stream.set function");
 
@@ -842,16 +842,18 @@ impl StreamWorker {
                 let result = self.engine.call(&function_id, input).await;
 
                 match result {
-                    Ok(Some(result)) => match serde_json::from_value::<UpdateResult>(result) {
-                        Ok(result) => Ok(result),
-                        Err(e) => {
-                            return FunctionResult::Failure(ErrorBody {
-                                message: format!("Failed to convert result to value: {}", e),
-                                code: "JSON_ERROR".to_string(),
-                                stacktrace: None,
-                            });
+                    Ok(Some(result)) => {
+                        match serde_json::from_value::<StreamUpdateResult>(result) {
+                            Ok(result) => Ok(result),
+                            Err(e) => {
+                                return FunctionResult::Failure(ErrorBody {
+                                    message: format!("Failed to convert result to value: {}", e),
+                                    code: "JSON_ERROR".to_string(),
+                                    stacktrace: None,
+                                });
+                            }
                         }
-                    },
+                    }
                     Ok(None) => Err(anyhow::anyhow!("Function returned no result")),
                     Err(error) => Err(anyhow::anyhow!("Failed to invoke function: {:?}", error)),
                 }
@@ -913,7 +915,7 @@ mod tests {
     };
 
     use async_trait::async_trait;
-    use iii_helpers::stream::{DeleteResult, SetResult, UpdateOp, UpdateResult};
+    use iii_helpers::stream::{StreamDeleteResult, StreamSetResult, StreamUpdateResult, UpdateOp};
     use serde_json::Value;
     use tokio::sync::mpsc;
 
@@ -982,14 +984,14 @@ mod tests {
     }
 
     struct FakeStreamAdapter {
-        set_result: Mutex<Result<SetResult, String>>,
+        set_result: Mutex<Result<StreamSetResult, String>>,
         get_result: Mutex<Result<Option<Value>, String>>,
-        delete_result: Mutex<Result<DeleteResult, String>>,
+        delete_result: Mutex<Result<StreamDeleteResult, String>>,
         get_group_result: Mutex<Result<Vec<Value>, String>>,
         list_groups_result: Mutex<Result<Vec<String>, String>>,
         list_all_result: Mutex<Result<Vec<StreamMetadata>, String>>,
         emit_event_result: Mutex<Result<(), String>>,
-        update_result: Mutex<Result<UpdateResult, String>>,
+        update_result: Mutex<Result<StreamUpdateResult, String>>,
         emitted_messages: Mutex<Vec<StreamWrapperMessage>>,
         destroy_called: AtomicBool,
         watch_events_called: AtomicBool,
@@ -998,17 +1000,17 @@ mod tests {
     impl Default for FakeStreamAdapter {
         fn default() -> Self {
             Self {
-                set_result: Mutex::new(Ok(SetResult {
+                set_result: Mutex::new(Ok(StreamSetResult {
                     old_value: None,
                     new_value: serde_json::json!({}),
                 })),
                 get_result: Mutex::new(Ok(None)),
-                delete_result: Mutex::new(Ok(DeleteResult { old_value: None })),
+                delete_result: Mutex::new(Ok(StreamDeleteResult { old_value: None })),
                 get_group_result: Mutex::new(Ok(Vec::new())),
                 list_groups_result: Mutex::new(Ok(Vec::new())),
                 list_all_result: Mutex::new(Ok(Vec::new())),
                 emit_event_result: Mutex::new(Ok(())),
-                update_result: Mutex::new(Ok(UpdateResult {
+                update_result: Mutex::new(Ok(StreamUpdateResult {
                     old_value: None,
                     new_value: serde_json::json!({}),
                     errors: Vec::new(),
@@ -1028,7 +1030,7 @@ mod tests {
             _group_id: &str,
             _item_id: &str,
             _data: Value,
-        ) -> anyhow::Result<SetResult> {
+        ) -> anyhow::Result<StreamSetResult> {
             self.set_result
                 .lock()
                 .expect("lock set_result")
@@ -1054,7 +1056,7 @@ mod tests {
             _stream_name: &str,
             _group_id: &str,
             _item_id: &str,
-        ) -> anyhow::Result<DeleteResult> {
+        ) -> anyhow::Result<StreamDeleteResult> {
             self.delete_result
                 .lock()
                 .expect("lock delete_result")
@@ -1130,7 +1132,7 @@ mod tests {
             _group_id: &str,
             _item_id: &str,
             _ops: Vec<UpdateOp>,
-        ) -> anyhow::Result<UpdateResult> {
+        ) -> anyhow::Result<StreamUpdateResult> {
             self.update_result
                 .lock()
                 .expect("lock update_result")
@@ -1760,7 +1762,7 @@ mod tests {
                     data: serde_json::json!({ "ignored": true }),
                 })
                 .await,
-            FunctionResult::Success(SetResult { new_value, .. }) if new_value == serde_json::json!({ "from": "custom-set" })
+            FunctionResult::Success(StreamSetResult { new_value, .. }) if new_value == serde_json::json!({ "from": "custom-set" })
         ));
         assert!(matches!(
             module
@@ -1770,7 +1772,7 @@ mod tests {
                     item_id: "item".to_string(),
                 })
                 .await,
-            FunctionResult::Success(DeleteResult { old_value: Some(value) }) if value == serde_json::json!({ "from": "custom-delete" })
+            FunctionResult::Success(StreamDeleteResult { old_value: Some(value) }) if value == serde_json::json!({ "from": "custom-delete" })
         ));
         assert!(matches!(
             module
@@ -1781,7 +1783,7 @@ mod tests {
                     ops: vec![UpdateOp::set("", serde_json::json!({ "count": 2 }))],
                 })
                 .await,
-            FunctionResult::Success(UpdateResult { new_value, .. }) if new_value == serde_json::json!({ "count": 2 })
+            FunctionResult::Success(StreamUpdateResult { new_value, .. }) if new_value == serde_json::json!({ "count": 2 })
         ));
     }
 

--- a/engine/tests/state_stream_update_e2e.rs
+++ b/engine/tests/state_stream_update_e2e.rs
@@ -3,7 +3,7 @@
 //
 // Closes iii-hq/iii#1546. Each test here exercises behavior that
 // requires going through `BuiltinKvStore` (persistence across calls,
-// op-batch interleaving, error plumbing into `UpdateResult`). The
+// op-batch interleaving, error plumbing into `StreamUpdateResult`). The
 // in-batch nested-merge mechanics — auto-create intermediates, replace
 // non-object intermediates, validation rejections — are covered by
 // the unit tests in `engine/src/update_ops.rs`.

--- a/sdk/packages/node/helpers/src/stream/index.ts
+++ b/sdk/packages/node/helpers/src/stream/index.ts
@@ -246,7 +246,7 @@ export type UpdateOpError = {
 }
 
 /** Result of a stream delete operation. */
-export type DeleteResult = {
+export type StreamDeleteResult = {
   /** Previous value (if it existed). */
   // biome-ignore lint/suspicious/noExplicitAny: any is fine here
   old_value?: any
@@ -296,6 +296,15 @@ export interface StreamJoinLeaveTriggerConfig {
   condition_function_id?: string
 }
 
+/** Detail of a stream change event containing the mutation type and data. */
+export type StreamChangeEventDetail = {
+  /** The kind of mutation (create, update, or delete). */
+  type: 'create' | 'update' | 'delete'
+  /** The data associated with the event. */
+  // biome-ignore lint/suspicious/noExplicitAny: any is fine here
+  data: any
+}
+
 /** Handler input for `stream` triggers, fired when an item changes via `stream::set`, `stream::update`, or `stream::delete`. */
 export interface StreamChangeEvent {
   /** The event type. */
@@ -308,10 +317,6 @@ export interface StreamChangeEvent {
   groupId: string
   /** The item ID that changed. */
   id?: string
-  /** The event detail object containing `type` and `data` fields. */
-  event: {
-    type: 'create' | 'update' | 'delete'
-    // biome-ignore lint/suspicious/noExplicitAny: any is fine here
-    data: any
-  }
+  /** The event detail containing mutation type and data. */
+  event: StreamChangeEventDetail
 }

--- a/sdk/packages/node/iii/src/stream.ts
+++ b/sdk/packages/node/iii/src/stream.ts
@@ -1,6 +1,6 @@
 import type {
-  DeleteResult,
   StreamDeleteInput,
+  StreamDeleteResult,
   StreamGetInput,
   StreamListGroupsInput,
   StreamListInput,
@@ -22,7 +22,7 @@ export interface IStream<TData> {
   /** Set (create or overwrite) a stream item. */
   set(input: StreamSetInput): Promise<StreamSetResult<TData> | null>
   /** Delete a stream item. */
-  delete(input: StreamDeleteInput): Promise<DeleteResult>
+  delete(input: StreamDeleteInput): Promise<StreamDeleteResult>
   /** List all items in a group. */
   list(input: StreamListInput): Promise<TData[]>
   /** List all group IDs in a stream. */

--- a/sdk/packages/python/helpers/src/iii_helpers/stream/__init__.py
+++ b/sdk/packages/python/helpers/src/iii_helpers/stream/__init__.py
@@ -7,6 +7,7 @@ from typing import Any, Generic, Literal, TypeVar
 from pydantic import BaseModel, Field, model_serializer
 
 __all__ = [
+    "MergePath",
     "StreamAuthInput",
     "StreamAuthResult",
     "StreamChangeEvent",
@@ -36,6 +37,12 @@ __all__ = [
 ]
 
 TData = TypeVar("TData")
+
+# Path target for a ``merge`` / ``append`` op. Accepts either a single
+# string (legacy / first-level key) or a list of literal segments
+# (nested path). Mirrors the Node ``string | string[]`` alias and the
+# Rust ``MergePath`` enum.
+MergePath = str | list[str]
 
 
 class StreamAuthInput(BaseModel):
@@ -222,8 +229,8 @@ class UpdateAppend(BaseModel):
     type: str = "append"
     # Optional. Accepts a single string (legacy / first-level key) or
     # a list of literal segments (nested append). ``None`` / ``""`` /
-    # ``[]`` all route to root append.
-    path: str | list[str] | None = None
+    # ``[]`` all route to root append. See :data:`MergePath`.
+    path: MergePath | None = None
     value: Any
 
     @model_serializer(mode="wrap")
@@ -276,8 +283,8 @@ class UpdateMerge(BaseModel):
     type: str = "merge"
     # Optional. Accepts a single string or a list of literal segments.
     # Pydantic resolves ``str | list[str]`` via smart-union: string
-    # input -> str, array input -> list[str].
-    path: str | list[str] | None = None
+    # input -> str, array input -> list[str]. See :data:`MergePath`.
+    path: MergePath | None = None
     value: Any
 
     @model_serializer(mode="wrap")

--- a/sdk/packages/python/iii/src/iii/__init__.py
+++ b/sdk/packages/python/iii/src/iii/__init__.py
@@ -12,7 +12,6 @@ from .iii_constants import (
 )
 from .iii_types import (
     MiddlewareFunctionInput,
-    StreamChannelRef,
     TriggerActionEnqueue,
 )
 from .stream import IStream
@@ -39,7 +38,6 @@ __all__ = [
     # RBAC types
     "MiddlewareFunctionInput",
     # Message types
-    "StreamChannelRef",
     "TriggerActionEnqueue",
     # Triggers
     "Trigger",
@@ -66,4 +64,15 @@ def __getattr__(name: str) -> Any:
             stacklevel=2,
         )
         return InvocationError
+    if name == "StreamChannelRef":
+        import warnings
+
+        warnings.warn(
+            "Importing StreamChannelRef from iii is deprecated; import it from iii.channel",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from .channel import StreamChannelRef
+
+        return StreamChannelRef
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/sdk/packages/rust/helpers/src/stream.rs
+++ b/sdk/packages/rust/helpers/src/stream.rs
@@ -209,7 +209,7 @@ pub struct UpdateOpError {
 
 /// Result of an atomic update operation
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct UpdateResult {
+pub struct StreamUpdateResult {
     /// The value before the update (None if key didn't exist)
     pub old_value: Option<Value>,
     /// The value after the update
@@ -222,7 +222,7 @@ pub struct UpdateResult {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct SetResult {
+pub struct StreamSetResult {
     /// The value before the update (None if key didn't exist)
     pub old_value: Option<Value>,
     /// The value after the update
@@ -230,7 +230,7 @@ pub struct SetResult {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
-pub struct DeleteResult {
+pub struct StreamDeleteResult {
     /// The value before the update (None if key didn't exist)
     pub old_value: Option<Value>,
 }
@@ -430,7 +430,7 @@ pub enum StreamEventType {
 
 /// Detail of a stream change event containing the mutation type and data.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct StreamEventDetail {
+pub struct StreamChangeEventDetail {
     /// The kind of mutation (create, update, or delete).
     #[serde(rename = "type")]
     pub event_type: StreamEventType,
@@ -456,7 +456,7 @@ pub struct StreamChangeEvent {
     /// The item ID that changed.
     pub id: Option<String>,
     /// The event detail containing mutation type and data.
-    pub event: StreamEventDetail,
+    pub event: StreamChangeEventDetail,
 }
 
 #[cfg(test)]
@@ -664,7 +664,7 @@ mod tests {
 
     #[test]
     fn update_result_with_errors_serializes_field() {
-        let result = UpdateResult {
+        let result = StreamUpdateResult {
             old_value: None,
             new_value: serde_json::json!({"a": 1}),
             errors: vec![UpdateOpError {
@@ -680,7 +680,7 @@ mod tests {
 
     #[test]
     fn update_result_without_errors_omits_field_from_json() {
-        let result = UpdateResult {
+        let result = StreamUpdateResult {
             old_value: None,
             new_value: serde_json::json!({"a": 1}),
             errors: vec![],

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -39,7 +39,7 @@ pub mod errors {
 // `iii-sdk/internal` (Node) and `iii.internal` (Python) have no crate-root
 // equivalent here. There is no `InternalHttpRequest` (the Rust SDK uses
 // `iii_helpers::http::HttpRequest`), and the stream result types
-// (`SetResult`, `UpdateResult`, `DeleteResult`) live in `iii_helpers::stream`
+// (`StreamSetResult`, `StreamUpdateResult`, `StreamDeleteResult`) live in `iii_helpers::stream`
 // and are consumed inside `stream_provider.rs` — they are not re-exported at
 // the crate root. Grouping them here would re-surface clean-break helpers
 // types into the SDK, which the `compile_fail` doctests below deliberately

--- a/sdk/packages/rust/iii/src/stream_provider.rs
+++ b/sdk/packages/rust/iii/src/stream_provider.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use iii_helpers::stream::{
-    DeleteResult, SetResult, StreamDeleteInput, StreamGetInput, StreamListGroupsInput,
-    StreamListInput, StreamSetInput, StreamUpdateInput, UpdateResult,
+    StreamDeleteInput, StreamDeleteResult, StreamGetInput, StreamListGroupsInput, StreamListInput,
+    StreamSetInput, StreamSetResult, StreamUpdateInput, StreamUpdateResult,
 };
 use serde_json::Value;
 
@@ -13,9 +13,9 @@ use crate::error::Error;
 #[async_trait]
 pub trait IStream: Send + Sync + 'static {
     async fn get(&self, input: StreamGetInput) -> Result<Option<Value>, Error>;
-    async fn set(&self, input: StreamSetInput) -> Result<Option<SetResult>, Error>;
-    async fn delete(&self, input: StreamDeleteInput) -> Result<DeleteResult, Error>;
+    async fn set(&self, input: StreamSetInput) -> Result<Option<StreamSetResult>, Error>;
+    async fn delete(&self, input: StreamDeleteInput) -> Result<StreamDeleteResult, Error>;
     async fn list(&self, input: StreamListInput) -> Result<Vec<Value>, Error>;
     async fn list_groups(&self, input: StreamListGroupsInput) -> Result<Vec<String>, Error>;
-    async fn update(&self, input: StreamUpdateInput) -> Result<Option<UpdateResult>, Error>;
+    async fn update(&self, input: StreamUpdateInput) -> Result<Option<StreamUpdateResult>, Error>;
 }

--- a/sdk/packages/rust/iii/tests/stream_provider_trait.rs
+++ b/sdk/packages/rust/iii/tests/stream_provider_trait.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use iii_helpers::stream::{
-    DeleteResult, SetResult, StreamDeleteInput, StreamGetInput, StreamListGroupsInput,
-    StreamListInput, StreamSetInput, StreamUpdateInput, UpdateResult,
+    StreamDeleteInput, StreamDeleteResult, StreamGetInput, StreamListGroupsInput, StreamListInput,
+    StreamSetInput, StreamSetResult, StreamUpdateInput, StreamUpdateResult,
 };
 use iii_sdk::IStream;
 use serde_json::Value;
@@ -13,11 +13,11 @@ impl IStream for DummyStream {
     async fn get(&self, _: StreamGetInput) -> Result<Option<Value>, iii_sdk::Error> {
         Ok(None)
     }
-    async fn set(&self, _: StreamSetInput) -> Result<Option<SetResult>, iii_sdk::Error> {
+    async fn set(&self, _: StreamSetInput) -> Result<Option<StreamSetResult>, iii_sdk::Error> {
         Ok(None)
     }
-    async fn delete(&self, _: StreamDeleteInput) -> Result<DeleteResult, iii_sdk::Error> {
-        Ok(DeleteResult::default())
+    async fn delete(&self, _: StreamDeleteInput) -> Result<StreamDeleteResult, iii_sdk::Error> {
+        Ok(StreamDeleteResult::default())
     }
     async fn list(&self, _: StreamListInput) -> Result<Vec<Value>, iii_sdk::Error> {
         Ok(vec![])
@@ -25,7 +25,10 @@ impl IStream for DummyStream {
     async fn list_groups(&self, _: StreamListGroupsInput) -> Result<Vec<String>, iii_sdk::Error> {
         Ok(vec![])
     }
-    async fn update(&self, _: StreamUpdateInput) -> Result<Option<UpdateResult>, iii_sdk::Error> {
+    async fn update(
+        &self,
+        _: StreamUpdateInput,
+    ) -> Result<Option<StreamUpdateResult>, iii_sdk::Error> {
         Ok(None)
     }
 }


### PR DESCRIPTION
## What

Closes the residual cross-language parity gaps found in the `@iii-dev/helpers` `stream` submodule. Renames only, no wire/field change.

- **Detail type** unified as `StreamChangeEventDetail`: Rust `StreamEventDetail` renamed; Node's inline `StreamChangeEvent.event` extracted to a named type; Python already matched.
- **`MergePath`** added to the Python helpers/stream public surface (`__all__` + used on `UpdateMerge.path`/`UpdateAppend.path`); Node and Rust already exported it.
- **Result types** unified to `StreamSetResult`/`StreamUpdateResult`/`StreamDeleteResult` across all three: Rust `SetResult`/`UpdateResult`/`DeleteResult` and Node `DeleteResult` renamed; Python already prefixed. Engine and workspace crates repointed to the new names.
- **Python `StreamChannelRef`** root access is now deprecated (via `__getattr__`, mirroring `IIIInvocationError`), matching the Node/Rust deprecated-alias model; still resolvable from root and from `iii.channel`.

## Verification

Node build + `tsc --noEmit` + helpers type-check; Python mypy + ruff (iii + helpers); Rust build + lib/doc tests + clippy `-D warnings` + fmt; `cargo build -p iii` (engine) + `cargo test -p iii --no-run`. Old names (`StreamEventDetail`, bare stream `SetResult`/`UpdateResult`/`DeleteResult`) gone; the distinct CLI `update::UpdateResult` enum correctly left untouched. Docs `helpers-lib.mdx` + `.skill.md` updated.

## Out of scope

`sdk/packages/node/iii-browser` carries its own independent copies of the stream types (not imported from helpers) and still uses the old `DeleteResult` name / inline event detail. A follow-up could align it.

Base: `sdk-refactor`.