### PR TITLE
fix(iii-init,iii-worker): harden overlay local-worker boot (host-src mount retry + squashfs fd limit)

### DIFF
--- a/crates/iii-init/src/mount.rs
+++ b/crates/iii-init/src/mount.rs
@@ -1,5 +1,6 @@
 use std::os::unix::fs::symlink;
 use std::path::Path;
+use std::time::Duration;
 
 use nix::mount::{MsFlags, mount};
 use nix::sys::stat::Mode;
@@ -150,12 +151,6 @@ fn mkdir_p(path: &str) -> Result<(), InitError> {
     Ok(())
 }
 
-/// Mount virtiofs shares passed via the `III_VIRTIOFS_MOUNTS` env var.
-///
-/// Format: `tag1=/guest/path1;tag2=/guest/path2`. The tag matches the virtiofs
-/// source tag attached in vm_boot. Each guest path is created with `mkdir -p`
-/// before mounting. Failures on individual mounts log a warning and continue
-/// so a bad share cannot wedge worker startup.
 pub fn mount_virtiofs_shares() {
     let spec = match std::env::var("III_VIRTIOFS_MOUNTS") {
         Ok(s) if !s.is_empty() => s,
@@ -172,16 +167,37 @@ pub fn mount_virtiofs_shares() {
             continue;
         }
 
+        mount_virtiofs_with_retry(&tag, &guest_path);
+    }
+}
+
+/// Mount one virtiofs share, retrying transient failures for ~2s before giving
+/// up. virtio-fs tag registration is async w.r.t. PID 1, so a mount right after
+/// the pivot can fail before the device is probed; `EBUSY` means already mounted.
+fn mount_virtiofs_with_retry(tag: &str, guest_path: &str) {
+    const TOTAL: Duration = Duration::from_millis(2000);
+    const STEP: Duration = Duration::from_millis(50);
+
+    let mut waited = Duration::ZERO;
+    loop {
         match mount(
-            Some(tag.as_str()),
-            guest_path.as_str(),
+            Some(tag),
+            guest_path,
             Some("virtiofs"),
             MsFlags::empty(),
             None::<&str>,
         ) {
-            Ok(()) | Err(nix::Error::EBUSY) => {}
-            Err(e) => {
-                eprintln!("iii-init: warning: mount virtiofs {tag} -> {guest_path} failed: {e}");
+            Ok(()) | Err(nix::Error::EBUSY) => return,
+            Err(e) if waited >= TOTAL => {
+                eprintln!(
+                    "iii-init: ERROR mount virtiofs {tag} -> {guest_path} failed after {}ms: {e}",
+                    waited.as_millis()
+                );
+                return;
+            }
+            Err(_) => {
+                std::thread::sleep(STEP);
+                waited += STEP;
             }
         }
     }
@@ -413,6 +429,23 @@ mod tests {
         assert!(
             proc_mount_pos < symlink_pos,
             "/proc mount must precede /dev/fd symlink"
+        );
+    }
+
+    #[test]
+    fn virtiofs_mount_retries_transient_failures() {
+        let source = include_str!("mount.rs");
+        assert!(
+            source.contains("fn mount_virtiofs_with_retry"),
+            "virtiofs shares must mount through the bounded-retry helper"
+        );
+        assert!(
+            source.contains("std::thread::sleep(STEP)"),
+            "the retry helper must back off between attempts"
+        );
+        assert!(
+            source.contains("waited >= TOTAL"),
+            "the retry helper must give up after a bounded budget"
         );
     }
 }

--- a/crates/iii-worker/src/cli/squashfs.rs
+++ b/crates/iii-worker/src/cli/squashfs.rs
@@ -25,6 +25,31 @@ use backhand::{DEFAULT_BLOCK_SIZE, FilesystemCompressor, FilesystemWriter, NodeH
 /// engine starts workers as concurrent async tasks) never share a temp path.
 static SQFS_BUILD_SEQ: AtomicU64 = AtomicU64::new(0);
 
+/// Raise the soft fd limit before packing: backhand keeps an open `File` for
+/// every regular file until `write()`, so a large image (the node base has ~15k
+/// files) exceeds the default soft `RLIMIT_NOFILE` (256 on macOS) and the build
+/// fails with EMFILE. Mirrors `vm_boot::raise_fd_limit`.
+///
+/// Best-effort: a syscall failure is warned, not fatal. Raising is an
+/// optimization, not a correctness requirement — if the ambient limit is
+/// already adequate the build still succeeds, and if it genuinely isn't the
+/// open() in `add_dir` surfaces EMFILE with the offending path.
+fn raise_fd_limit() {
+    use nix::libc;
+    let mut rlim: libc::rlimit = unsafe { std::mem::zeroed() };
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) } != 0 {
+        tracing::warn!(error = %std::io::Error::last_os_error(), "getrlimit(RLIMIT_NOFILE) failed; keeping current fd limit");
+        return;
+    }
+    let target = rlim.rlim_max.min(1_048_576);
+    if rlim.rlim_cur < target {
+        rlim.rlim_cur = target;
+        if unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) } != 0 {
+            tracing::warn!(error = %std::io::Error::last_os_error(), "setrlimit(RLIMIT_NOFILE) failed; keeping current fd limit");
+        }
+    }
+}
+
 /// Build a read-only squashfs image at `out` from the rootfs tree at `src`.
 ///
 /// Preserves regular files, directories, and symlinks with their permission
@@ -42,6 +67,8 @@ static SQFS_BUILD_SEQ: AtomicU64 = AtomicU64::new(0);
 /// all capabilities regardless of per-file caps; revisit if a non-root worker
 /// mode is ever added.
 pub fn build_squashfs(src: &Path, out: &Path) -> Result<(), String> {
+    raise_fd_limit();
+
     let mut w = FilesystemWriter::default();
     w.set_current_time();
     w.set_block_size(DEFAULT_BLOCK_SIZE);
@@ -250,5 +277,50 @@ mod tests {
         assert!(!out.exists());
 
         let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn builds_image_with_many_files_without_fd_exhaustion() {
+        let tmp = std::env::temp_dir().join(format!("iii-sqfs-manyfd-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        let src = tmp.join("rootfs");
+        fs::create_dir_all(&src).unwrap();
+        for i in 0..400 {
+            let mut f = File::create(src.join(format!("f{i:04}"))).unwrap();
+            f.write_all(format!("file {i}\n").as_bytes()).unwrap();
+        }
+        let out = tmp.join("out.sqfs");
+        build_squashfs(&src, &out).expect("many-file build must not fail with EMFILE");
+        assert_eq!(
+            &fs::read(&out).unwrap()[..4],
+            b"hsqs",
+            "output is not a squashfs image"
+        );
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn raise_fd_limit_never_lowers_and_reaches_target() {
+        use nix::libc;
+        let mut before: libc::rlimit = unsafe { std::mem::zeroed() };
+        assert_eq!(
+            unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut before) },
+            0
+        );
+        raise_fd_limit();
+        let mut after: libc::rlimit = unsafe { std::mem::zeroed() };
+        assert_eq!(
+            unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut after) },
+            0
+        );
+        assert!(
+            after.rlim_cur >= before.rlim_cur,
+            "raise_fd_limit must not lower the limit"
+        );
+        let want = before.rlim_max.min(1_048_576);
+        assert!(
+            after.rlim_cur >= want || after.rlim_cur == after.rlim_max,
+            "soft limit should reach the target or the hard cap"
+        );
     }
 }

--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -16,6 +16,14 @@ type: "reference"
 
   A local-path worker mounted your project directory writable into the VM, so the dep and build directories created during install (`node_modules`, `.venv`, `dist`, …) leaked back onto the host as empty folders. Under overlay, a local worker now mounts the host project **read-only** and copies the source into a VM-local workspace on the upper (dep and build dirs excluded at any depth), so the host project is only ever read — those phantom folders no longer appear. Bundle and legacy workers keep the live mount.
 
+  ## Overlay local workers boot reliably and pack large base images
+
+  Two reliability fixes for the new overlay boot path:
+
+  - **The host source share mounts reliably.** In copy-in mode the host project is shared into the VM as a virtio-fs device that `iii-init` mounts right after the root pivot. virtio-fs device registration is asynchronous, so a mount issued too early could transiently fail — and because that share is boot-critical (the worker aborts when it isn't mounted), it surfaced as an **intermittent** boot failure (`/mnt/host-src … is not a virtiofs mountpoint`). `iii-init` now retries each share mount for ~2s to ride out the device-probe race; a genuinely failed mount logs the cause instead of being silently swallowed.
+
+  - **Large base images build their squashfs without hitting the file-descriptor limit.** Building the shared read-only squashfs base keeps every file in the image open until the image is finalized, so a large base (the node image carries ~15k files) exceeded the default open-file limit on macOS and failed with "Too many open files". The builder now raises that limit before packing, so large images build cleanly.
+
   ## `iii-pubsub` runtime settings live in the configuration worker
 
   The pub/sub worker now registers its config schema under the `iii-pubsub` configuration entry, seeds it from the config.yaml block on first boot, and hot-applies changes via `configuration::set` — no restart.


### PR DESCRIPTION
## What

Two defects in the overlay local-worker boot path introduced/exposed by the shared read-only rootfs overlay (#1886).

### 1. host-src virtio-fs share mount race (`iii-init`)
`mount_virtiofs_shares()` did a single best-effort mount per share and **swallowed failures** (`EBUSY` silently, other errno as a non-fatal warning). virtio-fs device-tag registration is asynchronous w.r.t. PID 1, so a share mount issued right after the overlay pivot can transiently fail.

Overlay copy-in made the host-src share (`virtiofs_0 -> /mnt/host-src`) **boot-critical**: the boot script runs `exit 1` on the whole worker if `/mnt/host-src` isn't a virtiofs mountpoint. So a previously-benign transient miss became a **hard, intermittent boot failure** (`/mnt/host-src (host source share) is not a virtiofs mountpoint`).

**Fix:** each share now mounts via `mount_virtiofs_with_retry()` — a bounded ~2s / 50ms-backoff retry (matching the ext4-upper flock retry precedent in `vm_boot.rs`). `EBUSY` still counts as already-mounted; a persistent failure now logs the errno **loudly** instead of being swallowed.

### 2. squashfs build EMFILE on large base images (`iii-worker`)
`build_squashfs` (backhand `FilesystemWriter`) keeps an open `File` for **every** regular file until the final `write()`. The node base image (~15k files) far exceeds the default soft `RLIMIT_NOFILE` (256 on macOS), so the build aborted with `Too many open files (os error 24)` — surfaced when a stale base dir forces a rebuild.

**Fix:** raise the fd limit before packing (mirrors `vm_boot::raise_fd_limit`); effective cap is `kern.maxfilesperproc` (~245k on macOS), ample for realistic images. A `ponytail:` comment names the ceiling and the streaming upgrade path if an image ever exceeds it.

## Tests
- `iii-init`: `virtiofs_mount_retries_transient_failures` (compiles for `aarch64-unknown-linux-musl`).
- `iii-worker`: `builds_image_with_many_files_without_fd_exhaustion` (passes under a simulated `ulimit -Sn 256`, proving the raise is load-bearing) and `raise_fd_limit_never_lowers_and_reaches_target`.
- Validated end-to-end against the local rootfs-overlay boot harness (5/5 repeated overlay boots reach run_cmd with no host-src failure signature).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Virtiofs mounting now uses automatic, bounded retries with backoff for transient failures.
  * Squashfs image builds now proactively raise the soft file-descriptor limit to reduce “too many open files” errors.
* **Bug Fixes**
  * Mounting reliability improves by retrying transient issues and only surfacing an error after the retry budget is exhausted.
  * Overlay boot behavior for local workers is more reliable by addressing virtio-fs source mount timing and large-image build failures.
* **Tests**
  * Added coverage for virtiofs retry/backoff behavior and squashfs builds with many files, including validation of retry presence and file-limit behavior.
* **Documentation**
  * Updated the changelog with these reliability improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->