### PR TITLE
fix(release): add bump=none to iterate pre-release trains

### DIFF
--- a/.github/scripts/calculate_release_version.py
+++ b/.github/scripts/calculate_release_version.py
@@ -105,6 +105,37 @@ def next_dry_run_counter(base: str, existing_tags: list[str], tag_prefix: str) -
     return max(nums) + 1 if nums else 1
 
 
+def highest_inflight_prerelease_base(
+    existing_tags: list[str],
+    tag_prefix: str,
+    latest_stable: str | None,
+) -> str | None:
+    """Highest prerelease base, under ``tag_prefix``, strictly above the latest stable.
+
+    Drives the ``bump="none"`` path: it lets a release iterate an in-flight
+    prerelease train (e.g. ``0.19.5-next.1`` -> ``0.19.5-next.2``) without
+    advancing the base. Any prerelease channel counts toward the base
+    detection, so ``next`` and ``rc`` of the same upcoming release share it.
+
+    Returns ``None`` when no prerelease tag sits above ``latest_stable`` — the
+    alpha-from-stable case, where every prerelease anchors on the current
+    stable — so callers fall back to anchoring on the stable release itself.
+    """
+    pattern = re.compile(rf"^{re.escape(tag_prefix)}/v(\d+\.\d+\.\d+)-[a-z]+\.\d+$")
+    floor = parse_version(latest_stable) if latest_stable else None
+    best: Version | None = None
+    for t in existing_tags:
+        if not (m := pattern.match(t)):
+            continue
+        base = parse_version(m.group(1))
+        key = (base.major, base.minor, base.patch)
+        if floor is not None and key <= (floor.major, floor.minor, floor.patch):
+            continue
+        if best is None or key > (best.major, best.minor, best.patch):
+            best = base
+    return best.base if best else None
+
+
 def calculate_version(
     current: str,
     bump_type: str,
@@ -116,6 +147,10 @@ def calculate_version(
     """Decide the next version, accounting for the current prerelease train.
 
     Rules:
+      - `none` never advances the base: it iterates the prerelease
+        counter on the in-flight train (the highest prerelease base above
+        the latest stable), or on the latest stable when no such train
+        exists (alpha-from-stable). Requires a prerelease label.
       - Promoting a prerelease to stable (prerelease == "none" and current
         has a prerelease label) keeps the base as-is.
       - `patch` always increments the patch component of the current
@@ -131,15 +166,21 @@ def calculate_version(
     cur = parse_version(current)
 
     if bump_type == "none":
-        # Alpha-from-stable mode: keep the base anchored on the latest
-        # stable release (fall back to the current base if none exists)
-        # and only iterate the prerelease counter. Never bumps the base,
-        # so the official version is never advanced.
+        # Iterate-only mode: never advances the base, only the prerelease
+        # counter. Two scenarios resolve to the same operation:
+        #   - Continue an in-flight train (create-tag): if a prerelease tag
+        #     sits above the latest stable, anchor on its base so repeated
+        #     `none` releases iterate 0.19.5-next.1 -> .2 -> .3 instead of
+        #     re-bumping the base. To START a train, use patch/minor/major.
+        #   - Alpha-from-stable: when no prerelease train exists above the
+        #     latest stable, anchor on the stable release (fall back to the
+        #     current base when there is no stable yet).
         if prerelease not in PRERELEASE_LABELS:
             raise ValueError(
                 f"bump_type 'none' requires a prerelease label, got {prerelease!r}"
             )
-        new_base = latest_stable if latest_stable else cur.base
+        inflight = highest_inflight_prerelease_base(existing_tags, tag_prefix, latest_stable)
+        new_base = inflight or latest_stable or cur.base
         counter = next_prerelease_counter(new_base, prerelease, existing_tags, tag_prefix)
         return f"{new_base}-{prerelease}.{counter}"
 

--- a/.github/scripts/test_calculate_release_version.py
+++ b/.github/scripts/test_calculate_release_version.py
@@ -10,6 +10,7 @@ from calculate_release_version import (
     bump_base,
     calculate_version,
     detect_current_level,
+    highest_inflight_prerelease_base,
     latest_stable_from_tags,
     next_dry_run_counter,
     next_prerelease_counter,
@@ -126,6 +127,38 @@ class TestDryRunCounter:
     def test_existing(self):
         tags = ["iii/v0.12.0-dry-run.1", "iii/v0.12.0-dry-run.4"]
         assert next_dry_run_counter("0.12.0", tags, "iii") == 5
+
+
+# ---------- highest_inflight_prerelease_base ----------
+
+
+class TestHighestInflightPrereleaseBase:
+    def test_none_when_empty(self):
+        assert highest_inflight_prerelease_base([], "iii", "0.19.4") is None
+
+    def test_picks_base_above_stable(self):
+        tags = ["iii/v0.19.4", "iii/v0.19.5-next.1"]
+        assert highest_inflight_prerelease_base(tags, "iii", "0.19.4") == "0.19.5"
+
+    def test_ignores_base_at_or_below_stable(self):
+        tags = ["iii/v0.19.4-alpha.1", "iii/v0.19.3-next.9"]
+        assert highest_inflight_prerelease_base(tags, "iii", "0.19.4") is None
+
+    def test_picks_highest_across_trains(self):
+        tags = ["iii/v0.19.5-next.1", "iii/v0.20.0-rc.1"]
+        assert highest_inflight_prerelease_base(tags, "iii", "0.19.4") == "0.20.0"
+
+    def test_prefix_scoped(self):
+        tags = ["other/v0.30.0-next.1", "iii/v0.19.5-next.1"]
+        assert highest_inflight_prerelease_base(tags, "iii", "0.19.4") == "0.19.5"
+
+    def test_no_stable_floor_accepts_any_prerelease(self):
+        tags = ["iii/v0.5.0-next.1"]
+        assert highest_inflight_prerelease_base(tags, "iii", None) == "0.5.0"
+
+    def test_numeric_not_lexical_base_compare(self):
+        tags = ["iii/v0.19.5-next.1", "iii/v0.19.10-next.1"]
+        assert highest_inflight_prerelease_base(tags, "iii", "0.19.4") == "0.19.10"
 
 
 # ---------- latest_stable_from_tags ----------
@@ -922,3 +955,89 @@ class TestCalculateVersionBumpNone:
                 existing_tags=[],
                 tag_prefix="iii-alpha",
             )
+
+    # -- create-tag: none continues an in-flight train (the fix) --
+
+    def test_none_iterates_inflight_next_train(self):
+        # 0.19.5-next.1 already exists above stable 0.19.4 → none iterates it
+        # instead of re-bumping to 0.19.6 (the original release bug).
+        v = calculate_version(
+            current="0.19.5-next.1",
+            bump_type="none",
+            prerelease="next",
+            latest_stable="0.19.4",
+            existing_tags=["iii/v0.19.4", "iii/v0.19.5-next.1"],
+            tag_prefix="iii",
+        )
+        assert v == "0.19.5-next.2"
+
+    def test_none_picks_highest_inflight_base(self):
+        v = calculate_version(
+            current="0.20.0-next.1",
+            bump_type="none",
+            prerelease="next",
+            latest_stable="0.19.4",
+            existing_tags=[
+                "iii/v0.19.4",
+                "iii/v0.19.5-next.1",
+                "iii/v0.20.0-next.1",
+            ],
+            tag_prefix="iii",
+        )
+        assert v == "0.20.0-next.2"
+
+    def test_none_shares_base_across_channels(self):
+        # A next train set the base; switching to rc via none keeps the base.
+        v = calculate_version(
+            current="0.19.5-next.2",
+            bump_type="none",
+            prerelease="rc",
+            latest_stable="0.19.4",
+            existing_tags=["iii/v0.19.4", "iii/v0.19.5-next.1", "iii/v0.19.5-next.2"],
+            tag_prefix="iii",
+        )
+        assert v == "0.19.5-rc.1"
+
+    def test_none_ignores_train_at_or_below_stable(self):
+        # alpha case: every prerelease sits at the current stable, so none
+        # anchors on the stable rather than treating it as in-flight.
+        v = calculate_version(
+            current="0.19.4-alpha.2",
+            bump_type="none",
+            prerelease="alpha",
+            latest_stable="0.19.4",
+            existing_tags=[
+                "iii-alpha/v0.19.4-alpha.1",
+                "iii-alpha/v0.19.4-alpha.2",
+            ],
+            tag_prefix="iii-alpha",
+        )
+        assert v == "0.19.4-alpha.3"
+
+    def test_none_inflight_scan_is_prefix_scoped(self):
+        # An in-flight iii/ next train must not leak into an iii-alpha run.
+        v = calculate_version(
+            current="0.19.5-next.1",
+            bump_type="none",
+            prerelease="alpha",
+            latest_stable="0.19.4",
+            existing_tags=["iii/v0.19.4", "iii/v0.19.5-next.1"],
+            tag_prefix="iii-alpha",
+        )
+        assert v == "0.19.4-alpha.1"
+
+    def test_full_release_sequence_with_none_iteration(self):
+        """The exact flow the user wants: patch starts the train, none iterates,
+        promotion lands the intended patch (0.19.5, not 0.19.6)."""
+        tags = ["iii/v0.19.4"]
+        stable = "0.19.4"
+
+        def step(current, bump, pre):
+            result = calculate_version(current, bump, pre, stable, tags, "iii")
+            tags.append(f"iii/v{result}")
+            return result
+
+        assert step("0.19.4", "patch", "next") == "0.19.5-next.1"  # start train
+        assert step("0.19.5-next.1", "none", "next") == "0.19.5-next.2"  # iterate
+        assert step("0.19.5-next.2", "none", "next") == "0.19.5-next.3"  # iterate
+        assert step("0.19.5-next.3", "patch", "none") == "0.19.5"  # promote

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -10,13 +10,14 @@ on:
         options:
           - iii
       bump:
-        description: 'Version bump type'
+        description: 'Version bump type (none = iterate current pre-release train; requires a pre-release label)'
         required: true
         type: choice
         options:
           - patch
           - minor
           - major
+          - none
         default: patch
       prerelease:
         description: 'Pre-release label (none = stable release)'
@@ -62,10 +63,20 @@ jobs:
       - name: Pre-flight checks
         env:
           TARGET: ${{ inputs.target }}
+          BUMP: ${{ inputs.bump }}
+          PRERELEASE: ${{ inputs.prerelease }}
         run: |
           BRANCH=$(git rev-parse --abbrev-ref HEAD)
           if [[ "$BRANCH" != "main" ]]; then
             echo "::error::Must be on main branch (currently on $BRANCH)"
+            exit 1
+          fi
+
+          # bump=none only iterates an existing pre-release train, so it
+          # requires a pre-release label. Use patch/minor/major to START a
+          # train (they pick the base); none cannot infer one.
+          if [[ "$BUMP" == "none" && "$PRERELEASE" == "none" ]]; then
+            echo "::error::bump 'none' requires a pre-release label (alpha/beta/rc/next). Use patch/minor/major for a stable release."
             exit 1
           fi
 


### PR DESCRIPTION
## Problem

A stable release landed `0.19.6` when it should have been `0.19.5`.

Sequence that broke:
- stable `0.19.4`
- `next` → `0.19.5-next.1`
- `next` again → `0.19.6-next.1` (should be `0.19.5-next.2`)
- stable → promotes → `0.19.6` (should be `0.19.5`)

### Root cause

Two compounding factors:

1. `bump_manifests.py` writes the **pre-release** version (`0.19.5-next.1`) into `engine/Cargo.toml`, which is the calculator's source for "current".
2. The `patch` path in `calculate_release_version.py` always does `bump_base(cur.base, "patch")` — it cannot iterate an existing train (`calculate_version` only iterates for `minor`/`major`). So a second `patch + next` on top of `0.19.5-next.1` computes `bump_base("0.19.5")` = `0.19.6`.

Single `next` per patch worked (that's why earlier patch releases were fine); the bug only surfaces with **multiple** `next` pre-releases on the same patch release.

## Fix

Add a `none` bump that **iterates** an in-flight pre-release train without advancing the base:

- `patch`/`minor`/`major` **start** a train (they pick the base).
- `none` **iterates** it (`0.19.5-next.1` → `.2` → `.3`), then promote → `0.19.5`.

`none` anchors on the highest pre-release base above the latest stable; when none exists it falls back to the latest stable, **preserving `alpha-release.yml` semantics** (which relies on `--bump none` anchoring on the current stable, in its own `iii-alpha/` namespace).

## Changes

- `calculate_release_version.py`: new `highest_inflight_prerelease_base()` helper + rewritten `bump="none"` path.
- `create-tag.yml`: 4th bump option `none`; pre-flight rejects `bump=none` + `prerelease=none`.
- tests: +13 (helper, in-flight iteration, prefix isolation, full release sequence). 132 passing.

## Usage

| When | bump | pre |
|---|---|---|
| 1st pre-release (sets base) | patch/minor/major | next |
| iterate pre-releases | **none** | next |
| stable | patch/minor/major | none |

## Note

Residual footgun unchanged: using `patch` (instead of `none`) to iterate still re-bumps the base. `none` is the correct iterate path. Not blocked here because changing the base mid-train is sometimes intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a special `none` release option that continues an existing prerelease line instead of always moving to a new patch version.
  * Expanded release workflow options to include `none` and added clearer guidance for how it behaves.

* **Bug Fixes**
  * Improved version selection so prerelease iterations stay on the correct version track and don’t jump ahead unexpectedly.
  * Added validation to prevent invalid `none` release combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->