### PR TITLE
Sync compose env_file fixture for generated Docker projects

### DIFF
--- a/engine/src/cli/project/mod.rs
+++ b/engine/src/cli/project/mod.rs
@@ -346,8 +346,8 @@ async fn run_generate_docker(args: GenerateDockerArgs) -> i32 {
 /// The Dockerfile template carries a literal `__III_DEVICE_ID__` placeholder
 /// that we substitute with the actual device_id before writing, so the image
 /// no longer needs an `III_HOST_USER_ID` env var at runtime. The generated
-/// `.env` only carries the RabbitMQ password (used by the commented-out
-/// rabbitmq service in docker-compose.yml).
+/// `.env` carries RabbitMQ credentials that the engine reads while expanding
+/// `${VAR}` placeholders and that the commented-out RabbitMQ service can use.
 const DEVICE_ID_PLACEHOLDER: &str = "__III_DEVICE_ID__";
 
 async fn apply_docker(

--- a/engine/tests/fixtures/templates/docker/docker-compose.yml
+++ b/engine/tests/fixtures/templates/docker/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "9464:9464"    # Prometheus metrics
     volumes:
       - ./config.yaml:/app/config.yaml:ro
+    env_file: .env
     environment:
       - RUST_LOG=info
       - III_EXECUTION_CONTEXT=docker

--- a/engine/tests/project_init_e2e.rs
+++ b/engine/tests/project_init_e2e.rs
@@ -22,6 +22,14 @@ fn fixtures() -> PathBuf {
         .join("templates")
 }
 
+fn assert_compose_reads_env_file(project_dir: &Path) {
+    let compose = std::fs::read_to_string(project_dir.join("docker-compose.yml")).unwrap();
+    assert!(
+        compose.contains("env_file: .env"),
+        "docker-compose.yml should pass the generated .env into the engine container, got:\n{compose}"
+    );
+}
+
 #[test]
 fn project_init_creates_minimum_scaffold() {
     let dir = tempdir().unwrap();
@@ -164,6 +172,7 @@ fn project_init_with_docker_flag_writes_docker_assets_with_device_id() {
     assert!(dir.path().join("Dockerfile").exists());
     assert!(dir.path().join("docker-compose.yml").exists());
     assert!(dir.path().join(".env").exists());
+    assert_compose_reads_env_file(dir.path());
 
     let ini = std::fs::read_to_string(dir.path().join(".iii").join("project.ini")).unwrap();
     let device_id_in_ini = ini
@@ -217,6 +226,7 @@ fn project_generate_docker_uses_existing_project_ini_device_id() {
         dockerfile.contains("ENV III_HOST_USER_ID=preseeded-xyz"),
         "Dockerfile should bake the existing device_id, got:\n{dockerfile}"
     );
+    assert_compose_reads_env_file(dir.path());
 
     let env = std::fs::read_to_string(dir.path().join(".env")).unwrap();
     assert!(


### PR DESCRIPTION
## Summary
- mirror the generated Docker compose template change by adding `env_file: .env` to the `iii` service fixture
- document that the generated `.env` is read by the engine while expanding `${VAR}` placeholders
- add project init/generate-docker e2e assertions that generated compose files include `env_file: .env`

## Runtime template
- Companion runtime template PR: https://github.com/iii-hq/templates/pull/30
- This PR keeps iii tests and fixture coverage in sync with the canonical template source.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p iii --test project_init_e2e docker`
- `cargo clippy -p iii --test project_init_e2e -- --cap-lints warn`
- `git diff --check`
- YAML parse and structural check that `services.iii.env_file == ".env"` for both the fixture and templates PR checkout

## Notes
- `cargo clippy -p iii --test project_init_e2e -- -D warnings` currently fails on existing unrelated lints in `crates/iii-shell-client/src/lib.rs` (`== None` comparisons), so the scoped clippy validation was rerun with `--cap-lints warn`.

Refs #1884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated Docker Compose setups now load variables from `.env` for the engine container, improving support for environment-based configuration.
  * Clarified Docker template guidance so the generated `.env` behavior is described more accurately.

* **Tests**
  * Added coverage to verify generated Docker Compose files include `.env` loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->