### PR TITLE
fix(ci): use counter_prefix in release version notice

### DIFF
--- a/.github/scripts/calculate_release_version.py
+++ b/.github/scripts/calculate_release_version.py
@@ -262,7 +262,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.dry_run:
         base_ver = new_ver.split("-", 1)[0]
-        counter = next_dry_run_counter(base_ver, tags, tag_prefix)
+        counter = next_dry_run_counter(base_ver, tags, counter_prefix)
         new_ver = f"{base_ver}-dry-run.{counter}"
 
     py_ver = to_pep440(new_ver)
@@ -275,7 +275,7 @@ def main(argv: list[str] | None = None) -> int:
     _emit("current", current)
     _emit("is_prerelease", "true" if is_prerelease else "false")
     _emit("npm_tag", npm_tag)
-    print(f"::notice::{tag_prefix}: {current} -> {new_ver} (python: {py_ver})", file=sys.stderr)
+    print(f"::notice::{counter_prefix}: {current} -> {new_ver} (python: {py_ver})", file=sys.stderr)
     return 0
 
 


### PR DESCRIPTION
## Problem

The release job (`Bump Versions & Create Tag` → `Calculate versions`) crashed with:

```
NameError: name 'tag_prefix' is not defined. Did you mean: 'stable_prefix'?
```

`.github/scripts/calculate_release_version.py` computed the version correctly and emitted all outputs, then crashed on the final `::notice::` print because `tag_prefix` does not exist in `main()` — it's only a parameter inside `calculate_version`. The local names are `stable_prefix` / `counter_prefix`. Leftover from an incomplete rename.

## Fix

- Line 278 (`::notice::`): `tag_prefix` → `counter_prefix`
- Line 265 (`--dry-run` counter): same latent bug, also fixed (only triggers on dry-run path)

## Test

`python3 -m ast` parse passes; remaining `tag_prefix` references are function parameters in their own scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the internal release versioning calculation utility to improve handling of prerelease operations in dry-run mode, with enhancements to workflow notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->