### PR TITLE
docs(changelog): collapse the Changelog tab to a single index page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -156,28 +156,8 @@
           },
           {
             "tab": "Changelog",
-            "groups": [
-              {
-                "group": "Changelog",
-                "pages": [
-                  "changelog/index"
-                ]
-              },
-              {
-                "group": "0.16.0",
-                "pages": [
-                  "changelog/0-16-0/align-rust-register-function-with-signature"
-                ]
-              },
-              {
-                "group": "0.11.0",
-                "pages": [
-                  "changelog/0-11-0/everything-is-a-worker",
-                  "changelog/0-11-0/migrating-from-motia-js",
-                  "changelog/0-11-0/migrating-from-motia-py",
-                  "changelog/0-11-0/migrated-examples"
-                ]
-              }
+            "pages": [
+              "changelog/index"
             ]
           }
         ]
@@ -273,28 +253,8 @@
           },
           {
             "tab": "Changelog",
-            "groups": [
-              {
-                "group": "Changelog",
-                "pages": [
-                  "changelog/index"
-                ]
-              },
-              {
-                "group": "0.16.0",
-                "pages": [
-                  "changelog/0-16-0/align-rust-register-function-with-signature"
-                ]
-              },
-              {
-                "group": "0.11.0",
-                "pages": [
-                  "changelog/0-11-0/everything-is-a-worker",
-                  "changelog/0-11-0/migrating-from-motia-js",
-                  "changelog/0-11-0/migrating-from-motia-py",
-                  "changelog/0-11-0/migrated-examples"
-                ]
-              }
+            "pages": [
+              "changelog/index"
             ]
           }
         ]
@@ -387,28 +347,8 @@
           },
           {
             "tab": "Changelog",
-            "groups": [
-              {
-                "group": "Changelog",
-                "pages": [
-                  "changelog/index"
-                ]
-              },
-              {
-                "group": "0.16.0",
-                "pages": [
-                  "changelog/0-16-0/align-rust-register-function-with-signature"
-                ]
-              },
-              {
-                "group": "0.11.0",
-                "pages": [
-                  "changelog/0-11-0/everything-is-a-worker",
-                  "changelog/0-11-0/migrating-from-motia-js",
-                  "changelog/0-11-0/migrating-from-motia-py",
-                  "changelog/0-11-0/migrated-examples"
-                ]
-              }
+            "pages": [
+              "changelog/index"
             ]
           }
         ]
@@ -483,28 +423,8 @@
           },
           {
             "tab": "Changelog",
-            "groups": [
-              {
-                "group": "Changelog",
-                "pages": [
-                  "changelog/index"
-                ]
-              },
-              {
-                "group": "0.16.0",
-                "pages": [
-                  "changelog/0-16-0/align-rust-register-function-with-signature"
-                ]
-              },
-              {
-                "group": "0.11.0",
-                "pages": [
-                  "changelog/0-11-0/everything-is-a-worker",
-                  "changelog/0-11-0/migrating-from-motia-js",
-                  "changelog/0-11-0/migrating-from-motia-py",
-                  "changelog/0-11-0/migrated-examples"
-                ]
-              }
+            "pages": [
+              "changelog/index"
             ]
           }
         ]
@@ -579,28 +499,8 @@
           },
           {
             "tab": "Changelog",
-            "groups": [
-              {
-                "group": "Changelog",
-                "pages": [
-                  "changelog/index"
-                ]
-              },
-              {
-                "group": "0.16.0",
-                "pages": [
-                  "changelog/0-16-0/align-rust-register-function-with-signature"
-                ]
-              },
-              {
-                "group": "0.11.0",
-                "pages": [
-                  "changelog/0-11-0/everything-is-a-worker",
-                  "changelog/0-11-0/migrating-from-motia-js",
-                  "changelog/0-11-0/migrating-from-motia-py",
-                  "changelog/0-11-0/migrated-examples"
-                ]
-              }
+            "pages": [
+              "changelog/index"
             ]
           }
         ]
@@ -677,22 +577,8 @@
           },
           {
             "tab": "Changelog",
-            "groups": [
-              {
-                "group": "Changelog",
-                "pages": [
-                  "changelog/index"
-                ]
-              },
-              {
-                "group": "0.11.0",
-                "pages": [
-                  "changelog/0-11-0/everything-is-a-worker",
-                  "changelog/0-11-0/migrating-from-motia-js",
-                  "changelog/0-11-0/migrating-from-motia-py",
-                  "changelog/0-11-0/migrated-examples"
-                ]
-              }
+            "pages": [
+              "changelog/index"
             ]
           }
         ]
@@ -769,22 +655,8 @@
           },
           {
             "tab": "Changelog",
-            "groups": [
-              {
-                "group": "Changelog",
-                "pages": [
-                  "changelog/index"
-                ]
-              },
-              {
-                "group": "0.11.0",
-                "pages": [
-                  "changelog/0-11-0/everything-is-a-worker",
-                  "changelog/0-11-0/migrating-from-motia-js",
-                  "changelog/0-11-0/migrating-from-motia-py",
-                  "changelog/0-11-0/migrated-examples"
-                ]
-              }
+            "pages": [
+              "changelog/index"
             ]
           }
         ]
@@ -953,22 +825,8 @@
           },
           {
             "tab": "Changelog",
-            "groups": [
-              {
-                "group": "Changelog",
-                "pages": [
-                  "changelog"
-                ]
-              },
-              {
-                "group": "0.11.0",
-                "pages": [
-                  "changelog/0-11-0/everything-is-a-worker",
-                  "changelog/0-11-0/migrating-from-motia-js",
-                  "changelog/0-11-0/migrating-from-motia-py",
-                  "changelog/0-11-0/migrated-examples"
-                ]
-              }
+            "pages": [
+              "changelog"
             ]
           }
         ]


### PR DESCRIPTION
## What

Removes the per-version sidebar navigation from the **Changelog** tab. Every versioned section (0.20.x → 0.11.x) now points the Changelog tab straight at `changelog/index` — a single `pages` entry instead of `groups` with version-gated sub-entries.

## Why

The earlier approach mirrored each release into per-feature sidebar pages, which meant **maintaining the release notes in two places** (the `changelog/index` notes *and* the per-feature pages + `docs.json` groups). Every new release required updating both.

Collapsing to the single index page makes `changelog/index.mdx` the **one source of truth**. New releases the upstream adds to the index now show up automatically — no sidebar bookkeeping. `/changelog` still renders every release.

## Changes

- `docs/docs.json` — each version's Changelog tab converted from `groups` (Changelog / 0.16.0 / 0.11.0 / …) to a flat `pages: ["changelog/index"]`. Net: +16 / −158, single file.
- No content change to `changelog/index.mdx`; it keeps the full release notes.
- The `0-11-0/` and `0-16-0/` migration deep-dives stay as files (linked inline from the index), they're just no longer separate sidebar groups.

## Notes

- This supersedes the original per-feature-sidebar design in this branch (squashed away) — the single-page layout was chosen after local testing to avoid dual maintenance.
- CodeRabbit flagged the flattening as a regression against the *old* PR goal; that's expected — the single-source layout is the intended outcome, not an accidental removal.

Draft — open for review.