### PR TITLE
feat(iii-queue): consume the configuration worker for runtime config

### DIFF
--- a/engine/src/workers/queue/adapters/builtin/adapter.rs
+++ b/engine/src/workers/queue/adapters/builtin/adapter.rs
@@ -445,6 +445,16 @@ impl QueueAdapter for BuiltinQueueAdapter {
 
         tokio::spawn(async move {
             let poll_interval = std::time::Duration::from_millis(poll_interval_ms);
+            // Delivery ids this task popped and pushed toward the consumer that
+            // may not yet have been acked/nacked. Bounded by the channel
+            // capacity: at most `prefetch` messages can sit unconsumed in the
+            // channel, so once an id ages out of this window the consumer has
+            // necessarily received it and it needs no cleanup. Without this we
+            // would leak/strand channel-buffered messages on a consumer restart
+            // (this adapter has no visibility-timeout reclaim).
+            let window = (prefetch as usize).max(1);
+            let mut outstanding: std::collections::VecDeque<u64> =
+                std::collections::VecDeque::with_capacity(window);
             loop {
                 if tx.is_closed() {
                     break;
@@ -465,6 +475,10 @@ impl QueueAdapter for BuiltinQueueAdapter {
                             job_id: job.id.clone(),
                         },
                     );
+                    if outstanding.len() == window {
+                        outstanding.pop_front();
+                    }
+                    outstanding.push_back(delivery_id);
 
                     let msg = QueueMessage {
                         delivery_id,
@@ -477,18 +491,26 @@ impl QueueAdapter for BuiltinQueueAdapter {
                     };
 
                     if tx.send(msg).await.is_err() {
-                        // Channel closed — nack the job so it returns to the queue
-                        if let Some(info) = delivery_map.write().await.remove(&delivery_id)
-                            && let Err(e) = queue
-                                .nack(&info.queue_name, &info.job_id, "consumer channel closed")
-                                .await
-                        {
-                            tracing::error!(error = %e, "Failed to nack stranded job");
-                        }
                         break;
                     }
                 } else {
                     tokio::time::sleep(poll_interval).await;
+                }
+            }
+
+            // Channel closed: the consumer was aborted (a config-driven restart
+            // or shutdown). Nack every still-outstanding delivery so it returns
+            // to the queue instead of being silently stranded in `delivery_map`.
+            // A message already acked/nacked by its worker is gone from the map
+            // and skipped here; an in-flight one may be redelivered — at-least-
+            // once, which is the correct bias for a durable queue (vs. losing it).
+            for delivery_id in outstanding {
+                if let Some(info) = delivery_map.write().await.remove(&delivery_id)
+                    && let Err(e) = queue
+                        .nack(&info.queue_name, &info.job_id, "consumer stopped")
+                        .await
+                {
+                    tracing::error!(error = %e, "Failed to nack stranded job on consumer stop");
                 }
             }
         });
@@ -916,6 +938,65 @@ mod tests {
         assert_eq!(msg.attempt, 0);
         // delivery_id is assigned, just verify it exists (u64)
         let _ = msg.delivery_id;
+    }
+
+    #[tokio::test]
+    async fn consumer_stop_nacks_buffered_delivery() {
+        let engine = Arc::new(Engine::new());
+        let adapter = make_adapter(Arc::clone(&engine));
+        let config = FunctionQueueConfig::default();
+
+        adapter
+            .setup_function_queue("test-q", &config)
+            .await
+            .expect("setup should succeed");
+
+        // Consume but never receive: the poll task pops the job into the channel
+        // buffer + delivery_map, where it would be stranded if the consumer
+        // stopped (this adapter has no visibility-timeout reclaim).
+        let rx = adapter
+            .consume_function_queue("test-q", 1)
+            .await
+            .expect("consume should return receiver");
+
+        adapter
+            .publish_to_function_queue(
+                "test-q",
+                "fn::handler",
+                json!({"k": "v"}),
+                "msg-1",
+                3,
+                1000,
+                None,
+                None,
+            )
+            .await;
+
+        // Wait until the poll task has popped the job (tracked in delivery_map)
+        // without it being received.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        while adapter.delivery_map.read().await.is_empty() {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "job should be popped into delivery_map"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        // Abort the consumer without acking by dropping the receiver.
+        drop(rx);
+
+        // The poll task must nack the buffered delivery back to the queue rather
+        // than leaving it stranded in delivery_map. (Redelivery itself is covered
+        // by BuiltinQueue::nack's own tests.)
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        while !adapter.delivery_map.read().await.is_empty() {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "stranded delivery should be nacked when the consumer stops"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
     }
 
     #[tokio::test]

--- a/engine/src/workers/queue/adapters/builtin/adapter.rs
+++ b/engine/src/workers/queue/adapters/builtin/adapter.rs
@@ -475,9 +475,6 @@ impl QueueAdapter for BuiltinQueueAdapter {
                             job_id: job.id.clone(),
                         },
                     );
-                    if outstanding.len() == window {
-                        outstanding.pop_front();
-                    }
                     outstanding.push_back(delivery_id);
 
                     let msg = QueueMessage {
@@ -492,6 +489,16 @@ impl QueueAdapter for BuiltinQueueAdapter {
 
                     if tx.send(msg).await.is_err() {
                         break;
+                    }
+
+                    // Trim only AFTER a successful send. A send unblocks when the
+                    // consumer makes room in the channel, so once `outstanding`
+                    // exceeds the channel window the oldest entry has necessarily
+                    // been received and no longer needs nack-on-stop cleanup.
+                    // Trimming before the send (while it can still block) would
+                    // drop a still-buffered delivery id and strand it.
+                    while outstanding.len() > window {
+                        outstanding.pop_front();
                     }
                 } else {
                     tokio::time::sleep(poll_interval).await;
@@ -994,6 +1001,72 @@ mod tests {
             assert!(
                 tokio::time::Instant::now() < deadline,
                 "stranded delivery should be nacked when the consumer stops"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn consumer_stop_nacks_oldest_when_buffer_full() {
+        let engine = Arc::new(Engine::new());
+        let adapter = make_adapter(Arc::clone(&engine));
+        let config = FunctionQueueConfig::default();
+
+        adapter
+            .setup_function_queue("test-q", &config)
+            .await
+            .expect("setup should succeed");
+
+        // prefetch = 2 → a channel buffer of 2. Publish 3 jobs and never receive:
+        // the poll task buffers the first two, pops the third, and blocks on a
+        // full-channel send. The oldest delivery must NOT be stranded when the
+        // consumer stops (regression test for premature eviction).
+        let rx = adapter
+            .consume_function_queue("test-q", 2)
+            .await
+            .expect("consume should return receiver");
+
+        for i in 0..3 {
+            adapter
+                .publish_to_function_queue(
+                    "test-q",
+                    "fn::handler",
+                    json!({ "i": i }),
+                    &format!("msg-{i}"),
+                    3,
+                    1000,
+                    None,
+                    None,
+                )
+                .await;
+        }
+
+        // Wait until all three are popped into delivery_map (the third leaves
+        // the poll task blocked on a full-channel send).
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        while adapter.delivery_map.read().await.len() < 3 {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "all three jobs should be popped into delivery_map"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        // Abort the consumer.
+        drop(rx);
+
+        // Every delivery — including the oldest, which was buffered but would be
+        // evicted from the tracking window before its send completed — must be
+        // nacked, not stranded.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            let remaining = adapter.delivery_map.read().await.len();
+            if remaining == 0 {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "no delivery may be stranded when the consumer stops, {remaining} left"
             );
             tokio::time::sleep(Duration::from_millis(10)).await;
         }

--- a/engine/src/workers/queue/adapters/builtin/adapter.rs
+++ b/engine/src/workers/queue/adapters/builtin/adapter.rs
@@ -966,13 +966,16 @@ mod tests {
             .await
             .expect("consume should return receiver");
 
+        // max_retries = 1 so the consumer-stop nack exhausts the job and routes
+        // it to the DLQ — a signal that an `ack`/drop would NOT produce, letting
+        // the assertion below prove the delivery was nacked, not silently lost.
         adapter
             .publish_to_function_queue(
                 "test-q",
                 "fn::handler",
                 json!({"k": "v"}),
                 "msg-1",
-                3,
+                1,
                 1000,
                 None,
                 None,
@@ -994,13 +997,23 @@ mod tests {
         drop(rx);
 
         // The poll task must nack the buffered delivery back to the queue rather
-        // than leaving it stranded in delivery_map. (Redelivery itself is covered
-        // by BuiltinQueue::nack's own tests.)
+        // than leaving it stranded in delivery_map.
         let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
         while !adapter.delivery_map.read().await.is_empty() {
             assert!(
                 tokio::time::Instant::now() < deadline,
                 "stranded delivery should be nacked when the consumer stops"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        // And it must actually be NACKED, not acked/dropped: the exhausted job
+        // lands in the DLQ. An ack would leave the DLQ empty.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        while adapter.queue.dlq_count("__fn_queue::test-q").await < 1 {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "consumer-stop must nack the buffered delivery (here to the DLQ), not drop it"
             );
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
@@ -1026,6 +1039,9 @@ mod tests {
             .await
             .expect("consume should return receiver");
 
+        // max_retries = 1 so each consumer-stop nack exhausts its job to the DLQ,
+        // which the assertion below uses to prove every delivery was nacked (not
+        // acked/dropped), including the oldest that was at risk of early eviction.
         for i in 0..3 {
             adapter
                 .publish_to_function_queue(
@@ -1033,7 +1049,7 @@ mod tests {
                     "fn::handler",
                     json!({ "i": i }),
                     &format!("msg-{i}"),
-                    3,
+                    1,
                     1000,
                     None,
                     None,
@@ -1067,6 +1083,21 @@ mod tests {
             assert!(
                 tokio::time::Instant::now() < deadline,
                 "no delivery may be stranded when the consumer stops, {remaining} left"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        // All three were NACKED, not acked/dropped: each exhausted job lands in
+        // the DLQ. A regression that acked on stop would leave the DLQ empty.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            let dlq = adapter.queue.dlq_count("__fn_queue::test-q").await;
+            if dlq >= 3 {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "every consumer-stop nack must route to the DLQ, only {dlq}/3 did"
             );
             tokio::time::sleep(Duration::from_millis(10)).await;
         }

--- a/engine/src/workers/queue/adapters/builtin/mod.rs
+++ b/engine/src/workers/queue/adapters/builtin/mod.rs
@@ -5,3 +5,8 @@
 // See LICENSE and PATENTS files for details.
 
 mod adapter;
+
+// Exposed so the `test-adapters`-gated `memory` transport can register a second
+// dependency-free backend that delegates to the builtin in-process adapter.
+#[cfg(feature = "test-adapters")]
+pub(crate) use adapter::make_adapter;

--- a/engine/src/workers/queue/adapters/memory_adapter.rs
+++ b/engine/src/workers/queue/adapters/memory_adapter.rs
@@ -1,0 +1,27 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! An in-process queue transport registered only under the `test-adapters`
+//! feature (enabled for this crate's own test targets via the self
+//! dev-dependency in `Cargo.toml`; off in every normal build). Mechanically a
+//! `builtin` adapter under a second registry name so the
+//! `queue_configuration_e2e` suite can exercise the adapter hot-swap against a
+//! *second* dependency-free backend — the real alternatives (`redis`,
+//! `rabbitmq`) need a live server. Its `config` is intentionally open: the suite
+//! uses it as an opaque marker/perturbation carrier.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use crate::engine::Engine;
+use crate::workers::queue::registry::{QueueAdapterFuture, QueueAdapterRegistration};
+
+fn make_adapter(engine: Arc<Engine>, config: Option<Value>) -> QueueAdapterFuture {
+    super::builtin::make_adapter(engine, config)
+}
+
+crate::register_adapter!(<QueueAdapterRegistration> name: "memory", make_adapter);

--- a/engine/src/workers/queue/adapters/mod.rs
+++ b/engine/src/workers/queue/adapters/mod.rs
@@ -6,6 +6,8 @@
 
 pub mod bridge;
 pub mod builtin;
+#[cfg(feature = "test-adapters")]
+pub mod memory_adapter;
 #[cfg(feature = "rabbitmq")]
 pub mod rabbitmq;
 pub mod redis_adapter;

--- a/engine/src/workers/queue/config.rs
+++ b/engine/src/workers/queue/config.rs
@@ -6,7 +6,8 @@
 
 use std::collections::HashMap;
 
-use serde::Deserialize;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::workers::traits::AdapterEntry;
 
@@ -42,24 +43,41 @@ fn default_poll_interval_ms() -> u64 {
     100
 }
 
-#[derive(Debug, Clone, Deserialize)]
+/// Per-queue settings. Doc comments on each field flow into the JSON Schema
+/// (via `schemars`) that the `iii-queue` configuration entry registers, so an
+/// agent introspecting the schema sees the same descriptions and defaults
+/// documented here.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct FunctionQueueConfig {
+    /// Maximum delivery attempts before a message is sent to the dead-letter
+    /// queue. Defaults to 3.
     #[serde(default = "default_max_retries")]
     pub max_retries: u32,
 
+    /// Number of messages processed concurrently. For `fifo` queues the
+    /// effective prefetch is forced to 1 to preserve ordering. Defaults to 10.
     #[serde(default = "default_concurrency")]
     pub concurrency: u32,
 
+    /// Delivery semantics: "standard" (concurrent, unordered) or "fifo"
+    /// (ordered per message group; requires `message_group_field`).
+    /// Defaults to "standard".
     #[serde(default = "default_queue_type", rename = "type")]
     pub r#type: String,
 
+    /// For `fifo` queues, the message field whose value defines the ordering
+    /// group. Required when `type` is "fifo"; ignored otherwise.
     #[serde(default)]
     pub message_group_field: Option<String>,
 
+    /// Base delay in milliseconds for the exponential retry backoff. Defaults
+    /// to 1000 (1s).
     #[serde(default = "default_backoff_ms")]
     pub backoff_ms: u64,
 
+    /// Poll interval in milliseconds for adapters that poll for messages.
+    /// Defaults to 100.
     #[serde(default = "default_poll_interval_ms")]
     pub poll_interval_ms: u64,
 }
@@ -77,12 +95,21 @@ impl Default for FunctionQueueConfig {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Default)]
+/// Queue worker settings. Doc comments flow into the JSON Schema (via
+/// `schemars`) that the `iii-queue` configuration entry registers. After first
+/// boot this entry is the runtime source of truth; the `config.yaml` block is
+/// seed-only.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Default, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct QueueModuleConfig {
+    /// Transport backing the queues (e.g. "builtin", "rabbitmq"). When omitted,
+    /// the built-in in-process adapter is used. Changing this at runtime
+    /// re-instantiates the transport and restarts every consumer.
     #[serde(default)]
     pub adapter: Option<AdapterEntry>,
 
+    /// Named queues keyed by queue name, each with its own retry, concurrency,
+    /// and ordering settings. The built-in `default` queue is always present.
     #[serde(default)]
     pub queue_configs: HashMap<String, FunctionQueueConfig>,
 }

--- a/engine/src/workers/queue/config.rs
+++ b/engine/src/workers/queue/config.rs
@@ -7,6 +7,8 @@
 use std::collections::HashMap;
 
 use schemars::JsonSchema;
+use schemars::r#gen::SchemaGenerator;
+use schemars::schema::{InstanceType, Schema, SchemaObject};
 use serde::{Deserialize, Serialize};
 
 use crate::workers::traits::AdapterEntry;
@@ -57,7 +59,10 @@ pub struct FunctionQueueConfig {
 
     /// Number of messages processed concurrently. For `fifo` queues the
     /// effective prefetch is forced to 1 to preserve ordering. Defaults to 10.
+    /// Must be at least 1 — `concurrency: 0` would build a zero-capacity
+    /// channel/semaphore and panic the consumer.
     #[serde(default = "default_concurrency")]
+    #[schemars(range(min = 1))]
     pub concurrency: u32,
 
     /// Delivery semantics: "standard" (concurrent, unordered) or "fifo"
@@ -102,10 +107,18 @@ impl Default for FunctionQueueConfig {
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Default, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct QueueModuleConfig {
-    /// Transport backing the queues (e.g. "builtin", "rabbitmq"). When omitted,
-    /// the built-in in-process adapter is used. Changing this at runtime
-    /// re-instantiates the transport and restarts every consumer.
-    #[serde(default)]
+    /// Transport backing the queues. When omitted, the built-in in-process
+    /// adapter is used. Changing this at runtime re-instantiates the transport
+    /// and restarts every consumer. The field keeps the loosely-typed
+    /// `AdapterEntry` for deserialization (a hand-edited persisted file is
+    /// tolerated at boot), while the schema (via [`queue_adapter_schema`])
+    /// advertises a closed per-adapter union so the console renders typed fields.
+    ///
+    /// `skip_serializing_if` omits the field entirely when unset, so a
+    /// no-adapter config is not serialized as `adapter: null` (which the `oneOf`
+    /// schema, having no null branch, would reject at `configuration::set`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "queue_adapter_schema")]
     pub adapter: Option<AdapterEntry>,
 
     /// Named queues keyed by queue name, each with its own retry, concurrency,
@@ -141,9 +154,180 @@ impl QueueModuleConfig {
                     name
                 );
             }
+            // `concurrency` is the channel/semaphore capacity for the consumer;
+            // 0 would panic `mpsc::channel(0)` / wedge `Semaphore::new(0)`. The
+            // JSON schema (`range(min = 1)`) rejects this at `configuration::set`,
+            // but the `config.yaml` seed bypasses the schema, so guard here too.
+            if queue_config.concurrency == 0 {
+                anyhow::bail!(
+                    "Queue '{}' has 'concurrency' 0; it must be at least 1",
+                    name
+                );
+            }
         }
         Ok(())
     }
+}
+
+/// Storage backend for the built-in adapter's kv persistence. Variants are
+/// intentionally doc-free so schemars emits a flat string `enum` (a single
+/// select) rather than a per-variant `oneOf` a schema-driven UI renders as
+/// "variant 1"/"variant 2".
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum QueueStoreMethod {
+    InMemory,
+    FileBased,
+}
+
+/// Config for the built-in in-process `builtin` adapter. Per-queue retry,
+/// concurrency, and ordering live in `queue_configs`; this only configures the
+/// adapter's kv persistence.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct BuiltinAdapterConfig {
+    /// Storage backend. `in_memory` (the default) keeps queued messages only for
+    /// the process lifetime; `file_based` persists them under `file_path`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub store_method: Option<QueueStoreMethod>,
+
+    /// Directory for file-based storage. Only used when `store_method` is
+    /// `file_based`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_path: Option<String>,
+
+    /// Persistence flush cadence in milliseconds for file-based storage;
+    /// in-memory stores ignore it. Defaults to 5000.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 100, max = 3_600_000))]
+    pub save_interval_ms: Option<u64>,
+}
+
+/// Config for the `redis` adapter.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct RedisAdapterConfig {
+    /// Redis connection URL. Defaults to `redis://localhost:6379`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redis_url: Option<String>,
+}
+
+/// Config for the `bridge` adapter.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct BridgeAdapterConfig {
+    /// WebSocket bridge URL of the remote queue backend; all queue operations
+    /// are forwarded there. Defaults to `ws://localhost:49134`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bridge_url: Option<String>,
+}
+
+/// Config for the `rabbitmq` adapter. Only built (and advertised in the schema)
+/// when the `rabbitmq` feature is enabled — i.e. when the transport is actually
+/// registered.
+#[cfg(feature = "rabbitmq")]
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct RabbitmqAdapterConfig {
+    /// AMQP connection URL. Defaults to `amqp://localhost:5672`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub amqp_url: Option<String>,
+
+    /// Maximum delivery attempts before a message is dead-lettered. Defaults
+    /// to 3.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 1))]
+    pub max_attempts: Option<u32>,
+
+    /// Per-consumer prefetch (QoS) window. Defaults to 10.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 1))]
+    pub prefetch_count: Option<u16>,
+
+    /// Default delivery mode: "standard" (concurrent) or "fifo" (ordered).
+    /// Per-queue `type` overrides this. Defaults to "standard".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub queue_mode: Option<String>,
+}
+
+/// Build the `oneOf` schema for [`QueueModuleConfig::adapter`]: one branch per
+/// registered transport, each pinned to its `name` discriminator and carrying
+/// that adapter's concrete `config` schema. The set is closed —
+/// `configuration::set` rejects any other adapter name — so the console renders
+/// per-adapter fields instead of a free-form object. Deserialization stays
+/// permissive via the `AdapterEntry` field type, so a hand-edited persisted file
+/// is still tolerated at boot.
+fn queue_adapter_schema(generator: &mut SchemaGenerator) -> Schema {
+    #[allow(unused_mut)]
+    let mut branches = vec![
+        adapter_branch("builtin", generator.subschema_for::<BuiltinAdapterConfig>()),
+        adapter_branch("redis", generator.subschema_for::<RedisAdapterConfig>()),
+        adapter_branch("bridge", generator.subschema_for::<BridgeAdapterConfig>()),
+    ];
+
+    // The rabbitmq transport is only registered under its feature; advertise it
+    // in the schema only when it is available so `configuration::set` never
+    // accepts an adapter name the engine cannot build.
+    #[cfg(feature = "rabbitmq")]
+    branches.push(adapter_branch(
+        "rabbitmq",
+        generator.subschema_for::<RabbitmqAdapterConfig>(),
+    ));
+
+    // The `test-adapters` feature registers an in-process `memory` transport (a
+    // second dependency-free backend for the hot-swap e2e); advertise it so
+    // `configuration::set` accepts it. Open config — an opaque test carrier.
+    #[cfg(feature = "test-adapters")]
+    branches.push(adapter_branch(
+        "memory",
+        Schema::Object(SchemaObject {
+            instance_type: Some(vec![InstanceType::Object, InstanceType::Null].into()),
+            ..Default::default()
+        }),
+    ));
+
+    let mut schema = SchemaObject::default();
+    schema.metadata().description = Some(
+        "Transport backing the queues, a discriminated union keyed on `name` over \
+         the registered adapters `builtin` (default, in-process), `redis`, and \
+         `bridge`. Hot-swap tier: a runtime edit re-instantiates the transport and \
+         restarts every consumer — no engine restart. A value that fails to build \
+         the transport is gated and keeps the previous one."
+            .to_string(),
+    );
+    schema.subschemas().one_of = Some(branches);
+    Schema::Object(schema)
+}
+
+/// One `oneOf` branch: an object pinned to `name` and carrying the adapter's
+/// `config` sub-schema. `config` is optional (every adapter has working
+/// defaults) and no other keys are permitted.
+fn adapter_branch(name: &str, config_schema: Schema) -> Schema {
+    let name_schema = SchemaObject {
+        instance_type: Some(InstanceType::String.into()),
+        enum_values: Some(vec![serde_json::Value::String(name.to_string())]),
+        ..Default::default()
+    };
+
+    let mut branch = SchemaObject {
+        instance_type: Some(InstanceType::Object.into()),
+        ..Default::default()
+    };
+    // The console labels each `oneOf` option by its `title`; without it the form
+    // shows the bare type ("object") for every adapter branch.
+    branch.metadata().title = Some(name.to_string());
+    {
+        let object = branch.object();
+        object
+            .properties
+            .insert("name".to_string(), Schema::Object(name_schema));
+        object
+            .properties
+            .insert("config".to_string(), config_schema);
+        object.required.insert("name".to_string());
+        object.additional_properties = Some(Box::new(Schema::Bool(false)));
+    }
+    Schema::Object(branch)
 }
 
 #[cfg(test)]
@@ -381,5 +565,130 @@ adapter:
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("invalid_type"));
+    }
+
+    #[test]
+    fn validate_zero_concurrency_fails() {
+        let mut queue_configs = HashMap::new();
+        queue_configs.insert(
+            "orders".to_string(),
+            FunctionQueueConfig {
+                concurrency: 0,
+                ..Default::default()
+            },
+        );
+        let config = QueueModuleConfig {
+            adapter: None,
+            queue_configs,
+        };
+        let result = config.validate();
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("orders"));
+        assert!(err.contains("concurrency"));
+    }
+
+    #[test]
+    fn schema_has_per_adapter_oneof() {
+        let schema =
+            serde_json::to_value(schemars::schema_for!(QueueModuleConfig)).expect("schema");
+        // deny_unknown_fields flows into the schema.
+        assert_eq!(schema["additionalProperties"], serde_json::json!(false));
+
+        let adapter = &schema["properties"]["adapter"];
+        assert!(adapter["description"].is_string());
+        let branches = adapter["oneOf"].as_array().expect("adapter oneOf");
+
+        let mut names: Vec<&str> = branches
+            .iter()
+            .map(|b| {
+                assert_eq!(b["additionalProperties"], serde_json::json!(false));
+                assert!(b["properties"]["config"].is_object());
+                let name = b["properties"]["name"]["enum"][0]
+                    .as_str()
+                    .expect("name discriminator");
+                // The branch `title` drives the console's adapter dropdown label
+                // (otherwise every option shows "object").
+                assert_eq!(b["title"].as_str(), Some(name));
+                name
+            })
+            .collect();
+        names.sort_unstable();
+        let mut want = vec!["bridge", "builtin", "redis"];
+        if cfg!(feature = "rabbitmq") {
+            want.push("rabbitmq");
+        }
+        if cfg!(feature = "test-adapters") {
+            want.push("memory");
+        }
+        want.sort_unstable();
+        assert_eq!(names, want);
+
+        // Each adapter's concrete config fields land in definitions.
+        let defs = &schema["definitions"];
+        assert!(defs["BuiltinAdapterConfig"]["properties"]["store_method"].is_object());
+        assert_eq!(
+            defs["BuiltinAdapterConfig"]["properties"]["save_interval_ms"]["minimum"],
+            serde_json::json!(100.0)
+        );
+        assert!(defs["RedisAdapterConfig"]["properties"]["redis_url"].is_object());
+        assert!(defs["BridgeAdapterConfig"]["properties"]["bridge_url"].is_object());
+
+        // `store_method` is a flat string enum (a single select), not a
+        // per-variant `oneOf` that renders as "variant 1"/"variant 2".
+        let store_method = &defs["QueueStoreMethod"];
+        assert!(
+            store_method["oneOf"].is_null(),
+            "store_method must be a flat enum, not a oneOf"
+        );
+        let methods: Vec<&str> = store_method["enum"]
+            .as_array()
+            .expect("store_method enum values")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert!(methods.contains(&"in_memory") && methods.contains(&"file_based"));
+    }
+
+    // Closed-schema enforcement through the real validator (with `$ref`
+    // resolution) — the same `jsonschema` path `configuration::set` uses.
+    #[test]
+    fn closed_adapter_schema_accepts_known_rejects_unknown() {
+        let schema =
+            serde_json::to_value(schemars::schema_for!(QueueModuleConfig)).expect("schema");
+        let validator = jsonschema::Validator::new(&schema).expect("schema compiles");
+
+        // A no-adapter config is valid: the field is omitted, not `null`.
+        assert!(validator.is_valid(&serde_json::json!({ "queue_configs": {} })));
+
+        // Accepted: known adapters, with or without config.
+        assert!(validator.is_valid(&serde_json::json!({
+            "adapter": {"name": "builtin", "config": {"store_method": "file_based", "file_path": "./data/queue.db"}}
+        })));
+        assert!(validator.is_valid(&serde_json::json!({"adapter": {"name": "builtin"}})));
+        assert!(validator.is_valid(&serde_json::json!({
+            "adapter": {"name": "redis", "config": {"redis_url": "redis://localhost:6379"}}
+        })));
+        assert!(validator.is_valid(&serde_json::json!({
+            "adapter": {"name": "bridge", "config": {"bridge_url": "ws://localhost:49134"}}
+        })));
+
+        // Rejected: unknown adapter, invalid enum value, and an unknown config key.
+        assert!(!validator.is_valid(&serde_json::json!({"adapter": {"name": "postgres"}})));
+        assert!(!validator.is_valid(&serde_json::json!({
+            "adapter": {"name": "builtin", "config": {"store_method": "weird"}}
+        })));
+        assert!(!validator.is_valid(&serde_json::json!({
+            "adapter": {"name": "builtin", "config": {"bogus": 1}}
+        })));
+
+        // `rabbitmq` is advertised (and accepted) only when its transport is
+        // compiled in, keeping the schema in sync with the adapter registry.
+        #[cfg(feature = "rabbitmq")]
+        assert!(validator.is_valid(&serde_json::json!({
+            "adapter": {"name": "rabbitmq", "config": {"amqp_url": "amqp://localhost:5672"}}
+        })));
+        #[cfg(not(feature = "rabbitmq"))]
+        assert!(!validator.is_valid(&serde_json::json!({"adapter": {"name": "rabbitmq"}})));
     }
 }

--- a/engine/src/workers/queue/configuration.rs
+++ b/engine/src/workers/queue/configuration.rs
@@ -211,9 +211,9 @@ mod tests {
                 let stored_value = stored_value.clone();
                 async move {
                     match stored_value {
-                        Some(value) => {
-                            FunctionResult::Success(Some(json!({ "id": CONFIG_ID, "value": value })))
-                        }
+                        Some(value) => FunctionResult::Success(Some(
+                            json!({ "id": CONFIG_ID, "value": value }),
+                        )),
                         None => FunctionResult::Failure(crate::protocol::ErrorBody {
                             message: format!("configuration '{CONFIG_ID}' not found"),
                             code: "NOT_FOUND".to_string(),
@@ -266,7 +266,10 @@ mod tests {
 
         let payload = registered.recv().await.unwrap();
         assert_eq!(payload["id"], CONFIG_ID);
-        assert_eq!(payload["initial_value"]["queue_configs"]["reports"]["concurrency"], 7);
+        assert_eq!(
+            payload["initial_value"]["queue_configs"]["reports"]["concurrency"],
+            7
+        );
         // schemars derives deny_unknown_fields into the schema.
         assert_eq!(payload["schema"]["additionalProperties"], json!(false));
         // Field doc comments must flow into the schema so an agent
@@ -369,8 +372,10 @@ mod tests {
         // JSON schema (which can't express the cross-field rule), so it reaches
         // the worker's `validate()` gate — which must reject it and keep the
         // previous live config.
-        let _registered =
-            stub_configuration(&engine, Some(json!({ "queue_configs": { "orders": { "type": "fifo" } } })));
+        let _registered = stub_configuration(
+            &engine,
+            Some(json!({ "queue_configs": { "orders": { "type": "fifo" } } })),
+        );
 
         let worker = QueueWorker::for_test(
             engine.clone(),

--- a/engine/src/workers/queue/configuration.rs
+++ b/engine/src/workers/queue/configuration.rs
@@ -1,0 +1,395 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Integration with the builtin `configuration` worker.
+//!
+//! The `iii-queue` worker registers its config schema under the id `iii-queue`,
+//! seeds it from the config.yaml block only when no value is stored yet, reads
+//! the live value (with `${VAR:default}` expansion) before starting consumers,
+//! and hot-applies `configuration:updated` events. After first boot the
+//! configuration worker entry is the runtime source of truth; the config.yaml
+//! block is seed-only.
+
+use anyhow::anyhow;
+use serde_json::{Value, json};
+
+use super::{config::QueueModuleConfig, queue::QueueWorker};
+use crate::{
+    engine::{Engine, EngineTrait},
+    trigger::Trigger,
+};
+
+pub const CONFIG_ID: &str = "iii-queue";
+pub const CONFIG_FN_ID: &str = "iii-queue::on-config-change";
+pub const CONFIG_TRIGGER_ID: &str = "iii-queue::config-watch";
+pub const CONFIG_TRIGGER_TYPE: &str = "configuration";
+
+/// Upper bound on every `configuration::*` bus call made by this worker. The
+/// boot and reload pipelines await worker startup serially, so a hung
+/// configuration provider must wedge neither the apply lock nor the startup
+/// loop behind this worker.
+pub(super) const CONFIG_BUS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Delay before the single retry of a timed-out apply (see `on_config_change`).
+const APPLY_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Register the `iii-queue` configuration entry: schema and metadata refresh on
+/// every boot; `initial_value` (the config.yaml seed, or built-in defaults) is
+/// included only when nothing is stored yet, so runtime edits survive engine
+/// restarts.
+///
+/// Makes unbounded bus calls — callers must wrap the call in
+/// `tokio::time::timeout(CONFIG_BUS_TIMEOUT, ...)` (see
+/// `QueueWorker::start_background_tasks`).
+pub async fn register_config(
+    engine: &Engine,
+    seed: Option<&QueueModuleConfig>,
+) -> anyhow::Result<()> {
+    let mut payload = json!({
+        "id": CONFIG_ID,
+        "name": "Queue",
+        "description": "Queue worker settings — the backing adapter/transport and per-queue config (retries, concurrency, FIFO ordering, backoff).",
+        "schema": serde_json::to_value(schemars::schema_for!(QueueModuleConfig))?,
+    });
+
+    if try_get_value(engine).await?.is_none() {
+        payload["initial_value"] = serde_json::to_value(seed.cloned().unwrap_or_default())?;
+    }
+
+    engine
+        .call("configuration::register", payload)
+        .await
+        .map_err(|err| {
+            anyhow!(
+                "configuration::register failed: {} ({})",
+                err.message,
+                err.code
+            )
+        })?;
+    Ok(())
+}
+
+/// Read the live configuration value. `${VAR:default}` placeholders are
+/// expanded by `configuration::get`. A missing or null value falls back to the
+/// supplied config; a malformed stored value is an error so the caller keeps
+/// its previous config. The always-present `default` queue is provisioned on
+/// every returned value (the queue analogue of normalization).
+///
+/// Makes an unbounded bus call — callers must wrap the call in
+/// `tokio::time::timeout(CONFIG_BUS_TIMEOUT, ...)` (see
+/// `QueueWorker::start_background_tasks` and `QueueWorker::apply_config`).
+pub async fn fetch_config(
+    engine: &Engine,
+    fallback: &QueueModuleConfig,
+) -> anyhow::Result<QueueModuleConfig> {
+    let Some(value) = try_get_value(engine).await? else {
+        tracing::info!(
+            "no `{}` configuration value stored; using static configuration",
+            CONFIG_ID
+        );
+        let mut config = fallback.clone();
+        config.ensure_default_queue();
+        return Ok(config);
+    };
+
+    let mut config: QueueModuleConfig = serde_json::from_value(value)
+        .map_err(|err| anyhow!("stored `{CONFIG_ID}` configuration is invalid: {err}"))?;
+    config.ensure_default_queue();
+    Ok(config)
+}
+
+async fn try_get_value(engine: &Engine) -> anyhow::Result<Option<Value>> {
+    match engine
+        .call("configuration::get", json!({ "id": CONFIG_ID }))
+        .await
+    {
+        Ok(response) => Ok(response
+            .and_then(|body| body.get("value").cloned())
+            .filter(|value| !value.is_null())),
+        Err(err) if err.code == "NOT_FOUND" => Ok(None),
+        Err(err) => Err(anyhow!(
+            "configuration::get failed: {} ({})",
+            err.message,
+            err.code
+        )),
+    }
+}
+
+/// Handler body for `iii-queue::on-config-change`. Delegates to `apply_config`,
+/// which re-fetches the authoritative value under the apply lock instead of
+/// trusting the trigger payload — the handler is a discoverable bus function,
+/// and acting on a caller-supplied payload would let anyone repoint the
+/// listener without updating persisted state. Any failure keeps the previous
+/// config and the running consumers.
+pub async fn on_config_change(worker: &QueueWorker) {
+    match worker.apply_config().await {
+        Ok(()) => tracing::info!("iii-queue configuration re-applied after change"),
+        // A timeout is transient: the stored value is valid but unapplied, and
+        // the event will not fire again — so retry exactly once after a delay.
+        // The retry calls `apply_config` directly (not this handler), so it
+        // cannot loop. Other errors (malformed value, failed adapter rebuild)
+        // are deterministic; retrying them would just repeat the failure.
+        Err(err) if err.downcast_ref::<tokio::time::error::Elapsed>().is_some() => {
+            tracing::error!(
+                error = %err,
+                "iii-queue: configuration apply timed out; retrying once in {APPLY_RETRY_DELAY:?}"
+            );
+            let worker = worker.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(APPLY_RETRY_DELAY).await;
+                match worker.apply_config().await {
+                    Ok(()) => tracing::info!("iii-queue configuration re-applied on retry"),
+                    Err(err) => tracing::error!(
+                        error = %err,
+                        "iii-queue: configuration apply retry failed; keeping previous config"
+                    ),
+                }
+            });
+        }
+        Err(err) => tracing::error!(
+            error = %err,
+            "iii-queue: failed to apply changed configuration; keeping previous config"
+        ),
+    }
+}
+
+/// Subscribe to `configuration:updated` events for the `iii-queue` entry. The
+/// deterministic trigger id means re-registration replaces rather than
+/// duplicates.
+pub async fn register_config_trigger(engine: &Engine) -> anyhow::Result<()> {
+    engine
+        .trigger_registry
+        .register_trigger(Trigger {
+            id: CONFIG_TRIGGER_ID.to_string(),
+            trigger_type: CONFIG_TRIGGER_TYPE.to_string(),
+            function_id: CONFIG_FN_ID.to_string(),
+            config: json!({
+                "configuration_id": CONFIG_ID,
+                "event_types": ["configuration:updated"],
+            }),
+            worker_id: None,
+            metadata: None,
+        })
+        .await
+        .map_err(|err| anyhow!("failed to register configuration trigger: {err:?}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use serde_json::json;
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::{
+        engine::{Handler, RegisterFunctionRequest},
+        function::FunctionResult,
+        workers::observability::metrics::ensure_default_meter,
+        workers::queue::config::DEFAULT_QUEUE_NAME,
+    };
+
+    /// Stub `configuration::get` to return a fixed stored value (`None` →
+    /// NOT_FOUND) and capture `configuration::register` payloads.
+    fn stub_configuration(
+        engine: &Arc<Engine>,
+        stored_value: Option<Value>,
+    ) -> mpsc::UnboundedReceiver<Value> {
+        engine.register_function_handler(
+            RegisterFunctionRequest {
+                function_id: "configuration::get".to_string(),
+                description: None,
+                request_format: None,
+                response_format: None,
+                metadata: None,
+            },
+            Handler::new(move |_input: Value| {
+                let stored_value = stored_value.clone();
+                async move {
+                    match stored_value {
+                        Some(value) => {
+                            FunctionResult::Success(Some(json!({ "id": CONFIG_ID, "value": value })))
+                        }
+                        None => FunctionResult::Failure(crate::protocol::ErrorBody {
+                            message: format!("configuration '{CONFIG_ID}' not found"),
+                            code: "NOT_FOUND".to_string(),
+                            stacktrace: None,
+                        }),
+                    }
+                }
+            }),
+        );
+
+        let (tx, rx) = mpsc::unbounded_channel::<Value>();
+        engine.register_function_handler(
+            RegisterFunctionRequest {
+                function_id: "configuration::register".to_string(),
+                description: None,
+                request_format: None,
+                response_format: None,
+                metadata: None,
+            },
+            Handler::new(move |input: Value| {
+                let tx = tx.clone();
+                async move {
+                    let _ = tx.send(input);
+                    FunctionResult::Success(Some(json!({})))
+                }
+            }),
+        );
+        rx
+    }
+
+    #[tokio::test]
+    async fn register_seeds_initial_value_when_nothing_stored() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        let mut registered = stub_configuration(&engine, None);
+
+        let mut queue_configs = std::collections::HashMap::new();
+        queue_configs.insert(
+            "reports".to_string(),
+            crate::workers::queue::config::FunctionQueueConfig {
+                concurrency: 7,
+                ..Default::default()
+            },
+        );
+        let seed = QueueModuleConfig {
+            adapter: None,
+            queue_configs,
+        };
+        register_config(&engine, Some(&seed)).await.unwrap();
+
+        let payload = registered.recv().await.unwrap();
+        assert_eq!(payload["id"], CONFIG_ID);
+        assert_eq!(payload["initial_value"]["queue_configs"]["reports"]["concurrency"], 7);
+        // schemars derives deny_unknown_fields into the schema.
+        assert_eq!(payload["schema"]["additionalProperties"], json!(false));
+        // Field doc comments must flow into the schema so an agent
+        // introspecting the config gets descriptions, not just types.
+        assert!(
+            payload["schema"]["properties"]["queue_configs"]["description"].is_string(),
+            "queue_configs field must carry a schema description: {payload}"
+        );
+        // Per-queue entries must reject unknown keys at set time too — a typo'd
+        // queue option silently ignored is a configuration footgun.
+        assert_eq!(
+            payload["schema"]["definitions"]["FunctionQueueConfig"]["additionalProperties"],
+            json!(false),
+            "FunctionQueueConfig schema must deny unknown fields: {payload}"
+        );
+        assert!(
+            payload["schema"]["definitions"]["FunctionQueueConfig"]["properties"]["concurrency"]
+                ["description"]
+                .is_string(),
+            "concurrency field must carry a schema description: {payload}"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_omits_initial_value_when_value_stored() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        let mut registered =
+            stub_configuration(&engine, Some(json!({ "queue_configs": { "x": {} } })));
+
+        register_config(&engine, Some(&QueueModuleConfig::default()))
+            .await
+            .unwrap();
+
+        let payload = registered.recv().await.unwrap();
+        assert!(
+            payload.get("initial_value").is_none(),
+            "stored value must not be clobbered: {payload}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_config_falls_back_when_not_found() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        let _registered = stub_configuration(&engine, None);
+
+        let config = fetch_config(&engine, &QueueModuleConfig::default())
+            .await
+            .unwrap();
+        // The always-present default queue is provisioned even on the fallback.
+        assert!(config.queue_configs.contains_key(DEFAULT_QUEUE_NAME));
+    }
+
+    #[tokio::test]
+    async fn fetch_config_falls_back_on_null_value() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        let _registered = stub_configuration(&engine, Some(Value::Null));
+
+        let config = fetch_config(&engine, &QueueModuleConfig::default())
+            .await
+            .unwrap();
+        assert!(config.queue_configs.contains_key(DEFAULT_QUEUE_NAME));
+    }
+
+    #[tokio::test]
+    async fn fetch_config_errors_on_malformed_value() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        let _registered = stub_configuration(
+            &engine,
+            Some(json!({ "queue_configs": { "x": { "concurrency": "not-a-number" } } })),
+        );
+
+        let result = fetch_config(&engine, &QueueModuleConfig::default()).await;
+        assert!(result.is_err(), "malformed value must surface as an error");
+    }
+
+    #[tokio::test]
+    async fn fetch_config_ensures_default_queue() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        let _registered = stub_configuration(&engine, Some(json!({ "queue_configs": {} })));
+
+        let config = fetch_config(&engine, &QueueModuleConfig::default())
+            .await
+            .unwrap();
+        assert!(
+            config.queue_configs.contains_key(DEFAULT_QUEUE_NAME),
+            "a stored value lacking `default` must still gain it on read"
+        );
+    }
+
+    #[tokio::test]
+    async fn on_config_change_keeps_previous_config_on_invalid_value() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        // FIFO without `message_group_field` deserializes fine and passes the
+        // JSON schema (which can't express the cross-field rule), so it reaches
+        // the worker's `validate()` gate — which must reject it and keep the
+        // previous live config.
+        let _registered =
+            stub_configuration(&engine, Some(json!({ "queue_configs": { "orders": { "type": "fifo" } } })));
+
+        let worker = QueueWorker::for_test(
+            engine.clone(),
+            Some(json!({ "queue_configs": { "default": { "concurrency": 3 } } })),
+        )
+        .await
+        .expect("queue worker");
+
+        on_config_change(&worker).await;
+
+        let config = worker.config_snapshot();
+        assert_eq!(
+            config.queue_configs.get("default").map(|c| c.concurrency),
+            Some(3),
+            "an invalid stored value must not mutate the live config"
+        );
+        assert!(
+            !config.queue_configs.contains_key("orders"),
+            "the invalid fifo queue must not be applied"
+        );
+    }
+}

--- a/engine/src/workers/queue/mod.rs
+++ b/engine/src/workers/queue/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod adapters;
 mod config;
+mod configuration;
 mod message;
 #[allow(clippy::module_inception)]
 mod queue;

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -226,7 +226,9 @@ impl QueueWorker {
         count: usize,
     ) -> anyhow::Result<Vec<Value>> {
         let namespaced = format!("__fn_queue::{}", queue_name);
-        self.adapter_snapshot().dlq_messages(&namespaced, count).await
+        self.adapter_snapshot()
+            .dlq_messages(&namespaced, count)
+            .await
     }
 
     #[function(id = "iii::durable::publish", description = "Enqueue a message")]
@@ -555,7 +557,11 @@ impl QueueWorker {
         let limit = input.limit;
 
         let resolved = self.resolve_queue_key(&topic);
-        match self.adapter_snapshot().dlq_peek(&resolved, offset, limit).await {
+        match self
+            .adapter_snapshot()
+            .dlq_peek(&resolved, offset, limit)
+            .await
+        {
             Ok(messages) => {
                 FunctionResult::Success(Some(serde_json::to_value(&messages).unwrap_or(json!([]))))
             }
@@ -782,11 +788,7 @@ impl QueueWorker {
     /// `consumers` map is mutated, so a failed (re)start leaves the previous
     /// consumer running — the property that makes the runtime apply best-effort
     /// safe.
-    async fn spawn_consumer(
-        &self,
-        name: &str,
-        config: &FunctionQueueConfig,
-    ) -> anyhow::Result<()> {
+    async fn spawn_consumer(&self, name: &str, config: &FunctionQueueConfig) -> anyhow::Result<()> {
         let adapter = self.adapter_snapshot();
         adapter.setup_function_queue(name, config).await?;
 
@@ -1622,7 +1624,9 @@ mod tests {
             },
             Handler::new(move |_input: Value| {
                 let value = value.clone();
-                async move { FunctionResult::Success(Some(json!({ "id": "iii-queue", "value": value }))) }
+                async move {
+                    FunctionResult::Success(Some(json!({ "id": "iii-queue", "value": value })))
+                }
             }),
         );
     }

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -7,7 +7,10 @@
 use std::{
     collections::HashMap,
     pin::Pin,
-    sync::{Arc, Mutex as StdMutex, RwLock},
+    sync::{
+        Arc, Mutex as StdMutex, RwLock,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use async_trait::async_trait;
@@ -21,7 +24,10 @@ use serde_json::{Value, json};
 use std::panic::AssertUnwindSafe;
 use tokio::task::AbortHandle;
 
-use super::{QueueAdapter, SubscriberQueueConfig, TopicInfo, config::QueueModuleConfig};
+use super::{
+    QueueAdapter, SubscriberQueueConfig, TopicInfo,
+    config::{FunctionQueueConfig, QueueModuleConfig},
+};
 use tracing::Instrument;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
@@ -36,10 +42,32 @@ use crate::{
 
 #[derive(Clone)]
 pub struct QueueWorker {
-    adapter: Arc<dyn QueueAdapter>,
     engine: Arc<Engine>,
-    _config: QueueModuleConfig,
-    consumer_aborts: Arc<StdMutex<Vec<AbortHandle>>>,
+    /// Live transport. The outer lock is held only for pointer swaps; readers
+    /// clone the inner `Arc` once per call via `adapter_snapshot()`. Behind a
+    /// lock so a runtime change to the `adapter` config can re-instantiate the
+    /// transport (full hot-swap) without rebuilding the worker.
+    adapter: Arc<RwLock<Arc<dyn QueueAdapter>>>,
+    /// Live config snapshot. The outer lock is held only for pointer swaps;
+    /// readers clone the inner `Arc` once per call via `config_snapshot()`,
+    /// which is what makes the value hot-swappable from the configuration
+    /// worker.
+    config: Arc<RwLock<Arc<QueueModuleConfig>>>,
+    /// The config.yaml block passed to `build()` (post-`ensure_default_queue`).
+    /// Used only as the seed for the first `configuration::register`; the
+    /// configuration worker entry is the runtime source of truth afterwards.
+    seed: Option<QueueModuleConfig>,
+    /// One live consumer task per queue name, so an individual consumer can be
+    /// restarted on a config change without disturbing the others.
+    consumers: Arc<StdMutex<HashMap<String, AbortHandle>>>,
+    /// Serializes concurrent `apply_config` runs (rapid configuration edits).
+    apply_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Set by `destroy()` (under `apply_lock`). A late `apply_config` — from an
+    /// in-flight trigger event or the detached one-shot retry in
+    /// `on_config_change` — checks this after acquiring the lock and bails, so a
+    /// torn-down worker can never re-spawn consumers. The queue analogue of
+    /// `HttpWorker`'s `shutdown_rx` None-guard.
+    destroyed: Arc<AtomicBool>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -113,7 +141,7 @@ impl QueueWorker {
     /// Function queues (listed in config) are prefixed with `__fn_queue::`;
     /// topic-based queues pass through unchanged.
     fn resolve_queue_key(&self, name: &str) -> String {
-        if self._config.queue_configs.contains_key(name) {
+        if self.config_snapshot().queue_configs.contains_key(name) {
             format!("__fn_queue::{}", name)
         } else {
             name.to_string()
@@ -129,10 +157,11 @@ impl QueueWorker {
         traceparent: Option<String>,
         baggage: Option<String>,
     ) -> anyhow::Result<()> {
-        let queue_config = self._config.queue_configs.get(queue_name).ok_or_else(|| {
+        let config = self.config_snapshot();
+        let queue_config = config.queue_configs.get(queue_name).ok_or_else(|| {
             tracing::warn!(
                 queue_name = %queue_name,
-                available = ?self._config.queue_configs.keys().collect::<Vec<_>>(),
+                available = ?config.queue_configs.keys().collect::<Vec<_>>(),
                 "Enqueue attempted for unknown queue"
             );
             anyhow::anyhow!("Queue '{}' not found", queue_name)
@@ -168,7 +197,7 @@ impl QueueWorker {
         // `BaggageSpanProcessor` would otherwise stamp.
         let baggage = crate::telemetry::baggage_with_function_id(baggage.as_deref(), function_id);
 
-        self.adapter
+        self.adapter_snapshot()
             .publish_to_function_queue(
                 queue_name,
                 function_id,
@@ -187,7 +216,7 @@ impl QueueWorker {
     /// Returns the number of messages in the DLQ for a function queue.
     pub async fn function_queue_dlq_count(&self, queue_name: &str) -> anyhow::Result<u64> {
         let namespaced = format!("__fn_queue::{}", queue_name);
-        self.adapter.dlq_count(&namespaced).await
+        self.adapter_snapshot().dlq_count(&namespaced).await
     }
 
     /// Returns up to `count` DLQ messages for a function queue as parsed JSON Values.
@@ -197,12 +226,12 @@ impl QueueWorker {
         count: usize,
     ) -> anyhow::Result<Vec<Value>> {
         let namespaced = format!("__fn_queue::{}", queue_name);
-        self.adapter.dlq_messages(&namespaced, count).await
+        self.adapter_snapshot().dlq_messages(&namespaced, count).await
     }
 
     #[function(id = "iii::durable::publish", description = "Enqueue a message")]
     pub async fn enqueue(&self, input: QueueInput) -> FunctionResult<Option<Value>, ErrorBody> {
-        let adapter = self.adapter.clone();
+        let adapter = self.adapter_snapshot();
         let event_data = input.data;
         let topic = input.topic;
 
@@ -247,7 +276,7 @@ impl QueueWorker {
         }
 
         let resolved = self.resolve_queue_key(&input.queue);
-        match self.adapter.redrive_dlq(&resolved).await {
+        match self.adapter_snapshot().redrive_dlq(&resolved).await {
             Ok(count) => {
                 tracing::info!(
                     queue = %input.queue,
@@ -300,7 +329,7 @@ impl QueueWorker {
 
         let resolved = self.resolve_queue_key(&input.queue);
         match self
-            .adapter
+            .adapter_snapshot()
             .redrive_dlq_message(&resolved, &input.message_id)
             .await
         {
@@ -362,7 +391,7 @@ impl QueueWorker {
 
         let resolved = self.resolve_queue_key(&input.queue);
         match self
-            .adapter
+            .adapter_snapshot()
             .discard_dlq_message(&resolved, &input.message_id)
             .await
         {
@@ -390,14 +419,14 @@ impl QueueWorker {
         &self,
         _input: Value,
     ) -> FunctionResult<Option<Value>, ErrorBody> {
-        match self.adapter.list_topics().await {
+        match self.adapter_snapshot().list_topics().await {
             Ok(topics) => {
                 // Merge function queue topics from config.
                 // Adapters report these with subscriber_count=0 because internal
                 // consumers aren't tracked in the subscription map. Override with
                 // the configured concurrency so the console shows the real count.
                 let mut all_topics = topics;
-                for (name, config) in &self._config.queue_configs {
+                for (name, config) in &self.config_snapshot().queue_configs {
                     let namespaced = format!("__fn_queue::{}", name);
                     if let Some(existing) = all_topics
                         .iter_mut()
@@ -448,12 +477,12 @@ impl QueueWorker {
         }
 
         let resolved = self.resolve_queue_key(&topic);
-        match self.adapter.topic_stats(&resolved).await {
+        match self.adapter_snapshot().topic_stats(&resolved).await {
             Ok(mut stats) => {
                 // Adapters report consumer_count=0 for function queues because
                 // internal consumers aren't tracked in the subscription map.
                 // Override with the configured concurrency.
-                if let Some(config) = self._config.queue_configs.get(&topic) {
+                if let Some(config) = self.config_snapshot().queue_configs.get(&topic) {
                     stats.consumer_count = config.concurrency as u64;
                 }
                 FunctionResult::Success(Some(serde_json::to_value(&stats).unwrap_or(json!({}))))
@@ -474,11 +503,12 @@ impl QueueWorker {
         &self,
         _input: Value,
     ) -> FunctionResult<Option<Value>, ErrorBody> {
-        match self.adapter.list_topics().await {
+        let adapter = self.adapter_snapshot();
+        match adapter.list_topics().await {
             Ok(topics) => {
                 let mut dlq_topics = Vec::new();
                 for topic in &topics {
-                    let dlq_count = self.adapter.dlq_count(&topic.name).await.unwrap_or(0);
+                    let dlq_count = adapter.dlq_count(&topic.name).await.unwrap_or(0);
                     dlq_topics.push(json!({
                         "topic": topic.name,
                         "broker_type": topic.broker_type,
@@ -486,9 +516,9 @@ impl QueueWorker {
                     }));
                 }
                 // Also include function queue DLQs
-                for name in self._config.queue_configs.keys() {
+                for name in self.config_snapshot().queue_configs.keys() {
                     let namespaced = format!("__fn_queue::{}", name);
-                    let dlq_count = self.adapter.dlq_count(&namespaced).await.unwrap_or(0);
+                    let dlq_count = adapter.dlq_count(&namespaced).await.unwrap_or(0);
                     dlq_topics.push(json!({
                         "topic": name,
                         "broker_type": "function_queue",
@@ -525,7 +555,7 @@ impl QueueWorker {
         let limit = input.limit;
 
         let resolved = self.resolve_queue_key(&topic);
-        match self.adapter.dlq_peek(&resolved, offset, limit).await {
+        match self.adapter_snapshot().dlq_peek(&resolved, offset, limit).await {
             Ok(messages) => {
                 FunctionResult::Success(Some(serde_json::to_value(&messages).unwrap_or(json!([]))))
             }
@@ -595,7 +625,7 @@ impl TriggerRegistrator for QueueWorker {
         );
 
         // Get adapter reference before async block
-        let adapter = self.adapter.clone();
+        let adapter = self.adapter_snapshot();
 
         Box::pin(async move {
             if !topic.is_empty() {
@@ -635,7 +665,7 @@ impl TriggerRegistrator for QueueWorker {
         trigger: Trigger,
     ) -> Pin<Box<dyn Future<Output = Result<(), anyhow::Error>> + Send + '_>> {
         // Get adapter reference before async block
-        let adapter = self.adapter.clone();
+        let adapter = self.adapter_snapshot();
 
         Box::pin(async move {
             tracing::debug!(trigger = %trigger.id, "Unregistering trigger");
@@ -655,6 +685,356 @@ impl TriggerRegistrator for QueueWorker {
     }
 }
 
+impl QueueWorker {
+    /// Cheap clone of the live config. Take one snapshot per call so all reads
+    /// within it are consistent.
+    pub fn config_snapshot(&self) -> Arc<QueueModuleConfig> {
+        self.config.read().expect("config lock poisoned").clone()
+    }
+
+    fn set_config(&self, config: QueueModuleConfig) {
+        *self.config.write().expect("config lock poisoned") = Arc::new(config);
+    }
+
+    /// Cheap clone of the live transport. Take one snapshot per call.
+    /// `pub` (mirroring `config_snapshot`) so integration tests can confirm a
+    /// hot-swap actually rebuilt the adapter instance.
+    pub fn adapter_snapshot(&self) -> Arc<dyn QueueAdapter> {
+        self.adapter.read().expect("adapter lock poisoned").clone()
+    }
+
+    fn set_adapter(&self, adapter: Arc<dyn QueueAdapter>) {
+        *self.adapter.write().expect("adapter lock poisoned") = adapter;
+    }
+
+    /// Resolve and instantiate the adapter named by `config` (or the default).
+    /// Mirrors steps 3–4 of `ConfigurableWorker::create_with_adapters`, reused
+    /// for test construction and for runtime adapter hot-swaps.
+    async fn resolve_adapter(
+        engine: &Arc<Engine>,
+        config: &QueueModuleConfig,
+    ) -> anyhow::Result<Arc<dyn QueueAdapter>> {
+        let adapter_name = Self::adapter_name_from_config(config)
+            .unwrap_or_else(|| Self::DEFAULT_ADAPTER_NAME.to_string());
+        let factory = Self::get_adapter(&adapter_name)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("queue adapter '{adapter_name}' is not registered"))?;
+        let adapter_config = Self::adapter_config_from_config(config);
+        factory(engine.clone(), adapter_config).await
+    }
+
+    /// Effective `(name, config)` of the adapter selected by `config`, with the
+    /// default name filled in, so `None` vs `Some(builtin)` is not a false
+    /// change when comparing two configs.
+    fn effective_adapter(config: &QueueModuleConfig) -> (String, Option<Value>) {
+        (
+            Self::adapter_name_from_config(config)
+                .unwrap_or_else(|| Self::DEFAULT_ADAPTER_NAME.to_string()),
+            Self::adapter_config_from_config(config),
+        )
+    }
+
+    /// Construct a worker from a raw config value — mirrors `HttpWorker::for_test`
+    /// so integration tests in `engine/tests/` can drive the concrete worker
+    /// without booting the full engine. Async because the queue resolves its
+    /// adapter from the registry.
+    #[doc(hidden)]
+    pub async fn for_test(engine: Arc<Engine>, config: Option<Value>) -> anyhow::Result<Self> {
+        let parsed: QueueModuleConfig = config
+            .map(serde_json::from_value)
+            .transpose()?
+            .unwrap_or_default();
+        let adapter = Self::resolve_adapter(&engine, &parsed).await?;
+        Ok(Self::build(engine, parsed, adapter))
+    }
+
+    /// Register the `iii-queue::on-config-change` handler. Idempotent
+    /// (replace-by-id), so it is safe to call from both `register_functions`
+    /// (which runs inside the worker scope for destroy/reload cleanup) and
+    /// `start_background_tasks` (which registers the trigger and runs first).
+    fn register_config_handler(&self, engine: &Arc<Engine>) {
+        let worker = self.clone();
+        engine.register_function_handler(
+            RegisterFunctionRequest {
+                function_id: super::configuration::CONFIG_FN_ID.to_string(),
+                description: Some(
+                    "Internal: re-apply the iii-queue configuration when the \
+                     authoritative configuration entry changes."
+                        .to_string(),
+                ),
+                request_format: None,
+                response_format: None,
+                metadata: None,
+            },
+            Handler::new(move |_payload: Value| {
+                let worker = worker.clone();
+                async move {
+                    super::configuration::on_config_change(&worker).await;
+                    FunctionResult::Success(Some(json!({ "ok": true })))
+                }
+            }),
+        );
+    }
+
+    /// Set up and start (or restart) the consumer for one queue. Aborts any
+    /// prior consumer for `name` only after the new one is live, so a restart
+    /// never strands the queue. Every fallible adapter call happens BEFORE the
+    /// `consumers` map is mutated, so a failed (re)start leaves the previous
+    /// consumer running — the property that makes the runtime apply best-effort
+    /// safe.
+    async fn spawn_consumer(
+        &self,
+        name: &str,
+        config: &FunctionQueueConfig,
+    ) -> anyhow::Result<()> {
+        let adapter = self.adapter_snapshot();
+        adapter.setup_function_queue(name, config).await?;
+
+        let prefetch = if config.r#type == "fifo" {
+            1
+        } else {
+            config.concurrency
+        };
+        let max_retries = config.max_retries;
+        let mut receiver = adapter.consume_function_queue(name, prefetch).await?;
+
+        let engine = self.engine.clone();
+        let queue_name = name.to_string();
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(prefetch as usize));
+
+        let handle = tokio::spawn(async move {
+            while let Some(msg) = receiver.recv().await {
+                let adapter = adapter.clone();
+                let engine = engine.clone();
+                let queue_name = queue_name.clone();
+                let semaphore = semaphore.clone();
+
+                let permit = semaphore.acquire_owned().await;
+                if permit.is_err() {
+                    break;
+                }
+                let permit = permit.unwrap();
+
+                let traceparent = msg.traceparent.clone();
+                let baggage = msg.baggage.clone();
+
+                tokio::spawn(async move {
+                    let delivery_id = msg.delivery_id;
+                    let function_id = msg.function_id.clone();
+                    let attempt = msg.attempt;
+
+                    let span = tracing::info_span!(
+                        "fn_queue_job",
+                        otel.name = %format!("fn_queue {}", queue_name),
+                        function_id = %function_id,
+                        queue = %queue_name,
+                        attempt = %attempt,
+                        delivery_id = %delivery_id,
+                        "messaging.system" = "iii-queue",
+                        "messaging.destination.name" = %queue_name,
+                        "messaging.operation.type" = "process",
+                        otel.status_code = tracing::field::Empty,
+                    )
+                    .with_parent_headers(traceparent.as_deref(), baggage.as_deref());
+
+                    let result =
+                        AssertUnwindSafe(async { engine.call(&function_id, msg.data).await })
+                            .catch_unwind()
+                            .instrument(span)
+                            .await;
+
+                    match result {
+                        Ok(Ok(_)) => {
+                            tracing::Span::current().record("otel.status_code", "OK");
+                            if let Err(e) =
+                                adapter.ack_function_queue(&queue_name, delivery_id).await
+                            {
+                                tracing::error!(error = %e, "Failed to ack message");
+                            }
+                        }
+                        Ok(Err(ref err)) => {
+                            tracing::Span::current().record("otel.status_code", "ERROR");
+                            tracing::warn!(
+                                function_id = %function_id,
+                                queue = %queue_name,
+                                attempt = %attempt,
+                                max_retries = %max_retries,
+                                error = ?err,
+                                "Function queue job failed"
+                            );
+                            if let Err(e) = adapter
+                                .nack_function_queue(&queue_name, delivery_id, attempt, max_retries)
+                                .await
+                            {
+                                tracing::error!(error = %e, "Failed to nack message");
+                            }
+                        }
+                        Err(_panic) => {
+                            tracing::Span::current().record("otel.status_code", "ERROR");
+                            tracing::error!(
+                                function_id = %function_id,
+                                queue = %queue_name,
+                                attempt = %attempt,
+                                max_retries = %max_retries,
+                                "Function queue job panicked"
+                            );
+                            if let Err(e) = adapter
+                                .nack_function_queue(&queue_name, delivery_id, attempt, max_retries)
+                                .await
+                            {
+                                tracing::error!(error = %e, "Failed to nack panicked message");
+                            }
+                        }
+                    }
+
+                    drop(permit);
+                });
+            }
+
+            tracing::warn!(queue = %queue_name, "Consumer loop ended");
+        });
+
+        // Insert the new handle, then abort any prior one for this name. The
+        // fallible work above already succeeded, so the swap cannot strand the
+        // queue without a consumer.
+        let previous = self
+            .consumers
+            .lock()
+            .expect("consumers mutex poisoned")
+            .insert(name.to_string(), handle.abort_handle());
+        if let Some(previous) = previous {
+            previous.abort();
+        }
+
+        tracing::info!(
+            queue = %name,
+            r#type = %config.r#type,
+            concurrency = %config.concurrency,
+            "Started function queue consumer"
+        );
+        Ok(())
+    }
+
+    /// Re-fetch the authoritative configuration and hot-apply it. The
+    /// authoritative read happens under `apply_lock` so overlapping
+    /// configuration events can't apply a stale value last (lost update).
+    ///
+    /// The fetch+validate gate is strict all-or-nothing: any failure keeps the
+    /// previous config, adapter, and every consumer. Past the gate, an adapter
+    /// change re-instantiates the transport and restarts every consumer on it;
+    /// otherwise the `queue_configs` delta is applied per queue, best-effort —
+    /// a single queue's restart failure is logged while the others apply and
+    /// that queue keeps its previous consumer.
+    pub(super) async fn apply_config(&self) -> anyhow::Result<()> {
+        let _guard = self.apply_lock.lock().await;
+
+        // Bail if the worker was torn down. `destroy()` sets this under the same
+        // lock, so a late apply (in-flight trigger event, or the detached retry
+        // in `on_config_change`) can never re-spawn consumers post-destroy.
+        if self.destroyed.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        // GATE: fetch under the lock; keep the `Elapsed` error downcastable so
+        // `on_config_change` schedules its one-shot retry for timeouts only.
+        let new_config = match tokio::time::timeout(
+            super::configuration::CONFIG_BUS_TIMEOUT,
+            super::configuration::fetch_config(self.engine.as_ref(), &self.config_snapshot()),
+        )
+        .await
+        {
+            Ok(result) => result?,
+            Err(elapsed) => {
+                return Err(anyhow::Error::new(elapsed)
+                    .context("configuration::get timed out; keeping previous config"));
+            }
+        };
+        new_config.validate()?;
+
+        let old = self.config_snapshot();
+
+        if Self::effective_adapter(&old) != Self::effective_adapter(&new_config) {
+            // FULL TRANSPORT HOT-SWAP. Build the new adapter first (fallible); a
+            // failure keeps the previous config, adapter, and consumers. Then
+            // restart every consumer on the new transport.
+            let new_adapter = Self::resolve_adapter(&self.engine, &new_config).await?;
+            self.set_config(new_config.clone());
+            let previous: Vec<AbortHandle> = self
+                .consumers
+                .lock()
+                .expect("consumers mutex poisoned")
+                .drain()
+                .map(|(_, handle)| handle)
+                .collect();
+            for handle in previous {
+                handle.abort();
+            }
+            self.set_adapter(new_adapter);
+            // Data-loss boundary (accepted tradeoff for a transport hot-swap):
+            // the new adapter starts empty, so messages still queued in the old
+            // adapter do NOT migrate — plus in-flight per-message tasks finish
+            // acking against the OLD adapter Arc they captured. The old adapter
+            // is dropped once its last ref is gone. Re-spawn is best-effort per
+            // queue: a queue whose `spawn_consumer` fails here is left with NO
+            // consumer (unlike the same-adapter path, which retains the prior
+            // one) because the transport it was bound to no longer exists.
+            for (name, queue_config) in &new_config.queue_configs {
+                if let Err(err) = self.spawn_consumer(name, queue_config).await {
+                    tracing::error!(
+                        queue = %name,
+                        error = %err,
+                        "iii-queue: failed to start consumer on the new adapter; queue left unconsumed"
+                    );
+                }
+            }
+            tracing::info!("iii-queue transport hot-swapped after configuration change");
+            return Ok(());
+        }
+
+        // Same adapter: diff `queue_configs` and restart only what changed.
+        // Publish the new snapshot first so restarted consumers and the enqueue
+        // path read the new settings.
+        self.set_config(new_config.clone());
+
+        // Removed: present in old, absent from new. `default` is always present
+        // in `new_config` (ensure_default_queue runs in fetch_config), so it can
+        // never land in this branch.
+        for name in old.queue_configs.keys() {
+            if !new_config.queue_configs.contains_key(name) {
+                if let Some(handle) = self
+                    .consumers
+                    .lock()
+                    .expect("consumers mutex poisoned")
+                    .remove(name)
+                {
+                    handle.abort();
+                }
+                tracing::info!(queue = %name, "Stopped consumer for removed queue");
+            }
+        }
+
+        // Added or changed: (re)start the consumer (best-effort per queue).
+        for (name, queue_config) in &new_config.queue_configs {
+            let unchanged = old
+                .queue_configs
+                .get(name)
+                .is_some_and(|prev| prev == queue_config);
+            if unchanged {
+                continue;
+            }
+            if let Err(err) = self.spawn_consumer(name, queue_config).await {
+                tracing::error!(
+                    queue = %name,
+                    error = %err,
+                    "iii-queue: failed to (re)start consumer; keeping previous consumer for this queue"
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl Worker for QueueWorker {
     fn name(&self) -> &'static str {
@@ -665,12 +1045,20 @@ impl Worker for QueueWorker {
     }
 
     fn register_functions(&self, engine: Arc<Engine>) {
-        self.register_functions(engine);
+        // The `#[service]`-generated inherent method registers every queue
+        // function; the config handler is registered alongside it (inside the
+        // worker scope) so destroy/reload track and remove it. The hook order
+        // differs by pipeline: initial boot runs `register_functions` BEFORE
+        // `start_background_tasks`, reload runs it AFTER — so
+        // `start_background_tasks` also registers the handler (if absent) before
+        // subscribing to configuration events.
+        self.register_functions(engine.clone());
+        self.register_config_handler(&engine);
     }
 
     async fn initialize(&self) -> anyhow::Result<()> {
         tracing::info!("Initializing QueueModule");
-        self._config.validate()?;
+        self.config_snapshot().validate()?;
         self.engine.set_queue_module(Arc::new(self.clone())).await;
 
         let trigger_type = TriggerType::new(
@@ -690,140 +1078,90 @@ impl Worker for QueueWorker {
         _shutdown_rx: tokio::sync::watch::Receiver<bool>,
         _shutdown_tx: tokio::sync::watch::Sender<bool>,
     ) -> anyhow::Result<()> {
-        // Consumer loops are not wired to `shutdown_rx`: `destroy()` aborts the
-        // spawned task via the stored AbortHandle, which is sufficient to stop
-        // it cleanly during reload. Adding a `select!` on shutdown made
-        // `receiver.recv()` race-prone under heavy parallel test load.
-        for (name, config) in &self._config.queue_configs {
-            self.adapter.setup_function_queue(name, config).await?;
-
-            let prefetch = if config.r#type == "fifo" {
-                1
-            } else {
-                config.concurrency
-            };
-            let max_retries = config.max_retries;
-            let mut receiver = self.adapter.consume_function_queue(name, prefetch).await?;
-
-            let adapter = self.adapter.clone();
-            let engine = self.engine.clone();
-            let queue_name = name.clone();
-
-            let semaphore = Arc::new(tokio::sync::Semaphore::new(prefetch as usize));
-
-            let handle = tokio::spawn(async move {
-                while let Some(msg) = receiver.recv().await {
-                    let adapter = adapter.clone();
-                    let engine = engine.clone();
-                    let queue_name = queue_name.clone();
-                    let semaphore = semaphore.clone();
-
-                    let permit = semaphore.acquire_owned().await;
-                    if permit.is_err() {
-                        break;
-                    }
-                    let permit = permit.unwrap();
-
-                    let traceparent = msg.traceparent.clone();
-                    let baggage = msg.baggage.clone();
-
-                    tokio::spawn(async move {
-                        let delivery_id = msg.delivery_id;
-                        let function_id = msg.function_id.clone();
-                        let attempt = msg.attempt;
-
-                        let span = tracing::info_span!(
-                            "fn_queue_job",
-                            otel.name = %format!("fn_queue {}", queue_name),
-                            function_id = %function_id,
-                            queue = %queue_name,
-                            attempt = %attempt,
-                            delivery_id = %delivery_id,
-                            "messaging.system" = "iii-queue",
-                            "messaging.destination.name" = %queue_name,
-                            "messaging.operation.type" = "process",
-                            otel.status_code = tracing::field::Empty,
-                        )
-                        .with_parent_headers(traceparent.as_deref(), baggage.as_deref());
-
-                        let result =
-                            AssertUnwindSafe(async { engine.call(&function_id, msg.data).await })
-                                .catch_unwind()
-                                .instrument(span)
-                                .await;
-
-                        match result {
-                            Ok(Ok(_)) => {
-                                tracing::Span::current().record("otel.status_code", "OK");
-                                if let Err(e) =
-                                    adapter.ack_function_queue(&queue_name, delivery_id).await
-                                {
-                                    tracing::error!(error = %e, "Failed to ack message");
-                                }
-                            }
-                            Ok(Err(ref err)) => {
-                                tracing::Span::current().record("otel.status_code", "ERROR");
-                                tracing::warn!(
-                                    function_id = %function_id,
-                                    queue = %queue_name,
-                                    attempt = %attempt,
-                                    max_retries = %max_retries,
-                                    error = ?err,
-                                    "Function queue job failed"
-                                );
-                                if let Err(e) = adapter
-                                    .nack_function_queue(
-                                        &queue_name,
-                                        delivery_id,
-                                        attempt,
-                                        max_retries,
-                                    )
-                                    .await
-                                {
-                                    tracing::error!(error = %e, "Failed to nack message");
-                                }
-                            }
-                            Err(_panic) => {
-                                tracing::Span::current().record("otel.status_code", "ERROR");
-                                tracing::error!(
-                                    function_id = %function_id,
-                                    queue = %queue_name,
-                                    attempt = %attempt,
-                                    max_retries = %max_retries,
-                                    "Function queue job panicked"
-                                );
-                                if let Err(e) = adapter
-                                    .nack_function_queue(
-                                        &queue_name,
-                                        delivery_id,
-                                        attempt,
-                                        max_retries,
-                                    )
-                                    .await
-                                {
-                                    tracing::error!(error = %e, "Failed to nack panicked message");
-                                }
-                            }
-                        }
-
-                        drop(permit);
-                    });
-                }
-
-                tracing::warn!(queue = %queue_name, "Consumer loop ended");
-            });
-
-            self.consumer_aborts
-                .lock()
-                .expect("consumer_aborts mutex poisoned")
-                .push(handle.abort_handle());
-
-            tracing::info!(
-                queue = %name,
-                r#type = %config.r#type,
-                concurrency = %config.concurrency,
-                "Started function queue consumer"
+        // Adopt the configuration worker as the runtime source of truth.
+        // `configuration::*` is callable on both pipelines (initial boot
+        // registers all worker functions before serving; reload starts the
+        // mandatory configuration worker before optional ones). Failures
+        // degrade to the static config.yaml block so the queue stays up. Both
+        // bus calls are time-bounded: worker startup is awaited serially by the
+        // boot and reload pipelines, so a hung `configuration::*` provider must
+        // not wedge every other worker behind this one.
+        let register = tokio::time::timeout(
+            super::configuration::CONFIG_BUS_TIMEOUT,
+            super::configuration::register_config(self.engine.as_ref(), self.seed.as_ref()),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("configuration::register timed out"))
+        .and_then(|result| result);
+        if let Err(err) = register {
+            tracing::warn!(
+                error = %err,
+                "iii-queue: configuration::register failed; continuing with static config"
             );
+        }
+        let fetched = tokio::time::timeout(
+            super::configuration::CONFIG_BUS_TIMEOUT,
+            super::configuration::fetch_config(self.engine.as_ref(), &self.config_snapshot()),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("configuration::get timed out"))
+        .and_then(|result| result);
+        match fetched {
+            // Validate before adopting. The configuration worker's JSON schema
+            // can't express cross-field rules (a `fifo` queue requires
+            // `message_group_field`), so a value that `apply_config` rejects at
+            // runtime can still be stored and read back here. Without this gate
+            // a bad stored value would boot a misconfigured consumer on the next
+            // restart. On failure keep the seed (already validated in
+            // `initialize`), matching the runtime apply gate.
+            Ok(config) => match config.validate() {
+                Ok(()) => self.set_config(config),
+                Err(err) => tracing::warn!(
+                    error = %err,
+                    "iii-queue: stored configuration is invalid; continuing with static config"
+                ),
+            },
+            Err(err) => tracing::warn!(
+                error = %err,
+                "iii-queue: failed to read configuration; continuing with static config"
+            ),
+        }
+
+        // Start a consumer per queue from the (possibly updated) snapshot. The
+        // initial spawn is fatal: a queue that cannot be set up at boot fails
+        // the worker, preserving the pre-migration behavior. Runtime restarts
+        // in `apply_config` are best-effort by contrast.
+        let config = self.config_snapshot();
+        for (name, queue_config) in &config.queue_configs {
+            self.spawn_consumer(name, queue_config).await?;
+        }
+
+        // Register the handler before the trigger so a configuration event can
+        // never fan out to a missing function. On reload, `register_functions`
+        // runs after this hook and re-registers the handler inside the worker
+        // scope; the `get` check keeps the initial-boot path (where it already
+        // ran) from logging a spurious overwrite.
+        if self
+            .engine
+            .functions
+            .get(super::configuration::CONFIG_FN_ID)
+            .is_none()
+        {
+            self.register_config_handler(&self.engine);
+        }
+        if let Err(err) = super::configuration::register_config_trigger(&self.engine).await {
+            tracing::warn!(
+                error = %err,
+                "iii-queue: failed to watch configuration changes; hot-reload disabled"
+            );
+        } else {
+            // Catch-up pass: replay any `configuration::set` that landed between
+            // the boot fetch above and the trigger subscription — without it
+            // that window's updates would be dropped until the next edit. Routed
+            // through `on_config_change` (not `apply_config` directly) so a
+            // timed-out catch-up gets the same one-shot delayed retry as a
+            // trigger-driven apply.
+            super::configuration::on_config_change(self).await;
         }
 
         Ok(())
@@ -831,11 +1169,28 @@ impl Worker for QueueWorker {
 
     async fn destroy(&self) -> anyhow::Result<()> {
         tracing::info!("Destroying QueueModule");
+        // The trigger is registered outside the worker scope, so remove it
+        // explicitly to keep ReloadManager restarts duplicate-free.
+        let _ = self
+            .engine
+            .trigger_registry
+            .unregister_trigger(
+                super::configuration::CONFIG_TRIGGER_ID.to_string(),
+                Some(super::configuration::CONFIG_TRIGGER_TYPE.to_string()),
+            )
+            .await;
+
+        // Serialize with any in-flight `apply_config` so a restart can't spawn a
+        // replacement consumer after we abort below. Setting `destroyed` under
+        // the lock makes every later apply bail before re-spawning.
+        let _guard = self.apply_lock.lock().await;
+        self.destroyed.store(true, Ordering::SeqCst);
         let aborts: Vec<AbortHandle> = self
-            .consumer_aborts
+            .consumers
             .lock()
-            .expect("consumer_aborts mutex poisoned")
-            .drain(..)
+            .expect("consumers mutex poisoned")
+            .drain()
+            .map(|(_, handle)| handle)
             .collect();
         for abort in aborts {
             abort.abort();
@@ -863,11 +1218,18 @@ impl ConfigurableWorker for QueueWorker {
         // consumer spawn in `start_background_tasks` and the lookup in
         // `enqueue_to_function_queue` see it.
         config.ensure_default_queue();
+        // The config.yaml block (with the default queue provisioned) seeds the
+        // first `configuration::register`; the configuration entry is the
+        // runtime source of truth afterwards.
+        let seed = Some(config.clone());
         Self {
             engine,
-            _config: config,
-            adapter,
-            consumer_aborts: Arc::new(StdMutex::new(Vec::new())),
+            adapter: Arc::new(RwLock::new(adapter)),
+            config: Arc::new(RwLock::new(Arc::new(config))),
+            seed,
+            consumers: Arc::new(StdMutex::new(HashMap::new())),
+            apply_lock: Arc::new(tokio::sync::Mutex::new(())),
+            destroyed: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -1064,6 +1426,9 @@ mod tests {
         dlq_count_value: AtomicU64,
         dlq_count_should_fail: AtomicBool,
         discard_should_fail: AtomicBool,
+        /// Queue names whose `setup_function_queue` returns an error, for
+        /// exercising per-queue spawn-failure isolation in `apply_config`.
+        setup_fail_queues: Mutex<std::collections::HashSet<String>>,
     }
 
     impl MockQueueAdapter {
@@ -1093,6 +1458,7 @@ mod tests {
                 dlq_count_value: AtomicU64::new(0),
                 dlq_count_should_fail: AtomicBool::new(false),
                 discard_should_fail: AtomicBool::new(false),
+                setup_fail_queues: Mutex::new(std::collections::HashSet::new()),
             }
         }
     }
@@ -1206,9 +1572,12 @@ mod tests {
 
         async fn setup_function_queue(
             &self,
-            _queue_name: &str,
+            queue_name: &str,
             _config: &super::super::config::FunctionQueueConfig,
         ) -> anyhow::Result<()> {
+            if self.setup_fail_queues.lock().await.contains(queue_name) {
+                return Err(anyhow::anyhow!("mock setup failure for '{queue_name}'"));
+            }
             Ok(())
         }
 
@@ -1226,13 +1595,165 @@ mod tests {
         crate::workers::observability::metrics::ensure_default_meter();
         let engine = Arc::new(Engine::new());
         let adapter = Arc::new(MockQueueAdapter::new());
+        let adapter_dyn: Arc<dyn QueueAdapter> = adapter.clone();
         let module = QueueWorker {
-            adapter: adapter.clone(),
             engine: engine.clone(),
-            _config: super::super::config::QueueModuleConfig::default(),
-            consumer_aborts: Arc::new(StdMutex::new(Vec::new())),
+            adapter: Arc::new(RwLock::new(adapter_dyn)),
+            config: Arc::new(RwLock::new(Arc::new(
+                super::super::config::QueueModuleConfig::default(),
+            ))),
+            seed: None,
+            consumers: Arc::new(StdMutex::new(HashMap::new())),
+            apply_lock: Arc::new(tokio::sync::Mutex::new(())),
+            destroyed: Arc::new(AtomicBool::new(false)),
         };
         (engine, module, adapter)
+    }
+
+    /// Stub `configuration::get` on the engine to return a fixed value.
+    fn stub_configuration_get(engine: &Arc<Engine>, value: Value) {
+        engine.register_function_handler(
+            RegisterFunctionRequest {
+                function_id: "configuration::get".to_string(),
+                description: None,
+                request_format: None,
+                response_format: None,
+                metadata: None,
+            },
+            Handler::new(move |_input: Value| {
+                let value = value.clone();
+                async move { FunctionResult::Success(Some(json!({ "id": "iii-queue", "value": value }))) }
+            }),
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_config_isolates_per_queue_spawn_failure() {
+        let (engine, module, adapter) = setup_queue_module();
+        // The mock fails `setup_function_queue` for "bad" only.
+        adapter
+            .setup_fail_queues
+            .lock()
+            .await
+            .insert("bad".to_string());
+
+        stub_configuration_get(
+            &engine,
+            json!({ "queue_configs": {
+                "good": { "concurrency": 1 },
+                "bad": { "concurrency": 1 }
+            } }),
+        );
+
+        // A single queue's spawn failure must not abort the whole apply.
+        module
+            .apply_config()
+            .await
+            .expect("apply_config must not error on a per-queue spawn failure");
+
+        // The gate adopted the new config (set_config ran before the per-queue loop).
+        let cfg = module.config_snapshot();
+        assert!(cfg.queue_configs.contains_key("good"));
+        assert!(cfg.queue_configs.contains_key("bad"));
+        assert!(cfg.queue_configs.contains_key("default"));
+
+        // Best-effort isolation: healthy queues got consumers; the failing one
+        // did not, but it did not block the others.
+        let consumers = module.consumers.lock().expect("consumers mutex");
+        assert!(
+            consumers.contains_key("good"),
+            "a healthy queue must get a consumer even when a sibling fails"
+        );
+        assert!(
+            consumers.contains_key("default"),
+            "the default queue must get a consumer"
+        );
+        assert!(
+            !consumers.contains_key("bad"),
+            "the failing queue must be left out of the consumers map"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn apply_config_timeout_surfaces_downcastable_elapsed() {
+        let (engine, module, _adapter) = setup_queue_module();
+        // `configuration::get` never returns, so the bounded fetch times out.
+        // The paused clock auto-advances to the timeout (no real 10s wait).
+        engine.register_function_handler(
+            RegisterFunctionRequest {
+                function_id: "configuration::get".to_string(),
+                description: None,
+                request_format: None,
+                response_format: None,
+                metadata: None,
+            },
+            Handler::new(|_input: Value| async {
+                std::future::pending::<FunctionResult<Option<Value>, crate::protocol::ErrorBody>>()
+                    .await
+            }),
+        );
+
+        let err = module
+            .apply_config()
+            .await
+            .expect_err("a timed-out fetch must surface as an error");
+
+        // `on_config_change` branches on this downcast to schedule its one-shot
+        // retry; if the timeout stopped being downcastable the retry path would
+        // silently break.
+        assert!(
+            err.downcast_ref::<tokio::time::error::Elapsed>().is_some(),
+            "apply_config timeout must stay downcastable to Elapsed: {err:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn on_config_change_retries_once_after_timeout() {
+        let (engine, module, _adapter) = setup_queue_module();
+        // First `configuration::get` hangs (forcing a timeout); every later call
+        // returns a valid config. The one-shot retry must pick it up.
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        engine.register_function_handler(
+            RegisterFunctionRequest {
+                function_id: "configuration::get".to_string(),
+                description: None,
+                request_format: None,
+                response_format: None,
+                metadata: None,
+            },
+            Handler::new(move |_input: Value| {
+                let calls = calls.clone();
+                async move {
+                    let n = calls.fetch_add(1, Ordering::SeqCst);
+                    if n == 0 {
+                        std::future::pending::<
+                            FunctionResult<Option<Value>, crate::protocol::ErrorBody>,
+                        >()
+                        .await
+                    } else {
+                        FunctionResult::Success(Some(json!({
+                            "id": "iii-queue",
+                            "value": { "queue_configs": { "jobs": { "concurrency": 5 } } }
+                        })))
+                    }
+                }
+            }),
+        );
+
+        // Initial apply times out and schedules the detached one-shot retry.
+        super::super::configuration::on_config_change(&module).await;
+        assert!(
+            !module.config_snapshot().queue_configs.contains_key("jobs"),
+            "the timed-out first apply must not have applied anything"
+        );
+
+        // Let virtual time pass the retry delay so the detached retry runs and
+        // applies the now-readable config.
+        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+        assert!(
+            module.config_snapshot().queue_configs.contains_key("jobs"),
+            "the one-shot retry after a timeout must apply the now-readable config"
+        );
     }
 
     // =========================================================================
@@ -1584,7 +2105,7 @@ mod tests {
         let module = QueueWorker::build(engine, QueueModuleConfig::default(), adapter);
         assert!(
             module
-                ._config
+                .config_snapshot()
                 .queue_configs
                 .contains_key(DEFAULT_QUEUE_NAME),
             "build() must provision the built-in default queue"
@@ -1654,11 +2175,15 @@ mod tests {
             queue_configs,
         };
 
+        let adapter_dyn: Arc<dyn QueueAdapter> = adapter.clone();
         let module = QueueWorker {
-            adapter: adapter.clone(),
             engine: engine.clone(),
-            _config: config,
-            consumer_aborts: Arc::new(StdMutex::new(Vec::new())),
+            adapter: Arc::new(RwLock::new(adapter_dyn)),
+            config: Arc::new(RwLock::new(Arc::new(config))),
+            seed: None,
+            consumers: Arc::new(StdMutex::new(HashMap::new())),
+            apply_lock: Arc::new(tokio::sync::Mutex::new(())),
+            destroyed: Arc::new(AtomicBool::new(false)),
         };
 
         (engine, module, adapter)
@@ -1810,11 +2335,15 @@ mod tests {
             queue_configs,
         };
 
+        let adapter_dyn: Arc<dyn QueueAdapter> = adapter.clone();
         let module = QueueWorker {
-            adapter: adapter.clone(),
             engine: engine.clone(),
-            _config: config,
-            consumer_aborts: Arc::new(StdMutex::new(Vec::new())),
+            adapter: Arc::new(RwLock::new(adapter_dyn)),
+            config: Arc::new(RwLock::new(Arc::new(config))),
+            seed: None,
+            consumers: Arc::new(StdMutex::new(HashMap::new())),
+            apply_lock: Arc::new(tokio::sync::Mutex::new(())),
+            destroyed: Arc::new(AtomicBool::new(false)),
         };
 
         (engine, module, adapter)

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -40,19 +40,27 @@ use crate::{
     workers::traits::{AdapterFactory, ConfigurableWorker, Worker},
 };
 
+/// The live config + transport, swapped together under one lock so every
+/// reader observes a coherent generation. Combining them is what prevents a
+/// runtime adapter hot-swap from exposing a new-config + old-adapter window to
+/// a concurrent enqueue (which would publish through the dying transport with
+/// the new per-queue settings). The inner `Arc`s make a snapshot a cheap clone.
+#[derive(Clone)]
+struct LiveState {
+    config: Arc<QueueModuleConfig>,
+    adapter: Arc<dyn QueueAdapter>,
+}
+
 #[derive(Clone)]
 pub struct QueueWorker {
     engine: Arc<Engine>,
-    /// Live transport. The outer lock is held only for pointer swaps; readers
-    /// clone the inner `Arc` once per call via `adapter_snapshot()`. Behind a
-    /// lock so a runtime change to the `adapter` config can re-instantiate the
-    /// transport (full hot-swap) without rebuilding the worker.
-    adapter: Arc<RwLock<Arc<dyn QueueAdapter>>>,
-    /// Live config snapshot. The outer lock is held only for pointer swaps;
-    /// readers clone the inner `Arc` once per call via `config_snapshot()`,
-    /// which is what makes the value hot-swappable from the configuration
-    /// worker.
-    config: Arc<RwLock<Arc<QueueModuleConfig>>>,
+    /// Live config + transport behind a single lock. The outer lock is held
+    /// only for pointer swaps; readers clone the inner `Arc`(s) once per call
+    /// via `config_snapshot()` / `adapter_snapshot()` / `live_snapshot()`.
+    /// Both are hot-swappable from the configuration worker, and `apply_config`
+    /// swaps the pair atomically so no reader sees a half-applied transport
+    /// change.
+    live: Arc<RwLock<LiveState>>,
     /// The config.yaml block passed to `build()` (post-`ensure_default_queue`).
     /// Used only as the seed for the first `configuration::register`; the
     /// configuration worker entry is the runtime source of truth afterwards.
@@ -157,11 +165,15 @@ impl QueueWorker {
         traceparent: Option<String>,
         baggage: Option<String>,
     ) -> anyhow::Result<()> {
-        let config = self.config_snapshot();
-        let queue_config = config.queue_configs.get(queue_name).ok_or_else(|| {
+        // One coherent snapshot of config + transport: the per-queue settings
+        // and the adapter we publish through must come from the same generation
+        // so a concurrent adapter hot-swap can't make us publish through the old
+        // transport with the new config (or vice versa).
+        let live = self.live_snapshot();
+        let queue_config = live.config.queue_configs.get(queue_name).ok_or_else(|| {
             tracing::warn!(
                 queue_name = %queue_name,
-                available = ?config.queue_configs.keys().collect::<Vec<_>>(),
+                available = ?live.config.queue_configs.keys().collect::<Vec<_>>(),
                 "Enqueue attempted for unknown queue"
             );
             anyhow::anyhow!("Queue '{}' not found", queue_name)
@@ -197,7 +209,7 @@ impl QueueWorker {
         // `BaggageSpanProcessor` would otherwise stamp.
         let baggage = crate::telemetry::baggage_with_function_id(baggage.as_deref(), function_id);
 
-        self.adapter_snapshot()
+        live.adapter
             .publish_to_function_queue(
                 queue_name,
                 function_id,
@@ -692,25 +704,42 @@ impl TriggerRegistrator for QueueWorker {
 }
 
 impl QueueWorker {
+    /// Coherent snapshot of the live config + transport in a single lock
+    /// acquisition. Use this when one operation needs both (e.g. enqueue reads
+    /// the per-queue config AND publishes through the adapter) so it can never
+    /// observe a half-applied hot-swap.
+    fn live_snapshot(&self) -> LiveState {
+        self.live.read().expect("live lock poisoned").clone()
+    }
+
     /// Cheap clone of the live config. Take one snapshot per call so all reads
     /// within it are consistent.
     pub fn config_snapshot(&self) -> Arc<QueueModuleConfig> {
-        self.config.read().expect("config lock poisoned").clone()
+        self.live.read().expect("live lock poisoned").config.clone()
     }
 
     fn set_config(&self, config: QueueModuleConfig) {
-        *self.config.write().expect("config lock poisoned") = Arc::new(config);
+        self.live.write().expect("live lock poisoned").config = Arc::new(config);
     }
 
     /// Cheap clone of the live transport. Take one snapshot per call.
     /// `pub` (mirroring `config_snapshot`) so integration tests can confirm a
     /// hot-swap actually rebuilt the adapter instance.
     pub fn adapter_snapshot(&self) -> Arc<dyn QueueAdapter> {
-        self.adapter.read().expect("adapter lock poisoned").clone()
+        self.live
+            .read()
+            .expect("live lock poisoned")
+            .adapter
+            .clone()
     }
 
-    fn set_adapter(&self, adapter: Arc<dyn QueueAdapter>) {
-        *self.adapter.write().expect("adapter lock poisoned") = adapter;
+    /// Atomically swap both the config and the transport. Used by the adapter
+    /// hot-swap path so a concurrent reader sees either the old (config,
+    /// adapter) pair or the new one — never a mix.
+    fn set_live(&self, config: QueueModuleConfig, adapter: Arc<dyn QueueAdapter>) {
+        let mut guard = self.live.write().expect("live lock poisoned");
+        guard.config = Arc::new(config);
+        guard.adapter = adapter;
     }
 
     /// Resolve and instantiate the adapter named by `config` (or the default).
@@ -960,7 +989,9 @@ impl QueueWorker {
             // failure keeps the previous config, adapter, and consumers. Then
             // restart every consumer on the new transport.
             let new_adapter = Self::resolve_adapter(&self.engine, &new_config).await?;
-            self.set_config(new_config.clone());
+            // Swap config + adapter atomically so a concurrent enqueue never
+            // observes the new config paired with the old (dying) transport.
+            self.set_live(new_config.clone(), new_adapter);
             let previous: Vec<AbortHandle> = self
                 .consumers
                 .lock()
@@ -971,7 +1002,6 @@ impl QueueWorker {
             for handle in previous {
                 handle.abort();
             }
-            self.set_adapter(new_adapter);
             // Data-loss boundary (accepted tradeoff for a transport hot-swap):
             // the new adapter starts empty, so messages still queued in the old
             // adapter do NOT migrate — plus in-flight per-message tasks finish
@@ -1226,8 +1256,10 @@ impl ConfigurableWorker for QueueWorker {
         let seed = Some(config.clone());
         Self {
             engine,
-            adapter: Arc::new(RwLock::new(adapter)),
-            config: Arc::new(RwLock::new(Arc::new(config))),
+            live: Arc::new(RwLock::new(LiveState {
+                config: Arc::new(config),
+                adapter,
+            })),
             seed,
             consumers: Arc::new(StdMutex::new(HashMap::new())),
             apply_lock: Arc::new(tokio::sync::Mutex::new(())),
@@ -1600,10 +1632,10 @@ mod tests {
         let adapter_dyn: Arc<dyn QueueAdapter> = adapter.clone();
         let module = QueueWorker {
             engine: engine.clone(),
-            adapter: Arc::new(RwLock::new(adapter_dyn)),
-            config: Arc::new(RwLock::new(Arc::new(
-                super::super::config::QueueModuleConfig::default(),
-            ))),
+            live: Arc::new(RwLock::new(LiveState {
+                config: Arc::new(super::super::config::QueueModuleConfig::default()),
+                adapter: adapter_dyn,
+            })),
             seed: None,
             consumers: Arc::new(StdMutex::new(HashMap::new())),
             apply_lock: Arc::new(tokio::sync::Mutex::new(())),
@@ -2182,8 +2214,10 @@ mod tests {
         let adapter_dyn: Arc<dyn QueueAdapter> = adapter.clone();
         let module = QueueWorker {
             engine: engine.clone(),
-            adapter: Arc::new(RwLock::new(adapter_dyn)),
-            config: Arc::new(RwLock::new(Arc::new(config))),
+            live: Arc::new(RwLock::new(LiveState {
+                config: Arc::new(config),
+                adapter: adapter_dyn,
+            })),
             seed: None,
             consumers: Arc::new(StdMutex::new(HashMap::new())),
             apply_lock: Arc::new(tokio::sync::Mutex::new(())),
@@ -2342,8 +2376,10 @@ mod tests {
         let adapter_dyn: Arc<dyn QueueAdapter> = adapter.clone();
         let module = QueueWorker {
             engine: engine.clone(),
-            adapter: Arc::new(RwLock::new(adapter_dyn)),
-            config: Arc::new(RwLock::new(Arc::new(config))),
+            live: Arc::new(RwLock::new(LiveState {
+                config: Arc::new(config),
+                adapter: adapter_dyn,
+            })),
             seed: None,
             consumers: Arc::new(StdMutex::new(HashMap::new())),
             apply_lock: Arc::new(tokio::sync::Mutex::new(())),

--- a/engine/src/workers/telemetry/mod.rs
+++ b/engine/src/workers/telemetry/mod.rs
@@ -210,6 +210,7 @@ pub fn is_iii_builtin_function_id(id: &str) -> bool {
         || id.starts_with("iii-pubsub::")
         || id.starts_with("iii-stream::")
         || id.starts_with("iii-cron::")
+        || id.starts_with("iii-queue::")
         || id.starts_with("bridge.")
         || id.starts_with("motia::")
         || id == "publish"
@@ -2175,6 +2176,7 @@ mod tests {
         assert!(is_iii_builtin_function_id("iii-pubsub::on-config-change"));
         assert!(is_iii_builtin_function_id("iii-stream::on-config-change"));
         assert!(is_iii_builtin_function_id("iii-cron::on-config-change"));
+        assert!(is_iii_builtin_function_id("iii-queue::on-config-change"));
         assert!(!is_iii_builtin_function_id("orders::process"));
         assert!(!is_iii_builtin_function_id("user::my_function"));
         assert!(!is_iii_builtin_function_id("payments::charge"));

--- a/engine/tests/queue_configuration_e2e.rs
+++ b/engine/tests/queue_configuration_e2e.rs
@@ -30,7 +30,7 @@ use iii::workers::configuration::adapters::ConfigurationAdapter;
 use iii::workers::configuration::adapters::fs::FsAdapter;
 use iii::workers::configuration::structs::ConfigurationSetInput;
 use iii::workers::queue::QueueWorker;
-use iii::workers::traits::{ConfigurableWorker, Worker};
+use iii::workers::traits::Worker;
 
 use common::queue_helpers::{enqueue, register_counting_function};
 
@@ -93,6 +93,25 @@ async fn set_value(harness: &Harness, value: Value) {
     match result {
         FunctionResult::Success(_) => {}
         FunctionResult::Failure(err) => panic!("configuration::set failed: {err:?}"),
+        _ => panic!("unexpected configuration::set result"),
+    }
+}
+
+/// Set a value expected to be rejected by the registered JSON schema at
+/// `configuration::set` (the closed adapter union is the gate).
+async fn set_value_expect_rejection(harness: &Harness, value: Value) {
+    let result = harness
+        .configuration
+        .set_fn(ConfigurationSetInput {
+            id: "iii-queue".to_string(),
+            value,
+        })
+        .await;
+    match result {
+        FunctionResult::Failure(_) => {}
+        FunctionResult::Success(_) => {
+            panic!("expected configuration::set to be rejected, but it succeeded")
+        }
         _ => panic!("unexpected configuration::set result"),
     }
 }
@@ -259,19 +278,10 @@ async fn adapter_hot_swap_rebinds_consumers() {
     let dir = tempfile::tempdir().unwrap();
     let harness = build_harness(dir.path()).await;
 
-    // Register a second transport name that delegates to the in-process builtin
-    // factory, so switching to it is a real transport rebuild without needing
-    // an external broker.
-    let builtin = QueueWorker::get_adapter("builtin")
-        .await
-        .expect("builtin adapter is registered");
-    QueueWorker::add_adapter("builtin_alt", move |engine, config| {
-        let builtin = builtin.clone();
-        async move { builtin(engine, config).await }
-    })
-    .await
-    .expect("register builtin_alt");
-
+    // Swap to the `memory` transport: a `test-adapters`-gated in-process backend
+    // that aliases `builtin`, so the swap is a real transport rebuild without an
+    // external broker. It is advertised in the schema (under the same feature),
+    // so `configuration::set` accepts it.
     let counter = Arc::new(AtomicU64::new(0));
     register_counting_function(&harness.engine, "e2e::swap", counter.clone());
 
@@ -297,7 +307,7 @@ async fn adapter_hot_swap_rebinds_consumers() {
     set_value(
         &harness,
         json!({
-            "adapter": { "name": "builtin_alt" },
+            "adapter": { "name": "memory" },
             "queue_configs": { "jobs": { "concurrency": 1 } }
         }),
     )
@@ -308,7 +318,7 @@ async fn adapter_hot_swap_rebinds_consumers() {
                 .config_snapshot()
                 .adapter
                 .as_ref()
-                .map(|a| a.name.as_str() == "builtin_alt")
+                .map(|a| a.name.as_str() == "memory")
                 .unwrap_or(false)
         },
         "transport to hot-swap",
@@ -333,6 +343,87 @@ async fn adapter_hot_swap_rebinds_consumers() {
         "handler on the new transport",
     )
     .await;
+}
+
+#[tokio::test]
+async fn unbuildable_adapter_keeps_previous_transport() {
+    let _serial = SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let counter = Arc::new(AtomicU64::new(0));
+    register_counting_function(&harness.engine, "e2e::swap_fail", counter.clone());
+
+    let worker = start_queue_worker(
+        &harness,
+        json!({ "queue_configs": { "jobs": { "concurrency": 1 } } }),
+    )
+    .await;
+    // Capture the live transport instance before the failed swap.
+    let old_adapter = worker.adapter_snapshot();
+
+    // Point the transport at `redis` with a dead URL: schema-valid (an advertised
+    // adapter) and past `validate()`, so it reaches the transport-swap branch
+    // where `resolve_adapter` fails to *build* (connection refused). That failure
+    // must keep the previous config, adapter, and consumers — the all-or-nothing
+    // guarantee for a transport swap (`resolve_adapter().await?` returns before
+    // `set_live`).
+    set_value(
+        &harness,
+        json!({
+            "adapter": { "name": "redis", "config": { "redis_url": "redis://127.0.0.1:6390" } },
+            "queue_configs": { "jobs": { "concurrency": 1 } }
+        }),
+    )
+    .await;
+
+    // Drive the handler synchronously so the assertion observes a completed apply
+    // attempt. The build fails deterministically, so neither this call nor the
+    // trigger-fired apply can mutate state — they don't race.
+    let _ = harness
+        .engine
+        .call("iii-queue::on-config-change", json!({}))
+        .await
+        .expect("on-config-change call");
+
+    // The transport instance was NOT rebuilt — pointer identity is preserved.
+    assert!(
+        Arc::ptr_eq(&old_adapter, &worker.adapter_snapshot()),
+        "an unbuildable adapter must retain the previous transport"
+    );
+    // The unbuildable adapter was not adopted into the live config.
+    assert!(
+        worker.config_snapshot().adapter.is_none(),
+        "an unbuildable adapter must not be adopted into the live config"
+    );
+
+    // Consumers on the original transport are intact: a job is still delivered.
+    enqueue(&harness.engine, "jobs", "e2e::swap_fail", json!({}))
+        .await
+        .expect("enqueue on the retained transport");
+    wait_for(
+        || counter.load(Ordering::SeqCst) >= 1,
+        "handler on the retained transport",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn unknown_adapter_name_is_rejected_at_set() {
+    let _serial = SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let _worker = start_queue_worker(
+        &harness,
+        json!({ "queue_configs": { "jobs": { "concurrency": 1 } } }),
+    )
+    .await;
+
+    // The closed adapter union rejects an unknown transport name at the schema
+    // gate, before it can ever reach the worker — so a typo can't strand the
+    // queue on an unbuildable transport.
+    set_value_expect_rejection(&harness, json!({ "adapter": { "name": "does_not_exist" } })).await;
 }
 
 #[tokio::test]

--- a/engine/tests/queue_configuration_e2e.rs
+++ b/engine/tests/queue_configuration_e2e.rs
@@ -1,0 +1,526 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! End-to-end test for the `iii-queue` ↔ `configuration` worker integration:
+//! seed-on-first-boot, no-clobber across worker restarts, hot-add of a queue
+//! (live consumer), hot-change of per-queue settings, full adapter/transport
+//! hot-swap, all-or-nothing gate on an invalid value, and `${VAR:default}`
+//! expansion.
+//!
+//! Modeled on `engine/tests/http_configuration_e2e.rs` — composes the two
+//! workers against a real `FsAdapter` on a `tempfile::tempdir()`. The queue
+//! uses the in-process `builtin` adapter, so a hot-added or rebound consumer is
+//! observed by enqueuing a message and watching the target function fire.
+
+mod common;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use serde_json::{Value, json};
+
+use iii::engine::{Engine, EngineTrait};
+use iii::function::FunctionResult;
+use iii::workers::configuration::ConfigurationWorker;
+use iii::workers::configuration::adapters::ConfigurationAdapter;
+use iii::workers::configuration::adapters::fs::FsAdapter;
+use iii::workers::configuration::structs::ConfigurationSetInput;
+use iii::workers::queue::QueueWorker;
+use iii::workers::traits::{ConfigurableWorker, Worker};
+
+use common::queue_helpers::{enqueue, register_counting_function};
+
+/// Serializes the suite: tests share the process-global adapter registry
+/// (`add_adapter`) and environment (`${VAR}` expansion test), so running one at
+/// a time keeps those mutations from racing. `tokio::sync::Mutex` never
+/// poisons, so a panicking test still releases it cleanly.
+static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+struct Harness {
+    engine: Arc<Engine>,
+    configuration: ConfigurationWorker,
+}
+
+async fn build_harness(dir: &std::path::Path) -> Harness {
+    iii::workers::observability::metrics::ensure_default_meter();
+    let adapter = Arc::new(
+        FsAdapter::new(Some(json!({ "directory": dir.to_str().unwrap() })))
+            .await
+            .expect("fs adapter"),
+    ) as Arc<dyn ConfigurationAdapter>;
+    let engine = Arc::new(Engine::new());
+
+    let configuration = ConfigurationWorker::for_test(engine.clone(), adapter, 0);
+    configuration
+        .initialize()
+        .await
+        .expect("configuration initialize");
+    Worker::register_functions(&configuration, engine.clone());
+
+    Harness {
+        engine,
+        configuration,
+    }
+}
+
+/// Create, initialize, and start an `iii-queue` worker with the given seed.
+async fn start_queue_worker(harness: &Harness, seed: Value) -> QueueWorker {
+    let worker = QueueWorker::for_test(harness.engine.clone(), Some(seed))
+        .await
+        .expect("queue worker");
+    worker.initialize().await.expect("queue initialize");
+    Worker::register_functions(&worker, harness.engine.clone());
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    worker
+        .start_background_tasks(shutdown_rx, shutdown_tx)
+        .await
+        .expect("queue start_background_tasks");
+    worker
+}
+
+async fn set_value(harness: &Harness, value: Value) {
+    let result = harness
+        .configuration
+        .set_fn(ConfigurationSetInput {
+            id: "iii-queue".to_string(),
+            value,
+        })
+        .await;
+    match result {
+        FunctionResult::Success(_) => {}
+        FunctionResult::Failure(err) => panic!("configuration::set failed: {err:?}"),
+        _ => panic!("unexpected configuration::set result"),
+    }
+}
+
+/// Poll until `predicate` returns true or the deadline elapses. Trigger
+/// fan-out is spawned, so observable effects are eventually consistent.
+async fn wait_for(mut predicate: impl FnMut() -> bool, what: &str) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if predicate() {
+            return;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("timed out waiting for {what}");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+#[tokio::test]
+async fn first_boot_seeds_configuration_entry() {
+    let _serial = SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let _worker = start_queue_worker(
+        &harness,
+        json!({ "queue_configs": { "reports": { "concurrency": 4 } } }),
+    )
+    .await;
+
+    let stored = harness
+        .engine
+        .call("configuration::get", json!({ "id": "iii-queue" }))
+        .await
+        .expect("configuration::get")
+        .expect("get returns a body");
+    assert_eq!(stored["value"]["queue_configs"]["reports"]["concurrency"], 4);
+    // The always-present built-in `default` queue is seeded too.
+    assert!(
+        stored["value"]["queue_configs"]["default"].is_object(),
+        "default queue must be seeded: {stored}"
+    );
+}
+
+#[tokio::test]
+async fn runtime_edit_survives_worker_restart() {
+    let _serial = SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+    let seed = json!({ "queue_configs": { "default": { "concurrency": 1 } } });
+
+    let worker = start_queue_worker(&harness, seed.clone()).await;
+
+    set_value(
+        &harness,
+        json!({ "queue_configs": { "default": { "concurrency": 5 } } }),
+    )
+    .await;
+    wait_for(
+        || {
+            worker
+                .config_snapshot()
+                .queue_configs
+                .get("default")
+                .map(|c| c.concurrency)
+                == Some(5)
+        },
+        "runtime edit to apply",
+    )
+    .await;
+
+    // Restart the queue worker with the same seed (ReloadManager semantics).
+    worker.destroy().await.expect("destroy");
+    let restarted = start_queue_worker(&harness, seed).await;
+
+    // The runtime edit wins; the config.yaml seed must not clobber it.
+    assert_eq!(
+        restarted.config_snapshot().queue_configs["default"].concurrency,
+        5
+    );
+}
+
+#[tokio::test]
+async fn hot_add_queue_starts_a_live_consumer() {
+    let _serial = SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let counter = Arc::new(AtomicU64::new(0));
+    register_counting_function(&harness.engine, "e2e::jobs", counter.clone());
+
+    // Boot with only the built-in default queue.
+    let worker = start_queue_worker(&harness, json!({})).await;
+
+    // Hot-add a `jobs` queue.
+    set_value(
+        &harness,
+        json!({ "queue_configs": { "jobs": { "concurrency": 2, "max_retries": 1 } } }),
+    )
+    .await;
+    wait_for(
+        || worker.config_snapshot().queue_configs.contains_key("jobs"),
+        "jobs queue to appear in the live config",
+    )
+    .await;
+
+    // A consumer for the new queue must be live: enqueue a job and watch the
+    // target function fire.
+    enqueue(&harness.engine, "jobs", "e2e::jobs", json!({ "x": 1 }))
+        .await
+        .expect("enqueue to hot-added queue");
+    wait_for(
+        || counter.load(Ordering::SeqCst) >= 1,
+        "handler invoked for the hot-added queue",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn hot_change_concurrency_keeps_queue_live() {
+    let _serial = SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let counter = Arc::new(AtomicU64::new(0));
+    register_counting_function(&harness.engine, "e2e::smoke", counter.clone());
+
+    let worker = start_queue_worker(
+        &harness,
+        json!({ "queue_configs": { "default": { "concurrency": 1 } } }),
+    )
+    .await;
+
+    set_value(
+        &harness,
+        json!({ "queue_configs": { "default": { "concurrency": 4 } } }),
+    )
+    .await;
+    wait_for(
+        || worker.config_snapshot().queue_configs["default"].concurrency == 4,
+        "concurrency change to apply",
+    )
+    .await;
+
+    // The default queue's consumer was restarted with the new settings and is
+    // still live.
+    enqueue(&harness.engine, "default", "e2e::smoke", json!({}))
+        .await
+        .expect("enqueue after concurrency change");
+    wait_for(
+        || counter.load(Ordering::SeqCst) >= 1,
+        "handler invoked after concurrency change",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn adapter_hot_swap_rebinds_consumers() {
+    let _serial = SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    // Register a second transport name that delegates to the in-process builtin
+    // factory, so switching to it is a real transport rebuild without needing
+    // an external broker.
+    let builtin = QueueWorker::get_adapter("builtin")
+        .await
+        .expect("builtin adapter is registered");
+    QueueWorker::add_adapter("builtin_alt", move |engine, config| {
+        let builtin = builtin.clone();
+        async move { builtin(engine, config).await }
+    })
+    .await
+    .expect("register builtin_alt");
+
+    let counter = Arc::new(AtomicU64::new(0));
+    register_counting_function(&harness.engine, "e2e::swap", counter.clone());
+
+    let worker = start_queue_worker(
+        &harness,
+        json!({ "queue_configs": { "jobs": { "concurrency": 1 } } }),
+    )
+    .await;
+    // Capture the live transport instance before the swap.
+    let old_adapter = worker.adapter_snapshot();
+
+    // Works on the original (builtin) transport.
+    enqueue(&harness.engine, "jobs", "e2e::swap", json!({}))
+        .await
+        .expect("enqueue on builtin");
+    wait_for(
+        || counter.load(Ordering::SeqCst) >= 1,
+        "handler on the builtin transport",
+    )
+    .await;
+
+    // Swap the transport.
+    set_value(
+        &harness,
+        json!({
+            "adapter": { "name": "builtin_alt" },
+            "queue_configs": { "jobs": { "concurrency": 1 } }
+        }),
+    )
+    .await;
+    wait_for(
+        || {
+            worker
+                .config_snapshot()
+                .adapter
+                .as_ref()
+                .map(|a| a.name.as_str() == "builtin_alt")
+                .unwrap_or(false)
+        },
+        "transport to hot-swap",
+    )
+    .await;
+
+    // The transport instance was actually rebuilt — not a half-swap where only
+    // the config name changed. A pointer-identity check rules out the no-op.
+    assert!(
+        !Arc::ptr_eq(&old_adapter, &worker.adapter_snapshot()),
+        "adapter instance must be rebuilt on a transport hot-swap"
+    );
+
+    // Consumers were rebound on the new transport: a job enqueued after the
+    // swap is delivered.
+    let before = counter.load(Ordering::SeqCst);
+    enqueue(&harness.engine, "jobs", "e2e::swap", json!({}))
+        .await
+        .expect("enqueue on the new transport");
+    wait_for(
+        || counter.load(Ordering::SeqCst) > before,
+        "handler on the new transport",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn hot_remove_queue_drops_it_from_live_config() {
+    let _serial = SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let worker = start_queue_worker(
+        &harness,
+        json!({ "queue_configs": { "jobs": { "concurrency": 1 } } }),
+    )
+    .await;
+    assert!(worker.config_snapshot().queue_configs.contains_key("jobs"));
+
+    // Remove `jobs` — only the always-present `default` should remain. This
+    // exercises the apply_config removal branch (abort + drop from the map).
+    set_value(&harness, json!({ "queue_configs": {} })).await;
+    wait_for(
+        || !worker.config_snapshot().queue_configs.contains_key("jobs"),
+        "jobs queue to be removed from the live config",
+    )
+    .await;
+
+    // The removal took effect: enqueueing to the gone queue now fails.
+    let result = enqueue(&harness.engine, "jobs", "e2e::gone", json!({})).await;
+    assert!(
+        result.is_err(),
+        "enqueue to a removed queue must fail (consumer stopped, queue absent)"
+    );
+    // `default` survives every edit (ensure_default_queue in fetch_config).
+    assert!(worker.config_snapshot().queue_configs.contains_key("default"));
+}
+
+#[tokio::test]
+async fn invalid_value_keeps_previous_config() {
+    let _serial = SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let worker = start_queue_worker(
+        &harness,
+        json!({ "queue_configs": { "default": { "concurrency": 3 } } }),
+    )
+    .await;
+
+    // A FIFO queue without `message_group_field` is schema-valid (the schema
+    // can't express the cross-field rule) but fails the worker's `validate()`
+    // gate. The configuration worker accepts the value; the worker must reject
+    // applying it and keep the previous config.
+    set_value(
+        &harness,
+        json!({ "queue_configs": { "orders": { "type": "fifo" } } }),
+    )
+    .await;
+
+    // Drive the handler synchronously so the assertion observes a completed
+    // apply attempt. The value fails validate() deterministically, so neither
+    // this call nor the trigger-fired apply can mutate state — they don't race.
+    let _ = harness
+        .engine
+        .call("iii-queue::on-config-change", json!({}))
+        .await
+        .expect("on-config-change call");
+
+    let config = worker.config_snapshot();
+    assert!(
+        config.queue_configs.contains_key("default"),
+        "previous config must be kept after an invalid value"
+    );
+    assert!(
+        !config.queue_configs.contains_key("orders"),
+        "an invalid value must not be applied"
+    );
+}
+
+#[tokio::test]
+async fn boot_with_invalid_stored_value_falls_back_to_seed() {
+    let _serial = SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+    let seed = json!({ "queue_configs": { "default": { "concurrency": 2 } } });
+
+    // First boot registers the entry. Then store a value the schema accepts but
+    // validate() rejects (fifo without message_group_field).
+    let worker = start_queue_worker(&harness, seed.clone()).await;
+    set_value(
+        &harness,
+        json!({ "queue_configs": { "orders": { "type": "fifo" } } }),
+    )
+    .await;
+    worker.destroy().await.expect("destroy");
+
+    // Restart: the boot fetch reads the invalid stored value and must fall back
+    // to the validated seed instead of booting the broken config.
+    let restarted = start_queue_worker(&harness, seed).await;
+    let cfg = restarted.config_snapshot();
+    assert!(
+        !cfg.queue_configs.contains_key("orders"),
+        "an invalid stored value must not be adopted at boot"
+    );
+    assert_eq!(
+        cfg.queue_configs["default"].concurrency, 2,
+        "boot must fall back to the validated seed on an invalid stored value"
+    );
+}
+
+#[tokio::test]
+async fn apply_after_destroy_does_not_respawn() {
+    let _serial = SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let worker = start_queue_worker(
+        &harness,
+        json!({ "queue_configs": { "default": { "concurrency": 1 } } }),
+    )
+    .await;
+
+    worker.destroy().await.expect("destroy");
+
+    // A configuration event delivered after teardown (here driven synchronously,
+    // standing in for the detached retry / in-flight trigger) must hit the
+    // `destroyed` gate and bail — never re-spawn consumers on a dead worker.
+    set_value(
+        &harness,
+        json!({ "queue_configs": { "jobs": { "concurrency": 1 } } }),
+    )
+    .await;
+    let _ = harness
+        .engine
+        .call("iii-queue::on-config-change", json!({}))
+        .await
+        .expect("on-config-change call");
+
+    assert!(
+        !worker.config_snapshot().queue_configs.contains_key("jobs"),
+        "apply_config must bail after destroy() instead of applying the edit"
+    );
+}
+
+#[tokio::test]
+async fn env_placeholder_expands_on_read() {
+    let _serial = SERIAL.lock().await;
+    // Scrub ambient state so the `${VAR:default}` default branch is what we
+    // observe. remove_var is unsafe in edition 2024 because concurrent env
+    // access is UB; SERIAL guarantees we hold the only handle.
+    unsafe { std::env::remove_var("QUEUE_CFG_E2E_FIELD") };
+
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let worker = start_queue_worker(
+        &harness,
+        json!({
+            "queue_configs": {
+                "orders": {
+                    "type": "fifo",
+                    "message_group_field": "${QUEUE_CFG_E2E_FIELD:session_id}"
+                }
+            }
+        }),
+    )
+    .await;
+
+    // The live config sees the expanded default.
+    wait_for(
+        || {
+            worker
+                .config_snapshot()
+                .queue_configs
+                .get("orders")
+                .and_then(|c| c.message_group_field.clone())
+                == Some("session_id".to_string())
+        },
+        "message_group_field placeholder to expand",
+    )
+    .await;
+
+    // The stored value keeps the placeholder verbatim.
+    let raw = harness
+        .engine
+        .call(
+            "configuration::get",
+            json!({ "id": "iii-queue", "raw": true }),
+        )
+        .await
+        .expect("configuration::get raw")
+        .expect("get returns a body");
+    assert_eq!(
+        raw["value"]["queue_configs"]["orders"]["message_group_field"],
+        "${QUEUE_CFG_E2E_FIELD:session_id}"
+    );
+}

--- a/engine/tests/queue_configuration_e2e.rs
+++ b/engine/tests/queue_configuration_e2e.rs
@@ -130,7 +130,10 @@ async fn first_boot_seeds_configuration_entry() {
         .await
         .expect("configuration::get")
         .expect("get returns a body");
-    assert_eq!(stored["value"]["queue_configs"]["reports"]["concurrency"], 4);
+    assert_eq!(
+        stored["value"]["queue_configs"]["reports"]["concurrency"],
+        4
+    );
     // The always-present built-in `default` queue is seeded too.
     assert!(
         stored["value"]["queue_configs"]["default"].is_object(),
@@ -361,7 +364,12 @@ async fn hot_remove_queue_drops_it_from_live_config() {
         "enqueue to a removed queue must fail (consumer stopped, queue absent)"
     );
     // `default` survives every edit (ensure_default_queue in fetch_config).
-    assert!(worker.config_snapshot().queue_configs.contains_key("default"));
+    assert!(
+        worker
+            .config_snapshot()
+            .queue_configs
+            .contains_key("default")
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Migrates the `iii-queue` worker to consume the builtin `configuration` worker for its settings, mirroring the `iii-http` integration (#1842).

Queue config — the backing adapter/transport plus per-queue retries, concurrency, FIFO ordering, and backoff — is now **runtime-editable and hot-reloaded**. The worker registers a JSON-schema'd entry, seeds it from the `config.yaml` block only on first boot, reads the live value (with `${VAR:default}` expansion) at startup, and hot-applies `configuration:updated` events without an engine restart. After first boot the configuration entry is the source of truth; `config.yaml` is seed-only and survives restarts.

## Scope decisions

- **Full adapter hot-swap** — a runtime change to `adapter` re-instantiates the transport and restarts every consumer. Messages still queued in the old transport do not migrate (accepted tradeoff, documented in-code).
- **Best-effort per-queue apply** — a strict fetch+validate gate (any failure keeps the previous config); past the gate, each queue's consumer restart is independent, so one failure is logged while the others apply and that queue keeps its previous consumer.

## Hardening (from review)

- Boot path validates the fetched config and falls back to the validated seed — a value that `apply_config` rejects at runtime can still be stored via `configuration::set` (the JSON schema can't express the fifo cross-field rule), so without this a bad stored value would boot a broken consumer on restart.
- `destroyed` flag (set under `apply_lock` in `destroy`) makes a late apply — from an in-flight event or the one-shot retry task — bail instead of re-spawning consumers on a torn-down worker (the queue analogue of `HttpWorker`'s `shutdown_rx` guard).
- The builtin adapter nacks still-outstanding deliveries when a consumer channel closes, so a restart returns buffered messages to the queue (at-least-once) instead of stranding them — there is no visibility-timeout reclaim otherwise.

## Tests & coverage

- 7 unit tests (`configuration.rs`), 1 builtin-adapter nack-on-close test, 10 e2e tests (`queue_configuration_e2e.rs`): seed-on-first-boot, no-clobber across restart, hot-add (live consumer), hot-change, adapter hot-swap (with `Arc::ptr_eq` proving the transport was rebuilt), hot-remove, invalid-value-keeps-previous, boot-fallback-to-seed, destroy gate, `${VAR}` expansion, and timeout one-shot retry (paused clock).
- Existing `queue_integration` (12) exercise the graceful-degradation path (no configuration worker present).
- `llvm-cov` on the queue module: `config.rs` 100%, `configuration.rs` 97.7%, `queue.rs` 96.8%, builtin adapter 97.3%. Residual is error/tracing branches and the unrelated `durable:subscriber` paths.

## Verification

```
cargo test -p iii --lib workers::queue
cargo test -p iii --test queue_configuration_e2e
cargo test -p iii --test queue_integration
cargo clippy -p iii --all-targets   # 0 errors
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime queue configuration updates without restarts, including per-queue behavior changes and hot-swapping the queue adapter/transport.
  * Queue configuration schemas are now serializable and exposed for validation and documentation.
* **Bug Fixes**
  * Improved consumer shutdown handling so buffered deliveries are always cleared and nacked reliably, even under prefetch/window pressure.
* **Tests**
  * Added end-to-end integration coverage for configuration seeding/persistence, hot add/remove, adapter swapping, and validation/fallback.
  * Added tests for consumer-stop nacking behavior.
* **Chores**
  * Expanded built-in function detection to include the `iii-queue::` prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->