### PR TITLE
feat(configuration): strip redundant config.yaml blocks once persisted

### DIFF
--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -11,6 +11,14 @@ type: "reference"
   Editing and saving a file in a local-path worker on the overlay copy-in path could fail on the **first** save with `iii: ERROR /mnt/host-src … is not a virtiofs mountpoint`, then work on the next save. The host source watcher tried an in-VM **fast restart** first — but that re-runs the boot script, and in copy-in mode the script **detaches** `/mnt/host-src` once it has copied your project into the VM. The re-run hit the now-absent share and aborted; the watcher then fell back to a full VM restart, which is why the second save worked.
 
   The fast in-VM restart is now skipped for overlay copy-in workers, so they take a full VM restart — the only path that re-copies your edited source. (Even when it didn't error, a fast restart would have run **stale** source, since the project is copied at boot rather than live-mounted.) Legacy live-mount workers keep the fast restart; bundle workers don't auto-restart on source edits at all. Net: one save, one clean restart, running your latest changes.
+
+  ## `config.yaml` worker blocks are stripped once their value is persisted
+
+  Every worker's runtime settings already live in the configuration worker — the `config.yaml` block was **seed-only**, read once on first boot and ignored afterwards. But the block still sat in `config.yaml`, looking authoritative while being dead. Now, once a worker's value is persisted in the configuration store, its `config:` block is **removed from `config.yaml`** on the next boot: the `- name:` entry is kept and the block is replaced with a one-line breadcrumb pointing at where the value now lives (`./data/configuration/<id>.yaml` with the default `fs` adapter) and how to change it (`iii config set <id>` or `configuration::set`). This covers built-in workers (stripped on the first boot after they seed) and external workers like `shell` that register over the bus (stripped on the first boot after their value is in the store).
+
+  The rewrite is line-based and byte-preserving on purpose — it deletes only the contiguous block and inserts one comment, so comments, key order, and `${VAR:default}` placeholders in **other** blocks are left exactly as written (a `serde_yaml` round-trip would have mangled all three). The file is written atomically, and the strip is best-effort: a read/write failure is logged and never fails boot, and a second boot with the block already gone is a no-op. The strip runs before the file watcher starts, so it never trips a config reload.
+
+  Relatedly, the persisted store files are now **value-only**: the configuration worker writes just the setting value to `<id>.yaml` and no longer dumps the JSON schema alongside it, so the on-disk files are smaller and hand-editable.
 </Update>
 
 <Update label="0.19.6" description="June 2026">

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -22,6 +22,7 @@ pub mod worker_connections;
 pub mod workers {
     pub mod bridge_client;
     pub mod config;
+    pub mod config_rewrite;
     pub mod configuration;
     pub mod cron;
     pub mod engine_fn;

--- a/engine/src/workers/config.rs
+++ b/engine/src/workers/config.rs
@@ -764,6 +764,75 @@ impl EngineBuilder {
             }
         }
 
+        // Any worker entry whose value is already persisted in the
+        // configuration store has a redundant `config:` block in config.yaml.
+        // This covers built-in workers (which seed during the boot loop above,
+        // so their value is in the store by now) AND external workers like
+        // `shell` that register over the bus — an external worker's block is
+        // stripped on the first boot AFTER it persisted its value. Strip the
+        // block (keeping the `- name:` entry) and null the matching in-memory
+        // entry so a later reload's diff sees no change and doesn't needlessly
+        // restart the worker. Done before the watcher below exists, so these
+        // self-writes never trigger a reload.
+        if let Some(ref path) = config_path {
+            use crate::engine::EngineTrait;
+            use crate::workers::configuration::adapters::fs::{
+                ADAPTER_NAME, DEFAULT_DIRECTORY, FILE_EXTENSION,
+            };
+
+            // Where the fs adapter writes its `<id>.yaml` files, for the
+            // breadcrumb comment. `None` for a non-fs (e.g. bridge) adapter,
+            // where there is no local file to point at.
+            let store_dir: Option<String> = {
+                let adapter = running
+                    .iter()
+                    .find(|rw| rw.entry.name == "configuration")
+                    .and_then(|rw| rw.entry.config.as_ref())
+                    .and_then(|c| c.get("adapter"));
+                let name = adapter
+                    .and_then(|a| a.get("name"))
+                    .and_then(|n| n.as_str())
+                    .unwrap_or(ADAPTER_NAME);
+                (name == ADAPTER_NAME).then(|| {
+                    adapter
+                        .and_then(|a| a.get("config"))
+                        .and_then(|c| c.get("directory"))
+                        .and_then(|d| d.as_str())
+                        .unwrap_or(DEFAULT_DIRECTORY)
+                        .to_string()
+                })
+            };
+
+            for idx in 0..running.len() {
+                if running[idx].entry.config.is_none() {
+                    continue; // no `config:` block to strip
+                }
+                let id = running[idx].entry.name.clone();
+                let persisted = match engine
+                    .call("configuration::get", serde_json::json!({ "id": id }))
+                    .await
+                {
+                    Ok(Some(body)) => body.get("value").is_some_and(|v| !v.is_null()),
+                    // NOT_FOUND (Err) or no body → value not persisted yet; leave
+                    // the block so first-boot seeding still has it to read.
+                    _ => false,
+                };
+                if !persisted {
+                    continue;
+                }
+                let location = match store_dir {
+                    Some(ref dir) => format!("{dir}/{id}.{FILE_EXTENSION}"),
+                    None => "the configuration worker store".to_string(),
+                };
+                // Only null the in-memory entry when the block was actually
+                // removed, so a no-op/failed strip leaves memory and file
+                // agreeing (a later reload diff sees no phantom change).
+                if super::config_rewrite::apply_strip(path, &id, &location) {
+                    running[idx].entry.config = None;
+                }
+            }
+        }
+
         // Relay global shutdown into each per-worker shutdown channel so a
         // global Ctrl+C terminates every worker (including those added via
         // reload -- those get subscribed to the relay the next time around).

--- a/engine/src/workers/config_rewrite.rs
+++ b/engine/src/workers/config_rewrite.rs
@@ -1,0 +1,283 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Rewrites `config.yaml` after a worker seeds its `config:` block into the
+//! configuration store for the first time. The block is removed (the
+//! `- name:` entry is kept) and replaced with a comment pointing at the
+//! configuration worker, which is now the runtime source of truth.
+//!
+//! The edit is line-based on purpose: a `serde_yaml` round-trip would drop
+//! comments, reorder keys, and expand the `${VAR:default}` placeholders that
+//! other worker blocks rely on. We only ever delete a contiguous run of lines
+//! and insert one comment, so everything else in the file is byte-preserved.
+
+/// Comment left in place of a stripped `config:` block. `location` names where
+/// the value now lives (e.g. `./data/configuration/<id>.yaml` for the fs
+/// adapter).
+fn seed_comment(config_id: &str, location: &str) -> String {
+    format!(
+        "# '{config_id}': value now lives in the configuration worker at {location}. \
+         Edit at runtime via 'iii config set {config_id}' (or 'configuration::set'); \
+         this block is no longer read."
+    )
+}
+
+fn leading_spaces(line: &str) -> usize {
+    line.len() - line.trim_start_matches(' ').len()
+}
+
+/// If `line` is a `- name: <worker_name>` list item, return the indent (number
+/// of leading spaces before the dash). Tolerates quotes and trailing comments.
+fn entry_indent(line: &str, worker_name: &str) -> Option<usize> {
+    let indent = leading_spaces(line);
+    let rest = line[indent..].strip_prefix('-')?;
+    let value = rest.trim_start().strip_prefix("name:")?.trim();
+    // Strip quotes, then take the first whitespace-delimited token so a trailing
+    // `# comment` or alignment spaces don't defeat the match. Worker names are
+    // `[a-z0-9_-]`, so this is safe.
+    let value = value.trim_matches('"').trim_matches('\'');
+    let name = value.split_whitespace().next().unwrap_or("");
+    (name == worker_name).then_some(indent)
+}
+
+/// Remove the `config:` block of the worker whose `- name:` equals
+/// `worker_name`, replacing it with `comment`. Returns `None` (a no-op) when
+/// the entry is absent or already has no `config:` block — which makes a second
+/// call idempotent.
+///
+/// Only the **first** matching `- name:` is touched (duplicate instances across
+/// `workers:`/`modules:` are renamed by `assign_instance_ids`, and only the
+/// first occurrence seeds).
+pub(crate) fn strip_worker_config_block(
+    content: &str,
+    worker_name: &str,
+    comment: &str,
+) -> Option<String> {
+    let lines: Vec<&str> = content.split('\n').collect();
+
+    // 1. Locate the worker entry.
+    let (entry_idx, ent_indent) = lines
+        .iter()
+        .enumerate()
+        .find_map(|(i, l)| entry_indent(l, worker_name).map(|ind| (i, ind)))?;
+
+    // 2. Find this entry's `config:` key — scan its child lines (indent >
+    //    ent_indent) until the entry ends (a non-blank line at indent <=
+    //    ent_indent, i.e. the next list item or a dedent).
+    let mut config_idx = None;
+    let mut config_indent = 0;
+    for (i, line) in lines.iter().enumerate().skip(entry_idx + 1) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let indent = leading_spaces(line);
+        if indent <= ent_indent {
+            break; // end of this entry
+        }
+        let trimmed = line.trim_start();
+        if trimmed == "config:" || trimmed.starts_with("config:") {
+            config_idx = Some(i);
+            config_indent = indent;
+            break;
+        }
+    }
+    let config_idx = config_idx?;
+
+    // 3. Extend the block: the `config:` line plus every following nested line
+    //    (indent > config_indent). Blank lines are tentative — included only if
+    //    a deeper line follows, so blank separators before the next entry stay.
+    let mut last = config_idx;
+    let mut i = config_idx + 1;
+    while i < lines.len() {
+        let line = lines[i];
+        if line.trim().is_empty() {
+            i += 1;
+            continue;
+        }
+        if leading_spaces(line) > config_indent {
+            last = i;
+            i += 1;
+        } else {
+            break;
+        }
+    }
+
+    // 4. Rebuild: lines before the block, the comment at the block's indent,
+    //    then everything after the block (trailing blanks preserved).
+    let comment_line = format!("{}{}", " ".repeat(config_indent), comment);
+    let mut out: Vec<&str> = lines[..config_idx].to_vec();
+    out.push(&comment_line);
+    out.extend_from_slice(&lines[last + 1..]);
+    Some(out.join("\n"))
+}
+
+/// Read `path`, strip `config_id`'s block, and write it back atomically
+/// (temp + rename, preserving the file's permissions). Best-effort: any IO
+/// error is logged and swallowed so a failed rewrite never fails boot.
+///
+/// Returns `true` only when the file was actually rewritten. The caller uses
+/// this to keep its in-memory copy of the entry in sync with the file: on a
+/// no-op or a failed write the file still carries the block, so the in-memory
+/// config must NOT be cleared (else the next reload diff would see a phantom
+/// change and needlessly restart the worker).
+pub(crate) fn apply_strip(path: &str, config_id: &str, location: &str) -> bool {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(err) => {
+            tracing::warn!(path, error = %err, "config seed-strip: cannot read config file");
+            return false;
+        }
+    };
+    let Some(updated) = strip_worker_config_block(&raw, config_id, &seed_comment(config_id, location))
+    else {
+        return false; // nothing to strip (entry/block absent) — idempotent no-op
+    };
+    if let Err(err) = atomic_write(path, &updated) {
+        tracing::warn!(path, error = %err, "config seed-strip: failed to write config file");
+        return false;
+    }
+    tracing::info!(
+        config_id,
+        path,
+        "stripped seeded config block from config.yaml; value now lives in the configuration worker"
+    );
+    true
+}
+
+fn atomic_write(path: &str, content: &str) -> std::io::Result<()> {
+    let tmp = format!("{path}.tmp");
+    std::fs::write(&tmp, content)?;
+    if let Ok(meta) = std::fs::metadata(path) {
+        std::fs::set_permissions(&tmp, meta.permissions()).ok();
+    }
+    std::fs::rename(&tmp, path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const COMMENT: &str = "# moved";
+
+    fn sample() -> String {
+        // Two workers + a trailing top-level key. iii-stream carries `${VAR}`
+        // placeholders and a nested `config:` (under adapter) to prove neither
+        // is disturbed when iii-state is stripped, and that the nested config
+        // is removed wholesale when iii-stream is stripped.
+        "\
+workers:
+  - name: iii-stream
+    config:
+      port: ${STREAM_PORT:3112}
+      adapter:
+        name: redis
+        config:
+          redis_url: redis://localhost:6379
+  - name: iii-state
+    config:
+      adapter:
+        name: kv
+  # a standalone comment
+  - name: configuration
+    config:
+      ttl_seconds: 0
+rootfs: overlay
+"
+        .to_string()
+    }
+
+    #[test]
+    fn strips_block_and_inserts_comment_keeping_entry() {
+        let out = strip_worker_config_block(&sample(), "iii-state", COMMENT).unwrap();
+        assert!(out.contains("  - name: iii-state\n    # moved\n"));
+        // iii-state's adapter/kv lines are gone.
+        assert!(!out.contains("name: kv"));
+        // Other entries and the standalone comment survive untouched.
+        assert!(out.contains("redis_url: redis://localhost:6379"));
+        assert!(out.contains("  # a standalone comment"));
+        assert!(out.contains("  - name: configuration"));
+        assert!(out.contains("rootfs: overlay"));
+    }
+
+    #[test]
+    fn preserves_env_placeholders_in_other_blocks() {
+        let out = strip_worker_config_block(&sample(), "iii-state", COMMENT).unwrap();
+        assert!(out.contains("port: ${STREAM_PORT:3112}"));
+    }
+
+    #[test]
+    fn strips_nested_config_wholesale() {
+        // Stripping iii-stream must remove its block including the nested
+        // `config:` under adapter, without touching iii-state.
+        let out = strip_worker_config_block(&sample(), "iii-stream", COMMENT).unwrap();
+        assert!(out.contains("  - name: iii-stream\n    # moved\n"));
+        assert!(!out.contains("redis_url"));
+        assert!(out.contains("  - name: iii-state\n    config:"));
+    }
+
+    #[test]
+    fn idempotent_second_call_is_noop() {
+        let once = strip_worker_config_block(&sample(), "iii-state", COMMENT).unwrap();
+        assert!(strip_worker_config_block(&once, "iii-state", COMMENT).is_none());
+    }
+
+    #[test]
+    fn absent_entry_is_noop() {
+        assert!(strip_worker_config_block(&sample(), "iii-missing", COMMENT).is_none());
+    }
+
+    #[test]
+    fn entry_without_config_block_is_noop() {
+        let content = "\
+workers:
+  - name: iii-stream
+    image: foo:latest
+  - name: iii-state
+    config:
+      adapter:
+        name: kv
+";
+        assert!(strip_worker_config_block(content, "iii-stream", COMMENT).is_none());
+    }
+
+    #[test]
+    fn matches_entry_after_image_field() {
+        let content = "\
+workers:
+  - name: iii-stream
+    image: foo:latest
+    config:
+      port: 3112
+  - name: iii-state
+    config:
+      adapter:
+        name: kv
+";
+        let out = strip_worker_config_block(content, "iii-stream", COMMENT).unwrap();
+        assert!(out.contains("    image: foo:latest\n    # moved\n"));
+        assert!(!out.contains("port: 3112"));
+        assert!(out.contains("name: kv"));
+    }
+
+    #[test]
+    fn only_first_duplicate_entry_is_stripped() {
+        let content = "\
+workers:
+  - name: iii-stream
+    config:
+      port: 1
+modules:
+  - name: iii-stream
+    config:
+      port: 2
+";
+        let out = strip_worker_config_block(content, "iii-stream", COMMENT).unwrap();
+        // First occurrence stripped, second left intact.
+        assert!(out.contains("    # moved\n"));
+        assert!(!out.contains("port: 1"));
+        assert!(out.contains("port: 2"));
+    }
+}

--- a/engine/src/workers/config_rewrite.rs
+++ b/engine/src/workers/config_rewrite.rs
@@ -131,7 +131,8 @@ pub(crate) fn apply_strip(path: &str, config_id: &str, location: &str) -> bool {
             return false;
         }
     };
-    let Some(updated) = strip_worker_config_block(&raw, config_id, &seed_comment(config_id, location))
+    let Some(updated) =
+        strip_worker_config_block(&raw, config_id, &seed_comment(config_id, location))
     else {
         return false; // nothing to strip (entry/block absent) — idempotent no-op
     };

--- a/engine/tests/config_reload_e2e.rs
+++ b/engine/tests/config_reload_e2e.rs
@@ -58,6 +58,27 @@ fn write_config(path: &Path, contents: &str) {
     std::fs::write(path, contents).expect("write config file");
 }
 
+/// Poll `config.yaml` at `path` until it contains `needle` (the seed-strip
+/// breadcrumb), then return the rewritten contents. Panics after a generous
+/// deadline. The poll replaces a fixed sleep so slow CI runners (notably
+/// coverage instrumentation) don't flake when the strip pass runs slower than
+/// any constant wait — the file is written atomically, so once the breadcrumb
+/// is present the whole rewrite is.
+async fn wait_for_config_rewrite(path: &Path, needle: &str) -> String {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let contents = std::fs::read_to_string(path).unwrap_or_default();
+        if contents.contains(needle) {
+            return contents;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for config rewrite to contain {needle:?}; last content:\n{contents}"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
 fn make_dummy_function(id: &str) -> Function {
     Function {
         handler: Arc::new(|_invocation_id, _input, _session| {
@@ -317,17 +338,13 @@ modules: []
     let handle = tokio::spawn(async move { builder.serve().await });
 
     // serve() runs the serial boot loop (pubsub seeds), then the strip pass
-    // rewrites config.yaml — all before the file watcher is created.
-    tokio::time::sleep(Duration::from_millis(1000)).await;
-
-    let rewritten = std::fs::read_to_string(&path).expect("read rewritten config");
+    // rewrites config.yaml — all before the file watcher is created. Poll for
+    // the breadcrumb instead of a fixed sleep; the poll IS the assertion that
+    // the seed block was stripped and the breadcrumb comment written.
+    let rewritten = wait_for_config_rewrite(&path, "iii config set iii-pubsub").await;
 
     // Seed block gone, replaced by the breadcrumb comment; entry kept; the
     // non-seeding configuration block left intact.
-    assert!(
-        rewritten.contains("iii config set iii-pubsub"),
-        "expected seed-strip comment, got:\n{rewritten}"
-    );
     assert!(
         rewritten.contains(&format!("at {store_dir}/iii-pubsub.yaml")),
         "comment should point at the store location, got:\n{rewritten}"
@@ -412,13 +429,7 @@ modules: []
         .expect("build engine");
     let handle = tokio::spawn(async move { builder.serve().await });
 
-    tokio::time::sleep(Duration::from_millis(1000)).await;
-
-    let rewritten = std::fs::read_to_string(&path).expect("read rewritten config");
-    assert!(
-        rewritten.contains("iii config set iii-pubsub"),
-        "expected seed-strip comment on the already-persisted path, got:\n{rewritten}"
-    );
+    let rewritten = wait_for_config_rewrite(&path, "iii config set iii-pubsub").await;
     assert!(
         rewritten.contains(&format!("at {store_dir}/iii-pubsub.yaml")),
         "comment should point at the store location, got:\n{rewritten}"
@@ -495,13 +506,7 @@ modules: []
         .expect("build engine");
     let handle = tokio::spawn(async move { builder.serve().await });
 
-    tokio::time::sleep(Duration::from_millis(1000)).await;
-
-    let rewritten = std::fs::read_to_string(&path).expect("read rewritten config");
-    assert!(
-        rewritten.contains("iii config set fake-ext"),
-        "external worker block should be stripped with a breadcrumb, got:\n{rewritten}"
-    );
+    let rewritten = wait_for_config_rewrite(&path, "iii config set fake-ext").await;
     assert!(
         rewritten.contains(&format!("at {store_dir}/fake-ext.yaml")),
         "comment should point at the store location, got:\n{rewritten}"

--- a/engine/tests/config_reload_e2e.rs
+++ b/engine/tests/config_reload_e2e.rs
@@ -269,3 +269,254 @@ async fn config_reload_removes_worker_function_registrations() {
 
     drop(tmp);
 }
+
+// ---------------------------------------------------------------------------
+// First-boot seed strips the worker's config: block from config.yaml and moves
+// the value into the configuration store.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn first_seed_strips_config_block_and_moves_value_to_store() {
+    disable_builtin_daemons();
+
+    // The configuration worker persists value-only YAML into this temp dir so we
+    // can assert the seed landed there. iii-pubsub's `local` adapter binds no
+    // ports and writes no side-effect files, so it is a clean seeding subject.
+    let store = tempfile::tempdir().expect("store dir");
+    let store_dir = store.path().to_str().unwrap().to_string();
+
+    let tmp = tempfile::NamedTempFile::new().expect("create tempfile");
+    let path = tmp.path().to_path_buf();
+
+    let yaml = format!(
+        "workers:
+  - name: configuration
+    config:
+      adapter:
+        name: fs
+        config:
+          directory: {store_dir}
+      ttl_seconds: 0
+  - name: iii-pubsub
+    config:
+      adapter:
+        name: local
+modules: []
+"
+    );
+    write_config(&path, &yaml);
+
+    let cfg = EngineConfig::config_file(path.to_str().unwrap()).expect("load config");
+    let builder = EngineBuilder::new()
+        .with_config(cfg)
+        .with_config_path(path.to_str().unwrap())
+        .build()
+        .await
+        .expect("build engine");
+    let handle = tokio::spawn(async move { builder.serve().await });
+
+    // serve() runs the serial boot loop (pubsub seeds), then the strip pass
+    // rewrites config.yaml — all before the file watcher is created.
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    let rewritten = std::fs::read_to_string(&path).expect("read rewritten config");
+
+    // Seed block gone, replaced by the breadcrumb comment; entry kept; the
+    // non-seeding configuration block left intact.
+    assert!(
+        rewritten.contains("iii config set iii-pubsub"),
+        "expected seed-strip comment, got:\n{rewritten}"
+    );
+    assert!(
+        rewritten.contains(&format!("at {store_dir}/iii-pubsub.yaml")),
+        "comment should point at the store location, got:\n{rewritten}"
+    );
+    assert!(
+        !rewritten.contains("name: local"),
+        "pubsub seed block should be stripped, got:\n{rewritten}"
+    );
+    assert!(
+        rewritten.contains("- name: iii-pubsub"),
+        "the worker entry itself must be kept, got:\n{rewritten}"
+    );
+    assert!(
+        rewritten.contains(&format!("directory: {store_dir}")),
+        "the configuration worker block must be left intact, got:\n{rewritten}"
+    );
+
+    // The value moved into the configuration store (value-only YAML).
+    let stored = std::fs::read_to_string(store.path().join("iii-pubsub.yaml"))
+        .expect("store file should exist");
+    assert!(
+        stored.contains("local"),
+        "stored value should hold the seeded adapter, got:\n{stored}"
+    );
+
+    handle.abort();
+    let _ = handle.await;
+
+    drop(tmp);
+}
+
+// ---------------------------------------------------------------------------
+// A value already persisted in the store (from a prior boot) means the
+// config.yaml block is being ignored — it must still get stripped, even though
+// nothing is seeded this boot.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn already_persisted_value_also_strips_stale_config_block() {
+    disable_builtin_daemons();
+
+    let store = tempfile::tempdir().expect("store dir");
+    let store_dir = store.path().to_str().unwrap().to_string();
+
+    // Simulate a prior boot: the store already holds iii-pubsub's value (empty
+    // config = default adapter). The config.yaml block below is therefore being
+    // ignored at runtime — it must still get stripped.
+    std::fs::write(
+        store.path().join("iii-pubsub.yaml"),
+        "id: iii-pubsub\nname: PubSub\ndescription: pre-existing from a prior boot\nvalue: {}\n",
+    )
+    .expect("pre-seed store");
+
+    let tmp = tempfile::NamedTempFile::new().expect("create tempfile");
+    let path = tmp.path().to_path_buf();
+
+    let yaml = format!(
+        "workers:
+  - name: configuration
+    config:
+      adapter:
+        name: fs
+        config:
+          directory: {store_dir}
+      ttl_seconds: 0
+  - name: iii-pubsub
+    config:
+      adapter:
+        name: local
+modules: []
+"
+    );
+    write_config(&path, &yaml);
+
+    let cfg = EngineConfig::config_file(path.to_str().unwrap()).expect("load config");
+    let builder = EngineBuilder::new()
+        .with_config(cfg)
+        .with_config_path(path.to_str().unwrap())
+        .build()
+        .await
+        .expect("build engine");
+    let handle = tokio::spawn(async move { builder.serve().await });
+
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    let rewritten = std::fs::read_to_string(&path).expect("read rewritten config");
+    assert!(
+        rewritten.contains("iii config set iii-pubsub"),
+        "expected seed-strip comment on the already-persisted path, got:\n{rewritten}"
+    );
+    assert!(
+        rewritten.contains(&format!("at {store_dir}/iii-pubsub.yaml")),
+        "comment should point at the store location, got:\n{rewritten}"
+    );
+    assert!(
+        !rewritten.contains("name: local"),
+        "stale pubsub block should be stripped even when not seeding, got:\n{rewritten}"
+    );
+
+    // The pre-existing stored value was NOT overwritten by the config.yaml block
+    // — proving this was the already-persisted path, not a re-seed.
+    let stored = std::fs::read_to_string(store.path().join("iii-pubsub.yaml"))
+        .expect("store file should exist");
+    assert!(
+        stored.contains("value: {}"),
+        "stored value must stay the pre-existing empty config, not the config.yaml block, got:\n{stored}"
+    );
+
+    handle.abort();
+    let _ = handle.await;
+
+    drop(tmp);
+}
+
+// ---------------------------------------------------------------------------
+// External workers (e.g. `shell`) register over the bus and never call the
+// engine-side register_config. The strip is store-driven, so once their value
+// is in the store their stale config.yaml block is removed too — proven here
+// with a non-builtin worker that registers nothing in-process.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn external_worker_block_stripped_from_store_value_alone() {
+    disable_builtin_daemons();
+
+    let store = tempfile::tempdir().expect("store dir");
+    let store_dir = store.path().to_str().unwrap().to_string();
+
+    // Value already in the store from a prior boot, for a worker that never
+    // calls the engine-side register_config (the external-worker case).
+    std::fs::write(
+        store.path().join("fake-ext.yaml"),
+        "id: fake-ext\nname: Fake\ndescription: external stand-in\nvalue:\n  some_key: stored\n",
+    )
+    .expect("pre-seed store");
+
+    let tmp = tempfile::NamedTempFile::new().expect("create tempfile");
+    let path = tmp.path().to_path_buf();
+    let yaml = format!(
+        "workers:
+  - name: configuration
+    config:
+      adapter:
+        name: fs
+        config:
+          directory: {store_dir}
+      ttl_seconds: 0
+  - name: fake-ext
+    config:
+      some_key: from_config_yaml
+modules: []
+"
+    );
+    write_config(&path, &yaml);
+
+    let cfg = EngineConfig::config_file(path.to_str().unwrap()).expect("load config");
+    let builder = EngineBuilder::new()
+        .register_worker::<TestEphemeralWorker>("fake-ext")
+        .with_config(cfg)
+        .with_config_path(path.to_str().unwrap())
+        .build()
+        .await
+        .expect("build engine");
+    let handle = tokio::spawn(async move { builder.serve().await });
+
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    let rewritten = std::fs::read_to_string(&path).expect("read rewritten config");
+    assert!(
+        rewritten.contains("iii config set fake-ext"),
+        "external worker block should be stripped with a breadcrumb, got:\n{rewritten}"
+    );
+    assert!(
+        rewritten.contains(&format!("at {store_dir}/fake-ext.yaml")),
+        "comment should point at the store location, got:\n{rewritten}"
+    );
+    assert!(
+        !rewritten.contains("from_config_yaml"),
+        "stale external block should be gone, got:\n{rewritten}"
+    );
+    assert!(
+        rewritten.contains("- name: fake-ext"),
+        "the worker entry itself must be kept, got:\n{rewritten}"
+    );
+
+    handle.abort();
+    let _ = handle.await;
+
+    drop(tmp);
+}

--- a/engine/tests/observability_configuration_e2e.rs
+++ b/engine/tests/observability_configuration_e2e.rs
@@ -114,7 +114,10 @@ async fn set_value_expect_rejection(harness: &Harness, value: Value) {
 /// Poll until `predicate` returns true or the deadline elapses. Trigger
 /// fan-out is spawned, so observable effects are eventually consistent.
 async fn wait_for(mut predicate: impl FnMut() -> bool, what: &str) {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    // ponytail: 20s, not 5s — the happy path returns the moment `predicate`
+    // holds (polled every 25ms), so this only bounds the failure case. 5s was
+    // borderline under llvm-cov instrumentation and flaked the coverage job.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
     loop {
         if predicate() {
             return;


### PR DESCRIPTION
## What

After a worker's value is persisted in the configuration store, its `config:` block in `config.yaml` is dead weight — the store is the runtime source of truth (the block is seed-only) and a stale block silently drifts from reality.

On boot, **before the file watcher starts**, `serve()` now strips that block (keeping the `- name:` entry) for every worker entry whose value is already in the store, replacing it with a breadcrumb comment pointing at where the value lives:

```yaml
  - name: iii-stream
    # 'iii-stream': value now lives in the configuration worker at ./data/configuration/iii-stream.yaml. Edit at runtime via 'iii config set iii-stream' (or 'configuration::set'); this block is no longer read.
```

The location is resolved from the `configuration` worker's own fs-adapter `directory` (default `./data/configuration`); a non-fs adapter (e.g. `bridge`) falls back to "the configuration worker store".

## Why store-driven

The strip queries `configuration::get` rather than relying on each worker to report that it seeded. That makes it uniform across:
- **built-in workers** (stream, queue, cron, state, pubsub, observability, http) — they seed during the serial boot loop, so their value is in the store by the time the strip pass runs → stripped on first boot.
- **external workers** (e.g. `shell`, `coder`) — they register over the SDK bus under their config.yaml name and persist a value; their block is stripped on the first boot **after** they persisted.

Entries with no persisted value yet (e.g. a worker that hasn't run) are left untouched. No per-worker hooks needed — the entire feature is one new module plus one block in `serve()`.

## Safety

- The strip runs before the watcher exists, so self-writes never trigger a reload.
- The in-memory worker entry's config is nulled **only** on a confirmed file write, so a later reload diff sees no phantom change and doesn't needlessly restart the worker.
- Line-based edit (not a `serde_yaml` round-trip): comments, formatting, and `${VAR}` placeholders in other blocks are byte-preserved. Idempotent — a second pass finds no block and no-ops.

## Tradeoff (by design)

External workers connect after boot, so their block is stripped one boot late (never on the boot they first register). Same-boot stripping would need file-watcher self-write suppression (reload-storm risk); this keeps the simpler model that matches the existing seed-only semantics.

## Test plan

- `engine/src/workers/config_rewrite.rs` unit tests (8): strip/keep-entry, env-placeholder preservation, nested `config:`, idempotency, absent entry/block, after-`image:` field, first-of-duplicates.
- `engine/tests/config_reload_e2e.rs` (3 new, boot through `serve()`):
  - first-seed: block stripped + value moved to store + comment points at the store path.
  - already-persisted: pre-seeded store → block stripped on the not-seeding path, stored value not clobbered.
  - external worker: a non-builtin worker that registers nothing in-process → its block is stripped from the store value alone.
- Regression: 14 seed unit tests + 61 per-worker configuration e2e tests green; `cargo check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration files now automatically strip redundant per-worker `config` seed blocks after the worker’s value has been persisted, replacing removed sections with a breadcrumb pointing to the persisted config source to reduce unnecessary reload triggers.
  * Rewrites are performed early (before watching) and are best-effort to avoid blocking startup.
* **Tests**
  * Added end-to-end coverage for first-boot stripping, already-persisted values, and external/bus-style workers.
  * Added polling-based assertions for rewrite completion and increased an observability test timeout to reduce flakiness.
* **Documentation**
  * Updated the changelog with the new configuration-store and `config.yaml` behavior details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->