### PR TITLE
refactor(configuration): persist value-only YAML, drop schema from disk

### DIFF
--- a/engine/src/workers/configuration/README.md
+++ b/engine/src/workers/configuration/README.md
@@ -120,6 +120,7 @@ Returns: `id` (string), `name` (string), `description` (string), `schema` (objec
 | `NOT_REGISTERED` | `set` was called against an id that has not been passed to `register` yet. |
 | `INVALID_ID` | The id does not match `[a-z0-9_-]{1,64}` — the constraint applied so ids are safe filenames for the `fs` adapter. |
 | `SCHEMA_INVALID` | The supplied value does not satisfy the registered JSON Schema. The error message lists each violation. |
+| `SCHEMA_UNAVAILABLE` | `set` was called for an id whose schema is not yet known — the owning worker has not registered it this session. The `fs` adapter does not persist the schema, so it is absent until a worker re-registers after boot. |
 | `NOT_FOUND` | `get` or `schema` was called against an id that is not registered. |
 | `ADAPTER_ERROR` | The adapter failed to persist the change (disk error, bridge unreachable, etc.). |
 

--- a/engine/src/workers/configuration/adapters/fs.rs
+++ b/engine/src/workers/configuration/adapters/fs.rs
@@ -6,8 +6,11 @@
 
 //! File-system adapter — one YAML file per configuration id.
 //!
-//! Layout: `<directory>/<id>.yaml` where each file is a serialised
-//! [`ConfigurationEntry`]. The adapter watches the directory with `notify`
+//! Layout: `<directory>/<id>.yaml` holding the entry's id/name/description,
+//! `value`, and optional `metadata`. The JSON Schema is deliberately NOT
+//! persisted — it is large and workers re-register it on every boot, so the
+//! disk file stays focused on the value a human edits. The adapter watches the
+//! directory with `notify`
 //! and surfaces external edits through the `ExternalChange` channel so the
 //! worker can fire `configuration` triggers without depending on the source
 //! of the change.
@@ -123,8 +126,14 @@ impl FsAdapter {
     }
 
     async fn write_entry(&self, entry: &ConfigurationEntry) -> anyhow::Result<()> {
+        // schema omitted — see module doc; rebuilt from re-registration.
         let path = self.entry_path(&entry.id);
-        let yaml = serde_yaml::to_string(entry)
+        let mut doc = serde_yaml::to_value(entry)
+            .map_err(|e| anyhow::anyhow!("failed to serialise entry: {}", e))?;
+        if let Some(map) = doc.as_mapping_mut() {
+            map.remove("schema");
+        }
+        let yaml = serde_yaml::to_string(&doc)
             .map_err(|e| anyhow::anyhow!("failed to serialise entry: {}", e))?;
         let tmp = path.with_extension(format!("{}.tmp", FILE_EXTENSION));
         tokio::fs::write(&tmp, yaml.as_bytes()).await?;
@@ -270,19 +279,26 @@ impl ConfigurationAdapter for FsAdapter {
                 for (id, fresh) in snapshot.iter() {
                     match cache_guard.get(id) {
                         None => {
+                            // New file with no cached entry; its schema stays
+                            // null until the owning worker registers it.
                             events.push(ExternalChange::Registered(fresh.clone()));
                         }
+                        // `schema` is intentionally absent from this diff: it no
+                        // longer lives on disk, so an external edit can't change
+                        // it. Comparing it would flag every write as changed
+                        // (cached real schema vs disk's null).
                         Some(existing)
                             if existing.value != fresh.value
-                                || existing.schema != fresh.schema
                                 || existing.name != fresh.name
                                 || existing.description != fresh.description =>
                         {
+                            // Carry the cached schema forward so the event (and
+                            // the cache update below) keep the real schema rather
+                            // than blanking it to the disk's null.
+                            let mut entry = fresh.clone();
+                            entry.schema = existing.schema.clone();
                             let old_value = Some(existing.value.clone());
-                            events.push(ExternalChange::Updated {
-                                entry: fresh.clone(),
-                                old_value,
-                            });
+                            events.push(ExternalChange::Updated { entry, old_value });
                         }
                         _ => {}
                     }
@@ -369,6 +385,13 @@ mod tests {
 
         let path = dir.path().join("iii-stream.yaml");
         assert!(path.exists(), "yaml file should be created on disk");
+
+        let contents = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(
+            !contents.contains("schema"),
+            "schema must not be persisted to disk; got:\n{contents}"
+        );
+        assert!(contents.contains("port"), "value must be persisted");
     }
 
     #[tokio::test]
@@ -461,6 +484,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn loading_schemaless_file_defaults_schema_to_null() {
+        let dir = temp_dir();
+        // A value-only file (no `schema:` key) is exactly what `write_entry`
+        // now produces; loading it must default schema to null, not error.
+        let yaml = "id: noschema\nname: No Schema\ndescription: test\nvalue:\n  port: 3112\n";
+        tokio::fs::write(dir.path().join("noschema.yaml"), yaml)
+            .await
+            .unwrap();
+
+        let adapter = FsAdapter::new(Some(json!({ "directory": dir.path().to_str().unwrap() })))
+            .await
+            .unwrap();
+        let read = adapter.get("noschema").await.unwrap().unwrap();
+        assert!(
+            read.schema.is_null(),
+            "missing schema should default to null"
+        );
+        assert_eq!(read.value, json!({ "port": 3112 }));
+    }
+
+    #[tokio::test]
     async fn watcher_emits_registered_event_on_external_create() {
         let dir = temp_dir();
         let adapter = FsAdapter::new(Some(json!({ "directory": dir.path().to_str().unwrap() })))
@@ -482,6 +526,46 @@ mod tests {
         match evt {
             ExternalChange::Registered(e) => assert_eq!(e.id, "external"),
             other => panic!("unexpected change: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn watcher_carries_cached_schema_forward_on_external_update() {
+        let dir = temp_dir();
+        let adapter = FsAdapter::new(Some(json!({ "directory": dir.path().to_str().unwrap() })))
+            .await
+            .unwrap();
+        // Register so the adapter cache holds the real schema; the file on disk
+        // is value-only (write_entry drops schema).
+        adapter.register(sample_entry("watched")).await.unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        adapter.watch(tx).await.unwrap();
+
+        // External edit changing only the value, in the value-only on-disk format.
+        let edited =
+            "id: watched\nname: watched display\ndescription: test\nvalue:\n  port: 9999\n";
+        tokio::fs::write(dir.path().join("watched.yaml"), edited)
+            .await
+            .unwrap();
+
+        let evt = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("watcher should report an event")
+            .expect("channel closed");
+        match evt {
+            ExternalChange::Updated { entry, old_value } => {
+                assert_eq!(entry.value, json!({ "port": 9999 }));
+                assert_eq!(old_value, Some(json!({ "port": 3112 })));
+                // Schema is absent on disk but must be carried forward from cache,
+                // not blanked to null — and the value edit must fire exactly one
+                // Updated event (schema is no longer part of the diff).
+                assert_eq!(
+                    entry.schema,
+                    json!({ "type": "object" }),
+                    "cached schema must survive an external value edit"
+                );
+            }
+            other => panic!("expected Updated, got {:?}", other),
         }
     }
 

--- a/engine/src/workers/configuration/configuration.rs
+++ b/engine/src/workers/configuration/configuration.rs
@@ -316,6 +316,7 @@ fn store_error_to_failure(err: StoreError) -> ErrorBody {
         StoreError::NotRegistered(_) => "NOT_REGISTERED",
         StoreError::InvalidId(_) => "INVALID_ID",
         StoreError::SchemaInvalid(_) => "SCHEMA_INVALID",
+        StoreError::SchemaUnavailable(_) => "SCHEMA_UNAVAILABLE",
         StoreError::Adapter(_) => "ADAPTER_ERROR",
     };
     ErrorBody {
@@ -582,6 +583,33 @@ mod tests {
         match result {
             FunctionResult::Failure(err) => assert_eq!(err.code, "NOT_REGISTERED"),
             _ => panic!("expected NOT_REGISTERED"),
+        }
+    }
+
+    #[tokio::test]
+    async fn set_without_available_schema_returns_schema_unavailable() {
+        let (_engine, worker, _dir) = setup().await;
+        // Register with a null schema (the shape a disk-loaded entry has before
+        // its worker re-registers); no initial_value is validated.
+        worker
+            .register_fn(ConfigurationRegisterInput {
+                id: "iii-stream".into(),
+                name: "iii-stream display".into(),
+                description: "test".into(),
+                schema: Value::Null,
+                initial_value: None,
+                metadata: None,
+            })
+            .await;
+        let result = worker
+            .set_fn(ConfigurationSetInput {
+                id: "iii-stream".into(),
+                value: json!({ "port": 4242 }),
+            })
+            .await;
+        match result {
+            FunctionResult::Failure(err) => assert_eq!(err.code, "SCHEMA_UNAVAILABLE"),
+            _ => panic!("expected SCHEMA_UNAVAILABLE"),
         }
     }
 

--- a/engine/src/workers/configuration/store.rs
+++ b/engine/src/workers/configuration/store.rs
@@ -70,6 +70,10 @@ pub enum StoreError {
     InvalidId(String),
     #[error("schema validation failed: {0}")]
     SchemaInvalid(String),
+    #[error(
+        "configuration '{0}' has no schema available yet; the owning worker must register before values can be set"
+    )]
+    SchemaUnavailable(String),
     #[error(transparent)]
     Adapter(#[from] anyhow::Error),
 }
@@ -163,6 +167,11 @@ impl ConfigurationStore {
             None => return Err(StoreError::NotRegistered(id.to_string())),
         };
 
+        // No schema cached yet (the owning worker hasn't re-registered this
+        // session) — reject rather than validate against a null schema.
+        if entry.schema.is_null() {
+            return Err(StoreError::SchemaUnavailable(id.to_string()));
+        }
         if let Err(errs) = validate_against_schema(&value, &entry.schema) {
             return Err(StoreError::SchemaInvalid(errs.join("; ")));
         }
@@ -354,6 +363,57 @@ mod tests {
             view.schema, strict,
             "the stored schema must be refreshed to the tightened version"
         );
+    }
+
+    // `set` against an entry whose schema is null (the shape a disk-loaded entry
+    // has before its worker re-registers) must be rejected, then succeed once a
+    // real schema is registered.
+    #[tokio::test]
+    async fn set_without_schema_is_rejected_then_succeeds_after_register() {
+        use crate::workers::configuration::adapters::ConfigurationAdapter;
+        use crate::workers::configuration::adapters::fs::FsAdapter;
+
+        let dir = tempfile::tempdir().unwrap();
+        let adapter = Arc::new(
+            FsAdapter::new(Some(json!({ "directory": dir.path().to_str().unwrap() })))
+                .await
+                .unwrap(),
+        ) as Arc<dyn ConfigurationAdapter>;
+        let store = ConfigurationStore::new(adapter);
+
+        store
+            .register(
+                "demo".into(),
+                "Demo".into(),
+                String::new(),
+                Value::Null,
+                None,
+                None,
+            )
+            .await
+            .expect("register with a null schema (no value validated)");
+
+        let err = store
+            .set("demo", json!({ "port": 1 }))
+            .await
+            .expect_err("set must be rejected while no schema is available");
+        assert!(matches!(err, StoreError::SchemaUnavailable(_)));
+
+        store
+            .register(
+                "demo".into(),
+                "Demo".into(),
+                String::new(),
+                json!({ "type": "object" }),
+                None,
+                None,
+            )
+            .await
+            .expect("schema refresh");
+        store
+            .set("demo", json!({ "port": 1 }))
+            .await
+            .expect("set succeeds once a real schema is present");
     }
 
     #[test]

--- a/engine/src/workers/configuration/structs.rs
+++ b/engine/src/workers/configuration/structs.rs
@@ -21,7 +21,9 @@ pub struct ConfigurationEntry {
     pub name: String,
     /// One-line description of what this configuration controls.
     pub description: String,
-    /// JSON Schema describing the shape of `value`.
+    /// JSON Schema describing the shape of `value`. Not persisted to disk by
+    /// the fs adapter; rebuilt in-memory when the owning worker re-registers.
+    #[serde(default)]
     pub schema: Value,
     /// Stored configuration body. May contain `${VAR:default}` placeholders.
     #[serde(default)]


### PR DESCRIPTION
## What

The configuration worker's `fs` adapter wrote the full `ConfigurationEntry` to each `<id>.yaml`, including the JSON Schema. The schema dominated the file — `iii-observability.yaml` was 11.7K, almost all schema — and buried the one field a human actually edits: `value`.

This drops `schema:` from the persisted files. They now hold `id`, `name`, `description`, `value`, and optional `metadata`.

## Why it's safe to drop

Schema is redundant on disk: every worker re-sends its full JSON Schema via `configuration::register` on every boot. The on-disk copy only ever served a cold-start window before workers reconnect, so we rebuild it in-memory from re-registration instead.

## Changes

- **`structs.rs`** — `#[serde(default)]` on `schema` so a file with no `schema:` key loads as `null` instead of erroring (which would have dropped the value too). No `skip_serializing` added, so API responses still carry schema.
- **`adapters/fs.rs`** — `write_entry` serializes a value-only projection (drops `schema` via `to_value` + `Mapping::remove`); the watcher no longer diffs on `schema` (would fire spuriously on every write) and carries the cached schema forward on external edits so emitted events keep the real schema.
- **`store.rs`** — `set` rejects with a new `SCHEMA_UNAVAILABLE` error when no schema is cached yet (cold-start window before the owning worker re-registers), instead of failing opaquely against a null schema.
- **`configuration.rs`** / **`README.md`** — map `SchemaUnavailable` → `SCHEMA_UNAVAILABLE` + error-table row.

## Compatibility

- API responses (register return, `list`, `schema`, trigger events) still carry the schema from the in-memory cache.
- The `bridge` adapter reads schema from the remote engine's API response, not disk — unaffected.
- The `logging.rs` boot reader parses generic JSON and reads only `value` — unaffected.
- Existing files that still contain `schema:` load fine and shrink on the next write. Graceful auto-migration, no manual step.

## Tests

`cargo test -p iii configuration` → 105 passed. New coverage:
- `fs.rs::loading_schemaless_file_defaults_schema_to_null` — read tolerates missing schema.
- `fs.rs::register_and_get_round_trip` — written file has no `schema:`, value present.
- `fs.rs::watcher_carries_cached_schema_forward_on_external_update` — external value edit fires one `Updated` event carrying the original schema, not null.
- `store.rs::set_without_schema_is_rejected_then_succeeds_after_register` + `configuration.rs::set_without_available_schema_returns_schema_unavailable` — cold-start reject path and error code.

https://claude.ai/code/session_01HUkLgFkBPVChbwjY15UGDE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of configuration updates when a JSON schema isn’t available yet, returning `SCHEMA_UNAVAILABLE` instead of failing ambiguously.
  * Updated configuration file persistence to omit `schema` (it will be re-registered on startup) while preserving schema data for change detection.
* **Documentation**
  * Documented the new `SCHEMA_UNAVAILABLE` error code with an explanation of the missing-schema scenario.
* **Tests**
  * Added coverage for schema-unavailable behavior and schema preservation during external edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->