### PR TITLE
fix(iii-worker): infer --release for rust workers (MOT-3459 Defect 1)

### DIFF
--- a/crates/iii-worker/src/cli/project.rs
+++ b/crates/iii-worker/src/cli/project.rs
@@ -141,10 +141,16 @@ pub fn infer_scripts(kind: &str, package_manager: &str, entry: &str) -> (String,
             "python3 -m venv .venv && .venv/bin/pip install -e .".to_string(),
             format!(".venv/bin/python -m {}", entry),
         ),
+        // ponytail: --release on purpose, for disk not speed. A worker's
+        // per-VM `target` dir is never shared (no CARGO_TARGET_DIR), so debug's
+        // full debuginfo (130 MB binaries) + `incremental=true` churn pile up
+        // per worker (MOT-3459 Defect 1). Release defaults to no debuginfo and
+        // `incremental=false`. Must match the auto-detect path below and keep
+        // build/run on the same profile (mismatch = a second full target tree).
         ("rust", _) => (
             "command -v cargo >/dev/null || (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y)".to_string(),
-            "[ -f \"$HOME/.cargo/env\" ] && . \"$HOME/.cargo/env\"; cargo build".to_string(),
-            "[ -f \"$HOME/.cargo/env\" ] && . \"$HOME/.cargo/env\"; cargo run".to_string(),
+            "[ -f \"$HOME/.cargo/env\" ] && . \"$HOME/.cargo/env\"; cargo build --release".to_string(),
+            "[ -f \"$HOME/.cargo/env\" ] && . \"$HOME/.cargo/env\"; cargo run --release".to_string(),
         ),
         _ => (String::new(), String::new(), entry.to_string()),
     }
@@ -760,8 +766,11 @@ runtime:
     fn infer_scripts_rust() {
         let (setup, install, run) = infer_scripts("rust", "cargo", "src/main.rs");
         assert!(setup.contains("rustup"));
-        assert!(install.contains("cargo build"));
-        assert!(run.contains("cargo run"));
+        // MOT-3459 Defect 1: the inferred build must be --release (no debuginfo,
+        // no incremental) so per-worker `target` dirs don't bloat, and build/run
+        // must share the profile or `cargo run` rebuilds a second debug tree.
+        assert!(install.contains("cargo build --release"));
+        assert!(run.contains("cargo run --release"));
     }
 
     #[test]


### PR DESCRIPTION
Addresses **MOT-3459 Defect 1** (per-worker Rust build cache fills the disk) on the in-repo inference path. The primary fix is in the scaffold templates (iii-hq/templates#24); this aligns the iii-worker side.

## What

`infer_scripts` (project.rs) returned **debug** `cargo build` / `cargo run` for `kind: rust`, while the no-manifest auto-detect path in the same file already used `cargo build --release` / `cargo run --release`. This change aligns them.

## Why

A worker's `target/` is per-worker and never shared (there's no `CARGO_TARGET_DIR`; it lives on the per-worker rootfs clone, or the per-worker ext4 upper under the overlay model). The debug profile keeps full debuginfo (the ~130 MB binaries in the report) and `incremental = true` (the duplicate-artifact churn). Release defaults to neither, so the per-worker cache stays small. Keeping build and run on the same profile also avoids a latent trap: build-release + run-debug would materialize a second full target tree.

## Scope

`infer_scripts` is the **deprecated** path (it only fires when a manifest sets the deprecated `runtime.kind` *and* omits `scripts:`). The canonical default for scaffolded Rust workers is the template, fixed in iii-hq/templates#24. This PR makes the legacy inference path consistent with the still-live auto-detect path while it remains honored.

## Test

`cli::project::tests::infer_scripts_rust` now asserts `cargo build --release` and `cargo run --release` (same profile); it fails on the old debug strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Rust project builds and execution now use optimized release mode configuration instead of debug mode, improving performance.

* **Tests**
  * Updated test assertions to reflect new build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->