### PR TITLE
docs(skills): update skill catalog for 0.20 SDK clean break

### DIFF
--- a/engine/src/workers/engine_fn/skills/SKILL.md
+++ b/engine/src/workers/engine_fn/skills/SKILL.md
@@ -92,9 +92,9 @@ When one fits, install it: `worker::add { source: { kind: 'registry', name: '<wo
 import {
   registerWorker, // factory; opens the WS from your code's perspective synchronously
   TriggerAction, // .Void() | .Enqueue({ queue })
-  IIIInvocationError, // typed error thrown by iii.trigger()
-  Logger, // OTel-aware structured logger; falls back to console.*
+  InvocationError, // typed error thrown by iii.trigger()
 } from 'iii-sdk'
+import { Logger } from '@iii-dev/helpers/observability' // OTel-aware structured logger; falls back to console.*
 
 const iii = registerWorker(process.env.III_ENGINE_URL!, {
   workerName: 'my-worker', // appears in engine::workers::list
@@ -139,7 +139,7 @@ Schemas in `registerFunction` (`description`, `request_format`, `response_format
 
 ### Errors
 
-- **Throw inside the handler** → propagates to the caller as `IIIInvocationError` (carries `code`, `function_id`, `stacktrace`). Use for unexpected failures a retry might fix.
+- **Throw inside the handler** → propagates to the caller as `InvocationError` (carries `code`, `function_id`, `stacktrace`). Use for unexpected failures a retry might fix.
 - **Return a structured value** (`{ ok: false, reason }`) → the call succeeds; the caller branches on the shape. Use for expected failures (validation, not-found, business rules).
 
 Rule of thumb: if a retry might succeed, throw; if it will fail the same way, return a value.
@@ -261,5 +261,5 @@ Install, run, and remove workers. Each op is also `iii worker <cmd>` on the CLI.
 - **Reinventing what exists.** Run the discovery steps (`engine::functions::list`, then `directory::registry::workers::list`) before authoring anything.
 - **Hardwiring a remembered worker.** Pick the capability the live engine and registry surface, in order — not the one you reached for last time.
 - **Side-channel state between workers.** Don't have workers read each other's files or hit each other's endpoints; route every cross-worker call through `iii.trigger`, and use a shared-state worker (discover one in the registry) for shared key/value.
-- **Catching the wrong error type.** `iii.trigger()` throws `IIIInvocationError`; catch that specifically or you lose `code` / `function_id` / `stacktrace`.
+- **Catching the wrong error type.** `iii.trigger()` throws `InvocationError`; catch that specifically or you lose `code` / `function_id` / `stacktrace`.
 - **Trusting introspection over runtime probes.** An empty `*::list` can mean lag, not absence — a successful `iii.trigger()` is the authoritative signal.

--- a/engine/src/workers/worker/skills/SKILL.md
+++ b/engine/src/workers/worker/skills/SKILL.md
@@ -60,7 +60,7 @@ workers:
 Receives `AuthInput { headers, query_params, ip_address }`, returns `AuthResult`. Throw to reject the connection.
 
 ```typescript
-import type { AuthInput, AuthResult } from 'iii-sdk'
+import type { AuthInput, AuthResult } from '@iii-dev/helpers/worker-connection-manager'
 
 iii.registerFunction(
   'my-project::auth',
@@ -121,7 +121,7 @@ import type {
   OnFunctionRegistrationInput,
   OnTriggerRegistrationInput,
   OnTriggerTypeRegistrationInput,
-} from 'iii-sdk'
+} from '@iii-dev/helpers/worker-connection-manager'
 
 iii.registerFunction(
   'my-project::on-fn-reg',

--- a/skills/iii-architecture-patterns/SKILL.md
+++ b/skills/iii-architecture-patterns/SKILL.md
@@ -95,7 +95,7 @@ use iii_sdk::TriggerAction;
 use iii_sdk::protocol::TriggerRequest;
 use serde_json::json;
 
-async fn enqueue_charge(iii: iii_sdk::III, order: serde_json::Value) -> Result<serde_json::Value, iii_sdk::IIIError> {
+async fn enqueue_charge(iii: iii_sdk::IIIClient, order: serde_json::Value) -> Result<serde_json::Value, iii_sdk::Error> {
     iii.trigger(TriggerRequest {
         function_id: "state::update".into(),
         payload: json!({

--- a/skills/iii-architecture-patterns/SKILL.md
+++ b/skills/iii-architecture-patterns/SKILL.md
@@ -91,7 +91,8 @@ iii.register_function("orders::validate", validate)
 ### Rust
 
 ```rust
-use iii_sdk::{TriggerAction, TriggerRequest};
+use iii_sdk::TriggerAction;
+use iii_sdk::protocol::TriggerRequest;
 use serde_json::json;
 
 async fn enqueue_charge(iii: iii_sdk::III, order: serde_json::Value) -> Result<serde_json::Value, iii_sdk::IIIError> {

--- a/skills/iii-core-primitives/SKILL.md
+++ b/skills/iii-core-primitives/SKILL.md
@@ -174,10 +174,8 @@ iii.register_trigger({
 ### Rust
 
 ```rust
-use iii_sdk::{
-    register_worker, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerAction,
-    TriggerRequest,
-};
+use iii_sdk::{register_worker, InitOptions, RegisterFunction, TriggerAction};
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
 use serde_json::json;
 
 let iii = register_worker("ws://127.0.0.1:49134", InitOptions::default());

--- a/skills/iii-error-handling/SKILL.md
+++ b/skills/iii-error-handling/SKILL.md
@@ -44,12 +44,12 @@ Branch on exact `code` strings, but keep engine wire codes separate from SDK-loc
 ### Node
 
 ```typescript
-import { IIIInvocationError } from 'iii-sdk'
+import { InvocationError } from 'iii-sdk'
 
 try {
   await iii.trigger({ function_id: 'orders::charge', payload })
 } catch (error) {
-  if (error instanceof IIIInvocationError && error.code === 'FORBIDDEN') {
+  if (error instanceof InvocationError && error.code === 'FORBIDDEN') {
     throw new Error('Policy denied orders::charge')
   }
   throw error
@@ -59,16 +59,14 @@ try {
 ### Python
 
 ```python
-from iii import IIIForbiddenError, IIIInvocationError, IIITimeoutError
+from iii import InvocationError
 
 try:
     result = iii.trigger({"function_id": "orders::charge", "payload": payload})
-except IIIForbiddenError:
-    raise RuntimeError("Policy denied orders::charge")
-except IIITimeoutError:
-    raise RuntimeError("orders::charge timed out")
-except IIIInvocationError as exc:
-    if exc.code == "timeout":
+except InvocationError as exc:
+    if exc.code == "FORBIDDEN":
+        raise RuntimeError("Policy denied orders::charge")
+    if exc.code in ("TIMEOUT", "timeout"):
         raise RuntimeError("orders::charge timed out")
     raise RuntimeError(f"{exc.code}: {exc.message}")
 ```
@@ -78,10 +76,10 @@ except IIIInvocationError as exc:
 ```rust
 match iii.trigger(request).await {
     Ok(value) => value,
-    Err(iii_sdk::IIIError::Timeout) => {
+    Err(iii_sdk::Error::Timeout) => {
         return Err("orders::charge timed out".into());
     }
-    Err(iii_sdk::IIIError::Remote { code, message, .. }) if code == "FORBIDDEN" => {
+    Err(iii_sdk::Error::Remote { code, message, .. }) if code == "FORBIDDEN" => {
         return Err(format!("policy denied: {message}").into());
     }
     Err(err) => return Err(err.into()),

--- a/skills/iii-getting-started/SKILL.md
+++ b/skills/iii-getting-started/SKILL.md
@@ -53,13 +53,13 @@ Pick your language:
 
 ```bash
 # TypeScript / Node.js
-npm install iii-sdk
+npm install iii-sdk @iii-dev/helpers
 
 # Python
-pip install iii-sdk
+pip install iii-sdk iii-helpers
 
 # Rust
-cargo add iii-sdk
+cargo add iii-sdk iii-helpers
 ```
 
 ## Step 5: Write Your First Worker
@@ -67,7 +67,8 @@ cargo add iii-sdk
 ### TypeScript
 
 ```typescript
-import { registerWorker, Logger, TriggerAction } from "iii-sdk";
+import { registerWorker, TriggerAction } from "iii-sdk";
+import { Logger } from "@iii-dev/helpers/observability";
 
 const iii = registerWorker(process.env.III_URL ?? "ws://localhost:49134");
 
@@ -92,7 +93,8 @@ iii.registerTrigger({
 ### Python
 
 ```python
-from iii import register_worker, InitOptions, Logger
+from iii import register_worker, InitOptions
+from iii_helpers.observability import Logger
 
 iii = register_worker(address="ws://localhost:49134", options=InitOptions(worker_name="hello-worker"))
 
@@ -109,7 +111,9 @@ iii.register_trigger({"type": "http", "function_id": "hello::greet", "config": {
 ### Rust
 
 ```rust
-use iii_sdk::{register_worker, InitOptions, Logger, RegisterFunction, RegisterTriggerInput};
+use iii_sdk::{register_worker, InitOptions, RegisterFunction};
+use iii_sdk::protocol::RegisterTriggerInput;
+use iii_helpers::observability::Logger;
 use serde_json::json;
 
 let iii = register_worker("ws://127.0.0.1:49134", InitOptions::default());

--- a/skills/iii-sdk-reference/SKILL.md
+++ b/skills/iii-sdk-reference/SKILL.md
@@ -34,7 +34,11 @@ cargo add iii-sdk
 | Node.js | `iii-sdk` | Server-side TypeScript/JavaScript workers | Supports custom headers, Logger, OpenTelemetry, HTTP-invoked functions |
 | Browser | `iii-browser-sdk` | Web apps and interactive UI callbacks | Connect through an RBAC-protected listener; keep secrets server-side |
 | Python | `iii-sdk` | Sync or async Python workers | Use `trigger_async` inside async handlers |
-| Rust | `iii-sdk` | High-performance tokio workers | Handler error type should map into `IIIError` |
+| Rust | `iii-sdk` | High-performance tokio workers | Handler error type should map into `iii_sdk::Error` |
+
+`Logger`/OpenTelemetry, HTTP request/response types, stream, queue, and worker-connection types live in
+the helpers package — `@iii-dev/helpers` (Node, with submodules like `/observability` and `/http`) or
+`iii-helpers` (Python `iii_helpers.*`, Rust `iii_helpers::*`) — installed alongside the SDK.
 
 ## Common API Map
 
@@ -50,7 +54,8 @@ cargo add iii-sdk
 ## Node.js
 
 ```typescript
-import { Logger, registerWorker } from "iii-sdk";
+import { registerWorker } from "iii-sdk";
+import { Logger } from "@iii-dev/helpers/observability";
 
 const iii = registerWorker("ws://localhost:49134", {
   workerName: "node-worker",
@@ -91,7 +96,8 @@ custom WebSocket headers and must not hold backend secrets.
 ## Python
 
 ```python
-from iii import InitOptions, Logger, register_worker
+from iii import InitOptions, register_worker
+from iii_helpers.observability import Logger
 
 iii = register_worker(
     address="ws://localhost:49134",
@@ -106,7 +112,7 @@ iii.register_function("users::lookup", lookup_user)
 ```
 
 Python handlers may be sync or async. Use `await iii.trigger_async(request)` inside async handlers,
-and `iii.trigger(request)` in sync contexts. `ApiResponse` uses camelCase `statusCode`.
+and `iii.trigger(request)` in sync contexts. `HttpResponse` (from `iii_helpers.http`) uses camelCase `statusCode`.
 
 ## Rust
 


### PR DESCRIPTION
Updates the hand-authored `skills/` catalog and the `engine_fn`/`worker` SKILL.md examples to the 0.20 SDK API.

## Changes
- **Logger** moved out of every SDK root → `@iii-dev/helpers/observability` (Node), `iii_helpers.observability` (Python), `iii_helpers::observability` (Rust). Updated getting-started, sdk-reference, engine_fn.
- **Error types**: `IIIInvocationError`→`InvocationError`; `iii_sdk::IIIError`→`iii_sdk::Error`; removed `IIIForbiddenError`/`IIITimeoutError` → branch on `error.code`. Updated error-handling, engine_fn, architecture-patterns.
- **HTTP types**: `ApiResponse`/`ApiRequest`→`HttpResponse`/`HttpRequest` (helpers/http). Updated sdk-reference.
- **Auth/registration types**: `AuthInput`/`AuthResult`/`On*RegistrationInput` → `@iii-dev/helpers/worker-connection-manager` (`MiddlewareFunctionInput` stays at root). Updated worker.
- **Rust protocol types**: `RegisterTriggerInput`/`TriggerRequest` → `iii_sdk::protocol`; `iii_sdk::III`→`iii_sdk::IIIClient`. Updated core-primitives, architecture-patterns, getting-started.
- Install snippets now pull the helpers package alongside the SDK; added a helpers-packages note to sdk-reference.

## Notes
- The `iii-observability` engine worker name is unchanged (only the deprecated SDK package moved); engine-config and the observability worker skill are intentionally untouched.
- `skills/` is not covered by `.skill-check.yaml` (docs-mode only); validated via stale-symbol grep sweep.
- All symbol homes verified against SDK source on `sdk-refactor`.