### PR TITLE
feat(iii-queue): add RabbitMQ priority queue support

### DIFF
--- a/engine/src/workers/queue/adapters/bridge.rs
+++ b/engine/src/workers/queue/adapters/bridge.rs
@@ -320,6 +320,7 @@ impl QueueAdapter for BridgeAdapter {
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn publish_to_function_queue(
         &self,
         queue_name: &str,
@@ -330,6 +331,9 @@ impl QueueAdapter for BridgeAdapter {
         _backoff_ms: u64,
         _traceparent: Option<String>,
         _baggage: Option<String>,
+        // Priority is resolved by the remote engine via its own adapter; the
+        // bridge forwards the enqueue unchanged.
+        _priority: Option<u8>,
     ) {
         if let Err(e) = self
             .bridge

--- a/engine/src/workers/queue/adapters/builtin/adapter.rs
+++ b/engine/src/workers/queue/adapters/builtin/adapter.rs
@@ -395,6 +395,7 @@ impl QueueAdapter for BuiltinQueueAdapter {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn publish_to_function_queue(
         &self,
         queue_name: &str,
@@ -405,6 +406,9 @@ impl QueueAdapter for BuiltinQueueAdapter {
         backoff_ms: u64,
         traceparent: Option<String>,
         baggage: Option<String>,
+        // Priority is a RabbitMQ-only feature; the in-process builtin queue
+        // ignores it.
+        _priority: Option<u8>,
     ) {
         let namespaced_queue = format!("__fn_queue::{}", queue_name);
         let job = Job {
@@ -700,6 +704,7 @@ mod tests {
             delay_seconds: None,
             backoff_type: None,
             backoff_delay_ms: Some(1000),
+            max_priority: None,
         };
 
         let subscription_config = Some(config).map(|c| SubscriptionConfig {
@@ -729,6 +734,7 @@ mod tests {
             delay_seconds: None,
             backoff_type: None,
             backoff_delay_ms: None,
+            max_priority: None,
         };
 
         let subscription_config = Some(config).map(|c| SubscriptionConfig {
@@ -756,6 +762,7 @@ mod tests {
             delay_seconds: None,
             backoff_type: None,
             backoff_delay_ms: None,
+            max_priority: None,
         };
 
         let subscription_config = Some(config).map(|c| SubscriptionConfig {
@@ -782,6 +789,7 @@ mod tests {
             delay_seconds: None,
             backoff_type: None,
             backoff_delay_ms: None,
+            max_priority: None,
         };
 
         let subscription_config = Some(config).map(|c| SubscriptionConfig {
@@ -859,6 +867,7 @@ mod tests {
             delay_seconds: None,
             backoff_type: None,
             backoff_delay_ms: Some(25),
+            max_priority: None,
         };
         adapter
             .subscribe("jobs", "sub-fifo", "queue.success", None, Some(fifo_config))
@@ -872,6 +881,7 @@ mod tests {
             delay_seconds: None,
             backoff_type: None,
             backoff_delay_ms: Some(10),
+            max_priority: None,
         };
         adapter
             .subscribe(
@@ -936,6 +946,7 @@ mod tests {
                 1000,
                 None,
                 None,
+                None,
             )
             .await;
 
@@ -981,6 +992,7 @@ mod tests {
                 "msg-1",
                 1,
                 1000,
+                None,
                 None,
                 None,
             )
@@ -1055,6 +1067,7 @@ mod tests {
                     &format!("msg-{i}"),
                     1,
                     1000,
+                    None,
                     None,
                     None,
                 )
@@ -1133,6 +1146,7 @@ mod tests {
                 1000,
                 None,
                 None,
+                None,
             )
             .await;
 
@@ -1174,6 +1188,7 @@ mod tests {
                 "test-msg-id",
                 3,
                 1000,
+                None,
                 None,
                 None,
             )
@@ -1220,6 +1235,7 @@ mod tests {
                     "test-msg-id",
                     3,
                     1000,
+                    None,
                     None,
                     None,
                 )
@@ -1277,6 +1293,7 @@ mod tests {
                     1000,
                     None,
                     None,
+                    None,
                 )
                 .await;
         }
@@ -1319,6 +1336,7 @@ mod tests {
                 1000,
                 Some("00-abc-def-01".to_string()),
                 Some("key=value".to_string()),
+                None,
             )
             .await;
 

--- a/engine/src/workers/queue/adapters/rabbitmq/adapter.rs
+++ b/engine/src/workers/queue/adapters/rabbitmq/adapter.rs
@@ -247,7 +247,14 @@ impl QueueAdapter for RabbitMQAdapter {
         traceparent: Option<String>,
         baggage: Option<String>,
     ) {
-        let job = Job::new(topic, data, self.config.max_attempts, traceparent, baggage);
+        // Topic fanout publishes one message to every bound subscriber queue, so
+        // the priority is resolved once here from the adapter-level
+        // `priority_field`. Each subscriber queue honors it only if declared with
+        // `maxPriority`, and clamps it to its own `x-max-priority`.
+        let priority =
+            super::types::priority_from_data(&data, self.config.priority_field.as_deref());
+        let job = Job::new(topic, data, self.config.max_attempts, traceparent, baggage)
+            .with_priority(priority);
 
         if let Err(e) = self.topology.setup_topic(topic).await {
             tracing::error!(
@@ -307,9 +314,10 @@ impl QueueAdapter for RabbitMQAdapter {
             return;
         }
 
+        let subscriber_max_priority = queue_config.as_ref().and_then(|c| c.max_priority);
         if let Err(e) = self
             .topology
-            .setup_subscriber_queue(&topic, &function_id)
+            .setup_subscriber_queue(&topic, &function_id, subscriber_max_priority)
             .await
         {
             tracing::error!(
@@ -831,6 +839,7 @@ impl QueueAdapter for RabbitMQAdapter {
         Ok(results)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn publish_to_function_queue(
         &self,
         queue_name: &str,
@@ -841,6 +850,7 @@ impl QueueAdapter for RabbitMQAdapter {
         _backoff_ms: u64,
         traceparent: Option<String>,
         baggage: Option<String>,
+        priority: Option<u8>,
     ) {
         use super::naming::FnQueueNames;
 
@@ -872,11 +882,14 @@ impl QueueAdapter for RabbitMQAdapter {
             );
         }
 
-        let properties = lapin::BasicProperties::default()
+        let mut properties = lapin::BasicProperties::default()
             .with_content_type("application/json".into())
             .with_delivery_mode(2)
             .with_message_id(message_id.into())
             .with_headers(headers);
+        if let Some(p) = priority {
+            properties = properties.with_priority(p);
+        }
 
         match self
             .channel
@@ -906,7 +919,7 @@ impl QueueAdapter for RabbitMQAdapter {
         config: &FunctionQueueConfig,
     ) -> anyhow::Result<()> {
         self.topology
-            .setup_function_queue(queue_name, config.backoff_ms)
+            .setup_function_queue(queue_name, config.backoff_ms, config.max_priority)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to setup function queue topology: {}", e))
     }

--- a/engine/src/workers/queue/adapters/rabbitmq/publisher.rs
+++ b/engine/src/workers/queue/adapters/rabbitmq/publisher.rs
@@ -128,10 +128,16 @@ impl Publisher {
     ) -> Result<()> {
         let payload = serde_json::to_vec(job)?;
 
-        let properties = lapin::BasicProperties::default()
+        let mut properties = lapin::BasicProperties::default()
             .with_content_type("application/json".into())
             .with_delivery_mode(2)
             .with_headers(headers.unwrap_or_default());
+        // Carry the job's priority through fanout publishes, requeues, and
+        // DLQ-redrive republishes so ordering survives retries on priority
+        // queues. No-op on queues without `x-max-priority`.
+        if let Some(p) = job.priority {
+            properties = properties.with_priority(p);
+        }
 
         self.channel
             .basic_publish(

--- a/engine/src/workers/queue/adapters/rabbitmq/topology.rs
+++ b/engine/src/workers/queue/adapters/rabbitmq/topology.rs
@@ -67,7 +67,12 @@ impl TopologyManager {
         Ok(())
     }
 
-    pub async fn setup_subscriber_queue(&self, topic: &str, function_id: &str) -> Result<()> {
+    pub async fn setup_subscriber_queue(
+        &self,
+        topic: &str,
+        function_id: &str,
+        max_priority: Option<u8>,
+    ) -> Result<()> {
         let names = RabbitNames::new(topic);
 
         let queue_name = names.function_queue(function_id);
@@ -84,6 +89,9 @@ impl TopologyManager {
             )
             .await?;
 
+        let mut queue_args = FieldTable::default();
+        with_max_priority(&mut queue_args, max_priority);
+
         self.channel
             .queue_declare(
                 &queue_name,
@@ -91,7 +99,7 @@ impl TopologyManager {
                     durable: true,
                     ..Default::default()
                 },
-                FieldTable::default(),
+                queue_args,
             )
             .await?;
 
@@ -114,7 +122,12 @@ impl TopologyManager {
         Ok(())
     }
 
-    pub async fn setup_function_queue(&self, queue_name: &str, backoff_ms: u64) -> Result<()> {
+    pub async fn setup_function_queue(
+        &self,
+        queue_name: &str,
+        backoff_ms: u64,
+        max_priority: Option<u8>,
+    ) -> Result<()> {
         let names = FnQueueNames::new(queue_name);
 
         // Main exchange + queue with DLX to retry
@@ -138,6 +151,10 @@ impl TopologyManager {
             "x-dead-letter-exchange".into(),
             AMQPValue::LongString(names.dlq_exchange().into()),
         );
+        // A priority queue must be declared with `x-max-priority`; declare the
+        // retry queue with it too so retried messages keep their ordering (the
+        // `priority` property survives dead-lettering). The DLQ stays plain.
+        with_max_priority(&mut main_queue_args, max_priority);
 
         self.channel
             .queue_declare(
@@ -186,6 +203,7 @@ impl TopologyManager {
             "x-dead-letter-routing-key".into(),
             AMQPValue::LongString(queue_name.into()),
         );
+        with_max_priority(&mut retry_queue_args, max_priority);
 
         self.channel
             .queue_declare(
@@ -244,5 +262,15 @@ impl TopologyManager {
 
         tracing::debug!(queue = %queue_name, "Function queue RabbitMQ topology setup complete");
         Ok(())
+    }
+}
+
+/// Insert the `x-max-priority` declaration argument when a priority level is
+/// configured, turning the queue into a RabbitMQ priority queue. Declared as a
+/// signed integer (`AMQPValue::LongInt`) to match the canonical client encoding;
+/// the value is fixed at queue-creation time and cannot be changed later.
+fn with_max_priority(args: &mut FieldTable, max_priority: Option<u8>) {
+    if let Some(max) = max_priority {
+        args.insert("x-max-priority".into(), AMQPValue::LongInt(max as i32));
     }
 }

--- a/engine/src/workers/queue/adapters/rabbitmq/types.rs
+++ b/engine/src/workers/queue/adapters/rabbitmq/types.rs
@@ -24,6 +24,11 @@ pub struct Job {
     pub traceparent: Option<String>,
     #[serde(default)]
     pub baggage: Option<String>,
+    /// AMQP message priority (0..=queue `x-max-priority`). Carried on the job so
+    /// it survives requeue and DLQ-redrive republishes; stamped onto
+    /// `BasicProperties` at publish time. `None` means default priority.
+    #[serde(default)]
+    pub priority: Option<u8>,
 }
 
 impl Job {
@@ -46,7 +51,15 @@ impl Job {
                 .as_millis() as u64,
             traceparent,
             baggage,
+            priority: None,
         }
+    }
+
+    /// Attach a priority to the job (builder style). `None` leaves it at the
+    /// default priority.
+    pub fn with_priority(mut self, priority: Option<u8>) -> Self {
+        self.priority = priority;
+        self
     }
 
     pub fn increment_attempts(&mut self) {
@@ -56,6 +69,17 @@ impl Job {
     pub fn is_exhausted(&self) -> bool {
         self.attempts_made >= self.max_attempts
     }
+}
+
+/// Resolve an AMQP message priority from `data` given the configured field
+/// name. Returns `None` when no field is configured, the field is absent, or
+/// its value is not a non-negative integer. Values above 255 saturate to 255;
+/// the broker further clamps to each queue's `x-max-priority`.
+pub fn priority_from_data(data: &Value, priority_field: Option<&str>) -> Option<u8> {
+    let field = priority_field?;
+    let value = data.get(field)?;
+    let n = value.as_u64()?;
+    Some(n.min(u8::MAX as u64) as u8)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -83,6 +107,10 @@ pub struct RabbitMQConfig {
     pub max_attempts: u32,
     pub prefetch_count: u16,
     pub queue_mode: QueueMode,
+    /// Field in the message data whose integer value sets the priority of
+    /// messages published to topics (pub/sub fanout). `None` disables priority
+    /// stamping on the topic path.
+    pub priority_field: Option<String>,
 }
 
 impl Default for RabbitMQConfig {
@@ -92,6 +120,7 @@ impl Default for RabbitMQConfig {
             max_attempts: 3,
             prefetch_count: 10,
             queue_mode: QueueMode::default(),
+            priority_field: None,
         }
     }
 }
@@ -112,6 +141,9 @@ impl RabbitMQConfig {
             }
             if let Some(mode) = config.get("queue_mode").and_then(|v| v.as_str()) {
                 cfg.queue_mode = QueueMode::from_str(mode).unwrap_or_default();
+            }
+            if let Some(field) = config.get("priority_field").and_then(|v| v.as_str()) {
+                cfg.priority_field = Some(field.to_string());
             }
         }
 
@@ -136,5 +168,29 @@ mod tests {
         assert_eq!(job.attempts_made, 0);
         assert_eq!(job.max_attempts, 3);
         assert!(!job.is_exhausted());
+        assert_eq!(job.priority, None);
+    }
+
+    #[test]
+    fn test_job_with_priority() {
+        let job = Job::new("t", serde_json::json!({}), 1, None, None).with_priority(Some(7));
+        assert_eq!(job.priority, Some(7));
+    }
+
+    #[test]
+    fn test_priority_from_data() {
+        let data = serde_json::json!({ "priority": 9, "other": "x" });
+        // No field configured → None.
+        assert_eq!(priority_from_data(&data, None), None);
+        // Field present and integer.
+        assert_eq!(priority_from_data(&data, Some("priority")), Some(9));
+        // Field absent.
+        assert_eq!(priority_from_data(&data, Some("missing")), None);
+        // Non-integer value → None.
+        let str_data = serde_json::json!({ "priority": "high" });
+        assert_eq!(priority_from_data(&str_data, Some("priority")), None);
+        // Values above u8::MAX saturate.
+        let big = serde_json::json!({ "priority": 300 });
+        assert_eq!(priority_from_data(&big, Some("priority")), Some(255));
     }
 }

--- a/engine/src/workers/queue/adapters/rabbitmq/worker.rs
+++ b/engine/src/workers/queue/adapters/rabbitmq/worker.rs
@@ -27,6 +27,7 @@ pub struct Worker {
     engine: Arc<Engine>,
     semaphore: Option<Arc<Semaphore>>,
     queue_mode: QueueMode,
+    prefetch_count: u16,
 }
 
 impl Worker {
@@ -48,6 +49,7 @@ impl Worker {
             engine,
             semaphore,
             queue_mode,
+            prefetch_count,
         }
     }
 
@@ -59,6 +61,20 @@ impl Worker {
         consumer_tag: String,
         queue_name: String,
     ) {
+        // Apply per-consumer prefetch (QoS) so the broker keeps a backlog in the
+        // queue instead of shipping everything to this consumer at once. Without
+        // it a priority subscriber queue can't reorder (the broker only orders
+        // messages it has yet to deliver), and the queue loses backpressure. The
+        // function-queue consumer sets QoS the same way.
+        if let Err(e) = self
+            .channel
+            .basic_qos(self.prefetch_count, BasicQosOptions::default())
+            .await
+        {
+            tracing::error!(topic = %topic, error = ?e, "Failed to set consumer QoS");
+            return;
+        }
+
         let mut consumer = match self
             .channel
             .basic_consume(

--- a/engine/src/workers/queue/adapters/redis_adapter.rs
+++ b/engine/src/workers/queue/adapters/redis_adapter.rs
@@ -353,6 +353,7 @@ impl QueueAdapter for RedisAdapter {
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn publish_to_function_queue(
         &self,
         queue_name: &str,
@@ -363,6 +364,8 @@ impl QueueAdapter for RedisAdapter {
         _backoff_ms: u64,
         traceparent: Option<String>,
         baggage: Option<String>,
+        // RabbitMQ-only feature; the redis pub/sub adapter ignores it.
+        _priority: Option<u8>,
     ) {
         let channel = format!("__queue::{}", queue_name);
         let publisher = Arc::clone(&self.publisher);

--- a/engine/src/workers/queue/config.rs
+++ b/engine/src/workers/queue/config.rs
@@ -76,6 +76,23 @@ pub struct FunctionQueueConfig {
     #[serde(default)]
     pub message_group_field: Option<String>,
 
+    /// Declares the queue as a RabbitMQ priority queue with this many priority
+    /// levels (`x-max-priority`, 1–255; RabbitMQ recommends ≤ 10). When unset
+    /// the queue is not a priority queue. RabbitMQ-only — other adapters ignore
+    /// it. `x-max-priority` is fixed at queue-creation time: changing it for an
+    /// already-declared queue has no effect (the queue must be recreated).
+    /// Priority ordering is only observable at low `concurrency`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 1, max = 255))]
+    pub max_priority: Option<u8>,
+
+    /// The message field whose integer value sets each message's priority
+    /// (0..=`max_priority`; the broker clamps out-of-range values). Analogous to
+    /// `message_group_field`. Only meaningful when `max_priority` is set;
+    /// RabbitMQ-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub priority_field: Option<String>,
+
     /// Base delay in milliseconds for the exponential retry backoff. Defaults
     /// to 1000 (1s).
     #[serde(default = "default_backoff_ms")]
@@ -94,6 +111,8 @@ impl Default for FunctionQueueConfig {
             concurrency: default_concurrency(),
             r#type: default_queue_type(),
             message_group_field: None,
+            max_priority: None,
+            priority_field: None,
             backoff_ms: default_backoff_ms(),
             poll_interval_ms: default_poll_interval_ms(),
         }
@@ -161,6 +180,16 @@ impl QueueModuleConfig {
             if queue_config.concurrency == 0 {
                 anyhow::bail!(
                     "Queue '{}' has 'concurrency' 0; it must be at least 1",
+                    name
+                );
+            }
+            // `x-max-priority` must be a positive integer; 0 is rejected by the
+            // broker. The JSON schema (`range(min = 1)`) catches this at
+            // `configuration::set`, but the `config.yaml` seed bypasses the
+            // schema, so guard here too.
+            if queue_config.max_priority == Some(0) {
+                anyhow::bail!(
+                    "Queue '{}' has 'max_priority' 0; it must be between 1 and 255",
                     name
                 );
             }
@@ -248,6 +277,14 @@ pub struct RabbitmqAdapterConfig {
     /// Per-queue `type` overrides this. Defaults to "standard".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub queue_mode: Option<String>,
+
+    /// Message field whose integer value sets the priority of messages published
+    /// to **topics** (pub/sub fanout). A fanout publish is copied to every bound
+    /// subscriber queue, so the priority value is resolved once here at publish
+    /// time; each subscriber queue honors it only if declared with a
+    /// `maxPriority`. Function queues use their own per-queue `priority_field`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub priority_field: Option<String>,
 }
 
 /// Build the `oneOf` schema for [`QueueModuleConfig::adapter`]: one branch per
@@ -565,6 +602,69 @@ adapter:
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("invalid_type"));
+    }
+
+    #[test]
+    fn validate_zero_max_priority_fails() {
+        let mut queue_configs = HashMap::new();
+        queue_configs.insert(
+            "jobs".to_string(),
+            FunctionQueueConfig {
+                max_priority: Some(0),
+                ..Default::default()
+            },
+        );
+        let config = QueueModuleConfig {
+            adapter: None,
+            queue_configs,
+        };
+        let result = config.validate();
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("jobs"));
+        assert!(err.contains("max_priority"));
+    }
+
+    #[test]
+    fn validate_priority_queue_ok() {
+        let mut queue_configs = HashMap::new();
+        queue_configs.insert(
+            "jobs".to_string(),
+            FunctionQueueConfig {
+                max_priority: Some(10),
+                priority_field: Some("priority".to_string()),
+                concurrency: 1,
+                ..Default::default()
+            },
+        );
+        let config = QueueModuleConfig {
+            adapter: None,
+            queue_configs,
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn deserialize_priority_queue_config() {
+        let yaml = r#"
+queue_configs:
+  jobs:
+    type: standard
+    concurrency: 1
+    max_priority: 10
+    priority_field: priority
+adapter:
+  name: rabbitmq
+"#;
+        let config: QueueModuleConfig = serde_yaml::from_str(yaml).unwrap();
+        let jobs = config.queue_configs.get("jobs").unwrap();
+        assert_eq!(jobs.max_priority, Some(10));
+        assert_eq!(jobs.priority_field.as_deref(), Some("priority"));
+        // Defaults stay backward compatible: omitting both fields means no
+        // priority queue.
+        let plain: FunctionQueueConfig = serde_json::from_str(r#"{}"#).unwrap();
+        assert_eq!(plain.max_priority, None);
+        assert_eq!(plain.priority_field, None);
     }
 
     #[test]

--- a/engine/src/workers/queue/mod.rs
+++ b/engine/src/workers/queue/mod.rs
@@ -76,6 +76,7 @@ pub trait QueueAdapter: Send + Sync + 'static {
     }
 
     // Function queue transport methods
+    #[allow(clippy::too_many_arguments)]
     async fn publish_to_function_queue(
         &self,
         _queue_name: &str,
@@ -86,6 +87,9 @@ pub trait QueueAdapter: Send + Sync + 'static {
         _backoff_ms: u64,
         _traceparent: Option<String>,
         _baggage: Option<String>,
+        // AMQP message priority (`None` = default). Honored by adapters whose
+        // queues are declared as priority queues; others ignore it.
+        _priority: Option<u8>,
     ) {
         unimplemented!("publish_to_function_queue not implemented for this adapter")
     }

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -203,6 +203,16 @@ impl QueueWorker {
             }
         }
 
+        // Resolve the per-message priority from the configured `priority_field`
+        // (mirrors the FIFO `message_group_field` extraction above). Clamp to the
+        // queue's `max_priority`; the value is honored only by priority queues
+        // (RabbitMQ declared with `x-max-priority`) and ignored by other adapters.
+        let priority = queue_config.priority_field.as_ref().and_then(|field| {
+            let raw = data.get(field)?.as_u64()?;
+            let max = queue_config.max_priority.unwrap_or(u8::MAX) as u64;
+            Some(raw.min(max) as u8)
+        });
+
         // Name the function this message will run in the propagated baggage, so
         // the `fn_queue` consumer span (and the worker context it delivers) carry
         // `iii.function.id = <target>` rather than the enqueuer's id that
@@ -219,6 +229,7 @@ impl QueueWorker {
                 queue_config.backoff_ms,
                 traceparent,
                 baggage,
+                priority,
             )
             .await;
         crate::workers::telemetry::collector::track_queue_emit();
@@ -1513,6 +1524,7 @@ mod tests {
             *self.last_baggage.lock().await = baggage;
         }
 
+        #[allow(clippy::too_many_arguments)]
         async fn publish_to_function_queue(
             &self,
             _queue_name: &str,
@@ -1523,6 +1535,7 @@ mod tests {
             _backoff_ms: u64,
             _traceparent: Option<String>,
             _baggage: Option<String>,
+            _priority: Option<u8>,
         ) {
             self.enqueue_to_queue_count.fetch_add(1, Ordering::SeqCst);
         }
@@ -2425,6 +2438,7 @@ mod tests {
                 1000,
                 None,
                 None,
+                None,
             )
             .await;
 
@@ -2486,6 +2500,7 @@ mod tests {
                 "test-msg-id",
                 3,
                 100,
+                None,
                 None,
                 None,
             )
@@ -2552,6 +2567,7 @@ mod tests {
                     "test-msg-id",
                     3,
                     1000,
+                    None,
                     None,
                     None,
                 )
@@ -2628,6 +2644,7 @@ mod tests {
                     "test-msg-id",
                     3,
                     1000,
+                    None,
                     None,
                     None,
                 )

--- a/engine/src/workers/queue/subscriber_config.rs
+++ b/engine/src/workers/queue/subscriber_config.rs
@@ -24,6 +24,10 @@ pub struct SubscriberQueueConfig {
     pub delay_seconds: Option<u64>,
     pub backoff_type: Option<String>,
     pub backoff_delay_ms: Option<u64>,
+    /// Declares this subscriber's queue as a RabbitMQ priority queue with this
+    /// many levels (`x-max-priority`, 1–255). RabbitMQ-only; the priority value
+    /// of each message comes from the adapter-level `priority_field`.
+    pub max_priority: Option<u8>,
 }
 
 impl SubscriberQueueConfig {
@@ -93,6 +97,14 @@ impl SubscriberQueueConfig {
             as_u64,
             |v| v
         );
+        extract_field!(
+            config,
+            "maxPriority",
+            subscriber_config.max_priority,
+            has_any_value,
+            as_u64,
+            |v| v as u8
+        );
 
         if has_any_value {
             Some(subscriber_config)
@@ -133,6 +145,18 @@ mod tests {
             Some("exponential".to_string())
         );
         assert_eq!(subscriber_config.backoff_delay_ms, Some(2000));
+    }
+
+    #[test]
+    fn test_from_value_parses_max_priority() {
+        let config = json!({ "maxPriority": 10 });
+        let result = SubscriberQueueConfig::from_value(Some(&config)).expect("should parse");
+        assert_eq!(result.max_priority, Some(10));
+
+        // Absent maxPriority leaves it unset (not a priority queue).
+        let without = json!({ "type": "standard" });
+        let parsed = SubscriberQueueConfig::from_value(Some(&without)).expect("should parse");
+        assert_eq!(parsed.max_priority, None);
     }
 
     #[test]

--- a/engine/tests/common/rabbitmq_helpers.rs
+++ b/engine/tests/common/rabbitmq_helpers.rs
@@ -75,6 +75,53 @@ pub fn rabbitmq_queue_config_custom(
     })
 }
 
+/// Creates a RabbitMQ adapter queue config with a single priority queue named
+/// `"{prefix}-priority"`: `concurrency: 1` (so priority ordering is observable),
+/// `max_priority`, and `priority_field` reading the per-message priority from
+/// `data`.
+pub fn rabbitmq_priority_queue_config(
+    amqp_url: &str,
+    prefix: &str,
+    max_priority: u8,
+    priority_field: &str,
+) -> Value {
+    json!({
+        "adapter": {
+            "name": "rabbitmq",
+            "config": {
+                "amqp_url": amqp_url
+            }
+        },
+        "queue_configs": {
+            format!("{prefix}-priority"): {
+                "type": "standard",
+                "concurrency": 1,
+                "max_retries": 3,
+                "backoff_ms": 200,
+                "poll_interval_ms": 100,
+                "max_priority": max_priority,
+                "priority_field": priority_field
+            }
+        }
+    })
+}
+
+/// Creates a RabbitMQ adapter config whose **adapter-level** `priority_field` is
+/// used to stamp the priority of messages published to topics (pub/sub fanout).
+/// No function queues are declared — the subscriber declares its own priority
+/// queue via its `queue_config.maxPriority`.
+pub fn rabbitmq_priority_topic_config(amqp_url: &str, priority_field: &str) -> Value {
+    json!({
+        "adapter": {
+            "name": "rabbitmq",
+            "config": {
+                "amqp_url": amqp_url,
+                "priority_field": priority_field
+            }
+        }
+    })
+}
+
 /// Creates a RabbitMQ adapter queue config with the given AMQP URL and prefix.
 /// Defines two queues: "{prefix}-default" (standard) and "{prefix}-payment" (fifo).
 pub fn rabbitmq_queue_config(amqp_url: &str, prefix: &str) -> Value {

--- a/engine/tests/rabbitmq_queue_integration.rs
+++ b/engine/tests/rabbitmq_queue_integration.rs
@@ -30,7 +30,8 @@ use common::queue_helpers::{
     register_payload_capturing_function, register_slow_function,
 };
 use common::rabbitmq_helpers::{
-    get_rabbitmq, rabbitmq_queue_config, rabbitmq_queue_config_custom, test_prefix,
+    get_rabbitmq, rabbitmq_priority_queue_config, rabbitmq_priority_topic_config,
+    rabbitmq_queue_config, rabbitmq_queue_config_custom, test_prefix,
 };
 
 // ---------------------------------------------------------------------------
@@ -1419,5 +1420,293 @@ async fn rmq_fanout_dlq_per_function() {
     assert!(
         fail_count.load(Ordering::SeqCst) >= 1,
         "failing function should have been invoked at least once"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Priority queue tests
+// ---------------------------------------------------------------------------
+
+/// Registers a "gate" handler for the priority ordering tests. It records each
+/// message's `priority` field into `order`. The FIRST message it receives (the
+/// primer) fires `started` and then blocks on `release`, so the test can build a
+/// full backlog at the broker while the consumer holds one unacked message
+/// (prefetch must be 1). The backlog then drains highest-priority-first, which is
+/// what makes the ordering assertion deterministic.
+fn register_priority_gate_function(
+    engine: &Arc<Engine>,
+    function_id: &str,
+    order: Arc<Mutex<Vec<u64>>>,
+    started: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Notify>,
+) {
+    let is_first = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let function = Function {
+        handler: Arc::new(move |_invocation_id, input, _session| {
+            let order = order.clone();
+            let started = started.clone();
+            let release = release.clone();
+            let is_first = is_first.clone();
+            Box::pin(async move {
+                let p = input.get("priority").and_then(|v| v.as_u64()).unwrap_or(0);
+                if is_first.swap(false, Ordering::SeqCst) {
+                    started.notify_one();
+                    release.notified().await;
+                }
+                order.lock().await.push(p);
+                FunctionResult::Success(Some(json!({ "ok": true })))
+            })
+        }),
+        _function_id: function_id.to_string(),
+        _description: Some("priority gate test handler".to_string()),
+        request_format: None,
+        response_format: None,
+        metadata: None,
+    };
+    engine
+        .functions
+        .register_function(function_id.to_string(), function);
+}
+
+/// A priority function queue (`concurrency: 1`) drains the highest-priority
+/// message first. The primer is held unacked while the rest of the backlog is
+/// enqueued, so the broker reorders by priority on delivery.
+#[tokio::test]
+async fn rmq_priority_queue_orders_by_priority() {
+    let ctx = get_rabbitmq().await;
+    let prefix = test_prefix();
+    let queue = format!("{prefix}-priority");
+
+    let engine = {
+        iii::workers::observability::metrics::ensure_default_meter();
+        Arc::new(Engine::new())
+    };
+
+    let order: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+    let started = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    register_priority_gate_function(
+        &engine,
+        "test::rmq_priority",
+        order.clone(),
+        started.clone(),
+        release.clone(),
+    );
+
+    let module = QueueWorker::create(
+        engine.clone(),
+        Some(rabbitmq_priority_queue_config(
+            &ctx.amqp_url,
+            &prefix,
+            10,
+            "priority",
+        )),
+    )
+    .await
+    .expect("QueueWorker::create should succeed");
+    module.initialize().await.expect("init should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("start_background_tasks should succeed");
+
+    // Primer (lowest priority): grabbed first and held unacked while we build the
+    // backlog. prefetch=1 (concurrency=1) keeps the broker from delivering more.
+    enqueue(
+        &engine,
+        &queue,
+        "test::rmq_priority",
+        json!({ "priority": 0 }),
+    )
+    .await
+    .expect("enqueue primer should succeed");
+
+    tokio::time::timeout(Duration::from_secs(10), started.notified())
+        .await
+        .expect("primer should be picked up by the consumer");
+
+    // Enqueue the rest, scrambled, while the consumer is blocked on the primer.
+    for p in [3u64, 1, 5, 2, 4] {
+        enqueue(
+            &engine,
+            &queue,
+            "test::rmq_priority",
+            json!({ "priority": p }),
+        )
+        .await
+        .expect("enqueue should succeed");
+    }
+    // Let the broker enqueue the whole backlog before releasing the primer.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    release.notify_one();
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    let recorded = order.lock().await;
+    assert_eq!(
+        *recorded,
+        vec![0, 5, 4, 3, 2, 1],
+        "primer runs first, then the backlog drains highest-priority-first"
+    );
+}
+
+/// A priority queue is declared with `x-max-priority` on its main and retry
+/// queues (so priority survives retries); the DLQ stays a plain queue.
+#[tokio::test]
+async fn rmq_priority_queue_topology_declares_x_max_priority() {
+    let ctx = get_rabbitmq().await;
+    let prefix = test_prefix();
+    let queue = format!("{prefix}-priority");
+
+    let engine = {
+        iii::workers::observability::metrics::ensure_default_meter();
+        Arc::new(Engine::new())
+    };
+
+    let module = QueueWorker::create(
+        engine.clone(),
+        Some(rabbitmq_priority_queue_config(
+            &ctx.amqp_url,
+            &prefix,
+            7,
+            "priority",
+        )),
+    )
+    .await
+    .expect("QueueWorker::create should succeed");
+    module.initialize().await.expect("init should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("start_background_tasks should succeed");
+
+    let client = reqwest::Client::new();
+    let fetch_args = |q: String| {
+        let client = client.clone();
+        let mgmt = ctx.mgmt_url.clone();
+        async move {
+            let resp: Value = client
+                .get(format!("{mgmt}/api/queues/%2f/{q}"))
+                .basic_auth("guest", Some("guest"))
+                .send()
+                .await
+                .expect("management API request should succeed")
+                .json()
+                .await
+                .expect("management API response should be valid JSON");
+            resp
+        }
+    };
+
+    let main = fetch_args(format!("iii.__fn_queue::{queue}.queue")).await;
+    assert_eq!(
+        main["arguments"]["x-max-priority"].as_u64(),
+        Some(7),
+        "main queue should declare x-max-priority=7"
+    );
+
+    let retry = fetch_args(format!("iii.__fn_queue::{queue}::retry.queue")).await;
+    assert_eq!(
+        retry["arguments"]["x-max-priority"].as_u64(),
+        Some(7),
+        "retry queue should declare x-max-priority=7 so priority survives retries"
+    );
+
+    let dlq = fetch_args(format!("iii.__fn_queue::{queue}::dlq.queue")).await;
+    assert!(
+        dlq["arguments"].get("x-max-priority").is_none()
+            || dlq["arguments"]["x-max-priority"].is_null(),
+        "DLQ should not be a priority queue, got args: {}",
+        dlq["arguments"]
+    );
+}
+
+/// A subscriber (topic fanout) queue declared with `maxPriority` drains
+/// highest-priority-first. The priority value is resolved at publish time from
+/// the adapter-level `priority_field`.
+#[tokio::test]
+async fn rmq_subscriber_priority_orders_by_priority() {
+    use common::queue_helpers::enqueue_to_topic;
+    use iii::trigger::Trigger;
+
+    let ctx = get_rabbitmq().await;
+    let prefix = test_prefix();
+    let topic = format!("{prefix}-prio-topic");
+
+    let engine = {
+        iii::workers::observability::metrics::ensure_default_meter();
+        Arc::new(Engine::new())
+    };
+
+    let order: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+    let started = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    register_priority_gate_function(
+        &engine,
+        "test::rmq_sub_priority",
+        order.clone(),
+        started.clone(),
+        release.clone(),
+    );
+
+    let module = QueueWorker::create(
+        engine.clone(),
+        Some(rabbitmq_priority_topic_config(&ctx.amqp_url, "priority")),
+    )
+    .await
+    .expect("QueueWorker::create should succeed");
+    module.register_functions(engine.clone());
+    module.initialize().await.expect("init should succeed");
+    let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+        .await
+        .expect("start_background_tasks should succeed");
+
+    // Subscribe with a priority queue (maxPriority) and prefetch 1 (concurrency).
+    engine
+        .trigger_registry
+        .register_trigger(Trigger {
+            id: format!("trig-{}", Uuid::new_v4()),
+            trigger_type: "durable:subscriber".to_string(),
+            function_id: "test::rmq_sub_priority".to_string(),
+            config: json!({
+                "topic": &topic,
+                "queue_config": { "maxPriority": 10, "concurrency": 1 }
+            }),
+            worker_id: None,
+            metadata: None,
+        })
+        .await
+        .expect("register trigger should succeed");
+
+    // Let the subscriber queue get declared and its consumer attach.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    enqueue_to_topic(&engine, &topic, json!({ "priority": 0 }))
+        .await
+        .expect("enqueue primer should succeed");
+
+    tokio::time::timeout(Duration::from_secs(10), started.notified())
+        .await
+        .expect("primer should be picked up by the subscriber");
+
+    for p in [3u64, 1, 5, 2, 4] {
+        enqueue_to_topic(&engine, &topic, json!({ "priority": p }))
+            .await
+            .expect("enqueue should succeed");
+    }
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    release.notify_one();
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    let recorded = order.lock().await;
+    assert_eq!(
+        *recorded,
+        vec![0, 5, 4, 3, 2, 1],
+        "subscriber priority queue should drain highest-priority-first"
     );
 }


### PR DESCRIPTION
## What

Adds RabbitMQ **priority queue** support to the RabbitMQ queue provider. Higher-priority messages are delivered before lower-priority ones waiting in the same queue. Works on both **function (named) queues** and **subscriber (topic fanout) queues**.

The per-message priority is read from a payload field — mirroring how FIFO reads `message_group_field` — so there is **no change to the enqueue/publish API or the SDKs**.

## How it works

RabbitMQ priority needs two things together: the queue declared with `x-max-priority`, and each message published with the AMQP `priority` property (the broker delivers higher first and clamps to the queue's max).

**Configuration**
- Function queues (`queue_configs.<name>`):
  - `max_priority` — declares the queue with `x-max-priority` (1–255; RabbitMQ recommends ≤ 10).
  - `priority_field` — the integer field in the message `data` that sets each message's priority.
- Subscriber queues:
  - `maxPriority` in the subscriber's `queue_config` declares its per-function queue with `x-max-priority`.
  - Because one fanout publish is copied to every bound queue, the priority **value** is resolved once at publish time from the adapter-level `priority_field`.

```yaml
queue_configs:
  jobs:
    type: standard
    concurrency: 1          # priority ordering is only observable at low concurrency
    max_priority: 10        # declares x-max-priority
    priority_field: priority # read from data.priority
```

**Behavior**
- Topology declares both the main and retry queues with `x-max-priority` so priority survives retries; the DLQ stays a plain queue.
- The priority property is carried on the job and re-stamped on requeue and DLQ-redrive republishes.
- Other adapters (builtin, redis, bridge) accept the new `publish_to_function_queue` priority argument and ignore it (RabbitMQ-only feature).

**Subscriber consumer QoS fix:** the subscriber worker now applies per-consumer prefetch (`basic_qos`), matching the function-queue consumer. Without it the broker delivered the entire queue to the consumer at once, so priority ordering on subscriber queues would have had no effect; this also gives subscribers proper broker-side backpressure.

## Notes / constraints

- `x-max-priority` is fixed at queue-creation time. Enabling priority on an existing queue (or changing the level) requires recreating the queue; a runtime config change does not take effect on an already-declared queue.
- Priority ordering is only meaningful at low `concurrency` (high prefetch lets the broker hand out many messages before they can be reordered).

## Test plan

- [x] `cargo check -p iii --all-features --tests` — 0 errors
- [x] Lib unit suite — 1813 passed (incl. 9 new: config validation/deserialization, `maxPriority` parsing, payload-field extraction)
- [x] RabbitMQ integration (testcontainers) — 20 passed, including 3 new:
  - function-queue drains highest-priority-first
  - subscriber queue drains highest-priority-first
  - `x-max-priority` present on main + retry queues, absent on DLQ
- [x] Builtin queue integration — 12 passed (trait signature change)
- [x] clippy — 0 errors

Ordering tests are deterministic: a gate handler holds the first message unacked under prefetch=1 while the backlog is enqueued, so the broker provably reorders by priority on delivery.

https://claude.ai/code/session_011TpFhqmhPLVZPsuXPdJ6Fz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RabbitMQ priority queue support, including priority-based ordering for function queues and topic subscribers.
  * Introduced configuration for per-message priority extraction and per-queue maximum priority limits.
  * RabbitMQ now applies priority to outgoing AMQP messages and enables priority queues for main and retry paths.
* **Configuration**
  * Added validation rejecting `max_priority: 0`, and supports optional `priority_field`/`max_priority` when unset defaults remain unchanged.
* **Tests**
  * Added integration tests covering priority ordering and verifying queue topology (`x-max-priority`) behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->