### PR TITLE
fix(iii-init): re-run worker install after an early boot crash

### DIFF
--- a/crates/iii-init/src/lib.rs
+++ b/crates/iii-init/src/lib.rs
@@ -22,6 +22,8 @@ pub mod rlimit;
 // Linux syscalls. Keeping it unconditional makes unit tests on
 // macOS developer machines work without cross-compiling.
 pub mod child_exits;
+#[cfg(any(target_os = "linux", test))]
+mod prepared_marker;
 #[cfg(target_os = "linux")]
 pub mod shell_dispatcher;
 #[cfg(target_os = "linux")]

--- a/crates/iii-init/src/prepared_marker.rs
+++ b/crates/iii-init/src/prepared_marker.rs
@@ -1,0 +1,95 @@
+//! Prepared-marker invalidation policy for local worker boots.
+//!
+//! Kept platform-agnostic so the subtle timing rules are covered by the
+//! normal host test suite, even though `supervisor.rs` itself is Linux-only.
+
+use std::path::Path;
+use std::time::{Duration, Instant, SystemTime};
+
+/// True when `path` was modified within `window`.
+///
+/// A missing marker, unreadable metadata, or a marker timestamp in the future
+/// is not considered recent. The future case is deliberately conservative:
+/// otherwise clock skew could make every later runtime crash look like an
+/// install-adjacent boot failure forever.
+pub(crate) fn marker_is_recent(path: &Path, window: Duration) -> bool {
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+        .is_some_and(|age| age < window)
+}
+
+/// Decide whether a worker exit should clear the prepared marker.
+///
+/// `marker_existed_at_spawn` distinguishes a marker inherited from an earlier
+/// successful boot from one created by this boot script after setup/install.
+/// That matters for slow installs: the worker can crash immediately after a
+/// newly-created marker, even when the process has been alive longer than the
+/// raw boot-crash window.
+pub(crate) fn should_invalidate(
+    was_exit: bool,
+    code: i32,
+    spawned_at: Instant,
+    window: Duration,
+    marker_existed_at_spawn: bool,
+    marker_is_recent: bool,
+) -> bool {
+    if !was_exit || code == 0 {
+        return false;
+    }
+
+    if spawned_at.elapsed() < window {
+        return true;
+    }
+
+    !marker_existed_at_spawn && marker_is_recent
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_invalidate_classifies_exits() {
+        let now = Instant::now();
+        let old = now
+            .checked_sub(Duration::from_secs(35))
+            .expect("small Instant subtraction must work");
+        let window = Duration::from_secs(30);
+
+        // Real non-zero exit, just after spawn -> boot failure.
+        assert!(should_invalidate(true, 1, now, window, false, false));
+
+        // Clean exit -> not a failure.
+        assert!(!should_invalidate(true, 0, now, window, false, false));
+
+        // Signal death (e.g. SIGTERM shutdown) -> never a boot failure,
+        // even with a non-zero "128 + sig" code.
+        assert!(!should_invalidate(false, 143, now, window, false, false));
+
+        // Non-zero exit long after spawn with no fresh marker -> runtime crash.
+        assert!(!should_invalidate(true, 1, old, window, false, false));
+
+        // Long setup/install can exceed the raw spawn window. If this boot
+        // created the marker recently, an immediate worker crash still
+        // implicates the install/deps and should force re-prep.
+        assert!(should_invalidate(true, 1, old, window, false, true));
+
+        // A marker inherited from an earlier boot should not be invalidated
+        // solely because its timestamp is recent.
+        assert!(!should_invalidate(true, 1, old, window, true, true));
+    }
+
+    #[test]
+    fn marker_is_recent_handles_missing_and_recent_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".iii-prepared");
+        let window = Duration::from_secs(30);
+
+        assert!(!marker_is_recent(&path, window));
+
+        std::fs::write(&path, b"prepared").unwrap();
+        assert!(marker_is_recent(&path, window));
+    }
+}

--- a/crates/iii-init/src/supervisor.rs
+++ b/crates/iii-init/src/supervisor.rs
@@ -75,10 +75,9 @@ const III_SHELL_PORT_ENV: &str = "III_SHELL_PORT";
 const PREPARED_MARKER: &str = "/var/.iii-prepared";
 
 /// If the worker child exits non-zero within this window of its initial
-/// spawn, treat it as a failed boot (broken deps / bad install) rather
-/// than a runtime crash and invalidate the prepared marker. A worker that
-/// ran longer than this booted fine, so a later exit is a runtime failure
-/// and the deps are not suspect.
+/// spawn — or shortly after this boot creates the prepared marker — treat it
+/// as a failed boot (broken deps / bad install) rather than a runtime crash
+/// and invalidate the prepared marker.
 const BOOT_CRASH_WINDOW: Duration = Duration::from_secs(30);
 
 /// Stores the current child worker PID for async-signal-safe signal
@@ -139,10 +138,23 @@ fn invalidate_prepared_marker_at(path: &str) {
 
 /// True when a child exit should invalidate the prepared marker: a real
 /// process exit (not a signal — `kill_for_shutdown` uses SIGTERM and must
-/// not be mistaken for a crash) with a non-zero code, soon enough after
-/// the initial spawn to implicate the boot/deps rather than the runtime.
-fn is_boot_failure(was_exit: bool, code: i32, spawned_at: Instant) -> bool {
-    was_exit && code != 0 && spawned_at.elapsed() < BOOT_CRASH_WINDOW
+/// not be mistaken for a crash) with a non-zero code, either soon enough
+/// after initial spawn or soon enough after this boot created the marker to
+/// implicate the boot/deps rather than runtime behavior.
+fn should_invalidate_prepared_marker(
+    was_exit: bool,
+    code: i32,
+    spawned_at: Instant,
+    marker_existed_at_spawn: bool,
+) -> bool {
+    crate::prepared_marker::should_invalidate(
+        was_exit,
+        code,
+        spawned_at,
+        BOOT_CRASH_WINDOW,
+        marker_existed_at_spawn,
+        crate::prepared_marker::marker_is_recent(Path::new(PREPARED_MARKER), BOOT_CRASH_WINDOW),
+    )
 }
 
 /// Entry point called from `main::run` after all boot setup is complete.
@@ -209,6 +221,7 @@ fn maybe_spawn_shell_dispatcher() {
 /// Legacy path: spawn worker, reap zombies, exit with child's code.
 /// Identical to the pre-merge behavior of this module.
 fn run_legacy(cmd: String) -> Result<(), InitError> {
+    let marker_existed_at_spawn = Path::new(PREPARED_MARKER).exists();
     let child = Command::new("/bin/sh")
         .arg("-c")
         .arg(&cmd)
@@ -253,7 +266,7 @@ fn run_legacy(cmd: String) -> Result<(), InitError> {
         }
     };
 
-    if is_boot_failure(was_exit, status, spawned_at) {
+    if should_invalidate_prepared_marker(was_exit, status, spawned_at, marker_existed_at_spawn) {
         invalidate_prepared_marker_at(PREPARED_MARKER);
     }
 
@@ -271,6 +284,7 @@ fn run_supervised(cmd: String, workdir: String, port_name: String) -> Result<(),
         workdir,
     });
 
+    let marker_existed_at_spawn = Path::new(PREPARED_MARKER).exists();
     let initial_pid = state.spawn_initial().map_err(|e| {
         InitError::SpawnWorker(std::io::Error::other(format!(
             "supervisor spawn_initial failed: {e}"
@@ -278,10 +292,10 @@ fn run_supervised(cmd: String, workdir: String, port_name: String) -> Result<(),
     })?;
     CHILD_PID.store(initial_pid as i32, Ordering::SeqCst);
     attach_to_worker_cgroup(initial_pid as i32);
-    // Timed from the initial spawn, not from any host-driven restart: a
-    // worker that booted, ran, then crashed after a source-edit restart is
-    // a runtime failure, and its deps are fine. Only a crash close to the
-    // first spawn implicates the install.
+    // Timed from the initial spawn, not from any host-driven restart. The
+    // marker-recency check below covers slow setup/install flows where the
+    // marker is created long after this instant, just before the worker
+    // crashes on incomplete deps.
     let spawned_at = Instant::now();
 
     // Open the named virtio-console port and spawn the control loop on
@@ -344,7 +358,7 @@ fn run_supervised(cmd: String, workdir: String, port_name: String) -> Result<(),
         }
     };
 
-    if is_boot_failure(was_exit, status, spawned_at) {
+    if should_invalidate_prepared_marker(was_exit, status, spawned_at, marker_existed_at_spawn) {
         invalidate_prepared_marker_at(PREPARED_MARKER);
     }
 
@@ -464,26 +478,6 @@ mod tests {
         state.kill_for_shutdown().unwrap();
         // After shutdown, state has no child → terminal.
         assert!(exit_is_terminal(&state, new_pid as i32));
-    }
-
-    #[test]
-    fn is_boot_failure_classifies_exits() {
-        let now = Instant::now();
-
-        // Real non-zero exit, just after spawn → boot failure.
-        assert!(is_boot_failure(true, 1, now));
-
-        // Clean exit → not a failure.
-        assert!(!is_boot_failure(true, 0, now));
-
-        // Signal death (e.g. SIGTERM shutdown) → never a boot failure,
-        // even with a non-zero "128 + sig" code.
-        assert!(!is_boot_failure(false, 143, now));
-
-        // Non-zero exit, but long after spawn → runtime crash, deps fine.
-        if let Some(old) = now.checked_sub(BOOT_CRASH_WINDOW + Duration::from_secs(5)) {
-            assert!(!is_boot_failure(true, 1, old));
-        }
     }
 
     #[test]

--- a/crates/iii-init/src/supervisor.rs
+++ b/crates/iii-init/src/supervisor.rs
@@ -35,6 +35,7 @@ use std::io::BufReader;
 use std::path::Path;
 use std::process::Command;
 use std::sync::atomic::{AtomicI32, Ordering};
+use std::time::{Duration, Instant};
 
 use nix::sys::wait::{WaitStatus, waitpid};
 use nix::unistd::Pid;
@@ -58,6 +59,27 @@ const III_WORKER_WORKDIR_ENV: &str = "III_WORKER_WORKDIR";
 /// the named port can't be found in sysfs, exec is simply unavailable
 /// for this VM — the worker child keeps running normally.
 const III_SHELL_PORT_ENV: &str = "III_SHELL_PORT";
+
+/// Marker file the host boot script touches after a successful
+/// setup+install (see `local_worker.rs::build_libkrun_local_script`). Its
+/// presence makes subsequent boots skip the install step and reuse the
+/// VM-local dep dirs. `/var` is host-backed, so the marker — and the
+/// cached deps — survive VM restarts.
+///
+/// The gate trusts the install command's exit code, not the resulting
+/// dep tree. An install that exits 0 but leaves an incomplete `node_modules`
+/// (e.g. a transient drop of one package) gets frozen behind the marker:
+/// every later boot reuses the broken deps and the worker crashes on the
+/// same missing import forever. Deleting this marker on an early crash
+/// forces the next boot to re-run install and self-heal.
+const PREPARED_MARKER: &str = "/var/.iii-prepared";
+
+/// If the worker child exits non-zero within this window of its initial
+/// spawn, treat it as a failed boot (broken deps / bad install) rather
+/// than a runtime crash and invalidate the prepared marker. A worker that
+/// ran longer than this booted fine, so a later exit is a runtime failure
+/// and the deps are not suspect.
+const BOOT_CRASH_WINDOW: Duration = Duration::from_secs(30);
 
 /// Stores the current child worker PID for async-signal-safe signal
 /// forwarding. 0 means no child has been spawned yet. Updated both on
@@ -99,6 +121,28 @@ fn install_signal_handlers() {
 /// done in `mount.rs` and may not exist on all kernels).
 fn attach_to_worker_cgroup(pid: i32) {
     let _ = std::fs::write("/sys/fs/cgroup/worker/cgroup.procs", pid.to_string());
+}
+
+/// Delete the prepared marker so the next boot re-runs setup/install.
+/// Best-effort: a missing marker (already gone, or never prepared) and a
+/// read-only `/var` are both non-fatal — we only log the unexpected case.
+fn invalidate_prepared_marker_at(path: &str) {
+    match std::fs::remove_file(path) {
+        Ok(()) => eprintln!(
+            "iii-init: worker exited non-zero during boot; cleared {path} \
+             so the next start re-runs install"
+        ),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => eprintln!("iii-init: warning: could not clear {path}: {e}"),
+    }
+}
+
+/// True when a child exit should invalidate the prepared marker: a real
+/// process exit (not a signal — `kill_for_shutdown` uses SIGTERM and must
+/// not be mistaken for a crash) with a non-zero code, soon enough after
+/// the initial spawn to implicate the boot/deps rather than the runtime.
+fn is_boot_failure(was_exit: bool, code: i32, spawned_at: Instant) -> bool {
+    was_exit && code != 0 && spawned_at.elapsed() < BOOT_CRASH_WINDOW
 }
 
 /// Entry point called from `main::run` after all boot setup is complete.
@@ -175,20 +219,24 @@ fn run_legacy(cmd: String) -> Result<(), InitError> {
     CHILD_PID.store(child_pid, Ordering::SeqCst);
 
     attach_to_worker_cgroup(child_pid);
+    let spawned_at = Instant::now();
 
     // PID 1 supervisor loop: wait for children, reap orphans (INIT-07).
     // Before applying our own termination logic, consult the shell
     // dispatcher's exit registry — exits belonging to `iii worker
     // exec` children must be forwarded to the dispatcher's waiter
     // thread, not silently discarded as "orphans".
-    let status = loop {
+    //
+    // The loop breaks with `(code, was_exit)` so the post-loop boot-crash
+    // check can tell a real non-zero process exit from a signal death.
+    let (status, was_exit) = loop {
         match waitpid(Pid::from_raw(-1), None) {
             Ok(WaitStatus::Exited(pid, code)) => {
                 if crate::child_exits::dispatch_exit(pid.as_raw(), code) {
                     continue;
                 }
                 if pid.as_raw() == child_pid {
-                    break code;
+                    break (code, true);
                 }
             }
             Ok(WaitStatus::Signaled(pid, sig, _)) => {
@@ -196,14 +244,18 @@ fn run_legacy(cmd: String) -> Result<(), InitError> {
                     continue;
                 }
                 if pid.as_raw() == child_pid {
-                    break 128 + sig as i32;
+                    break (128 + sig as i32, false);
                 }
             }
-            Ok(_) => continue,                  // stop/continue/etc, keep waiting
-            Err(nix::Error::ECHILD) => break 0, // no more children
-            Err(_) => break 1,                  // unexpected error
+            Ok(_) => continue, // stop/continue/etc, keep waiting
+            Err(nix::Error::ECHILD) => break (0, false), // no more children
+            Err(_) => break (1, false), // unexpected error
         }
     };
+
+    if is_boot_failure(was_exit, status, spawned_at) {
+        invalidate_prepared_marker_at(PREPARED_MARKER);
+    }
 
     std::process::exit(status);
 }
@@ -226,6 +278,11 @@ fn run_supervised(cmd: String, workdir: String, port_name: String) -> Result<(),
     })?;
     CHILD_PID.store(initial_pid as i32, Ordering::SeqCst);
     attach_to_worker_cgroup(initial_pid as i32);
+    // Timed from the initial spawn, not from any host-driven restart: a
+    // worker that booted, ran, then crashed after a source-edit restart is
+    // a runtime failure, and its deps are fine. Only a crash close to the
+    // first spawn implicates the install.
+    let spawned_at = Instant::now();
 
     // Open the named virtio-console port and spawn the control loop on
     // a dedicated thread. If the port isn't present (sysfs not mounted,
@@ -263,14 +320,14 @@ fn run_supervised(cmd: String, workdir: String, port_name: String) -> Result<(),
     // `exit_is_terminal` — otherwise an exec child's exit code would
     // look like an orphan and the dispatcher's waiter thread would
     // wait forever.
-    let status = loop {
+    let (status, was_exit) = loop {
         match waitpid(Pid::from_raw(-1), None) {
             Ok(WaitStatus::Exited(pid, code)) => {
                 if crate::child_exits::dispatch_exit(pid.as_raw(), code) {
                     continue;
                 }
                 if exit_is_terminal(&state, pid.as_raw()) {
-                    break code;
+                    break (code, true);
                 }
             }
             Ok(WaitStatus::Signaled(pid, sig, _)) => {
@@ -278,14 +335,18 @@ fn run_supervised(cmd: String, workdir: String, port_name: String) -> Result<(),
                     continue;
                 }
                 if exit_is_terminal(&state, pid.as_raw()) {
-                    break 128 + sig as i32;
+                    break (128 + sig as i32, false);
                 }
             }
-            Ok(_) => continue,                  // stop/continue/etc — keep waiting
-            Err(nix::Error::ECHILD) => break 0, // no more children
-            Err(_) => break 1,
+            Ok(_) => continue, // stop/continue/etc — keep waiting
+            Err(nix::Error::ECHILD) => break (0, false), // no more children
+            Err(_) => break (1, false),
         }
     };
+
+    if is_boot_failure(was_exit, status, spawned_at) {
+        invalidate_prepared_marker_at(PREPARED_MARKER);
+    }
 
     std::process::exit(status);
 }
@@ -403,5 +464,43 @@ mod tests {
         state.kill_for_shutdown().unwrap();
         // After shutdown, state has no child → terminal.
         assert!(exit_is_terminal(&state, new_pid as i32));
+    }
+
+    #[test]
+    fn is_boot_failure_classifies_exits() {
+        let now = Instant::now();
+
+        // Real non-zero exit, just after spawn → boot failure.
+        assert!(is_boot_failure(true, 1, now));
+
+        // Clean exit → not a failure.
+        assert!(!is_boot_failure(true, 0, now));
+
+        // Signal death (e.g. SIGTERM shutdown) → never a boot failure,
+        // even with a non-zero "128 + sig" code.
+        assert!(!is_boot_failure(false, 143, now));
+
+        // Non-zero exit, but long after spawn → runtime crash, deps fine.
+        if let Some(old) = now.checked_sub(BOOT_CRASH_WINDOW + Duration::from_secs(5)) {
+            assert!(!is_boot_failure(true, 1, old));
+        }
+    }
+
+    #[test]
+    fn invalidate_prepared_marker_removes_and_tolerates_missing() {
+        let path =
+            std::env::temp_dir().join(format!("iii-init-prepared-test-{}", std::process::id()));
+        let path_str = path.to_str().unwrap();
+
+        std::fs::write(&path, b"prepared").unwrap();
+        assert!(path.exists());
+
+        // Removes an existing marker.
+        invalidate_prepared_marker_at(path_str);
+        assert!(!path.exists());
+
+        // Tolerates an already-missing marker (no panic, no error).
+        invalidate_prepared_marker_at(path_str);
+        assert!(!path.exists());
     }
 }

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -262,6 +262,11 @@ echo "iii: workspace ready; deps mounted VM-local from $DEPS_ROOT" >&2"#
         if !project.install_cmd.is_empty() {
             parts.push(project.install_cmd.clone());
         }
+        // Marker means "install ran with exit 0", not "deps are complete".
+        // iii-init deletes it (see supervisor.rs PREPARED_MARKER) when the
+        // worker crashes early, so an install that exits 0 but leaves a
+        // partial dep tree re-runs on the next boot instead of staying
+        // frozen.
         parts.push("mkdir -p /var && touch /var/.iii-prepared".to_string());
     }
 


### PR DESCRIPTION
## Problem

A worker can get permanently stuck in `function_not_found`. Hit while following the quickstart:

```
$ iii trigger math::add_two_numbers a=10 b=20
Error: { "code": "function_not_found", "message": "Function math::add_two_numbers not found" }
```

`caller-worker` (TS, owns `math::add_two_numbers`) was crashing on boot:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@iii-dev/observability' imported from /workspace/src/worker.ts
```

The VM's `node_modules` had `iii-sdk` but **not** `@iii-dev/observability` — a declared, published dependency. The first `npm install` exited 0 but left an incomplete tree (transient partial install). The worker crashed before registering its functions, so the trigger never resolved.

## Why it persists (the real bug)

`build_libkrun_local_script` runs setup/install once, gated by `/var/.iii-prepared`, and the dep dirs live in `/var/iii/deps` bind-mounted across restarts. The marker records only that **install exited 0**, not that the dep tree is **complete**. So a partial-but-exit-0 install gets frozen: every later boot reuses the broken deps and crashes on the same missing import. `iii worker restart` can't recover — only clearing the worker's artifacts does.

The transient install drop itself isn't reliably reproducible (a clean re-prep installs the package fine), so the durable fix targets the *persistence*, not the trigger.

## Fix

PID-1 (`iii-init`) deletes `/var/.iii-prepared` when the worker child exits **non-zero within 30s of its initial spawn**, forcing the next boot to re-run install and self-heal. Guards:

- **Process exits only, not signals** — `kill_for_shutdown` uses SIGTERM; an intentional shutdown must not look like a crash.
- **Timed from the initial spawn** — a crash after a source-edit restart is a runtime bug, not bad deps, so it shouldn't trigger a reinstall.

Applies to both legacy and supervised modes.

## Tradeoff

A worker with a genuine early-startup bug will re-run install on each boot. `npm install`/`pip install` are cheap and idempotent when deps are already complete, and the worker is crash-looping regardless — so this only adds self-heal attempts, never breaks a healthy worker.

## Tests

- `is_boot_failure_classifies_exits` — exit vs signal, zero vs non-zero, inside vs outside the window.
- `invalidate_prepared_marker_removes_and_tolerates_missing` — removes an existing marker; a missing marker is a no-op.

`cargo test -p iii-init` green; `cargo fmt`/`clippy` clean.