### PR TITLE
feat(ci): trigger downstream validations after release

### DIFF
--- a/.github/workflows/WORKFLOWS.md
+++ b/.github/workflows/WORKFLOWS.md
@@ -169,8 +169,12 @@ setup (parse tag metadata, Slack notification)
   ├─► publish-builtin-workers ► _publish-engine-workers.yml
   └─► publish-worker-skills ► _publish-worker-skills.yml
   │
+  ├─► trigger-validations (dispatch downstream smoke/quickstart on success)
+  │
   └─► notify-complete (aggregated Slack status)
 ```
+
+**Downstream validations:** once every publish job succeeds (non-dry-run), `trigger-validations` dispatches `init-smoke.yml` in `iii-hq/templates` and `quickstart-validate.yml` in `iii-hq/quickstart-validator`, passing `channel=next` for a prerelease or `channel=main` for a stable release. Both repos report results to their own Slack threads. Requires the `III_CI_APP` GitHub App installed on both repos with `actions: write`.
 
 **Setup job** parses the tag to determine:
 - `version` — stripped prefix (e.g., `iii/v1.2.3` becomes `1.2.3`)
@@ -180,7 +184,7 @@ setup (parse tag metadata, Slack notification)
 
 **Concurrency:** only one iii release runs at a time per repository.
 
-**Skipped on dry run:** GitHub Release creation, Homebrew publish.
+**Skipped on dry run:** GitHub Release creation, Homebrew publish, downstream validations.
 
 ---
 

--- a/.github/workflows/release-iii.yml
+++ b/.github/workflows/release-iii.yml
@@ -647,6 +647,57 @@ jobs:
     secrets: inherit
 
   # ──────────────────────────────────────────────────────────────
+  # Trigger downstream validations
+  #
+  # Once every publish job has succeeded (the validators install the
+  # freshly-published artifacts), dispatch the smoke/quickstart workflows
+  # in the templates and quickstart-validator repos. A prerelease publishes
+  # the `next` channel; a stable release publishes `main`. Skipped on
+  # dry-run and whenever any publish job failed (`!failure()`).
+  # ──────────────────────────────────────────────────────────────
+
+  trigger-validations:
+    name: Trigger downstream validations
+    needs:
+      - setup
+      - engine-release
+      - worker-release
+      - console-release
+      - sdk-npm
+      - sdk-npm-browser
+      - sdk-py
+      - sdk-rust
+      - sdk-go
+      - observability-npm
+      - observability-py
+      - observability-rust
+      - publish-builtin-workers
+      - publish-worker-skills
+    if: ${{ !cancelled() && !failure() && needs.setup.outputs.dry_run != 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      CHANNEL: ${{ needs.setup.outputs.is_prerelease == 'true' && 'next' || 'main' }}
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.III_CI_APP_ID }}
+          private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
+          owner: iii-hq
+          repositories: templates,quickstart-validator
+
+      - name: Dispatch validation workflows
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          echo "::notice::Dispatching downstream validations (channel=${CHANNEL})"
+          gh workflow run init-smoke.yml \
+            --repo iii-hq/templates --ref main -f channel="$CHANNEL"
+          gh workflow run quickstart-validate.yml \
+            --repo iii-hq/quickstart-validator --ref main -f channel="$CHANNEL"
+
+  # ──────────────────────────────────────────────────────────────
   # Notification: Complete
   # ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Adds a `trigger-validations` job to the iii release pipeline (`release-iii.yml`). Once every publish job succeeds (non-dry-run), it dispatches the validation workflows in the downstream repos:

- `iii-hq/templates` → `init-smoke.yml`
- `iii-hq/quickstart-validator` → `quickstart-validate.yml`

## Channel selection

The dispatched `channel` input is derived from the release type:

- **prerelease** → `channel=next`
- **stable** → `channel=main`

Each release validates only the channel it just published.

## Behavior

- Gated on `!cancelled() && !failure() && dry_run != 'true'` — only fires after a fully successful, real release. Any failed publish job skips it.
- Fire-and-forget: both target repos already report results to their own Slack threads.
- Cross-repo token via `create-github-app-token` scoped to `templates,quickstart-validator` (same pattern as the existing homebrew-tap / create-tag dispatches).

## Prerequisite

The `iii-hq-ci` GitHub App must be installed on **both** target repos with **`Actions: write`** (workflow_dispatch). `templates` is already installed; verify:

- [ ] `iii-hq-ci` has `Actions: write`
- [ ] `iii-hq-ci` installed on `quickstart-validator`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation workflows that trigger after successful releases to verify compatibility with downstream projects.
  * Validations differentiate between prerelease and stable release channels.
  * Validation results are automatically reported to Slack for team visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->