### PR TITLE
fix(ci): grant id-token: write to alpha-release (fixes startup_failure)

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -36,7 +36,8 @@ on:
         default: false
 
 permissions:
-  contents: write
+  contents: write # prepare tag push, go tag, GitHub prerelease + binary uploads
+  id-token: write # OIDC / npm + pypi provenance (sdk-node, _py.yml)
 
 jobs:
   prepare:


### PR DESCRIPTION
## Problem
Running **Alpha Release** failed with `startup_failure` (no jobs ran), e.g. run 27642864831.

## Root cause
`alpha-release.yml` top-level `permissions:` listed only `contents: write`. Declaring any `permissions:` block defaults every unlisted scope to `none`, so `id-token` was `none`. The `sdk-node` job and `_py.yml` request `id-token: write` (npm/pypi provenance / OIDC); a job/reusable cannot escalate beyond the caller, so GitHub rejected the workflow at startup.

## Fix
Add `id-token: write` to top-level permissions (mirrors `release-iii.yml`). One line.

## Security
No change to fork exposure: alpha-release is `workflow_dispatch` (maintainer-only, repo branches only) — forks cannot trigger it. Most jobs downscope via their own `permissions:` blocks; id-token is effectively used only by the npm/pypi publish jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation security permissions to support proper handling of alpha releases and artifact publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->