### PR TITLE
docs(readme): add worker and package download badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,18 @@
 
 ![iii: point-to-point integrations vs zero-integration via shared runtime](.github/assets/zero-integration.png)
 
+<!-- Release -->
 [![Docker](https://img.shields.io/docker/v/iiidev/iii?label=docker)](https://hub.docker.com/r/iiidev/iii)
 [![npm](https://img.shields.io/npm/v/iii-sdk?label=npm)](https://www.npmjs.com/package/iii-sdk)
 [![PyPI](https://img.shields.io/pypi/v/iii-sdk?label=pypi)](https://pypi.org/project/iii-sdk/)
 [![Crates.io](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fcrates.io%2Fapi%2Fv1%2Fcrates%2Fiii-sdk&query=%24.crate.max_stable_version&label=crates.io&prefix=v&color=orange)](https://crates.io/crates/iii-sdk)
+
+<!-- Downloads -->
+[![Worker downloads](https://workers.iii.dev/badge/downloads.svg)](https://workers.iii.dev/)
+[![Weekly worker downloads](https://workers.iii.dev/badge/weekly.svg)](https://workers.iii.dev/)
+[![npm downloads](https://img.shields.io/npm/dt/iii-sdk?label=npm%20downloads&color=cb3837)](https://www.npmjs.com/package/iii-sdk)
+[![PyPI downloads](https://static.pepy.tech/personalized-badge/iii-sdk?period=total&units=international_system&left_color=grey&right_color=blue&left_text=pypi%20downloads)](https://pepy.tech/projects/iii-sdk)
+[![Crates.io downloads](https://img.shields.io/crates/d/iii-sdk?label=crates.io%20downloads&color=e6a04c)](https://crates.io/crates/iii-sdk)
 
 ## What is iii?
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,18 @@ See the [Quickstart guide](https://iii.dev/docs/quickstart) for step-by-step tut
 - [Examples](https://github.com/iii-hq/iii-examples)
 - [Contributing](CONTRIBUTING.md)
 
+## Star History
+
+<p align="center">
+  <a href="https://www.star-history.com/?repos=iii-hq%2Fiii&type=date&legend=top-left">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=iii-hq/iii&type=date&theme=dark&legend=bottom-right" />
+      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=iii-hq/iii&type=date&legend=bottom-right" />
+      <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=iii-hq/iii&type=date&legend=bottom-right" />
+    </picture>
+  </a>
+</p>
+
 ## License
 
 The iii is licensed as such:

--- a/README.md
+++ b/README.md
@@ -3,18 +3,33 @@
 ![iii: point-to-point integrations vs zero-integration via shared runtime](.github/assets/zero-integration.png)
 
 <!-- Release -->
-[![Docker](https://img.shields.io/docker/v/iiidev/iii?label=docker)](https://hub.docker.com/r/iiidev/iii)
-[![npm](https://img.shields.io/npm/v/iii-sdk?label=npm)](https://www.npmjs.com/package/iii-sdk)
-[![PyPI](https://img.shields.io/pypi/v/iii-sdk?label=pypi)](https://pypi.org/project/iii-sdk/)
-[![Crates.io](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fcrates.io%2Fapi%2Fv1%2Fcrates%2Fiii-sdk&query=%24.crate.max_stable_version&label=crates.io&prefix=v&color=orange)](https://crates.io/crates/iii-sdk)
+<p align="center">
+  <a href="https://hub.docker.com/r/iiidev/iii"><img src="https://img.shields.io/docker/v/iiidev/iii?label=docker" alt="Docker"></a>
+  <a href="https://www.npmjs.com/package/iii-sdk"><img src="https://img.shields.io/npm/v/iii-sdk?label=npm" alt="npm"></a>
+  <a href="https://pypi.org/project/iii-sdk/"><img src="https://img.shields.io/pypi/v/iii-sdk?label=pypi" alt="PyPI"></a>
+  <a href="https://crates.io/crates/iii-sdk"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fcrates.io%2Fapi%2Fv1%2Fcrates%2Fiii-sdk&query=%24.crate.max_stable_version&label=crates.io&prefix=v&color=orange" alt="Crates.io"></a>
+  <a href="https://discord.gg/iiidev"><img src="https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
+</p>
 
 <!-- Downloads -->
-[![Worker downloads](https://workers.iii.dev/badge/downloads.svg)](https://workers.iii.dev/)
-[![Weekly worker downloads](https://workers.iii.dev/badge/weekly.svg)](https://workers.iii.dev/)
-[![Docker pulls](https://img.shields.io/docker/pulls/iiidev/iii?label=docker%20pulls&color=2496ed)](https://hub.docker.com/r/iiidev/iii)
-[![npm downloads](https://img.shields.io/npm/dt/iii-sdk?label=npm%20downloads&color=cb3837)](https://www.npmjs.com/package/iii-sdk)
-[![PyPI downloads](https://static.pepy.tech/personalized-badge/iii-sdk?period=total&units=international_system&left_color=grey&right_color=blue&left_text=pypi%20downloads)](https://pepy.tech/projects/iii-sdk)
-[![Crates.io downloads](https://img.shields.io/crates/d/iii-sdk?label=crates.io%20downloads&color=e6a04c)](https://crates.io/crates/iii-sdk)
+<p align="center">
+  <a href="https://workers.iii.dev/"><img src="https://workers.iii.dev/badge/downloads.svg" alt="Worker downloads"></a>
+  <a href="https://workers.iii.dev/"><img src="https://workers.iii.dev/badge/weekly.svg" alt="Weekly worker downloads"></a>
+  <a href="https://hub.docker.com/r/iiidev/iii"><img src="https://img.shields.io/docker/pulls/iiidev/iii?label=docker%20pulls&color=2496ed" alt="Docker pulls"></a>
+  <a href="https://www.npmjs.com/package/iii-sdk"><img src="https://img.shields.io/npm/dt/iii-sdk?label=npm%20downloads&color=cb3837" alt="npm downloads"></a>
+  <a href="https://pepy.tech/projects/iii-sdk"><img src="https://static.pepy.tech/personalized-badge/iii-sdk?period=total&units=international_system&left_color=grey&right_color=blue&left_text=pypi%20downloads" alt="PyPI downloads"></a>
+  <a href="https://crates.io/crates/iii-sdk"><img src="https://img.shields.io/crates/d/iii-sdk?label=crates.io%20downloads&color=e6a04c" alt="Crates.io downloads"></a>
+</p>
+
+<!-- Index -->
+<p align="center">
+  <a href="https://iii.dev/docs/quickstart">Quickstart</a> ·
+  <a href="https://iii.dev/docs">Docs</a> ·
+  <a href="https://workers.iii.dev/">Workers</a> ·
+  <a href="https://iii.dev/docs/using-iii/console">Console</a> ·
+  <a href="https://github.com/iii-hq/iii-examples">Examples</a> ·
+  <a href="https://discord.gg/iiidev">Discord</a>
+</p>
 
 ## What is iii?
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@
 
 <!-- Index -->
 <p align="center">
-  <a href="https://iii.dev/docs/quickstart">Quickstart</a> ·
-  <a href="https://iii.dev/docs">Docs</a> ·
-  <a href="https://workers.iii.dev/">Workers</a> ·
-  <a href="https://iii.dev/docs/using-iii/console">Console</a> ·
-  <a href="https://github.com/iii-hq/iii-examples">Examples</a> ·
-  <a href="https://discord.gg/iiidev">Discord</a>
+  <a href="#what-is-iii">What is iii?</a> ·
+  <a href="#quick-start">Quick Start</a> ·
+  <a href="#add-workers">Add Workers</a> ·
+  <a href="#sdks">SDKs</a> ·
+  <a href="#agent-skills">Agent Skills</a> ·
+  <a href="#console">Console</a> ·
+  <a href="#resources">Resources</a>
 </p>
 
 ## What is iii?

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <!-- Downloads -->
 [![Worker downloads](https://workers.iii.dev/badge/downloads.svg)](https://workers.iii.dev/)
 [![Weekly worker downloads](https://workers.iii.dev/badge/weekly.svg)](https://workers.iii.dev/)
+[![Docker pulls](https://img.shields.io/docker/pulls/iiidev/iii?label=docker%20pulls&color=2496ed)](https://hub.docker.com/r/iiidev/iii)
 [![npm downloads](https://img.shields.io/npm/dt/iii-sdk?label=npm%20downloads&color=cb3837)](https://www.npmjs.com/package/iii-sdk)
 [![PyPI downloads](https://static.pepy.tech/personalized-badge/iii-sdk?period=total&units=international_system&left_color=grey&right_color=blue&left_text=pypi%20downloads)](https://pepy.tech/projects/iii-sdk)
 [![Crates.io downloads](https://img.shields.io/crates/d/iii-sdk?label=crates.io%20downloads&color=e6a04c)](https://crates.io/crates/iii-sdk)


### PR DESCRIPTION
## Summary

Adds a **downloads** badge row to the README, splitting badges into two groups:

- **Release** (existing): Docker, npm, PyPI, crates.io versions
- **Downloads** (new):
  - `worker downloads` — registry all-time installs (`workers.iii.dev/badge/downloads.svg`)
  - `weekly` — registry rolling 7-day installs (`workers.iii.dev/badge/weekly.svg`)
  - `npm downloads` — shields.io total
  - `pypi downloads` — pepy total (personalized label so it reads `pypi downloads`, not bare `downloads`)
  - `crates.io downloads` — shields.io total

## Depends on registry change

> [!IMPORTANT]
> The `worker downloads` and `weekly` badges resolve to `https://workers.iii.dev/badge/*.svg`, which are added in **iii-hq/registry#54**. Those two badges will 404 until that PR merges **and** the registry deploys to production. The npm / pypi / crates download badges work immediately.

Merge order:
1. Merge + deploy iii-hq/registry#54 (adds the `/badge/{metric}.svg` registry endpoints)
2. Merge this PR

## Notes

- pepy uses `personalized-badge` with `left_text=pypi%20downloads` because the default pepy badge label is just `downloads` with no package-manager name.
- No content changes beyond the badge block.

## Test plan

- [ ] After registry#54 deploys: confirm `worker downloads` + `weekly` badges render in the README
- [x] npm / pypi / crates download badges resolve (verified live)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized the README badge area into two centered sections: **“Release”** (version badges plus a Discord join badge) and **“Downloads”** (download statistics across distribution channels).
  * Updated the badge/layout structure by removing the previous single-row badge layout and adjusting where the **Index** link row appears.
  * Added a new centered **“Star History”** section with embedded charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->