### PR TITLE
feat(website): resolve pretty URLs via CloudFront KVS, drop per-page terraform apply

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -92,6 +92,35 @@ jobs:
             --include "AGENTS.md" \
             --exclude "blog/*"
 
+      # Keep the CloudFront KeyValueStore route map (pretty URL → .html) in sync
+      # with the website/*.html files we just uploaded. This is what lets a new
+      # page work without a `terraform apply` (MOT-3669): the redirects function
+      # reads this store at the edge. Runs AFTER the HTML sync so a key is never
+      # published before its object exists. `concurrency: deploy-website`
+      # serializes deploys, so the describe-time ETag stays valid for update-keys.
+      - name: Sync pretty-URL route map to CloudFront KeyValueStore
+        if: ${{ vars.CF_KVS_ARN != '' }}
+        env:
+          KVS_ARN: ${{ vars.CF_KVS_ARN }}
+        run: |
+          set -euo pipefail
+          etag=$(aws cloudfront-keyvaluestore describe-key-value-store \
+            --kvs-arn "$KVS_ARN" --query ETag --output text)
+          aws cloudfront-keyvaluestore list-keys \
+            --kvs-arn "$KVS_ARN" --query 'Items' --output json > /tmp/kvs-current.json
+          ops=$(pnpm --filter iii-website exec tsx scripts/routes-kvs.ts --current /tmp/kvs-current.json)
+          puts=$(jq -c '.Puts' <<<"$ops")
+          deletes=$(jq -c '.Deletes' <<<"$ops")
+          if [ "$puts" = '[]' ] && [ "$deletes" = '[]' ]; then
+            echo "KVS route map already in sync; nothing to update."
+            exit 0
+          fi
+          args=(--kvs-arn "$KVS_ARN" --if-match "$etag")
+          [ "$puts" != '[]' ] && args+=(--puts "$puts")
+          [ "$deletes" != '[]' ] && args+=(--deletes "$deletes")
+          aws cloudfront-keyvaluestore update-keys "${args[@]}"
+          echo "KVS route map updated. puts=$puts deletes=$deletes"
+
       # Blog assets under _astro/ are content-hashed by Astro, so they're
       # safe to mark immutable. HTML and rss.xml must revalidate so new posts
       # surface immediately after the CloudFront invalidation.

--- a/infra/terraform/website/cloudfront.tf
+++ b/infra/terraform/website/cloudfront.tf
@@ -25,12 +25,24 @@ resource "aws_cloudfront_origin_access_control" "site" {
   signing_protocol                  = "sigv4"
 }
 
+# Pretty-URL → *.html route map read by the redirects function at the edge.
+# Terraform owns the store; the key/value DATA is owned by deploy-website.yml,
+# which syncs it from website/*.html on every content deploy. That decoupling is
+# the whole point of this resource: adding a page no longer needs a `terraform
+# apply` to republish the function (MOT-3669).
+resource "aws_cloudfront_key_value_store" "routes" {
+  name    = "iii-website-prod-routes"
+  comment = "Pretty-URL → .html map for the redirects function; data synced by deploy-website.yml, not Terraform"
+}
+
 resource "aws_cloudfront_function" "redirects" {
   name    = "iii-website-prod-redirects"
   runtime = "cloudfront-js-2.0"
-  comment = "viewer-request (default behavior only): www->apex, SPA fallback"
+  comment = "viewer-request (default behavior only): www->apex, pretty-URL rewrite via KVS, real 404"
   publish = true
   code    = file("${path.module}/cloudfront_functions/redirects.js")
+
+  key_value_store_associations = [aws_cloudfront_key_value_store.routes.arn]
 }
 
 resource "aws_cloudfront_response_headers_policy" "site" {

--- a/infra/terraform/website/cloudfront_functions/redirects.js
+++ b/infra/terraform/website/cloudfront_functions/redirects.js
@@ -1,5 +1,7 @@
 // Viewer-request handler for the default (S3) behavior. Tested in redirects.test.js.
 
+import cf from 'cloudfront'
+
 function redirect(location) {
   return {
     statusCode: 301,
@@ -55,9 +57,16 @@ function serializeQuerystring(qs) {
   return parts.length ? '?' + parts.join('&') : ''
 }
 
+// Pretty-URL route map (/<page> → /<page>.html) lives in a CloudFront
+// KeyValueStore, populated by deploy-website.yml from the set of website/*.html
+// files. Adding a page needs no code change and no `terraform apply` — see
+// infra/terraform/website/README.md. The function is associated with exactly
+// one store, so cf.kvs() needs no store id.
+var routes = cf.kvs()
+
 // biome-ignore lint/correctness/noUnusedVariables: CloudFront Function entry point
 // biome-ignore lint/complexity/useOptionalChain: cloudfront-js-2.0 does NOT support optional chaining
-function handler(event) {
+async function handler(event) {
   var request = event.request
   var uri = request.uri
   var host = request.headers && request.headers.host ? request.headers.host.value : undefined
@@ -67,18 +76,6 @@ function handler(event) {
   }
 
   if (uri.indexOf('/.well-known/') === 0) return request
-
-  // Pretty URLs → matching *.html objects in S3 (Option A). Add a key when you
-  // ship a new top-level page as `pagename.html`.
-  var htmlPretty = {
-    '/manifesto': '/manifesto.html',
-    '/privacy-policy': '/privacy-policy.html',
-  }
-  var htmlTarget = htmlPretty[uri]
-  if (htmlTarget !== undefined) {
-    request.uri = htmlTarget
-    return request
-  }
 
   // /blog/* — Astro emits build.format: 'directory' with trailingSlash:
   // 'always', so canonical URLs are /blog/<slug>/. CloudFront's
@@ -103,14 +100,23 @@ function handler(event) {
     return request
   }
 
-  // Real 404 for extensionless paths not in the pretty-URL map. Previously
-  // this rewrote to /index.html (soft-404 cloning the homepage) — see
-  // notFound() comment above for the SEO impact.
+  // Extensionless top-level paths resolve to a pretty page via the KVS route
+  // map (e.g. /privacy-policy → /privacy-policy.html), or return a real 404.
+  // Previously the map was hardcoded here, so a new page needed a `terraform
+  // apply` to republish the function; it now lives in a CloudFront
+  // KeyValueStore that deploy-website.yml syncs from website/*.html, making a
+  // new page a content-only change. See notFound() for why unknown paths 404
+  // instead of falling back to /index.html.
   if (uri !== '/' && uri.charAt(uri.length - 1) !== '/') {
     const lastSlash = uri.lastIndexOf('/')
     const lastSegment = uri.substring(lastSlash + 1)
     if (lastSegment.indexOf('.') === -1) {
-      return notFound()
+      try {
+        request.uri = await routes.get(uri)
+        return request
+      } catch (err) {
+        return notFound()
+      }
     }
   }
 

--- a/infra/terraform/website/cloudfront_functions/redirects.test.js
+++ b/infra/terraform/website/cloudfront_functions/redirects.test.js
@@ -1,13 +1,41 @@
 // redirects.js is authored for the cloudfront-js-2.0 runtime and has no CJS/ESM
-// wrapper, so we load it via `new Function(...)` rather than `require`.
+// wrapper, so we load it via `new Function(...)` rather than `require`. The
+// runtime's `import cf from 'cloudfront'` is invalid inside a Function body, so
+// we strip that line and inject a mock `cf` whose KeyValueStore is backed by an
+// in-memory route map (production populates the real KVS from website/*.html).
 
 const test = require('node:test')
 const assert = require('node:assert/strict')
 const fs = require('node:fs')
 const path = require('node:path')
 
-const source = fs.readFileSync(path.join(__dirname, 'redirects.js'), 'utf8')
-const handler = new Function(source + '\nreturn handler;')()
+const rawSource = fs.readFileSync(path.join(__dirname, 'redirects.js'), 'utf8')
+const source = rawSource.replace(/^\s*import\s+cf\s+from\s+'cloudfront';?[^\n]*$/m, '')
+
+// Bind a handler to a specific KVS route map. cf.kvs().get(key) resolves to the
+// mapped value or rejects when the key is absent — mirroring the real
+// CloudFront KeyValueStore data-plane semantics (a miss throws).
+function makeHandler(routeMap) {
+  const cf = {
+    kvs() {
+      return {
+        get(key) {
+          if (Object.prototype.hasOwnProperty.call(routeMap, key)) {
+            return Promise.resolve(routeMap[key])
+          }
+          return Promise.reject(new Error('KeyNotFound: ' + key))
+        },
+      }
+    },
+  }
+  return new Function('cf', source + '\nreturn handler;')(cf)
+}
+
+// Default map mirrors the two pretty pages that ship in website/ today.
+const handler = makeHandler({
+  '/manifesto': '/manifesto.html',
+  '/privacy-policy': '/privacy-policy.html',
+})
 
 function buildEvent(uri, host, querystring) {
   return {
@@ -49,53 +77,53 @@ function isNotFound(result) {
 // function's in-isolation behavior — they no longer rewrite to /index.html
 // because the SPA fallback was replaced with a real 404 (was: soft-404
 // homepage clone, see notFound() in redirects.js).
-test('/docs → function returns 404 in isolation (production routes via docs behavior)', () => {
-  const result = handler(buildEvent('/docs', 'iii.dev'))
+test('/docs → function returns 404 in isolation (production routes via docs behavior)', async () => {
+  const result = await handler(buildEvent('/docs', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.ok(isNotFound(result))
 })
 
-test('/docs/quickstart → function returns 404 in isolation (production routes via docs behavior)', () => {
-  const result = handler(buildEvent('/docs/quickstart', 'iii.dev'))
+test('/docs/quickstart → function returns 404 in isolation (production routes via docs behavior)', async () => {
+  const result = await handler(buildEvent('/docs/quickstart', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.ok(isNotFound(result))
 })
 
-test('/docsfoo → 404 (not under /docs/, not a known pretty URL)', () => {
-  const result = handler(buildEvent('/docsfoo', 'iii.dev'))
+test('/docsfoo → 404 (not under /docs/, not a known pretty URL)', async () => {
+  const result = await handler(buildEvent('/docsfoo', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.ok(isNotFound(result))
 })
 
-test('/llms.txt → pass through unchanged (static file)', () => {
-  const result = handler(buildEvent('/llms.txt', 'iii.dev'))
+test('/llms.txt → pass through unchanged (static file)', async () => {
+  const result = await handler(buildEvent('/llms.txt', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/llms.txt')
 })
 
-test('www.iii.dev/ → 301 https://iii.dev/', () => {
-  const result = handler(buildEvent('/', 'www.iii.dev'))
+test('www.iii.dev/ → 301 https://iii.dev/', async () => {
+  const result = await handler(buildEvent('/', 'www.iii.dev'))
   assert.ok(isRedirect(result))
   assert.equal(locationOf(result), 'https://iii.dev/')
 })
 
-test('www.iii.dev/some/page → 301 https://iii.dev/some/page', () => {
-  const result = handler(buildEvent('/some/page', 'www.iii.dev'))
+test('www.iii.dev/some/page → 301 https://iii.dev/some/page', async () => {
+  const result = await handler(buildEvent('/some/page', 'www.iii.dev'))
   assert.ok(isRedirect(result))
   assert.equal(locationOf(result), 'https://iii.dev/some/page')
 })
 
-test('www.iii.dev/docs/foo → 301 https://iii.dev/docs/foo', () => {
-  const result = handler(buildEvent('/docs/foo', 'www.iii.dev'))
+test('www.iii.dev/docs/foo → 301 https://iii.dev/docs/foo', async () => {
+  const result = await handler(buildEvent('/docs/foo', 'www.iii.dev'))
   assert.ok(isRedirect(result))
   assert.equal(locationOf(result), 'https://iii.dev/docs/foo')
 })
 
-test('www.iii.dev preserves querystring with multiValue and empty params', () => {
+test('www.iii.dev preserves querystring with multiValue and empty params', async () => {
   // Mirrors the CloudFront Functions querystring shape: repeated keys spill into
   // multiValue, value-less keys arrive as empty strings, and special chars must
   // be re-encoded.
-  const result = handler(
+  const result = await handler(
     buildEvent('/some/page', 'www.iii.dev', {
       a: { value: '1', multiValue: [{ value: '2' }] },
       empty: { value: '' },
@@ -106,17 +134,17 @@ test('www.iii.dev preserves querystring with multiValue and empty params', () =>
   assert.equal(locationOf(result), 'https://iii.dev/some/page?a=1&a=2&empty=&ref=hello%20world')
 })
 
-test('www.iii.dev with no querystring → no trailing ?', () => {
-  const result = handler(buildEvent('/some/page', 'www.iii.dev', {}))
+test('www.iii.dev with no querystring → no trailing ?', async () => {
+  const result = await handler(buildEvent('/some/page', 'www.iii.dev', {}))
   assert.ok(isRedirect(result))
   assert.equal(locationOf(result), 'https://iii.dev/some/page')
 })
 
-test('www.iii.dev percent-encodes reserved chars in keys and values', () => {
+test('www.iii.dev percent-encodes reserved chars in keys and values', async () => {
   // Values containing &, =, #, + would otherwise corrupt the redirect target
   // (& splits params, # ends the URL into a fragment, + flips to space on parse,
   // = confuses some clients). Keys with spaces must also be encoded.
-  const result = handler(
+  const result = await handler(
     buildEvent('/p', 'www.iii.dev', {
       'weird key': { value: 'a&b=c+d#e' },
     }),
@@ -125,112 +153,112 @@ test('www.iii.dev percent-encodes reserved chars in keys and values', () => {
   assert.equal(locationOf(result), 'https://iii.dev/p?weird%20key=a%26b%3Dc%2Bd%23e')
 })
 
-test('unknown extensionless path → 404 (was SPA fallback to /index.html)', () => {
+test('unknown extensionless path → 404 (was SPA fallback to /index.html)', async () => {
   const qs = { utm_source: { value: 'twitter' }, ref: { value: 'launch' } }
   const event = buildEvent('/some/route', 'iii.dev', qs)
-  const result = handler(event)
+  const result = await handler(event)
   assert.ok(!isRedirect(result))
   assert.ok(isNotFound(result))
 })
 
-test('/ (root) → pass through unchanged', () => {
-  const result = handler(buildEvent('/', 'iii.dev'))
+test('/ (root) → pass through unchanged', async () => {
+  const result = await handler(buildEvent('/', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/')
 })
 
-test('/some/client/route → 404 (no client-side routing on the static site)', () => {
-  const result = handler(buildEvent('/some/client/route', 'iii.dev'))
+test('/some/client/route → 404 (no client-side routing on the static site)', async () => {
+  const result = await handler(buildEvent('/some/client/route', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.ok(isNotFound(result))
 })
 
-test('/manifesto → rewrite uri to /manifesto.html (flat HTML, Option A)', () => {
-  const result = handler(buildEvent('/manifesto', 'iii.dev'))
+test('/manifesto → rewrite uri to /manifesto.html (flat HTML, Option A)', async () => {
+  const result = await handler(buildEvent('/manifesto', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/manifesto.html')
 })
 
-test('/manifesto.html → pass through unchanged', () => {
-  const result = handler(buildEvent('/manifesto.html', 'iii.dev'))
+test('/manifesto.html → pass through unchanged', async () => {
+  const result = await handler(buildEvent('/manifesto.html', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/manifesto.html')
 })
 
-test('/manifesto/ trailing slash → pass through (pretty-URL rewrite only matches exact extensionless path)', () => {
-  const result = handler(buildEvent('/manifesto/', 'iii.dev'))
+test('/manifesto/ trailing slash → pass through (pretty-URL rewrite only matches exact extensionless path)', async () => {
+  const result = await handler(buildEvent('/manifesto/', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/manifesto/')
 })
 
-test('www.iii.dev/manifesto → 301 https://iii.dev/manifesto (host-redirect runs before pretty-URL rewrite)', () => {
-  const result = handler(buildEvent('/manifesto', 'www.iii.dev'))
+test('www.iii.dev/manifesto → 301 https://iii.dev/manifesto (host-redirect runs before pretty-URL rewrite)', async () => {
+  const result = await handler(buildEvent('/manifesto', 'www.iii.dev'))
   assert.ok(isRedirect(result))
   assert.equal(locationOf(result), 'https://iii.dev/manifesto')
 })
 
-test('/privacy-policy → rewrite uri to /privacy-policy.html (flat HTML, Option A)', () => {
-  const result = handler(buildEvent('/privacy-policy', 'iii.dev'))
+test('/privacy-policy → rewrite uri to /privacy-policy.html (flat HTML, Option A)', async () => {
+  const result = await handler(buildEvent('/privacy-policy', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/privacy-policy.html')
 })
 
-test('/privacy-policy.html → pass through unchanged', () => {
-  const result = handler(buildEvent('/privacy-policy.html', 'iii.dev'))
+test('/privacy-policy.html → pass through unchanged', async () => {
+  const result = await handler(buildEvent('/privacy-policy.html', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/privacy-policy.html')
 })
 
-test('www.iii.dev/privacy-policy → 301 https://iii.dev/privacy-policy (host-redirect runs before pretty-URL rewrite)', () => {
-  const result = handler(buildEvent('/privacy-policy', 'www.iii.dev'))
+test('www.iii.dev/privacy-policy → 301 https://iii.dev/privacy-policy (host-redirect runs before pretty-URL rewrite)', async () => {
+  const result = await handler(buildEvent('/privacy-policy', 'www.iii.dev'))
   assert.ok(isRedirect(result))
   assert.equal(locationOf(result), 'https://iii.dev/privacy-policy')
 })
 
-test('/AGENTS.md → pass through unchanged', () => {
-  const result = handler(buildEvent('/AGENTS.md', 'iii.dev'))
+test('/AGENTS.md → pass through unchanged', async () => {
+  const result = await handler(buildEvent('/AGENTS.md', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/AGENTS.md')
 })
 
-test('/foo/ trailing slash → pass through unchanged (no SPA rewrite)', () => {
-  const result = handler(buildEvent('/foo/', 'iii.dev'))
+test('/foo/ trailing slash → pass through unchanged (no SPA rewrite)', async () => {
+  const result = await handler(buildEvent('/foo/', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/foo/')
 })
 
-test('/missing.jpg → pass through unchanged (S3 returns 404)', () => {
-  const result = handler(buildEvent('/missing.jpg', 'iii.dev'))
+test('/missing.jpg → pass through unchanged (S3 returns 404)', async () => {
+  const result = await handler(buildEvent('/missing.jpg', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/missing.jpg')
 })
 
-test('/ai → 404 (no /ai route on the static site; was soft-404 homepage clone)', () => {
-  const result = handler(buildEvent('/ai', 'iii.dev'))
+test('/ai → 404 (no /ai route on the static site; was soft-404 homepage clone)', async () => {
+  const result = await handler(buildEvent('/ai', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.ok(isNotFound(result))
 })
 
-test('/assets/main.abc123.js → pass through unchanged', () => {
-  const result = handler(buildEvent('/assets/main.abc123.js', 'iii.dev'))
+test('/assets/main.abc123.js → pass through unchanged', async () => {
+  const result = await handler(buildEvent('/assets/main.abc123.js', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/assets/main.abc123.js')
 })
 
-test('/favicon.svg → pass through unchanged', () => {
-  const result = handler(buildEvent('/favicon.svg', 'iii.dev'))
+test('/favicon.svg → pass through unchanged', async () => {
+  const result = await handler(buildEvent('/favicon.svg', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/favicon.svg')
 })
 
-test('/.well-known/vercel/project.json → pass through (no SPA rewrite)', () => {
-  const result = handler(buildEvent('/.well-known/vercel/project.json', 'iii.dev'))
+test('/.well-known/vercel/project.json → pass through (no SPA rewrite)', async () => {
+  const result = await handler(buildEvent('/.well-known/vercel/project.json', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/.well-known/vercel/project.json')
 })
 
-test('/.well-known/foo (no extension) → pass through, NOT SPA rewritten', () => {
-  const result = handler(buildEvent('/.well-known/foo', 'iii.dev'))
+test('/.well-known/foo (no extension) → pass through, NOT SPA rewritten', async () => {
+  const result = await handler(buildEvent('/.well-known/foo', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/.well-known/foo', '.well-known is an explicit exemption from SPA fallback')
 })
@@ -243,90 +271,132 @@ test('/.well-known/foo (no extension) → pass through, NOT SPA rewritten', () =
 // extensionless paths must 301 to the canonical trailing-slash form.
 // ---------------------------------------------------------------------------
 
-test('/blog → 301 https://iii.dev/blog/ (canonical trailing slash)', () => {
-  const result = handler(buildEvent('/blog', 'iii.dev'))
+test('/blog → 301 https://iii.dev/blog/ (canonical trailing slash)', async () => {
+  const result = await handler(buildEvent('/blog', 'iii.dev'))
   assert.ok(isRedirect(result))
   assert.equal(locationOf(result), 'https://iii.dev/blog/')
 })
 
-test('/blog/ → rewrite to /blog/index.html', () => {
-  const result = handler(buildEvent('/blog/', 'iii.dev'))
+test('/blog/ → rewrite to /blog/index.html', async () => {
+  const result = await handler(buildEvent('/blog/', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/blog/index.html')
 })
 
-test('/blog/hello-world/ → rewrite to /blog/hello-world/index.html', () => {
-  const result = handler(buildEvent('/blog/hello-world/', 'iii.dev'))
+test('/blog/hello-world/ → rewrite to /blog/hello-world/index.html', async () => {
+  const result = await handler(buildEvent('/blog/hello-world/', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/blog/hello-world/index.html')
 })
 
-test('/blog/hello-world (no trailing slash) → 301 to /blog/hello-world/', () => {
-  const result = handler(buildEvent('/blog/hello-world', 'iii.dev'))
+test('/blog/hello-world (no trailing slash) → 301 to /blog/hello-world/', async () => {
+  const result = await handler(buildEvent('/blog/hello-world', 'iii.dev'))
   assert.ok(isRedirect(result))
   assert.equal(locationOf(result), 'https://iii.dev/blog/hello-world/')
 })
 
-test('/blog/foo/bar/ → rewrite to /blog/foo/bar/index.html (nested)', () => {
-  const result = handler(buildEvent('/blog/foo/bar/', 'iii.dev'))
+test('/blog/foo/bar/ → rewrite to /blog/foo/bar/index.html (nested)', async () => {
+  const result = await handler(buildEvent('/blog/foo/bar/', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/blog/foo/bar/index.html')
 })
 
-test('/blog/rss.xml → pass through unchanged (file with extension)', () => {
-  const result = handler(buildEvent('/blog/rss.xml', 'iii.dev'))
+test('/blog/rss.xml → pass through unchanged (file with extension)', async () => {
+  const result = await handler(buildEvent('/blog/rss.xml', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/blog/rss.xml')
 })
 
-test('/blog/_astro/style.abc123.css → pass through unchanged (hashed asset)', () => {
-  const result = handler(buildEvent('/blog/_astro/style.abc123.css', 'iii.dev'))
+test('/blog/_astro/style.abc123.css → pass through unchanged (hashed asset)', async () => {
+  const result = await handler(buildEvent('/blog/_astro/style.abc123.css', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/blog/_astro/style.abc123.css')
 })
 
-test('/blogfoo → NOT matched as /blog/, falls through to 404', () => {
+test('/blogfoo → NOT matched as /blog/, falls through to 404', async () => {
   // Boundary check: the /blog/ prefix must require the trailing slash so
   // unrelated top-level paths like /blogfoo or /blogfest are not hijacked.
-  const result = handler(buildEvent('/blogfoo', 'iii.dev'))
+  const result = await handler(buildEvent('/blogfoo', 'iii.dev'))
   assert.ok(!isRedirect(result))
   assert.ok(isNotFound(result))
 })
 
-test('/blog/hello-world/ preserves querystring on rewrite', () => {
+test('/blog/hello-world/ preserves querystring on rewrite', async () => {
   const qs = { utm_source: { value: 'rss' } }
-  const result = handler(buildEvent('/blog/hello-world/', 'iii.dev', qs))
+  const result = await handler(buildEvent('/blog/hello-world/', 'iii.dev', qs))
   assert.ok(!isRedirect(result))
   assert.equal(result.uri, '/blog/hello-world/index.html')
   assert.equal(result.querystring, qs)
 })
 
-test('/blog/hello-world (no slash) preserves querystring on 301', () => {
-  const result = handler(
-    buildEvent('/blog/hello-world', 'iii.dev', { utm_source: { value: 'rss' } }),
-  )
+test('/blog/hello-world (no slash) preserves querystring on 301', async () => {
+  const result = await handler(buildEvent('/blog/hello-world', 'iii.dev', { utm_source: { value: 'rss' } }))
   assert.ok(isRedirect(result))
   assert.equal(locationOf(result), 'https://iii.dev/blog/hello-world/?utm_source=rss')
 })
 
-test('www.iii.dev/blog/hello-world/ → 301 apex (host check runs first)', () => {
-  const result = handler(buildEvent('/blog/hello-world/', 'www.iii.dev'))
+test('www.iii.dev/blog/hello-world/ → 301 apex (host check runs first)', async () => {
+  const result = await handler(buildEvent('/blog/hello-world/', 'www.iii.dev'))
   assert.ok(isRedirect(result))
   assert.equal(locationOf(result), 'https://iii.dev/blog/hello-world/')
 })
 
-test('preview-host /blog/foo → 301 to same preview host (preserves origin)', () => {
+test('preview-host /blog/foo → 301 to same preview host (preserves origin)', async () => {
   // Don't lock /blog/* redirects to apex — preview deploys must redirect to
   // the same hostname so reviewers stay on the preview environment.
-  const result = handler(buildEvent('/blog/foo', 'preview.iii.dev'))
+  const result = await handler(buildEvent('/blog/foo', 'preview.iii.dev'))
   assert.ok(isRedirect(result))
   assert.equal(locationOf(result), 'https://preview.iii.dev/blog/foo/')
 })
 
-test('missing host header → still 404 for unknown extensionless paths', () => {
+test('missing host header → still 404 for unknown extensionless paths', async () => {
   const event = buildEvent('/some/page', undefined)
   delete event.request.headers.host
-  const result = handler(event)
+  const result = await handler(event)
   assert.ok(!isRedirect(result))
   assert.ok(isNotFound(result))
+})
+
+// ---------------------------------------------------------------------------
+// KVS route map — pretty-URL resolution now reads a CloudFront KeyValueStore
+// instead of a hardcoded object, so adding a page is a content-only change
+// (deploy-website.yml syncs the store from website/*.html; no terraform apply).
+// These cases exercise the lookup against bespoke maps via makeHandler().
+// ---------------------------------------------------------------------------
+
+test('KVS hit: a page present only in the store resolves with no code change', async () => {
+  const h = makeHandler({ '/pricing': '/pricing.html' })
+  const result = await h(buildEvent('/pricing', 'iii.dev'))
+  assert.ok(!isRedirect(result))
+  assert.equal(result.uri, '/pricing.html')
+})
+
+test('KVS miss: extensionless path absent from the store → real 404', async () => {
+  const h = makeHandler({ '/manifesto': '/manifesto.html' })
+  const result = await h(buildEvent('/privacy-policy', 'iii.dev'))
+  assert.ok(!isRedirect(result))
+  assert.ok(isNotFound(result))
+})
+
+test('KVS value is honored verbatim (key and value need not share a stem)', async () => {
+  const h = makeHandler({ '/legal': '/privacy-policy.html' })
+  const result = await h(buildEvent('/legal', 'iii.dev'))
+  assert.ok(!isRedirect(result))
+  assert.equal(result.uri, '/privacy-policy.html')
+})
+
+test('empty store: every extensionless path 404s, static files still pass through', async () => {
+  const h = makeHandler({})
+  const notFoundResult = await h(buildEvent('/manifesto', 'iii.dev'))
+  assert.ok(isNotFound(notFoundResult))
+  const assetResult = await h(buildEvent('/favicon.svg', 'iii.dev'))
+  assert.ok(!isRedirect(assetResult))
+  assert.equal(assetResult.uri, '/favicon.svg')
+})
+
+test('www host redirects before any KVS lookup (host check wins)', async () => {
+  const h = makeHandler({ '/pricing': '/pricing.html' })
+  const result = await h(buildEvent('/pricing', 'www.iii.dev'))
+  assert.ok(isRedirect(result))
+  assert.equal(locationOf(result), 'https://iii.dev/pricing')
 })

--- a/infra/terraform/website/iam_github_oidc.tf
+++ b/infra/terraform/website/iam_github_oidc.tf
@@ -75,6 +75,20 @@ data "aws_iam_policy_document" "github_deploy_website" {
     ]
     resources = [aws_cloudfront_distribution.site.arn]
   }
+
+  # KVS data plane: deploy-website.yml reads the current route map and applies a
+  # batch put/delete to keep it in sync with website/*.html. Scoped to the one
+  # store; least-privilege (no key reads beyond the list needed to diff).
+  statement {
+    sid    = "CloudFrontKeyValueStoreSync"
+    effect = "Allow"
+    actions = [
+      "cloudfront-keyvaluestore:DescribeKeyValueStore",
+      "cloudfront-keyvaluestore:ListKeys",
+      "cloudfront-keyvaluestore:UpdateKeys",
+    ]
+    resources = [aws_cloudfront_key_value_store.routes.arn]
+  }
 }
 
 resource "aws_iam_policy" "github_deploy_website" {

--- a/infra/terraform/website/outputs.tf
+++ b/infra/terraform/website/outputs.tf
@@ -28,6 +28,11 @@ output "cert_arn" {
   value       = aws_acm_certificate.site.arn
 }
 
+output "routes_kvs_arn" {
+  description = "ARN of the CloudFront KeyValueStore holding the pretty-URL route map — set as GitHub repo variable CF_KVS_ARN so deploy-website.yml can sync it"
+  value       = aws_cloudfront_key_value_store.routes.arn
+}
+
 output "github_deploy_role_arn" {
   description = "IAM role ARN assumed by GitHub Actions from iii-hq/iii main branch + production env — set as GitHub secret AWS_DEPLOY_ROLE_ARN"
   value       = aws_iam_role.github_deploy_website.arn

--- a/website/scripts/routes-kvs.test.ts
+++ b/website/scripts/routes-kvs.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { desiredRoutes, diff } from './routes-kvs'
+
+test('desiredRoutes maps page files to pretty keys and excludes index.html', () => {
+  const result = desiredRoutes(['index.html', 'manifesto.html', 'privacy-policy.html'])
+  assert.deepEqual(result, [
+    { Key: '/manifesto', Value: '/manifesto.html' },
+    { Key: '/privacy-policy', Value: '/privacy-policy.html' },
+  ])
+})
+
+test('desiredRoutes ignores non-html files and sorts by key', () => {
+  const result = desiredRoutes(['pricing.html', 'favicon.svg', 'about.html', 'sitemap.xml'])
+  assert.deepEqual(result, [
+    { Key: '/about', Value: '/about.html' },
+    { Key: '/pricing', Value: '/pricing.html' },
+  ])
+})
+
+test('diff: a new page becomes a Put, nothing deleted', () => {
+  const desired = [
+    { Key: '/manifesto', Value: '/manifesto.html' },
+    { Key: '/pricing', Value: '/pricing.html' },
+  ]
+  const current = [{ Key: '/manifesto', Value: '/manifesto.html' }]
+  assert.deepEqual(diff(desired, current), {
+    Puts: [{ Key: '/pricing', Value: '/pricing.html' }],
+    Deletes: [],
+  })
+})
+
+test('diff: a removed page becomes a Delete', () => {
+  const desired = [{ Key: '/manifesto', Value: '/manifesto.html' }]
+  const current = [
+    { Key: '/manifesto', Value: '/manifesto.html' },
+    { Key: '/old', Value: '/old.html' },
+  ]
+  assert.deepEqual(diff(desired, current), {
+    Puts: [],
+    Deletes: [{ Key: '/old' }],
+  })
+})
+
+test('diff: a changed value becomes a Put', () => {
+  const desired = [{ Key: '/legal', Value: '/privacy-policy.html' }]
+  const current = [{ Key: '/legal', Value: '/legal.html' }]
+  assert.deepEqual(diff(desired, current), {
+    Puts: [{ Key: '/legal', Value: '/privacy-policy.html' }],
+    Deletes: [],
+  })
+})
+
+test('diff: identical desired and current is a no-op', () => {
+  const entries = [
+    { Key: '/manifesto', Value: '/manifesto.html' },
+    { Key: '/privacy-policy', Value: '/privacy-policy.html' },
+  ]
+  assert.deepEqual(diff(entries, [...entries]), { Puts: [], Deletes: [] })
+})

--- a/website/scripts/routes-kvs.ts
+++ b/website/scripts/routes-kvs.ts
@@ -1,0 +1,77 @@
+// Generates the pretty-URL → .html route map that deploy-website.yml syncs into
+// the CloudFront KeyValueStore. The map is derived from the set of top-level
+// *.html files in website/ (index.html excluded — it's the apex default root
+// object, served without a rewrite). Adding a page is therefore a content-only
+// change: drop foo.html, link to /foo, and the next deploy makes the clean URL
+// resolve — no `terraform apply` (MOT-3669). See infra/terraform/website/README.md.
+//
+// Usage (run from the website/ package dir):
+//   tsx scripts/routes-kvs.ts                    # print desired map: [{Key,Value}]
+//   tsx scripts/routes-kvs.ts --current cur.json # print {Puts,Deletes} vs current
+import { readdirSync, readFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
+export interface KvsEntry {
+  Key: string
+  Value: string
+}
+
+export interface KvsOps {
+  Puts: KvsEntry[]
+  Deletes: { Key: string }[]
+}
+
+const HTML_EXT = '.html'
+
+// Map each top-level page file (foo.html) to its pretty-URL key (/foo → /foo.html).
+// index.html is the apex default_root_object and is served without a rewrite.
+export function desiredRoutes(htmlFiles: string[]): KvsEntry[] {
+  return htmlFiles
+    .filter((f) => f.endsWith(HTML_EXT) && f !== 'index.html')
+    .map((f) => ({ Key: `/${f.slice(0, -HTML_EXT.length)}`, Value: `/${f}` }))
+    .sort((a, b) => a.Key.localeCompare(b.Key))
+}
+
+// Diff desired against the store's current contents into a single batch update:
+// Puts for new or changed values, Deletes for keys no longer backed by a file.
+export function diff(desired: KvsEntry[], current: KvsEntry[]): KvsOps {
+  const currentByKey = new Map(current.map((e) => [e.Key, e.Value]))
+  const desiredKeys = new Set(desired.map((e) => e.Key))
+  return {
+    Puts: desired.filter((e) => currentByKey.get(e.Key) !== e.Value),
+    Deletes: current.filter((e) => !desiredKeys.has(e.Key)).map((e) => ({ Key: e.Key })),
+  }
+}
+
+function listFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((d) => d.isFile())
+    .map((d) => d.name)
+}
+
+function main(): void {
+  const desired = desiredRoutes(listFiles(process.cwd()))
+
+  const currentFlagIdx = process.argv.indexOf('--current')
+  if (currentFlagIdx === -1) {
+    process.stdout.write(`${JSON.stringify(desired)}\n`)
+    return
+  }
+
+  const currentPath = process.argv[currentFlagIdx + 1]
+  if (!currentPath) {
+    console.error('--current requires a file path')
+    process.exitCode = 1
+    return
+  }
+  // `aws cloudfront-keyvaluestore list-keys --query Items` yields [] for an empty
+  // store and may yield null when the query misses — normalize both to [].
+  const raw = readFileSync(currentPath, 'utf8').trim()
+  const current: KvsEntry[] = raw && raw !== 'null' ? JSON.parse(raw) : []
+  process.stdout.write(`${JSON.stringify(diff(desired, current))}\n`)
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+if (invokedDirectly) {
+  main()
+}


### PR DESCRIPTION
## Problem (MOT-3669)

Adding a top-level page like `/privacy-policy` required **two** things on **two different pipelines**:

| | Where it lives | How it ships | When live |
|---|---|---|---|
| `privacy-policy.html` | `website/` → S3 | `deploy-website.yml` `aws s3 sync` — **automatic** on push to `main` | minutes after merge |
| `/privacy-policy` → `/privacy-policy.html` rewrite | hardcoded `htmlPretty` map in the redirects **CloudFront Function** | `terraform apply` (publishes the function) — **manual**, no apply automation | only after someone applies |

So the `.html` shipped automatically, but the clean-URL rewrite didn't. Until the manual apply ran, `/privacy-policy` fell through to the real-404 branch and 404'd — which is why the footer link had to be pointed at the literal `/privacy-policy.html` as a workaround.

## Fix

Move the pretty-URL → `.html` map out of the function source and into a **CloudFront KeyValueStore (KVS)**. The function reads it at the edge (async); `deploy-website.yml` syncs it from `website/*.html` on every content deploy — same automatic pipeline as the HTML.

**Adding a page is now a content-only change:** drop `foo.html`, link to `/foo`, merge. The clean URL resolves on the next deploy. No `terraform apply`.

### Changes
- **`redirects.js`** — `async` handler; KVS lookup replaces the hardcoded map. The pretty-URL rewrite and the real-404 fallback are unified into a single extensionless-path branch, so `/`, `/blog/*`, and `*.html` never incur a KVS read. The `notFound()` SEO behavior is preserved (KVS miss → real 404).
- **`redirects.test.js`** — loader strips the `import cf from 'cloudfront'` line and injects a mock `cf.kvs()`; tests are `await`ed; +6 KVS cases (hit, miss→404, verbatim value, empty store, www precedence). **46/46 pass.**
- **`routes-kvs.ts` (+ test)** — derives the desired map from `website/*.html` (excludes `index.html`) and diffs it against the store into a batch `{Puts, Deletes}`. 6 unit tests.
- **`deploy-website.yml`** — after the HTML sync (so a key never points at a missing object), describe → list → diff → `update-keys`. Gated on the `CF_KVS_ARN` repo var, so it no-ops until that's set. `concurrency: deploy-website` serializes deploys, keeping the describe-time ETag valid.
- **Terraform** — `aws_cloudfront_key_value_store.routes` + function association, a least-privilege IAM data-plane grant on the deploy role (`Describe`/`ListKeys`/`UpdateKeys`), and a `routes_kvs_arn` output. `terraform validate` passes. Terraform owns the *store*; the pipeline owns the *data* (the AWS provider has no key resource — data is decoupled by design).

## Rollout (one-time)

Terraform can't seed KVS *data*, so the first rollout populates the store out-of-band. To avoid a 404 window on `/manifesto` + `/privacy-policy`, apply in two phases:

1. **Apply 1** — create the KVS + IAM grant only (temporarily comment out `key_value_store_associations` so the function keeps its current behavior).
2. **Populate** — set repo var `CF_KVS_ARN = terraform output -raw routes_kvs_arn`, then trigger `deploy-website.yml` (or run its KVS step locally) to seed `/manifesto` + `/privacy-policy`.
3. **Apply 2** — re-add `key_value_store_associations` and apply; the function now reads a populated store. No 404 window.
4. Revert the footer "privacy" link from `/privacy-policy.html` back to `/privacy-policy`.

(If a brief 404 on those two secondary pages is acceptable, collapse to a single apply + immediate deploy.)

## Test plan
- [x] `redirects.test.js` — 46/46 pass (40 existing behaviors unchanged + 6 KVS cases)
- [x] `routes-kvs.test.ts` — 6/6 pass; generator verified against real `website/*.html` and against empty / stale-key stores
- [x] `terraform fmt` (clean) + `terraform validate` (success)
- [ ] Post-apply smoke: `curl -I https://iii.dev/privacy-policy` → 200; unknown extensionless path → 404
- [ ] Deploy a throwaway `test-page.html` and confirm `/test-page` resolves with no apply

Note: an unrelated pre-existing test failure (`blog-posts.test.ts` "finds hello-world") exists on `main` — there's no `hello-world.md` in the local blog content; this PR touches no blog files.

Closes MOT-3669.

https://claude.ai/code/session_01N9Xi9vXLynC4JsaCwPJhVq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated website routing infrastructure to use CloudFront KeyValueStore for pretty URL resolution, replacing previous SPA fallback behavior.
  * Deployment workflow now syncs URL mappings to CloudFront with automatic reconciliation.

* **Tests**
  * Added comprehensive test coverage for routing and URL mapping logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->