### PR TITLE
fix(website): point footer privacy link to /privacy-policy.html

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -5971,7 +5971,7 @@ iii.register_function(
     </div>
 
     <div class="foot-bottom">
-      <span>© Motia LLC · <a href="/privacy-policy">privacy</a></span>
+      <span>© Motia LLC · <a href="/privacy-policy.html">privacy</a></span>
       <span>pronounced <span class="pron">"three eye"</span></span>
     </div>
   </section>


### PR DESCRIPTION
## Problem

The footer privacy link points to `/privacy-policy`, but clicking it serves the homepage. The pretty-URL rewrite (`/privacy-policy` → `/privacy-policy.html`) lives in the Terraform-managed CloudFront redirects function, and that apply has not run in production. So the deployed function does not know the route and falls through to its soft-404, which rewrites to `/index.html`.

- `/privacy-policy.html` → 200, serves the real page (S3 sync deployed it)
- `/privacy-policy` → 200, serves the homepage (stale function)

## Fix

Point the footer link at the deployed `/privacy-policy.html` object so it works immediately via the normal S3-sync deploy, no infra change required.

Once `terraform apply` runs for `infra/terraform/website` (publishing the redirects function with the `/privacy-policy` key), the pretty URL will resolve and this can be reverted to `/privacy-policy`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the privacy policy link in the footer to properly route to the privacy policy page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->