### PR TITLE
feat(engine): runtime-configurable iii-stream via the configuration worker

### DIFF
--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -15,6 +15,14 @@ type: "reference"
   The `adapter` field advertises a **concrete per-adapter schema** — a discriminated union keyed on `name` over the built-in `local` and `redis` adapters. Each branch is closed: `redis` carries a typed `redis_url`, and `local` (which takes no config) is a closed empty object, so `configuration::set` rejects an unknown adapter name *and* a junk config key on either branch, while a schema-driven UI renders per-adapter fields instead of a free-form object. Deserialization stays lenient, so a hand-edited persisted file is still tolerated at boot.
 
   As with the other workers, the config.yaml block is **seed-only** once a value is persisted; change settings via `configuration::set` or by editing the persisted file (`./data/configuration/iii-pubsub.yaml` with the default `fs` adapter). `${VAR:default}` placeholders expand on read.
+
+  ## `iii-stream` runtime settings live in the configuration worker
+
+  The WebSocket stream worker now registers its config schema under the `iii-stream` configuration entry, seeds it from the config.yaml block on first boot, and hot-applies changes via `configuration::set` — no restart. The schema carries per-field descriptions, rejects unknown keys at set time, and expands `${VAR:default}` placeholders on read. As with the other workers, the config.yaml block is **seed-only** once a value is persisted — change settings via `configuration::set` or by editing the persisted file (`./data/configuration/iii-stream.yaml` with the default `fs` adapter), and a runtime edit survives engine restarts.
+
+  Each field applies on its own tier. `auth_function` applies to new connections immediately — no rebind. A `host`/`port` change **rebinds the listener**: the new address is bound and the server respawned before the old listener is torn down, a failed bind keeps the previous server, and live connections on the old address are dropped (clients reconnect). An `adapter` change **hot-swaps the pub/sub backend**: the new backend is built, swapped in, and its event pump restarted; the swap is gated (a value that fails to build keeps the previous backend), and existing connections stay bound to the previous backend until they close, so prefer a quiet moment to repoint the adapter in a multi-instance deployment.
+
+  The `adapter` field advertises a **concrete per-adapter schema** — a discriminated union keyed on `name` over the built-in `kv`, `redis`, and `bridge` adapters, each with its own typed `config` (`kv`: `store_method` / `file_path` / `save_interval_ms` / `channel_size`; `redis`: `redis_url`; `bridge`: `bridge_url`). `configuration::set` validates adapter settings against it and rejects an unknown adapter name or stray config key, and a schema-driven UI renders per-adapter fields instead of a free-form object. Deserialization stays lenient, so a hand-edited persisted file is still tolerated at boot.
 </Update>
 
 <Update label="0.19.4" description="June 2026">

--- a/engine/src/workers/stream/README.md
+++ b/engine/src/workers/stream/README.md
@@ -62,7 +62,11 @@ Each field applies on its own tier:
 - **`host`/`port`** trigger a **listener rebind**: the new address is bound, the
   WebSocket server is respawned on it, and the old listener is torn down. Live
   connections on the old address are dropped (clients reconnect). The rebind is
-  gated — a value that fails to bind keeps the previous server running.
+  gated — a value that fails to bind keeps the previous server running. Note that
+  changing **only the host on the same port** between overlapping interfaces (e.g.
+  `0.0.0.0` ↔ `127.0.0.1`) won't rebind: the new address can't bind while the old
+  listener still holds the port, so the change is logged and the previous server
+  kept. Change the port too, or restart, to move between overlapping interfaces.
 - **`adapter`** triggers a **full backend hot-swap**: the new pub/sub backend is
   built, swapped in, and its event pump restarted. New connections use it; the
   swap is gated (a value that fails to build the backend keeps the previous one).

--- a/engine/src/workers/stream/README.md
+++ b/engine/src/workers/stream/README.md
@@ -45,6 +45,31 @@ npx skills add iii-hq/iii --full-depth --skill iii-stream
 | `auth_function` | string | Function ID to authenticate WebSocket connections. |
 | `adapter` | Adapter | Adapter for stream storage and real-time delivery. |
 
+## Runtime configuration (hot reload)
+
+`iii-stream` registers its configuration with the builtin `configuration` worker
+under the id **`iii-stream`**, so the fields above can be read and changed at
+runtime (e.g. `configuration::set { id: "iii-stream", value: { ... } }`) without
+restarting the engine. The config.yaml block is the **seed** used on first boot
+only; afterwards the configuration entry is the runtime source of truth and a
+runtime edit survives engine restarts. Values are validated against the schema
+at set time, and `${VAR:default}` placeholders are expanded on read.
+
+Each field applies on its own tier:
+
+- **`auth_function`** applies to new connections immediately — no rebind. (It is
+  consulted only when a client connects, so existing connections are unaffected.)
+- **`host`/`port`** trigger a **listener rebind**: the new address is bound, the
+  WebSocket server is respawned on it, and the old listener is torn down. Live
+  connections on the old address are dropped (clients reconnect). The rebind is
+  gated — a value that fails to bind keeps the previous server running.
+- **`adapter`** triggers a **full backend hot-swap**: the new pub/sub backend is
+  built, swapped in, and its event pump restarted. New connections use it; the
+  swap is gated (a value that fails to build the backend keeps the previous one).
+  Existing connections remain bound to the **previous** backend until they close,
+  so they no longer receive new events — prefer a quiet moment to repoint the
+  adapter in a multi-instance deployment.
+
 ## Adapters
 
 ### redis

--- a/engine/src/workers/stream/config.rs
+++ b/engine/src/workers/stream/config.rs
@@ -4,6 +4,9 @@
 // This software is patent protected. We welcome discussions - reach out at team@iii.dev
 // See LICENSE and PATENTS files for details.
 
+use schemars::JsonSchema;
+use schemars::r#gen::SchemaGenerator;
+use schemars::schema::{InstanceType, Schema, SchemaObject};
 use serde::{Deserialize, Serialize};
 
 use crate::workers::traits::AdapterEntry;
@@ -15,7 +18,7 @@ use crate::workers::traits::AdapterEntry;
 /// source of truth. `host`/`port` and `adapter` hot-apply at runtime (the
 /// server rebinds; the pub/sub backend is hot-swapped); `auth_function` applies
 /// to new connections.
-#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct StreamModuleConfig {
     /// TCP port the WebSocket server binds to. Defaults to `3112`. A change
@@ -38,7 +41,17 @@ pub struct StreamModuleConfig {
     /// adapter; use `redis` (or `bridge`) for multi-instance deployments. A
     /// change hot-swaps the backend: new connections use it, while existing
     /// connections remain bound to the previous backend until they close.
-    #[serde(default)]
+    ///
+    /// Advertised as a discriminated union keyed on `name` (see
+    /// [`stream_adapter_schema`]) so the console renders per-adapter fields; the
+    /// field type stays the loosely-typed `AdapterEntry` so a hand-edited
+    /// persisted file is still tolerated at boot.
+    ///
+    /// `skip_serializing_if` matters: the closed `oneOf` schema has no null
+    /// branch, so an absent adapter must be omitted (not serialized as `null`)
+    /// or `configuration::register`/`set` would reject the seed value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "stream_adapter_schema")]
     pub adapter: Option<AdapterEntry>,
 }
 
@@ -59,6 +72,124 @@ impl Default for StreamModuleConfig {
             auth_function: None,
         }
     }
+}
+
+/// Storage backend for the file-backed `kv` adapter: `in_memory` (volatile,
+/// process-lifetime storage, lost on shutdown — not for production) or
+/// `file_based` (persisted under `file_path`, flushed on the `save_interval_ms`
+/// cadence). Variants are intentionally doc-free so schemars emits a flat string
+/// `enum` (a single select) rather than a per-variant `oneOf` that a
+/// schema-driven UI renders as "variant 1", "variant 2".
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum KvStoreMethod {
+    InMemory,
+    FileBased,
+}
+
+/// Configuration for the built-in `kv` stream adapter, which backs both storage
+/// and in-process pub/sub delivery.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct KvAdapterConfig {
+    /// Storage backend. `in_memory` (the default) keeps data only for the
+    /// process lifetime; `file_based` persists it under `file_path`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub store_method: Option<KvStoreMethod>,
+
+    /// Directory for file-based storage. Only used when `store_method` is
+    /// `file_based`. Defaults to `kv_store_data.db`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_path: Option<String>,
+
+    /// Persistence flush cadence in milliseconds for file-based storage;
+    /// in-memory stores ignore it. Defaults to 5000.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 100, max = 3_600_000))]
+    pub save_interval_ms: Option<u64>,
+
+    /// Capacity of the in-process broadcast channel backing pub/sub delivery.
+    /// Defaults to 256. Raise it if bursts of stream events outrun slow
+    /// subscribers (a full channel drops the oldest undelivered events).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 1, max = 1_048_576))]
+    pub channel_size: Option<u64>,
+}
+
+/// Configuration for the built-in `redis` stream adapter.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct RedisAdapterConfig {
+    /// Redis connection URL. Defaults to `redis://localhost:6379`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redis_url: Option<String>,
+}
+
+/// Configuration for the built-in `bridge` stream adapter.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct BridgeAdapterConfig {
+    /// WebSocket bridge URL of the remote stream backend; all stream pub/sub is
+    /// forwarded there. Defaults to `ws://localhost:49134`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bridge_url: Option<String>,
+}
+
+/// Build the `oneOf` schema for [`StreamModuleConfig::adapter`]: one branch per
+/// built-in adapter, each pinned to its `name` discriminator and carrying that
+/// adapter's concrete `config` schema. The set is closed — `configuration::set`
+/// rejects any other adapter name — so the console renders per-adapter fields
+/// instead of a free-form object. Deserialization stays permissive via the
+/// `AdapterEntry` field type, so a hand-edited persisted file is still tolerated
+/// at boot.
+fn stream_adapter_schema(generator: &mut SchemaGenerator) -> Schema {
+    let branches = vec![
+        adapter_branch("kv", generator.subschema_for::<KvAdapterConfig>()),
+        adapter_branch("redis", generator.subschema_for::<RedisAdapterConfig>()),
+        adapter_branch("bridge", generator.subschema_for::<BridgeAdapterConfig>()),
+    ];
+
+    let mut schema = SchemaObject::default();
+    schema.metadata().description = Some(
+        "Pub/sub backend for stream distribution, advertised as a discriminated \
+         union keyed on `name` over the built-in adapters `kv` (default), `redis`, \
+         and `bridge`. A change hot-swaps the backend: new connections use it, while \
+         existing connections remain bound to the previous backend until they close."
+            .to_string(),
+    );
+    schema.subschemas().one_of = Some(branches);
+    Schema::Object(schema)
+}
+
+/// One `oneOf` branch: an object pinned to `name` and carrying the adapter's
+/// `config` sub-schema. `config` is optional (every adapter has working
+/// defaults) and no other keys are permitted.
+fn adapter_branch(name: &str, config_schema: Schema) -> Schema {
+    let name_schema = SchemaObject {
+        instance_type: Some(InstanceType::String.into()),
+        enum_values: Some(vec![serde_json::Value::String(name.to_string())]),
+        ..Default::default()
+    };
+
+    let mut branch = SchemaObject {
+        instance_type: Some(InstanceType::Object.into()),
+        ..Default::default()
+    };
+    // The console labels each `oneOf` option by its `title`; without it the
+    // form shows the bare type ("object") for every adapter branch.
+    branch.metadata().title = Some(name.to_string());
+    {
+        let object = branch.object();
+        object
+            .properties
+            .insert("name".to_string(), Schema::Object(name_schema));
+        object
+            .properties
+            .insert("config".to_string(), config_schema);
+        object.required.insert("name".to_string());
+        object.additional_properties = Some(Box::new(Schema::Bool(false)));
+    }
+    Schema::Object(branch)
 }
 
 #[cfg(test)]
@@ -176,5 +307,93 @@ auth_function: "check_auth"
             schema["properties"]["adapter"]["description"].is_string(),
             "adapter field must carry a schema description: {schema}"
         );
+    }
+
+    #[test]
+    fn schema_advertises_per_adapter_oneof() {
+        let schema = serde_json::to_value(schemars::schema_for!(StreamModuleConfig)).unwrap();
+
+        // The adapter is a discriminated union over the built-in adapters, keyed
+        // on `name`, each branch carrying a concrete `config` schema — so the
+        // console renders per-adapter fields instead of "unsupported schema".
+        let adapter = &schema["properties"]["adapter"];
+        let branches = adapter["oneOf"].as_array().expect("adapter oneOf");
+        assert_eq!(branches.len(), 3);
+        let mut names: Vec<&str> = branches
+            .iter()
+            .map(|b| {
+                assert_eq!(b["additionalProperties"], serde_json::json!(false));
+                assert!(b["properties"]["config"].is_object());
+                let name = b["properties"]["name"]["enum"][0]
+                    .as_str()
+                    .expect("name discriminator");
+                // The branch `title` drives the console's adapter dropdown label
+                // (otherwise every option shows "object").
+                assert_eq!(b["title"].as_str(), Some(name));
+                name
+            })
+            .collect();
+        names.sort_unstable();
+        assert_eq!(names, vec!["bridge", "kv", "redis"]);
+
+        // Each adapter's concrete config fields land in definitions, including
+        // the stream-specific `channel_size` on the kv adapter.
+        let defs = &schema["definitions"];
+        assert!(defs["KvAdapterConfig"]["properties"]["store_method"].is_object());
+        assert!(defs["KvAdapterConfig"]["properties"]["channel_size"].is_object());
+        assert!(defs["RedisAdapterConfig"]["properties"]["redis_url"].is_object());
+        assert!(defs["BridgeAdapterConfig"]["properties"]["bridge_url"].is_object());
+
+        // `store_method` is a flat string enum (a single select), not a
+        // per-variant `oneOf` that renders as "variant 1"/"variant 2".
+        let store_method = &defs["KvStoreMethod"];
+        assert!(
+            store_method["oneOf"].is_null(),
+            "store_method must be a flat enum, not a oneOf"
+        );
+        let methods: Vec<&str> = store_method["enum"]
+            .as_array()
+            .expect("store_method enum values")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert!(methods.contains(&"in_memory") && methods.contains(&"file_based"));
+    }
+
+    // Closed-schema enforcement through the real validator (with `$ref`
+    // resolution) — the same `jsonschema` path `configuration::set` uses.
+    #[test]
+    fn closed_adapter_schema_accepts_known_rejects_unknown() {
+        let schema = serde_json::to_value(schemars::schema_for!(StreamModuleConfig)).unwrap();
+        let validator = jsonschema::Validator::new(&schema).expect("schema compiles");
+
+        // Accepted: known adapters, with or without config.
+        assert!(validator.is_valid(&serde_json::json!({ "adapter": { "name": "kv" } })));
+        assert!(validator.is_valid(&serde_json::json!({
+            "adapter": { "name": "kv", "config": { "store_method": "file_based", "channel_size": 1024 } }
+        })));
+        assert!(validator.is_valid(&serde_json::json!({
+            "adapter": { "name": "redis", "config": { "redis_url": "redis://localhost:6379" } }
+        })));
+        assert!(validator.is_valid(&serde_json::json!({
+            "adapter": { "name": "bridge", "config": { "bridge_url": "ws://localhost:49134" } }
+        })));
+
+        // Rejected: unknown adapter, invalid enum, unknown config key,
+        // out-of-range channel_size, and the stale `url` key (redis reads
+        // `redis_url`).
+        assert!(!validator.is_valid(&serde_json::json!({ "adapter": { "name": "postgres" } })));
+        assert!(!validator.is_valid(&serde_json::json!({
+            "adapter": { "name": "kv", "config": { "store_method": "weird" } }
+        })));
+        assert!(!validator.is_valid(&serde_json::json!({
+            "adapter": { "name": "kv", "config": { "bogus": 1 } }
+        })));
+        assert!(!validator.is_valid(&serde_json::json!({
+            "adapter": { "name": "kv", "config": { "channel_size": 0 } }
+        })));
+        assert!(!validator.is_valid(&serde_json::json!({
+            "adapter": { "name": "redis", "config": { "url": "redis://localhost" } }
+        })));
     }
 }

--- a/engine/src/workers/stream/config.rs
+++ b/engine/src/workers/stream/config.rs
@@ -8,18 +8,36 @@ use serde::{Deserialize, Serialize};
 
 use crate::workers::traits::AdapterEntry;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+/// Runtime configuration for the `iii-stream` WebSocket server.
+///
+/// Consumed by the builtin `configuration` worker: the config.yaml block seeds
+/// this entry on first boot, after which the configuration entry is the runtime
+/// source of truth. `host`/`port` and `adapter` hot-apply at runtime (the
+/// server rebinds; the pub/sub backend is hot-swapped); `auth_function` applies
+/// to new connections.
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct StreamModuleConfig {
+    /// TCP port the WebSocket server binds to. Defaults to `3112`. A change
+    /// rebinds the listener at runtime (dropping live connections on the old
+    /// address).
     #[serde(default = "default_port")]
     pub port: u16,
 
+    /// Host/interface the WebSocket server binds to. Defaults to `0.0.0.0`
+    /// (all interfaces). A change rebinds the listener at runtime.
     #[serde(default = "default_host")]
     pub host: String,
 
+    /// Optional function id invoked at connection upgrade to authenticate a
+    /// client. A change applies to new connections only.
     #[serde(default)]
     pub auth_function: Option<String>,
 
+    /// Pub/sub backend for stream distribution. Defaults to the built-in `kv`
+    /// adapter; use `redis` (or `bridge`) for multi-instance deployments. A
+    /// change hot-swaps the backend: new connections use it, while existing
+    /// connections remain bound to the previous backend until they close.
     #[serde(default)]
     pub adapter: Option<AdapterEntry>,
 }
@@ -133,5 +151,30 @@ auth_function: "check_auth"
         assert_eq!(config.port, 7777);
         assert_eq!(config.host, "10.0.0.1");
         assert_eq!(config.auth_function, Some("check_auth".to_string()));
+    }
+
+    #[test]
+    fn schema_denies_unknown_fields_and_documents_fields() {
+        let schema = serde_json::to_value(schemars::schema_for!(StreamModuleConfig)).unwrap();
+
+        // `deny_unknown_fields` must flow into the schema so `configuration::set`
+        // rejects typo'd keys (e.g. `prt`) at set time rather than silently
+        // ignoring them.
+        assert_eq!(
+            schema["additionalProperties"],
+            serde_json::json!(false),
+            "schema must deny unknown fields: {schema}"
+        );
+
+        // Field doc comments must become schema descriptions so an agent
+        // introspecting the config sees intent, not just types.
+        assert!(
+            schema["properties"]["port"]["description"].is_string(),
+            "port field must carry a schema description: {schema}"
+        );
+        assert!(
+            schema["properties"]["adapter"]["description"].is_string(),
+            "adapter field must carry a schema description: {schema}"
+        );
     }
 }

--- a/engine/src/workers/stream/configuration.rs
+++ b/engine/src/workers/stream/configuration.rs
@@ -1,0 +1,398 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Integration with the builtin `configuration` worker.
+//!
+//! The `iii-stream` worker registers its config schema under the id
+//! `iii-stream`, seeds it from the config.yaml block only when no value is
+//! stored yet, reads the live value (with `${VAR:default}` expansion) before
+//! binding, and hot-applies `configuration:updated` events. After first boot
+//! the configuration worker entry is the runtime source of truth; the
+//! config.yaml block is seed-only.
+
+use anyhow::anyhow;
+use serde_json::{Value, json};
+
+use super::{config::StreamModuleConfig, stream::StreamWorker};
+use crate::{
+    engine::{Engine, EngineTrait},
+    trigger::Trigger,
+};
+
+pub const CONFIG_ID: &str = "iii-stream";
+pub const CONFIG_FN_ID: &str = "iii-stream::on-config-change";
+pub const CONFIG_TRIGGER_ID: &str = "iii-stream::config-watch";
+pub const CONFIG_TRIGGER_TYPE: &str = "configuration";
+
+/// Upper bound on every `configuration::*` bus call made by this worker.
+/// `configuration::get` is overwrite-by-id on the bus, so a hung provider
+/// must wedge neither the apply lock nor — worse — the serial worker-startup
+/// loops in the boot and reload pipelines.
+pub(super) const CONFIG_BUS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Delay before the single retry of a timed-out apply (see `on_config_change`).
+const APPLY_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Register the `iii-stream` configuration entry: schema and metadata refresh
+/// on every boot; `initial_value` (the config.yaml seed, or built-in defaults)
+/// is included only when nothing is stored yet, so runtime edits survive engine
+/// restarts.
+///
+/// Makes unbounded bus calls — callers must wrap the call in
+/// `tokio::time::timeout(CONFIG_BUS_TIMEOUT, ...)` (see
+/// `StreamWorker::start_background_tasks`).
+pub async fn register_config(
+    engine: &Engine,
+    seed: Option<&StreamModuleConfig>,
+) -> anyhow::Result<()> {
+    let mut payload = json!({
+        "id": CONFIG_ID,
+        "name": "Stream",
+        "description": "WebSocket stream server settings — host/port binding, connection auth function, and the pub/sub adapter backend.",
+        "schema": serde_json::to_value(schemars::schema_for!(StreamModuleConfig))?,
+    });
+
+    if try_get_value(engine).await?.is_none() {
+        payload["initial_value"] = serde_json::to_value(seed.cloned().unwrap_or_default())?;
+    }
+
+    engine
+        .call("configuration::register", payload)
+        .await
+        .map_err(|err| {
+            anyhow!(
+                "configuration::register failed: {} ({})",
+                err.message,
+                err.code
+            )
+        })?;
+    Ok(())
+}
+
+/// Read the live configuration value. `${VAR:default}` placeholders are
+/// expanded by `configuration::get`. A missing or null value falls back to the
+/// supplied config; a malformed stored value is an error so the caller keeps
+/// its previous config.
+///
+/// Makes an unbounded bus call — callers must wrap the call in
+/// `tokio::time::timeout(CONFIG_BUS_TIMEOUT, ...)` (see
+/// `StreamWorker::start_background_tasks` and `StreamWorker::apply_config`).
+pub async fn fetch_config(
+    engine: &Engine,
+    fallback: &StreamModuleConfig,
+) -> anyhow::Result<StreamModuleConfig> {
+    let Some(value) = try_get_value(engine).await? else {
+        tracing::info!(
+            "no `{}` configuration value stored; using static configuration",
+            CONFIG_ID
+        );
+        return Ok(fallback.clone());
+    };
+
+    let config: StreamModuleConfig = serde_json::from_value(value)
+        .map_err(|err| anyhow!("stored `{CONFIG_ID}` configuration is invalid: {err}"))?;
+    Ok(config)
+}
+
+async fn try_get_value(engine: &Engine) -> anyhow::Result<Option<Value>> {
+    match engine
+        .call("configuration::get", json!({ "id": CONFIG_ID }))
+        .await
+    {
+        Ok(response) => Ok(response
+            .and_then(|body| body.get("value").cloned())
+            .filter(|value| !value.is_null())),
+        Err(err) if err.code == "NOT_FOUND" => Ok(None),
+        Err(err) => Err(anyhow!(
+            "configuration::get failed: {} ({})",
+            err.message,
+            err.code
+        )),
+    }
+}
+
+/// Handler body for `iii-stream::on-config-change`. Delegates to `apply_config`,
+/// which re-fetches the authoritative value under the apply lock instead of
+/// trusting the trigger payload — the handler is a discoverable bus function,
+/// and acting on a caller-supplied payload would let anyone repoint the
+/// listener or pub/sub backend without updating persisted state. Any failure
+/// keeps the previous config, server, and adapter.
+pub async fn on_config_change(worker: &StreamWorker) {
+    match worker.apply_config().await {
+        Ok(()) => tracing::info!("iii-stream configuration re-applied after change"),
+        // A timeout is transient: the stored value is valid but unapplied, and
+        // the event will not fire again — so retry exactly once after a delay.
+        // The retry calls `apply_config` directly (not this handler), so it
+        // cannot loop. Other errors (malformed value, failed bind, unresolvable
+        // adapter) are deterministic; retrying them would just repeat the
+        // failure.
+        Err(err) if err.downcast_ref::<tokio::time::error::Elapsed>().is_some() => {
+            tracing::error!(
+                error = %err,
+                "iii-stream: configuration apply timed out; retrying once in {APPLY_RETRY_DELAY:?}"
+            );
+            let worker = worker.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(APPLY_RETRY_DELAY).await;
+                match worker.apply_config().await {
+                    Ok(()) => {
+                        tracing::info!("iii-stream configuration re-applied on retry")
+                    }
+                    Err(err) => tracing::error!(
+                        error = %err,
+                        "iii-stream: configuration apply retry failed; keeping previous config"
+                    ),
+                }
+            });
+        }
+        Err(err) => tracing::error!(
+            error = %err,
+            "iii-stream: failed to apply changed configuration; keeping previous config"
+        ),
+    }
+}
+
+/// Subscribe to `configuration:updated` events for the `iii-stream` entry. The
+/// deterministic trigger id means re-registration replaces rather than
+/// duplicates.
+pub async fn register_config_trigger(engine: &Engine) -> anyhow::Result<()> {
+    engine
+        .trigger_registry
+        .register_trigger(Trigger {
+            id: CONFIG_TRIGGER_ID.to_string(),
+            trigger_type: CONFIG_TRIGGER_TYPE.to_string(),
+            function_id: CONFIG_FN_ID.to_string(),
+            config: json!({
+                "configuration_id": CONFIG_ID,
+                "event_types": ["configuration:updated"],
+            }),
+            worker_id: None,
+            metadata: None,
+        })
+        .await
+        .map_err(|err| anyhow!("failed to register configuration trigger: {err:?}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use serde_json::json;
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::{
+        engine::{Handler, RegisterFunctionRequest},
+        function::FunctionResult,
+        workers::observability::metrics::ensure_default_meter,
+    };
+
+    /// Stub `configuration::get` to return a fixed stored value (`None` →
+    /// NOT_FOUND) and capture `configuration::register` payloads.
+    fn stub_configuration(
+        engine: &Arc<Engine>,
+        stored_value: Option<Value>,
+    ) -> mpsc::UnboundedReceiver<Value> {
+        engine.register_function_handler(
+            RegisterFunctionRequest {
+                function_id: "configuration::get".to_string(),
+                description: None,
+                request_format: None,
+                response_format: None,
+                metadata: None,
+            },
+            Handler::new(move |_input: Value| {
+                let stored_value = stored_value.clone();
+                async move {
+                    match stored_value {
+                        Some(value) => FunctionResult::Success(Some(
+                            json!({ "id": CONFIG_ID, "value": value }),
+                        )),
+                        None => FunctionResult::Failure(crate::protocol::ErrorBody {
+                            message: format!("configuration '{CONFIG_ID}' not found"),
+                            code: "NOT_FOUND".to_string(),
+                            stacktrace: None,
+                        }),
+                    }
+                }
+            }),
+        );
+
+        let (tx, rx) = mpsc::unbounded_channel::<Value>();
+        engine.register_function_handler(
+            RegisterFunctionRequest {
+                function_id: "configuration::register".to_string(),
+                description: None,
+                request_format: None,
+                response_format: None,
+                metadata: None,
+            },
+            Handler::new(move |input: Value| {
+                let tx = tx.clone();
+                async move {
+                    let _ = tx.send(input);
+                    FunctionResult::Success(Some(json!({})))
+                }
+            }),
+        );
+        rx
+    }
+
+    #[tokio::test]
+    async fn register_seeds_initial_value_when_nothing_stored() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        let mut registered = stub_configuration(&engine, None);
+
+        let seed = StreamModuleConfig {
+            port: 4242,
+            ..StreamModuleConfig::default()
+        };
+        register_config(&engine, Some(&seed)).await.unwrap();
+
+        let payload = registered.recv().await.unwrap();
+        assert_eq!(payload["id"], CONFIG_ID);
+        assert_eq!(payload["initial_value"]["port"], 4242);
+        // schemars derives deny_unknown_fields into the schema.
+        assert_eq!(payload["schema"]["additionalProperties"], json!(false));
+        assert!(payload["schema"]["properties"]["port"].is_object());
+        // Field doc comments must flow into the schema so an agent
+        // introspecting the config gets descriptions, not just types.
+        assert!(
+            payload["schema"]["properties"]["port"]["description"].is_string(),
+            "port field must carry a schema description: {payload}"
+        );
+        assert!(
+            payload["schema"]["properties"]["adapter"]["description"].is_string(),
+            "adapter field must carry a schema description: {payload}"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_omits_initial_value_when_value_stored() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        let mut registered = stub_configuration(&engine, Some(json!({ "port": 9999 })));
+
+        register_config(&engine, Some(&StreamModuleConfig::default()))
+            .await
+            .unwrap();
+
+        let payload = registered.recv().await.unwrap();
+        assert!(
+            payload.get("initial_value").is_none(),
+            "stored value must not be clobbered: {payload}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_config_falls_back_when_not_found() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        let _registered = stub_configuration(&engine, None);
+
+        let fallback = StreamModuleConfig {
+            port: 5555,
+            ..StreamModuleConfig::default()
+        };
+        let config = fetch_config(&engine, &fallback).await.unwrap();
+        assert_eq!(config.port, 5555);
+    }
+
+    #[tokio::test]
+    async fn fetch_config_falls_back_on_null_value() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        let _registered = stub_configuration(&engine, Some(Value::Null));
+
+        let config = fetch_config(&engine, &StreamModuleConfig::default())
+            .await
+            .unwrap();
+        assert_eq!(config.port, StreamModuleConfig::default().port);
+    }
+
+    #[tokio::test]
+    async fn fetch_config_errors_on_malformed_value() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        let _registered = stub_configuration(&engine, Some(json!({ "port": "not-a-port" })));
+
+        let result = fetch_config(&engine, &StreamModuleConfig::default()).await;
+        assert!(result.is_err(), "malformed value must surface as an error");
+    }
+
+    #[tokio::test]
+    async fn fetch_config_reads_stored_adapter() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        let _registered = stub_configuration(
+            &engine,
+            Some(
+                json!({ "adapter": { "name": "redis", "config": { "redis_url": "redis://x:6379" } } }),
+            ),
+        );
+
+        let config = fetch_config(&engine, &StreamModuleConfig::default())
+            .await
+            .unwrap();
+        let adapter = config.adapter.expect("stored adapter is read back");
+        assert_eq!(adapter.name, "redis");
+    }
+
+    #[tokio::test]
+    async fn on_config_change_keeps_previous_config_on_malformed_value() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        let _registered = stub_configuration(&engine, Some(json!({ "port": "not-a-port" })));
+
+        let worker = StreamWorker::for_test(
+            engine.clone(),
+            Some(json!({ "host": "127.0.0.1", "port": 4242 })),
+        )
+        .await
+        .expect("stream worker");
+
+        on_config_change(&worker).await;
+
+        assert_eq!(
+            worker.config_snapshot().port,
+            4242,
+            "a malformed stored value must not mutate the live config"
+        );
+    }
+
+    #[tokio::test]
+    async fn on_config_change_keeps_previous_config_on_unresolvable_adapter() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        // Deserializes and passes the schema, but no factory is registered for
+        // this adapter name, so the apply gate rejects it.
+        let _registered = stub_configuration(
+            &engine,
+            Some(json!({ "adapter": { "name": "does-not-exist" } })),
+        );
+
+        let worker = StreamWorker::for_test(
+            engine.clone(),
+            Some(json!({ "adapter": { "name": "kv", "config": { "lock_index": "keep" } } })),
+        )
+        .await
+        .expect("stream worker");
+
+        on_config_change(&worker).await;
+
+        assert_eq!(
+            worker
+                .config_snapshot()
+                .adapter
+                .as_ref()
+                .map(|a| a.name.as_str()),
+            Some("kv"),
+            "an unresolvable adapter must keep the previous config"
+        );
+    }
+}

--- a/engine/src/workers/stream/mod.rs
+++ b/engine/src/workers/stream/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod adapters;
 mod config;
+mod configuration;
 mod connection;
 mod socket;
 #[allow(clippy::module_inception)]

--- a/engine/src/workers/stream/socket.rs
+++ b/engine/src/workers/stream/socket.rs
@@ -14,7 +14,7 @@ use crate::{
     engine::Engine,
     workers::stream::{
         StreamIncomingMessage, StreamWorker,
-        adapters::{StreamAdapter, StreamConnection},
+        adapters::StreamConnection,
         connection::SocketStreamConnection,
         structs::{StreamAuthContext, StreamOutbound},
         trigger::StreamTriggers,
@@ -23,8 +23,6 @@ use crate::{
 
 pub struct StreamSocketManager {
     pub engine: Arc<Engine>,
-    pub auth_function: Option<String>,
-    adapter: Arc<dyn StreamAdapter>,
     stream_module: Arc<StreamWorker>,
     triggers: Arc<StreamTriggers>,
 }
@@ -32,18 +30,20 @@ pub struct StreamSocketManager {
 impl StreamSocketManager {
     pub fn new(
         engine: Arc<Engine>,
-        adapter: Arc<dyn StreamAdapter>,
         stream_module: Arc<StreamWorker>,
-        auth_function: Option<String>,
         triggers: Arc<StreamTriggers>,
     ) -> Self {
         Self {
             engine,
-            adapter,
             stream_module,
-            auth_function,
             triggers,
         }
+    }
+
+    /// The live connection-auth function id, read from the worker's hot config
+    /// snapshot so a runtime `auth_function` edit applies to new connections.
+    pub fn auth_function(&self) -> Option<String> {
+        self.stream_module.config_snapshot().auth_function.clone()
     }
 
     pub async fn socket_handler(
@@ -84,8 +84,12 @@ impl StreamSocketManager {
         let connection_id = connection.id.to_string();
         let connection = Arc::new(connection);
 
-        if let Err(e) = self
-            .adapter
+        // Capture the live adapter once for this connection's lifetime: a
+        // later hot-swap repoints new connections to the new backend, while
+        // this connection stays bound to the backend it subscribed to (so its
+        // unsubscribe below targets the right registry).
+        let adapter = self.stream_module.adapter_snapshot();
+        if let Err(e) = adapter
             .subscribe(connection_id.clone(), connection.clone())
             .await
         {
@@ -130,7 +134,7 @@ impl StreamSocketManager {
         }
 
         writer.abort();
-        if let Err(e) = self.adapter.unsubscribe(connection_id).await {
+        if let Err(e) = adapter.unsubscribe(connection_id).await {
             tracing::error!(error = %e, "Failed to unsubscribe connection");
         }
         connection.cleanup().await;
@@ -178,8 +182,8 @@ mod tests {
         workers::{
             observability::metrics::ensure_default_meter,
             stream::{
-                StreamOutboundMessage, StreamWrapperMessage, config::StreamModuleConfig,
-                structs::StreamIncomingMessageData,
+                StreamOutboundMessage, StreamWrapperMessage, adapters::StreamAdapter,
+                config::StreamModuleConfig, structs::StreamIncomingMessageData,
             },
             traits::ConfigurableWorker,
         },
@@ -352,9 +356,7 @@ mod tests {
         ));
         let manager = Arc::new(StreamSocketManager::new(
             engine.clone(),
-            adapter,
             module.clone(),
-            None,
             module.triggers.clone(),
         ));
 

--- a/engine/src/workers/stream/stream.rs
+++ b/engine/src/workers/stream/stream.rs
@@ -7,7 +7,10 @@
 use std::{
     collections::HashMap,
     net::SocketAddr,
-    sync::{Arc, Mutex as StdMutex, RwLock as SyncRwLock},
+    sync::{
+        Arc, Mutex as StdMutex, RwLock as SyncRwLock,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use axum::{
@@ -55,15 +58,49 @@ use crate::{
     },
 };
 
+/// The runtime-swappable pieces of the worker: the live configuration and the
+/// live pub/sub adapter. Held together behind one lock so an adapter hot-swap
+/// publishes the new config and backend atomically.
+struct LiveState {
+    config: Arc<StreamModuleConfig>,
+    adapter: Arc<dyn StreamAdapter>,
+}
+
 #[derive(Clone)]
 pub struct StreamWorker {
-    config: StreamModuleConfig,
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub adapter: Arc<dyn StreamAdapter>,
     engine: Arc<Engine>,
+    /// Live config + adapter, swapped atomically by `apply_config`. Readers
+    /// clone the inner `Arc`s via `config_snapshot`/`adapter_snapshot`.
+    live: Arc<SyncRwLock<LiveState>>,
+    /// The config.yaml block; used only for `register_config`'s initial value
+    /// and the boot bind/adapter fallback.
+    seed: Option<StreamModuleConfig>,
 
     pub triggers: Arc<StreamTriggers>,
-    task_aborts: Arc<StdMutex<Vec<AbortHandle>>>,
+    /// Abort handle for the running axum server task (rebound on host/port
+    /// change).
+    server_abort: Arc<StdMutex<Option<AbortHandle>>>,
+    /// Abort handle for the adapter `watch_events` pump (restarted on an
+    /// adapter hot-swap).
+    watch_abort: Arc<StdMutex<Option<AbortHandle>>>,
+    /// Stored once the server is live; `apply_config` refuses to rebind/swap
+    /// while this is `None`, and `destroy` clears it to block late applies.
+    shutdown_rx: Arc<StdMutex<Option<tokio::sync::watch::Receiver<bool>>>>,
+    /// Serializes overlapping `apply_config` runs (last write wins).
+    apply_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Set by `destroy` so a late retry can't resurrect the server/adapter.
+    destroyed: Arc<AtomicBool>,
+}
+
+/// True for hosts that restrict the listener to the local machine
+/// ("localhost", 127.0.0.0/8, ::1). Used by the boot bind fallback to refuse
+/// widening a loopback-only stored address to a non-loopback seed.
+fn is_loopback_host(host: &str) -> bool {
+    host == "localhost"
+        || host
+            .parse::<std::net::IpAddr>()
+            .map(|ip| ip.is_loopback())
+            .unwrap_or(false)
 }
 
 async fn ws_handler(
@@ -75,7 +112,7 @@ async fn ws_handler(
 ) -> impl IntoResponse {
     let module = module.clone();
 
-    if let Some(auth_function) = module.auth_function.clone() {
+    if let Some(auth_function) = module.auth_function() {
         let engine = module.engine.clone();
         let input = StreamAuthInput {
             headers: headers_to_map(&headers),
@@ -133,21 +170,50 @@ impl Worker for StreamWorker {
     }
 
     fn register_functions(&self, engine: Arc<Engine>) {
+        self.register_config_handler(&engine);
         self.register_functions(engine);
     }
 
     async fn destroy(&self) -> anyhow::Result<()> {
         tracing::info!("Destroying StreamWorker");
-        let aborts: Vec<AbortHandle> = self
-            .task_aborts
+        // Best-effort: the trigger is registered outside the worker scope, so
+        // remove it explicitly to keep ReloadManager restarts duplicate-free.
+        let _ = self
+            .engine
+            .trigger_registry
+            .unregister_trigger(
+                super::configuration::CONFIG_TRIGGER_ID.to_string(),
+                Some(super::configuration::CONFIG_TRIGGER_TYPE.to_string()),
+            )
+            .await;
+
+        // Serialize with any in-flight `apply_config`, then block future
+        // applies/rebinds: `destroyed` short-circuits apply, and clearing
+        // `shutdown_rx` makes the rebind/swap path refuse outright.
+        let _guard = self.apply_lock.lock().await;
+        self.destroyed.store(true, Ordering::SeqCst);
+        self.shutdown_rx
             .lock()
-            .expect("stream task_aborts mutex poisoned")
-            .drain(..)
-            .collect();
-        for abort in aborts {
-            abort.abort();
+            .expect("stream shutdown_rx mutex poisoned")
+            .take();
+
+        if let Some(server) = self
+            .server_abort
+            .lock()
+            .expect("stream server_abort mutex poisoned")
+            .take()
+        {
+            server.abort();
         }
-        let _ = self.adapter.destroy().await;
+        if let Some(watch) = self
+            .watch_abort
+            .lock()
+            .expect("stream watch_abort mutex poisoned")
+            .take()
+        {
+            watch.abort();
+        }
+        let _ = self.adapter_snapshot().destroy().await;
         Ok(())
     }
 
@@ -189,77 +255,154 @@ impl Worker for StreamWorker {
 
     async fn start_background_tasks(
         &self,
-        mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+        shutdown_rx: tokio::sync::watch::Receiver<bool>,
         _shutdown_tx: tokio::sync::watch::Sender<bool>,
     ) -> anyhow::Result<()> {
-        let socket_manager = Arc::new(StreamSocketManager::new(
-            self.engine.clone(),
-            self.adapter.clone(),
-            Arc::new(self.clone()),
-            self.config.auth_function.clone(),
-            self.triggers.clone(),
-        ));
-        let raw_addr = format!("{}:{}", self.config.host, self.config.port);
-        let addr: SocketAddr = raw_addr
-            .parse()
-            .map_err(|err| anyhow::anyhow!("invalid stream bind address {}: {}", raw_addr, err))?;
-        tracing::info!("Starting StreamWorker on {}", addr.to_string().purple());
-        let listener = TcpListener::bind(addr)
-            .await
-            .map_err(|err| crate::workers::traits::bind_address_error(addr, err))?;
-        let app = Router::new()
-            .route("/", get(ws_handler))
-            .with_state(socket_manager);
-
-        let mut server_shutdown_rx = shutdown_rx.clone();
-        let server_handle = tokio::spawn(async move {
-            tracing::info!(
-                "Stream API listening on address: {}",
-                addr.to_string().purple()
+        // Adopt the configuration worker as the runtime source of truth. Both
+        // bus calls are time-bounded: worker startup is awaited serially by the
+        // boot and reload pipelines, so a hung `configuration::*` provider must
+        // not wedge every other worker behind this one. Failures degrade to the
+        // static config.yaml block so the stream server stays up.
+        let register = tokio::time::timeout(
+            super::configuration::CONFIG_BUS_TIMEOUT,
+            super::configuration::register_config(self.engine.as_ref(), self.seed.as_ref()),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("configuration::register timed out"))
+        .and_then(|result| result);
+        if let Err(err) = register {
+            tracing::warn!(
+                error = %err,
+                "iii-stream: configuration::register failed; continuing with static config"
             );
+        }
+        let fetched = tokio::time::timeout(
+            super::configuration::CONFIG_BUS_TIMEOUT,
+            super::configuration::fetch_config(self.engine.as_ref(), &self.config_snapshot()),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("configuration::get timed out"))
+        .and_then(|result| result);
+        match fetched {
+            Ok(config) => self.set_config(Arc::new(config)),
+            Err(err) => tracing::warn!(
+                error = %err,
+                "iii-stream: failed to read configuration; continuing with static config"
+            ),
+        }
 
-            let serve = axum::serve(
-                listener,
-                app.into_make_service_with_connect_info::<SocketAddr>(),
-            )
-            .with_graceful_shutdown(async move {
-                while server_shutdown_rx.changed().await.is_ok() {
-                    if *server_shutdown_rx.borrow() {
-                        break;
+        // Bind after the fetch so a runtime-edited host/port survives restarts.
+        // If the stored address can't be bound, fall back to the seed address
+        // rather than failing the whole worker start — GUARDED: requires an
+        // explicit seed, the addresses must differ, and it must not widen a
+        // loopback-only stored host to a non-loopback seed. The fallback may
+        // revert `live.config` to the seed, so adapter adoption is deferred
+        // until AFTER the bind: it must reconcile against the config actually
+        // being served, never a stored value we failed to honor.
+        let config = self.config_snapshot();
+        let addr = format!("{}:{}", config.host, config.port);
+        let listener = match TcpListener::bind(&addr).await {
+            Ok(listener) => listener,
+            Err(err) => {
+                let Some(fallback) = self.seed.clone() else {
+                    return Err(crate::workers::traits::bind_address_error(&addr, err));
+                };
+                let fallback_addr = format!("{}:{}", fallback.host, fallback.port);
+                let widens_loopback =
+                    is_loopback_host(&config.host) && !is_loopback_host(&fallback.host);
+                if fallback_addr == addr || widens_loopback {
+                    if widens_loopback {
+                        tracing::error!(
+                            stored = %addr,
+                            seed = %fallback_addr,
+                            "iii-stream: refusing seed fallback that would widen a \
+                             loopback-only address to a non-loopback interface"
+                        );
                     }
+                    return Err(crate::workers::traits::bind_address_error(&addr, err));
                 }
-            });
-            if let Err(e) = serve.await {
-                tracing::error!(error = %e, "Stream server exited with error");
+                tracing::error!(
+                    error = %err,
+                    stored = %addr,
+                    fallback = %fallback_addr,
+                    "iii-stream: stored configuration address cannot be bound; serving on the \
+                     seed address — fix the stored `iii-stream` configuration value"
+                );
+                self.set_config(Arc::new(fallback));
+                TcpListener::bind(&fallback_addr).await.map_err(|err| {
+                    crate::workers::traits::bind_address_error(&fallback_addr, err)
+                })?
             }
-        });
+        };
+        let addr = {
+            let config = self.config_snapshot();
+            format!("{}:{}", config.host, config.port)
+        };
+        tracing::info!("Starting StreamWorker on {}", addr.purple());
 
-        let adapter = self.adapter.clone();
-        let watch_handle = tokio::spawn(async move {
-            tokio::select! {
-                result = adapter.watch_events() => {
-                    if let Err(e) = result {
-                        tracing::error!(error = %e, "Failed to watch events");
-                    }
-                }
-                _ = async {
-                    while shutdown_rx.changed().await.is_ok() {
-                        if *shutdown_rx.borrow() {
-                            break;
-                        }
-                    }
-                } => {
-                    tracing::info!("Stream watch_events shutdown signal received");
-                }
+        // Boot adoption of the adapter, reconciled against the config actually
+        // served (post-bind, so a fallback's reverted config is honored).
+        // `build()` resolved the adapter from the seed; the served config may
+        // select a different backend, so resolve and adopt it — keeping config
+        // and adapter consistent. A resolve failure keeps the seed adapter
+        // (logged) rather than failing worker start.
+        let served_config = self.config_snapshot();
+        let adapter_outdated = self.seed.as_ref().is_none_or(|seed| {
+            Self::effective_adapter(seed) != Self::effective_adapter(&served_config)
+        });
+        if adapter_outdated {
+            match Self::resolve_adapter(&self.engine, &served_config).await {
+                Ok(adapter) => self.set_adapter(adapter),
+                Err(err) => tracing::warn!(
+                    error = %err,
+                    "iii-stream: stored adapter could not be resolved at boot; keeping seed adapter"
+                ),
             }
-        });
+        }
 
-        let mut aborts = self
-            .task_aborts
+        // Spawn the server and the adapter watch pump.
+        let server = self.spawn_server(listener, addr, shutdown_rx.clone());
+        *self
+            .server_abort
             .lock()
-            .expect("stream task_aborts mutex poisoned");
-        aborts.push(server_handle.abort_handle());
-        aborts.push(watch_handle.abort_handle());
+            .expect("stream server_abort mutex poisoned") = Some(server);
+        let watch = self.spawn_watch(self.adapter_snapshot(), shutdown_rx.clone());
+        *self
+            .watch_abort
+            .lock()
+            .expect("stream watch_abort mutex poisoned") = Some(watch);
+
+        // Store the receiver only once the server is live: `apply_config`
+        // refuses to rebind/swap while this is `None`, so a stray
+        // on-config-change cannot act during (or instead of) the boot sequence.
+        *self
+            .shutdown_rx
+            .lock()
+            .expect("stream shutdown_rx mutex poisoned") = Some(shutdown_rx);
+
+        // Register the handler before the trigger so an event can never fan out
+        // to a missing function. The `get` check keeps the initial-boot path
+        // (where `register_functions` already ran it) from logging a spurious
+        // overwrite.
+        if self
+            .engine
+            .functions
+            .get(super::configuration::CONFIG_FN_ID)
+            .is_none()
+        {
+            self.register_config_handler(&self.engine);
+        }
+        if let Err(err) = super::configuration::register_config_trigger(&self.engine).await {
+            tracing::warn!(
+                error = %err,
+                "iii-stream: failed to watch configuration changes; hot-reload disabled"
+            );
+        } else {
+            // Catch-up pass: replay any `configuration::set` that landed between
+            // the boot fetch above and the trigger subscription. Routed through
+            // `on_config_change` so a timed-out catch-up gets the one-shot retry.
+            super::configuration::on_config_change(self).await;
+        }
 
         Ok(())
     }
@@ -279,12 +422,20 @@ impl ConfigurableWorker for StreamWorker {
     }
 
     fn build(engine: Arc<Engine>, config: Self::Config, adapter: Arc<Self::Adapter>) -> Self {
+        let seed = Some(config.clone());
         Self {
-            config,
-            adapter,
             engine,
+            live: Arc::new(SyncRwLock::new(LiveState {
+                config: Arc::new(config),
+                adapter,
+            })),
+            seed,
             triggers: Arc::new(StreamTriggers::new()),
-            task_aborts: Arc::new(StdMutex::new(Vec::new())),
+            server_abort: Arc::new(StdMutex::new(None)),
+            watch_abort: Arc::new(StdMutex::new(None)),
+            shutdown_rx: Arc::new(StdMutex::new(None)),
+            apply_lock: Arc::new(tokio::sync::Mutex::new(())),
+            destroyed: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -294,6 +445,337 @@ impl ConfigurableWorker for StreamWorker {
 
     fn adapter_config_from_config(config: &Self::Config) -> Option<Value> {
         config.adapter.as_ref().and_then(|a| a.config.clone())
+    }
+}
+
+impl StreamWorker {
+    /// Snapshot the live configuration (cheap `Arc` clone, no lock held by the
+    /// caller).
+    pub fn config_snapshot(&self) -> Arc<StreamModuleConfig> {
+        self.live
+            .read()
+            .expect("stream live state poisoned")
+            .config
+            .clone()
+    }
+
+    /// Snapshot the live pub/sub adapter (cheap `Arc` clone).
+    pub fn adapter_snapshot(&self) -> Arc<dyn StreamAdapter> {
+        self.live
+            .read()
+            .expect("stream live state poisoned")
+            .adapter
+            .clone()
+    }
+
+    fn set_config(&self, config: Arc<StreamModuleConfig>) {
+        self.live
+            .write()
+            .expect("stream live state poisoned")
+            .config = config;
+    }
+
+    fn set_adapter(&self, adapter: Arc<dyn StreamAdapter>) {
+        self.live
+            .write()
+            .expect("stream live state poisoned")
+            .adapter = adapter;
+    }
+
+    fn set_live(&self, config: Arc<StreamModuleConfig>, adapter: Arc<dyn StreamAdapter>) {
+        let mut guard = self.live.write().expect("stream live state poisoned");
+        guard.config = config;
+        guard.adapter = adapter;
+    }
+
+    /// The effective `(adapter_name, adapter_config)`, so `None` and an explicit
+    /// built-in default compare equal — no false "changed" verdict on boot
+    /// adoption or an `auth_function`-only edit.
+    fn effective_adapter(config: &StreamModuleConfig) -> (String, Option<Value>) {
+        (
+            Self::adapter_name_from_config(config)
+                .unwrap_or_else(|| Self::DEFAULT_ADAPTER_NAME.to_string()),
+            Self::adapter_config_from_config(config),
+        )
+    }
+
+    /// Resolve an `Arc<dyn StreamAdapter>` from a config, mirroring steps 3–4 of
+    /// `create_with_adapters` so a runtime adapter edit builds the same backend
+    /// the boot path would.
+    async fn resolve_adapter(
+        engine: &Arc<Engine>,
+        config: &StreamModuleConfig,
+    ) -> anyhow::Result<Arc<dyn StreamAdapter>> {
+        let adapter_name = Self::adapter_name_from_config(config)
+            .unwrap_or_else(|| Self::DEFAULT_ADAPTER_NAME.to_string());
+        let factory = Self::get_adapter(&adapter_name).await.ok_or_else(|| {
+            anyhow::anyhow!("stream adapter factory '{}' not found", adapter_name)
+        })?;
+        let adapter_config = Self::adapter_config_from_config(config);
+        factory(engine.clone(), adapter_config).await
+    }
+
+    /// Build a worker straight from a JSON config for tests (async because
+    /// adapter resolution is). Mirrors `create_with_adapters` then `build`.
+    pub async fn for_test(engine: Arc<Engine>, config: Option<Value>) -> anyhow::Result<Self> {
+        let parsed: StreamModuleConfig = config
+            .map(serde_json::from_value)
+            .transpose()?
+            .unwrap_or_default();
+        let adapter = Self::resolve_adapter(&engine, &parsed).await?;
+        Ok(Self::build(engine, parsed, adapter))
+    }
+
+    /// Register the `iii-stream::on-config-change` handler (idempotent by id).
+    fn register_config_handler(&self, engine: &Arc<Engine>) {
+        let worker = self.clone();
+        engine.register_function_handler(
+            RegisterFunctionRequest {
+                function_id: super::configuration::CONFIG_FN_ID.to_string(),
+                description: Some("Apply iii-stream configuration changes".to_string()),
+                request_format: None,
+                response_format: None,
+                metadata: Some(serde_json::json!({ "internal": true })),
+            },
+            Handler::new(move |_input: Value| {
+                let worker = worker.clone();
+                async move {
+                    super::configuration::on_config_change(&worker).await;
+                    FunctionResult::Success(Some(serde_json::json!({})))
+                }
+            }),
+        );
+    }
+
+    /// Spawn the axum WebSocket server for an already-bound listener and return
+    /// its abort handle. The socket manager reads the worker's live config and
+    /// adapter per connection, so `auth_function`/adapter edits apply without a
+    /// respawn; only a host/port change needs a rebind.
+    fn spawn_server(
+        &self,
+        listener: TcpListener,
+        addr_display: String,
+        mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    ) -> AbortHandle {
+        let socket_manager = Arc::new(StreamSocketManager::new(
+            self.engine.clone(),
+            Arc::new(self.clone()),
+            self.triggers.clone(),
+        ));
+        let app = Router::new()
+            .route("/", get(ws_handler))
+            .with_state(socket_manager);
+        let handle = tokio::spawn(async move {
+            tracing::info!("Stream API listening on address: {}", addr_display.purple());
+            let serve = axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .with_graceful_shutdown(async move {
+                while shutdown_rx.changed().await.is_ok() {
+                    if *shutdown_rx.borrow() {
+                        break;
+                    }
+                }
+            });
+            if let Err(e) = serve.await {
+                tracing::error!(address = %addr_display, error = %e, "Stream server exited with error");
+            }
+        });
+        handle.abort_handle()
+    }
+
+    /// Spawn the adapter `watch_events` pump for the given adapter and return
+    /// its abort handle. Restarted on an adapter hot-swap; the captured `Arc`
+    /// keeps the backend alive for as long as the pump runs.
+    fn spawn_watch(
+        &self,
+        adapter: Arc<dyn StreamAdapter>,
+        mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    ) -> AbortHandle {
+        let handle = tokio::spawn(async move {
+            tokio::select! {
+                result = adapter.watch_events() => {
+                    if let Err(e) = result {
+                        tracing::error!(error = %e, "Failed to watch events");
+                    }
+                }
+                _ = async {
+                    while shutdown_rx.changed().await.is_ok() {
+                        if *shutdown_rx.borrow() {
+                            break;
+                        }
+                    }
+                } => {
+                    tracing::info!("Stream watch_events shutdown signal received");
+                }
+            }
+        });
+        handle.abort_handle()
+    }
+
+    /// Schedule graceful teardown of an adapter that was just swapped out.
+    ///
+    /// Each WebSocket connection captures its own `Arc` to the backend it
+    /// subscribed to and holds it for its lifetime (see
+    /// `StreamSocketManager::socket_handler`), so the previous backend must stay
+    /// alive while any orphaned connection still uses it. We poll until only
+    /// this task's `Arc` remains — every orphaned connection (and the aborted
+    /// watch pump) has released it — then run `StreamAdapter::destroy()` so
+    /// stateful backends (redis closes connections, bridge stops its socket
+    /// thread) release their resources. A plain `Arc` drop would NOT run
+    /// `destroy()`. Bounded so a never-closing connection can't keep the task
+    /// (and the backend) alive forever.
+    fn schedule_adapter_teardown(previous_adapter: Arc<dyn StreamAdapter>) {
+        const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+        const MAX_DRAIN: std::time::Duration = std::time::Duration::from_secs(600);
+        tokio::spawn(async move {
+            let deadline = tokio::time::Instant::now() + MAX_DRAIN;
+            // strong_count == 1 means only this task holds the previous backend.
+            while Arc::strong_count(&previous_adapter) > 1 {
+                if tokio::time::Instant::now() >= deadline {
+                    tracing::warn!(
+                        "iii-stream: previous adapter still referenced after {MAX_DRAIN:?}; \
+                         tearing it down anyway"
+                    );
+                    break;
+                }
+                tokio::time::sleep(POLL_INTERVAL).await;
+            }
+            if let Err(err) = previous_adapter.destroy().await {
+                tracing::warn!(error = %err, "iii-stream: previous adapter teardown failed");
+            }
+        });
+    }
+
+    /// Re-fetch the authoritative configuration and hot-apply it under
+    /// `apply_lock` (so overlapping events can't apply a stale value last).
+    /// All-or-nothing on the fallible prerequisites: a failed adapter resolve or
+    /// listener bind keeps the previous config, adapter, and server.
+    ///
+    /// `auth_function`-only change → swap the config snapshot (the running
+    /// server reads it per connection). `adapter` change → build the new
+    /// backend, swap it in, and restart the `watch_events` pump (existing
+    /// connections stay bound to the previous backend until they close).
+    /// `host`/`port` change → bind the new address, respawn the server on it,
+    /// then abort the old listener.
+    pub(super) async fn apply_config(&self) -> anyhow::Result<()> {
+        let _guard = self.apply_lock.lock().await;
+
+        // `destroy` sets this and aborts the server; a late retry must not
+        // resurrect anything (or build a throwaway adapter below).
+        if self.destroyed.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        let new_config = match tokio::time::timeout(
+            super::configuration::CONFIG_BUS_TIMEOUT,
+            super::configuration::fetch_config(self.engine.as_ref(), &self.config_snapshot()),
+        )
+        .await
+        {
+            Ok(result) => result?,
+            // Keep the `Elapsed` error downcastable: `on_config_change`
+            // schedules a one-shot retry for timeouts specifically.
+            Err(elapsed) => {
+                return Err(anyhow::Error::new(elapsed)
+                    .context("configuration::get timed out; keeping previous config"));
+            }
+        };
+
+        let old = self.config_snapshot();
+        let addr_changed =
+            (old.host.as_str(), old.port) != (new_config.host.as_str(), new_config.port);
+        let adapter_changed = Self::effective_adapter(&old) != Self::effective_adapter(&new_config);
+
+        if !addr_changed && !adapter_changed {
+            // Pure `auth_function` (or no-op) change: the server reads the live
+            // config per connection, so a snapshot swap is all that is needed.
+            self.set_config(Arc::new(new_config));
+            return Ok(());
+        }
+
+        // Resolve every fallible prerequisite BEFORE mutating live state, so a
+        // failure leaves the previous config/adapter/server untouched.
+        let new_adapter = if adapter_changed {
+            Some(Self::resolve_adapter(&self.engine, &new_config).await?)
+        } else {
+            None
+        };
+
+        // The `shutdown_rx` check doubles as the started/destroyed guard
+        // (`destroy` clears it). Checking it before binding means a post-destroy
+        // retry can never transiently bind the stored address.
+        let shutdown_rx = self
+            .shutdown_rx
+            .lock()
+            .expect("stream shutdown_rx mutex poisoned")
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("stream server was never started; cannot apply"))?;
+
+        let new_addr = format!("{}:{}", new_config.host, new_config.port);
+        let listener = if addr_changed {
+            Some(
+                TcpListener::bind(&new_addr)
+                    .await
+                    .map_err(|err| crate::workers::traits::bind_address_error(&new_addr, err))?,
+            )
+        } else {
+            None
+        };
+
+        // Capture the outgoing adapter before the swap so it can be torn down
+        // once it has drained (see `schedule_adapter_teardown`). Only relevant
+        // when the adapter actually changes.
+        let previous_adapter = new_adapter.as_ref().map(|_| self.adapter_snapshot());
+
+        // Past the gate — commit.
+        let new_config = Arc::new(new_config);
+        match &new_adapter {
+            Some(adapter) => self.set_live(new_config, adapter.clone()),
+            None => self.set_config(new_config),
+        }
+
+        // Adapter swap: restart the watch pump on the new backend, abort the
+        // old pump (releasing its old-adapter `Arc`). Existing connections keep
+        // their own old-adapter `Arc` alive until they close, so they stay bound
+        // to the previous backend (accepted: they no longer receive new events).
+        if let Some(adapter) = new_adapter {
+            let new_watch = self.spawn_watch(adapter, shutdown_rx.clone());
+            let previous = self
+                .watch_abort
+                .lock()
+                .expect("stream watch_abort mutex poisoned")
+                .replace(new_watch);
+            if let Some(previous) = previous {
+                previous.abort();
+            }
+            // Tear down the swapped-out backend once no live connection still
+            // references it, so stateful backends (redis/bridge) release their
+            // resources without cutting off orphaned connections mid-swap.
+            if let Some(previous_adapter) = previous_adapter {
+                Self::schedule_adapter_teardown(previous_adapter);
+            }
+        }
+
+        // Address change: respawn the server on the new listener, then abort
+        // the old one (the addresses differ, so no self-conflict). Live
+        // connections on the old listener are dropped — same semantics as
+        // `destroy`.
+        if let Some(listener) = listener {
+            let new_server = self.spawn_server(listener, new_addr.clone(), shutdown_rx);
+            let previous = self
+                .server_abort
+                .lock()
+                .expect("stream server_abort mutex poisoned")
+                .replace(new_server);
+            if let Some(previous) = previous {
+                previous.abort();
+            }
+            tracing::info!(new = %new_addr, "iii-stream server rebound after configuration change");
+        }
+
+        Ok(())
     }
 }
 
@@ -447,7 +929,7 @@ impl StreamWorker {
 
         let function_id = format!("stream::set({})", stream_name);
         let function = self.engine.functions.get(&function_id);
-        let adapter = self.adapter.clone();
+        let adapter = self.adapter_snapshot();
 
         let result: anyhow::Result<SetResult> = match function {
             Some(_) => {
@@ -534,7 +1016,7 @@ impl StreamWorker {
 
         let function_id = format!("stream::get({})", stream_name);
         let function = self.engine.functions.get(&function_id);
-        let adapter = self.adapter.clone();
+        let adapter = self.adapter_snapshot();
 
         crate::workers::telemetry::collector::track_stream_get();
         match function {
@@ -584,7 +1066,7 @@ impl StreamWorker {
         let item_id = input.item_id;
         let function_id = format!("stream::delete({})", stream_name);
         let function = self.engine.functions.get(&function_id);
-        let adapter = self.adapter.clone();
+        let adapter = self.adapter_snapshot();
 
         let result: anyhow::Result<DeleteResult> = match function {
             Some(_) => {
@@ -660,7 +1142,7 @@ impl StreamWorker {
 
         let function_id = format!("stream::list({})", stream_name);
         let function = self.engine.functions.get(&function_id);
-        let adapter = self.adapter.clone();
+        let adapter = self.adapter_snapshot();
 
         crate::workers::telemetry::collector::track_stream_list();
         match function {
@@ -712,7 +1194,7 @@ impl StreamWorker {
 
         let function_id = format!("stream::list_groups({})", stream_name);
         let function = self.engine.functions.get(&function_id);
-        let adapter = self.adapter.clone();
+        let adapter = self.adapter_snapshot();
 
         match function {
             Some(_) => {
@@ -757,7 +1239,7 @@ impl StreamWorker {
         &self,
         _input: StreamListAllInput,
     ) -> FunctionResult<StreamListAllResult, ErrorBody> {
-        let adapter = self.adapter.clone();
+        let adapter = self.adapter_snapshot();
 
         match adapter.list_all_stream().await {
             Ok(stream) => {
@@ -796,7 +1278,7 @@ impl StreamWorker {
 
         self.invoke_triggers(message.clone()).await;
 
-        if let Err(e) = self.adapter.emit_event(message).await {
+        if let Err(e) = self.adapter_snapshot().emit_event(message).await {
             tracing::error!(error = %e, "Failed to emit stream send event");
             return FunctionResult::Failure(ErrorBody {
                 message: format!("Failed to send event: {}", e),
@@ -826,7 +1308,7 @@ impl StreamWorker {
 
         let function_id = format!("stream::update({})", stream_name);
         let function = self.engine.functions.get(&function_id);
-        let adapter = self.adapter.clone();
+        let adapter = self.adapter_snapshot();
 
         let result: anyhow::Result<UpdateResult> = match function {
             Some(_) => {
@@ -937,6 +1419,42 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn effective_adapter_treats_none_as_default() {
+        use crate::workers::traits::AdapterEntry;
+
+        // An absent adapter and an explicit built-in-default adapter must
+        // compare equal, so boot adoption (or an auth_function-only edit) is not
+        // mistaken for an adapter change that would trigger a needless hot-swap.
+        let none = StreamModuleConfig::default();
+        assert!(none.adapter.is_none());
+        let explicit = StreamModuleConfig {
+            adapter: Some(AdapterEntry {
+                name: StreamWorker::DEFAULT_ADAPTER_NAME.to_string(),
+                config: None,
+            }),
+            ..StreamModuleConfig::default()
+        };
+        assert_eq!(
+            StreamWorker::effective_adapter(&none),
+            StreamWorker::effective_adapter(&explicit),
+            "None and the explicit default adapter must be the same effective adapter"
+        );
+
+        let other = StreamModuleConfig {
+            adapter: Some(AdapterEntry {
+                name: "redis".to_string(),
+                config: None,
+            }),
+            ..StreamModuleConfig::default()
+        };
+        assert_ne!(
+            StreamWorker::effective_adapter(&none),
+            StreamWorker::effective_adapter(&other),
+            "a different adapter name must be a different effective adapter"
+        );
+    }
 
     struct RecordingConnection {
         tx: mpsc::UnboundedSender<StreamWrapperMessage>,
@@ -1173,7 +1691,7 @@ mod tests {
         // Subscribe to events
         let (tx, mut rx) = mpsc::unbounded_channel();
         module
-            .adapter
+            .adapter_snapshot()
             .subscribe(
                 "test-subscriber".to_string(),
                 Arc::new(RecordingConnection { tx }),
@@ -1182,7 +1700,7 @@ mod tests {
             .expect("Should subscribe successfully");
 
         // Start event watcher
-        let watcher_adapter = module.adapter.clone();
+        let watcher_adapter = module.adapter_snapshot();
         let watcher = tokio::spawn(async move {
             let _ = watcher_adapter.watch_events().await;
         });
@@ -1307,7 +1825,7 @@ mod tests {
         // Subscribe to events
         let (tx, mut rx) = mpsc::unbounded_channel();
         module
-            .adapter
+            .adapter_snapshot()
             .subscribe(
                 "test-subscriber".to_string(),
                 Arc::new(RecordingConnection { tx }),
@@ -1316,7 +1834,7 @@ mod tests {
             .expect("Should subscribe successfully");
 
         // Start event watcher
-        let watcher_adapter = module.adapter.clone();
+        let watcher_adapter = module.adapter_snapshot();
         let watcher = tokio::spawn(async move {
             let _ = watcher_adapter.watch_events().await;
         });
@@ -1387,7 +1905,7 @@ mod tests {
         // Subscribe to events
         let (tx, mut rx) = mpsc::unbounded_channel();
         module
-            .adapter
+            .adapter_snapshot()
             .subscribe(
                 "test-subscriber".to_string(),
                 Arc::new(RecordingConnection { tx }),
@@ -1396,7 +1914,7 @@ mod tests {
             .expect("Should subscribe successfully");
 
         // Start event watcher
-        let watcher_adapter = module.adapter.clone();
+        let watcher_adapter = module.adapter_snapshot();
         let watcher = tokio::spawn(async move {
             let _ = watcher_adapter.watch_events().await;
         });

--- a/engine/src/workers/stream/stream.rs
+++ b/engine/src/workers/stream/stream.rs
@@ -351,7 +351,18 @@ impl Worker for StreamWorker {
             Self::effective_adapter(seed) != Self::effective_adapter(&served_config)
         });
         if adapter_outdated {
-            match Self::resolve_adapter(&self.engine, &served_config).await {
+            // Time-bounded like the boot `configuration::*` calls above: a
+            // backend whose `build` hangs must not wedge the serial worker
+            // startup loop. A timeout degrades like any resolve failure —
+            // keep the seed adapter.
+            let resolved = tokio::time::timeout(
+                super::configuration::CONFIG_BUS_TIMEOUT,
+                Self::resolve_adapter(&self.engine, &served_config),
+            )
+            .await
+            .map_err(|_| anyhow::anyhow!("stream adapter build timed out"))
+            .and_then(|result| result);
+            match resolved {
                 Ok(adapter) => self.set_adapter(adapter),
                 Err(err) => {
                     // Keep the live config consistent with the adapter actually
@@ -708,9 +719,26 @@ impl StreamWorker {
         }
 
         // Resolve every fallible prerequisite BEFORE mutating live state, so a
-        // failure leaves the previous config/adapter/server untouched.
+        // failure leaves the previous config/adapter/server untouched. The
+        // adapter build is time-bounded (like the `configuration::*` bus calls):
+        // a custom backend whose `build` hangs must not wedge `apply_lock` —
+        // and with it `destroy`, which also takes that lock.
         let new_adapter = if adapter_changed {
-            Some(Self::resolve_adapter(&self.engine, &new_config).await?)
+            match tokio::time::timeout(
+                super::configuration::CONFIG_BUS_TIMEOUT,
+                Self::resolve_adapter(&self.engine, &new_config),
+            )
+            .await
+            {
+                Ok(result) => Some(result?),
+                // Keep the `Elapsed` downcastable so `on_config_change` retries
+                // a transient build timeout once, like a `configuration::get`
+                // timeout.
+                Err(elapsed) => {
+                    return Err(anyhow::Error::new(elapsed)
+                        .context("stream adapter build timed out; keeping previous config"));
+                }
+            }
         } else {
             None
         };

--- a/engine/src/workers/stream/stream.rs
+++ b/engine/src/workers/stream/stream.rs
@@ -353,10 +353,22 @@ impl Worker for StreamWorker {
         if adapter_outdated {
             match Self::resolve_adapter(&self.engine, &served_config).await {
                 Ok(adapter) => self.set_adapter(adapter),
-                Err(err) => tracing::warn!(
-                    error = %err,
-                    "iii-stream: stored adapter could not be resolved at boot; keeping seed adapter"
-                ),
+                Err(err) => {
+                    // Keep the live config consistent with the adapter actually
+                    // being served: revert just the adapter field to the seed's
+                    // (the backend `build` resolved, still running), so
+                    // `config_snapshot()` never advertises a backend that isn't
+                    // up — which would also let a future no-op apply comparison
+                    // treat the unresolved adapter as already applied and never
+                    // retry it.
+                    tracing::warn!(
+                        error = %err,
+                        "iii-stream: stored adapter could not be resolved at boot; keeping seed adapter"
+                    );
+                    let mut reconciled = (*served_config).clone();
+                    reconciled.adapter = self.seed.as_ref().and_then(|seed| seed.adapter.clone());
+                    self.set_config(Arc::new(reconciled));
+                }
             }
         }
 

--- a/engine/src/workers/telemetry/mod.rs
+++ b/engine/src/workers/telemetry/mod.rs
@@ -208,6 +208,7 @@ pub fn is_iii_builtin_function_id(id: &str) -> bool {
         || id.starts_with("iii-http::")
         || id.starts_with("iii-state::")
         || id.starts_with("iii-pubsub::")
+        || id.starts_with("iii-stream::")
         || id.starts_with("bridge.")
         || id.starts_with("motia::")
         || id == "publish"
@@ -2171,6 +2172,7 @@ mod tests {
         assert!(is_iii_builtin_function_id("iii-http::on-config-change"));
         assert!(is_iii_builtin_function_id("iii-state::on-config-change"));
         assert!(is_iii_builtin_function_id("iii-pubsub::on-config-change"));
+        assert!(is_iii_builtin_function_id("iii-stream::on-config-change"));
         assert!(!is_iii_builtin_function_id("orders::process"));
         assert!(!is_iii_builtin_function_id("user::my_function"));
         assert!(!is_iii_builtin_function_id("payments::charge"));

--- a/engine/tests/stream_configuration_e2e.rs
+++ b/engine/tests/stream_configuration_e2e.rs
@@ -94,6 +94,27 @@ async fn set_value(harness: &Harness, value: Value) {
     }
 }
 
+/// Assert `configuration::set` rejects a value against the closed adapter schema
+/// with `SCHEMA_INVALID` (the bus guard that keeps an unknown adapter name or a
+/// stray config key from ever reaching the worker).
+async fn set_value_expect_rejection(harness: &Harness, value: Value) {
+    let result = harness
+        .configuration
+        .set_fn(ConfigurationSetInput {
+            id: CONFIG_ID.to_string(),
+            value: value.clone(),
+        })
+        .await;
+    match result {
+        FunctionResult::Failure(err) => assert_eq!(
+            err.code, "SCHEMA_INVALID",
+            "expected schema rejection for {value}: {err:?}"
+        ),
+        FunctionResult::Success(_) => panic!("configuration::set must reject {value}"),
+        _ => panic!("unexpected configuration::set result for {value}"),
+    }
+}
+
 /// Invoke the config-change handler synchronously so assertions can't pass
 /// vacuously before the (also async) trigger fan-out applies the change.
 async fn drive_apply(harness: &Harness) {
@@ -318,14 +339,32 @@ async fn boot_resolve_failure_reconciles_config_to_served_adapter() {
     let dir = tempfile::tempdir().unwrap();
     let harness = build_harness(dir.path()).await;
 
+    // First boot seeds + persists a valid `iii-stream` entry to disk.
     let first = start_stream_worker(&harness, json!({ "host": "127.0.0.1", "port": 0 })).await;
-    // Bindable port, but an adapter name with no registered factory.
-    set_value(
-        &harness,
-        json!({ "host": "127.0.0.1", "port": 0, "adapter": { "name": "does-not-exist" } }),
-    )
-    .await;
     first.destroy().await.expect("destroy");
+
+    // Hand-edit the persisted yaml so its stored adapter is an unresolvable name.
+    // This bypasses `configuration::set`'s closed-schema guard exactly as a
+    // manual edit of the persisted file would; deserialization stays lenient, so
+    // the bad value loads on the next prime.
+    let entry_path = dir.path().join("iii-stream.yaml");
+    let mut entry: serde_yaml::Value =
+        serde_yaml::from_str(&std::fs::read_to_string(&entry_path).expect("read persisted entry"))
+            .expect("parse persisted entry");
+    entry
+        .get_mut("value")
+        .and_then(|v| v.as_mapping_mut())
+        .expect("persisted value mapping")
+        .insert(
+            serde_yaml::Value::String("adapter".to_string()),
+            serde_yaml::from_str("name: does-not-exist").unwrap(),
+        );
+    std::fs::write(&entry_path, serde_yaml::to_string(&entry).unwrap())
+        .expect("write hand-edited entry");
+
+    // A fresh harness re-primes the configuration store from disk, loading the
+    // unresolvable adapter that the bus would never have accepted.
+    let harness = build_harness(dir.path()).await;
 
     let restarted = StreamWorker::for_test(
         harness.engine.clone(),
@@ -387,32 +426,38 @@ async fn adapter_hot_swap_rebuilds_backend() {
 }
 
 #[tokio::test]
-async fn unresolvable_adapter_keeps_previous_backend() {
+async fn set_rejects_unknown_adapter_and_stray_config() {
+    // The closed per-adapter schema guards `configuration::set`: an unknown
+    // adapter name or a config key outside the chosen adapter's schema is
+    // rejected at the bus, so the worker never has to resolve a backend that
+    // can't exist. (The worker's defensive keep-previous behavior for a
+    // hand-edited persisted file that bypasses this guard is covered by the
+    // `configuration.rs` unit tests.)
     let _serial = PORT_SERIAL.lock().await;
     let dir = tempfile::tempdir().unwrap();
     let harness = build_harness(dir.path()).await;
 
-    let worker = start_stream_worker(&harness, json!({ "host": "127.0.0.1", "port": 0 })).await;
-    let before = worker.adapter_snapshot();
+    let _worker = start_stream_worker(&harness, json!({ "host": "127.0.0.1", "port": 0 })).await;
 
-    // An adapter name with no registered factory deserializes fine and passes
-    // the JSON schema, so it reaches the apply gate — where resolving the
-    // backend fails and the previous adapter/config must stand.
-    set_value(
+    // Unknown adapter name.
+    set_value_expect_rejection(
         &harness,
         json!({ "host": "127.0.0.1", "port": 0, "adapter": { "name": "does-not-exist" } }),
     )
     .await;
-    drive_apply(&harness).await;
-
-    assert!(
-        Arc::ptr_eq(&before, &worker.adapter_snapshot()),
-        "a failed resolve must keep the previous backend"
-    );
-    assert!(
-        worker.config_snapshot().adapter.is_none(),
-        "a failed resolve must keep the previous config"
-    );
+    // Stray config key for a known adapter (kv reads store_method/file_path/
+    // save_interval_ms/channel_size).
+    set_value_expect_rejection(
+        &harness,
+        json!({ "host": "127.0.0.1", "port": 0, "adapter": { "name": "kv", "config": { "bogus": 1 } } }),
+    )
+    .await;
+    // A valid known adapter is still accepted.
+    set_value(
+        &harness,
+        json!({ "host": "127.0.0.1", "port": 0, "adapter": { "name": "redis", "config": { "redis_url": "redis://localhost:6379" } } }),
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/engine/tests/stream_configuration_e2e.rs
+++ b/engine/tests/stream_configuration_e2e.rs
@@ -309,6 +309,49 @@ async fn boot_rebuilds_adapter_from_persisted_value() {
 }
 
 #[tokio::test]
+async fn boot_resolve_failure_reconciles_config_to_served_adapter() {
+    // When the persisted config selects an unresolvable adapter, boot keeps the
+    // seed-built backend AND reverts the live config's adapter field to match,
+    // so config_snapshot() never advertises a backend that is not running (and a
+    // future no-op apply comparison can't treat the bad adapter as applied).
+    let _serial = PORT_SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let first = start_stream_worker(&harness, json!({ "host": "127.0.0.1", "port": 0 })).await;
+    // Bindable port, but an adapter name with no registered factory.
+    set_value(
+        &harness,
+        json!({ "host": "127.0.0.1", "port": 0, "adapter": { "name": "does-not-exist" } }),
+    )
+    .await;
+    first.destroy().await.expect("destroy");
+
+    let restarted = StreamWorker::for_test(
+        harness.engine.clone(),
+        Some(json!({ "host": "127.0.0.1", "port": 0 })),
+    )
+    .await
+    .expect("stream worker");
+    let seed_adapter = restarted.adapter_snapshot();
+    restarted.initialize().await.expect("initialize");
+    Worker::register_functions(&restarted, harness.engine.clone());
+    restarted
+        .start_background_tasks(harness.shutdown_rx.clone(), harness.shutdown_tx.clone())
+        .await
+        .expect("start_background_tasks");
+
+    assert!(
+        Arc::ptr_eq(&seed_adapter, &restarted.adapter_snapshot()),
+        "an unresolvable boot adapter must keep the seed-built backend"
+    );
+    assert!(
+        restarted.config_snapshot().adapter.is_none(),
+        "the live config adapter must be reconciled to the served (seed) backend, not the unresolved stored value"
+    );
+}
+
+#[tokio::test]
 async fn adapter_hot_swap_rebuilds_backend() {
     let _serial = PORT_SERIAL.lock().await;
     let dir = tempfile::tempdir().unwrap();

--- a/engine/tests/stream_configuration_e2e.rs
+++ b/engine/tests/stream_configuration_e2e.rs
@@ -1,0 +1,557 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! End-to-end test for the `iii-stream` ↔ `configuration` worker integration:
+//! seed-on-first-boot, no-clobber across worker restarts, an `auth_function`
+//! hot-apply with no rebind, a full pub/sub adapter hot-swap, a host/port
+//! rebind of the live WebSocket listener, the strict gates that keep the
+//! previous adapter/server when a stored value cannot be resolved or bound, and
+//! `${VAR:default}` expansion on read.
+//!
+//! Modeled on `engine/tests/http_configuration_e2e.rs` — composes the two
+//! workers against a real `FsAdapter` on a `tempfile::tempdir()`. No engine
+//! boot, no client WebSocket, no subprocess.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{Value, json};
+
+use iii::engine::{Engine, EngineTrait};
+use iii::function::FunctionResult;
+use iii::workers::configuration::ConfigurationWorker;
+use iii::workers::configuration::adapters::ConfigurationAdapter;
+use iii::workers::configuration::adapters::fs::FsAdapter;
+use iii::workers::configuration::structs::ConfigurationSetInput;
+use iii::workers::stream::StreamWorker;
+use iii::workers::traits::Worker;
+
+const CONFIG_ID: &str = "iii-stream";
+
+struct Harness {
+    engine: Arc<Engine>,
+    configuration: ConfigurationWorker,
+    // Keep the shutdown channel alive for the worker lifecycle: dropping the
+    // sender would gracefully stop the stream server task.
+    shutdown_tx: tokio::sync::watch::Sender<bool>,
+    shutdown_rx: tokio::sync::watch::Receiver<bool>,
+}
+
+async fn build_harness(dir: &std::path::Path) -> Harness {
+    iii::workers::observability::metrics::ensure_default_meter();
+    let adapter = Arc::new(
+        FsAdapter::new(Some(json!({ "directory": dir.to_str().unwrap() })))
+            .await
+            .expect("fs adapter"),
+    ) as Arc<dyn ConfigurationAdapter>;
+    let engine = Arc::new(Engine::new());
+
+    let configuration = ConfigurationWorker::for_test(engine.clone(), adapter, 0);
+    configuration
+        .initialize()
+        .await
+        .expect("configuration initialize");
+    Worker::register_functions(&configuration, engine.clone());
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    Harness {
+        engine,
+        configuration,
+        shutdown_tx,
+        shutdown_rx,
+    }
+}
+
+/// Create, initialize, and start an `iii-stream` worker with the given seed.
+async fn start_stream_worker(harness: &Harness, seed: Value) -> StreamWorker {
+    let worker = StreamWorker::for_test(harness.engine.clone(), Some(seed))
+        .await
+        .expect("stream worker");
+    worker.initialize().await.expect("stream initialize");
+    Worker::register_functions(&worker, harness.engine.clone());
+    worker
+        .start_background_tasks(harness.shutdown_rx.clone(), harness.shutdown_tx.clone())
+        .await
+        .expect("stream start_background_tasks");
+    worker
+}
+
+async fn set_value(harness: &Harness, value: Value) {
+    let result = harness
+        .configuration
+        .set_fn(ConfigurationSetInput {
+            id: CONFIG_ID.to_string(),
+            value,
+        })
+        .await;
+    match result {
+        FunctionResult::Success(_) => {}
+        FunctionResult::Failure(err) => panic!("configuration::set failed: {err:?}"),
+        _ => panic!("unexpected configuration::set result"),
+    }
+}
+
+/// Invoke the config-change handler synchronously so assertions can't pass
+/// vacuously before the (also async) trigger fan-out applies the change.
+async fn drive_apply(harness: &Harness) {
+    harness
+        .engine
+        .call("iii-stream::on-config-change", json!({}))
+        .await
+        .expect("config-change handler is invocable");
+}
+
+async fn stored_value(harness: &Harness, raw: bool) -> Value {
+    harness
+        .engine
+        .call("configuration::get", json!({ "id": CONFIG_ID, "raw": raw }))
+        .await
+        .expect("configuration::get")
+        .expect("get returns a body")
+}
+
+/// Poll until `predicate` returns true or the deadline elapses. Trigger
+/// fan-out is spawned, so observable effects are eventually consistent.
+async fn wait_for(mut predicate: impl FnMut() -> bool, what: &str) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if predicate() {
+            return;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("timed out waiting for {what}");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+async fn wait_for_async<F, Fut>(mut predicate: F, what: &str)
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if predicate().await {
+            return;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("timed out waiting for {what}");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// Serializes the whole suite so no two tests contend for TCP ports. The stream
+/// worker binds a real listener in `start_background_tasks`; cargo runs these
+/// `#[tokio::test]`s in parallel, so without this lock two tests could draw the
+/// same just-freed ephemeral port and collide with `EADDRINUSE`. Each test
+/// holds the lock for its whole lifetime. `tokio::sync::Mutex` never poisons, so
+/// a panicking test still releases it cleanly.
+static PORT_SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Reserve a free TCP port by binding to port 0 and dropping the listener.
+/// Safe against cross-test reuse only while [`PORT_SERIAL`] is held.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+#[tokio::test]
+async fn first_boot_seeds_configuration_entry() {
+    let _serial = PORT_SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let _worker = start_stream_worker(
+        &harness,
+        json!({ "host": "127.0.0.1", "port": 0, "auth_function": "auth::seeded" }),
+    )
+    .await;
+
+    let stored = stored_value(&harness, false).await;
+    assert_eq!(stored["id"], CONFIG_ID);
+    assert_eq!(stored["value"]["host"], "127.0.0.1");
+    assert_eq!(stored["value"]["port"], 0);
+    assert_eq!(stored["value"]["auth_function"], "auth::seeded");
+}
+
+#[tokio::test]
+async fn auth_function_hot_applies_without_rebind() {
+    let _serial = PORT_SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let worker = start_stream_worker(&harness, json!({ "host": "127.0.0.1", "port": 0 })).await;
+    assert!(worker.config_snapshot().auth_function.is_none());
+    let before = worker.adapter_snapshot();
+
+    // Same address + same adapter: only `auth_function` changes, so the running
+    // server picks it up per connection with no rebind and no adapter swap.
+    set_value(
+        &harness,
+        json!({ "host": "127.0.0.1", "port": 0, "auth_function": "auth::live" }),
+    )
+    .await;
+
+    wait_for(
+        || worker.config_snapshot().auth_function.as_deref() == Some("auth::live"),
+        "auth_function to hot-apply",
+    )
+    .await;
+    assert!(
+        Arc::ptr_eq(&before, &worker.adapter_snapshot()),
+        "an auth_function-only change must not rebuild the adapter"
+    );
+}
+
+#[tokio::test]
+async fn runtime_edits_survive_worker_restart() {
+    let _serial = PORT_SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+    let seed = json!({ "host": "127.0.0.1", "port": 0 });
+
+    let worker = start_stream_worker(&harness, seed.clone()).await;
+
+    // Operator repoints the adapter at runtime.
+    set_value(
+        &harness,
+        json!({ "host": "127.0.0.1", "port": 0, "adapter": { "name": "kv", "config": { "channel_size": 128 } } }),
+    )
+    .await;
+    drive_apply(&harness).await;
+    wait_for(
+        || {
+            worker
+                .config_snapshot()
+                .adapter
+                .as_ref()
+                .and_then(|a| a.config.as_ref())
+                .and_then(|c| c["channel_size"].as_u64())
+                == Some(128)
+        },
+        "adapter edit to apply",
+    )
+    .await;
+
+    // "Restart": a fresh worker with a different seed must NOT clobber the
+    // stored value, and must adopt it as the live config (the boot fetch makes
+    // the persisted value the source of truth). The adapter instance rebuild is
+    // covered separately by `boot_rebuilds_adapter_from_persisted_value`.
+    worker.destroy().await.expect("destroy");
+    let restarted = start_stream_worker(
+        &harness,
+        json!({ "host": "127.0.0.1", "port": 0, "adapter": { "name": "kv" } }),
+    )
+    .await;
+
+    assert_eq!(
+        restarted
+            .config_snapshot()
+            .adapter
+            .as_ref()
+            .and_then(|a| a.config.as_ref())
+            .and_then(|c| c["channel_size"].as_u64()),
+        Some(128),
+        "restarted worker must adopt the persisted adapter, not its seed"
+    );
+}
+
+#[tokio::test]
+async fn boot_rebuilds_adapter_from_persisted_value() {
+    // Observes the boot adapter-adoption path directly (not via config_snapshot,
+    // which the boot fetch sets regardless): the seed-built adapter instance
+    // must be REPLACED at boot when the persisted value selects a different
+    // effective adapter. Asserting `Arc` identity makes this non-vacuous — a
+    // regression that drops boot adoption would leave the seed adapter in place
+    // and fail here.
+    let _serial = PORT_SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    // First boot seeds + registers, then persist an adapter differing from the
+    // restart worker's seed.
+    let first = start_stream_worker(&harness, json!({ "host": "127.0.0.1", "port": 0 })).await;
+    set_value(
+        &harness,
+        json!({ "host": "127.0.0.1", "port": 0, "adapter": { "name": "kv", "config": { "channel_size": 200 } } }),
+    )
+    .await;
+    first.destroy().await.expect("destroy");
+
+    // Restart with a seed whose effective adapter (kv, no config) differs from
+    // the persisted one, so boot adoption must rebuild the backend.
+    let restarted = StreamWorker::for_test(
+        harness.engine.clone(),
+        Some(json!({ "host": "127.0.0.1", "port": 0 })),
+    )
+    .await
+    .expect("stream worker");
+    let seed_adapter = restarted.adapter_snapshot();
+    restarted.initialize().await.expect("initialize");
+    Worker::register_functions(&restarted, harness.engine.clone());
+    restarted
+        .start_background_tasks(harness.shutdown_rx.clone(), harness.shutdown_tx.clone())
+        .await
+        .expect("start_background_tasks");
+
+    assert!(
+        !Arc::ptr_eq(&seed_adapter, &restarted.adapter_snapshot()),
+        "boot adoption must rebuild the adapter from the persisted value, not keep the seed instance"
+    );
+}
+
+#[tokio::test]
+async fn adapter_hot_swap_rebuilds_backend() {
+    let _serial = PORT_SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let worker = start_stream_worker(&harness, json!({ "host": "127.0.0.1", "port": 0 })).await;
+    let before = worker.adapter_snapshot();
+
+    // A distinguishing adapter config flips the effective adapter, forcing the
+    // full backend hot-swap path. Address is unchanged, so no rebind.
+    set_value(
+        &harness,
+        json!({ "host": "127.0.0.1", "port": 0, "adapter": { "name": "kv", "config": { "channel_size": 64 } } }),
+    )
+    .await;
+    drive_apply(&harness).await;
+
+    let after = worker.adapter_snapshot();
+    assert!(
+        !Arc::ptr_eq(&before, &after),
+        "an adapter change must rebuild the backend instance"
+    );
+    assert_eq!(
+        worker
+            .config_snapshot()
+            .adapter
+            .as_ref()
+            .and_then(|a| a.config.as_ref())
+            .and_then(|c| c["channel_size"].as_u64()),
+        Some(64),
+        "the live config must reflect the applied adapter"
+    );
+}
+
+#[tokio::test]
+async fn unresolvable_adapter_keeps_previous_backend() {
+    let _serial = PORT_SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let worker = start_stream_worker(&harness, json!({ "host": "127.0.0.1", "port": 0 })).await;
+    let before = worker.adapter_snapshot();
+
+    // An adapter name with no registered factory deserializes fine and passes
+    // the JSON schema, so it reaches the apply gate — where resolving the
+    // backend fails and the previous adapter/config must stand.
+    set_value(
+        &harness,
+        json!({ "host": "127.0.0.1", "port": 0, "adapter": { "name": "does-not-exist" } }),
+    )
+    .await;
+    drive_apply(&harness).await;
+
+    assert!(
+        Arc::ptr_eq(&before, &worker.adapter_snapshot()),
+        "a failed resolve must keep the previous backend"
+    );
+    assert!(
+        worker.config_snapshot().adapter.is_none(),
+        "a failed resolve must keep the previous config"
+    );
+}
+
+#[tokio::test]
+async fn port_change_rebinds_the_listener() {
+    let _serial = PORT_SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let port_a = free_port();
+    let port_b = free_port();
+    assert_ne!(port_a, port_b);
+
+    let _worker =
+        start_stream_worker(&harness, json!({ "host": "127.0.0.1", "port": port_a })).await;
+    tokio::net::TcpStream::connect(("127.0.0.1", port_a))
+        .await
+        .expect("initial port accepts connections");
+
+    set_value(&harness, json!({ "host": "127.0.0.1", "port": port_b })).await;
+
+    wait_for_async(
+        || async {
+            tokio::net::TcpStream::connect(("127.0.0.1", port_b))
+                .await
+                .is_ok()
+        },
+        "rebind to the new port",
+    )
+    .await;
+
+    // The old listener is torn down once the new one is live.
+    wait_for_async(
+        || async {
+            tokio::net::TcpStream::connect(("127.0.0.1", port_a))
+                .await
+                .is_err()
+        },
+        "old listener to release the previous port",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn failed_rebind_keeps_previous_server() {
+    let _serial = PORT_SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let port_a = free_port();
+    let port_b = free_port();
+    assert_ne!(port_a, port_b);
+
+    let worker =
+        start_stream_worker(&harness, json!({ "host": "127.0.0.1", "port": port_a })).await;
+    tokio::net::TcpStream::connect(("127.0.0.1", port_a))
+        .await
+        .expect("initial port accepts connections");
+
+    // Occupy port_b so the rebind's bind() fails. Hold it for the rest of the
+    // test.
+    let _blocker = std::net::TcpListener::bind(("127.0.0.1", port_b)).expect("occupy port_b");
+
+    set_value(&harness, json!({ "host": "127.0.0.1", "port": port_b })).await;
+    drive_apply(&harness).await;
+
+    // Old server still serving on port_a; the live config was not mutated.
+    tokio::net::TcpStream::connect(("127.0.0.1", port_a))
+        .await
+        .expect("old port still accepts after failed rebind");
+    assert_eq!(worker.config_snapshot().port, port_a);
+}
+
+#[tokio::test]
+async fn restart_falls_back_to_seed_when_stored_address_unbindable() {
+    let _serial = PORT_SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let port_a = free_port();
+    let port_b = free_port();
+    assert_ne!(port_a, port_b);
+    let seed = json!({ "host": "127.0.0.1", "port": port_a });
+
+    let worker = start_stream_worker(&harness, seed.clone()).await;
+
+    // Occupy port_b for the whole test, then persist an edit pointing at it.
+    // The hot rebind fails (all-or-nothing), but the bad value is now stored.
+    let _blocker = std::net::TcpListener::bind(("127.0.0.1", port_b)).expect("occupy port_b");
+    set_value(&harness, json!({ "host": "127.0.0.1", "port": port_b })).await;
+    drive_apply(&harness).await;
+
+    // Restart (ReloadManager semantics). The boot fetch returns the stored
+    // unbindable address; the worker must fall back to the seed instead of
+    // failing to start — a bad runtime edit must not become a stream outage.
+    worker.destroy().await.expect("destroy");
+    wait_for_async(
+        || async {
+            tokio::net::TcpStream::connect(("127.0.0.1", port_a))
+                .await
+                .is_err()
+        },
+        "old listener to release port_a",
+    )
+    .await;
+    let restarted = start_stream_worker(&harness, seed).await;
+
+    tokio::net::TcpStream::connect(("127.0.0.1", port_a))
+        .await
+        .expect("restarted server falls back to the seed address");
+    assert_eq!(restarted.config_snapshot().port, port_a);
+}
+
+#[tokio::test]
+async fn restart_refuses_seed_fallback_that_widens_loopback() {
+    let _serial = PORT_SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let port_a = free_port();
+    let port_b = free_port();
+    assert_ne!(port_a, port_b);
+    // Non-loopback seed; the runtime edit restricts the listener to loopback.
+    let seed = json!({ "host": "0.0.0.0", "port": port_a });
+
+    let worker = start_stream_worker(&harness, seed.clone()).await;
+
+    let _blocker = std::net::TcpListener::bind(("127.0.0.1", port_b)).expect("occupy port_b");
+    set_value(&harness, json!({ "host": "127.0.0.1", "port": port_b })).await;
+    drive_apply(&harness).await;
+
+    worker.destroy().await.expect("destroy");
+    wait_for_async(
+        || async {
+            tokio::net::TcpStream::connect(("127.0.0.1", port_a))
+                .await
+                .is_err()
+        },
+        "old listener to release port_a",
+    )
+    .await;
+
+    // Restart: the stored loopback address cannot bind, and the 0.0.0.0 seed
+    // would WIDEN the listen surface — the worker must refuse and fail to start
+    // rather than silently exposing every interface.
+    let restarted = StreamWorker::for_test(harness.engine.clone(), Some(seed))
+        .await
+        .expect("stream worker");
+    restarted.initialize().await.expect("initialize");
+    Worker::register_functions(&restarted, harness.engine.clone());
+    let result = restarted
+        .start_background_tasks(harness.shutdown_rx.clone(), harness.shutdown_tx.clone())
+        .await;
+    assert!(
+        result.is_err(),
+        "loopback-widening fallback must be refused, got: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn env_placeholders_expand_on_read() {
+    let _serial = PORT_SERIAL.lock().await;
+    // Scrub the var so the `${VAR:default}` default branch is what we exercise.
+    // SAFETY: runs before the harness spawns any task; remove_var is unsafe in
+    // edition 2024 because concurrent env access is UB.
+    unsafe { std::env::remove_var("STREAM_CFG_E2E_HOST") };
+
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let worker = start_stream_worker(
+        &harness,
+        json!({ "host": "${STREAM_CFG_E2E_HOST:127.0.0.1}", "port": 0 }),
+    )
+    .await;
+
+    // The live snapshot sees the expanded value.
+    assert_eq!(worker.config_snapshot().host, "127.0.0.1");
+
+    // The stored value keeps the placeholder verbatim (raw read).
+    let raw = stored_value(&harness, true).await;
+    assert_eq!(
+        raw["value"]["host"], "${STREAM_CFG_E2E_HOST:127.0.0.1}",
+        "the persisted value must retain the placeholder for re-expansion"
+    );
+}


### PR DESCRIPTION
## What

Migrates the **`iii-stream`** WebSocket worker to consume the builtin `configuration` worker — runtime-editable, hot-reloaded config — mirroring the already-merged `iii-http` (#1842) and `iii-state` migrations.

It registers a JSON-schema'd config entry under id `iii-stream`, seeds it from the `config.yaml` block **only on first boot**, reads the live value (with `${VAR:default}` expansion), and hot-applies `configuration:updated` events without an engine restart. After first boot the configuration entry is the runtime source of truth, and a runtime edit survives restarts.

## Per-field tiers (confirmed with @anderson)

The config now lives behind a hot-swappable `LiveState { config, adapter }` cell. Each field applies on its own tier:

| Field | Runtime behavior |
|---|---|
| `auth_function` | Read per connection from the live snapshot — applies to **new connections**, no rebind. |
| `host` / `port` | **Listener rebind** (bind new → respawn axum server → abort old), like `iii-http`. Live connections on the old address are dropped. |
| `adapter` | **Full pub/sub backend hot-swap** (like `iii-queue`/`iii-cron`): build new backend → swap in → restart `watch_events` pump. New connections use it; existing connections stay bound to the **previous** backend until they close (accepted orphaning). |

The boot bind keeps the guarded seed fallback (explicit seed, differing address, **no loopback widening**). Boot adapter adoption runs **after** the bind so the live adapter is always reconciled against the config actually being served.

## Review

Authored, then put through a 5-dimension adversarial review workflow (13 agents, per-finding verification). Two substantive findings fixed before this PR:

- **(high)** Boot bind-fallback could leave the live adapter inconsistent with the served config — fixed by moving adapter adoption to after the bind.
- **(medium)** A swapped-out adapter was never `destroy()`'d (resource leak for redis/bridge) — fixed with a drain-then-`destroy()` task that waits until no live connection still holds the old backend.

## Tests

- `config.rs`: schema test (deny-unknown-fields → `additionalProperties:false`, doc-comment descriptions).
- `configuration.rs`: 8 unit tests (seed-on-first-boot, no-clobber, fetch fallback/malformed, unresolvable adapter keeps previous).
- `stream.rs`: `effective_adapter` normalization unit test.
- `tests/stream_configuration_e2e.rs` (new, 11 cases): seed-on-first-boot, no-clobber across restart, auth hot-apply (no rebind), adapter hot-swap, **boot adapter rebuild** (non-vacuous, asserts `Arc` identity), unresolvable adapter, port rebind, failed rebind keeps server, seed fallback, loopback-widening refusal, `${VAR:default}` expansion.

`cargo fmt`, `clippy` (clean on touched files), 69 lib stream tests + 11 e2e green locally.

## Known follow-up

A behavioral test asserting the **restarted `watch_events` pump delivers** through the swapped-in backend needs in-crate WS-client harness infra and is left as a follow-up; the swap path is unit-verified and the production code is correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime (hot-reload) support for stream worker configuration via the configuration system, with persisted settings taking over after first boot.
  * `auth_function` updates affect new WebSocket connections; `host`/`port` rebind behavior is guarded; `adapter` changes hot-swap the backend with safe fallback when updates fail.

* **Documentation**
  * Documented persistence/boot semantics, `${VAR:default}` placeholder expansion on reads, and per-field hot-reload behavior.
  * Documented the typed adapter schema (discriminated by adapter name) and validation behavior.

* **Tests**
  * Added end-to-end coverage for hot reload, failure handling, placeholder expansion, and schema-guard enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->