### PR TITLE
Preserve state keys

### DIFF
--- a/console/packages/console-frontend/src/api/state/state.test.ts
+++ b/console/packages/console-frontend/src/api/state/state.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchStateItems } from './state'
+
+function mockStateItems(payload: unknown): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      json: async () => payload,
+    })),
+  )
+}
+
+describe('fetchStateItems', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses explicit item keys', async () => {
+    mockStateItems({ items: [{ key: 'worker', value: { status: 'ready' } }] })
+
+    const { items } = await fetchStateItems('runtime')
+
+    expect(items[0]).toMatchObject({
+      groupId: 'runtime',
+      key: 'worker',
+      value: { status: 'ready' },
+      type: 'object',
+    })
+  })
+
+  it('uses map keys for object-shaped item responses', async () => {
+    mockStateItems({ items: { 'files/worker/config.yaml': { raw: true } } })
+
+    const { items } = await fetchStateItems('runtime')
+
+    expect(items[0].key).toBe('files/worker/config.yaml')
+    expect(items[0].value).toEqual({ raw: true })
+  })
+
+  it('uses explicit item keys before generated object entry keys', async () => {
+    mockStateItems({ items: { 'item-0': { key: 'worker', value: { status: 'ready' } } } })
+
+    const { items } = await fetchStateItems('runtime')
+
+    expect(items[0].key).toBe('worker')
+    expect(items[0].value).toEqual({ status: 'ready' })
+  })
+
+  it('uses embedded state_key before falling back', async () => {
+    mockStateItems({ items: [{ state_key: 'last_test_suite', status: 'PASS' }] })
+
+    const { items } = await fetchStateItems('runtime')
+
+    expect(items[0].key).toBe('last_test_suite')
+    expect(items[0].value).toEqual({ state_key: 'last_test_suite', status: 'PASS' })
+  })
+
+  it('does not invent item-N labels when keys are missing', async () => {
+    mockStateItems({ items: [{ status: 'unknown' }] })
+
+    const { items } = await fetchStateItems('runtime')
+
+    expect(items[0].key).toBe('(missing key 0)')
+  })
+})

--- a/console/packages/console-frontend/src/api/state/state.ts
+++ b/console/packages/console-frontend/src/api/state/state.ts
@@ -22,6 +22,74 @@ export interface StateGroup {
 // State Functions (used functions only)
 // ============================================================================
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function stateItemValue(item: Record<string, unknown>): unknown {
+  if ('value' in item && (nonEmptyString(item.key) || nonEmptyString(item.state_key))) {
+    return item.value
+  }
+
+  return item
+}
+
+function makeStateItem(groupId: string, key: string, value: unknown): StateItem {
+  return {
+    groupId,
+    key,
+    value,
+    type: typeof value === 'object' ? 'object' : typeof value,
+    timestamp: Date.now(),
+  }
+}
+
+function fallbackKey(index: number): string {
+  return `(missing key ${index})`
+}
+
+function isGeneratedItemKey(key: string): boolean {
+  return /^item-\d+$/.test(key)
+}
+
+function normalizeStateItem(groupId: string, item: unknown, index: number): StateItem {
+  if (Array.isArray(item) && item.length >= 2) {
+    const key = nonEmptyString(item[0])
+    if (key) return makeStateItem(groupId, key, item[1])
+  }
+
+  if (isRecord(item)) {
+    const key =
+      nonEmptyString(item.key) ?? nonEmptyString(item.state_key) ?? nonEmptyString(item.id)
+    return makeStateItem(groupId, key ?? fallbackKey(index), stateItemValue(item))
+  }
+
+  return makeStateItem(groupId, fallbackKey(index), item)
+}
+
+function normalizeStateItems(groupId: string, rawItems: unknown): StateItem[] {
+  if (Array.isArray(rawItems)) {
+    return rawItems.map((item, index) => normalizeStateItem(groupId, item, index))
+  }
+
+  if (isRecord(rawItems)) {
+    return Object.entries(rawItems).map(([key, value], index) => {
+      const embeddedKey = isRecord(value)
+        ? (nonEmptyString(value.key) ?? nonEmptyString(value.state_key) ?? nonEmptyString(value.id))
+        : null
+      const entryKey = key && !isGeneratedItemKey(key) ? key : null
+      const itemValue = isRecord(value) ? stateItemValue(value) : value
+      return makeStateItem(groupId, embeddedKey ?? entryKey ?? fallbackKey(index), itemValue)
+    })
+  }
+
+  return []
+}
+
 export async function fetchStateItems(
   groupId: string,
 ): Promise<{ items: StateItem[]; count: number }> {
@@ -31,17 +99,9 @@ export async function fetchStateItems(
     body: JSON.stringify({ scope: groupId }),
   })
   if (!res.ok) throw new Error('Failed to fetch state items')
-  const data = await unwrapResponse<{ items: unknown[] }>(res)
-  const items: StateItem[] = (data.items || []).map((item: unknown, index: number) => {
-    const typedItem = item as Record<string, unknown>
-    return {
-      groupId,
-      key: (typedItem.id as string) || `item-${index}`,
-      value: item,
-      type: typeof item === 'object' ? 'object' : typeof item,
-      timestamp: Date.now(),
-    }
-  })
+  const data = await unwrapResponse<{ items?: unknown } | Record<string, unknown> | unknown[]>(res)
+  const rawItems = Array.isArray(data) || !isRecord(data) || !('items' in data) ? data : data.items
+  const items = normalizeStateItems(groupId, rawItems)
   return { items, count: items.length }
 }
 

--- a/engine/src/builtins/kv.rs
+++ b/engine/src/builtins/kv.rs
@@ -569,6 +569,16 @@ impl BuiltinKvStore {
             .map_or(vec![], |topic| topic.values().cloned().collect())
     }
 
+    pub async fn list_entries(&self, index: String) -> Vec<(String, Value)> {
+        let store = self.store.read().await;
+        store.get(&index).map_or(vec![], |topic| {
+            topic
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect()
+        })
+    }
+
     pub async fn list_groups(&self) -> Vec<String> {
         let store = self.store.read().await;
         store.keys().cloned().collect()

--- a/engine/src/workers/state/adapters/bridge.rs
+++ b/engine/src/workers/state/adapters/bridge.rs
@@ -19,7 +19,7 @@ use crate::{
         registry::{StateAdapterFuture, StateAdapterRegistration},
         structs::{
             StateDeleteInput, StateGetGroupInput, StateGetInput, StateListGroupsInput,
-            StateSetInput, StateUpdateInput,
+            StateListItem, StateSetInput, StateUpdateInput,
         },
     },
 };
@@ -36,6 +36,77 @@ impl BridgeAdapter {
 
         Ok(Self { bridge })
     }
+}
+
+fn decode_list_item(item: Value, index: usize) -> StateListItem {
+    match item {
+        Value::Array(mut tuple) if tuple.len() >= 2 => {
+            if let Some(key) = tuple.first().and_then(Value::as_str).map(str::to_string) {
+                let value = tuple.swap_remove(1);
+                return StateListItem { key, value };
+            }
+            StateListItem {
+                key: format!("(missing key {index})"),
+                value: Value::Array(tuple),
+            }
+        }
+        Value::Object(mut object) => {
+            let key = object
+                .get("key")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .or_else(|| {
+                    object
+                        .get("state_key")
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                });
+            match key {
+                Some(key) => {
+                    let value = object
+                        .remove("value")
+                        .unwrap_or_else(|| Value::Object(object));
+                    StateListItem { key, value }
+                }
+                None => StateListItem {
+                    key: format!("(missing key {index})"),
+                    value: Value::Object(object),
+                },
+            }
+        }
+        value => StateListItem {
+            key: format!("(missing key {index})"),
+            value,
+        },
+    }
+}
+
+fn decode_list_result(result: Value) -> anyhow::Result<Vec<StateListItem>> {
+    if let Ok(items) = serde_json::from_value::<Vec<StateListItem>>(result.clone()) {
+        return Ok(items);
+    }
+
+    let result = result.get("items").cloned().unwrap_or(result);
+
+    if let Some(object) = result.as_object() {
+        return Ok(object
+            .iter()
+            .map(|(key, value)| StateListItem {
+                key: key.clone(),
+                value: value.clone(),
+            })
+            .collect());
+    }
+
+    if let Value::Array(items) = result {
+        return Ok(items
+            .into_iter()
+            .enumerate()
+            .map(|(index, item)| decode_list_item(item, index))
+            .collect());
+    }
+
+    anyhow::bail!("invalid state::list response: expected array, object, or items field")
 }
 
 #[async_trait]
@@ -130,7 +201,7 @@ impl StateAdapter for BridgeAdapter {
         Ok(())
     }
 
-    async fn list(&self, scope: &str) -> anyhow::Result<Vec<Value>> {
+    async fn list(&self, scope: &str) -> anyhow::Result<Vec<StateListItem>> {
         let data = StateGetGroupInput {
             scope: scope.to_string(),
         };
@@ -146,8 +217,7 @@ impl StateAdapter for BridgeAdapter {
             .await
             .map_err(|e| anyhow::anyhow!("Failed to list values via bridge: {}", e))?;
 
-        serde_json::from_value::<Vec<Value>>(result)
-            .map_err(|e| anyhow::anyhow!("Failed to deserialize list result: {}", e))
+        decode_list_result(result)
     }
 
     async fn list_groups(&self) -> anyhow::Result<Vec<String>> {

--- a/engine/src/workers/state/adapters/kv_store.rs
+++ b/engine/src/workers/state/adapters/kv_store.rs
@@ -17,6 +17,7 @@ use crate::{
     workers::state::{
         adapters::StateAdapter,
         registry::{StateAdapterFuture, StateAdapterRegistration},
+        structs::StateListItem,
     },
 };
 
@@ -70,8 +71,14 @@ impl StateAdapter for BuiltinKvStoreAdapter {
             .await)
     }
 
-    async fn list(&self, scope: &str) -> anyhow::Result<Vec<Value>> {
-        Ok(self.storage.list(scope.to_string()).await)
+    async fn list(&self, scope: &str) -> anyhow::Result<Vec<StateListItem>> {
+        Ok(self
+            .storage
+            .list_entries(scope.to_string())
+            .await
+            .into_iter()
+            .map(|(key, value)| StateListItem { key, value })
+            .collect())
     }
 
     async fn list_groups(&self) -> anyhow::Result<Vec<String>> {
@@ -163,8 +170,14 @@ mod tests {
             .await
             .expect("List should succeed");
         assert_eq!(list.len(), 2);
-        assert!(list.contains(&data1));
-        assert!(list.contains(&data2));
+        assert!(list.contains(&StateListItem {
+            key: item1_id.to_string(),
+            value: data1
+        }));
+        assert!(list.contains(&StateListItem {
+            key: item2_id.to_string(),
+            value: data2
+        }));
     }
 
     #[tokio::test]

--- a/engine/src/workers/state/adapters/mod.rs
+++ b/engine/src/workers/state/adapters/mod.rs
@@ -12,6 +12,8 @@ use async_trait::async_trait;
 use iii_sdk::{UpdateOp, UpdateResult, types::SetResult};
 use serde_json::Value;
 
+use super::structs::StateListItem;
+
 #[async_trait]
 pub trait StateAdapter: Send + Sync {
     async fn set(&self, scope: &str, key: &str, value: Value) -> anyhow::Result<SetResult>;
@@ -23,7 +25,7 @@ pub trait StateAdapter: Send + Sync {
         key: &str,
         ops: Vec<UpdateOp>,
     ) -> anyhow::Result<UpdateResult>;
-    async fn list(&self, scope: &str) -> anyhow::Result<Vec<Value>>;
+    async fn list(&self, scope: &str) -> anyhow::Result<Vec<StateListItem>>;
     async fn list_groups(&self) -> anyhow::Result<Vec<String>>;
     async fn destroy(&self) -> anyhow::Result<()>;
 

--- a/engine/src/workers/state/adapters/redis_adapter.rs
+++ b/engine/src/workers/state/adapters/redis_adapter.rs
@@ -19,6 +19,7 @@ use crate::{
         state::{
             adapters::StateAdapter,
             registry::{StateAdapterFuture, StateAdapterRegistration},
+            structs::StateListItem,
         },
     },
 };
@@ -187,7 +188,7 @@ impl StateAdapter for StateRedisAdapter {
         Ok(())
     }
 
-    async fn list(&self, scope: &str) -> anyhow::Result<Vec<Value>> {
+    async fn list(&self, scope: &str) -> anyhow::Result<Vec<StateListItem>> {
         let scope_key = format!("state:{}", scope);
         let mut conn = self.publisher.lock().await;
 
@@ -197,11 +198,10 @@ impl StateAdapter for StateRedisAdapter {
             .map_err(|e| anyhow::anyhow!("Failed to get group from Redis: {}", e))?;
 
         let mut result = Vec::new();
-        for v in values.into_values() {
-            result.push(
-                serde_json::from_str(&v)
-                    .map_err(|e| anyhow::anyhow!("Failed to deserialize value: {}", e))?,
-            );
+        for (key, v) in values {
+            let value = serde_json::from_str(&v)
+                .map_err(|e| anyhow::anyhow!("Failed to deserialize value: {}", e))?;
+            result.push(StateListItem { key, value });
         }
         Ok(result)
     }

--- a/engine/src/workers/state/state.rs
+++ b/engine/src/workers/state/state.rs
@@ -716,7 +716,10 @@ impl StateWorker {
         }
     }
 
-    #[function(id = "state::list", description = "Get a group from state")]
+    #[function(
+        id = "state::list",
+        description = "List key/value entries from a state scope"
+    )]
     pub async fn list(
         &self,
         input: StateGetGroupInput,
@@ -769,7 +772,7 @@ mod tests {
     use super::*;
     use crate::workers::{
         observability::metrics::ensure_default_meter,
-        state::adapters::kv_store::BuiltinKvStoreAdapter,
+        state::{adapters::kv_store::BuiltinKvStoreAdapter, structs::StateListItem},
     };
     use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -834,7 +837,7 @@ mod tests {
         set_result: SetResult,
         get_result: Option<Value>,
         update_result: UpdateResult,
-        list_values: Vec<Value>,
+        list_values: Vec<StateListItem>,
         groups: Vec<String>,
         destroy_called: AtomicBool,
     }
@@ -901,7 +904,7 @@ mod tests {
             }
         }
 
-        async fn list(&self, _scope: &str) -> anyhow::Result<Vec<Value>> {
+        async fn list(&self, _scope: &str) -> anyhow::Result<Vec<StateListItem>> {
             match self.list_error {
                 Some(message) => Err(anyhow::anyhow!(message)),
                 None => Ok(self.list_values.clone()),
@@ -1236,6 +1239,12 @@ mod tests {
             FunctionResult::Success(Some(value)) => {
                 let arr = value.as_array().expect("list should return array");
                 assert_eq!(arr.len(), 3);
+                let mut entries = arr.clone();
+                entries.sort_by(|a, b| a["key"].as_str().cmp(&b["key"].as_str()));
+                for (i, entry) in entries.iter().enumerate() {
+                    assert_eq!(entry["key"], format!("item-{i}"));
+                    assert_eq!(entry["value"], serde_json::json!({"index": i}));
+                }
             }
             _ => panic!("Expected Success with Some value"),
         }

--- a/engine/src/workers/state/structs.rs
+++ b/engine/src/workers/state/structs.rs
@@ -52,6 +52,14 @@ pub struct StateGetGroupInput {
     pub scope: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct StateListItem {
+    /// Identifier for the value within the scope.
+    pub key: String,
+    /// Stored value for this key.
+    pub value: Value,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct StateListGroupsInput {}
 

--- a/engine/src/workers/state/trigger.rs
+++ b/engine/src/workers/state/trigger.rs
@@ -107,7 +107,9 @@ mod tests {
 
     use super::*;
     use crate::workers::{
-        state::{StateWorker, adapters::StateAdapter, config::StateModuleConfig},
+        state::{
+            StateWorker, adapters::StateAdapter, config::StateModuleConfig, structs::StateListItem,
+        },
         traits::ConfigurableWorker,
     };
 
@@ -148,7 +150,7 @@ mod tests {
             })
         }
 
-        async fn list(&self, _scope: &str) -> anyhow::Result<Vec<serde_json::Value>> {
+        async fn list(&self, _scope: &str) -> anyhow::Result<Vec<StateListItem>> {
             Ok(Vec::new())
         }
 

--- a/sdk/packages/node/iii-browser/src/state.ts
+++ b/sdk/packages/node/iii-browser/src/state.ts
@@ -40,6 +40,14 @@ export type StateListInput = {
   scope: string
 }
 
+/** One entry returned when listing a state scope. */
+export type StateListItem<TData> = {
+  /** Key within the scope. */
+  key: string
+  /** Stored value for the key. */
+  value: TData
+}
+
 /** Result of a state set operation. */
 export type StateSetResult<TData> = {
   /** Previous value (if it existed). */
@@ -112,8 +120,8 @@ export interface IState {
   set<TData>(input: StateSetInput): Promise<StateSetResult<TData> | null>
   /** Delete a state value. */
   delete(input: StateDeleteInput): Promise<DeleteResult>
-  /** List all values in a scope. */
-  list<TData>(input: StateListInput): Promise<TData[]>
+  /** List all key/value entries in a scope. */
+  list<TData>(input: StateListInput): Promise<StateListItem<TData>[]>
   /** Apply atomic update operations to a state value. */
   update<TData>(input: StateUpdateInput): Promise<StateUpdateResult<TData> | null>
 }

--- a/sdk/packages/node/iii-example/src/state.ts
+++ b/sdk/packages/node/iii-example/src/state.ts
@@ -4,6 +4,7 @@ import type {
   StateDeleteResult,
   StateGetInput,
   StateListInput,
+  StateListItem,
   StateSetInput,
   StateSetResult,
   StateUpdateInput,
@@ -18,7 +19,8 @@ export const state: IState = {
     iii.trigger({ function_id: 'state::set', payload: input }),
   delete: (input: StateDeleteInput): Promise<StateDeleteResult> =>
     iii.trigger({ function_id: 'state::delete', payload: input }),
-  list: <TData>(input: StateListInput): Promise<TData[]> => iii.trigger({ function_id: 'state::list', payload: input }),
+  list: <TData>(input: StateListInput): Promise<StateListItem<TData>[]> =>
+    iii.trigger({ function_id: 'state::list', payload: input }),
   update: <TData>(input: StateUpdateInput): Promise<StateUpdateResult<TData> | null> =>
     iii.trigger({ function_id: 'state::update', payload: input }),
 }

--- a/sdk/packages/node/iii/src/state.ts
+++ b/sdk/packages/node/iii/src/state.ts
@@ -40,6 +40,14 @@ export type StateListInput = {
   scope: string
 }
 
+/** One entry returned when listing a state scope. */
+export type StateListItem<TData> = {
+  /** Key within the scope. */
+  key: string
+  /** Stored value for the key. */
+  value: TData
+}
+
 /** Result of a state set operation. */
 export type StateSetResult<TData> = {
   /** Previous value (if it existed). */
@@ -114,8 +122,8 @@ export interface IState {
   set<TData>(input: StateSetInput): Promise<StateSetResult<TData> | null>
   /** Delete a state value. */
   delete(input: StateDeleteInput): Promise<DeleteResult>
-  /** List all values in a scope. */
-  list<TData>(input: StateListInput): Promise<TData[]>
+  /** List all key/value entries in a scope. */
+  list<TData>(input: StateListInput): Promise<StateListItem<TData>[]>
   /** Apply atomic update operations to a state value. */
   update<TData>(input: StateUpdateInput): Promise<StateUpdateResult<TData> | null>
 }

--- a/sdk/packages/node/iii/tests/state.test.ts
+++ b/sdk/packages/node/iii/tests/state.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { StateEventType, type StateEventData, type StateSetResult } from '../src/state'
+import { StateEventType, type StateEventData, type StateListItem, type StateSetResult } from '../src/state'
 import type { UpdateAppend, UpdateOp } from '../src/stream'
 import type { FunctionRef, Trigger } from '../src/types'
 import { execute, iii, logger } from './utils'
@@ -122,15 +122,21 @@ describe('State Operations', () => {
         })
       }
 
-      const result: TestDataWithId[] = await iii.trigger({
+      const result: StateListItem<TestDataWithId>[] = await iii.trigger({
         function_id: 'state::list',
         payload: { scope },
       })
-      const sort = (a: TestDataWithId, b: TestDataWithId) => a.id.localeCompare(b.id)
+      const sort = (a: StateListItem<TestDataWithId>, b: StateListItem<TestDataWithId>) =>
+        a.key.localeCompare(b.key)
 
       expect(Array.isArray(result)).toBe(true)
       expect(result.length).toBeGreaterThanOrEqual(items.length)
-      expect(result.sort(sort)).toEqual(items.sort(sort))
+      expect(result.sort(sort)).toEqual(
+        items.sort((a, b) => a.id.localeCompare(b.id)).map(item => ({
+          key: item.id,
+          value: item,
+        })),
+      )
     })
   })
 

--- a/sdk/packages/python/iii/src/iii/state.py
+++ b/sdk/packages/python/iii/src/iii/state.py
@@ -44,6 +44,13 @@ class StateListInput(BaseModel):
     scope: str
 
 
+class StateListItem(BaseModel, Generic[TData]):
+    """One entry returned when listing a state scope."""
+
+    key: str
+    value: TData
+
+
 class StateUpdateInput(BaseModel):
     """Input for atomically updating a state value."""
 
@@ -116,8 +123,8 @@ class IState(ABC, Generic[TData]):
         ...
 
     @abstractmethod
-    async def list(self, input: StateListInput) -> list[TData]:
-        """List all values in a scope."""
+    async def list(self, input: StateListInput) -> list[StateListItem[TData]]:
+        """List all key/value entries in a scope."""
         ...
 
     @abstractmethod

--- a/sdk/packages/python/iii/tests/test_state.py
+++ b/sdk/packages/python/iii/tests/test_state.py
@@ -175,9 +175,12 @@ async def test_state_list_all_items_in_scope(iii_client: III):
 
     assert isinstance(result, list)
     assert len(result) >= len(items)
-    sorted_result = sorted(result, key=lambda x: x["id"])
+    sorted_result = sorted(result, key=lambda x: x["key"])
     sorted_items = sorted(items, key=lambda x: x["id"])
-    assert sorted_result == sorted_items
+    assert sorted_result == [
+        {"key": item["id"], "value": item}
+        for item in sorted_items
+    ]
 
 
 @pytest.mark.asyncio

--- a/sdk/packages/rust/iii/tests/state.rs
+++ b/sdk/packages/rust/iii/tests/state.rs
@@ -233,12 +233,15 @@ async fn state_list_all_items_in_scope() {
     assert!(arr.len() >= items.len());
 
     let mut result_sorted = arr.clone();
-    result_sorted.sort_by(|a, b| a["id"].as_str().cmp(&b["id"].as_str()));
+    result_sorted.sort_by(|a, b| a["key"].as_str().cmp(&b["key"].as_str()));
 
     let mut items_sorted = items.clone();
     items_sorted.sort_by(|a, b| a["id"].as_str().cmp(&b["id"].as_str()));
 
-    assert_eq!(result_sorted, items_sorted);
+    for (entry, item) in result_sorted.iter().zip(items_sorted.iter()) {
+        assert_eq!(entry["key"], item["id"]);
+        assert_eq!(entry["value"], *item);
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #1896.

Tests:
- `corepack pnpm --filter console-frontend test -- src/api/state/state.test.ts`
- `corepack pnpm --filter console-frontend lint`
- `corepack pnpm --filter console-frontend build`

- [x] I license my contributions to this repository under Apache 2.0, and I have all necessary rights over the code I am contributing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced state listing to normalize multiple response shapes and reliably extract keys/values, including clear placeholder keys when identifiers are missing.
  * State listing results now consistently return keyed entries (`key` + `value`) instead of value-only arrays.
* **New Features**
  * Added a key/value index listing capability in the key-value store layer.
* **Tests**
  * Expanded and updated normalization and listing tests to cover multiple formats and verify keyed output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->