### PR TITLE
refactor(sdk)!: remove deprecated symbol shims for the 0.20 clean break

### DIFF
--- a/console/packages/console-rust/src/bridge/error.rs
+++ b/console/packages/console-rust/src/bridge/error.rs
@@ -1,18 +1,18 @@
-use iii_sdk::IIIError;
+use iii_sdk::Error;
 use serde_json::{json, Value};
 
-/// Maps a IIIError to an HTTP response format
-pub fn error_response(error: IIIError) -> Value {
+/// Maps a Error to an HTTP response format
+pub fn error_response(error: Error) -> Value {
     let (status_code, message) = match error {
-        IIIError::NotConnected => (503, "Bridge is not connected".to_string()),
-        IIIError::Timeout => (504, "Invocation timed out".to_string()),
-        IIIError::Remote { code, message, .. } => {
+        Error::NotConnected => (503, "Bridge is not connected".to_string()),
+        Error::Timeout => (504, "Invocation timed out".to_string()),
+        Error::Remote { code, message, .. } => {
             (502, format!("Remote error ({}): {}", code, message))
         }
-        IIIError::Handler(msg) => (500, format!("Handler error: {}", msg)),
-        IIIError::Serde(msg) => (500, format!("Serialization error: {}", msg)),
-        IIIError::WebSocket(msg) => (503, format!("WebSocket error: {}", msg)),
-        IIIError::Runtime(msg) => (500, format!("Runtime error: {}", msg)),
+        Error::Handler(msg) => (500, format!("Handler error: {}", msg)),
+        Error::Serde(msg) => (500, format!("Serialization error: {}", msg)),
+        Error::WebSocket(msg) => (503, format!("WebSocket error: {}", msg)),
+        Error::Runtime(msg) => (500, format!("Runtime error: {}", msg)),
     };
 
     json!({

--- a/console/packages/console-rust/src/bridge/functions.rs
+++ b/console/packages/console-rust/src/bridge/functions.rs
@@ -1,5 +1,5 @@
 use iii_sdk::protocol::TriggerRequest;
-use iii_sdk::{RegisterFunction, III};
+use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{json, Value};
 use std::collections::HashSet;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -15,7 +15,7 @@ fn validate_flow_id(id: &str) -> Result<String, Value> {
             .chars()
             .all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == '.')
     {
-        return Err(error_response(iii_sdk::IIIError::Handler(format!(
+        return Err(error_response(iii_sdk::Error::Handler(format!(
             "Invalid flow_id: {}",
             id
         ))));
@@ -33,7 +33,7 @@ fn parse_bool_param(input: &Value, key: &str) -> bool {
     }
 }
 
-async fn handle_health(bridge: &III) -> Value {
+async fn handle_health(bridge: &IIIClient) -> Value {
     match bridge
         .trigger(TriggerRequest {
             function_id: "engine::health::check".to_string(),
@@ -48,7 +48,7 @@ async fn handle_health(bridge: &III) -> Value {
     }
 }
 
-async fn handle_workers(bridge: &III) -> Value {
+async fn handle_workers(bridge: &IIIClient) -> Value {
     match bridge
         .trigger(TriggerRequest {
             function_id: "engine::workers::list".to_string(),
@@ -63,7 +63,7 @@ async fn handle_workers(bridge: &III) -> Value {
     }
 }
 
-async fn handle_triggers_list(bridge: &III, input: Value) -> Value {
+async fn handle_triggers_list(bridge: &IIIClient, input: Value) -> Value {
     // The console `/triggers` route historically returned INSTANCES (subscriber
     // rows). After the engine_fn rework, `engine::triggers::list` returns
     // trigger TYPES, while instances now live behind
@@ -97,7 +97,7 @@ async fn handle_triggers_list(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_functions_list(bridge: &III, input: Value) -> Value {
+async fn handle_functions_list(bridge: &IIIClient, input: Value) -> Value {
     let include_internal = parse_bool_param(&input, "include_internal");
     let effective_input = json!({ "include_internal": include_internal });
     match bridge
@@ -114,7 +114,7 @@ async fn handle_functions_list(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_status(bridge: &III) -> Value {
+async fn handle_status(bridge: &IIIClient) -> Value {
     let (workers_result, functions_result, metrics_result) = tokio::join!(
         bridge.trigger(TriggerRequest {
             function_id: "engine::workers::list".to_string(),
@@ -164,7 +164,7 @@ async fn handle_status(bridge: &III) -> Value {
     }))
 }
 
-async fn handle_trigger_types(bridge: &III) -> Value {
+async fn handle_trigger_types(bridge: &IIIClient) -> Value {
     // After the engine_fn rework, `engine::triggers::list` returns trigger
     // TYPES directly with their `id` field. We just collect the ids — no need
     // to derive them from instances. The legacy static seeds are preserved as
@@ -219,7 +219,7 @@ async fn handle_trigger_types(bridge: &III) -> Value {
     }
 }
 
-async fn handle_alerts_list(bridge: &III) -> Value {
+async fn handle_alerts_list(bridge: &IIIClient) -> Value {
     match bridge
         .trigger(TriggerRequest {
             function_id: "engine::alerts::list".to_string(),
@@ -234,7 +234,7 @@ async fn handle_alerts_list(bridge: &III) -> Value {
     }
 }
 
-async fn handle_sampling_rules(bridge: &III) -> Value {
+async fn handle_sampling_rules(bridge: &IIIClient) -> Value {
     match bridge
         .trigger(TriggerRequest {
             function_id: "engine::sampling::rules".to_string(),
@@ -249,7 +249,7 @@ async fn handle_sampling_rules(bridge: &III) -> Value {
     }
 }
 
-async fn handle_otel_logs_list(bridge: &III, input: Value) -> Value {
+async fn handle_otel_logs_list(bridge: &IIIClient, input: Value) -> Value {
     let effective_input = input.get("body").cloned().unwrap_or(input);
     match bridge
         .trigger(TriggerRequest {
@@ -265,7 +265,7 @@ async fn handle_otel_logs_list(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_otel_logs_clear(bridge: &III) -> Value {
+async fn handle_otel_logs_clear(bridge: &IIIClient) -> Value {
     match bridge
         .trigger(TriggerRequest {
             function_id: "engine::logs::clear".to_string(),
@@ -280,7 +280,7 @@ async fn handle_otel_logs_clear(bridge: &III) -> Value {
     }
 }
 
-async fn handle_otel_traces_list(bridge: &III, input: Value) -> Value {
+async fn handle_otel_traces_list(bridge: &IIIClient, input: Value) -> Value {
     let effective_input = input.get("body").cloned().unwrap_or(input);
     match bridge
         .trigger(TriggerRequest {
@@ -296,7 +296,7 @@ async fn handle_otel_traces_list(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_otel_traces_clear(bridge: &III) -> Value {
+async fn handle_otel_traces_clear(bridge: &IIIClient) -> Value {
     match bridge
         .trigger(TriggerRequest {
             function_id: "engine::traces::clear".to_string(),
@@ -311,7 +311,7 @@ async fn handle_otel_traces_clear(bridge: &III) -> Value {
     }
 }
 
-async fn handle_otel_traces_tree(bridge: &III, input: Value) -> Value {
+async fn handle_otel_traces_tree(bridge: &IIIClient, input: Value) -> Value {
     // Extract trace_id from body wrapper or top-level input
     // API triggers wrap POST body inside a "body" field
     let trace_id = input
@@ -323,7 +323,7 @@ async fn handle_otel_traces_tree(bridge: &III, input: Value) -> Value {
     let trace_id = match trace_id {
         Some(id) => id.to_string(),
         None => {
-            return error_response(iii_sdk::IIIError::Handler(
+            return error_response(iii_sdk::Error::Handler(
                 "Missing trace_id in request".to_string(),
             ))
         }
@@ -345,7 +345,7 @@ async fn handle_otel_traces_tree(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_metrics_detailed(bridge: &III, input: Value) -> Value {
+async fn handle_metrics_detailed(bridge: &IIIClient, input: Value) -> Value {
     let effective_input = input.get("body").cloned().unwrap_or(input);
     match bridge
         .trigger(TriggerRequest {
@@ -361,7 +361,7 @@ async fn handle_metrics_detailed(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_rollups_list(bridge: &III, input: Value) -> Value {
+async fn handle_rollups_list(bridge: &IIIClient, input: Value) -> Value {
     let effective_input = input.get("body").cloned().unwrap_or(input);
     match bridge
         .trigger(TriggerRequest {
@@ -377,7 +377,7 @@ async fn handle_rollups_list(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_state_groups_list(bridge: &III, _input: Value) -> Value {
+async fn handle_state_groups_list(bridge: &IIIClient, _input: Value) -> Value {
     // Always use state::list_groups - no filtering by stream_name needed
     match bridge
         .trigger(TriggerRequest {
@@ -408,7 +408,7 @@ async fn handle_state_groups_list(bridge: &III, _input: Value) -> Value {
     }
 }
 
-async fn handle_state_group_items(bridge: &III, input: Value) -> Value {
+async fn handle_state_group_items(bridge: &IIIClient, input: Value) -> Value {
     // Extract scope from body or top-level input
     let scope = input
         .get("body")
@@ -446,13 +446,13 @@ async fn handle_state_group_items(bridge: &III, input: Value) -> Value {
                 Err(err) => error_response(err),
             }
         }
-        None => error_response(iii_sdk::IIIError::Handler(
+        None => error_response(iii_sdk::Error::Handler(
             "Missing scope in request".to_string(),
         )),
     }
 }
 
-async fn handle_state_item_set(bridge: &III, input: Value) -> Value {
+async fn handle_state_item_set(bridge: &IIIClient, input: Value) -> Value {
     // Extract path parameters (from URL: /states/:group/item)
     let path_params = input.get("path_params");
     let body = input.get("body");
@@ -465,7 +465,7 @@ async fn handle_state_item_set(bridge: &III, input: Value) -> Value {
     let group_id = match group_id {
         Some(id) => id.to_string(),
         None => {
-            return error_response(iii_sdk::IIIError::Handler(
+            return error_response(iii_sdk::Error::Handler(
                 "Missing group in path parameters".to_string(),
             ))
         }
@@ -480,7 +480,7 @@ async fn handle_state_item_set(bridge: &III, input: Value) -> Value {
     let item_id = match item_id {
         Some(id) => id.to_string(),
         None => {
-            return error_response(iii_sdk::IIIError::Handler(
+            return error_response(iii_sdk::Error::Handler(
                 "Missing key in request body".to_string(),
             ))
         }
@@ -493,7 +493,7 @@ async fn handle_state_item_set(bridge: &III, input: Value) -> Value {
     let data = match data {
         Some(value) => value.clone(),
         None => {
-            return error_response(iii_sdk::IIIError::Handler(
+            return error_response(iii_sdk::Error::Handler(
                 "Missing value in request body".to_string(),
             ))
         }
@@ -519,7 +519,7 @@ async fn handle_state_item_set(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_state_item_delete(bridge: &III, input: Value) -> Value {
+async fn handle_state_item_delete(bridge: &IIIClient, input: Value) -> Value {
     // Extract path parameters (from URL: /states/:group/item/:key)
     let path_params = input.get("path_params");
 
@@ -532,7 +532,7 @@ async fn handle_state_item_delete(bridge: &III, input: Value) -> Value {
     let group_id = match group_id {
         Some(id) => id.to_string(),
         None => {
-            return error_response(iii_sdk::IIIError::Handler(
+            return error_response(iii_sdk::Error::Handler(
                 "Missing group in path parameters".to_string(),
             ))
         }
@@ -546,7 +546,7 @@ async fn handle_state_item_delete(bridge: &III, input: Value) -> Value {
     let item_id = match item_id {
         Some(id) => id.to_string(),
         None => {
-            return error_response(iii_sdk::IIIError::Handler(
+            return error_response(iii_sdk::Error::Handler(
                 "Missing key in path parameters".to_string(),
             ))
         }
@@ -571,7 +571,7 @@ async fn handle_state_item_delete(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_adapters(bridge: &III) -> Value {
+async fn handle_adapters(bridge: &IIIClient) -> Value {
     // `handle_adapters` reads INSTANCE rows to derive which modules + trigger
     // handlers are active, so it points at `engine::registered-triggers::list`
     // now (the old `engine::triggers::list` returns TYPES post-rework).
@@ -732,7 +732,7 @@ async fn handle_adapters(bridge: &III) -> Value {
     }))
 }
 
-async fn handle_streams_list(bridge: &III) -> Value {
+async fn handle_streams_list(bridge: &IIIClient) -> Value {
     match bridge
         .trigger(TriggerRequest {
             function_id: "stream::list_all".to_string(),
@@ -785,7 +785,7 @@ async fn handle_streams_list(bridge: &III) -> Value {
     }
 }
 
-async fn handle_flow_config_get(bridge: &III, input: Value) -> Value {
+async fn handle_flow_config_get(bridge: &IIIClient, input: Value) -> Value {
     // Get flow_id from path_params or query_params
     let flow_id = input
         .get("path_params")
@@ -802,7 +802,7 @@ async fn handle_flow_config_get(bridge: &III, input: Value) -> Value {
     let flow_id = match flow_id {
         Some(id) => id.to_string(),
         None => {
-            return error_response(iii_sdk::IIIError::Handler(
+            return error_response(iii_sdk::Error::Handler(
                 "Missing flow_id parameter".to_string(),
             ))
         }
@@ -842,7 +842,7 @@ async fn handle_flow_config_get(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_invoke(bridge: &III, input: Value) -> Value {
+async fn handle_invoke(bridge: &IIIClient, input: Value) -> Value {
     let body = input.get("body").unwrap_or(&input);
 
     let function_id = body
@@ -853,7 +853,7 @@ async fn handle_invoke(bridge: &III, input: Value) -> Value {
     let function_id = match function_id {
         Some(id) => id.to_string(),
         None => {
-            return error_response(iii_sdk::IIIError::Handler(
+            return error_response(iii_sdk::Error::Handler(
                 "Missing function_id in request".to_string(),
             ))
         }
@@ -879,7 +879,7 @@ async fn handle_invoke(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_cron_trigger(bridge: &III, input: Value) -> Value {
+async fn handle_cron_trigger(bridge: &IIIClient, input: Value) -> Value {
     let body = input.get("body").unwrap_or(&input);
 
     let trigger_id = body
@@ -890,7 +890,7 @@ async fn handle_cron_trigger(bridge: &III, input: Value) -> Value {
     let trigger_id = match trigger_id {
         Some(id) if !id.is_empty() => id.to_string(),
         _ => {
-            return error_response(iii_sdk::IIIError::Handler(
+            return error_response(iii_sdk::Error::Handler(
                 "Missing trigger_id in request".to_string(),
             ))
         }
@@ -937,7 +937,7 @@ async fn handle_cron_trigger(bridge: &III, input: Value) -> Value {
         let trigger = match trigger_match {
             Some(trigger) => trigger,
             None => {
-                return error_response(iii_sdk::IIIError::Handler(format!(
+                return error_response(iii_sdk::Error::Handler(format!(
                     "Cron trigger '{}' not found",
                     trigger_id
                 )))
@@ -950,7 +950,7 @@ async fn handle_cron_trigger(bridge: &III, input: Value) -> Value {
             .unwrap_or_default();
 
         if trigger_type != "cron" {
-            return error_response(iii_sdk::IIIError::Handler(format!(
+            return error_response(iii_sdk::Error::Handler(format!(
                 "Trigger '{}' is not a cron trigger",
                 trigger_id
             )));
@@ -959,7 +959,7 @@ async fn handle_cron_trigger(bridge: &III, input: Value) -> Value {
         match trigger.get("function_id").and_then(|v| v.as_str()) {
             Some(id) if !id.is_empty() => id.to_string(),
             _ => {
-                return error_response(iii_sdk::IIIError::Handler(format!(
+                return error_response(iii_sdk::Error::Handler(format!(
                     "Cron trigger '{}' has no function_id",
                     trigger_id
                 )))
@@ -998,7 +998,7 @@ async fn handle_cron_trigger(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_flow_config_save(bridge: &III, input: Value) -> Value {
+async fn handle_flow_config_save(bridge: &IIIClient, input: Value) -> Value {
     let body = input.get("body").cloned().unwrap_or(input.clone());
 
     let flow_id = input
@@ -1010,7 +1010,7 @@ async fn handle_flow_config_save(bridge: &III, input: Value) -> Value {
     let flow_id = match flow_id {
         Some(id) => id.to_string(),
         None => {
-            return error_response(iii_sdk::IIIError::Handler(
+            return error_response(iii_sdk::Error::Handler(
                 "Missing flow_id parameter".to_string(),
             ))
         }
@@ -1044,7 +1044,7 @@ async fn handle_flow_config_save(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_queues_list(bridge: &III) -> Value {
+async fn handle_queues_list(bridge: &IIIClient) -> Value {
     match bridge
         .trigger(TriggerRequest {
             function_id: "engine::queue::list_topics".to_string(),
@@ -1059,7 +1059,7 @@ async fn handle_queues_list(bridge: &III) -> Value {
     }
 }
 
-async fn handle_queue_detail(bridge: &III, input: Value) -> Value {
+async fn handle_queue_detail(bridge: &IIIClient, input: Value) -> Value {
     let topic = input
         .get("path_params")
         .and_then(|p| p.get("topic"))
@@ -1069,7 +1069,7 @@ async fn handle_queue_detail(bridge: &III, input: Value) -> Value {
     let topic = match topic {
         Some(t) => t.to_string(),
         None => {
-            return error_response(iii_sdk::IIIError::Handler(
+            return error_response(iii_sdk::Error::Handler(
                 "Missing topic in path parameters".to_string(),
             ))
         }
@@ -1089,7 +1089,7 @@ async fn handle_queue_detail(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_queue_publish(bridge: &III, input: Value) -> Value {
+async fn handle_queue_publish(bridge: &IIIClient, input: Value) -> Value {
     let topic = input
         .get("path_params")
         .and_then(|p| p.get("topic"))
@@ -1099,7 +1099,7 @@ async fn handle_queue_publish(bridge: &III, input: Value) -> Value {
     let topic = match topic {
         Some(t) => t.to_string(),
         None => {
-            return error_response(iii_sdk::IIIError::Handler(
+            return error_response(iii_sdk::Error::Handler(
                 "Missing topic in path parameters".to_string(),
             ))
         }
@@ -1122,7 +1122,7 @@ async fn handle_queue_publish(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_dlq_list(bridge: &III) -> Value {
+async fn handle_dlq_list(bridge: &IIIClient) -> Value {
     match bridge
         .trigger(TriggerRequest {
             function_id: "engine::queue::dlq_topics".to_string(),
@@ -1137,7 +1137,7 @@ async fn handle_dlq_list(bridge: &III) -> Value {
     }
 }
 
-async fn handle_dlq_messages(bridge: &III, input: Value) -> Value {
+async fn handle_dlq_messages(bridge: &IIIClient, input: Value) -> Value {
     let topic = input
         .get("path_params")
         .and_then(|p| p.get("topic"))
@@ -1147,7 +1147,7 @@ async fn handle_dlq_messages(bridge: &III, input: Value) -> Value {
     let topic = match topic {
         Some(t) => t.to_string(),
         None => {
-            return error_response(iii_sdk::IIIError::Handler(
+            return error_response(iii_sdk::Error::Handler(
                 "Missing topic in path parameters".to_string(),
             ))
         }
@@ -1171,7 +1171,7 @@ async fn handle_dlq_messages(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_dlq_redrive(bridge: &III, input: Value) -> Value {
+async fn handle_dlq_redrive(bridge: &IIIClient, input: Value) -> Value {
     let topic = input
         .get("path_params")
         .and_then(|p| p.get("topic"))
@@ -1181,7 +1181,7 @@ async fn handle_dlq_redrive(bridge: &III, input: Value) -> Value {
     let topic = match topic {
         Some(t) => t.to_string(),
         None => {
-            return error_response(iii_sdk::IIIError::Handler(
+            return error_response(iii_sdk::Error::Handler(
                 "Missing topic in path parameters".to_string(),
             ))
         }
@@ -1201,7 +1201,7 @@ async fn handle_dlq_redrive(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_dlq_redrive_message(bridge: &III, input: Value) -> Value {
+async fn handle_dlq_redrive_message(bridge: &IIIClient, input: Value) -> Value {
     let topic = input
         .get("path_params")
         .and_then(|p| p.get("topic"))
@@ -1215,7 +1215,7 @@ async fn handle_dlq_redrive_message(bridge: &III, input: Value) -> Value {
     let (topic, message_id) = match (topic, message_id) {
         (Some(t), Some(m)) => (t.to_string(), m.to_string()),
         _ => {
-            return error_response(iii_sdk::IIIError::Handler(
+            return error_response(iii_sdk::Error::Handler(
                 "Missing topic or message id in path parameters".to_string(),
             ))
         }
@@ -1235,7 +1235,7 @@ async fn handle_dlq_redrive_message(bridge: &III, input: Value) -> Value {
     }
 }
 
-async fn handle_dlq_discard_message(bridge: &III, input: Value) -> Value {
+async fn handle_dlq_discard_message(bridge: &IIIClient, input: Value) -> Value {
     let topic = input
         .get("path_params")
         .and_then(|p| p.get("topic"))
@@ -1249,7 +1249,7 @@ async fn handle_dlq_discard_message(bridge: &III, input: Value) -> Value {
     let (topic, message_id) = match (topic, message_id) {
         (Some(t), Some(m)) => (t.to_string(), m.to_string()),
         _ => {
-            return error_response(iii_sdk::IIIError::Handler(
+            return error_response(iii_sdk::Error::Handler(
                 "Missing topic or message id in path parameters".to_string(),
             ))
         }
@@ -1269,7 +1269,7 @@ async fn handle_dlq_discard_message(bridge: &III, input: Value) -> Value {
     }
 }
 
-pub fn register_functions(bridge: &III) {
+pub fn register_functions(bridge: &IIIClient) {
     let b = bridge.clone();
     bridge.register_function(
         "engine::console::health",

--- a/console/packages/console-rust/src/bridge/triggers.rs
+++ b/console/packages/console-rust/src/bridge/triggers.rs
@@ -1,10 +1,10 @@
 use iii_sdk::protocol::RegisterTriggerInput;
-use iii_sdk::{IIIError, III};
+use iii_sdk::{Error, IIIClient};
 use serde_json::json;
 use tracing::info;
 
 /// Most triggers use HTTP GET method. The invoke endpoint uses POST.
-pub fn register_triggers(bridge: &III) -> Result<(), IIIError> {
+pub fn register_triggers(bridge: &IIIClient) -> Result<(), Error> {
     let triggers = vec![
         ("engine::console::status", "_console/status", "GET"),
         ("engine::console::health", "_console/health", "GET"),

--- a/console/packages/console-rust/src/main.rs
+++ b/console/packages/console-rust/src/main.rs
@@ -160,12 +160,12 @@ async fn main() -> Result<()> {
     let bridge = iii_sdk::register_worker(
         &bridge_url,
         iii_sdk::InitOptions {
-            metadata: Some(iii_sdk::WorkerMetadata {
+            metadata: Some(iii_sdk::runtime::WorkerMetadata {
                 name: "iii-console".to_string(),
                 description: Some(
                     "Web console UI and observability dashboard for the iii engine.".to_string(),
                 ),
-                ..iii_sdk::WorkerMetadata::default()
+                ..iii_sdk::runtime::WorkerMetadata::default()
             }),
             otel: otel_config,
             headers: None,

--- a/crates/iii-worker/src/cli/sandbox.rs
+++ b/crates/iii-worker/src/cli/sandbox.rs
@@ -8,7 +8,7 @@
 //! that calls the sandbox daemon directly via `iii.trigger(TriggerRequest{...})`.
 
 use iii_sdk::protocol::TriggerRequest;
-use iii_sdk::{III, IIIError, InitOptions, register_worker};
+use iii_sdk::{Error, IIIClient, InitOptions, register_worker};
 use serde_json::{Value, json};
 
 use crate::cli::rootfs_cache;
@@ -24,8 +24,8 @@ const DAEMON_DEFAULT_EXEC_TIMEOUT_MS: u64 = 300_000;
 const EXEC_TRIGGER_MARGIN_MS: u64 = 5_000;
 
 /// Connect to the local engine on the given port. Returns the connected
-/// `III` handle; callers are responsible for `iii.shutdown()` before return.
-fn connect(port: u16) -> III {
+/// `IIIClient` handle; callers are responsible for `iii.shutdown()` before return.
+fn connect(port: u16) -> IIIClient {
     register_worker(&format!("ws://127.0.0.1:{port}"), InitOptions::default())
 }
 
@@ -77,7 +77,7 @@ async fn preflight_pull_if_preset(image: &str) {
 /// payload only has a message (or the body isn't JSON at all), the
 /// formatted string falls back to bare message / raw error display so we
 /// never strip information.
-fn handler_error_message(err: &IIIError) -> String {
+fn handler_error_message(err: &Error) -> String {
     let raw = err.to_string();
     let stripped = raw.strip_prefix("handler error: ").unwrap_or(&raw);
     let Some(brace) = stripped.find('{') else {
@@ -302,7 +302,7 @@ pub async fn handle_exec(
     // when absent the handler defaults to DAEMON_DEFAULT_EXEC_TIMEOUT_MS. Either
     // way we add EXEC_TRIGGER_MARGIN_MS so the daemon's own deadline fires before
     // the trigger times out, ensuring proper timed_out signalling rather than a
-    // bare IIIError::Timeout.
+    // bare Error::Timeout.
     let trigger_timeout_ms =
         Some(timeout_ms.unwrap_or(DAEMON_DEFAULT_EXEC_TIMEOUT_MS) + EXEC_TRIGGER_MARGIN_MS);
 
@@ -585,7 +585,7 @@ pub async fn handle_download(
     local_path: String,
     port: u16,
 ) -> i32 {
-    use iii_sdk::{ChannelReader, StreamChannelRef};
+    use iii_sdk::channel::{ChannelReader, StreamChannelRef};
     use tokio::io::AsyncWriteExt;
 
     let iii = connect(port);
@@ -683,11 +683,11 @@ pub async fn handle_download(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use iii_sdk::IIIError;
+    use iii_sdk::Error;
 
     #[test]
     fn extracts_message_from_flat_payload() {
-        let e = IIIError::Handler(
+        let e = Error::Handler(
             r#"{"type":"SandboxNotFound","code":"S002","message":"sandbox abc not found"}"#.into(),
         );
         assert_eq!(handler_error_message(&e), "[S002] sandbox abc not found");
@@ -695,9 +695,8 @@ mod tests {
 
     #[test]
     fn extracts_message_from_nested_payload() {
-        let e = IIIError::Handler(
-            r#"{"error":{"code":"S002","message":"sandbox abc not found"}}"#.into(),
-        );
+        let e =
+            Error::Handler(r#"{"error":{"code":"S002","message":"sandbox abc not found"}}"#.into());
         assert_eq!(handler_error_message(&e), "[S002] sandbox abc not found");
     }
 
@@ -706,7 +705,7 @@ mod tests {
     /// no `[None]`-style placeholder, no thrown information.
     #[test]
     fn omits_code_prefix_when_only_message_present() {
-        let e = IIIError::Handler(r#"{"message":"some other error"}"#.into());
+        let e = Error::Handler(r#"{"message":"some other error"}"#.into());
         assert_eq!(handler_error_message(&e), "some other error");
     }
 
@@ -715,7 +714,7 @@ mod tests {
     /// in stderr where shell scripts can grep for it.
     #[test]
     fn fs_trigger_payload_carries_s_code_without_doubled_prefix() {
-        let e = IIIError::Handler(
+        let e = Error::Handler(
             r#"{"type":"filesystem","code":"S211","message":"path not found: /tmp/no/such/file","retryable":false}"#
                 .into(),
         );
@@ -735,7 +734,7 @@ mod tests {
 
     #[test]
     fn falls_back_on_non_json_handler_body() {
-        let e = IIIError::Handler("bad request: missing field".into());
+        let e = Error::Handler("bad request: missing field".into());
         assert_eq!(
             handler_error_message(&e),
             "handler error: bad request: missing field"
@@ -744,7 +743,7 @@ mod tests {
 
     #[test]
     fn falls_back_on_non_handler_variant() {
-        let e = IIIError::Timeout;
+        let e = Error::Timeout;
         assert_eq!(handler_error_message(&e), "invocation timed out");
     }
 }

--- a/crates/iii-worker/src/cli/worker_manager_daemon.rs
+++ b/crates/iii-worker/src/cli/worker_manager_daemon.rs
@@ -25,9 +25,9 @@ use crate::core::{
     stop as core_stop, update as core_update,
 };
 use iii_helpers::observability::OtelConfig;
+use iii_sdk::runtime::WorkerMetadata;
 use iii_sdk::{
-    III, IIIError, InitOptions, RegisterFunction, RegisterTriggerType, WorkerMetadata,
-    register_worker,
+    Error, IIIClient, InitOptions, RegisterFunction, RegisterTriggerType, register_worker,
 };
 use schemars::{JsonSchema, schema_for};
 use serde_json::{Value, json};
@@ -161,19 +161,19 @@ pub fn bad_request_payload(function_id: &str, e: &serde_json::Error) -> String {
     err_payload(&err)
 }
 
-/// Surface op failures as `IIIError::Remote` so the wire `ErrorBody.code`
+/// Surface op failures as `Error::Remote` so the wire `ErrorBody.code`
 /// is the stable W-code (instead of the generic `invocation_failed`) and no
 /// dispatch-loop backtrace gets attached to an expected error.
-fn op_error(e: &WorkerOpError) -> IIIError {
-    IIIError::Remote {
+fn op_error(e: &WorkerOpError) -> Error {
+    Error::Remote {
         code: e.kind().code().to_string(),
         message: err_payload(e),
         stacktrace: None,
     }
 }
 
-fn bad_request_error(function_id: &str, e: &serde_json::Error) -> IIIError {
-    IIIError::Remote {
+fn bad_request_error(function_id: &str, e: &serde_json::Error) -> Error {
+    Error::Remote {
         code: WorkerOpErrorKind::BadRequest.code().to_string(),
         message: bad_request_payload(function_id, e),
         stacktrace: None,
@@ -264,7 +264,7 @@ fn describe_op(rf: RegisterFunction, function_id: &str) -> RegisterFunction {
     }))
 }
 
-fn register_all(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
+fn register_all(iii: &IIIClient, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     register_add(iii, project_root.clone(), sink.clone());
     register_remove(iii, project_root.clone(), sink.clone());
     register_update(iii, project_root.clone(), sink.clone());
@@ -414,7 +414,7 @@ fn schema_table() -> &'static [(&'static str, Option<Value>, Option<Value>)] {
     &TABLE
 }
 
-fn register_logs(iii: &III) {
+fn register_logs(iii: &IIIClient) {
     let _ =
         iii.register_function(
             "worker::logs",
@@ -430,7 +430,7 @@ fn register_logs(iii: &III) {
         );
 }
 
-fn register_schema(iii: &III) {
+fn register_schema(iii: &IIIClient) {
     let rf = RegisterFunction::new_async_with_bad_request(
         |req: SchemaRequest| async move {
             let filter = req.function_id.as_deref();
@@ -449,7 +449,7 @@ fn register_schema(iii: &III) {
                     }
                 })
                 .collect();
-            Ok::<_, IIIError>(SchemaResponse { schemas })
+            Ok::<_, Error>(SchemaResponse { schemas })
         },
         |e| bad_request_error("worker::schema", &e),
     );
@@ -532,7 +532,7 @@ async fn build_status(name: &str) -> Result<StatusOutcome, WorkerOpError> {
     })
 }
 
-fn register_status(iii: &III) {
+fn register_status(iii: &IIIClient) {
     let rf = RegisterFunction::new_async_with_bad_request(
         |opts: StatusOptions| async move { build_status(&opts.name).await.map_err(|e| op_error(&e)) },
         |e| bad_request_error("worker::status", &e),
@@ -545,7 +545,7 @@ fn register_status(iii: &III) {
 /// validate → fix → `worker::add`. Accepts exactly one of `manifest` (inline
 /// YAML text, preferred for authoring) or `path` (host file or worker dir,
 /// resolved like `worker::add { kind: "local" }`).
-fn register_validate(iii: &III) {
+fn register_validate(iii: &IIIClient) {
     let rf = RegisterFunction::new_async_with_bad_request(
         |opts: ValidateOptions| async move {
             let report: ManifestReport = match (opts.manifest, opts.path) {
@@ -597,7 +597,7 @@ fn register_validate(iii: &III) {
                     }
                 }
             };
-            Ok::<_, IIIError>(report)
+            Ok::<_, Error>(report)
         },
         |e| bad_request_error("worker::validate", &e),
     );
@@ -611,7 +611,7 @@ fn sink_ref<'a>(sink: &'a Arc<IIIEventSink>) -> &'a dyn EventSink {
     &**sink
 }
 
-fn register_add(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
+fn register_add(iii: &IIIClient, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         "worker::add",
         describe_op(
@@ -633,7 +633,7 @@ fn register_add(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     );
 }
 
-fn register_remove(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
+fn register_remove(iii: &IIIClient, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         "worker::remove",
         describe_op(
@@ -655,7 +655,7 @@ fn register_remove(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     );
 }
 
-fn register_update(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
+fn register_update(iii: &IIIClient, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         "worker::update",
         describe_op(
@@ -677,7 +677,7 @@ fn register_update(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     );
 }
 
-fn register_start(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
+fn register_start(iii: &IIIClient, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         "worker::start",
         describe_op(
@@ -699,7 +699,7 @@ fn register_start(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     );
 }
 
-fn register_stop(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
+fn register_stop(iii: &IIIClient, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         "worker::stop",
         describe_op(
@@ -721,7 +721,7 @@ fn register_stop(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     );
 }
 
-fn register_list(iii: &III, project_root: PathBuf) {
+fn register_list(iii: &IIIClient, project_root: PathBuf) {
     // `Option<ListOptions>` keeps the lenient default: a `null` payload
     // deserializes to `None` (→ defaults) and `{}` to `Some(default)`, while
     // any other malformed shape still fails deserialization and returns the
@@ -748,7 +748,7 @@ fn register_list(iii: &III, project_root: PathBuf) {
     let _ = iii.register_function("worker::list", rf);
 }
 
-fn register_clear(iii: &III, project_root: PathBuf, sink: Arc<IIIEventSink>) {
+fn register_clear(iii: &IIIClient, project_root: PathBuf, sink: Arc<IIIEventSink>) {
     let _ = iii.register_function(
         "worker::clear",
         describe_op(
@@ -818,11 +818,11 @@ mod tests {
         assert_eq!(resp.as_ref().unwrap(), &hello_world_example_json());
     }
 
-    // `III` exposes no registry listing, so the duplicate-registration
+    // `IIIClient` exposes no registry listing, so the duplicate-registration
     // panic is the only externally observable proof that `register_all`
     // claimed a function id.
-    fn offline_iii_with_sink() -> (III, Arc<IIIEventSink>) {
-        let iii = III::new("ws://127.0.0.1:9");
+    fn offline_iii_with_sink() -> (IIIClient, Arc<IIIEventSink>) {
+        let iii = IIIClient::new("ws://127.0.0.1:9");
         let subs: Subscriptions = Arc::new(Mutex::new(HashMap::new()));
         let sink = Arc::new(IIIEventSink::new(iii.clone(), subs, CallerMode::Trigger));
         (iii, sink)
@@ -836,7 +836,7 @@ mod tests {
 
         iii.register_function(
             "worker::status",
-            RegisterFunction::new_async(|input: Value| async move { Ok::<_, IIIError>(input) }),
+            RegisterFunction::new_async(|input: Value| async move { Ok::<_, Error>(input) }),
         );
     }
 
@@ -848,7 +848,7 @@ mod tests {
 
         iii.register_function(
             "worker::validate",
-            RegisterFunction::new_async(|input: Value| async move { Ok::<_, IIIError>(input) }),
+            RegisterFunction::new_async(|input: Value| async move { Ok::<_, Error>(input) }),
         );
     }
 

--- a/crates/iii-worker/src/cli/worker_trigger.rs
+++ b/crates/iii-worker/src/cli/worker_trigger.rs
@@ -22,7 +22,8 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use iii_sdk::protocol::TriggerRequest;
-use iii_sdk::{III, IIIError, TriggerAction, TriggerConfig, TriggerHandler};
+use iii_sdk::trigger::{TriggerConfig, TriggerHandler};
+use iii_sdk::{Error, IIIClient, TriggerAction};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -206,7 +207,7 @@ pub type Subscriptions = Arc<Mutex<HashMap<String, Subscription>>>;
 
 /// `TriggerHandler` for the `worker` trigger type. Inserts on register,
 /// removes on unregister. Rejects malformed `WorkerTriggerConfig`
-/// payloads with [`IIIError::Handler`] so the engine reports them back
+/// payloads with [`Error::Handler`] so the engine reports them back
 /// to the caller with `trigger_registration_failed`.
 pub struct WorkerTriggerHandler {
     subs: Subscriptions,
@@ -220,12 +221,12 @@ impl WorkerTriggerHandler {
 
 #[async_trait]
 impl TriggerHandler for WorkerTriggerHandler {
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         let parsed: WorkerTriggerConfig = if config.config.is_null() {
             WorkerTriggerConfig::default()
         } else {
             serde_json::from_value(config.config.clone())
-                .map_err(|e| IIIError::Handler(format!("invalid WorkerTriggerConfig: {e}")))?
+                .map_err(|e| Error::Handler(format!("invalid WorkerTriggerConfig: {e}")))?
         };
         let mut subs = self.subs.lock().unwrap_or_else(|e| e.into_inner());
         subs.insert(
@@ -238,7 +239,7 @@ impl TriggerHandler for WorkerTriggerHandler {
         Ok(())
     }
 
-    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         let mut subs = self.subs.lock().unwrap_or_else(|e| e.into_inner());
         subs.remove(&config.id);
         Ok(())
@@ -263,7 +264,7 @@ pub struct IIIEventSink {
 }
 
 impl IIIEventSink {
-    pub fn new(iii: III, subs: Subscriptions, caller_mode: CallerMode) -> Self {
+    pub fn new(iii: IIIClient, subs: Subscriptions, caller_mode: CallerMode) -> Self {
         let (dispatch_tx, mut dispatch_rx) =
             tokio::sync::mpsc::unbounded_channel::<(String, serde_json::Value)>();
         // Spawn the dispatcher only when a tokio runtime is available.
@@ -590,7 +591,7 @@ mod tests {
             metadata: None,
         };
         let err = handler.register_trigger(cfg).await.unwrap_err();
-        assert!(matches!(err, IIIError::Handler(_)));
+        assert!(matches!(err, Error::Handler(_)));
     }
 
     #[test]

--- a/crates/iii-worker/src/sandbox_daemon/errors.rs
+++ b/crates/iii-worker/src/sandbox_daemon/errors.rs
@@ -423,7 +423,7 @@ impl SandboxError {
 /// in `SandboxErrorWire` and `map_err`-ing into it makes `Display` emit
 /// that JSON, so callers (CLI, agents, engine clients) see the exact
 /// same body they did when handlers wrote
-/// `IIIError::Handler(serde_json::to_string(&e.to_payload())…)` by hand.
+/// `Error::Handler(serde_json::to_string(&e.to_payload())…)` by hand.
 ///
 /// SDK contract dependency: this wrapper is load-bearing only as long as
 /// `iii_sdk::IntoAsyncHandler` collapses `E` via `e.to_string()` (i.e.
@@ -459,9 +459,9 @@ impl std::fmt::Debug for SandboxErrorWire {
     }
 }
 
-impl From<SandboxErrorWire> for iii_sdk::IIIError {
+impl From<SandboxErrorWire> for iii_sdk::Error {
     fn from(err: SandboxErrorWire) -> Self {
-        iii_sdk::IIIError::Handler(err.to_string())
+        iii_sdk::Error::Handler(err.to_string())
     }
 }
 
@@ -668,7 +668,7 @@ mod tests {
 
     /// Pins the wire format `RegisterFunction::new_async` callers see for
     /// `sandbox::*` errors. Before the migration, handlers wrote
-    /// `IIIError::Handler(serde_json::to_string(&e.to_payload())…)`
+    /// `Error::Handler(serde_json::to_string(&e.to_payload())…)`
     /// directly; after, they `map_err` into `SandboxErrorWire` and the
     /// SDK's async-handler glue calls `Display`. This test asserts both
     /// paths produce the same JSON bytes, so callers branching on

--- a/crates/iii-worker/src/sandbox_daemon/fs/chmod.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/chmod.rs
@@ -87,7 +87,7 @@ pub async fn handle_chmod<R: FsRunner + ?Sized>(
 }
 
 pub(super) fn register(
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
     registry: Arc<SandboxRegistry>,
     runner: Arc<dyn FsRunner>,
 ) {

--- a/crates/iii-worker/src/sandbox_daemon/fs/grep.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/grep.rs
@@ -114,7 +114,7 @@ pub async fn handle_grep<R: FsRunner + ?Sized>(
 }
 
 pub(super) fn register(
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
     registry: Arc<SandboxRegistry>,
     runner: Arc<dyn FsRunner>,
 ) {

--- a/crates/iii-worker/src/sandbox_daemon/fs/ls.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/ls.rs
@@ -66,7 +66,7 @@ pub async fn handle_ls<R: FsRunner + ?Sized>(
 }
 
 pub(super) fn register(
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
     registry: Arc<SandboxRegistry>,
     runner: Arc<dyn FsRunner>,
 ) {

--- a/crates/iii-worker/src/sandbox_daemon/fs/mkdir.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/mkdir.rs
@@ -85,7 +85,7 @@ pub async fn handle_mkdir<R: FsRunner + ?Sized>(
 }
 
 pub(super) fn register(
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
     registry: Arc<SandboxRegistry>,
     runner: Arc<dyn FsRunner>,
 ) {

--- a/crates/iii-worker/src/sandbox_daemon/fs/mod.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/mod.rs
@@ -27,7 +27,11 @@ use std::sync::Arc;
 use crate::sandbox_daemon::registry::SandboxRegistry;
 
 /// Register all ten `sandbox::fs::*` triggers with the III engine.
-pub fn register_all(iii: &iii_sdk::III, registry: Arc<SandboxRegistry>, runner: Arc<dyn FsRunner>) {
+pub fn register_all(
+    iii: &iii_sdk::IIIClient,
+    registry: Arc<SandboxRegistry>,
+    runner: Arc<dyn FsRunner>,
+) {
     ls::register(iii, registry.clone(), runner.clone());
     stat::register(iii, registry.clone(), runner.clone());
     mkdir::register(iii, registry.clone(), runner.clone());

--- a/crates/iii-worker/src/sandbox_daemon/fs/mv.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/mv.rs
@@ -80,7 +80,7 @@ pub async fn handle_mv<R: FsRunner + ?Sized>(
 }
 
 pub(super) fn register(
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
     registry: Arc<SandboxRegistry>,
     runner: Arc<dyn FsRunner>,
 ) {

--- a/crates/iii-worker/src/sandbox_daemon/fs/read.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/read.rs
@@ -86,7 +86,7 @@ pub async fn handle_read<R: FsRunner + ?Sized>(
     req: ReadRequest,
     registry: &SandboxRegistry,
     runner: &R,
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
 ) -> Result<ReadResponse, SandboxError> {
     let id = Uuid::parse_str(&req.sandbox_id).map_err(|_| {
         SandboxError::InvalidRequest(format!(
@@ -178,7 +178,7 @@ pub async fn handle_read<R: FsRunner + ?Sized>(
 /// the buffered bytes so the channel still serves the same payload to
 /// legacy subscribers).
 async fn stream_via_channel(
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
     mut reader: Box<dyn tokio::io::AsyncRead + Unpin + Send>,
     meta: iii_shell_proto::FsReadMeta,
     body: Option<String>,
@@ -245,7 +245,7 @@ async fn stream_via_channel(
 // ---------------------------------------------------------------------------
 
 pub(super) fn register(
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
     registry: Arc<SandboxRegistry>,
     runner: Arc<dyn FsRunner>,
 ) {
@@ -282,15 +282,15 @@ pub(super) fn register(
 // Tests
 // ---------------------------------------------------------------------------
 //
-// Unit tests for `handle_read` require a real `iii_sdk::III` that connects
+// Unit tests for `handle_read` require a real `iii_sdk::IIIClient` that connects
 // to a live engine (for `create_channel`). Without an engine, the call
 // fails at channel allocation. End-to-end coverage is deferred to Phase 6
 // (external_known_sandbox_fs.rs). The S001/S002 guard tests below pass a
-// dummy `&iii_sdk::III` value from `register_worker` so they don't need
+// dummy `&iii_sdk::IIIClient` value from `register_worker` so they don't need
 // a live engine — they assert early-exit before the channel call.
 //
 // NOTE: S001/S002 tests are omitted here because constructing even a
-// disconnected `III` handle requires starting the background runtime thread
+// disconnected `IIIClient` handle requires starting the background runtime thread
 // and a valid engine URL. The guard logic (UUID parse and registry lookup)
 // is identical to every other fs trigger and is covered by those test suites.
 // The background-task lifecycle (pump loop) is covered by Phase 6 e2e tests.

--- a/crates/iii-worker/src/sandbox_daemon/fs/rm.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/rm.rs
@@ -76,7 +76,7 @@ pub async fn handle_rm<R: FsRunner + ?Sized>(
 }
 
 pub(super) fn register(
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
     registry: Arc<SandboxRegistry>,
     runner: Arc<dyn FsRunner>,
 ) {

--- a/crates/iii-worker/src/sandbox_daemon/fs/sed.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/sed.rs
@@ -141,7 +141,7 @@ pub async fn handle_sed<R: FsRunner + ?Sized>(
 }
 
 pub(super) fn register(
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
     registry: Arc<SandboxRegistry>,
     runner: Arc<dyn FsRunner>,
 ) {

--- a/crates/iii-worker/src/sandbox_daemon/fs/stat.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/stat.rs
@@ -86,7 +86,7 @@ pub async fn handle_stat<R: FsRunner + ?Sized>(
 }
 
 pub(super) fn register(
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
     registry: Arc<SandboxRegistry>,
     runner: Arc<dyn FsRunner>,
 ) {

--- a/crates/iii-worker/src/sandbox_daemon/fs/write.rs
+++ b/crates/iii-worker/src/sandbox_daemon/fs/write.rs
@@ -45,7 +45,7 @@ use crate::sandbox_daemon::{
 pub struct ChannelReaderAdapter {
     reader: Arc<ChannelReader>,
     pending_buf: Vec<u8>,
-    pending_task: Option<tokio::task::JoinHandle<Result<Option<Vec<u8>>, iii_sdk::IIIError>>>,
+    pending_task: Option<tokio::task::JoinHandle<Result<Option<Vec<u8>>, iii_sdk::Error>>>,
     eof: bool,
 }
 
@@ -303,7 +303,7 @@ pub async fn handle_write<R: FsRunner + ?Sized>(
 // ---------------------------------------------------------------------------
 
 pub(super) fn register(
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
     registry: Arc<SandboxRegistry>,
     runner: Arc<dyn FsRunner>,
 ) {

--- a/crates/iii-worker/src/sandbox_daemon/mod.rs
+++ b/crates/iii-worker/src/sandbox_daemon/mod.rs
@@ -104,7 +104,8 @@ If detail.fix is non-null, your next call is fn(detail.fix).
 use std::sync::Arc;
 
 use iii_helpers::observability::OtelConfig;
-use iii_sdk::{InitOptions, RegisterFunction, WorkerMetadata, register_worker};
+use iii_sdk::runtime::WorkerMetadata;
+use iii_sdk::{InitOptions, RegisterFunction, register_worker};
 
 use crate::sandbox_daemon::config::SandboxConfig;
 use crate::sandbox_daemon::errors::SandboxErrorWire;
@@ -197,7 +198,7 @@ pub async fn serve(config: SandboxConfig, engine_url: &str) -> anyhow::Result<()
 }
 
 fn register_sandbox_create(
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
     registry: Arc<crate::sandbox_daemon::SandboxRegistry>,
     cfg: Arc<crate::sandbox_daemon::config::SandboxConfig>,
     launcher: Arc<crate::sandbox_daemon::adapters::IiiWorkerLauncher>,
@@ -243,7 +244,7 @@ fn register_sandbox_create(
 }
 
 fn register_sandbox_exec(
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
     registry: Arc<crate::sandbox_daemon::SandboxRegistry>,
     runner: Arc<crate::sandbox_daemon::adapters::ShellProtoRunner>,
 ) {
@@ -279,7 +280,7 @@ fn register_sandbox_exec(
 }
 
 fn register_sandbox_stop(
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
     registry: Arc<crate::sandbox_daemon::SandboxRegistry>,
     stopper: Arc<crate::sandbox_daemon::adapters::SignalStopper>,
 ) {
@@ -310,7 +311,7 @@ fn register_sandbox_stop(
 }
 
 fn register_sandbox_list(
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
     registry: Arc<crate::sandbox_daemon::SandboxRegistry>,
 ) {
     // Note: pre-migration this handler used
@@ -338,7 +339,7 @@ fn register_sandbox_list(
                     &result,
                     start.elapsed().as_millis() as u64,
                 );
-                Ok::<_, iii_sdk::IIIError>(result.unwrap())
+                Ok::<_, iii_sdk::Error>(result.unwrap())
             }
         })
         .description("List active sandboxes"),
@@ -346,7 +347,7 @@ fn register_sandbox_list(
 }
 
 fn register_sandbox_catalog_list(
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
     cfg: Arc<crate::sandbox_daemon::config::SandboxConfig>,
 ) {
     let _ = iii.register_function(
@@ -365,7 +366,7 @@ fn register_sandbox_catalog_list(
                         &result,
                         start.elapsed().as_millis() as u64,
                     );
-                    Ok::<_, iii_sdk::IIIError>(result.unwrap())
+                    Ok::<_, iii_sdk::Error>(result.unwrap())
                 }
             },
         )

--- a/crates/iii-worker/src/sandbox_daemon/run.rs
+++ b/crates/iii-worker/src/sandbox_daemon/run.rs
@@ -328,7 +328,7 @@ fn step_error(step: &str, sandbox_id: Option<&str>, e: SandboxError) -> SandboxE
 // ---------------------------------------------------------------------------
 
 pub(super) fn register(
-    iii: &iii_sdk::III,
+    iii: &iii_sdk::IIIClient,
     registry: Arc<SandboxRegistry>,
     cfg: Arc<SandboxConfig>,
     launcher: Arc<crate::sandbox_daemon::adapters::IiiWorkerLauncher>,

--- a/crates/iii-worker/tests/fixtures/templates/worker-bare/src/main.rs
+++ b/crates/iii-worker/tests/fixtures/templates/worker-bare/src/main.rs
@@ -1,4 +1,4 @@
-use iii_sdk::{IIIError, InitOptions, RegisterFunction, register_worker};
+use iii_sdk::{Error, InitOptions, RegisterFunction, register_worker};
 use serde_json::{Value, json};
 
 #[tokio::main]
@@ -14,7 +14,7 @@ async fn main() -> anyhow::Result<()> {
                 .get("name")
                 .and_then(|v| v.as_str())
                 .unwrap_or("world");
-            Ok::<Value, IIIError>(json!({ "greeting": format!("hello, {name}") }))
+            Ok::<Value, Error>(json!({ "greeting": format!("hello, {name}") }))
         }),
     );
 

--- a/crates/iii-worker/tests/sandbox_fs_read_buffer_boundary.rs
+++ b/crates/iii-worker/tests/sandbox_fs_read_buffer_boundary.rs
@@ -126,7 +126,7 @@ async fn invalid_utf8_under_threshold_falls_through_to_stream() {
         meta_size: size,
     };
 
-    // Note: handle_read requires a real `iii_sdk::III` to call create_channel
+    // Note: handle_read requires a real `iii_sdk::IIIClient` to call create_channel
     // on. We can't construct one cleanly in a unit test (it tries to
     // connect to the engine). Instead, this test asserts the easier
     // invariant: the buffering logic detects invalid UTF-8 by feeding the
@@ -158,7 +158,7 @@ async fn invalid_utf8_under_threshold_falls_through_to_stream() {
 async fn valid_utf8_under_threshold_returns_utf8_string_invariant() {
     // Pin the inverse invariant: valid UTF-8 under the cap must populate
     // `body: Some(s)`. As above, we assert at the structural level pending
-    // an integration harness with a live `iii_sdk::III`.
+    // an integration harness with a live `iii_sdk::IIIClient`.
     let small_text = "hello world\n".repeat(100);
     assert!(small_text.len() < 1024 * 1024);
     assert!(std::str::from_utf8(small_text.as_bytes()).is_ok());

--- a/docs/changelog/0-20-0/cross-language-parity.mdx
+++ b/docs/changelog/0-20-0/cross-language-parity.mdx
@@ -32,8 +32,8 @@ The streaming request and response types keep the `StreamRequest` and `StreamRes
 | `IIIForbiddenError`, `IIITimeoutError` | Python | check the error `code` on the invocation error, matching Node and Rust |
 | `TriggerActionType` alias | Node | use the `TriggerAction` value |
 | `FieldPath` (separate path helper) | Rust | use `UpdateSet` and `UpdateMerge`; the merge and append path argument is the retained `MergePath` |
-| `Logger` re-export | Node | import from `@iii-dev/observability` |
-| OpenTelemetry suite re-export | Python | import from `iii-observability` |
+| `Logger` re-export | Node | import from `@iii-dev/helpers/observability` |
+| OpenTelemetry suite re-export | Python | import from `iii_helpers.observability` |
 
 ## Migration
 

--- a/docs/changelog/0-20-0/organize-sdk-imports.mdx
+++ b/docs/changelog/0-20-0/organize-sdk-imports.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'Grouping SDK exports into submodules'
-description: 'The invocation error types are renamed (InvocationError, Error) and the channel, trigger, and runtime types move to named submodules across the Node, Python, and Rust SDKs. The old root paths keep working as deprecated aliases.'
+description: 'The invocation error types are renamed (InvocationError, Error) and the channel, trigger, and runtime types move to named submodules across the Node, Python, and Rust SDKs. The old root paths are removed in 0.20.0; code must move to the new submodule and name paths.'
 ---
 
 ## What changed
 
-The flat root export surface of the three SDKs is being reorganized into named submodules. This slice covers four groups. Old import paths continue to work as deprecated re-exports, so upgrading requires no immediate code changes.
+The flat root export surface of the three SDKs is reorganized into named submodules. This slice covers four groups. The old root import paths are removed in 0.20.0, so upgrading requires moving these imports to their new paths.
 
 | Group | Node subpath | Python submodule | Rust module |
 | --- | --- | --- | --- |
@@ -25,7 +25,7 @@ The `III` prefix is dropped from the invocation error types.
 | Python | `IIIInvocationError` | `InvocationError` | `iii.errors` |
 | Rust | `IIIError` | `Error` | `iii_sdk::errors::Error` |
 
-Behavior is unchanged. In Node, the thrown error's `name` is now `InvocationError`. In Python, importing `IIIInvocationError` from the package root emits a `DeprecationWarning`. The old names stay exported from the package root as deprecated aliases.
+Behavior is unchanged. In Node, the thrown error's `name` is now `InvocationError`. The old names are removed from the package root in 0.20.0; import the new names from their canonical paths.
 
 ## Submodule contents
 
@@ -39,7 +39,7 @@ The set per language matches each SDK's existing surface. Symbols absent from a 
 
 ## Migration
 
-Update imports to the new paths. No runtime change is required until the deprecated root re-exports are removed in a future breaking release.
+Update imports to the new paths. The old root paths are removed in 0.20.0, so this move is required.
 
 Node:
 
@@ -76,4 +76,4 @@ use iii_sdk::runtime::FunctionRef;
 
 ## Why
 
-The SDK root re-exported dozens of symbols flatly. Grouping them into `errors`, `channel`, `trigger`, and `runtime` submodules makes the surface navigable and prepares for extracting standalone libraries later. Shipping the moves with deprecated aliases keeps the change backward compatible while consumers migrate.
+The SDK root re-exported dozens of symbols flatly. Grouping them into `errors`, `channel`, `trigger`, and `runtime` submodules makes the surface navigable and prepares for extracting standalone libraries later. 0.20.0 is a clean break: the old root paths are removed rather than kept as aliases.

--- a/docs/changelog/0-20-0/submodule-clean-break.mdx
+++ b/docs/changelog/0-20-0/submodule-clean-break.mdx
@@ -52,7 +52,7 @@ use iii_sdk::engine::EngineFunctions;
 
 ## Note on the earlier submodule slice
 
-The first submodule slice (`errors`, `channel`, `trigger`, `runtime`) kept the old root paths working as deprecated aliases. The groups in this slice and the types extracted into `@iii-dev/helpers` instead remove the root export. Prefer the submodule and helpers paths for everything; the remaining deprecated root aliases will be removed in a future release.
+The first submodule slice (`errors`, `channel`, `trigger`, `runtime`) and the groups in this slice, along with the types extracted into `@iii-dev/helpers`, all remove the root export in 0.20.0. Use the submodule and helpers paths for everything; the old root paths no longer work in this release.
 
 ## Why
 

--- a/docs/next/sdk-reference/node-sdk.mdx
+++ b/docs/next/sdk-reference/node-sdk.mdx
@@ -31,7 +31,7 @@ function registerWorker(address: string, options?: InitOptions): IIIClient;
 Pass the engine's SDK WebSocket URL (e.g. `process.env.III_URL`) as `address`. `options` configures
 worker identity (`workerName`, plus an optional `workerDescription`, a one-line summary surfaced
 in `engine::workers::list` / `engine::workers::info`), timeouts, reconnection, and OpenTelemetry. The returned `IIIClient` carries every
-method below. (`ISdk` remains as a deprecated alias for `IIIClient`.)
+method below. (The handle is named `IIIClient`; the former name `ISdk` has been removed.)
 
 `TelemetryOptions` is the public type for the worker's telemetry labels (`language`, `project_name`,
 `framework`, `amplitude_api_key`), exported from `iii-sdk` to match the Python and Rust SDKs.
@@ -52,8 +52,8 @@ worker.registerFunction(
 JSON Schemas (stored alongside the function for the iii console and agent-readable skills).
 
 The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii-sdk/runtime`
-subpath (`import type { FunctionRef } from 'iii-sdk/runtime'`). They stay re-exported from the
-package root as deprecated aliases.
+subpath (`import type { FunctionRef } from 'iii-sdk/runtime'`). They are not exported from the
+package root.
 
 The `IIIConnectionState` type is provided only by the `iii-sdk/runtime` subpath
 (`import type { IIIConnectionState } from 'iii-sdk/runtime'`). It is not exported from the
@@ -85,8 +85,8 @@ The returned `Trigger` carries the runtime handle. Drop the trigger with `Trigge
 there is no top-level `unregisterTrigger` function.
 
 The `Trigger`, `TriggerConfig`, and `TriggerHandler` types are exported from the `iii-sdk/trigger`
-subpath (`import type { TriggerHandler } from 'iii-sdk/trigger'`). They stay re-exported from the
-package root as deprecated aliases.
+subpath (`import type { TriggerHandler } from 'iii-sdk/trigger'`). They are not exported from the
+package root.
 
 ### `registerTriggerType`
 
@@ -154,8 +154,8 @@ class InvocationError extends Error {
 }
 ```
 
-The former name `IIIInvocationError` is still exported from the package root as a deprecated alias.
-Prefer `InvocationError` from `iii-sdk/errors`.
+The former name `IIIInvocationError` has been removed. Import `InvocationError` from
+`iii-sdk/errors`.
 
 Common `code` values come from the engine: `invocation_failed` (handler threw), `invocation_stopped`
 (engine timeout), `function_not_found`, `function_not_invokable`, `TIMEOUT` (client-side timeout),
@@ -164,8 +164,8 @@ Common `code` values come from the engine: `invocation_failed` (handler threw), 
 ## Channels
 
 Import channel symbols from the `iii-sdk/channel` subpath
-(`import { ChannelReader, ChannelWriter } from 'iii-sdk/channel'`). They stay exported from the
-package root as deprecated re-exports.
+(`import { ChannelReader, ChannelWriter } from 'iii-sdk/channel'`). They are not exported from the
+package root.
 
 `ChannelReader` and `ChannelWriter` are runtime classes wrapping the engine's stream WebSockets.
 `StreamChannelRef` is the type passed between SDK calls to identify a channel:
@@ -185,9 +185,9 @@ Node `Readable` plus `.sendMessage()` and `.onMessage()`; `ChannelWriter` expose
 ## Logger
 
 `Logger` is a runtime class with `info`, `warn`, `error`, and `debug` methods, each
-`(message: string, data?: unknown) => void`. Import it from `@iii-dev/observability`; it is no
-longer re-exported from `iii-sdk`. The output integrates with the SDK's OpenTelemetry setup; see
-iii-observability for the export side.
+`(message: string, data?: unknown) => void`. Import it from `@iii-dev/helpers/observability`; it is
+not exported from `iii-sdk`. The output integrates with the SDK's OpenTelemetry setup; see
+the iii-observability worker for the export side.
 
 ## Info types
 

--- a/docs/next/sdk-reference/node-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/node-sdk.mdx.skill.md
@@ -29,7 +29,7 @@ function registerWorker(address: string, options?: InitOptions): IIIClient;
 Pass the engine's SDK WebSocket URL (e.g. `process.env.III_URL`) as `address`. `options` configures
 worker identity (`workerName`, plus an optional `workerDescription`, a one-line summary surfaced
 in `engine::workers::list` / `engine::workers::info`), timeouts, reconnection, and OpenTelemetry. The returned `IIIClient` carries every
-method below. (`ISdk` remains as a deprecated alias for `IIIClient`.)
+method below. (The handle is named `IIIClient`; the former name `ISdk` has been removed.)
 
 `TelemetryOptions` is the public type for the worker's telemetry labels (`language`, `project_name`,
 `framework`, `amplitude_api_key`), exported from `iii-sdk` to match the Python and Rust SDKs.
@@ -50,8 +50,8 @@ worker.registerFunction(
 JSON Schemas (stored alongside the function for the iii console and agent-readable skills).
 
 The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii-sdk/runtime`
-subpath (`import type { FunctionRef } from 'iii-sdk/runtime'`). They stay re-exported from the
-package root as deprecated aliases.
+subpath (`import type { FunctionRef } from 'iii-sdk/runtime'`). They are not exported from the
+package root.
 
 The `IIIConnectionState` type is provided only by the `iii-sdk/runtime` subpath
 (`import type { IIIConnectionState } from 'iii-sdk/runtime'`). It is not exported from the
@@ -83,8 +83,8 @@ The returned `Trigger` carries the runtime handle. Drop the trigger with `Trigge
 there is no top-level `unregisterTrigger` function.
 
 The `Trigger`, `TriggerConfig`, and `TriggerHandler` types are exported from the `iii-sdk/trigger`
-subpath (`import type { TriggerHandler } from 'iii-sdk/trigger'`). They stay re-exported from the
-package root as deprecated aliases.
+subpath (`import type { TriggerHandler } from 'iii-sdk/trigger'`). They are not exported from the
+package root.
 
 ### `registerTriggerType`
 
@@ -152,8 +152,8 @@ class InvocationError extends Error {
 }
 ```
 
-The former name `IIIInvocationError` is still exported from the package root as a deprecated alias.
-Prefer `InvocationError` from `iii-sdk/errors`.
+The former name `IIIInvocationError` has been removed. Import `InvocationError` from
+`iii-sdk/errors`.
 
 Common `code` values come from the engine: `invocation_failed` (handler threw), `invocation_stopped`
 (engine timeout), `function_not_found`, `function_not_invokable`, `TIMEOUT` (client-side timeout),
@@ -162,8 +162,8 @@ Common `code` values come from the engine: `invocation_failed` (handler threw), 
 ## Channels
 
 Import channel symbols from the `iii-sdk/channel` subpath
-(`import { ChannelReader, ChannelWriter } from 'iii-sdk/channel'`). They stay exported from the
-package root as deprecated re-exports.
+(`import { ChannelReader, ChannelWriter } from 'iii-sdk/channel'`). They are not exported from the
+package root.
 
 `ChannelReader` and `ChannelWriter` are runtime classes wrapping the engine's stream WebSockets.
 `StreamChannelRef` is the type passed between SDK calls to identify a channel:
@@ -183,9 +183,9 @@ Node `Readable` plus `.sendMessage()` and `.onMessage()`; `ChannelWriter` expose
 ## Logger
 
 `Logger` is a runtime class with `info`, `warn`, `error`, and `debug` methods, each
-`(message: string, data?: unknown) => void`. Import it from `@iii-dev/observability`; it is no
-longer re-exported from `iii-sdk`. The output integrates with the SDK's OpenTelemetry setup; see
-iii-observability for the export side.
+`(message: string, data?: unknown) => void`. Import it from `@iii-dev/helpers/observability`; it is
+not exported from `iii-sdk`. The output integrates with the SDK's OpenTelemetry setup; see
+the iii-observability worker for the export side.
 
 ## Info types
 

--- a/docs/next/sdk-reference/python-sdk.mdx
+++ b/docs/next/sdk-reference/python-sdk.mdx
@@ -60,8 +60,7 @@ def register_function(
 helper. They are stored alongside the function for the iii console and the agent-readable skills.
 
 The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii.runtime` submodule
-(`from iii.runtime import FunctionRef`). They stay importable from the package root as deprecated
-re-exports.
+(`from iii.runtime import FunctionRef`). They are not importable from the package root.
 
 The `IIIConnectionState` type is provided only by the `iii.runtime` submodule
 (`from iii.runtime import IIIConnectionState`). It is not importable from the package root.
@@ -99,8 +98,8 @@ Drop the trigger with `trigger.unregister()` on the returned handle. There is no
 `unregister_trigger` method.
 
 The `Trigger`, `TriggerConfig`, and `TriggerHandler` types are exported from the `iii.trigger`
-submodule (`from iii.trigger import TriggerHandler`). They stay importable from the package root as
-deprecated re-exports.
+submodule (`from iii.trigger import TriggerHandler`). They are not importable from the package
+root.
 
 ### `register_trigger_type`
 
@@ -171,13 +170,13 @@ Every invocation failure raises `InvocationError`, imported from the `iii.errors
 | other         | Any other engine-side rejection.  |
 
 `InvocationError` has `code`, `message`, `function_id`, and `stacktrace` attributes. The former
-name `IIIInvocationError` stays importable from the package root as a deprecated alias.
+name `IIIInvocationError` has been removed; import `InvocationError` from `iii.errors`.
 
 ## Channels
 
 Import channel types from the `iii.channel` submodule
-(`from iii.channel import ChannelReader, ChannelWriter`). They stay importable from the package root
-as deprecated re-exports.
+(`from iii.channel import ChannelReader, ChannelWriter`). They are not importable from the package
+root.
 
 `ChannelReader` and `ChannelWriter` wrap the engine's stream WebSockets. `StreamChannelRef`
 identifies a channel:
@@ -194,8 +193,8 @@ Both classes are constructed with the engine's WS base URL and a `StreamChannelR
 ## Logger
 
 `Logger` exposes `info`, `warn`, `error`, and `debug`, each accepting a message and an optional
-data dict. Import it from `iii_observability`; it is no longer re-exported from `iii`. The output
-integrates with the SDK's OpenTelemetry setup; see iii-observability for the export side.
+data dict. Import it from `iii_helpers.observability`; it is not exported from `iii`. The output
+integrates with the SDK's OpenTelemetry setup; see the iii-observability worker for the export side.
 
 ## Info types
 

--- a/docs/next/sdk-reference/python-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/python-sdk.mdx.skill.md
@@ -58,8 +58,7 @@ def register_function(
 helper. They are stored alongside the function for the iii console and the agent-readable skills.
 
 The `FunctionRef` and `TriggerTypeRef` handle types are exported from the `iii.runtime` submodule
-(`from iii.runtime import FunctionRef`). They stay importable from the package root as deprecated
-re-exports.
+(`from iii.runtime import FunctionRef`). They are not importable from the package root.
 
 The `IIIConnectionState` type is provided only by the `iii.runtime` submodule
 (`from iii.runtime import IIIConnectionState`). It is not importable from the package root.
@@ -97,8 +96,8 @@ Drop the trigger with `trigger.unregister()` on the returned handle. There is no
 `unregister_trigger` method.
 
 The `Trigger`, `TriggerConfig`, and `TriggerHandler` types are exported from the `iii.trigger`
-submodule (`from iii.trigger import TriggerHandler`). They stay importable from the package root as
-deprecated re-exports.
+submodule (`from iii.trigger import TriggerHandler`). They are not importable from the package
+root.
 
 ### `register_trigger_type`
 
@@ -169,13 +168,13 @@ Every invocation failure raises `InvocationError`, imported from the `iii.errors
 | other         | Any other engine-side rejection.  |
 
 `InvocationError` has `code`, `message`, `function_id`, and `stacktrace` attributes. The former
-name `IIIInvocationError` stays importable from the package root as a deprecated alias.
+name `IIIInvocationError` has been removed; import `InvocationError` from `iii.errors`.
 
 ## Channels
 
 Import channel types from the `iii.channel` submodule
-(`from iii.channel import ChannelReader, ChannelWriter`). They stay importable from the package root
-as deprecated re-exports.
+(`from iii.channel import ChannelReader, ChannelWriter`). They are not importable from the package
+root.
 
 `ChannelReader` and `ChannelWriter` wrap the engine's stream WebSockets. `StreamChannelRef`
 identifies a channel:
@@ -192,8 +191,8 @@ Both classes are constructed with the engine's WS base URL and a `StreamChannelR
 ## Logger
 
 `Logger` exposes `info`, `warn`, `error`, and `debug`, each accepting a message and an optional
-data dict. Import it from `iii_observability`; it is no longer re-exported from `iii`. The output
-integrates with the SDK's OpenTelemetry setup; see iii-observability for the export side.
+data dict. Import it from `iii_helpers.observability`; it is not exported from `iii`. The output
+integrates with the SDK's OpenTelemetry setup; see the iii-observability worker for the export side.
 
 ## Info types
 

--- a/docs/next/sdk-reference/rust-sdk.mdx
+++ b/docs/next/sdk-reference/rust-sdk.mdx
@@ -31,7 +31,7 @@ pub fn register_worker(address: &str, options: InitOptions) -> IIIClient;
 ```
 
 The returned `IIIClient` carries every method below. Spawned async tasks are driven on the SDK's
-internal tokio runtime. (`III` remains as a deprecated alias for `IIIClient`.)
+internal tokio runtime. (The handle is named `IIIClient`; the former name `III` has been removed.)
 
 ### `register_function`
 
@@ -65,8 +65,8 @@ Drop the trigger with `trigger.unregister()` on the returned handle. There is no
 `unregister_trigger`.
 
 The `Trigger`, `TriggerConfig`, `TriggerHandler`, and `IIITrigger` types are exported from the
-`iii_sdk::trigger` submodule (`use iii_sdk::trigger::IIITrigger`). They stay reachable at the crate
-root as deprecated re-exports.
+`iii_sdk::trigger` submodule (`use iii_sdk::trigger::IIITrigger`). They are not reachable at the
+crate root.
 
 ### `register_trigger_type`
 
@@ -146,8 +146,7 @@ pub enum Error {
 }
 ```
 
-The former name `IIIError` stays reachable at the crate root as a deprecated alias; prefer
-`iii_sdk::errors::Error`.
+The former name `IIIError` has been removed; use `iii_sdk::errors::Error`.
 
 `ErrorBody` carries the engine's `{ code, message, stacktrace? }` payload; match on
 `Error::Remote(body) => body.code.as_str()` to branch on engine error codes
@@ -162,8 +161,8 @@ and `None` for transport, serde, or handler errors. Exported as `iii_sdk::Invoca
 ## Channels
 
 Import channel types from the `iii_sdk::channel` submodule
-(`use iii_sdk::channel::{ChannelReader, ChannelWriter}`). They stay reachable at the crate root as
-deprecated re-exports.
+(`use iii_sdk::channel::{ChannelReader, ChannelWriter}`). They are not reachable at the crate
+root.
 
 `ChannelReader` and `ChannelWriter` wrap the engine's stream WebSockets. `StreamChannelRef`
 identifies a channel:
@@ -204,8 +203,7 @@ pub enum IIIConnectionState {
 
 The runtime/worker types (`FunctionRef`, `TriggerTypeRef`, `IIIConnectionState`, `WorkerMetadata`,
 `FunctionInfo`, `TriggerInfo`, `WorkerInfo`) are exported from the `iii_sdk::runtime` submodule
-(`use iii_sdk::runtime::FunctionInfo`). They stay reachable at the crate root as deprecated
-re-exports.
+(`use iii_sdk::runtime::FunctionInfo`). They are not reachable at the crate root.
 
 The SDK re-exports the engine's structured introspection types:
 
@@ -222,7 +220,7 @@ The SDK re-exports the engine's structured introspection types:
   framework / project labels plus an Amplitude key, used by iii-telemetry for anonymous usage
   reporting; distinct from the OpenTelemetry observability surfaces owned by iii-observability),
   `isolation`. `TelemetryOptions` is exported at the crate root (matching Node and Python);
-  the former name `WorkerTelemetryMeta` stays as a deprecated alias.
+  the former name `WorkerTelemetryMeta` has been removed.
 
 ## `MessageType`
 

--- a/docs/next/sdk-reference/rust-sdk.mdx.skill.md
+++ b/docs/next/sdk-reference/rust-sdk.mdx.skill.md
@@ -29,7 +29,7 @@ pub fn register_worker(address: &str, options: InitOptions) -> IIIClient;
 ```
 
 The returned `IIIClient` carries every method below. Spawned async tasks are driven on the SDK's
-internal tokio runtime. (`III` remains as a deprecated alias for `IIIClient`.)
+internal tokio runtime. (The handle is named `IIIClient`; the former name `III` has been removed.)
 
 ### `register_function`
 
@@ -63,8 +63,8 @@ Drop the trigger with `trigger.unregister()` on the returned handle. There is no
 `unregister_trigger`.
 
 The `Trigger`, `TriggerConfig`, `TriggerHandler`, and `IIITrigger` types are exported from the
-`iii_sdk::trigger` submodule (`use iii_sdk::trigger::IIITrigger`). They stay reachable at the crate
-root as deprecated re-exports.
+`iii_sdk::trigger` submodule (`use iii_sdk::trigger::IIITrigger`). They are not reachable at the
+crate root.
 
 ### `register_trigger_type`
 
@@ -144,8 +144,7 @@ pub enum Error {
 }
 ```
 
-The former name `IIIError` stays reachable at the crate root as a deprecated alias; prefer
-`iii_sdk::errors::Error`.
+The former name `IIIError` has been removed; use `iii_sdk::errors::Error`.
 
 `ErrorBody` carries the engine's `{ code, message, stacktrace? }` payload; match on
 `Error::Remote(body) => body.code.as_str()` to branch on engine error codes
@@ -160,8 +159,8 @@ and `None` for transport, serde, or handler errors. Exported as `iii_sdk::Invoca
 ## Channels
 
 Import channel types from the `iii_sdk::channel` submodule
-(`use iii_sdk::channel::{ChannelReader, ChannelWriter}`). They stay reachable at the crate root as
-deprecated re-exports.
+(`use iii_sdk::channel::{ChannelReader, ChannelWriter}`). They are not reachable at the crate
+root.
 
 `ChannelReader` and `ChannelWriter` wrap the engine's stream WebSockets. `StreamChannelRef`
 identifies a channel:
@@ -202,8 +201,7 @@ pub enum IIIConnectionState {
 
 The runtime/worker types (`FunctionRef`, `TriggerTypeRef`, `IIIConnectionState`, `WorkerMetadata`,
 `FunctionInfo`, `TriggerInfo`, `WorkerInfo`) are exported from the `iii_sdk::runtime` submodule
-(`use iii_sdk::runtime::FunctionInfo`). They stay reachable at the crate root as deprecated
-re-exports.
+(`use iii_sdk::runtime::FunctionInfo`). They are not reachable at the crate root.
 
 The SDK re-exports the engine's structured introspection types:
 
@@ -220,7 +218,7 @@ The SDK re-exports the engine's structured introspection types:
   framework / project labels plus an Amplitude key, used by iii-telemetry for anonymous usage
   reporting; distinct from the OpenTelemetry observability surfaces owned by iii-observability),
   `isolation`. `TelemetryOptions` is exported at the crate root (matching Node and Python);
-  the former name `WorkerTelemetryMeta` stays as a deprecated alias.
+  the former name `WorkerTelemetryMeta` has been removed.
 
 ## `MessageType`
 

--- a/engine/src/cli_trigger/exec.rs
+++ b/engine/src/cli_trigger/exec.rs
@@ -5,7 +5,7 @@
 // See LICENSE and PATENTS files for details.
 
 use iii_sdk::protocol::TriggerRequest;
-use iii_sdk::{IIIError, InitOptions, register_worker};
+use iii_sdk::{Error, InitOptions, register_worker};
 use serde_json::Value;
 
 use super::TriggerCliError;
@@ -41,7 +41,7 @@ pub async fn invoke(
             }
             Ok(())
         }
-        Err(IIIError::Remote {
+        Err(Error::Remote {
             code,
             message,
             stacktrace,
@@ -64,12 +64,12 @@ pub async fn invoke(
     }
 }
 
-fn map_trigger_error(e: IIIError) -> anyhow::Error {
+fn map_trigger_error(e: Error) -> anyhow::Error {
     match e {
-        IIIError::Timeout => anyhow::anyhow!(
+        Error::Timeout => anyhow::anyhow!(
             "Timed out waiting for the engine (no response within the timeout). Is the engine running at the given address and port?"
         ),
-        IIIError::WebSocket(msg) => anyhow::anyhow!("WebSocket error: {}", msg),
+        Error::WebSocket(msg) => anyhow::anyhow!("WebSocket error: {}", msg),
         other => anyhow::Error::new(other),
     }
 }

--- a/engine/src/workers/bridge_client/mod.rs
+++ b/engine/src/workers/bridge_client/mod.rs
@@ -8,7 +8,7 @@ use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use iii_sdk::protocol::TriggerRequest;
-use iii_sdk::{III, IIIError, InitOptions, TriggerAction, register_worker};
+use iii_sdk::{Error, IIIClient, InitOptions, TriggerAction, register_worker};
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -59,7 +59,7 @@ pub struct InvokeInput {
 #[derive(Clone)]
 pub struct BridgeClientWorker {
     engine: Arc<Engine>,
-    bridge: III,
+    bridge: IIIClient,
     config: BridgeClientConfig,
 }
 
@@ -255,7 +255,7 @@ impl Worker for BridgeClientWorker {
                     async move {
                         match engine.call(&local_function, input).await {
                             Ok(result) => Ok(result.unwrap_or(Value::Null)),
-                            Err(err) => Err(IIIError::Remote {
+                            Err(err) => Err(Error::Remote {
                                 code: err.code,
                                 message: err.message,
                                 stacktrace: err.stacktrace,

--- a/engine/src/workers/configuration/adapters/bridge.rs
+++ b/engine/src/workers/configuration/adapters/bridge.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
-use iii_sdk::{III, InitOptions, RegisterFunction, register_worker};
+use iii_sdk::{IIIClient, InitOptions, RegisterFunction, register_worker};
 use serde::Serialize;
 use serde_json::Value;
 use tokio::sync::OnceCell;
@@ -40,10 +40,10 @@ const RELAY_FUNCTION_ID: &str = "configuration::__bridge_relay";
 const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 
 pub struct BridgeAdapter {
-    bridge: Arc<III>,
-    /// Holds onto the relay [`iii_sdk::Trigger`] handle so the SDK keeps
+    bridge: Arc<IIIClient>,
+    /// Holds onto the relay [`iii_sdk::trigger::Trigger`] handle so the SDK keeps
     /// the remote subscription alive for the worker's lifetime.
-    relay_trigger: Mutex<Option<iii_sdk::Trigger>>,
+    relay_trigger: Mutex<Option<iii_sdk::trigger::Trigger>>,
     /// Set lazily by `watch` — used by the relay function below.
     sender: OnceCell<ExternalChangeSender>,
 }
@@ -128,7 +128,7 @@ impl ConfigurationAdapter for BridgeAdapter {
 
     async fn get(&self, id: &str) -> anyhow::Result<Option<ConfigurationEntry>> {
         // We treat any remote error as "absent" here because the SDK's
-        // `IIIError` is already string-wrapped by `call` above, so we can't
+        // `Error` is already string-wrapped by `call` above, so we can't
         // cleanly distinguish a NOT_FOUND from a network/timeout failure
         // without a wider refactor. Log the underlying error so transient
         // remote failures aren't completely silent.
@@ -246,7 +246,7 @@ impl ConfigurationAdapter for BridgeAdapter {
                 let sender_lookup = sender_lookup.clone();
                 async move {
                     let event: ConfigurationEventData = serde_json::from_value(payload)
-                        .map_err(|e| iii_sdk::IIIError::Handler(e.to_string()))?;
+                        .map_err(|e| iii_sdk::Error::Handler(e.to_string()))?;
                     if let Some(tx) = sender_lookup.get() {
                         let entry = ConfigurationEntry {
                             id: event.id.clone(),
@@ -266,7 +266,7 @@ impl ConfigurationAdapter for BridgeAdapter {
                         };
                         let _ = tx.send(change);
                     }
-                    Ok::<Value, iii_sdk::IIIError>(Value::Null)
+                    Ok::<Value, iii_sdk::Error>(Value::Null)
                 }
             }),
         );

--- a/engine/src/workers/queue/adapters/bridge.rs
+++ b/engine/src/workers/queue/adapters/bridge.rs
@@ -8,7 +8,8 @@ use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
-use iii_sdk::{III, IIIError, InitOptions, Trigger, TriggerAction, register_worker};
+use iii_sdk::trigger::Trigger;
+use iii_sdk::{Error, IIIClient, InitOptions, TriggerAction, register_worker};
 use serde_json::Value;
 use tokio::sync::RwLock;
 use uuid::Uuid;
@@ -54,7 +55,7 @@ struct SubscriptionInfo {
 /// - Functions registered via bridge persist for bridge lifetime
 pub struct BridgeAdapter {
     engine: Arc<Engine>,
-    bridge: Arc<III>,
+    bridge: Arc<IIIClient>,
     subscriptions: Arc<RwLock<HashMap<String, SubscriptionInfo>>>,
 }
 
@@ -225,7 +226,7 @@ impl QueueAdapter for BridgeAdapter {
                                         "Error invoking condition function"
                                     );
                                     tracing::Span::current().record("otel.status_code", "ERROR");
-                                    return Err(IIIError::Remote {
+                                    return Err(Error::Remote {
                                         code: err.code,
                                         message: err.message,
                                         stacktrace: err.stacktrace,
@@ -238,11 +239,11 @@ impl QueueAdapter for BridgeAdapter {
                         match engine.call(&function_id, data).await {
                             Ok(result) => {
                                 tracing::Span::current().record("otel.status_code", "OK");
-                                Ok::<Value, IIIError>(result.unwrap_or(Value::Null))
+                                Ok::<Value, Error>(result.unwrap_or(Value::Null))
                             }
                             Err(err) => {
                                 tracing::Span::current().record("otel.status_code", "ERROR");
-                                Err(IIIError::Remote {
+                                Err(Error::Remote {
                                     code: err.code,
                                     message: err.message,
                                     stacktrace: err.stacktrace,

--- a/engine/src/workers/state/adapters/bridge.rs
+++ b/engine/src/workers/state/adapters/bridge.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use iii_helpers::stream::{StreamSetResult, StreamUpdateResult, UpdateOp};
 use iii_sdk::protocol::TriggerRequest;
-use iii_sdk::{III, InitOptions, register_worker};
+use iii_sdk::{IIIClient, InitOptions, register_worker};
 use serde_json::Value;
 
 use crate::{
@@ -25,7 +25,7 @@ use crate::{
 };
 
 pub struct BridgeAdapter {
-    bridge: Arc<III>,
+    bridge: Arc<IIIClient>,
 }
 
 impl BridgeAdapter {

--- a/engine/src/workers/stream/adapters/bridge.rs
+++ b/engine/src/workers/stream/adapters/bridge.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use iii_helpers::stream::{StreamDeleteResult, StreamSetResult, StreamUpdateResult, UpdateOp};
 use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
-use iii_sdk::{III, InitOptions, register_worker};
+use iii_sdk::{IIIClient, InitOptions, register_worker};
 use serde_json::Value;
 
 use crate::{
@@ -34,7 +34,7 @@ pub const STREAM_EVENTS_TOPIC: &str = "stream.events";
 pub struct BridgeAdapter {
     pub_sub: Arc<BuiltInPubSubLite>,
     handler_function_id: String,
-    bridge: Arc<III>,
+    bridge: Arc<IIIClient>,
 }
 
 impl BridgeAdapter {
@@ -263,7 +263,7 @@ impl StreamAdapter for BridgeAdapter {
                         }
                         Err(e) => {
                             tracing::error!(error = %e, "Failed to deserialize stream message");
-                            Err(iii_sdk::IIIError::Remote {
+                            Err(iii_sdk::Error::Remote {
                                 code: "DESERIALIZATION_ERROR".to_string(),
                                 message: format!("Failed to deserialize stream message: {}", e),
                                 stacktrace: None,

--- a/engine/tests/worker_trigger_e2e.rs
+++ b/engine/tests/worker_trigger_e2e.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 use iii::EngineBuilder;
 use iii::workers::config::EngineConfig;
 use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
-use iii_sdk::{III, InitOptions, RegisterFunction, register_worker};
+use iii_sdk::{IIIClient, InitOptions, RegisterFunction, register_worker};
 use iii_worker::cli::app::WorkerManagerDaemonArgs;
 use iii_worker::cli::worker_manager_daemon;
 use serde_json::{Value, json};
@@ -132,7 +132,7 @@ async fn wait_for_ws(port: u16) {
 /// 10s deadline. Without this gate the test could race the daemon's WS
 /// connection and `iii.trigger("worker::add", ...)` would return
 /// `function_not_found`.
-async fn wait_for_worker_add_function(probe: &III) {
+async fn wait_for_worker_add_function(probe: &IIIClient) {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
     loop {
         let resp = probe
@@ -180,7 +180,7 @@ struct Subscriber {
 /// Register a named handler that pushes every invocation into an mpsc, then
 /// bind a `worker` trigger with `filter` against the same id. Returns the
 /// receiver so the test can drain it post-fire.
-fn register_subscriber(iii: &III, function_id: &str, filter: Value) -> Subscriber {
+fn register_subscriber(iii: &IIIClient, function_id: &str, filter: Value) -> Subscriber {
     let (tx, rx) = mpsc::unbounded_channel::<Value>();
     let tx_for_handler = tx.clone();
     iii.register_function(
@@ -189,7 +189,7 @@ fn register_subscriber(iii: &III, function_id: &str, filter: Value) -> Subscribe
             let tx = tx_for_handler.clone();
             async move {
                 let _ = tx.send(req);
-                Ok::<_, iii_sdk::IIIError>(json!({}))
+                Ok::<_, iii_sdk::Error>(json!({}))
             }
         })
         .description("e2e test subscriber"),

--- a/sdk/packages/node/iii-example/src/trigger-types.ts
+++ b/sdk/packages/node/iii-example/src/trigger-types.ts
@@ -7,8 +7,9 @@
  * 3. Listing all available trigger types with their schemas
  */
 
-import { EngineFunctions } from 'iii-sdk'
-import type { TriggerConfig, TriggerHandler, TriggerTypeRef } from 'iii-sdk'
+import { EngineFunctions } from 'iii-sdk/engine'
+import type { TriggerConfig, TriggerHandler } from 'iii-sdk/trigger'
+import type { TriggerTypeRef } from 'iii-sdk/runtime'
 import { iii } from './iii'
 
 /**

--- a/sdk/packages/node/iii/src/errors.ts
+++ b/sdk/packages/node/iii/src/errors.ts
@@ -51,16 +51,3 @@ export function isErrorBody(value: unknown): value is {
     (v.stacktrace === undefined || typeof v.stacktrace === 'string')
   )
 }
-
-/**
- * @deprecated Renamed to {@link InvocationError}; import from `iii-sdk/errors`.
- */
-export const IIIInvocationError = InvocationError
-/**
- * @deprecated Renamed to {@link InvocationError}.
- */
-export type IIIInvocationError = InvocationError
-/**
- * @deprecated Renamed to {@link InvocationErrorInit}.
- */
-export type IIIInvocationErrorInit = InvocationErrorInit

--- a/sdk/packages/node/iii/src/helpers.ts
+++ b/sdk/packages/node/iii/src/helpers.ts
@@ -1,17 +1,17 @@
 /**
- * Helper free functions that operate on an {@link ISdk} instance.
+ * Helper free functions that operate on an {@link IIIClient} instance.
  *
  * These were previously instance methods on the SDK. They take the iii
- * instance as the first argument so the public API surface of `ISdk` stays
+ * instance as the first argument so the public API surface of `IIIClient` stays
  * focused on the core lifecycle and registration methods.
  */
-import type { Channel, ISdk } from './types'
+import type { Channel, IIIClient } from './types'
 import type { IStream } from './stream'
 
 export { ChannelDirection, ChannelItem } from './channels'
 export { extractChannelRefs, isChannelRef } from './utils'
 
-type IIIWithHelperShims = ISdk & {
+type IIIWithHelperShims = IIIClient & {
   __helpers_create_channel(bufferSize?: number): Promise<Channel>
   __helpers_create_stream<T>(name: string, stream: IStream<T>): void
 }
@@ -19,9 +19,9 @@ type IIIWithHelperShims = ISdk & {
 /**
  * Create a streaming channel pair for worker-to-worker data transfer.
  *
- * Free-function form of the previous `ISdk.createChannel` instance method.
+ * Free-function form of the previous `IIIClient.createChannel` instance method.
  */
-export function createChannel(iii: ISdk, bufferSize?: number): Promise<Channel> {
+export function createChannel(iii: IIIClient, bufferSize?: number): Promise<Channel> {
   return (iii as IIIWithHelperShims).__helpers_create_channel(bufferSize)
 }
 
@@ -29,8 +29,8 @@ export function createChannel(iii: ISdk, bufferSize?: number): Promise<Channel> 
  * Register a custom stream implementation by wiring its 5 callable methods
  * to `stream::get/set/delete/list/list_groups`.
  *
- * Free-function form of the previous `ISdk.createStream` instance method.
+ * Free-function form of the previous `IIIClient.createStream` instance method.
  */
-export function createStream<TData>(iii: ISdk, streamName: string, stream: IStream<TData>): void {
+export function createStream<TData>(iii: IIIClient, streamName: string, stream: IStream<TData>): void {
   ;(iii as IIIWithHelperShims).__helpers_create_stream(streamName, stream)
 }

--- a/sdk/packages/node/iii/src/iii-types.ts
+++ b/sdk/packages/node/iii/src/iii-types.ts
@@ -132,7 +132,7 @@ export type MiddlewareFunctionInput = {
 }
 
 /**
- * Request object passed to {@link ISdk.trigger}.
+ * Request object passed to {@link IIIClient.trigger}.
  *
  * @typeParam TInput - Type of the payload.
  */

--- a/sdk/packages/node/iii/src/index.ts
+++ b/sdk/packages/node/iii/src/index.ts
@@ -1,11 +1,4 @@
-/** @deprecated Import channel symbols from `iii-sdk/channel`. */
-export { ChannelReader, ChannelWriter } from './channel'
-/** @deprecated Import `Channel` / `StreamChannelRef` from `iii-sdk/channel`. */
-export type { Channel, StreamChannelRef } from './channel'
-
 export { InvocationError, type InvocationErrorInit } from './errors'
-/** @deprecated Renamed; import `InvocationError` / `InvocationErrorInit` from `iii-sdk/errors`. */
-export { IIIInvocationError, type IIIInvocationErrorInit } from './errors'
 
 export { type InitOptions, registerWorker, type TelemetryOptions, TriggerAction } from './iii'
 
@@ -13,13 +6,4 @@ export type { EnqueueResult } from '@iii-dev/helpers/queue'
 
 export type { MiddlewareFunctionInput } from './iii-types'
 
-/** @deprecated Import trigger types from `iii-sdk/trigger`. */
-export type { Trigger, TriggerConfig, TriggerHandler } from './trigger'
-
 export type { IIIClient, StreamRequest, StreamResponse } from './types'
-
-/** @deprecated Renamed to `IIIClient`. */
-export type { ISdk } from './types'
-
-/** @deprecated Import runtime types from `iii-sdk/runtime`. */
-export type { FunctionRef, TriggerTypeRef } from './runtime'

--- a/sdk/packages/node/iii/src/stream.ts
+++ b/sdk/packages/node/iii/src/stream.ts
@@ -11,7 +11,7 @@ import type {
 } from '@iii-dev/helpers/stream'
 
 /**
- * Interface for custom stream implementations. Passed to `ISdk.createStream`
+ * Interface for custom stream implementations. Passed to `IIIClient.createStream`
  * to override the engine's built-in stream storage.
  *
  * @typeParam TData - Type of the data stored in the stream.

--- a/sdk/packages/node/iii/src/triggers.ts
+++ b/sdk/packages/node/iii/src/triggers.ts
@@ -17,7 +17,7 @@ export type TriggerConfig<TConfig> = {
 
 /**
  * Handler interface for custom trigger types. Passed to
- * `ISdk.registerTriggerType`.
+ * `IIIClient.registerTriggerType`.
  *
  * @typeParam TConfig - Type of the trigger-specific configuration.
  *

--- a/sdk/packages/node/iii/src/types.ts
+++ b/sdk/packages/node/iii/src/types.ts
@@ -213,9 +213,6 @@ export interface IIIClient {
   shutdown(): Promise<void>
 }
 
-/** @deprecated Renamed to `IIIClient`. */
-export type ISdk = IIIClient
-
 /**
  * Handle returned by {@link IIIClient.registerTrigger}. Use `unregister()` to
  * remove the trigger from the engine.

--- a/sdk/packages/node/iii/tests/data-channels.test.ts
+++ b/sdk/packages/node/iii/tests/data-channels.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { ChannelReader, ChannelWriter } from '../src'
+import type { ChannelReader, ChannelWriter } from '../src/channel'
 import { createChannel } from '../src/helpers'
 import { iii, sleep } from './utils'
 

--- a/sdk/packages/node/iii/tests/errors.test.ts
+++ b/sdk/packages/node/iii/tests/errors.test.ts
@@ -67,20 +67,12 @@ describe('isErrorBody', () => {
   })
 })
 
-describe('errors subpath and back-compat', () => {
+describe('errors subpath', () => {
   it('exports InvocationError from the iii-sdk/errors subpath', async () => {
     const errs = await import('../src/errors')
     expect(errs.InvocationError).toBeDefined()
     expect(typeof errs.InvocationError).toBe('function')
     const root = await import('../src/index')
     expect(root.InvocationError).toBe(errs.InvocationError)
-  })
-
-  it('keeps the deprecated IIIInvocationError alias pointing at InvocationError', async () => {
-    const errs = await import('../src/errors')
-    const root = await import('../src/index')
-    expect(root.IIIInvocationError).toBe(errs.InvocationError)
-    const err = new root.IIIInvocationError({ code: 'FORBIDDEN', message: 'nope' })
-    expect(err).toBeInstanceOf(errs.InvocationError)
   })
 })

--- a/sdk/packages/node/iii/tests/exports.test.ts
+++ b/sdk/packages/node/iii/tests/exports.test.ts
@@ -30,13 +30,13 @@ describe('Package Exports', () => {
     expect(Object.keys(stateModule).length).toBeGreaterThan(0)
   })
 
-  it('should export channel symbols from the subpath and keep the deprecated root shim', async () => {
+  it('should export channel symbols from the subpath only, not the root', async () => {
     const ch = await import('../src/channel')
     expect(ch.ChannelReader).toBeDefined()
     expect(ch.ChannelWriter).toBeDefined()
-    const root = await import('../src/index')
-    expect(root.ChannelReader).toBe(ch.ChannelReader)
-    expect(root.ChannelWriter).toBe(ch.ChannelWriter)
+    const root = (await import('../src/index')) as Record<string, unknown>
+    expect(root.ChannelReader).toBeUndefined()
+    expect(root.ChannelWriter).toBeUndefined()
   })
 
   it('should import the trigger subpath module', async () => {

--- a/sdk/packages/node/iii/tests/helpers.test.ts
+++ b/sdk/packages/node/iii/tests/helpers.test.ts
@@ -26,7 +26,7 @@ describe('helpers module', () => {
   })
 })
 
-describe('ISdk public surface', () => {
+describe('IIIClient public surface', () => {
   it('no longer exposes relocated methods', async () => {
     const iii = registerWorker('ws://localhost:9') as unknown as Record<string, unknown>
     try {

--- a/sdk/packages/node/iii/tests/service-triggers.test.ts
+++ b/sdk/packages/node/iii/tests/service-triggers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { ChannelReader } from '../src'
+import type { ChannelReader } from '../src/channel'
 import { createChannel } from '../src/helpers'
 import { EngineFunctions } from '../src/iii-constants'
 import { iii, sleep } from './utils'

--- a/sdk/packages/node/iii/tests/trigger-registration-error.test.ts
+++ b/sdk/packages/node/iii/tests/trigger-registration-error.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { WebSocketServer, type WebSocket } from 'ws'
 import { registerWorker } from '../src/iii'
-import type { ISdk } from '../src/types'
+import type { IIIClient } from '../src/types'
 
 describe('trigger registration error surfacing', () => {
   let wss: WebSocketServer
   let url: string
-  let sdk: ISdk | undefined
+  let sdk: IIIClient | undefined
   let serverSocket: WebSocket | undefined
 
   beforeEach(async () => {

--- a/sdk/packages/node/iii/tests/trigger-type-lifecycle.test.ts
+++ b/sdk/packages/node/iii/tests/trigger-type-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { TriggerAction, registerWorker } from '../src/index'
-import type { ISdk } from '../src/types'
+import type { IIIClient } from '../src/types'
 import type { TriggerConfig } from '../src/triggers'
 import { engineWsUrl, sleep } from './utils'
 
@@ -12,14 +12,14 @@ const TRIGGER_CONFIG = { tag: 'test' }
 type TestTriggerConfig = { tag: string }
 
 describe('Trigger type lifecycle (two workers)', () => {
-  let provider: ISdk
-  let consumer: ISdk
+  let provider: IIIClient
+  let consumer: IIIClient
   const bindings = new Map<string, TriggerConfig<TestTriggerConfig>>()
   let registerTriggerSpy: ReturnType<typeof vi.fn>
   let unregisterTriggerSpy: ReturnType<typeof vi.fn>
   let handlerSpy: ReturnType<typeof vi.fn>
 
-  function createProvider(): ISdk {
+  function createProvider(): IIIClient {
     bindings.clear()
     registerTriggerSpy = vi.fn(async (cfg: TriggerConfig<TestTriggerConfig>) => {
       bindings.set(cfg.id, cfg)
@@ -130,7 +130,7 @@ describe('Trigger type lifecycle (two workers)', () => {
     unregisterTriggerSpy.mockClear()
 
     await consumer.shutdown()
-    consumer = undefined as unknown as ISdk
+    consumer = undefined as unknown as IIIClient
     await sleep(400)
 
     expect(unregisterTriggerSpy).toHaveBeenCalledTimes(1)

--- a/sdk/packages/python/iii-example/src/trigger_types.py
+++ b/sdk/packages/python/iii-example/src/trigger_types.py
@@ -8,12 +8,9 @@ Shows three patterns:
 
 from typing import Any
 
-from iii import (
-    IIIClient,
-    RegisterTriggerTypeInput,
-    TriggerConfig,
-    TriggerHandler,
-)
+from iii import IIIClient
+from iii.protocol import RegisterTriggerTypeInput
+from iii.trigger import TriggerConfig, TriggerHandler
 from pydantic import BaseModel, Field
 
 # ── Webhook trigger type ─────────────────────────────────────────────────

--- a/sdk/packages/python/iii/src/iii/__init__.py
+++ b/sdk/packages/python/iii/src/iii/__init__.py
@@ -1,14 +1,10 @@
 """III SDK for Python."""
 
-from typing import Any
-
 from iii_helpers.queue import EnqueueResult
 
-from .channels import ChannelReader, ChannelWriter
 from .errors import InvocationError
 from .iii import TriggerAction, register_worker
 from .iii_constants import (
-    FunctionRef,
     InitOptions,
     TelemetryOptions,
 )
@@ -18,22 +14,16 @@ from .iii_types import (
     TriggerActionVoid,
 )
 from .stream import IStream
-from .triggers import Trigger, TriggerConfig, TriggerHandler, TriggerTypeRef
 from .types import (
-    Channel,
     IIIClient,
     StreamRequest,
     StreamResponse,
 )
 
 __all__ = [
-    # Channels
-    "ChannelReader",
-    "ChannelWriter",
     # Errors
     "InvocationError",
     # Core
-    "FunctionRef",
     "InitOptions",
     "register_worker",
     "TelemetryOptions",
@@ -45,40 +35,10 @@ __all__ = [
     "TriggerActionVoid",
     # Queue
     "EnqueueResult",
-    # Triggers
-    "Trigger",
-    "TriggerConfig",
-    "TriggerHandler",
-    "TriggerTypeRef",
     # Types
-    "Channel",
     "IIIClient",
     "StreamRequest",
     "StreamResponse",
     # Stream
     "IStream",
 ]
-
-
-def __getattr__(name: str) -> Any:
-    if name == "IIIInvocationError":
-        import warnings
-
-        warnings.warn(
-            "IIIInvocationError is deprecated; import InvocationError from iii.errors",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return InvocationError
-    if name == "StreamChannelRef":
-        import warnings
-
-        warnings.warn(
-            "Importing StreamChannelRef from iii is deprecated; import it from iii.channel",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        from .channel import StreamChannelRef
-
-        return StreamChannelRef
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/sdk/packages/python/iii/src/iii/errors.py
+++ b/sdk/packages/python/iii/src/iii/errors.py
@@ -70,7 +70,3 @@ def _wrap_wire_error(
         function_id=function_id,
         invocation_id=invocation_id,
     )
-
-
-# Back-compat alias; renamed to InvocationError in Stage 1. Deprecated.
-IIIInvocationError = InvocationError

--- a/sdk/packages/python/iii/tests/test_channel_submodule.py
+++ b/sdk/packages/python/iii/tests/test_channel_submodule.py
@@ -1,4 +1,4 @@
-"""The iii.channel submodule exposes the channel types; the root keeps the shims."""
+"""The iii.channel submodule exposes the channel types; the root no longer does."""
 
 
 def test_channel_subpath() -> None:
@@ -7,8 +7,8 @@ def test_channel_subpath() -> None:
     assert all(x is not None for x in (ChannelReader, ChannelWriter, StreamChannelRef, Channel))
 
 
-def test_channel_root_shim() -> None:
+def test_channel_types_not_at_root() -> None:
     import iii
-    from iii.channel import ChannelReader as SubReader
 
-    assert iii.ChannelReader is SubReader
+    for name in ("Channel", "ChannelReader", "ChannelWriter", "StreamChannelRef"):
+        assert not hasattr(iii, name)

--- a/sdk/packages/python/iii/tests/test_errors.py
+++ b/sdk/packages/python/iii/tests/test_errors.py
@@ -153,18 +153,16 @@ class TestWrapWireError:
         assert err.stacktrace is None
 
 
-class TestErrorsSubmoduleAndBackCompat:
+class TestErrorsSubmodule:
     def test_subpath_import(self) -> None:
         from iii.errors import InvocationError as FromErrors
 
         assert FromErrors is InvocationError
 
-    def test_deprecated_alias_warns(self) -> None:
-        import warnings
+    def test_removed_alias_not_at_root(self) -> None:
+        import pytest
 
         import iii
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            assert iii.IIIInvocationError is InvocationError
-        assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+        with pytest.raises(AttributeError):
+            _ = iii.IIIInvocationError

--- a/sdk/packages/python/iii/tests/test_rbac_workers.py
+++ b/sdk/packages/python/iii/tests/test_rbac_workers.py
@@ -9,10 +9,9 @@ from iii import (
     InitOptions,
     InvocationError,
     MiddlewareFunctionInput,
-    TriggerConfig,
-    TriggerHandler,
     register_worker,
 )
+from iii.trigger import TriggerConfig, TriggerHandler
 from iii_helpers.worker_connection_manager import (
     AuthInput,
     AuthResult,

--- a/sdk/packages/python/iii/tests/test_runtime_submodule.py
+++ b/sdk/packages/python/iii/tests/test_runtime_submodule.py
@@ -1,4 +1,4 @@
-"""The iii.runtime submodule exposes the runtime types; the root keeps the shims."""
+"""The iii.runtime submodule exposes the runtime types; the root no longer does."""
 
 
 def test_runtime_subpath() -> None:
@@ -8,8 +8,8 @@ def test_runtime_subpath() -> None:
     assert TriggerTypeRef is not None
 
 
-def test_runtime_root_shim() -> None:
+def test_runtime_types_not_at_root() -> None:
     import iii
-    from iii.runtime import FunctionRef as SubFunctionRef
 
-    assert iii.FunctionRef is SubFunctionRef
+    for name in ("FunctionRef", "TriggerTypeRef"):
+        assert not hasattr(iii, name)

--- a/sdk/packages/python/iii/tests/test_trigger_submodule.py
+++ b/sdk/packages/python/iii/tests/test_trigger_submodule.py
@@ -1,4 +1,4 @@
-"""The iii.trigger submodule exposes the trigger types; the root keeps the shims."""
+"""The iii.trigger submodule exposes the trigger types; the root no longer does."""
 
 
 def test_trigger_subpath() -> None:
@@ -7,11 +7,11 @@ def test_trigger_subpath() -> None:
     assert all(x is not None for x in (Trigger, TriggerConfig, TriggerHandler))
 
 
-def test_trigger_root_shim() -> None:
+def test_trigger_types_not_at_root() -> None:
     import iii
-    from iii.trigger import Trigger as SubTrigger
 
-    assert iii.Trigger is SubTrigger
+    for name in ("Trigger", "TriggerConfig", "TriggerHandler", "TriggerTypeRef"):
+        assert not hasattr(iii, name)
 
 
 def test_trigger_action_void_at_root() -> None:

--- a/sdk/packages/python/iii/tests/test_trigger_type_lifecycle.py
+++ b/sdk/packages/python/iii/tests/test_trigger_type_lifecycle.py
@@ -6,8 +6,9 @@ from typing import Any
 
 import pytest
 
-from iii import TriggerAction, TriggerConfig, TriggerHandler, register_worker
+from iii import TriggerAction, register_worker
 from iii.iii import III
+from iii.trigger import TriggerConfig, TriggerHandler
 
 ENGINE_WS_URL = os.environ.get("III_URL", "ws://localhost:49199")
 

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -939,11 +939,12 @@ impl IIIClient {
     /// # Examples
     /// ```rust,no_run
     /// # use iii_sdk::{IIIClient, RegisterTriggerType};
+    /// # use iii_sdk::trigger::{TriggerConfig, TriggerHandler};
     /// # struct MyHandler;
     /// # #[async_trait::async_trait]
-    /// # impl iii_sdk::TriggerHandler for MyHandler {
-    /// #     async fn register_trigger(&self, _: iii_sdk::TriggerConfig) -> Result<(), iii_sdk::Error> { Ok(()) }
-    /// #     async fn unregister_trigger(&self, _: iii_sdk::TriggerConfig) -> Result<(), iii_sdk::Error> { Ok(()) }
+    /// # impl TriggerHandler for MyHandler {
+    /// #     async fn register_trigger(&self, _: TriggerConfig) -> Result<(), iii_sdk::Error> { Ok(()) }
+    /// #     async fn unregister_trigger(&self, _: TriggerConfig) -> Result<(), iii_sdk::Error> { Ok(()) }
     /// # }
     /// # #[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)] struct MyConfig { url: String }
     /// # #[derive(serde::Deserialize, schemars::JsonSchema)] struct MyRequest { data: String }

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -45,32 +45,13 @@ pub mod errors {
 // types into the SDK, which the `compile_fail` doctests below deliberately
 // forbid. Hence the `internal` grouping is a no-op for Rust.
 
-#[deprecated(since = "0.19.0", note = "import from iii_sdk::trigger")]
-pub use builtin_triggers::IIITrigger;
-#[deprecated(since = "0.19.0", note = "import from iii_sdk::channel")]
-pub use channels::{ChannelReader, ChannelWriter, StreamChannelRef};
-#[deprecated(
-    since = "0.19.0",
-    note = "renamed to Error; import from iii_sdk::errors"
-)]
-pub use error::Error as IIIError;
 pub use error::{Error, InvocationError};
-#[deprecated(since = "0.20.0", note = "renamed to IIIClient")]
-pub use iii::IIIClient as III;
 pub use iii::TelemetryOptions;
-#[deprecated(since = "0.20.0", note = "renamed to TelemetryOptions")]
-pub use iii::TelemetryOptions as WorkerTelemetryMeta;
-#[deprecated(since = "0.19.0", note = "import from iii_sdk::runtime")]
-pub use iii::{FunctionInfo, FunctionRef, TriggerInfo, TriggerTypeRef, WorkerInfo, WorkerMetadata};
 pub use iii::{IIIClient, RegisterFunction, RegisterTriggerType};
 pub use iii_helpers::queue::EnqueueResult;
 pub use protocol::{Message, TriggerAction};
 pub use stream_provider::IStream;
 pub use structs::MiddlewareFunctionInput;
-#[deprecated(since = "0.19.0", note = "import from iii_sdk::trigger")]
-pub use triggers::{Trigger, TriggerConfig, TriggerHandler};
-#[deprecated(since = "0.19.0", note = "import from iii_sdk::channel")]
-pub use types::Channel;
 pub use types::{StreamRequest, StreamResponse};
 
 /// Configuration options passed to [`register_worker`].
@@ -233,6 +214,49 @@ fn _ensure_channel_submodule_path() {}
 /// ```
 #[allow(dead_code)]
 fn _ensure_errors_submodule_path() {}
+
+// ---------------------------------------------------------------------------
+// 0.20 clean break: the deprecated crate-root re-exports and renamed aliases
+// are removed. The relocated types live under their canonical submodule paths
+// (`iii_sdk::{trigger,channel,runtime}`) and the renamed types use their new
+// names (`IIIClient`, `Error`, `TelemetryOptions`).
+// ---------------------------------------------------------------------------
+
+/// ```compile_fail
+/// use iii_sdk::{Channel, ChannelReader, ChannelWriter, StreamChannelRef};
+/// ```
+#[allow(dead_code)]
+fn _ensure_channel_types_not_top_level() {}
+
+/// ```compile_fail
+/// use iii_sdk::{IIITrigger, Trigger, TriggerConfig, TriggerHandler};
+/// ```
+#[allow(dead_code)]
+fn _ensure_trigger_types_not_top_level() {}
+
+/// ```compile_fail
+/// use iii_sdk::{FunctionInfo, FunctionRef, TriggerInfo, TriggerTypeRef, WorkerInfo, WorkerMetadata};
+/// ```
+#[allow(dead_code)]
+fn _ensure_runtime_types_not_top_level() {}
+
+/// ```compile_fail
+/// use iii_sdk::III;
+/// ```
+#[allow(dead_code)]
+fn _ensure_renamed_client_alias_removed() {}
+
+/// ```compile_fail
+/// use iii_sdk::IIIError;
+/// ```
+#[allow(dead_code)]
+fn _ensure_renamed_error_alias_removed() {}
+
+/// ```compile_fail
+/// use iii_sdk::WorkerTelemetryMeta;
+/// ```
+#[allow(dead_code)]
+fn _ensure_renamed_telemetry_alias_removed() {}
 
 // ---------------------------------------------------------------------------
 // Stream types relocated to `iii_helpers::stream`: they are no longer reachable

--- a/sdk/packages/rust/iii/tests/error_wire.rs
+++ b/sdk/packages/rust/iii/tests/error_wire.rs
@@ -1,6 +1,6 @@
 //! Wire-level tests for handler error mapping (no running engine needed).
 //!
-//! `IIIError::Remote` is a structured, expected error owned by the handler:
+//! `Error::Remote` is a structured, expected error owned by the handler:
 //! its `code` must reach the wire `ErrorBody.code` verbatim and
 //! `stacktrace: None` must NOT be backfilled with a dispatch-loop backtrace.
 //! Non-`Remote` handler errors keep the legacy `invocation_failed` code with
@@ -13,7 +13,7 @@ use std::time::Duration;
 use serde_json::{Value, json};
 
 use common::mock_engine::{MockEngine, count_type};
-use iii_sdk::{IIIError, InitOptions, RegisterFunction, register_worker};
+use iii_sdk::{Error, InitOptions, RegisterFunction, register_worker};
 
 fn find_result<'a>(msgs: &'a [Value], invocation_id: &str) -> Option<&'a Value> {
     msgs.iter()
@@ -28,7 +28,7 @@ async fn remote_error_passes_code_through_without_backfilled_stacktrace() {
     let _f = iii.register_function(
         "test::remote_err",
         RegisterFunction::new_async(|_: Value| async move {
-            Err::<Value, _>(IIIError::Remote {
+            Err::<Value, _>(Error::Remote {
                 code: "W105".to_string(),
                 message: "{\"code\":\"W105\",\"type\":\"WorkerOpError\"}".to_string(),
                 stacktrace: None,
@@ -82,7 +82,7 @@ async fn non_remote_error_keeps_invocation_failed_with_backfilled_stacktrace() {
     let _f = iii.register_function(
         "test::handler_err",
         RegisterFunction::new_async(|_: Value| async move {
-            Err::<Value, _>(IIIError::Handler("boom".to_string()))
+            Err::<Value, _>(Error::Handler("boom".to_string()))
         }),
     );
 

--- a/sdk/packages/rust/iii/tests/registration_dedup.rs
+++ b/sdk/packages/rust/iii/tests/registration_dedup.rs
@@ -21,9 +21,9 @@ use serde_json::{Value, json};
 
 use iii_sdk::protocol::RegisterTriggerInput;
 use iii_sdk::runtime::IIIConnectionState;
+use iii_sdk::trigger::{TriggerConfig, TriggerHandler};
 use iii_sdk::{
-    Error, IIIClient, InitOptions, RegisterFunction, RegisterTriggerType, TriggerConfig,
-    TriggerHandler, register_worker,
+    Error, IIIClient, InitOptions, RegisterFunction, RegisterTriggerType, register_worker,
 };
 
 use common::mock_engine::{MockEngine, count_register, count_type};

--- a/sdk/packages/rust/iii/tests/trigger_type_lifecycle.rs
+++ b/sdk/packages/rust/iii/tests/trigger_type_lifecycle.rs
@@ -9,9 +9,8 @@ use serial_test::serial;
 use async_trait::async_trait;
 use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
 use iii_sdk::runtime::IIIConnectionState;
-use iii_sdk::{
-    Error, InitOptions, RegisterFunction, TriggerConfig, TriggerHandler, register_worker,
-};
+use iii_sdk::trigger::{TriggerConfig, TriggerHandler};
+use iii_sdk::{Error, InitOptions, RegisterFunction, register_worker};
 use serde_json::{Value, json};
 use tokio::time::Duration;
 


### PR DESCRIPTION
## What

A **clean break** for 0.20.x: removes the deprecated backward-compatibility re-exports and renamed aliases across the three SDKs so 0.19.x imports stop resolving. Consumers move to the canonical submodule paths / new names.

Built on the `sdk-refactor` branch.

> **Observability is intentionally NOT broken here.** The standalone `@iii-dev/observability` / `iii-observability` packages stay published as **deprecated shims** (re-export the helpers observability submodule + emit a deprecation signal). Their removal is deferred to a later release. This PR does not touch them.

## Removed deprecated re-exports & renamed aliases

| Kind | Removed | Use instead |
| --- | --- | --- |
| Main client | Node `ISdk`, Rust `III` | `IIIClient` |
| Errors | `IIIInvocationError`/`IIIInvocationErrorInit`, Rust `IIIError` | `InvocationError`/`InvocationErrorInit` (`*/errors`), Rust `Error` (`iii_sdk::errors`) |
| Telemetry | Rust `WorkerTelemetryMeta` | `TelemetryOptions` |
| Channel | `Channel`, `ChannelReader`, `ChannelWriter`, `StreamChannelRef` at root | `*/channel` submodule |
| Trigger | `Trigger`, `TriggerConfig`, `TriggerHandler`, Rust `IIITrigger` at root | `*/trigger` submodule |
| Runtime | `FunctionRef`, `TriggerTypeRef` (+ Rust `FunctionInfo`/`TriggerInfo`/`WorkerInfo`/`WorkerMetadata`) at root | `*/runtime` submodule |

Python's root `__getattr__` deprecation shims (`IIIInvocationError`, `StreamChannelRef`) and the channel/trigger/runtime root re-exports are removed too, bringing the Python root surface to parity with Node/Rust.

## Consumers & infra migrated

- All first-party Rust consumers (engine, console, `crates/iii-worker`, examples, the `worker-bare` template) repointed to canonical paths.
- Node `iii` internals (`helpers.ts`) and the `trigger-types` example repointed; export-surface tests flipped to assert the removed symbols are no longer at the root.
- Rust `compile_fail` doctests added to guard the removed crate-root symbols.
- 0.20.0 changelog + `next/` SDK reference docs (incl. rendered `.skill.md`) updated. Logger import guidance points at `@iii-dev/helpers/observability` (the canonical path; the standalone shim is deprecated).

## Verification (all green)

- **Rust**: `cargo build --workspace`, `cargo clippy --workspace --all-targets` (0 errors), `cargo fmt --all -- --check`, lib + doc tests, `cargo test --workspace --no-run`.
- **Node**: `tsc --noEmit` clean; `vitest` 213/227 pass — the 14 remaining are bridge **integration** tests needing a live engine (spawned in CI's "SDK Node Tests" job).
- **Python**: `ruff check src` clean, `mypy src` clean; `pytest` 323/324 — the 1 remaining is a bridge integration test needing the engine (spawned in CI's Python job).

## Breaking changes

Intentionally breaks 0.19.x→0.20.x source compatibility for the renamed/relocated symbols. Migration is import-path/name only; behavior is unchanged. Observability importers are unaffected (deprecated shim still works).