### PR TITLE
fix(iii-worker): rerun install on `worker add --force` when dependencies change

### DIFF
--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -553,12 +553,18 @@ pub async fn handle_local_add(
             // Expected when the full managed-dir wipe above already succeeded.
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => {
+                // Abort: a surviving marker makes the next boot skip
+                // setup/install and reuse stale deps (MOT-3585). Failing here
+                // is better than reporting --force success with stale gating.
                 eprintln!(
-                    "  {} could not remove prepared marker {}: {}",
-                    "warning:".yellow(),
+                    "{} could not remove the prepared marker {}: {}\n  \
+                     Aborting --force so the worker is not left with a stale \
+                     reinstall marker; fix the error (e.g. permissions) and retry.",
+                    "error:".red(),
                     prepared_marker.display(),
                     e
                 );
+                return 1;
             }
         }
         if reset_config {

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -545,12 +545,7 @@ pub async fn handle_local_add(
         // file (e.g. added a package to pyproject.toml) gets the stale cache
         // and a ModuleNotFoundError at runtime. Removing the tiny marker file
         // is far more reliable than the recursive dir wipe.
-        let prepared_marker = dirs::home_dir()
-            .unwrap_or_default()
-            .join(".iii/managed")
-            .join(&worker_name)
-            .join("var")
-            .join(".iii-prepared");
+        let prepared_marker = super::managed::prepared_marker_path(&worker_name);
         match std::fs::remove_file(&prepared_marker) {
             Ok(()) => {
                 tracing::debug!(marker = %prepared_marker.display(), "removed prepared marker on --force");
@@ -1009,7 +1004,10 @@ async fn start_worker_impl(
     //    in the fast path. Printing a "Using cached deps" banner every
     //    start made it look like install was running every restart (it
     //    wasn't), which confused users reading watcher.log tails.
-    let prepared_marker = managed_dir.join("var").join(".iii-prepared");
+    // Derive from the already-resolved `managed_dir` (built behind the strict
+    // home_dir() guard above) rather than re-resolving via worker name, so the
+    // marker check can't diverge from the dir this function actually uses.
+    let prepared_marker = super::managed::prepared_marker_in(&managed_dir);
     let is_prepared = prepared_marker.exists();
 
     // 6. Build env with engine URL + OCI env + config.yaml env

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -537,6 +537,35 @@ pub async fn handle_local_add(
                 freed as f64 / 1_048_576.0
             );
         }
+        // Defense-in-depth (MOT-3585): guarantee the in-VM dependency install
+        // reruns on --force even if delete_worker_artifacts above partially
+        // failed and left the managed dir (and its `.iii-prepared` marker) on
+        // disk. The marker is what gates setup_cmd/install_cmd in
+        // build_libkrun_local_script; if it survives, a user who changed a lock
+        // file (e.g. added a package to pyproject.toml) gets the stale cache
+        // and a ModuleNotFoundError at runtime. Removing the tiny marker file
+        // is far more reliable than the recursive dir wipe.
+        let prepared_marker = dirs::home_dir()
+            .unwrap_or_default()
+            .join(".iii/managed")
+            .join(&worker_name)
+            .join("var")
+            .join(".iii-prepared");
+        match std::fs::remove_file(&prepared_marker) {
+            Ok(()) => {
+                tracing::debug!(marker = %prepared_marker.display(), "removed prepared marker on --force");
+            }
+            // Expected when the full managed-dir wipe above already succeeded.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                eprintln!(
+                    "  {} could not remove prepared marker {}: {}",
+                    "warning:".yellow(),
+                    prepared_marker.display(),
+                    e
+                );
+            }
+        }
         if reset_config {
             let _ = super::config_file::remove_worker(&worker_name);
         }

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -6192,7 +6192,10 @@ dependencies:
             std::fs::create_dir_all(&image_dir).unwrap();
             std::fs::write(image_dir.join("layer.tar"), "fake image bytes").unwrap();
             let image_bytes = dir_size(&image_dir);
-            assert!(image_bytes > 0, "OCI image dir must free > 0 bytes (the trigger)");
+            assert!(
+                image_bytes > 0,
+                "OCI image dir must free > 0 bytes (the trigger)"
+            );
 
             let managed_dir = home.join(".iii/managed").join(name);
             let marker = managed_dir.join("var").join(".iii-prepared");

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -2647,6 +2647,36 @@ pub fn is_engine_running() -> bool {
     is_engine_running_on(super::config_file::manager_port())
 }
 
+/// Absolute path to a worker's managed directory: `~/.iii/managed/{name}`.
+/// Single source of truth for the managed-dir scheme so call sites can't
+/// drift apart.
+pub fn managed_worker_dir(worker_name: &str) -> std::path::PathBuf {
+    dirs::home_dir()
+        .unwrap_or_default()
+        .join(".iii/managed")
+        .join(worker_name)
+}
+
+/// Appends the `.iii-prepared` marker suffix to an already-resolved managed
+/// dir: `{managed_dir}/var/.iii-prepared`. Prefer this at call sites that
+/// already hold a `managed_dir` (e.g. one built behind a strict `home_dir()`
+/// guard) so the marker inherits that resolution instead of recomputing
+/// `home_dir()` with the weaker `unwrap_or_default()` fallback below.
+pub fn prepared_marker_in(managed_dir: &std::path::Path) -> std::path::PathBuf {
+    managed_dir.join("var").join(".iii-prepared")
+}
+
+/// Absolute path to a worker's `.iii-prepared` marker:
+/// `~/.iii/managed/{name}/var/.iii-prepared`. The marker gates the in-VM
+/// setup_cmd/install_cmd in `build_libkrun_local_script`; if it drifts or
+/// survives a `--force`, a changed lock file silently reuses stale deps
+/// (MOT-3585). Keeping the path in one helper is what prevents that drift.
+/// Use at call sites that only have a worker name; otherwise prefer
+/// `prepared_marker_in` with an already-resolved `managed_dir`.
+pub fn prepared_marker_path(worker_name: &str) -> std::path::PathBuf {
+    prepared_marker_in(&managed_worker_dir(worker_name))
+}
+
 /// Deletes local artifacts for a worker (binary dir or OCI image dir).
 /// Returns the number of bytes freed, or 0 if nothing was found.
 ///
@@ -6125,6 +6155,68 @@ dependencies:
             assert!(
                 freed > 0,
                 "freed byte total should account for the removed artifacts"
+            );
+        });
+    }
+
+    #[test]
+    fn delete_worker_artifacts_removes_managed_dir_when_oci_image_freed_first() {
+        // MOT-3585 sibling case: the old `if freed == 0` guard tripped on ANY
+        // earlier freed bytes, not just a binary artifact — the OCI image cache
+        // branch frees bytes too. Here the freed>0 trigger comes from the OCI
+        // image dir, and we assert the managed dir is still wiped AND that
+        // `freed` sums both trees with no double-count (they are DISTINCT:
+        // ~/.iii/images/{hash} vs ~/.iii/managed/{name}), exercising the
+        // claim in delete_worker_artifacts' source comment.
+        in_temp_dir(|dir| {
+            let _env_guard = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let home = dir.join("home");
+            std::fs::create_dir_all(&home).unwrap();
+            let _home_guard = set_env_var_for_test("HOME", &home);
+
+            let name = "mot3585-oci-artifacts";
+            let image_ref = "ghcr.io/iii-hq/mot3585-oci:1.0";
+
+            // config.yaml is read from the CWD by get_worker_start_info; mapping
+            // the worker to an image makes delete_worker_artifacts enter the OCI
+            // branch (the freed>0 trigger here, instead of a binary artifact).
+            std::fs::write(
+                dir.join("config.yaml"),
+                format!("workers:\n  - name: {name}\n    image: {image_ref}\n"),
+            )
+            .unwrap();
+
+            let image_dir = image_cache_dir(image_ref);
+            std::fs::create_dir_all(&image_dir).unwrap();
+            std::fs::write(image_dir.join("layer.tar"), "fake image bytes").unwrap();
+            let image_bytes = dir_size(&image_dir);
+            assert!(image_bytes > 0, "OCI image dir must free > 0 bytes (the trigger)");
+
+            let managed_dir = home.join(".iii/managed").join(name);
+            let marker = managed_dir.join("var").join(".iii-prepared");
+            std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+            std::fs::write(&marker, "").unwrap();
+            std::fs::create_dir_all(managed_dir.join("var/iii/deps/.venv")).unwrap();
+            std::fs::write(managed_dir.join("var/iii/deps/.venv/pyvenv.cfg"), "stale").unwrap();
+            let managed_bytes = dir_size(&managed_dir);
+
+            let freed = delete_worker_artifacts(name);
+
+            assert!(
+                !managed_dir.exists(),
+                "managed dir must be removed even when the OCI image was freed first"
+            );
+            assert!(
+                !marker.exists(),
+                "prepared marker must be gone so the next boot reruns install"
+            );
+            assert!(!image_dir.exists(), "OCI image cache must be removed too");
+            assert_eq!(
+                freed,
+                image_bytes + managed_bytes,
+                "freed must sum the distinct image and managed trees with no double-count"
             );
         });
     }

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -2708,20 +2708,21 @@ pub fn delete_worker_artifacts(worker_name: &str) -> u64 {
         }
     }
 
-    // Local-path worker: ~/.iii/managed/{name}/ (same as OCI)
+    // Local-path worker: ~/.iii/managed/{name}/. This is a DISTINCT path from
+    // the OCI image cache (~/.iii/images/{hash}/), so there is no double-count
+    // to guard against. Always remove it when present — leaving it behind on
+    // --force strands the `.iii-prepared` marker and the /var/iii/deps caches,
+    // which silently skips the in-VM dependency reinstall (MOT-3585).
     let managed_dir = home.join(".iii/managed").join(worker_name);
     if managed_dir.is_dir() {
-        // Only count if we haven't already freed anything (avoid double-counting with OCI)
-        if freed == 0 {
-            freed += dir_size(&managed_dir);
-            if let Err(e) = std::fs::remove_dir_all(&managed_dir) {
-                eprintln!(
-                    "  {} Failed to remove {}: {}",
-                    "warning:".yellow(),
-                    managed_dir.display(),
-                    e
-                );
-            }
+        freed += dir_size(&managed_dir);
+        if let Err(e) = std::fs::remove_dir_all(&managed_dir) {
+            eprintln!(
+                "  {} Failed to remove {}: {}",
+                "warning:".yellow(),
+                managed_dir.display(),
+                e
+            );
         }
     }
 
@@ -6072,6 +6073,60 @@ dependencies:
     fn delete_worker_artifacts_nothing_to_delete() {
         let freed = delete_worker_artifacts("__iii_test_no_artifacts_exist__");
         assert_eq!(freed, 0);
+    }
+
+    #[test]
+    fn delete_worker_artifacts_removes_managed_dir_even_when_binary_exists() {
+        // Regression for MOT-3585: a leftover binary artifact must NOT stop the
+        // managed dir (which holds the `.iii-prepared` marker and the
+        // /var/iii/deps caches) from being wiped. Before the fix, managed-dir
+        // removal was gated behind `if freed == 0`, so any earlier freed bytes
+        // (a co-named binary or OCI image) stranded the marker, which silently
+        // skipped the in-VM dependency reinstall on `--force`.
+        in_temp_dir(|dir| {
+            let _env_guard = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let home = dir.join("home");
+            std::fs::create_dir_all(&home).unwrap();
+            let _home_guard = set_env_var_for_test("HOME", &home);
+
+            let name = "mot3585-mixed-artifacts";
+
+            // Binary artifact at ~/.iii/workers/{name}/ — frees > 0 bytes, which
+            // is exactly the condition that used to trip the `if freed == 0`
+            // guard and leave the managed dir behind.
+            let binary_dir = home.join(".iii/workers").join(name);
+            std::fs::create_dir_all(&binary_dir).unwrap();
+            std::fs::write(binary_dir.join("blob"), "fake binary bytes").unwrap();
+
+            // Managed dir as a prepared local worker would have it: a populated
+            // `/bin`, the `.iii-prepared` marker, and a dep cache under
+            // /var/iii/deps.
+            let managed_dir = home.join(".iii/managed").join(name);
+            let marker = managed_dir.join("var").join(".iii-prepared");
+            std::fs::create_dir_all(managed_dir.join("bin")).unwrap();
+            std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+            std::fs::write(&marker, "").unwrap();
+            std::fs::create_dir_all(managed_dir.join("var/iii/deps/.venv")).unwrap();
+            std::fs::write(managed_dir.join("var/iii/deps/.venv/pyvenv.cfg"), "stale").unwrap();
+
+            let freed = delete_worker_artifacts(name);
+
+            assert!(
+                !managed_dir.exists(),
+                "managed dir must be removed even when a binary artifact was freed first"
+            );
+            assert!(
+                !marker.exists(),
+                "prepared marker must be gone so the next boot reruns install"
+            );
+            assert!(!binary_dir.exists(), "binary artifact must be removed too");
+            assert!(
+                freed > 0,
+                "freed byte total should account for the removed artifacts"
+            );
+        });
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/status.rs
+++ b/crates/iii-worker/src/cli/status.rs
@@ -16,7 +16,9 @@ use colored::Colorize;
 use std::time::{Duration, Instant, SystemTime};
 
 use super::config_file::{ResolvedWorkerType, resolve_worker_type, worker_exists};
-use super::managed::{is_engine_running_on, is_worker_running};
+use super::managed::{
+    is_engine_running_on, is_worker_running, managed_worker_dir, prepared_marker_in,
+};
 
 /// Live-progress overlay for `render_with_progress` / `headline_with_progress`.
 /// Bumped from `watch_until_ready` so each redraw visibly changes even when
@@ -223,9 +225,9 @@ impl WorkerStatus {
         let is_local = matches!(resolved, ResolvedWorkerType::Local { .. });
 
         let home = dirs::home_dir().unwrap_or_default();
-        let managed_dir = home.join(".iii/managed").join(name);
+        let managed_dir = managed_worker_dir(name);
         let managed_dir_exists = managed_dir.is_dir();
-        let prepared = managed_dir.join("var").join(".iii-prepared").exists();
+        let prepared = prepared_marker_in(&managed_dir).exists();
 
         let pid = read_pid(name);
         let running = is_worker_running(name);

--- a/crates/iii-worker/tests/local_worker_integration.rs
+++ b/crates/iii-worker/tests/local_worker_integration.rs
@@ -26,9 +26,15 @@ use iii_worker::cli::project::{ProjectInfo, WORKER_MANIFEST};
 use std::collections::HashMap;
 
 /// RAII guard overriding `HOME` for tests that exercise `~/.iii` artifact
-/// paths (via `dirs::home_dir()`), restoring the prior value on drop. The
-/// async `handle_local_add` tests that use it run under `in_temp_dir_async`'s
-/// `CWD_LOCK`, which serializes them, so a dedicated env lock isn't required.
+/// paths (via `dirs::home_dir()`), restoring the prior value on drop.
+///
+/// SAFETY INVARIANT (load-bearing, not optional): `HOME` is process-global,
+/// so the `unsafe` `set_var`/`remove_var` below are only sound while *every*
+/// HOME-reading test in this binary holds `CWD_LOCK` via `in_temp_dir_async`,
+/// which serializes them. This guard is constructed only inside such closures.
+/// A future test that reads `dirs::home_dir()` (directly or transitively)
+/// outside `in_temp_dir_async` would race this guard and must not be added
+/// without holding the same lock — there is no separate env lock here.
 struct HomeGuard {
     original: Option<std::ffi::OsString>,
 }
@@ -521,6 +527,111 @@ async fn handle_local_add_force_removes_prepared_marker() {
         assert!(
             !marker.exists(),
             "`.iii-prepared` marker must be removed on --force so install reruns"
+        );
+
+        // Root-cause coverage: the whole managed dir (marker + the
+        // /var/iii/deps caches) must be wiped, not just the marker. Without
+        // these, the test passes even if the `delete_worker_artifacts`
+        // managed-dir wipe regresses, because the defense-in-depth
+        // `remove_file` deletes the marker on its own. A surviving dep cache
+        // is half of MOT-3585: a changed lock file would reuse stale deps.
+        assert!(
+            !managed_dir.exists(),
+            "managed dir must be wiped on --force, not stranded by a freed binary artifact"
+        );
+        assert!(
+            !managed_dir.join("var/iii/deps/node_modules").exists(),
+            "stale dep cache must be removed on --force so a changed lock file reinstalls"
+        );
+    })
+    .await;
+}
+
+/// MOT-3585 part 2 (defense-in-depth): when the managed-dir wipe in
+/// `delete_worker_artifacts` fails and strands the dir + marker, the explicit
+/// `.iii-prepared` removal must still fire so the next boot reruns install.
+/// This is the ONLY test that exercises the `Ok(())` arm of that fallback —
+/// the happy-path tests wipe the dir successfully, so their `remove_file`
+/// always hits the no-op `NotFound` arm instead.
+///
+/// We force the wipe to fail deterministically by making the managed dir
+/// unreadable (`0o300`: execute+write, no read), so `remove_dir_all` can't
+/// enumerate it, while the direct `remove_file(.../var/.iii-prepared)` path
+/// still resolves (execute on the dirs, write on `var/`). Unix-only because it
+/// relies on POSIX permission semantics.
+#[cfg(unix)]
+#[tokio::test]
+async fn handle_local_add_force_removes_marker_when_dir_wipe_fails() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // root bypasses POSIX permission checks, so the 0o300 sabotage below would
+    // NOT block remove_dir_all — the wipe would succeed, the dir would vanish,
+    // and the `managed_dir.exists()` precondition would fail. Skip honestly
+    // (common in container CI that runs as root) rather than fail or, worse,
+    // pass for the wrong reason.
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!(
+            "skipping handle_local_add_force_removes_marker_when_dir_wipe_fails: \
+             running as root, the 0o300 permission sabotage is ineffective"
+        );
+        return;
+    }
+
+    in_temp_dir_async(|| async {
+        let cwd = std::env::current_dir().unwrap();
+
+        let home = cwd.join("home");
+        std::fs::create_dir_all(&home).unwrap();
+        let _home_guard = HomeGuard::new(&home);
+
+        let project_dir = cwd.join("my-worker");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(project_dir.join("package.json"), "{}").unwrap();
+        std::fs::write(
+            project_dir.join(WORKER_MANIFEST),
+            "name: my-worker\nruntime:\n  kind: typescript\n  package_manager: npm\n  entry: src/index.ts\n",
+        )
+        .unwrap();
+
+        TestConfigBuilder::new()
+            .with_worker("my-worker", Some("/old/path"))
+            .build(&cwd);
+
+        let managed_dir = home.join(".iii/managed/my-worker");
+        let marker = managed_dir.join("var/.iii-prepared");
+        std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+        std::fs::write(&marker, "").unwrap();
+
+        // Sabotage the wipe: unreadable managed dir => remove_dir_all fails to
+        // enumerate, leaving the dir + marker behind for the fallback to clean.
+        std::fs::set_permissions(&managed_dir, std::fs::Permissions::from_mode(0o300)).unwrap();
+
+        // Restore perms on scope exit OR unwind, so a panic inside
+        // handle_local_add can't leave the 0o300 subtree behind to defeat
+        // TempDir cleanup. `exists()` assertions below still work at 0o300
+        // (execute bit is set), so restoring after them is unnecessary.
+        struct RestorePerms<'a>(&'a std::path::Path);
+        impl Drop for RestorePerms<'_> {
+            fn drop(&mut self) {
+                let _ =
+                    std::fs::set_permissions(self.0, std::fs::Permissions::from_mode(0o755));
+            }
+        }
+        let _restore = RestorePerms(&managed_dir);
+
+        let result =
+            handle_local_add(project_dir.to_str().unwrap(), true, false, true, false).await;
+
+        assert_eq!(result, 0, "force add should still succeed when the dir wipe fails");
+        assert!(
+            !marker.exists(),
+            "defense-in-depth remove_file must clear the marker even when the dir wipe failed"
+        );
+        // The dir itself is expected to survive (the wipe failed) — that is the
+        // whole point of the marker-only fallback.
+        assert!(
+            managed_dir.exists(),
+            "precondition: the sabotaged dir should still be present, proving the wipe failed"
         );
     })
     .await;

--- a/crates/iii-worker/tests/local_worker_integration.rs
+++ b/crates/iii-worker/tests/local_worker_integration.rs
@@ -25,6 +25,35 @@ use iii_worker::cli::local_worker::{
 use iii_worker::cli::project::{ProjectInfo, WORKER_MANIFEST};
 use std::collections::HashMap;
 
+/// RAII guard overriding `HOME` for tests that exercise `~/.iii` artifact
+/// paths (via `dirs::home_dir()`), restoring the prior value on drop. The
+/// async `handle_local_add` tests that use it run under `in_temp_dir_async`'s
+/// `CWD_LOCK`, which serializes them, so a dedicated env lock isn't required.
+struct HomeGuard {
+    original: Option<std::ffi::OsString>,
+}
+
+impl HomeGuard {
+    fn new(path: &std::path::Path) -> Self {
+        let original = std::env::var_os("HOME");
+        // SAFETY: test-only; serialized with sibling CWD/HOME tests via CWD_LOCK.
+        unsafe { std::env::set_var("HOME", path) };
+        Self { original }
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        // SAFETY: test-only; serialized with sibling CWD/HOME tests via CWD_LOCK.
+        unsafe {
+            match &self.original {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Group 1: Pure function tests (no filesystem, no async)
 // ──────────────────────────────────────────────────────────────────────────────
@@ -428,6 +457,70 @@ async fn handle_local_add_force_replaces_existing() {
             "stored path '{}' should contain new canonical path '{}'",
             stored,
             canonical_project.display()
+        );
+    })
+    .await;
+}
+
+/// MOT-3585: `--force` must invalidate the `.iii-prepared` marker so the next
+/// boot reruns the in-VM dependency install — even when a co-named binary
+/// artifact also exists, which used to trip the `if freed == 0` guard in
+/// `delete_worker_artifacts` and strand the managed dir (marker + dep caches).
+#[tokio::test]
+async fn handle_local_add_force_removes_prepared_marker() {
+    in_temp_dir_async(|| async {
+        let cwd = std::env::current_dir().unwrap();
+
+        // Sandbox HOME so we touch a temp ~/.iii, never the developer's real one.
+        let home = cwd.join("home");
+        std::fs::create_dir_all(&home).unwrap();
+        let _home_guard = HomeGuard::new(&home);
+
+        // Project with a manifest (no `dependencies:` block → no network).
+        let project_dir = cwd.join("my-worker");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(project_dir.join("package.json"), "{}").unwrap();
+        std::fs::write(
+            project_dir.join(WORKER_MANIFEST),
+            "name: my-worker\nruntime:\n  kind: typescript\n  package_manager: npm\n  entry: src/index.ts\n",
+        )
+        .unwrap();
+
+        // Pre-seed config.yaml so the --force replace path runs.
+        TestConfigBuilder::new()
+            .with_worker("my-worker", Some("/old/path"))
+            .build(&cwd);
+
+        // Simulate a previously-prepared worker: a binary artifact (frees > 0,
+        // the regression trigger) plus the managed dir holding the marker and a
+        // dep cache.
+        let binary_dir = home.join(".iii/workers/my-worker");
+        std::fs::create_dir_all(&binary_dir).unwrap();
+        std::fs::write(binary_dir.join("blob"), "bytes").unwrap();
+
+        let managed_dir = home.join(".iii/managed/my-worker");
+        let marker = managed_dir.join("var/.iii-prepared");
+        std::fs::create_dir_all(managed_dir.join("bin")).unwrap();
+        std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+        std::fs::write(&marker, "").unwrap();
+        std::fs::create_dir_all(managed_dir.join("var/iii/deps/node_modules")).unwrap();
+
+        let result =
+            handle_local_add(project_dir.to_str().unwrap(), true, false, true, false).await;
+        assert_eq!(result, 0, "force add should succeed");
+
+        // Config entry replaced with the new canonical path.
+        let stored = get_worker_path("my-worker").expect("worker path should be stored");
+        assert!(
+            !stored.contains("/old/path"),
+            "stale path should be replaced, got '{}'",
+            stored
+        );
+
+        // The reinstall trigger: the marker must be gone after --force.
+        assert!(
+            !marker.exists(),
+            "`.iii-prepared` marker must be removed on --force so install reruns"
         );
     })
     .await;

--- a/crates/iii-worker/tests/local_worker_integration.rs
+++ b/crates/iii-worker/tests/local_worker_integration.rs
@@ -35,10 +35,18 @@ use std::collections::HashMap;
 /// A future test that reads `dirs::home_dir()` (directly or transitively)
 /// outside `in_temp_dir_async` would race this guard and must not be added
 /// without holding the same lock — there is no separate env lock here.
+///
+/// Unix-only: `dirs::home_dir()` honors `HOME` only on Unix. On Windows it
+/// resolves via the Known Folder API (FOLDERID_Profile) and ignores `HOME`,
+/// so this guard cannot sandbox `~/.iii`, and a `--force` test would run
+/// `remove_dir_all` against the real user home. The `~/.iii` libkrun worker
+/// surface this exercises is Unix-only anyway.
+#[cfg(unix)]
 struct HomeGuard {
     original: Option<std::ffi::OsString>,
 }
 
+#[cfg(unix)]
 impl HomeGuard {
     fn new(path: &std::path::Path) -> Self {
         let original = std::env::var_os("HOME");
@@ -48,6 +56,7 @@ impl HomeGuard {
     }
 }
 
+#[cfg(unix)]
 impl Drop for HomeGuard {
     fn drop(&mut self) {
         // SAFETY: test-only; serialized with sibling CWD/HOME tests via CWD_LOCK.
@@ -472,6 +481,10 @@ async fn handle_local_add_force_replaces_existing() {
 /// boot reruns the in-VM dependency install — even when a co-named binary
 /// artifact also exists, which used to trip the `if freed == 0` guard in
 /// `delete_worker_artifacts` and strand the managed dir (marker + dep caches).
+///
+/// Unix-only: relies on `HomeGuard` sandboxing `~/.iii` via `HOME`, which
+/// `dirs::home_dir()` honors only on Unix (see `HomeGuard`).
+#[cfg(unix)]
 #[tokio::test]
 async fn handle_local_add_force_removes_prepared_marker() {
     in_temp_dir_async(|| async {
@@ -632,6 +645,84 @@ async fn handle_local_add_force_removes_marker_when_dir_wipe_fails() {
         assert!(
             managed_dir.exists(),
             "precondition: the sabotaged dir should still be present, proving the wipe failed"
+        );
+    })
+    .await;
+}
+
+/// MOT-3585: when the explicit `.iii-prepared` removal hits a hard error (not
+/// NotFound), `--force` must FAIL (exit 1) rather than report success while a
+/// stale marker survives — a stale marker makes the next boot skip
+/// setup/install and reuse stale deps, which is the bug this PR fixes.
+///
+/// We make `var/` read-only (`0o500`) so both `delete_worker_artifacts`'
+/// recursive wipe and the direct `remove_file` fallback fail with
+/// PermissionDenied, leaving the marker in place. Unix-only and skipped under
+/// root (root bypasses the permission check).
+#[cfg(unix)]
+#[tokio::test]
+async fn handle_local_add_force_fails_when_marker_removal_errors() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!(
+            "skipping handle_local_add_force_fails_when_marker_removal_errors: \
+             running as root, the read-only var/ sabotage is ineffective"
+        );
+        return;
+    }
+
+    in_temp_dir_async(|| async {
+        let cwd = std::env::current_dir().unwrap();
+
+        let home = cwd.join("home");
+        std::fs::create_dir_all(&home).unwrap();
+        let _home_guard = HomeGuard::new(&home);
+
+        let project_dir = cwd.join("my-worker");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(project_dir.join("package.json"), "{}").unwrap();
+        std::fs::write(
+            project_dir.join(WORKER_MANIFEST),
+            "name: my-worker\nruntime:\n  kind: typescript\n  package_manager: npm\n  entry: src/index.ts\n",
+        )
+        .unwrap();
+
+        TestConfigBuilder::new()
+            .with_worker("my-worker", Some("/old/path"))
+            .build(&cwd);
+
+        let managed_dir = home.join(".iii/managed/my-worker");
+        let var_dir = managed_dir.join("var");
+        let marker = var_dir.join(".iii-prepared");
+        std::fs::create_dir_all(&var_dir).unwrap();
+        std::fs::write(&marker, "").unwrap();
+
+        // Read-only var/ (r-x, no write): the marker can be unlinked by neither
+        // the recursive wipe nor the explicit remove_file, so the hard-error
+        // arm fires.
+        std::fs::set_permissions(&var_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+        // Restore perms on scope exit/unwind so TempDir cleanup isn't defeated.
+        struct RestorePerms<'a>(&'a std::path::Path);
+        impl Drop for RestorePerms<'_> {
+            fn drop(&mut self) {
+                let _ =
+                    std::fs::set_permissions(self.0, std::fs::Permissions::from_mode(0o755));
+            }
+        }
+        let _restore = RestorePerms(&var_dir);
+
+        let result =
+            handle_local_add(project_dir.to_str().unwrap(), true, false, true, false).await;
+
+        assert_eq!(
+            result, 1,
+            "--force must fail when the prepared marker cannot be removed"
+        );
+        assert!(
+            marker.exists(),
+            "precondition: the marker should still be present, proving removal failed"
         );
     })
     .await;

--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -41,6 +41,12 @@ type: "reference"
 
   Also fixed: a forced local re-add returned the raw path (`/tmp/hello-world`) as the worker name instead of the manifest name (`hello-world`) — no other `worker::*` op accepts the path form, so the response was a dead end.
 
+  ## `worker add --force` reruns install when dependencies change
+
+  `--force` is the documented way to rebuild a local worker after its `iii.worker.yaml` or lock file changes. It stops the worker and clears artifacts, but a leftover binary or OCI image under `~/.iii` could trip an `if freed == 0` guard that left the managed directory in place — and with it the `.iii-prepared` marker and the `/var/iii/deps` caches. The next boot saw the marker, skipped `setup`/`install`, and reused stale dependencies, so a freshly added package surfaced as a `ModuleNotFoundError` at runtime.
+
+  The managed directory is now always wiped on `--force` (it is a distinct path from the image cache, so there was never a double-count to guard against), and the `.iii-prepared` marker is removed explicitly as a backstop even when the directory wipe partially fails. A changed lock file reinstalls.
+
   ## W120 tells you when the lock holder is the daemon itself
 
   When the worker lock is held by the `iii-worker-ops` daemon — the process serving the `worker::*` API — the W120 `LockBusy` error now says so and tells the caller **not** to kill that pid. From a real harness session: an LLM saw "lock held by pid N", killed N, and took down the entire worker management API it was using.


### PR DESCRIPTION
## What

Make `iii worker add --force` actually reinstall a local worker's dependencies when its lock file or `iii.worker.yaml` changes, instead of silently reusing a stale dependency cache.

## Why

MOT-3585. `--force` is the documented way to rebuild a local worker after deps change. It stops the worker and calls `delete_worker_artifacts`, but that function gated the managed-dir wipe behind `if freed == 0`. When an earlier artifact (a co-named binary, or the OCI image cache) freed bytes first, the guard skipped the wipe and left `~/.iii/managed/{name}/` in place — including the `.iii-prepared` marker and the `/var/iii/deps` caches. The next boot saw the marker, skipped `setup`/`install`, and reused stale deps, so a freshly added package surfaced as a `ModuleNotFoundError` at runtime.

## Notes

**The fix (`crates/iii-worker/src/cli/`):**
- `managed.rs` — remove the `if freed == 0` guard so the managed dir is always wiped. It is a distinct path from the binary dir, the OCI image cache, and the bundle dir, so there was never a double-count to guard against; the guard was the bug.
- `local_worker.rs` — defense-in-depth: on `--force`, remove the `.iii-prepared` marker explicitly (handling `NotFound` as a no-op) so install reruns even if the directory wipe partially fails.
- Centralize the marker path behind `managed_worker_dir` / `prepared_marker_in` / `prepared_marker_path` helpers and route the three sites (force block, boot readiness check, `worker::status`) through them — the `var/.iii-prepared` scheme now has one source of truth, since path-coupling drift is exactly what this class of bug comes from.

**Tests (`tests/local_worker_integration.rs`, `managed.rs`):**
- Unit regression for the binary-trigger and OCI-image-trigger cases of the dropped guard (the OCI test also asserts no double-count across the distinct trees).
- `#[cfg(unix)]` test for the defense-in-depth marker removal when the dir wipe fails (unreadable `0o300` dir); skipped under root and panic-safe.
- Strengthened the existing `--force` test to assert the managed dir and dep cache are wiped (so it catches the root-cause regression, not just the marker removal).

**Verification:** `cargo test -p iii-worker` (lib + `local_worker_integration`) passes; clippy clean on the changed files. No breaking changes.

**Review:** went through two `/review` passes (multi-lens adversarial). All findings were INFORMATIONAL and addressed. One pre-existing, unrelated item left for separate follow-up: `tests/common/isolation.rs::in_temp_dir_async` restores CWD via a bare statement rather than a Drop guard, so a panic in any integration test leaks CWD to siblings.

Changelog entry added under 0.20.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `worker add --force` now reliably clears the managed worker directory, including the “prepared” marker and any dependency cache remnants.
  * Ensures the “prepared” marker backstop is removed even when a directory wipe only partially succeeds.
* **New Features**
  * Improved managed-state path handling so worker status reporting aligns with the updated `--force` behavior.
* **Tests**
  * Added integration tests for different deletion orderings and for permission-failure scenarios.
* **Documentation**
  * Updated the changelog to reflect the refined `worker add --force` cache-clearing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->