### PR TITLE
fix(infra): default manage_apex/www_records to true (prevent DNS destroy on apply)

### DIFF
--- a/infra/terraform/website/variables.tf
+++ b/infra/terraform/website/variables.tf
@@ -65,20 +65,21 @@ variable "csp_report_only" {
 }
 
 variable "manage_apex_records" {
-  # Leave false until Phase 4 cutover. When false, the apex records are not managed
-  # by this module (they already exist — manually created in Route53, not
-  # External-DNS-owned). Flip to true after importing the existing records.
+  # Cutover is done: the iii.dev apex A/AAAA records have been imported and are now
+  # managed by this module (they exist in state at index [0]). Kept as a variable
+  # so it can be flipped off for a teardown, but it must stay true in prod —
+  # setting it false marks the live apex records for destruction.
   description = "Whether Terraform manages the iii.dev apex A/AAAA Route53 records."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "manage_www_records" {
-  # Leave false until www.iii.dev has been released by External-DNS (argocd PR
-  # removing the iii-dev-www Ingress has merged + synced). Flip to true after
-  # importing the existing records. Decoupled from apex so the two can be
-  # cut over independently to limit blast radius.
+  # Cutover is done: the www.iii.dev A/AAAA records have been imported and are now
+  # managed by this module (they exist in state at index [0]). Decoupled from apex
+  # so the two can be torn down independently, but it must stay true in prod —
+  # setting it false marks the live www records for destruction.
   description = "Whether Terraform manages the www.iii.dev A/AAAA Route53 records."
   type        = bool
-  default     = false
+  default     = true
 }


### PR DESCRIPTION
## Problem

The `iii.dev` and `www.iii.dev` apex/www A + AAAA records are imported and managed by the `infra/terraform/website` module — they exist in state at index `[0]`:

```
aws_route53_record.apex_a[0]
aws_route53_record.apex_aaaa[0]
aws_route53_record.www_a[0]
aws_route53_record.www_aaaa[0]
```

But `manage_apex_records` and `manage_www_records` still **defaulted to `false`**, which sets `count = 0`. So an untargeted `terraform apply` planned to **destroy the live apex + www DNS records** (`count 1 -> 0`) — i.e. take iii.dev offline. The "leave false until cutover, flip to true after importing" comments were stale; the cutover already happened.

## Fix

Default both variables to `true` so the committed config matches the applied state, and refresh the comments to reflect post-cutover reality.

## Verification (prod state, read-only)

`terraform plan` with the **new defaults** (no `-var` overrides):

```
# aws_sns_topic_subscription.email will be created
Plan: 1 to add, 0 to change, 0 to destroy.
```

The 4 DNS records are no longer marked for destruction. `terraform fmt` clean, `terraform validate` success.

Note: the remaining `aws_sns_topic_subscription.email` is unrelated, pre-existing, non-destructive drift (alarm email subscription) — out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled default DNS record management for the `iii.dev` apex and `www.iii.dev` subdomain.
  * These A/AAAA records are now managed automatically by this configuration unless the feature is explicitly disabled, improving consistency and reducing manual setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->