### PR TITLE
fix(console): restore request-body pre-fill on functions page

### DIFF
--- a/console/packages/console-frontend/src/api/events/functions.ts
+++ b/console/packages/console-frontend/src/api/events/functions.ts
@@ -14,6 +14,19 @@ export interface FunctionInfo {
   internal?: boolean
 }
 
+// `engine::functions::info` (via `_console/functions/:function_id`) is the only
+// surface that carries the request/response schemas — the list route returns
+// slim summaries without them.
+export interface FunctionDetail {
+  function_id: string
+  worker_name: string
+  description: string | null
+  request_schema: unknown | null
+  response_schema: unknown | null
+  metadata: Record<string, unknown> | null
+  registered_triggers: unknown[]
+}
+
 export interface TriggerInfo {
   id: string
   trigger_type: string
@@ -53,6 +66,15 @@ export async function fetchFunctions(options?: {
     functions: data.functions || [],
     count: (data.functions || []).length,
   }
+}
+
+export async function fetchFunctionDetail(functionId: string): Promise<FunctionDetail> {
+  // Function ids are path-segment-safe (`::`-delimited, no slashes) and the
+  // engine's http trigger router does not percent-decode path params, so the
+  // id is interpolated raw rather than URL-encoded.
+  const res = await fetch(`${getDevtoolsApi()}/functions/${functionId}`)
+  if (!res.ok) throw new Error('Failed to fetch function detail')
+  return unwrapResponse<FunctionDetail>(res)
 }
 
 export async function fetchTriggers(options?: {

--- a/console/packages/console-frontend/src/api/index.ts
+++ b/console/packages/console-frontend/src/api/index.ts
@@ -19,12 +19,14 @@ export { ConfigProvider, useConfig } from './config-provider'
 // Events - Functions
 export type {
   EventsInfo,
+  FunctionDetail,
   FunctionInfo,
   TriggerInfo,
   TriggerTypeInfo,
 } from './events/functions'
 export {
   fetchEventsInfo,
+  fetchFunctionDetail,
   fetchFunctions,
   fetchTriggers,
   fetchTriggerTypes,

--- a/console/packages/console-frontend/src/routes/functions.tsx
+++ b/console/packages/console-frontend/src/routes/functions.tsx
@@ -16,10 +16,15 @@ import {
   X,
   XCircle,
 } from 'lucide-react'
-import { useEffect, useReducer } from 'react'
+import { useEffect, useReducer, useRef } from 'react'
 import { z } from 'zod'
 import type { FunctionInfo } from '@/api'
-import { functionsQuery, invokeFunction as invokeFunctionApi, workersQuery } from '@/api'
+import {
+  fetchFunctionDetail,
+  functionsQuery,
+  invokeFunction as invokeFunctionApi,
+  workersQuery,
+} from '@/api'
 import { Badge, Button } from '@/components/ui/card'
 import { EmptyState } from '@/components/ui/empty-state'
 import { JsonViewer } from '@/components/ui/json-viewer'
@@ -145,6 +150,10 @@ function FunctionsPage() {
   const [invocationState, dispatchInvocation] = useReducer(invocationReducer, invocationInitial)
   const { invoking, invocationResult, requestBody } = invocationState
 
+  // Tracks the currently-selected function id so an in-flight detail fetch can
+  // be discarded if the user selects a different function before it resolves.
+  const selectedFunctionRef = useRef<string | null>(null)
+
   const {
     data: functionsData,
     isLoading: loadingFunctions,
@@ -260,12 +269,27 @@ function FunctionsPage() {
 
   const handleSelectFunction = (fn: FunctionInfo) => {
     if (selectedFunction?.function_id === fn.function_id) {
+      selectedFunctionRef.current = null
       dispatchUi({ type: 'SET_SELECTED_FUNCTION', payload: null })
     } else {
+      selectedFunctionRef.current = fn.function_id
       dispatchUi({ type: 'SET_SELECTED_FUNCTION', payload: fn })
       dispatchInvocation({ type: 'CLEAR_RESULT' })
-      const template = fn.request_format ? generateTemplate(fn.request_format) : '{\n  \n}'
-      dispatchInvocation({ type: 'SET_REQUEST_BODY', body: template })
+      // The list route returns slim summaries without schemas. Fetch the
+      // detail to pre-fill the request body from `request_schema`; fall back to
+      // an empty object if the schema is absent or the fetch fails.
+      dispatchInvocation({ type: 'SET_REQUEST_BODY', body: '{\n  \n}' })
+      fetchFunctionDetail(fn.function_id)
+        .then((detail) => {
+          if (selectedFunctionRef.current !== fn.function_id) return
+          const template = detail.request_schema
+            ? generateTemplate(detail.request_schema)
+            : '{\n  \n}'
+          dispatchInvocation({ type: 'SET_REQUEST_BODY', body: template })
+        })
+        .catch(() => {
+          // Keep the empty-object fallback already set above.
+        })
     }
   }
 

--- a/console/packages/console-rust/src/bridge/functions.rs
+++ b/console/packages/console-rust/src/bridge/functions.rs
@@ -113,6 +113,41 @@ async fn handle_functions_list(bridge: &III, input: Value) -> Value {
     }
 }
 
+async fn handle_function_detail(bridge: &III, input: Value) -> Value {
+    // The list route (`engine::functions::list`) returns slim summaries with no
+    // schemas after the engine_fn rework. `engine::functions::info` is the only
+    // surface that carries `request_schema`/`response_schema`, so the console
+    // detail panel fetches it per-function to drive request-body pre-fill and
+    // the schema viewer.
+    let function_id = input
+        .get("path_params")
+        .and_then(|p| p.get("function_id"))
+        .and_then(|v| v.as_str())
+        .or_else(|| input.get("function_id").and_then(|v| v.as_str()));
+
+    let function_id = match function_id {
+        Some(id) if !id.is_empty() => id.to_string(),
+        _ => {
+            return error_response(iii_sdk::IIIError::Handler(
+                "Missing function_id in path parameters".to_string(),
+            ))
+        }
+    };
+
+    match bridge
+        .trigger(TriggerRequest {
+            function_id: "engine::functions::info".to_string(),
+            payload: json!({ "function_id": function_id }),
+            action: None,
+            timeout_ms: Some(5000),
+        })
+        .await
+    {
+        Ok(data) => success_response(data),
+        Err(err) => error_response(err),
+    }
+}
+
 async fn handle_status(bridge: &III) -> Value {
     let (workers_result, functions_result, metrics_result) = tokio::join!(
         bridge.trigger(TriggerRequest {
@@ -1293,6 +1328,15 @@ pub fn register_functions(bridge: &III) {
         RegisterFunction::new_async(move |input: Value| {
             let bridge = b.clone();
             async move { Ok(handle_functions_list(&bridge, input).await) }
+        }),
+    );
+
+    let b = bridge.clone();
+    bridge.register_function(
+        "engine::console::function_detail",
+        RegisterFunction::new_async(move |input: Value| {
+            let bridge = b.clone();
+            async move { Ok(handle_function_detail(&bridge, input).await) }
         }),
     );
 

--- a/console/packages/console-rust/src/bridge/triggers.rs
+++ b/console/packages/console-rust/src/bridge/triggers.rs
@@ -8,6 +8,11 @@ pub fn register_triggers(bridge: &III) -> Result<(), IIIError> {
         ("engine::console::status", "_console/status", "GET"),
         ("engine::console::health", "_console/health", "GET"),
         ("engine::console::functions", "_console/functions", "GET"),
+        (
+            "engine::console::function_detail",
+            "_console/functions/:function_id",
+            "GET",
+        ),
         ("engine::console::triggers", "_console/triggers", "GET"),
         (
             "engine::console::trigger_types",


### PR DESCRIPTION
## Summary

Fixes the request-body editor pre-fill regression on the console **Functions** page reported in #1856. After upgrading from `0.11.2` to `0.19.2`, selecting a function with a request schema no longer pre-filled a template — the editor stayed empty.

## Root cause

The discovery builtins were reworked (#1675). The list route `engine::functions::list` changed its response struct:

| | `0.11.2` | `0.19.2` |
|---|---|---|
| List struct | `FunctionInfo` | `FunctionSummary` |
| Fields | `function_id`, `description`, **`request_format`**, `response_format`, `metadata` | `function_id`, `worker_name`, `description` |

The schema was moved off the list and onto the **detail** route (`engine::functions::info`), where it was also renamed `request_format` → `request_schema`.

The console detail panel still read `fn.request_format` off the **list** payload:

```ts
const template = fn.request_format ? generateTemplate(fn.request_format) : '{\n  \n}'
```

Since the list no longer returns any schema, `fn.request_format` is always `undefined`, so the editor always fell back to the empty object. Two combined breakages:

1. The list returns no schema at all (only the detail route does).
2. Even on the detail route the field is `request_schema`, not `request_format`.

## Fix

Fetch the function detail when a function is selected and build the template from `request_schema`.

**Backend (`console-rust`)** — new detail endpoint, mirroring the existing `queue_detail` pattern:
- `bridge/functions.rs`: `handle_function_detail` forwards to `engine::functions::info`.
- `bridge/triggers.rs`: registers `GET _console/functions/:function_id`.

**Frontend (`console-frontend`)**:
- `api/events/functions.ts`: `FunctionDetail` type + `fetchFunctionDetail(id)`.
- `routes/functions.tsx`: on select, fetch the detail and pre-fill from `request_schema`. Falls back to an empty object when the schema is absent or the fetch fails; an in-flight fetch is discarded if the selection changes before it resolves.

> Note: function ids are path-segment-safe (`::`-delimited, no slashes) and the http trigger router does not percent-decode path params, so the id is interpolated raw rather than URL-encoded.

## Testing

Verified end-to-end against a running engine + console:

- `GET _console/functions` → slim summaries, **no** schema (confirms the regression).
- `GET _console/functions/engine::functions::info` → returns `request_schema`.
- Running the frontend's `generateTemplate` over that response yields the expected pre-fill:

```json
{
  "function_id": ""
}
```

Checks: `tsc -b` clean, `biome` clean, `cargo check` + `cargo test` (console-rust) pass.

Closes #1856


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-function detail retrieval, including full request/response schema and related metadata.
  * Function request bodies are now auto-generated from the currently selected function’s request schema.
* **Bug Fixes**
  * Switching functions now reliably clears prior results and avoids stale in-flight updates overwriting the request body.
* **Platform**
  * Introduced a new backend console endpoint to fetch function details by function ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->