### PR TITLE
fix(ci): alpha-release publishes iii-helpers + fixes worker payload

### DIFF
--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -21,6 +21,11 @@ on:
         required: false
         type: string
         default: ''
+      ref:
+        description: 'Git ref to checkout (default: the triggering ref). The payload builder asserts engine/Cargo.toml matches the published version, so this must point at the version-bumped commit.'
+        required: false
+        type: string
+        default: ''
       registry_tag:
         description: 'Registry tag (latest, next, ...)'
         required: false
@@ -44,6 +49,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -139,6 +139,7 @@ jobs:
         run: >-
           pnpm
           --filter "@iii-dev/observability"
+          --filter "@iii-dev/helpers"
           --filter iii-sdk
           --filter iii-browser-sdk
           build
@@ -157,6 +158,7 @@ jobs:
         run: >-
           pnpm
           --filter "@iii-dev/observability"
+          --filter "@iii-dev/helpers"
           --filter iii-sdk
           --filter iii-browser-sdk
           -r publish
@@ -177,9 +179,23 @@ jobs:
     secrets:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
 
+  helpers-py:
+    name: Helpers Python (pypi)
+    needs: prepare
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/_py.yml
+    with:
+      package_path: sdk/packages/python/helpers
+      ref: ${{ needs.prepare.outputs.tag }}
+      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
+    secrets:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+
   sdk-py:
     name: SDK Python (pypi)
-    needs: [prepare, observability-py]
+    # iii depends on iii-observability and iii-helpers; publish them first
+    # so the package is installable from PyPI.
+    needs: [prepare, observability-py, helpers-py]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_py.yml
     with:
@@ -201,9 +217,23 @@ jobs:
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
+  helpers-rust:
+    name: Helpers Rust (cargo)
+    needs: prepare
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/_rust-cargo.yml
+    with:
+      package_path: sdk/packages/rust/helpers
+      ref: ${{ needs.prepare.outputs.tag }}
+      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
+    secrets:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
   sdk-rust:
     name: SDK Rust (cargo)
-    needs: [prepare, observability-rust]
+    # iii-sdk depends on both iii-observability and iii-helpers; cargo
+    # publish resolves those from crates.io, so both must be published first.
+    needs: [prepare, observability-rust, helpers-rust]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_rust-cargo.yml
     with:
@@ -381,6 +411,9 @@ jobs:
       worker_dir: ${{ matrix.worker_dir }}
       version: ${{ needs.prepare.outputs.version }}
       release_tag: ${{ needs.prepare.outputs.tag }}
+      # Checkout the version-bumped commit: build_engine_publish_payload.py
+      # asserts engine/Cargo.toml matches the published version.
+      ref: ${{ needs.prepare.outputs.tag }}
       registry_tag: alpha
     secrets:
       WORKERS_REGISTRY_API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}


### PR DESCRIPTION
Alpha-release-only fixes, split out of the SDK-refactor branch (keeps sdk-refactor refactor-only).

## 1. Publish `iii-helpers` in all ecosystems
`iii-sdk` (rust/node) and `iii` (python) depend on `iii-helpers`, but the alpha flow never published it:
- **crates.io**: `cargo publish` hard-failed (`no matching package named iii-helpers`). Added `helpers-rust`; `sdk-rust` now depends on it.
- **pypi**: added `helpers-py`; `sdk-py` depends on it.
- **npm**: added `@iii-dev/helpers` to the `sdk-node` pnpm publish.

(npm/pypi don't verify deps at publish, so they were green but produced uninstallable packages.)

## 2. Worker payload version mismatch
`publish-builtin-workers` failed at *Build payload*:
```
ValueError: engine worker version mismatch: input is 0.19.4-alpha.1, engine/Cargo.toml is 0.19.4
```
`_publish-engine-workers.yml` checked out the **branch** (unbumped `engine/Cargo.toml`) while publishing the alpha version. Added a `ref` input and pass the alpha tag so it checks out the version-bumped commit.

## Scope / safety
- All changes are alpha-release-only. The helpers paths reference `@iii-dev/helpers` packages that only exist on the SDK-refactor branch, so the helpers jobs are **dormant on main** until that lands (alpha-release also refuses to run on `main`).
- `_publish-engine-workers.yml` `ref` input is optional (default `''`) — backward-compatible with `release-iii.yml`.

Note: the `bump_manifests` iii-helpers version-pin fix stays on the SDK-refactor branch (it's release tooling the official pipeline needs too, and depends on iii-helpers existing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to include helpers packages in SDK publishing pipeline.
  * Improved engine worker publishing process to ensure version consistency across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->