### PR TITLE
fix(website): restore clean /privacy-policy footer link

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -5971,7 +5971,7 @@ iii.register_function(
     </div>
 
     <div class="foot-bottom">
-      <span>© Motia LLC · <a href="/privacy-policy.html">privacy</a></span>
+      <span>© Motia LLC · <a href="/privacy-policy">privacy</a></span>
       <span>pronounced <span class="pron">"three eye"</span></span>
     </div>
   </section>


### PR DESCRIPTION
## What

Reverts the footer "privacy" link from `/privacy-policy.html` back to the clean `/privacy-policy`.

## Why

The `.html` link was a temporary workaround (#1887) for the era when pretty URLs required a manual `terraform apply` to publish. That's resolved: #1902 (MOT-3669) moved the pretty-URL → `.html` route map into a CloudFront KeyValueStore that the deploy pipeline syncs automatically.

The rollout is now live in prod — `https://iii.dev/privacy-policy` returns `200` — so the workaround is no longer needed and the footer can point at the clean URL again.

## Verification

```
GET https://iii.dev/privacy-policy           -> 200
GET https://iii.dev/manifesto                -> 200
GET https://iii.dev/<unknown-extensionless>  -> 404
```

Closes the last item on MOT-3669.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the footer’s privacy policy link to open the correct page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->