### PR TITLE
fix(sdk): normalize auth result defaults across SDK languages

### DIFF
--- a/docs/next/sdk-reference/helpers-lib.mdx
+++ b/docs/next/sdk-reference/helpers-lib.mdx
@@ -250,25 +250,25 @@ invoke and what context is forwarded to the middleware.
 
 ```typescript Node
 export type AuthResult = {
-  allowed_functions: string[]
-  forbidden_functions: string[]
+  allowed_functions?: string[]
+  forbidden_functions?: string[]
   allowed_trigger_types?: string[]
-  allow_trigger_type_registration: boolean
+  allow_trigger_type_registration?: boolean
   allow_function_registration?: boolean
-  context: Record<string, unknown>
+  context?: Record<string, unknown>
   function_registration_prefix?: string
 }
 ```
 
 ```python Python
 class AuthResult(BaseModel):
-    allowed_functions: list[str]
-    forbidden_functions: list[str]
+    allowed_functions: list[str] = []
+    forbidden_functions: list[str] = []
     allowed_trigger_types: list[str] | None = None
-    allow_trigger_type_registration: bool
+    allow_trigger_type_registration: bool = False
     allow_function_registration: bool = True
     function_registration_prefix: str | None = None
-    context: dict[str, Any]
+    context: dict[str, Any] = {}
 ```
 
 ```rust Rust
@@ -279,7 +279,7 @@ pub struct AuthResult {
     pub forbidden_functions: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_trigger_types: Option<Vec<String>>,
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub allow_trigger_type_registration: bool,
     #[serde(default = "default_true")]
     pub allow_function_registration: bool,

--- a/docs/next/sdk-reference/helpers-lib.mdx.skill.md
+++ b/docs/next/sdk-reference/helpers-lib.mdx.skill.md
@@ -248,25 +248,25 @@ invoke and what context is forwarded to the middleware.
 
 ```typescript Node
 export type AuthResult = {
-  allowed_functions: string[]
-  forbidden_functions: string[]
+  allowed_functions?: string[]
+  forbidden_functions?: string[]
   allowed_trigger_types?: string[]
-  allow_trigger_type_registration: boolean
+  allow_trigger_type_registration?: boolean
   allow_function_registration?: boolean
-  context: Record<string, unknown>
+  context?: Record<string, unknown>
   function_registration_prefix?: string
 }
 ```
 
 ```python Python
 class AuthResult(BaseModel):
-    allowed_functions: list[str]
-    forbidden_functions: list[str]
+    allowed_functions: list[str] = []
+    forbidden_functions: list[str] = []
     allowed_trigger_types: list[str] | None = None
-    allow_trigger_type_registration: bool
+    allow_trigger_type_registration: bool = False
     allow_function_registration: bool = True
     function_registration_prefix: str | None = None
-    context: dict[str, Any]
+    context: dict[str, Any] = {}
 ```
 
 ```rust Rust
@@ -277,7 +277,7 @@ pub struct AuthResult {
     pub forbidden_functions: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_trigger_types: Option<Vec<String>>,
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub allow_trigger_type_registration: bool,
     #[serde(default = "default_true")]
     pub allow_function_registration: bool,

--- a/sdk/packages/node/helpers/src/worker-connection-manager/index.ts
+++ b/sdk/packages/node/helpers/src/worker-connection-manager/index.ts
@@ -18,18 +18,18 @@ export type AuthInput = {
  * middleware.
  */
 export type AuthResult = {
-  /** Additional function IDs to allow beyond the `expose_functions` config. */
-  allowed_functions: string[]
-  /** Function IDs to deny even if they match `expose_functions`. Takes precedence over allowed. */
-  forbidden_functions: string[]
+  /** Additional function IDs to allow beyond the `expose_functions` config. Defaults to `[]` if omitted. */
+  allowed_functions?: string[]
+  /** Function IDs to deny even if they match `expose_functions`. Takes precedence over allowed. Defaults to `[]` if omitted. */
+  forbidden_functions?: string[]
   /** Trigger type IDs the worker may register triggers for. When omitted, all types are allowed. */
   allowed_trigger_types?: string[]
-  /** Whether the worker may register new trigger types. */
-  allow_trigger_type_registration: boolean
+  /** Whether the worker may register new trigger types. Defaults to `false` if omitted. */
+  allow_trigger_type_registration?: boolean
   /** Whether the worker may register new functions. Defaults to `true` if omitted. */
   allow_function_registration?: boolean
-  /** Arbitrary context forwarded to the middleware function on every invocation. */
-  context: Record<string, unknown>
+  /** Arbitrary context forwarded to the middleware function on every invocation. Defaults to `{}` if omitted. */
+  context?: Record<string, unknown>
   /** Optional prefix applied to all function IDs registered by this worker. */
   function_registration_prefix?: string
 }

--- a/sdk/packages/node/iii-browser/src/iii-types.ts
+++ b/sdk/packages/node/iii-browser/src/iii-types.ts
@@ -123,18 +123,18 @@ export type AuthInput = {
  * middleware.
  */
 export type AuthResult = {
-  /** Additional function IDs to allow beyond the `expose_functions` config. */
-  allowed_functions: string[]
-  /** Function IDs to deny even if they match `expose_functions`. Takes precedence over allowed. */
-  forbidden_functions: string[]
+  /** Additional function IDs to allow beyond the `expose_functions` config. Defaults to `[]` if omitted. */
+  allowed_functions?: string[]
+  /** Function IDs to deny even if they match `expose_functions`. Takes precedence over allowed. Defaults to `[]` if omitted. */
+  forbidden_functions?: string[]
   /** Trigger type IDs the worker may register triggers for. When omitted, all types are allowed. */
   allowed_trigger_types?: string[]
-  /** Whether the worker may register new trigger types. */
-  allow_trigger_type_registration: boolean
+  /** Whether the worker may register new trigger types. Defaults to `false` if omitted. */
+  allow_trigger_type_registration?: boolean
   /** Whether the worker may register new functions. Defaults to `true` if omitted. */
   allow_function_registration?: boolean
-  /** Arbitrary context forwarded to the middleware function on every invocation. */
-  context: Record<string, unknown>
+  /** Arbitrary context forwarded to the middleware function on every invocation. Defaults to `{}` if omitted. */
+  context?: Record<string, unknown>
   /** Optional prefix applied to all function IDs registered by this worker. */
   function_registration_prefix?: string
 }

--- a/sdk/packages/python/helpers/src/iii_helpers/worker_connection_manager/__init__.py
+++ b/sdk/packages/python/helpers/src/iii_helpers/worker_connection_manager/__init__.py
@@ -54,9 +54,11 @@ class AuthResult(BaseModel):
     """
 
     allowed_functions: list[str] = Field(
+        default_factory=list,
         description="Additional function IDs to allow beyond ``expose_functions``.",
     )
     forbidden_functions: list[str] = Field(
+        default_factory=list,
         description="Function IDs to deny even if they match ``expose_functions``.",
     )
     allowed_trigger_types: list[str] | None = Field(
@@ -64,7 +66,8 @@ class AuthResult(BaseModel):
         description="Trigger type IDs the worker may register triggers for. When ``None``, all types are allowed.",
     )
     allow_trigger_type_registration: bool = Field(
-        description="Whether the worker may register new trigger types.",
+        default=False,
+        description="Whether the worker may register new trigger types. Defaults to ``False``.",
     )
     allow_function_registration: bool = Field(
         default=True,
@@ -75,6 +78,7 @@ class AuthResult(BaseModel):
         description="Optional prefix applied to all function IDs registered by this worker.",
     )
     context: dict[str, Any] = Field(
+        default_factory=dict,
         description="Arbitrary context forwarded to the middleware function on every invocation.",
     )
 

--- a/sdk/packages/rust/helpers/src/worker_connection_manager.rs
+++ b/sdk/packages/rust/helpers/src/worker_connection_manager.rs
@@ -38,8 +38,8 @@ pub struct AuthResult {
     /// When `None`, all types are allowed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_trigger_types: Option<Vec<String>>,
-    /// Whether the worker may register new trigger types.
-    #[serde(default = "default_true")]
+    /// Whether the worker may register new trigger types. Defaults to `false`.
+    #[serde(default)]
     pub allow_trigger_type_registration: bool,
     /// Whether the worker may register new functions. Defaults to `true`.
     #[serde(default = "default_true")]
@@ -157,4 +157,23 @@ pub struct OnFunctionRegistrationResult {
     /// Mapped metadata.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Defaults must match the engine's canonical AuthResult
+    // (engine/src/workers/worker/rbac_session.rs).
+    #[test]
+    fn auth_result_defaults_match_engine() {
+        let result: AuthResult = serde_json::from_str("{}").unwrap();
+        assert_eq!(result.allowed_functions, Vec::<String>::new());
+        assert_eq!(result.forbidden_functions, Vec::<String>::new());
+        assert_eq!(result.allowed_trigger_types, None);
+        assert!(!result.allow_trigger_type_registration);
+        assert!(result.allow_function_registration);
+        assert_eq!(result.context, Value::Object(Default::default()));
+        assert_eq!(result.function_registration_prefix, None);
+    }
 }


### PR DESCRIPTION
## Problem

The engine deserializes the RBAC auth function's return value into `AuthResult` (`engine/src/workers/worker/rbac_session.rs`) — the source of truth for field defaults. After the helpers refactor, the three SDK helper `AuthResult` types drifted from it.

- **Security-relevant:** the Rust helper defaulted `allow_trigger_type_registration` to `true` while the engine defaults it to `false`. A Rust auth handler omitting the field implied a *permissive* trigger-type-registration grant — opposite of the engine's deny-by-default contract.
- **Inconsistent contract:** Node and Python helpers made `allowed_functions`, `forbidden_functions`, `allow_trigger_type_registration`, and `context` required, while the engine treats them as optional-with-default.

## Canonical defaults (engine)

| field | default |
|---|---|
| `allowed_functions` / `forbidden_functions` | `[]` |
| `allowed_trigger_types` | omit / `None` |
| `allow_trigger_type_registration` | `false` |
| `allow_function_registration` | `true` |
| `context` | `{}` |
| `function_registration_prefix` | omit / `None` |

## Changes

- **Rust** helper: `allow_trigger_type_registration` `default = "default_true"` → `#[serde(default)]` (false). Added a deserialize test pinning all defaults to the engine's values.
- **Python** helper: `default_factory=list` / `default_factory=dict`, `allow_trigger_type_registration` `default=False`.
- **Node** helper + `iii-browser`: the four fields made optional with documented defaults in JSDoc.
- **Docs**: `helpers-lib.mdx` and its rendered `.mdx.skill.md` mirror updated.

## Verification

- `cargo build -p iii-helpers` ✓
- `cargo test -p iii-helpers --lib auth_result_defaults_match_engine` ✓
- Python: `AuthResult()` (all omitted) → `allow_trigger_type_registration is False`, `allowed_functions == []`, `context == {}` ✓
- Node change only widens the type (required → optional); no consumers read these fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `AuthResult` type documentation across TypeScript, Python, and Rust SDKs with optional fields and clearer default values.

* **Bug Fixes**
  * Fixed inconsistent default behavior for `allow_trigger_type_registration` field across SDK implementations to properly reflect `false` as the default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->