### PR TITLE
fix(release): publish iii-helpers before iii-observability

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -169,7 +169,9 @@ jobs:
 
   observability-py:
     name: Observability Python (pypi)
-    needs: prepare
+    # The shim pins iii-helpers at the release version; publish helpers first so
+    # PyPI can resolve the dependency.
+    needs: [prepare, helpers-py]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_py.yml
     with:
@@ -207,7 +209,9 @@ jobs:
 
   observability-rust:
     name: Observability Rust (cargo)
-    needs: prepare
+    # The shim depends on iii-helpers; cargo publish resolves it from crates.io,
+    # so helpers must be published first.
+    needs: [prepare, helpers-rust]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_rust-cargo.yml
     with:

--- a/.github/workflows/release-iii.yml
+++ b/.github/workflows/release-iii.yml
@@ -476,7 +476,9 @@ jobs:
 
   observability-py:
     name: Observability Python Publish
-    needs: [setup, create-iii-release]
+    # The shim pins iii-helpers at the release version; publish helpers first so
+    # PyPI can resolve the dependency.
+    needs: [setup, create-iii-release, helpers-py]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_py.yml
     with:
@@ -540,7 +542,9 @@ jobs:
 
   observability-rust:
     name: Observability Rust Publish
-    needs: [setup, create-iii-release]
+    # The shim depends on iii-helpers; cargo publish resolves it from crates.io,
+    # so helpers must be published first.
+    needs: [setup, create-iii-release, helpers-rust]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_rust-cargo.yml
     with:


### PR DESCRIPTION
## What

Make the `observability-rust` / `observability-py` publish jobs depend on `helpers-rust` / `helpers-py` in both the alpha and stable release pipelines.

## Why

In the alpha run [27825806195](https://github.com/iii-hq/iii/actions/runs/27825806195) two things went wrong:

1. **Observability Rust publish failed** — the `iii-observability` shim depends on `iii-helpers`, but `observability-rust` only `needs: prepare`, so it ran in parallel with `helpers-rust`. `cargo publish` resolves deps against crates.io, and observability resolved before helpers had uploaded the matching version:

   ```
   error: failed to select a version for the requirement `iii-helpers = "^0.19.4-alpha.4"`
   candidate versions found which didn't match: 0.19.4-alpha.3, 0.19.4-alpha.2
   ```

   (It passed in earlier alpha runs only by luck of timing.)

2. **SDK Rust was skipped** — `sdk-rust` gates on `observability-rust` via `needs` + `if: ${{ !failure() && !cancelled() }}`. When observability-rust failed, that condition went false and sdk-rust skipped. Not a separate bug — a cascade from #1.

Node is unaffected: it publishes the whole workspace in one job via `pnpm -r publish`, which resolves topological order itself. PyPI doesn't verify deps at publish time so `observability-py` happened to pass, but it had the same latent race — fixed here too for safety.

## Change

`observability-rust` → `needs: [..., helpers-rust]`; `observability-py` → `needs: [..., helpers-py]`. Publish order is now **helpers → observability → sdk**.