### PR TITLE
fix(iii-worker): full VM restart for overlay local workers on source edits

### DIFF
--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -309,6 +309,16 @@ pub struct WatchSourceArgs {
     /// Absolute project directory to watch recursively
     #[arg(long, value_name = "PATH")]
     pub project: String,
+
+    /// Worker runs in the overlay copy-in workspace model (host project is
+    /// copied into a VM-local /workspace at boot, then /mnt/host-src is
+    /// detached). Set by `iii worker start` from the authoritative
+    /// `overlay::overlay_active()` decision. When set, the watcher always does
+    /// a full VM restart on source edits — the in-VM fast restart would re-run
+    /// the boot script against the now-detached share and fail. Absent ⇒
+    /// live-mount (legacy/bundle), where the fast restart is valid.
+    #[arg(long)]
+    pub overlay: bool,
 }
 
 /// Arguments for the `worker-manager-daemon` subcommand. Started by

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -1371,7 +1371,7 @@ async fn start_worker_impl(
     if !disable_watcher
         && exit_code == 0
         && let Err(e) =
-            spawn_source_watcher(worker_name, project_path, &managed_dir_for_watcher).await
+            spawn_source_watcher(worker_name, project_path, &managed_dir_for_watcher, overlay).await
     {
         eprintln!(
             "  {} source watcher failed to start: {}. Source edits will not auto-restart.",
@@ -1396,6 +1396,7 @@ async fn spawn_source_watcher(
     worker_name: &str,
     project_path: &Path,
     managed_dir: &Path,
+    overlay: bool,
 ) -> std::io::Result<()> {
     use std::path::PathBuf;
 
@@ -1447,6 +1448,12 @@ async fn spawn_source_watcher(
         .stdin(std::process::Stdio::null())
         .stdout(log_file)
         .stderr(log_file2);
+    // Hand the authoritative workspace model to the watcher so it never has to
+    // re-derive overlay-ness from the (best-effort, ambiguous) .iii-layout
+    // marker. Only passed when overlay; absence means live-mount.
+    if overlay {
+        cmd.arg("--overlay");
+    }
 
     #[cfg(unix)]
     unsafe {

--- a/crates/iii-worker/src/cli/overlay.rs
+++ b/crates/iii-worker/src/cli/overlay.rs
@@ -78,13 +78,27 @@ fn marker_path(managed_dir: &Path) -> PathBuf {
     managed_dir.join(LAYOUT_MARKER)
 }
 
-/// The worker's recorded layout, or `None` when unmarked (a pre-overlay
-/// install, or a fresh worker).
+/// Like [`read_layout`], but keeps the distinction between a *missing* marker
+/// (`Ok(None)` — a legacy/pre-overlay or fresh worker) and a marker that
+/// exists yet *can't be read* (`Err` — EACCES/EIO/ESTALE, a locked or
+/// truncated file, a path that isn't a regular file, …). Callers that must
+/// fail safe on an unreadable marker use this; [`read_layout`] collapses
+/// every error to `None`, which is the wrong default for a safety guard.
+pub fn try_read_layout(managed_dir: &Path) -> std::io::Result<Option<String>> {
+    match std::fs::read_to_string(marker_path(managed_dir)) {
+        Ok(s) => {
+            let trimmed = s.trim();
+            Ok((!trimmed.is_empty()).then(|| trimmed.to_string()))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
 pub fn read_layout(managed_dir: &Path) -> Option<String> {
-    std::fs::read_to_string(marker_path(managed_dir))
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
+    // Lossy by design: a missing OR unreadable marker both collapse to `None`.
+    // Callers that need to tell those apart use `try_read_layout`.
+    try_read_layout(managed_dir).ok().flatten()
 }
 
 /// Stamp the worker's layout marker.
@@ -139,6 +153,26 @@ mod tests {
         write_layout(&d, "legacy");
         assert_eq!(read_layout(&d).as_deref(), Some("legacy"));
         let _ = std::fs::remove_dir_all(&d);
+    }
+
+    #[test]
+    fn try_read_layout_distinguishes_absent_from_unreadable() {
+        let d = tmp("try-read");
+        // Absent marker → Ok(None), NOT an error (a legacy/fresh worker).
+        assert!(matches!(try_read_layout(&d), Ok(None)));
+        // Present marker → Ok(Some(trimmed)).
+        write_layout(&d, LAYOUT_OVERLAY);
+        assert_eq!(
+            try_read_layout(&d).unwrap().as_deref(),
+            Some(LAYOUT_OVERLAY)
+        );
+        // Unreadable marker (a directory where the file should be) → Err, so
+        // callers can fail safe instead of mistaking it for "absent".
+        let d2 = tmp("try-read-dir");
+        std::fs::create_dir_all(d2.join(LAYOUT_MARKER)).unwrap();
+        assert!(try_read_layout(&d2).is_err());
+        let _ = std::fs::remove_dir_all(&d);
+        let _ = std::fs::remove_dir_all(&d2);
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/overlay.rs
+++ b/crates/iii-worker/src/cli/overlay.rs
@@ -78,27 +78,13 @@ fn marker_path(managed_dir: &Path) -> PathBuf {
     managed_dir.join(LAYOUT_MARKER)
 }
 
-/// Like [`read_layout`], but keeps the distinction between a *missing* marker
-/// (`Ok(None)` — a legacy/pre-overlay or fresh worker) and a marker that
-/// exists yet *can't be read* (`Err` — EACCES/EIO/ESTALE, a locked or
-/// truncated file, a path that isn't a regular file, …). Callers that must
-/// fail safe on an unreadable marker use this; [`read_layout`] collapses
-/// every error to `None`, which is the wrong default for a safety guard.
-pub fn try_read_layout(managed_dir: &Path) -> std::io::Result<Option<String>> {
-    match std::fs::read_to_string(marker_path(managed_dir)) {
-        Ok(s) => {
-            let trimmed = s.trim();
-            Ok((!trimmed.is_empty()).then(|| trimmed.to_string()))
-        }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(e) => Err(e),
-    }
-}
-
+/// The worker's recorded layout, or `None` when unmarked (a pre-overlay
+/// install, or a fresh worker).
 pub fn read_layout(managed_dir: &Path) -> Option<String> {
-    // Lossy by design: a missing OR unreadable marker both collapse to `None`.
-    // Callers that need to tell those apart use `try_read_layout`.
-    try_read_layout(managed_dir).ok().flatten()
+    std::fs::read_to_string(marker_path(managed_dir))
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 /// Stamp the worker's layout marker.
@@ -153,26 +139,6 @@ mod tests {
         write_layout(&d, "legacy");
         assert_eq!(read_layout(&d).as_deref(), Some("legacy"));
         let _ = std::fs::remove_dir_all(&d);
-    }
-
-    #[test]
-    fn try_read_layout_distinguishes_absent_from_unreadable() {
-        let d = tmp("try-read");
-        // Absent marker → Ok(None), NOT an error (a legacy/fresh worker).
-        assert!(matches!(try_read_layout(&d), Ok(None)));
-        // Present marker → Ok(Some(trimmed)).
-        write_layout(&d, LAYOUT_OVERLAY);
-        assert_eq!(
-            try_read_layout(&d).unwrap().as_deref(),
-            Some(LAYOUT_OVERLAY)
-        );
-        // Unreadable marker (a directory where the file should be) → Err, so
-        // callers can fail safe instead of mistaking it for "absent".
-        let d2 = tmp("try-read-dir");
-        std::fs::create_dir_all(d2.join(LAYOUT_MARKER)).unwrap();
-        assert!(try_read_layout(&d2).is_err());
-        let _ = std::fs::remove_dir_all(&d);
-        let _ = std::fs::remove_dir_all(&d2);
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/source_watcher.rs
+++ b/crates/iii-worker/src/cli/source_watcher.rs
@@ -514,17 +514,50 @@ where
     Ok(())
 }
 
-/// Production restart dispatcher.
+/// Whether the in-VM supervisor fast restart is valid for this change.
 ///
-/// For `ChangeKind::Source`, tries the supervisor fast path first. If
-/// the supervisor is unreachable (not installed, crashed, timeout), or
-/// if the change is a `DepManifest`, falls back to a full VM restart
-/// via `iii-worker start <name>`.
-///
-/// Invoked by `watch_and_restart` on every debounced file-change
-/// burst.
+/// Valid only for a regular source edit on a live-mount worker
+/// (legacy/bundle), where `/workspace` IS the host project and a process
+/// restart picks up the edit. INVALID for:
+///   - `DepManifest` changes — deps reinstall only at boot, so a full VM
+///     restart is required.
+///   - overlay copy-in workers — the host project is copied into a VM-local
+///     `/workspace` at boot and `/mnt/host-src` is then detached, so an in-VM
+///     restart re-runs `dev-run.sh`, fails its host-src mountpoint check, and
+///     even on success would serve stale source. Only a full VM restart
+///     re-copies.
+fn fast_restart_eligible(kind: ChangeKind, overlay_copyin: bool) -> bool {
+    matches!(kind, ChangeKind::Source) && !overlay_copyin
+}
+
+/// Returns `true` if `worker_name` runs in the overlay copy-in layout, read
+/// from its on-disk `.iii-layout` marker under `~/.iii/managed`. An unknown
+/// home dir or an unmarked (legacy) worker yields `false`.
+fn is_overlay_copyin(worker_name: &str) -> bool {
+    let Some(home) = dirs::home_dir() else {
+        return false;
+    };
+    is_overlay_copyin_in(&home.join(".iii").join("managed"), worker_name)
+}
+
+/// Path-injectable core of [`is_overlay_copyin`], so the marker→bool mapping
+/// is testable without a real `$HOME`.
+fn is_overlay_copyin_in(managed_root: &Path, worker_name: &str) -> bool {
+    crate::cli::overlay::read_layout(&managed_root.join(worker_name)).as_deref()
+        == Some(crate::cli::overlay::LAYOUT_OVERLAY)
+}
+
 pub fn restart_via_cli(worker_name: &str, kind: ChangeKind) {
-    if matches!(kind, ChangeKind::Source) {
+    // Overlay copy-in workers detach /mnt/host-src after the boot-time copy
+    // (see local_worker's dev-run.sh), so an in-VM supervisor fast restart
+    // would re-run that whole script and fail its host-src mountpoint check
+    // (`iii: ERROR /mnt/host-src ... is not a virtiofs mountpoint`) — and even
+    // on success would serve stale source, since the project is copied into a
+    // VM-local /workspace at boot, not live-mounted. Only a full VM restart
+    // re-copies. So the fast path is valid only for a source edit on a
+    // live-mount (legacy/bundle) worker.
+    let overlay = is_overlay_copyin(worker_name);
+    if fast_restart_eligible(kind, overlay) {
         match try_fast_restart(worker_name) {
             Ok(()) => {
                 tracing::info!(
@@ -542,10 +575,19 @@ pub fn restart_via_cli(worker_name: &str, kind: ChangeKind) {
                 );
             }
         }
-    } else {
+    } else if matches!(kind, ChangeKind::DepManifest) {
+        // Dep-manifest changes always full-restart so the install reruns at
+        // boot, regardless of workspace model — report that as the reason.
         tracing::info!(
             worker = %worker_name,
             "source watcher: dep manifest changed, forcing full VM restart"
+        );
+    } else {
+        // Source edit on an overlay copy-in worker: the fast path is unsafe
+        // here (see above), so go straight to a full VM restart.
+        tracing::info!(
+            worker = %worker_name,
+            "source watcher: overlay copy-in worker, forcing full VM restart"
         );
     }
 
@@ -652,6 +694,44 @@ mod tests {
             args.iter().any(|a| *a == "--no-wait"),
             "watcher slow-path restart must pass --no-wait to avoid polluting watcher.log"
         );
+    }
+
+    /// Regression lock for the overlay dev-loop bug: a source edit on an
+    /// overlay copy-in worker MUST take the full VM restart, never the in-VM
+    /// fast path. `dev-run.sh` detaches `/mnt/host-src` after the boot-time
+    /// copy, so a fast restart re-runs that script and fails its mountpoint
+    /// check (`iii: ERROR /mnt/host-src ... is not a virtiofs mountpoint`),
+    /// surfacing as "save once errors, save again works".
+    #[test]
+    fn fast_path_eligible_only_for_live_mount_source_edits() {
+        // Live-mount (legacy/bundle) source edit: fast path is valid.
+        assert!(fast_restart_eligible(ChangeKind::Source, false));
+        // Overlay copy-in source edit: must full-restart (the bug this fixes).
+        assert!(!fast_restart_eligible(ChangeKind::Source, true));
+        // Dep-manifest changes always force a full restart (reinstall at boot).
+        assert!(!fast_restart_eligible(ChangeKind::DepManifest, false));
+        assert!(!fast_restart_eligible(ChangeKind::DepManifest, true));
+    }
+
+    #[test]
+    fn overlay_copyin_detected_from_layout_marker() {
+        let managed_root =
+            std::env::temp_dir().join(format!("iii-watcher-overlay-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&managed_root);
+        std::fs::create_dir_all(&managed_root).unwrap();
+
+        // Unmarked dir (legacy) and a never-started worker → not overlay.
+        std::fs::create_dir_all(managed_root.join("legacy-worker")).unwrap();
+        assert!(!is_overlay_copyin_in(&managed_root, "legacy-worker"));
+        assert!(!is_overlay_copyin_in(&managed_root, "never-started"));
+
+        // `.iii-layout` == "overlay" → overlay copy-in.
+        let ov = managed_root.join("ov-worker");
+        std::fs::create_dir_all(&ov).unwrap();
+        std::fs::write(ov.join(".iii-layout"), crate::cli::overlay::LAYOUT_OVERLAY).unwrap();
+        assert!(is_overlay_copyin_in(&managed_root, "ov-worker"));
+
+        let _ = std::fs::remove_dir_all(&managed_root);
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/source_watcher.rs
+++ b/crates/iii-worker/src/cli/source_watcher.rs
@@ -530,48 +530,21 @@ fn fast_restart_eligible(kind: ChangeKind, overlay_copyin: bool) -> bool {
     matches!(kind, ChangeKind::Source) && !overlay_copyin
 }
 
-/// Returns `true` if `worker_name` runs in the overlay copy-in layout, read
-/// from its on-disk `.iii-layout` marker under `~/.iii/managed`. An unmarked
-/// (legacy) worker yields `false`; an *unreadable* marker fails safe to `true`
-/// (see [`is_overlay_copyin_in`]). A missing home dir yields `false`: without
-/// `~/.iii` the supervisor control socket is also unreachable, so the fast
-/// path self-corrects via `try_fast_restart`'s fallback instead of sticking.
-fn is_overlay_copyin(worker_name: &str) -> bool {
-    let Some(home) = dirs::home_dir() else {
-        return false;
-    };
-    is_overlay_copyin_in(&home.join(".iii").join("managed"), worker_name)
-}
-
-/// Path-injectable core of [`is_overlay_copyin`], so the marker→bool mapping
-/// (including the fail-safe-on-unreadable behavior) is testable without a real
-/// `$HOME`.
-fn is_overlay_copyin_in(managed_root: &Path, worker_name: &str) -> bool {
-    match crate::cli::overlay::try_read_layout(&managed_root.join(worker_name)) {
-        Ok(layout) => layout.as_deref() == Some(crate::cli::overlay::LAYOUT_OVERLAY),
-        // Marker exists but is unreadable (EACCES/EIO/ESTALE, truncated, not a
-        // regular file, …): we can't tell what this worker is, so fail safe
-        // toward a full VM restart — the path that works for EVERY worker
-        // model. The control socket is still reachable in this case, so a fast
-        // restart would "succeed" (RPC accepted) and skip the fallback,
-        // silently reintroducing the /mnt/host-src bug this guard prevents. A
-        // genuinely MISSING marker is `Ok(None)` → treated as legacy (fast path
-        // kept), since absence is overwhelmingly a legacy worker, not overlay.
-        Err(_) => true,
-    }
-}
-
-pub fn restart_via_cli(worker_name: &str, kind: ChangeKind) {
-    // Overlay copy-in workers detach /mnt/host-src after the boot-time copy
-    // (see local_worker's dev-run.sh), so an in-VM supervisor fast restart
-    // would re-run that whole script and fail its host-src mountpoint check
-    // (`iii: ERROR /mnt/host-src ... is not a virtiofs mountpoint`) — and even
-    // on success would serve stale source, since the project is copied into a
-    // VM-local /workspace at boot, not live-mounted. Only a full VM restart
-    // re-copies. So the fast path is valid only for a source edit on a
-    // live-mount (legacy/bundle) worker.
-    let overlay = is_overlay_copyin(worker_name);
-    if fast_restart_eligible(kind, overlay) {
+pub fn restart_via_cli(worker_name: &str, kind: ChangeKind, overlay_copyin: bool) {
+    // `overlay_copyin` is handed down from `iii worker start`, which decided
+    // the workspace model authoritatively (`overlay::overlay_active()`) at the
+    // moment it spawned this watcher. We deliberately do NOT re-derive it from
+    // the on-disk `.iii-layout` marker: that marker is written best-effort (a
+    // swallowed write failure leaves it absent), and an absent marker is
+    // ambiguous between a legacy worker and an overlay worker whose write
+    // failed — so inferring from it can fail OPEN to the unsafe fast path. The
+    // fast path is valid only for a source edit on a live-mount (legacy/bundle)
+    // worker, because overlay copy-in detaches /mnt/host-src after the
+    // boot-time copy: an in-VM fast restart re-runs dev-run.sh, fails its
+    // host-src mountpoint check (`iii: ERROR /mnt/host-src ... is not a
+    // virtiofs mountpoint`), and even on success would serve stale source.
+    // Only a full VM restart re-copies.
+    if fast_restart_eligible(kind, overlay_copyin) {
         match try_fast_restart(worker_name) {
             Ok(()) => {
                 tracing::info!(
@@ -725,41 +698,6 @@ mod tests {
         // Dep-manifest changes always force a full restart (reinstall at boot).
         assert!(!fast_restart_eligible(ChangeKind::DepManifest, false));
         assert!(!fast_restart_eligible(ChangeKind::DepManifest, true));
-    }
-
-    fn overlay_copyin_detected_from_layout_marker() {
-        let tmp = tempfile::tempdir().unwrap();
-        let managed_root = tmp.path();
-        let marker = |name: &str| managed_root.join(name).join(".iii-layout");
-        let mk = |name: &str| std::fs::create_dir_all(managed_root.join(name)).unwrap();
-
-        // Unmarked dir (legacy) and a never-started worker → not overlay (fast OK).
-        mk("legacy-worker");
-        assert!(!is_overlay_copyin_in(managed_root, "legacy-worker"));
-        assert!(!is_overlay_copyin_in(managed_root, "never-started"));
-
-        // `.iii-layout` == "overlay" → overlay copy-in (full restart).
-        mk("ov-worker");
-        std::fs::write(marker("ov-worker"), crate::cli::overlay::LAYOUT_OVERLAY).unwrap();
-        assert!(is_overlay_copyin_in(managed_root, "ov-worker"));
-
-        // Trim contract this guard depends on: a trailing newline still resolves
-        // to overlay (the marker is sometimes written with one).
-        mk("ov-worker-nl");
-        std::fs::write(marker("ov-worker-nl"), "overlay\n").unwrap();
-        assert!(is_overlay_copyin_in(managed_root, "ov-worker-nl"));
-
-        // A non-overlay marker value (e.g. a future "legacy" stamp) → fast OK.
-        mk("legacy-marked");
-        std::fs::write(marker("legacy-marked"), "legacy").unwrap();
-        assert!(!is_overlay_copyin_in(managed_root, "legacy-marked"));
-
-        // Fail-safe: an UNREADABLE marker (here a directory where the file
-        // should be, so read_to_string errors with a non-NotFound kind) must be
-        // treated as overlay, so the watcher takes the safe full VM restart
-        // rather than the fast path that reintroduces the /mnt/host-src bug.
-        std::fs::create_dir_all(marker("unreadable-worker")).unwrap();
-        assert!(is_overlay_copyin_in(managed_root, "unreadable-worker"));
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/source_watcher.rs
+++ b/crates/iii-worker/src/cli/source_watcher.rs
@@ -531,8 +531,11 @@ fn fast_restart_eligible(kind: ChangeKind, overlay_copyin: bool) -> bool {
 }
 
 /// Returns `true` if `worker_name` runs in the overlay copy-in layout, read
-/// from its on-disk `.iii-layout` marker under `~/.iii/managed`. An unknown
-/// home dir or an unmarked (legacy) worker yields `false`.
+/// from its on-disk `.iii-layout` marker under `~/.iii/managed`. An unmarked
+/// (legacy) worker yields `false`; an *unreadable* marker fails safe to `true`
+/// (see [`is_overlay_copyin_in`]). A missing home dir yields `false`: without
+/// `~/.iii` the supervisor control socket is also unreachable, so the fast
+/// path self-corrects via `try_fast_restart`'s fallback instead of sticking.
 fn is_overlay_copyin(worker_name: &str) -> bool {
     let Some(home) = dirs::home_dir() else {
         return false;
@@ -541,10 +544,21 @@ fn is_overlay_copyin(worker_name: &str) -> bool {
 }
 
 /// Path-injectable core of [`is_overlay_copyin`], so the marker→bool mapping
-/// is testable without a real `$HOME`.
+/// (including the fail-safe-on-unreadable behavior) is testable without a real
+/// `$HOME`.
 fn is_overlay_copyin_in(managed_root: &Path, worker_name: &str) -> bool {
-    crate::cli::overlay::read_layout(&managed_root.join(worker_name)).as_deref()
-        == Some(crate::cli::overlay::LAYOUT_OVERLAY)
+    match crate::cli::overlay::try_read_layout(&managed_root.join(worker_name)) {
+        Ok(layout) => layout.as_deref() == Some(crate::cli::overlay::LAYOUT_OVERLAY),
+        // Marker exists but is unreadable (EACCES/EIO/ESTALE, truncated, not a
+        // regular file, …): we can't tell what this worker is, so fail safe
+        // toward a full VM restart — the path that works for EVERY worker
+        // model. The control socket is still reachable in this case, so a fast
+        // restart would "succeed" (RPC accepted) and skip the fallback,
+        // silently reintroducing the /mnt/host-src bug this guard prevents. A
+        // genuinely MISSING marker is `Ok(None)` → treated as legacy (fast path
+        // kept), since absence is overwhelmingly a legacy worker, not overlay.
+        Err(_) => true,
+    }
 }
 
 pub fn restart_via_cli(worker_name: &str, kind: ChangeKind) {
@@ -713,25 +727,39 @@ mod tests {
         assert!(!fast_restart_eligible(ChangeKind::DepManifest, true));
     }
 
-    #[test]
     fn overlay_copyin_detected_from_layout_marker() {
-        let managed_root =
-            std::env::temp_dir().join(format!("iii-watcher-overlay-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&managed_root);
-        std::fs::create_dir_all(&managed_root).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let managed_root = tmp.path();
+        let marker = |name: &str| managed_root.join(name).join(".iii-layout");
+        let mk = |name: &str| std::fs::create_dir_all(managed_root.join(name)).unwrap();
 
-        // Unmarked dir (legacy) and a never-started worker → not overlay.
-        std::fs::create_dir_all(managed_root.join("legacy-worker")).unwrap();
-        assert!(!is_overlay_copyin_in(&managed_root, "legacy-worker"));
-        assert!(!is_overlay_copyin_in(&managed_root, "never-started"));
+        // Unmarked dir (legacy) and a never-started worker → not overlay (fast OK).
+        mk("legacy-worker");
+        assert!(!is_overlay_copyin_in(managed_root, "legacy-worker"));
+        assert!(!is_overlay_copyin_in(managed_root, "never-started"));
 
-        // `.iii-layout` == "overlay" → overlay copy-in.
-        let ov = managed_root.join("ov-worker");
-        std::fs::create_dir_all(&ov).unwrap();
-        std::fs::write(ov.join(".iii-layout"), crate::cli::overlay::LAYOUT_OVERLAY).unwrap();
-        assert!(is_overlay_copyin_in(&managed_root, "ov-worker"));
+        // `.iii-layout` == "overlay" → overlay copy-in (full restart).
+        mk("ov-worker");
+        std::fs::write(marker("ov-worker"), crate::cli::overlay::LAYOUT_OVERLAY).unwrap();
+        assert!(is_overlay_copyin_in(managed_root, "ov-worker"));
 
-        let _ = std::fs::remove_dir_all(&managed_root);
+        // Trim contract this guard depends on: a trailing newline still resolves
+        // to overlay (the marker is sometimes written with one).
+        mk("ov-worker-nl");
+        std::fs::write(marker("ov-worker-nl"), "overlay\n").unwrap();
+        assert!(is_overlay_copyin_in(managed_root, "ov-worker-nl"));
+
+        // A non-overlay marker value (e.g. a future "legacy" stamp) → fast OK.
+        mk("legacy-marked");
+        std::fs::write(marker("legacy-marked"), "legacy").unwrap();
+        assert!(!is_overlay_copyin_in(managed_root, "legacy-marked"));
+
+        // Fail-safe: an UNREADABLE marker (here a directory where the file
+        // should be, so read_to_string errors with a non-NotFound kind) must be
+        // treated as overlay, so the watcher takes the safe full VM restart
+        // rather than the fast path that reintroduces the /mnt/host-src bug.
+        std::fs::create_dir_all(marker("unreadable-worker")).unwrap();
+        assert!(is_overlay_copyin_in(managed_root, "unreadable-worker"));
     }
 
     #[test]

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -582,10 +582,16 @@ async fn async_main() -> anyhow::Result<()> {
         Commands::WatchSource(args) => {
             let project = std::path::PathBuf::from(&args.project);
             let worker = args.worker.clone();
+            // Authoritative workspace model from `iii worker start` (see
+            // WatchSourceArgs::overlay). Passed into the dispatcher so it never
+            // re-derives overlay-ness from the on-disk marker.
+            let overlay = args.overlay;
             let watch = iii_worker::cli::source_watcher::watch_and_restart(
                 worker,
                 project,
-                iii_worker::cli::source_watcher::restart_via_cli,
+                move |name: &str, kind| {
+                    iii_worker::cli::source_watcher::restart_via_cli(name, kind, overlay)
+                },
             );
             // Engine anchor: the watcher sidecar must not outlive the engine
             // that (transitively) spawned it — `killall -9 iii` previously

--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -10,7 +10,7 @@ type: "reference"
 
   Editing and saving a file in a local-path worker on the overlay copy-in path could fail on the **first** save with `iii: ERROR /mnt/host-src … is not a virtiofs mountpoint`, then work on the next save. The host source watcher tried an in-VM **fast restart** first — but that re-runs the boot script, and in copy-in mode the script **detaches** `/mnt/host-src` once it has copied your project into the VM. The re-run hit the now-absent share and aborted; the watcher then fell back to a full VM restart, which is why the second save worked.
 
-  The fast in-VM restart is now skipped for overlay copy-in workers — they always take a full VM restart, the only path that re-copies your edited source. (Even when it didn't error, a fast restart would have run **stale** source, since the project is copied at boot rather than live-mounted.) Live-mount workers — legacy and bundle — keep the fast restart. Net: one save, one clean restart, running your latest changes.
+  The fast in-VM restart is now skipped for overlay copy-in workers, so they take a full VM restart — the only path that re-copies your edited source. (Even when it didn't error, a fast restart would have run **stale** source, since the project is copied at boot rather than live-mounted.) Legacy live-mount workers keep the fast restart; bundle workers don't auto-restart on source edits at all. Net: one save, one clean restart, running your latest changes.
 </Update>
 
 <Update label="0.19.6" description="June 2026">

--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -5,6 +5,14 @@ owner: "devrel"
 type: "reference"
 ---
 
+<Update label="0.19.7" description="June 2026">
+  ## Saving a file in a local overlay worker restarts cleanly the first time
+
+  Editing and saving a file in a local-path worker on the overlay copy-in path could fail on the **first** save with `iii: ERROR /mnt/host-src … is not a virtiofs mountpoint`, then work on the next save. The host source watcher tried an in-VM **fast restart** first — but that re-runs the boot script, and in copy-in mode the script **detaches** `/mnt/host-src` once it has copied your project into the VM. The re-run hit the now-absent share and aborted; the watcher then fell back to a full VM restart, which is why the second save worked.
+
+  The fast in-VM restart is now skipped for overlay copy-in workers — they always take a full VM restart, the only path that re-copies your edited source. (Even when it didn't error, a fast restart would have run **stale** source, since the project is copied at boot rather than live-mounted.) Live-mount workers — legacy and bundle — keep the fast restart. Net: one save, one clean restart, running your latest changes.
+</Update>
+
 <Update label="0.19.6" description="June 2026">
   ## Overlay workers boot on every architecture
 


### PR DESCRIPTION
## Symptom

Editing and saving a file in a local-path worker on the **overlay copy-in** path fails on the **first** save with:

```
iii: ERROR /mnt/host-src (host source share) is not a virtiofs mountpoint (share missing or mount failed)
```

…then works on the next save.

## Root cause

The host source watcher (`source_watcher.rs::restart_via_cli`) tries an **in-VM fast restart** first for source edits. The in-VM supervisor (`iii-init` → `iii-supervisor`) re-runs the entire worker command, which is `exec bash /opt/iii/dev-run.sh`.

In overlay copy-in mode that script (`local_worker.rs`) does: check `/mnt/host-src` is a virtio-fs mount → `tar`-copy it into a VM-local `/workspace` → **`umount /mnt/host-src`** ("host project untouched"). So on the in-VM re-run the share is already detached, the mountpoint check fails, and the worker exits 1. The watcher then falls back to a full VM restart, which re-mounts host-src fresh — hence "second save works".

Tell-tale in the logs: there is **no** `iii-init: ERROR mount virtiofs ... failed after 2000ms` line. The share wasn't a *failed* mount, it was a *detached* one — `iii-init` never re-ran, only `dev-run.sh` did.

Secondary latent bug: even when it didn't error, a fast in-VM restart in copy-in mode runs **stale** source — host-src is detached, so the edit is never re-copied. Only a full VM restart re-copies.

## Fix

`restart_via_cli` now skips the in-VM fast restart for overlay copy-in workers (detected via the per-worker `.iii-layout` marker, `overlay::read_layout() == "overlay"`) and always does a full VM restart. Legacy and bundle live-mount workers keep the fast restart, where it's both correct and faster.

New helpers: `fast_restart_eligible(kind, overlay)` (pure predicate, regression-locked) and `is_overlay_copyin()` / `is_overlay_copyin_in()` (path-injectable for tests).

Tradeoff: overlay-mode saves now always do a full VM reboot (a few seconds) instead of a fast in-place restart. Not a regression — the fast path was both erroring and serving stale source in this mode.

## Testing

- `cargo test -p iii-worker --lib source_watcher` → 41 passed, including two new tests:
  - `fast_path_eligible_only_for_live_mount_source_edits` — locks all four `ChangeKind × overlay` combinations (fast path only for Source on a live-mount worker).
  - `overlay_copyin_detected_from_layout_marker` — hermetic check of the `.iii-layout` → bool mapping.
- `cargo fmt -p iii-worker -- --check` → clean.
- `cargo clippy -p iii-worker --lib` → no new warnings in the changed file.
- Changelog entry added under `0.19.7`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed first-save failures in overlay copy-in workers by ensuring source changes trigger full VM restarts instead of fast restarts.

* **Documentation**
  * Updated changelog documenting overlay copy-in worker restart behavior improvements.

* **Tests**
  * Added regression tests for restart eligibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->