### PR TITLE
refactor(sdk): re-export TriggerActionVoid and EnqueueResult from the SDK root

### DIFF
--- a/docs/changelog/0-20-0/extract-helpers-lib.mdx
+++ b/docs/changelog/0-20-0/extract-helpers-lib.mdx
@@ -19,13 +19,15 @@ The user-facing types that the three SDKs share with the engine move out of the 
 | Submodule | Symbols |
 | --- | --- |
 | http | `HttpAuthConfig`, `HttpInvocationConfig`, `HttpMethod`, the `http` handler helper, buffered `HttpRequest` and `HttpResponse` |
-| queue | `EnqueueResult` |
+| queue | `EnqueueResult` (also re-exported from the root SDK, see below) |
 | stream | the stream trigger configs, events, IO inputs, auth and result types, and the update operations (`UpdateOp`, `UpdateOpError`, `MergePath`, `UpdateSet`, `UpdateMerge`, and the other `Update*` variants) |
 | worker-connection-manager | `AuthInput`, `AuthResult`, and the six `On{Function,Trigger,TriggerType}Registration{Input,Result}` types |
 
 ## What stays in the root SDK
 
 Types that reference core-only types stay in the root SDK in all three languages, because moving them would create a dependency cycle from the helpers package back into the core SDK: `IStream`, the streaming `StreamRequest` and `StreamResponse`, `MiddlewareFunctionInput`, and `TriggerActionEnqueue`. The root SDK depends on `iii-helpers` and imports the moved types from the submodules internally where its own code needs them.
+
+`EnqueueResult` is the exception in the `queue` submodule: its canonical home is `iii_helpers::queue`, but it is also re-exported from the root SDK as the return companion to `TriggerAction.Enqueue`, so it remains importable from `iii-sdk` / `iii` / `iii_sdk` without a migration.
 
 ## Migration
 
@@ -35,10 +37,10 @@ Node:
 
 ```ts
 // Before
-import { HttpAuthConfig, EnqueueResult } from 'iii-sdk'
+import { HttpAuthConfig } from 'iii-sdk'
 // After
 import { HttpAuthConfig } from '@iii-dev/helpers/http'
-import { EnqueueResult } from '@iii-dev/helpers/queue'
+// EnqueueResult needs no migration; it stays importable from 'iii-sdk'
 ```
 
 Python:

--- a/docs/changelog/0-20-0/submodule-clean-break.mdx
+++ b/docs/changelog/0-20-0/submodule-clean-break.mdx
@@ -23,9 +23,10 @@ The root SDK surface continues to be grouped into named submodules. This slice a
 | internal | `InternalHttpRequest` |
 | utils (Python) | `extract_request_format`, `extract_response_format`, `python_type_to_format` |
 | runtime | `IIIConnectionState` now joins the runtime group |
-| trigger (Python) | `TriggerActionVoid` now joins the trigger group |
 
 Per-language differences are respected: a symbol that does not exist in a language is not added there.
+
+`TriggerActionVoid` (Python) is also grouped under `iii.trigger`, but it stays exported from the package root as the companion to `TriggerActionEnqueue`, so it is reachable from both `iii` and `iii.trigger`.
 
 ## Migration
 

--- a/docs/next/sdk-reference/helpers-lib.mdx
+++ b/docs/next/sdk-reference/helpers-lib.mdx
@@ -30,8 +30,9 @@ The `queue` submodule defines the types used for queue-routed invocations.
 ### `EnqueueResult`
 
 Result returned when a function is invoked with the `enqueue` action. The engine acknowledges the
-enqueue and returns a receipt identifier. `EnqueueResult` is provided by the `queue` submodule and
-must be imported from there (`@iii-dev/helpers/queue`, `iii_helpers.queue`, `iii_helpers::queue`).
+enqueue and returns a receipt identifier. `EnqueueResult` is defined by the `queue` submodule
+(`@iii-dev/helpers/queue`, `iii_helpers.queue`, `iii_helpers::queue`) and is also re-exported from
+the root SDK (`iii-sdk`, `iii`, `iii_sdk`) as the return companion to `TriggerAction.Enqueue`.
 
 <CodeGroup>
 

--- a/docs/next/sdk-reference/helpers-lib.mdx.skill.md
+++ b/docs/next/sdk-reference/helpers-lib.mdx.skill.md
@@ -28,8 +28,9 @@ The `queue` submodule defines the types used for queue-routed invocations.
 ### `EnqueueResult`
 
 Result returned when a function is invoked with the `enqueue` action. The engine acknowledges the
-enqueue and returns a receipt identifier. `EnqueueResult` is provided by the `queue` submodule and
-must be imported from there (`@iii-dev/helpers/queue`, `iii_helpers.queue`, `iii_helpers::queue`).
+enqueue and returns a receipt identifier. `EnqueueResult` is defined by the `queue` submodule
+(`@iii-dev/helpers/queue`, `iii_helpers.queue`, `iii_helpers::queue`) and is also re-exported from
+the root SDK (`iii-sdk`, `iii`, `iii_sdk`) as the return companion to `TriggerAction.Enqueue`.
 
 <CodeGroup>
 

--- a/docs/next/sdk-reference/python-sdk.mdx
+++ b/docs/next/sdk-reference/python-sdk.mdx
@@ -79,8 +79,9 @@ The protocol message and register-input types (`MessageType`, `RegisterFunctionM
 the `iii.protocol` submodule (`from iii.protocol import MessageType`). They are not importable from
 the package root.
 
-The `TriggerActionVoid` type is provided only by the `iii.trigger` submodule
-(`from iii.trigger import TriggerActionVoid`). It is not importable from the package root.
+The `TriggerActionVoid` type is exported from the package root (`from iii import TriggerActionVoid`),
+alongside `TriggerActionEnqueue`, and is also grouped under the `iii.trigger` submodule
+(`from iii.trigger import TriggerActionVoid`).
 
 The `extract_request_format`, `extract_response_format`, and `python_type_to_format` helpers are
 provided only by the `iii.utils` submodule (`from iii.utils import python_type_to_format`). They are

--- a/docs/next/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/python-sdk.mdx.skill.md
@@ -77,8 +77,9 @@ The protocol message and register-input types (`MessageType`, `RegisterFunctionM
 the `iii.protocol` submodule (`from iii.protocol import MessageType`). They are not importable from
 the package root.
 
-The `TriggerActionVoid` type is provided only by the `iii.trigger` submodule
-(`from iii.trigger import TriggerActionVoid`). It is not importable from the package root.
+The `TriggerActionVoid` type is exported from the package root (`from iii import TriggerActionVoid`),
+alongside `TriggerActionEnqueue`, and is also grouped under the `iii.trigger` submodule
+(`from iii.trigger import TriggerActionVoid`).
 
 The `extract_request_format`, `extract_response_format`, and `python_type_to_format` helpers are
 provided only by the `iii.utils` submodule (`from iii.utils import python_type_to_format`). They are

--- a/sdk/packages/node/iii/src/index.ts
+++ b/sdk/packages/node/iii/src/index.ts
@@ -9,6 +9,8 @@ export { IIIInvocationError, type IIIInvocationErrorInit } from './errors'
 
 export { type InitOptions, registerWorker, type TelemetryOptions, TriggerAction } from './iii'
 
+export type { EnqueueResult } from '@iii-dev/helpers/queue'
+
 export type { MiddlewareFunctionInput } from './iii-types'
 
 /** @deprecated Import trigger types from `iii-sdk/trigger`. */

--- a/sdk/packages/node/iii/tests/exports.test.ts
+++ b/sdk/packages/node/iii/tests/exports.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest'
+import type { EnqueueResult } from '../src/index'
 import { registerWorker } from '../src/index'
 import { iii } from './utils'
 
@@ -49,5 +50,11 @@ describe('Package Exports', () => {
   it('exposes the TelemetryOptions type via the barrel', async () => {
     // Type-only; presence is enforced by tsc. This asserts the module resolves.
     await expect(import('../src/index')).resolves.toBeDefined()
+  })
+
+  it('re-exports the EnqueueResult type from the barrel', () => {
+    // Type-only; presence is enforced by tsc.
+    const receipt: EnqueueResult = { messageReceiptId: 'abc' }
+    expect(receipt.messageReceiptId).toBe('abc')
   })
 })

--- a/sdk/packages/python/iii/src/iii/__init__.py
+++ b/sdk/packages/python/iii/src/iii/__init__.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from iii_helpers.queue import EnqueueResult
+
 from .channels import ChannelReader, ChannelWriter
 from .errors import InvocationError
 from .iii import TriggerAction, register_worker
@@ -13,6 +15,7 @@ from .iii_constants import (
 from .iii_types import (
     MiddlewareFunctionInput,
     TriggerActionEnqueue,
+    TriggerActionVoid,
 )
 from .stream import IStream
 from .triggers import Trigger, TriggerConfig, TriggerHandler, TriggerTypeRef
@@ -39,6 +42,9 @@ __all__ = [
     "MiddlewareFunctionInput",
     # Message types
     "TriggerActionEnqueue",
+    "TriggerActionVoid",
+    # Queue
+    "EnqueueResult",
     # Triggers
     "Trigger",
     "TriggerConfig",

--- a/sdk/packages/python/iii/tests/test_trigger_submodule.py
+++ b/sdk/packages/python/iii/tests/test_trigger_submodule.py
@@ -12,3 +12,20 @@ def test_trigger_root_shim() -> None:
     from iii.trigger import Trigger as SubTrigger
 
     assert iii.Trigger is SubTrigger
+
+
+def test_trigger_action_void_at_root() -> None:
+    import iii
+    from iii.iii_types import TriggerActionVoid
+
+    assert iii.TriggerActionVoid is TriggerActionVoid
+    assert "TriggerActionVoid" in iii.__all__
+
+
+def test_enqueue_result_at_root() -> None:
+    from iii_helpers.queue import EnqueueResult
+
+    import iii
+
+    assert iii.EnqueueResult is EnqueueResult
+    assert "EnqueueResult" in iii.__all__

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -63,6 +63,7 @@ pub use iii::TelemetryOptions as WorkerTelemetryMeta;
 #[deprecated(since = "0.19.0", note = "import from iii_sdk::runtime")]
 pub use iii::{FunctionInfo, FunctionRef, TriggerInfo, TriggerTypeRef, WorkerInfo, WorkerMetadata};
 pub use iii::{IIIClient, RegisterFunction, RegisterTriggerType};
+pub use iii_helpers::queue::EnqueueResult;
 pub use protocol::{Message, TriggerAction};
 pub use stream_provider::IStream;
 pub use structs::MiddlewareFunctionInput;
@@ -321,3 +322,14 @@ fn _ensure_protocol_submodule_path() {}
 /// ```
 #[allow(dead_code)]
 fn _ensure_protocol_types_not_top_level() {}
+
+// ---------------------------------------------------------------------------
+// EnqueueResult is re-exported at the crate root for convenience alongside
+// `TriggerAction`, mirroring its canonical home in `iii_helpers::queue`.
+// ---------------------------------------------------------------------------
+
+/// ```rust,no_run
+/// use iii_sdk::EnqueueResult;
+/// ```
+#[allow(dead_code)]
+fn _ensure_enqueue_result_at_root() {}


### PR DESCRIPTION
## What

Restore two symbols to the **root** SDK surface that the helpers/submodule reorg (#1848) moved out:

- **`EnqueueResult`** — re-exported from the root in all three SDKs (Node, Python, Rust) as the return companion to `TriggerAction.Enqueue`. Its canonical home stays `@iii-dev/helpers/queue` / `iii_helpers.queue` / `iii_helpers::queue`; the root simply re-exports it.
- **`TriggerActionVoid`** — re-exported from the **Python** root alongside the already-kept `TriggerActionEnqueue`. Node and Rust express the void action through the `TriggerAction` factory/enum (already at the root), so they need no change for this symbol.

## Why

`EnqueueResult` is the result type returned by `trigger(...)` with an enqueue action, and `TriggerActionEnqueue` already stays at the root — its result type and its `Void` sibling should be reachable from the same place. Re-exporting is safe: `iii-helpers` has no dependency on the root SDK, so there is no import cycle.

## Changes

| SDK | Change |
| --- | --- |
| Node | `index.ts` re-exports `EnqueueResult` from `@iii-dev/helpers/queue` |
| Python | `__init__.py` re-exports `TriggerActionVoid` and `EnqueueResult`; added to `__all__` |
| Rust | `lib.rs` re-exports `iii_helpers::queue::EnqueueResult` |

## Tests

- **Node**: barrel exposes the `EnqueueResult` type (tsc-enforced).
- **Python**: `iii.TriggerActionVoid` / `iii.EnqueueResult` identity + presence in `__all__`.
- **Rust**: positive doctest asserting `use iii_sdk::EnqueueResult;` compiles.

Docs updated: the 0.20.0 changelog entries and the `next/` SDK reference pages (incl. rendered `.skill.md`).

## Verification

- Node: build + `tsc --noEmit` + full vitest — green.
- Python: full pytest (324 passed) + mypy (strict, clean) + ruff on changed files — green.
- Rust: `cargo build` + lib/doc tests + clippy `-D warnings` + fmt — green.

Base: `sdk-refactor`.