### PR TITLE
fix(configuration): numeric fields can be used with env variables

### DIFF
--- a/engine/config.yaml
+++ b/engine/config.yaml
@@ -154,7 +154,7 @@ workers:
       adapter:
         name: fs
         config:
-          directory: ./iii-config
+          directory: ./config
       # 0 disables TTL cleanup. Set >0 (in seconds) to delete a configuration
       # entry whose last subscriber trigger has been unregistered for that long.
       ttl_seconds: 0

--- a/engine/config.yaml
+++ b/engine/config.yaml
@@ -154,7 +154,7 @@ workers:
       adapter:
         name: fs
         config:
-          directory: ./data/configuration
+          directory: ./iii-config
       # 0 disables TTL cleanup. Set >0 (in seconds) to delete a configuration
       # entry whose last subscriber trigger has been unregistered for that long.
       ttl_seconds: 0

--- a/engine/src/logging.rs
+++ b/engine/src/logging.rs
@@ -796,7 +796,7 @@ mod tests {
     fn boot_read_path_constants_align_with_fs_adapter() {
         use crate::workers::configuration::adapters::fs;
         assert_eq!(fs::ADAPTER_NAME, "fs");
-        assert_eq!(fs::DEFAULT_DIRECTORY, "./iii-config");
+        assert_eq!(fs::DEFAULT_DIRECTORY, "./config");
         assert_eq!(fs::FILE_EXTENSION, "yaml");
         assert_eq!(
             format!(

--- a/engine/src/logging.rs
+++ b/engine/src/logging.rs
@@ -537,22 +537,21 @@ fn read_persisted_observability_value(cfg: &EngineConfig) -> Option<serde_json::
     };
     let value = entry.get("value").cloned().filter(|v| !v.is_null())?;
 
-    // `expand_value` panics on a `${VAR}` placeholder with no default and no
-    // env value. At runtime that fails one bus call; here it would brick
-    // every engine start until the data file is hand-edited — so contain it
-    // and fall back to the yaml block.
-    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        crate::workers::configuration::store::expand_value(&value)
-    })) {
-        Ok(expanded) => Some(expanded),
-        Err(_) => {
-            eprintln!(
-                "persisted configuration entry {} references an environment variable with no value and no default; using the config.yaml block",
-                path.display()
-            );
-            None
-        }
+    // Expand `${VAR:default}` (with scalar type-coercion) the same way
+    // `configuration::get` does. A `${VAR}` with no env value and no default
+    // can't be resolved at boot: log an ERROR and fall back to the config.yaml
+    // block rather than load a value still carrying literal `${VAR}` text.
+    // `expand_value` never panics, so no `catch_unwind` guard is needed.
+    let (expanded, missing) = crate::workers::configuration::store::expand_value(&value);
+    if !missing.is_empty() {
+        eprintln!(
+            "persisted configuration entry {} references environment variable(s) with no value and no default ({}); it will not be loaded — using the config.yaml block",
+            path.display(),
+            missing.join(", ")
+        );
+        return None;
     }
+    Some(expanded)
 }
 
 pub fn init_log_from_engine_config(cfg: &EngineConfig) {
@@ -797,7 +796,7 @@ mod tests {
     fn boot_read_path_constants_align_with_fs_adapter() {
         use crate::workers::configuration::adapters::fs;
         assert_eq!(fs::ADAPTER_NAME, "fs");
-        assert_eq!(fs::DEFAULT_DIRECTORY, "./data/configuration");
+        assert_eq!(fs::DEFAULT_DIRECTORY, "./iii-config");
         assert_eq!(fs::FILE_EXTENSION, "yaml");
         assert_eq!(
             format!(
@@ -1362,6 +1361,43 @@ mod tests {
 
         let resolved = resolve_boot_observability_config(&cfg).expect("entry present");
         assert_eq!(resolved.service_name.as_deref(), Some("fallback-name"));
+    }
+
+    #[test]
+    fn boot_merge_coerces_typed_placeholder() {
+        // #1916: a templated numeric field must coerce to an integer so the
+        // typed config deserializes, instead of arriving as a string and
+        // dropping the persisted value back to the yaml block.
+        unsafe {
+            std::env::remove_var("III_BOOT_LOGS_MAX");
+        }
+        let dir = tempfile::tempdir().unwrap();
+        write_persisted_entry(
+            dir.path(),
+            serde_json::json!({ "logs_max_count": "${III_BOOT_LOGS_MAX:4096}" }),
+        );
+        let cfg = boot_cfg_with_dir(dir.path(), serde_json::json!({ "logs_max_count": 1 }));
+
+        let resolved = resolve_boot_observability_config(&cfg).expect("entry present");
+        assert_eq!(resolved.logs_max_count, Some(4096));
+    }
+
+    #[test]
+    fn boot_merge_falls_back_when_required_var_missing_no_panic() {
+        // `${VAR}` with no default and no env value can't be resolved at boot:
+        // fall back to the yaml block without panicking (catch_unwind removed).
+        unsafe {
+            std::env::remove_var("III_BOOT_LOGS_MAX_MISSING");
+        }
+        let dir = tempfile::tempdir().unwrap();
+        write_persisted_entry(
+            dir.path(),
+            serde_json::json!({ "logs_max_count": "${III_BOOT_LOGS_MAX_MISSING}" }),
+        );
+        let cfg = boot_cfg_with_dir(dir.path(), serde_json::json!({ "logs_max_count": 123 }));
+
+        let resolved = resolve_boot_observability_config(&cfg).expect("entry present");
+        assert_eq!(resolved.logs_max_count, Some(123));
     }
 
     #[test]

--- a/engine/src/workers/config_rewrite.rs
+++ b/engine/src/workers/config_rewrite.rs
@@ -15,7 +15,7 @@
 //! and insert one comment, so everything else in the file is byte-preserved.
 
 /// Comment left in place of a stripped `config:` block. `location` names where
-/// the value now lives (e.g. `./data/configuration/<id>.yaml` for the fs
+/// the value now lives (e.g. `./iii-config/<id>.yaml` for the fs
 /// adapter).
 fn seed_comment(config_id: &str, location: &str) -> String {
     format!(

--- a/engine/src/workers/config_rewrite.rs
+++ b/engine/src/workers/config_rewrite.rs
@@ -15,7 +15,7 @@
 //! and insert one comment, so everything else in the file is byte-preserved.
 
 /// Comment left in place of a stripped `config:` block. `location` names where
-/// the value now lives (e.g. `./iii-config/<id>.yaml` for the fs
+/// the value now lives (e.g. `./config/<id>.yaml` for the fs
 /// adapter).
 fn seed_comment(config_id: &str, location: &str) -> String {
     format!(

--- a/engine/src/workers/configuration/README.md
+++ b/engine/src/workers/configuration/README.md
@@ -28,7 +28,7 @@ npx skills add iii-hq/iii --full-depth --skill configuration
     adapter:
       name: fs
       config:
-        directory: ./iii-config
+        directory: ./config
     ttl_seconds: 0
 ```
 
@@ -48,14 +48,14 @@ File-system adapter that stores one YAML file per configuration id and watches t
 ```yaml
 name: fs
 config:
-  directory: ./iii-config
+  directory: ./config
 ```
 
 | Field | Type | Description |
 |---|---|---|
-| `directory` | string | Directory holding `<id>.yaml` files. Created on boot. Defaults to `./iii-config`. |
+| `directory` | string | Directory holding `<id>.yaml` files. Created on boot. Defaults to `./config`. |
 
-The default location was previously `./data/configuration`. When running on the default `./iii-config`, the adapter performs a one-time soft migration on boot: every `<id>.yaml` still in `./data/configuration` is moved across (logged at INFO). If a file with the same name already exists in `./iii-config`, that file is **skipped with a WARNING** and the legacy copy is left untouched for you to reconcile. An explicit `directory:` override disables the migration.
+The default location was previously `./data/configuration`. When running on the default `./config`, the adapter performs a one-time soft migration on boot: every `<id>.yaml` still in `./data/configuration` is moved across (logged at INFO). If a file with the same name already exists in `./config`, that file is **skipped with a WARNING** and the legacy copy is left untouched for you to reconcile. An explicit `directory:` override disables the migration.
 
 External writes / edits / removals to the watched directory are debounced (500 ms) and replayed as `configuration:registered`, `configuration:updated`, or `configuration:deleted` events through the same trigger fan-out used by SDK calls. A hand-edit that fails schema validation (after `${VAR}` expansion) is **rejected with a WARNING** — the previous good value is kept rather than loaded.
 

--- a/engine/src/workers/configuration/README.md
+++ b/engine/src/workers/configuration/README.md
@@ -28,7 +28,7 @@ npx skills add iii-hq/iii --full-depth --skill configuration
     adapter:
       name: fs
       config:
-        directory: ./data/configuration
+        directory: ./iii-config
     ttl_seconds: 0
 ```
 
@@ -48,14 +48,16 @@ File-system adapter that stores one YAML file per configuration id and watches t
 ```yaml
 name: fs
 config:
-  directory: ./data/configuration
+  directory: ./iii-config
 ```
 
 | Field | Type | Description |
 |---|---|---|
-| `directory` | string | Directory holding `<id>.yaml` files. Created on boot. Defaults to `./data/configuration`. |
+| `directory` | string | Directory holding `<id>.yaml` files. Created on boot. Defaults to `./iii-config`. |
 
-External writes / edits / removals to the watched directory are debounced (500 ms) and replayed as `configuration:registered`, `configuration:updated`, or `configuration:deleted` events through the same trigger fan-out used by SDK calls.
+The default location was previously `./data/configuration`. When running on the default `./iii-config`, the adapter performs a one-time soft migration on boot: every `<id>.yaml` still in `./data/configuration` is moved across (logged at INFO). If a file with the same name already exists in `./iii-config`, that file is **skipped with a WARNING** and the legacy copy is left untouched for you to reconcile. An explicit `directory:` override disables the migration.
+
+External writes / edits / removals to the watched directory are debounced (500 ms) and replayed as `configuration:registered`, `configuration:updated`, or `configuration:deleted` events through the same trigger fan-out used by SDK calls. A hand-edit that fails schema validation (after `${VAR}` expansion) is **rejected with a WARNING** — the previous good value is kept rather than loaded.
 
 ### bridge
 

--- a/engine/src/workers/configuration/adapters/fs.rs
+++ b/engine/src/workers/configuration/adapters/fs.rs
@@ -44,7 +44,7 @@ pub(crate) const ADAPTER_NAME: &str = "fs";
 // `DEFAULT_DIRECTORY` / `FILE_EXTENSION` are `pub(crate)` so boot-time
 // persisted-config readers (e.g. the `iii-state` boot-read) resolve the same
 // on-disk location the configuration worker persists entries under.
-pub(crate) const DEFAULT_DIRECTORY: &str = "./iii-config";
+pub(crate) const DEFAULT_DIRECTORY: &str = "./config";
 pub(crate) const FILE_EXTENSION: &str = "yaml";
 /// The previous default store location. When the resolved directory is the
 /// current default and this legacy folder still holds entries, `new` migrates
@@ -126,8 +126,7 @@ impl FsAdapter {
         let mut moved = 0usize;
         while let Ok(Some(entry)) = read_dir.next_entry().await {
             let path = entry.path();
-            if !path.is_file()
-                || path.extension().and_then(|e| e.to_str()) != Some(FILE_EXTENSION)
+            if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some(FILE_EXTENSION)
             {
                 continue;
             }
@@ -317,7 +316,7 @@ impl ConfigurationAdapter for FsAdapter {
         })
         .map_err(|e| anyhow::anyhow!("failed to create configuration watcher: {}", e))?;
         // Watch an absolute path: the macOS FSEvents backend can silently fail
-        // to deliver events for a relative path like `./iii-config`, which is
+        // to deliver events for a relative path like `./config`, which is
         // exactly the default. Canonicalize (the dir always exists by now —
         // `new` created it) and fall back to the raw path only if that fails.
         let watch_path = std::fs::canonicalize(&directory).unwrap_or_else(|_| directory.clone());

--- a/engine/src/workers/configuration/adapters/fs.rs
+++ b/engine/src/workers/configuration/adapters/fs.rs
@@ -44,8 +44,13 @@ pub(crate) const ADAPTER_NAME: &str = "fs";
 // `DEFAULT_DIRECTORY` / `FILE_EXTENSION` are `pub(crate)` so boot-time
 // persisted-config readers (e.g. the `iii-state` boot-read) resolve the same
 // on-disk location the configuration worker persists entries under.
-pub(crate) const DEFAULT_DIRECTORY: &str = "./data/configuration";
+pub(crate) const DEFAULT_DIRECTORY: &str = "./iii-config";
 pub(crate) const FILE_EXTENSION: &str = "yaml";
+/// The previous default store location. When the resolved directory is the
+/// current default and this legacy folder still holds entries, `new` migrates
+/// them across once (a soft transition) so upgrading doesn't silently start the
+/// store from empty. An explicit `directory:` override is never touched.
+const LEGACY_DEFAULT_DIRECTORY: &str = "./data/configuration";
 
 pub struct FsAdapter {
     directory: PathBuf,
@@ -73,6 +78,13 @@ impl FsAdapter {
             )
         })?;
 
+        // Soft transition: when running on the current default location, move any
+        // entries left in the legacy default folder across once. Guarded on the
+        // default dir, so an explicit `directory:` override is never disturbed.
+        if directory.as_path() == Path::new(DEFAULT_DIRECTORY) {
+            Self::migrate_legacy_default(&directory).await;
+        }
+
         let cache = Self::load_directory(&directory).await?;
         tracing::info!(
             directory = %directory.display(),
@@ -89,6 +101,70 @@ impl FsAdapter {
 
     fn entry_path(&self, id: &str) -> PathBuf {
         self.directory.join(format!("{}.{}", id, FILE_EXTENSION))
+    }
+
+    /// One-time soft migration of `*.yaml` entries from the legacy default
+    /// store location ([`LEGACY_DEFAULT_DIRECTORY`]) into `target`.
+    async fn migrate_legacy_default(target: &Path) {
+        Self::migrate_dir(Path::new(LEGACY_DEFAULT_DIRECTORY), target).await;
+    }
+
+    /// Move every `*.yaml` entry from `legacy` into `target`. Best-effort: a
+    /// file already present in `target` is left in place (WARNING, the legacy
+    /// copy is kept so the operator can reconcile); any I/O error is logged and
+    /// the file is skipped. Never fails the adapter.
+    async fn migrate_dir(legacy: &Path, target: &Path) {
+        if legacy == target {
+            return;
+        }
+        let mut read_dir = match tokio::fs::read_dir(legacy).await {
+            Ok(rd) => rd,
+            // Legacy folder absent (a fresh install) — nothing to migrate.
+            Err(_) => return,
+        };
+
+        let mut moved = 0usize;
+        while let Ok(Some(entry)) = read_dir.next_entry().await {
+            let path = entry.path();
+            if !path.is_file()
+                || path.extension().and_then(|e| e.to_str()) != Some(FILE_EXTENSION)
+            {
+                continue;
+            }
+            let Some(name) = path.file_name() else {
+                continue;
+            };
+            let dest = target.join(name);
+            if tokio::fs::try_exists(&dest).await.unwrap_or(false) {
+                tracing::warn!(
+                    file = %name.to_string_lossy(),
+                    location = %target.display(),
+                    "Skipped migrating configuration file from the legacy '{}' folder: a file with that name already exists in the new location; the legacy copy was left untouched",
+                    LEGACY_DEFAULT_DIRECTORY,
+                );
+                continue;
+            }
+            match tokio::fs::rename(&path, &dest).await {
+                Ok(()) => moved += 1,
+                Err(err) => tracing::warn!(
+                    file = %name.to_string_lossy(),
+                    error = %err,
+                    "Failed to migrate configuration file from the legacy '{}' folder; leaving it in place",
+                    LEGACY_DEFAULT_DIRECTORY,
+                ),
+            }
+        }
+
+        if moved > 0 {
+            tracing::info!(
+                from = %legacy.display(),
+                to = %target.display(),
+                count = moved,
+                "The configuration store now defaults to '{}'; migrated existing entries out of the legacy '{}' folder",
+                DEFAULT_DIRECTORY,
+                LEGACY_DEFAULT_DIRECTORY,
+            );
+        }
     }
 
     async fn load_directory(dir: &Path) -> anyhow::Result<HashMap<String, ConfigurationEntry>> {
@@ -240,16 +316,25 @@ impl ConfigurationAdapter for FsAdapter {
             }
         })
         .map_err(|e| anyhow::anyhow!("failed to create configuration watcher: {}", e))?;
+        // Watch an absolute path: the macOS FSEvents backend can silently fail
+        // to deliver events for a relative path like `./iii-config`, which is
+        // exactly the default. Canonicalize (the dir always exists by now —
+        // `new` created it) and fall back to the raw path only if that fails.
+        let watch_path = std::fs::canonicalize(&directory).unwrap_or_else(|_| directory.clone());
         watcher
-            .watch(&directory, RecursiveMode::NonRecursive)
+            .watch(&watch_path, RecursiveMode::NonRecursive)
             .map_err(|e| {
                 anyhow::anyhow!(
                     "failed to watch configuration directory '{}': {}",
-                    directory.display(),
+                    watch_path.display(),
                     e
                 )
             })?;
         *self.watcher.lock().await = Some(watcher);
+        tracing::info!(
+            directory = %watch_path.display(),
+            "Watching configuration directory for external edits (hot-reload enabled)"
+        );
 
         // Debounce loop: drains every queued raw event in a 500ms window
         // and then diffs the directory snapshot against the cache, emitting
@@ -567,6 +652,126 @@ mod tests {
             }
             other => panic!("expected Updated, got {:?}", other),
         }
+    }
+
+    #[tokio::test]
+    async fn internal_set_does_not_echo_through_watcher() {
+        // An internal `set` writes the file AND updates the adapter cache, so
+        // the watcher's diff sees disk == cache and emits nothing. This is what
+        // stops a save → reload → save loop. (An *external* edit, where the
+        // cache is stale relative to disk, still fires — see the tests above.)
+        let dir = temp_dir();
+        let adapter = FsAdapter::new(Some(json!({ "directory": dir.path().to_str().unwrap() })))
+            .await
+            .unwrap();
+        adapter.register(sample_entry("looptest")).await.unwrap();
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        adapter.watch(tx).await.unwrap();
+
+        adapter
+            .set("looptest", json!({ "port": 4242 }))
+            .await
+            .unwrap();
+
+        // Well past the 500ms debounce: the self-write must not surface as an
+        // external change.
+        let echoed = tokio::time::timeout(Duration::from_millis(1500), rx.recv()).await;
+        assert!(
+            echoed.is_err(),
+            "an internal set must not echo back through the watcher (would loop)"
+        );
+    }
+
+    #[tokio::test]
+    async fn migrate_dir_moves_yaml_entries_and_ignores_others() {
+        let legacy = temp_dir();
+        let target = temp_dir();
+        let stream = "id: iii-stream\nvalue:\n  port: 1\n";
+        tokio::fs::write(legacy.path().join("iii-stream.yaml"), stream)
+            .await
+            .unwrap();
+        tokio::fs::write(legacy.path().join("iii-http.yaml"), "id: iii-http\n")
+            .await
+            .unwrap();
+        // A non-yaml file must be left behind.
+        tokio::fs::write(legacy.path().join("notes.txt"), "ignore me")
+            .await
+            .unwrap();
+
+        FsAdapter::migrate_dir(legacy.path(), target.path()).await;
+
+        assert!(target.path().join("iii-stream.yaml").exists());
+        assert!(target.path().join("iii-http.yaml").exists());
+        assert_eq!(
+            tokio::fs::read_to_string(target.path().join("iii-stream.yaml"))
+                .await
+                .unwrap(),
+            stream,
+            "content must be preserved across the move"
+        );
+        // Moved, not copied.
+        assert!(!legacy.path().join("iii-stream.yaml").exists());
+        assert!(!legacy.path().join("iii-http.yaml").exists());
+        // Non-yaml left untouched in the legacy folder.
+        assert!(!target.path().join("notes.txt").exists());
+        assert!(legacy.path().join("notes.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn migrate_dir_skips_conflicts_and_keeps_legacy_copy() {
+        let legacy = temp_dir();
+        let target = temp_dir();
+        tokio::fs::write(
+            legacy.path().join("iii-stream.yaml"),
+            "id: iii-stream\nvalue:\n  port: 1\n",
+        )
+        .await
+        .unwrap();
+        tokio::fs::write(legacy.path().join("iii-http.yaml"), "id: iii-http\n")
+            .await
+            .unwrap();
+        // The new location already has a file with the same name (different
+        // content): the migration of THAT file must be skipped (WARNING).
+        let existing = "id: iii-stream\nvalue:\n  port: 999\n";
+        tokio::fs::write(target.path().join("iii-stream.yaml"), existing)
+            .await
+            .unwrap();
+
+        FsAdapter::migrate_dir(legacy.path(), target.path()).await;
+
+        // Conflict: target keeps its own content; legacy copy is left in place.
+        assert_eq!(
+            tokio::fs::read_to_string(target.path().join("iii-stream.yaml"))
+                .await
+                .unwrap(),
+            existing,
+            "a conflicting file must not be overwritten"
+        );
+        assert!(
+            legacy.path().join("iii-stream.yaml").exists(),
+            "the conflicting legacy copy is kept for the operator to reconcile"
+        );
+        // The non-conflicting file still migrates.
+        assert!(target.path().join("iii-http.yaml").exists());
+        assert!(!legacy.path().join("iii-http.yaml").exists());
+    }
+
+    #[tokio::test]
+    async fn migrate_dir_is_a_noop_when_legacy_absent() {
+        let target = temp_dir();
+        let legacy = target.path().join("nonexistent-legacy");
+        // Must not panic or create anything.
+        FsAdapter::migrate_dir(&legacy, target.path()).await;
+        assert!(
+            tokio::fs::read_dir(target.path())
+                .await
+                .unwrap()
+                .next_entry()
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/engine/src/workers/configuration/configuration.rs
+++ b/engine/src/workers/configuration/configuration.rs
@@ -254,8 +254,9 @@ impl ConfigurationWorker {
     /// feed the watcher and create a save→reload→save loop.
     pub(crate) async fn handle_external_change(&self, change: ExternalChange) {
         let edited = match &change {
-            ExternalChange::Registered(entry)
-            | ExternalChange::Updated { entry, .. } => Some(entry),
+            ExternalChange::Registered(entry) | ExternalChange::Updated { entry, .. } => {
+                Some(entry)
+            }
             ExternalChange::Deleted { .. } => None,
         };
         if let Some(entry) = edited
@@ -980,7 +981,10 @@ mod tests {
             .await;
         // initialize() primes the cache, registers the trigger type, and starts
         // the directory watcher — exactly as a real boot does.
-        worker.initialize().await.expect("initialize starts the watcher");
+        worker
+            .initialize()
+            .await
+            .expect("initialize starts the watcher");
 
         // Edit the file the way an operator would, in the value-only on-disk
         // format `write_entry` produces (no schema key).

--- a/engine/src/workers/configuration/configuration.rs
+++ b/engine/src/workers/configuration/configuration.rs
@@ -25,7 +25,7 @@ use crate::{
         configuration::{
             adapters::{ConfigurationAdapter, ExternalChange, RegisterKind},
             config::ConfigurationModuleConfig,
-            store::{ConfigurationStore, StoreError, expand_value},
+            store::{ConfigurationStore, StoreError, expand_value, validate_against_schema},
             structs::{
                 ConfigurationEntry, ConfigurationEventData, ConfigurationEventType,
                 ConfigurationGetInput, ConfigurationGetResult, ConfigurationListInput,
@@ -244,7 +244,42 @@ impl ConfigurationWorker {
     }
 
     /// Apply a watcher-surfaced change into the cache and broadcast.
+    ///
+    /// A hand-edit of a `<id>.yaml` file must not be able to clobber the running
+    /// config with an invalid value. For create/update edits we validate the
+    /// APPLIED (env-expanded + coerced) value against the cached schema (the
+    /// adapter's watcher carries the real schema forward — disk never holds it);
+    /// on failure we log a WARNING and drop the edit, leaving the previous good
+    /// value in the store. We never write the file back here, so this path can't
+    /// feed the watcher and create a save→reload→save loop.
     pub(crate) async fn handle_external_change(&self, change: ExternalChange) {
+        let edited = match &change {
+            ExternalChange::Registered(entry)
+            | ExternalChange::Updated { entry, .. } => Some(entry),
+            ExternalChange::Deleted { .. } => None,
+        };
+        if let Some(entry) = edited
+            && !entry.schema.is_null()
+        {
+            let (applied, missing) = expand_value(&entry.value);
+            if !missing.is_empty() {
+                tracing::warn!(
+                    id = %entry.id,
+                    vars = %missing.join(", "),
+                    "Configuration file edit references unset environment variable(s) with no default; keeping the previous value"
+                );
+                return;
+            }
+            if let Err(errs) = validate_against_schema(&applied, &entry.schema) {
+                tracing::warn!(
+                    id = %entry.id,
+                    errors = %errs.join("; "),
+                    "Configuration file edit is invalid against its schema; keeping the previous value"
+                );
+                return;
+            }
+        }
+
         self.store.apply_external(&change).await;
         let event = match change {
             ExternalChange::Registered(entry) => entry_to_event(
@@ -266,6 +301,25 @@ impl ConfigurationWorker {
                 None,
             ),
         };
+        // Make hot-reload observable: an operator who edits a file on disk
+        // should see that the engine picked it up.
+        match event.event_type {
+            ConfigurationEventType::Registered => tracing::info!(
+                id = %event.id,
+                "Loaded new configuration '{}' from a file added on disk",
+                event.id
+            ),
+            ConfigurationEventType::Updated => tracing::info!(
+                id = %event.id,
+                "Reloaded configuration '{}' from an external file edit",
+                event.id
+            ),
+            ConfigurationEventType::Deleted => tracing::info!(
+                id = %event.id,
+                "Dropped configuration '{}' whose file was removed from disk",
+                event.id
+            ),
+        }
         self.fan_out(event).await;
     }
 
@@ -305,8 +359,11 @@ fn entry_to_event(
         name: entry.name.clone(),
         description: entry.description.clone(),
         schema: entry.schema.clone(),
-        old_value: old_value.map(|v| expand_value(&v)),
-        new_value: new_value_raw.map(|v| expand_value(&v)),
+        // Best-effort fan-out: subscribers see resolved `${VAR:default}` values.
+        // Unresolved vars are surfaced on the `get` path, not here, so the
+        // `missing` list is intentionally dropped.
+        old_value: old_value.map(|v| expand_value(&v).0),
+        new_value: new_value_raw.map(|v| expand_value(&v).0),
         metadata: entry.metadata.clone(),
     }
 }
@@ -404,14 +461,54 @@ impl ConfigurationWorker {
     ) -> FunctionResult<ConfigurationGetResult, ErrorBody> {
         match self.store.get(&input.id).await {
             Some(entry) => {
-                let value = if input.raw {
-                    entry.value
-                } else {
-                    expand_value(&entry.value)
-                };
+                if input.raw {
+                    return FunctionResult::Success(ConfigurationGetResult {
+                        id: entry.id,
+                        value: entry.value,
+                    });
+                }
+
+                // Validate the APPLIED (env-expanded + type-coerced) value, not
+                // the raw template. On failure we do NOT hand back a broken
+                // value (it would deserialize-fail in the consumer and silently
+                // fall back to defaults); instead we log an ERROR naming the id
+                // and return a Failure so the consumer keeps its previous /
+                // default config. Consumers only special-case NOT_FOUND, so any
+                // other code resolves to "not loaded".
+                let (applied, missing) = expand_value(&entry.value);
+                if !missing.is_empty() {
+                    tracing::error!(
+                        id = %entry.id,
+                        vars = %missing.join(", "),
+                        "Configuration references environment variable(s) with no value and no default; it will not be loaded"
+                    );
+                    return FunctionResult::Failure(ErrorBody {
+                        message: format!(
+                            "configuration '{}' references unset environment variable(s) with no default: {}",
+                            entry.id,
+                            missing.join(", ")
+                        ),
+                        code: "EXPAND_FAILED".to_string(),
+                        stacktrace: None,
+                    });
+                }
+                if !entry.schema.is_null()
+                    && let Err(errs) = validate_against_schema(&applied, &entry.schema)
+                {
+                    tracing::error!(
+                        id = %entry.id,
+                        errors = %errs.join("; "),
+                        "Configuration is invalid after environment expansion; it will not be loaded"
+                    );
+                    return FunctionResult::Failure(ErrorBody {
+                        message: format!("schema validation failed: {}", errs.join("; ")),
+                        code: "SCHEMA_INVALID".to_string(),
+                        stacktrace: None,
+                    });
+                }
                 FunctionResult::Success(ConfigurationGetResult {
                     id: entry.id,
-                    value,
+                    value: applied,
                 })
             }
             None => FunctionResult::Failure(ErrorBody {
@@ -652,6 +749,264 @@ mod tests {
             }
             _ => panic!("expected raw get success"),
         }
+    }
+
+    // #1916: a templated integer field must register (validation runs on the
+    // APPLIED value) and `get` must coerce it to a real integer.
+    #[tokio::test]
+    async fn register_and_get_coerces_templated_integer_port() {
+        let (_engine, worker, _dir) = setup().await;
+        unsafe {
+            std::env::remove_var("CFG_GET_TPORT");
+        }
+        let result = worker
+            .register_fn(register_input(
+                "iii-stream",
+                Some(json!({ "port": "${CFG_GET_TPORT:3111}" })),
+            ))
+            .await;
+        assert!(
+            matches!(result, FunctionResult::Success(_)),
+            "a templated integer port must pass register (validated against the coerced value)"
+        );
+
+        let got = worker
+            .get_fn(ConfigurationGetInput {
+                id: "iii-stream".into(),
+                raw: false,
+            })
+            .await;
+        match got {
+            FunctionResult::Success(out) => {
+                assert_eq!(out.value["port"], json!(3111));
+                assert!(out.value["port"].is_i64(), "must be coerced to an integer");
+            }
+            _ => panic!("expected get success with a coerced integer"),
+        }
+
+        // The raw template is preserved on disk / for re-evaluation.
+        let raw = worker
+            .get_fn(ConfigurationGetInput {
+                id: "iii-stream".into(),
+                raw: true,
+            })
+            .await;
+        match raw {
+            FunctionResult::Success(out) => {
+                assert_eq!(out.value["port"], json!("${CFG_GET_TPORT:3111}"))
+            }
+            _ => panic!("expected raw get success"),
+        }
+    }
+
+    // #1916: when the applied value violates the schema, `get` must log + fail
+    // with SCHEMA_INVALID ("won't be loaded"), not hand back a broken value.
+    // Disk-loaded entries skip register validation, then the worker re-registers
+    // the schema — replicated here by injecting the entry directly.
+    #[tokio::test]
+    async fn get_fails_schema_invalid_when_applied_value_violates_schema() {
+        let (_engine, worker, _dir) = setup().await;
+        unsafe {
+            std::env::remove_var("CFG_GET_BADPORT");
+        }
+        worker
+            .store
+            .apply_external(&ExternalChange::Registered(ConfigurationEntry {
+                id: "iii-stream".into(),
+                name: "iii-stream".into(),
+                description: String::new(),
+                schema: schema_object_required_port(),
+                value: json!({ "port": "${CFG_GET_BADPORT:notaport}" }),
+                metadata: None,
+            }))
+            .await;
+
+        let got = worker
+            .get_fn(ConfigurationGetInput {
+                id: "iii-stream".into(),
+                raw: false,
+            })
+            .await;
+        match got {
+            FunctionResult::Failure(err) => assert_eq!(err.code, "SCHEMA_INVALID"),
+            _ => panic!("expected SCHEMA_INVALID failure"),
+        }
+    }
+
+    // #1916: a `${VAR}` with no env value and no default can't be evaluated at
+    // read time — `get` must fail with EXPAND_FAILED (and not panic).
+    #[tokio::test]
+    async fn get_fails_expand_failed_when_required_var_missing() {
+        let (_engine, worker, _dir) = setup().await;
+        unsafe {
+            std::env::remove_var("CFG_GET_REQUIRED");
+        }
+        worker
+            .store
+            .apply_external(&ExternalChange::Registered(ConfigurationEntry {
+                id: "iii-stream".into(),
+                name: "iii-stream".into(),
+                description: String::new(),
+                schema: schema_object_required_port(),
+                value: json!({ "port": "${CFG_GET_REQUIRED}" }),
+                metadata: None,
+            }))
+            .await;
+
+        let got = worker
+            .get_fn(ConfigurationGetInput {
+                id: "iii-stream".into(),
+                raw: false,
+            })
+            .await;
+        match got {
+            FunctionResult::Failure(err) => assert_eq!(err.code, "EXPAND_FAILED"),
+            _ => panic!("expected EXPAND_FAILED failure"),
+        }
+    }
+
+    // --- hot-reload: external file-edit validation ---
+
+    fn updated_change(value: Value, old: Value) -> ExternalChange {
+        ExternalChange::Updated {
+            entry: ConfigurationEntry {
+                id: "iii-stream".into(),
+                name: "iii-stream".into(),
+                description: String::new(),
+                schema: schema_object_required_port(),
+                value,
+                metadata: None,
+            },
+            old_value: Some(old),
+        }
+    }
+
+    #[tokio::test]
+    async fn external_change_applies_valid_edit() {
+        let (_engine, worker, _dir) = setup().await;
+        worker
+            .register_fn(register_input("iii-stream", Some(json!({ "port": 1 }))))
+            .await;
+
+        worker
+            .handle_external_change(updated_change(json!({ "port": 2 }), json!({ "port": 1 })))
+            .await;
+
+        let entry = worker.store.get("iii-stream").await.expect("entry");
+        assert_eq!(
+            entry.value,
+            json!({ "port": 2 }),
+            "a valid file edit must hot-reload into the store"
+        );
+    }
+
+    #[tokio::test]
+    async fn external_change_rejects_invalid_edit_and_keeps_previous() {
+        let (_engine, worker, _dir) = setup().await;
+        worker
+            .register_fn(register_input("iii-stream", Some(json!({ "port": 1 }))))
+            .await;
+
+        worker
+            .handle_external_change(updated_change(
+                json!({ "port": "not-an-integer" }),
+                json!({ "port": 1 }),
+            ))
+            .await;
+
+        let entry = worker.store.get("iii-stream").await.expect("entry");
+        assert_eq!(
+            entry.value,
+            json!({ "port": 1 }),
+            "an invalid file edit must be dropped (warned), keeping the previous value"
+        );
+    }
+
+    #[tokio::test]
+    async fn external_change_rejects_unresolved_env_var() {
+        let (_engine, worker, _dir) = setup().await;
+        unsafe {
+            std::env::remove_var("CFG_EXT_MISSING");
+        }
+        worker
+            .register_fn(register_input("iii-stream", Some(json!({ "port": 1 }))))
+            .await;
+
+        worker
+            .handle_external_change(updated_change(
+                json!({ "port": "${CFG_EXT_MISSING}" }),
+                json!({ "port": 1 }),
+            ))
+            .await;
+
+        let entry = worker.store.get("iii-stream").await.expect("entry");
+        assert_eq!(
+            entry.value,
+            json!({ "port": 1 }),
+            "an edit referencing an unresolved env var must be dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn external_change_applies_when_schema_unknown() {
+        let (_engine, worker, _dir) = setup().await;
+        // A brand-new file the owning worker hasn't claimed yet: schema is null,
+        // so it can't be validated here — apply it and let `get` validate later
+        // once the owner registers a real schema.
+        worker
+            .handle_external_change(ExternalChange::Registered(ConfigurationEntry {
+                id: "fresh".into(),
+                name: "fresh".into(),
+                description: String::new(),
+                schema: Value::Null,
+                value: json!({ "port": "anything" }),
+                metadata: None,
+            }))
+            .await;
+
+        let entry = worker.store.get("fresh").await.expect("entry applied");
+        assert_eq!(entry.value, json!({ "port": "anything" }));
+    }
+
+    // End-to-end hot-reload: register → initialize (starts the watcher) → edit
+    // the file on disk → the store reflects the new value. Covers the full
+    // `initialize → watcher → handle_external_change` wiring the per-handler
+    // tests above don't exercise (the gap behind the "edit did nothing" report).
+    #[tokio::test]
+    async fn external_file_edit_hot_reloads_through_the_watcher() {
+        let (_engine, worker, dir) = setup().await;
+        worker
+            .register_fn(register_input("iii-stream", Some(json!({ "port": 1 }))))
+            .await;
+        // initialize() primes the cache, registers the trigger type, and starts
+        // the directory watcher — exactly as a real boot does.
+        worker.initialize().await.expect("initialize starts the watcher");
+
+        // Edit the file the way an operator would, in the value-only on-disk
+        // format `write_entry` produces (no schema key).
+        let path = dir.path().join("iii-stream.yaml");
+        tokio::fs::write(
+            &path,
+            "id: iii-stream\nname: iii-stream display\ndescription: test\nvalue:\n  port: 3114\n",
+        )
+        .await
+        .expect("write the external edit");
+
+        // The watcher debounces ~500ms; poll the store until it reflects the edit.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if let Some(entry) = worker.store.get("iii-stream").await
+                && entry.value == json!({ "port": 3114 })
+            {
+                break;
+            }
+            if tokio::time::Instant::now() > deadline {
+                panic!("hot-reload did not apply the external file edit within 5s");
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        worker.destroy().await.expect("destroy stops the watcher");
     }
 
     #[tokio::test]

--- a/engine/src/workers/configuration/iii.worker.yaml
+++ b/engine/src/workers/configuration/iii.worker.yaml
@@ -7,5 +7,5 @@ config:
   adapter:
     name: fs
     config:
-      directory: ./data/configuration
+      directory: ./iii-config
   ttl_seconds: 0

--- a/engine/src/workers/configuration/iii.worker.yaml
+++ b/engine/src/workers/configuration/iii.worker.yaml
@@ -7,5 +7,5 @@ config:
   adapter:
     name: fs
     config:
-      directory: ./iii-config
+      directory: ./config
   ttl_seconds: 0

--- a/engine/src/workers/configuration/skills/SKILL.md
+++ b/engine/src/workers/configuration/skills/SKILL.md
@@ -9,7 +9,7 @@ description: >-
 
 The `configuration` worker is a server-side registry of named entries. Every entry has an id (e.g. `iii-stream`, `billing-service`), a human-readable name and description, a JSON Schema describing the value shape, and a JSON value validated against that schema. Workers call `configuration::register` once at startup to declare their schema and `configuration::set` to publish values; consumers call `configuration::get` / `configuration::list` to read and bind a `configuration` trigger to react to changes without polling.
 
-The default `fs` adapter persists one YAML file per id under `./iii-config` and watches the directory for external edits, so manual edits to those files surface as `configuration:updated` events the same way SDK calls do. The `bridge` adapter delegates to a remote engine and re-broadcasts its events into the local fan-out — the function surface is identical across adapters. The worker is enabled by default in `engine/config.yaml`.
+The default `fs` adapter persists one YAML file per id under `./config` and watches the directory for external edits, so manual edits to those files surface as `configuration:updated` events the same way SDK calls do. The `bridge` adapter delegates to a remote engine and re-broadcasts its events into the local fan-out — the function surface is identical across adapters. The worker is enabled by default in `engine/config.yaml`.
 
 A per-id TTL (off by default) cleans up entries whose last subscriber trigger has unregistered, scoped to the lifecycle of ephemeral workers that come and go without an explicit teardown step.
 

--- a/engine/src/workers/configuration/skills/SKILL.md
+++ b/engine/src/workers/configuration/skills/SKILL.md
@@ -9,7 +9,7 @@ description: >-
 
 The `configuration` worker is a server-side registry of named entries. Every entry has an id (e.g. `iii-stream`, `billing-service`), a human-readable name and description, a JSON Schema describing the value shape, and a JSON value validated against that schema. Workers call `configuration::register` once at startup to declare their schema and `configuration::set` to publish values; consumers call `configuration::get` / `configuration::list` to read and bind a `configuration` trigger to react to changes without polling.
 
-The default `fs` adapter persists one YAML file per id under `./data/configuration` and watches the directory for external edits, so manual edits to those files surface as `configuration:updated` events the same way SDK calls do. The `bridge` adapter delegates to a remote engine and re-broadcasts its events into the local fan-out — the function surface is identical across adapters. The worker is enabled by default in `engine/config.yaml`.
+The default `fs` adapter persists one YAML file per id under `./iii-config` and watches the directory for external edits, so manual edits to those files surface as `configuration:updated` events the same way SDK calls do. The `bridge` adapter delegates to a remote engine and re-broadcasts its events into the local fan-out — the function surface is identical across adapters. The worker is enabled by default in `engine/config.yaml`.
 
 A per-id TTL (off by default) cleans up entries whose last subscriber trigger has unregistered, scoped to the lifecycle of ephemeral workers that come and go without an explicit teardown step.
 

--- a/engine/src/workers/configuration/store.rs
+++ b/engine/src/workers/configuration/store.rs
@@ -113,9 +113,12 @@ pub fn expand_value(v: &Value) -> (Value, Vec<String>) {
 fn expand_value_inner(v: &Value, missing: &mut Vec<String>) -> Value {
     match v {
         Value::String(s) => expand_string(s, missing),
-        Value::Array(items) => {
-            Value::Array(items.iter().map(|i| expand_value_inner(i, missing)).collect())
-        }
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|i| expand_value_inner(i, missing))
+                .collect(),
+        ),
         Value::Object(map) => {
             let mut out: Map<String, Value> = Map::with_capacity(map.len());
             for (k, val) in map {
@@ -233,7 +236,9 @@ impl ConfigurationStore {
         // re-validated later at read time, once the var is present.
         if validate {
             let (applied, missing) = expand_value(&value);
-            if missing.is_empty() && let Err(errs) = validate_against_schema(&applied, &schema) {
+            if missing.is_empty()
+                && let Err(errs) = validate_against_schema(&applied, &schema)
+            {
                 return Err(StoreError::SchemaInvalid(errs.join("; ")));
             }
         }
@@ -268,7 +273,9 @@ impl ConfigurationStore {
         // Validate the APPLIED value (see `register`); the raw template is what
         // gets stored, so it can be re-evaluated whenever the env changes.
         let (applied, missing) = expand_value(&value);
-        if missing.is_empty() && let Err(errs) = validate_against_schema(&applied, &entry.schema) {
+        if missing.is_empty()
+            && let Err(errs) = validate_against_schema(&applied, &entry.schema)
+        {
             return Err(StoreError::SchemaInvalid(errs.join("; ")));
         }
 

--- a/engine/src/workers/configuration/store.rs
+++ b/engine/src/workers/configuration/store.rs
@@ -12,29 +12,114 @@
 //! back to the adapter; writes update both atomically.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::env;
+use std::sync::{Arc, LazyLock};
 
 use jsonschema::Validator;
+use regex::Regex;
 use serde_json::{Map, Value};
 use tokio::sync::RwLock;
 
-use crate::workers::config::EngineConfig;
 use crate::workers::configuration::adapters::{
     ConfigurationAdapter, ExternalChange, RegisterOutcome, SetOutcome,
 };
 use crate::workers::configuration::structs::{ConfigurationEntry, ConfigurationSchemaView};
 
-/// Walk a JSON value and replace every string leaf with the env-var-expanded
-/// form (`${VAR:default}` → process env or default). Maps and arrays are
-/// walked recursively; non-string scalars pass through unchanged.
-pub fn expand_value(v: &Value) -> Value {
+/// Regex matching a single `${VAR}` / `${VAR:default}` reference. The class
+/// `[^}:]+` / `[^}]*` mirrors `EngineConfig::expand_env_vars`
+/// (`engine/src/workers/config.rs`) and the console's `env-template.ts`
+/// parser, so all three readers agree on the grammar.
+static ENV_VAR_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\$\{([^}:]+)(?::([^}]*))?\}").unwrap());
+
+/// Matches a string that is a single whole `${...}` placeholder (optionally
+/// padded by whitespace) and nothing else. Only such "lone" placeholders get
+/// scalar type-coercion after substitution — mirroring how an unquoted YAML
+/// scalar (`port: ${HTTP_PORT:3111}`) used to infer its type back when
+/// `config.yaml` expanded env vars on raw text *before* parsing. Mixed /
+/// embedded templates (surrounding text or multiple placeholders) stay strings.
+static LONE_PLACEHOLDER: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s*\$\{[^}]*\}\s*$").unwrap());
+
+/// Non-panicking env-var substitution for one string. Mirrors the CLI's
+/// `expand_env_vars` (`crates/iii-worker/src/cli/config_file.rs`): on a missing
+/// var with no default, the var name is recorded in `missing` and the literal
+/// `${VAR}` is left in place so partial output stays usable. The engine-only
+/// `__III_ENGINE_VERSION__` sentinel default is honored (config.rs parity).
+///
+/// Unlike `EngineConfig::expand_env_vars` this NEVER panics — the configuration
+/// worker's read/boot paths must surface a missing var as a loggable error, not
+/// brick the engine.
+fn expand_leaf(s: &str, missing: &mut Vec<String>) -> String {
+    ENV_VAR_RE
+        .replace_all(s, |caps: &regex::Captures| {
+            let var_name = &caps[1];
+            let default_value = caps.get(2).map(|m| m.as_str());
+            match env::var(var_name) {
+                Ok(value) => value,
+                Err(_) => match default_value {
+                    Some("__III_ENGINE_VERSION__") => env!("CARGO_PKG_VERSION").to_string(),
+                    Some(default) => default.to_string(),
+                    None => {
+                        missing.push(var_name.to_string());
+                        caps[0].to_string()
+                    }
+                },
+            }
+        })
+        .to_string()
+}
+
+/// Expand one string leaf, coercing scalar types when the original is a lone
+/// `${...}` placeholder. The substituted text of a lone placeholder is
+/// re-parsed as a YAML 1.2 scalar (`serde_yaml`) so `"8080"`→`8080`,
+/// `"true"`→`true`, while bare words / `007` / `on`/`off` stay strings — the
+/// same type inference unquoted YAML applied to the legacy `config.yaml` reader.
+///
+/// IMPORTANT: keep this coercion in lock-step with the console's
+/// `coerceScalar` in
+/// `workers/console/web/.../schema-form/validate.ts`, or UI and engine will
+/// disagree about which env-driven values are valid.
+fn expand_string(s: &str, missing: &mut Vec<String>) -> Value {
+    let substituted = expand_leaf(s, missing);
+    if LONE_PLACEHOLDER.is_match(s) {
+        let trimmed = substituted.trim();
+        // `${X:}` (empty default) keeps an empty string; YAML would read "" as null.
+        if trimmed.is_empty() {
+            return Value::String(substituted);
+        }
+        if let Ok(parsed) = serde_yaml::from_str::<Value>(trimmed) {
+            return parsed;
+        }
+    }
+    Value::String(substituted)
+}
+
+/// Walk a JSON value, replacing every string leaf with its env-expanded +
+/// type-coerced form (`${VAR:default}` → process env or default). Maps and
+/// arrays are walked recursively; non-string scalars pass through unchanged.
+///
+/// Returns the expanded value plus the list of `${VAR}` references that had no
+/// env value and no default (deduplicated by occurrence order). A non-empty
+/// list means the value cannot be fully evaluated: read/boot callers must log
+/// an ERROR and skip loading rather than handing back a value still carrying
+/// literal `${VAR}` text.
+pub fn expand_value(v: &Value) -> (Value, Vec<String>) {
+    let mut missing: Vec<String> = Vec::new();
+    let expanded = expand_value_inner(v, &mut missing);
+    (expanded, missing)
+}
+
+fn expand_value_inner(v: &Value, missing: &mut Vec<String>) -> Value {
     match v {
-        Value::String(s) => Value::String(EngineConfig::expand_env_vars(s)),
-        Value::Array(items) => Value::Array(items.iter().map(expand_value).collect()),
+        Value::String(s) => expand_string(s, missing),
+        Value::Array(items) => {
+            Value::Array(items.iter().map(|i| expand_value_inner(i, missing)).collect())
+        }
         Value::Object(map) => {
             let mut out: Map<String, Value> = Map::with_capacity(map.len());
             for (k, val) in map {
-                out.insert(k.clone(), expand_value(val));
+                out.insert(k.clone(), expand_value_inner(val, missing));
             }
             Value::Object(out)
         }
@@ -141,8 +226,16 @@ impl ConfigurationStore {
             (None, None) => (Value::Null, false),
         };
 
-        if validate && let Err(errs) = validate_against_schema(&value, &schema) {
-            return Err(StoreError::SchemaInvalid(errs.join("; ")));
+        // Validate the APPLIED (env-expanded + type-coerced) value, never the
+        // raw template: `${HTTP_PORT:3111}` must validate as the integer 3111,
+        // not be rejected as a string. A value that can't be fully evaluated
+        // yet (a var with no env value and no default) is stored raw and
+        // re-validated later at read time, once the var is present.
+        if validate {
+            let (applied, missing) = expand_value(&value);
+            if missing.is_empty() && let Err(errs) = validate_against_schema(&applied, &schema) {
+                return Err(StoreError::SchemaInvalid(errs.join("; ")));
+            }
         }
 
         let entry = ConfigurationEntry {
@@ -172,7 +265,10 @@ impl ConfigurationStore {
         if entry.schema.is_null() {
             return Err(StoreError::SchemaUnavailable(id.to_string()));
         }
-        if let Err(errs) = validate_against_schema(&value, &entry.schema) {
+        // Validate the APPLIED value (see `register`); the raw template is what
+        // gets stored, so it can be re-evaluated whenever the env changes.
+        let (applied, missing) = expand_value(&value);
+        if missing.is_empty() && let Err(errs) = validate_against_schema(&applied, &entry.schema) {
             return Err(StoreError::SchemaInvalid(errs.join("; ")));
         }
 
@@ -251,7 +347,8 @@ mod tests {
             std::env::set_var("CFG_TEST_HOST", "db.local");
         }
         let input = json!({ "host": "${CFG_TEST_HOST:fallback}", "port": 5432 });
-        let expanded = expand_value(&input);
+        let (expanded, missing) = expand_value(&input);
+        assert!(missing.is_empty());
         assert_eq!(expanded["host"], "db.local");
         assert_eq!(expanded["port"], 5432);
     }
@@ -262,7 +359,7 @@ mod tests {
             std::env::remove_var("CFG_TEST_MISSING");
         }
         let input = json!({ "url": "${CFG_TEST_MISSING:http://default}" });
-        assert_eq!(expand_value(&input)["url"], "http://default");
+        assert_eq!(expand_value(&input).0["url"], "http://default");
     }
 
     #[test]
@@ -276,7 +373,7 @@ mod tests {
                 { "name": "static" }
             ]
         });
-        let out = expand_value(&input);
+        let (out, _missing) = expand_value(&input);
         assert_eq!(out["users"][0]["name"], "alice");
         assert_eq!(out["users"][1]["name"], "static");
     }
@@ -284,8 +381,109 @@ mod tests {
     #[test]
     fn expand_value_passes_non_string_scalars_through() {
         let input = json!({ "n": 42, "b": true, "nil": null });
-        let out = expand_value(&input);
+        let (out, _missing) = expand_value(&input);
         assert_eq!(out, input);
+    }
+
+    // --- #1916: scalar type-coercion for lone `${...}` placeholders ---
+    //
+    // These pin the coercion contract the console mirrors in
+    // `workers/console/web/.../schema-form/validate.ts::coerceScalar`.
+
+    #[test]
+    fn expand_value_coerces_lone_placeholder_default_to_integer() {
+        // The headline bug: `port: ${HTTP_PORT:3111}` must become the integer
+        // 3111, not the string "3111".
+        unsafe {
+            std::env::remove_var("CFG_COERCE_PORT");
+        }
+        let input = json!({ "port": "${CFG_COERCE_PORT:3111}" });
+        let (out, missing) = expand_value(&input);
+        assert!(missing.is_empty());
+        assert_eq!(out["port"], json!(3111));
+        assert!(out["port"].is_i64(), "must coerce to a JSON integer");
+    }
+
+    #[test]
+    fn expand_value_coerces_lone_placeholder_env_to_integer() {
+        unsafe {
+            std::env::set_var("CFG_COERCE_ENVPORT", "8080");
+        }
+        let input = json!({ "port": "${CFG_COERCE_ENVPORT:3111}" });
+        let (out, _missing) = expand_value(&input);
+        assert_eq!(out["port"], json!(8080));
+        assert!(out["port"].is_i64());
+    }
+
+    #[test]
+    fn expand_value_coerces_bool_and_float() {
+        unsafe {
+            std::env::remove_var("CFG_COERCE_FLAG");
+            std::env::remove_var("CFG_COERCE_RATIO");
+        }
+        let input = json!({
+            "flag": "${CFG_COERCE_FLAG:true}",
+            "ratio": "${CFG_COERCE_RATIO:3.5}",
+        });
+        let (out, _missing) = expand_value(&input);
+        assert_eq!(out["flag"], json!(true));
+        assert_eq!(out["ratio"], json!(3.5));
+    }
+
+    #[test]
+    fn expand_value_keeps_bare_string_default() {
+        unsafe {
+            std::env::remove_var("CFG_COERCE_HOST");
+        }
+        let input = json!({ "host": "${CFG_COERCE_HOST:localhost}" });
+        let (out, _missing) = expand_value(&input);
+        assert_eq!(out["host"], json!("localhost"));
+    }
+
+    #[test]
+    fn expand_value_keeps_yaml_keyword_strings() {
+        // serde_yaml (YAML 1.2 core) does NOT treat on/off/yes/no as booleans;
+        // they must round-trip as strings, not get mangled into bools.
+        unsafe {
+            std::env::remove_var("CFG_COERCE_MODE");
+        }
+        let input = json!({ "mode": "${CFG_COERCE_MODE:on}" });
+        let (out, _missing) = expand_value(&input);
+        assert_eq!(out["mode"], json!("on"));
+    }
+
+    #[test]
+    fn expand_value_does_not_coerce_embedded_template() {
+        // Surrounding text means the leaf stays a string even if the result
+        // looks numeric.
+        unsafe {
+            std::env::remove_var("CFG_COERCE_EMB");
+        }
+        let input = json!({ "url": "redis://${CFG_COERCE_EMB:6379}" });
+        let (out, _missing) = expand_value(&input);
+        assert_eq!(out["url"], json!("redis://6379"));
+    }
+
+    #[test]
+    fn expand_value_empty_default_stays_empty_string() {
+        unsafe {
+            std::env::remove_var("CFG_COERCE_EMPTY");
+        }
+        let input = json!({ "name": "${CFG_COERCE_EMPTY:}" });
+        let (out, _missing) = expand_value(&input);
+        assert_eq!(out["name"], json!(""));
+    }
+
+    #[test]
+    fn expand_value_reports_missing_var_without_panic() {
+        unsafe {
+            std::env::remove_var("CFG_COERCE_REQUIRED");
+        }
+        let input = json!({ "port": "${CFG_COERCE_REQUIRED}" });
+        let (out, missing) = expand_value(&input);
+        assert_eq!(missing, vec!["CFG_COERCE_REQUIRED".to_string()]);
+        // Literal left in place so partial output is still inspectable.
+        assert_eq!(out["port"], json!("${CFG_COERCE_REQUIRED}"));
     }
 
     #[test]

--- a/engine/src/workers/observability/README.md
+++ b/engine/src/workers/observability/README.md
@@ -53,7 +53,7 @@ after first boot, edit the entry (console, or `configuration::set
 alone has no effect anymore.
 
 With the default file-backed adapter the entry persists at
-`./iii-config/iii-observability.yaml` and is read again at every
+`./config/iii-observability.yaml` and is read again at every
 engine start — *before* logging/tracing init — so even restart-tier fields
 edited at runtime apply on the next start. `${VAR:default}` placeholders work
 in string fields and are expanded on read.

--- a/engine/src/workers/observability/README.md
+++ b/engine/src/workers/observability/README.md
@@ -53,7 +53,7 @@ after first boot, edit the entry (console, or `configuration::set
 alone has no effect anymore.
 
 With the default file-backed adapter the entry persists at
-`./data/configuration/iii-observability.yaml` and is read again at every
+`./iii-config/iii-observability.yaml` and is read again at every
 engine start — *before* logging/tracing init — so even restart-tier fields
 edited at runtime apply on the next start. `${VAR:default}` placeholders work
 in string fields and are expanded on read.

--- a/engine/src/workers/observability/config.rs
+++ b/engine/src/workers/observability/config.rs
@@ -368,7 +368,7 @@ impl ObservabilityWorkerConfig {
     ///
     /// The JSON Schema rejects out-of-range values at `configuration::set`
     /// time, but stored entries can predate a schema tightening or be
-    /// hand-edited on disk (`./data/configuration/iii-observability.yaml`),
+    /// hand-edited on disk (`./iii-config/iii-observability.yaml`),
     /// so the top-level ratio and count fields are re-normalized on every
     /// read: ratios are clamped into `0..=1` and zero counts fall back to the
     /// built-in defaults (`None`) rather than creating zero-capacity stores.

--- a/engine/src/workers/observability/config.rs
+++ b/engine/src/workers/observability/config.rs
@@ -368,7 +368,7 @@ impl ObservabilityWorkerConfig {
     ///
     /// The JSON Schema rejects out-of-range values at `configuration::set`
     /// time, but stored entries can predate a schema tightening or be
-    /// hand-edited on disk (`./iii-config/iii-observability.yaml`),
+    /// hand-edited on disk (`./config/iii-observability.yaml`),
     /// so the top-level ratio and count fields are re-normalized on every
     /// read: ratios are clamped into `0..=1` and zero counts fall back to the
     /// built-in defaults (`None`) rather than creating zero-capacity stores.

--- a/engine/src/workers/pubsub/README.md
+++ b/engine/src/workers/pubsub/README.md
@@ -37,7 +37,7 @@ npx skills add iii-hq/iii --full-depth --skill iii-pubsub
 
 Runtime settings live in the **`configuration` worker** under id **`iii-pubsub`**. The worker registers its JSON Schema at startup, reads the live value via `configuration::get` (so `${VAR:default}` placeholders in string fields expand against the process env), and hot-applies changes when the value updates.
 
-The config.yaml block above is **seed-only**: it is installed as the initial value on first boot, when no value is stored yet. After that, the configuration worker entry is the source of truth — change the adapter via `configuration::set` or by editing the persisted file (`./data/configuration/iii-pubsub.yaml` with the default `fs` adapter); both propagate without an engine restart. Edits to the config.yaml block are ignored once a value is stored.
+The config.yaml block above is **seed-only**: it is installed as the initial value on first boot, when no value is stored yet. After that, the configuration worker entry is the source of truth — change the adapter via `configuration::set` or by editing the persisted file (`./iii-config/iii-pubsub.yaml` with the default `fs` adapter); both propagate without an engine restart. Edits to the config.yaml block are ignored once a value is stored.
 
 ### Hot Reload
 

--- a/engine/src/workers/pubsub/README.md
+++ b/engine/src/workers/pubsub/README.md
@@ -37,7 +37,7 @@ npx skills add iii-hq/iii --full-depth --skill iii-pubsub
 
 Runtime settings live in the **`configuration` worker** under id **`iii-pubsub`**. The worker registers its JSON Schema at startup, reads the live value via `configuration::get` (so `${VAR:default}` placeholders in string fields expand against the process env), and hot-applies changes when the value updates.
 
-The config.yaml block above is **seed-only**: it is installed as the initial value on first boot, when no value is stored yet. After that, the configuration worker entry is the source of truth — change the adapter via `configuration::set` or by editing the persisted file (`./iii-config/iii-pubsub.yaml` with the default `fs` adapter); both propagate without an engine restart. Edits to the config.yaml block are ignored once a value is stored.
+The config.yaml block above is **seed-only**: it is installed as the initial value on first boot, when no value is stored yet. After that, the configuration worker entry is the source of truth — change the adapter via `configuration::set` or by editing the persisted file (`./config/iii-pubsub.yaml` with the default `fs` adapter); both propagate without an engine restart. Edits to the config.yaml block are ignored once a value is stored.
 
 ### Hot Reload
 

--- a/engine/src/workers/rest_api/README.md
+++ b/engine/src/workers/rest_api/README.md
@@ -22,7 +22,7 @@ npx skills add iii-hq/iii --full-depth --skill iii-http
 
 Runtime settings live in the **`configuration` worker** under id **`iii-http`**. The worker registers its JSON Schema at startup, reads the live value via `configuration::get` (so `${VAR:default}` placeholders in string fields expand against the process env), and hot-applies changes when the value updates.
 
-The config.yaml block below is **seed-only**: it is installed as the initial value on first boot, when no value is stored yet. After that, the configuration worker entry is the source of truth — change settings via `configuration::set` or by editing the persisted file (`./iii-config/iii-http.yaml` with the default `fs` adapter); both propagate without an engine restart. Edits to the config.yaml block are ignored once a value is stored.
+The config.yaml block below is **seed-only**: it is installed as the initial value on first boot, when no value is stored yet. After that, the configuration worker entry is the source of truth — change settings via `configuration::set` or by editing the persisted file (`./config/iii-http.yaml` with the default `fs` adapter); both propagate without an engine restart. Edits to the config.yaml block are ignored once a value is stored.
 
 ### Sample Seed Configuration
 

--- a/engine/src/workers/rest_api/README.md
+++ b/engine/src/workers/rest_api/README.md
@@ -22,7 +22,7 @@ npx skills add iii-hq/iii --full-depth --skill iii-http
 
 Runtime settings live in the **`configuration` worker** under id **`iii-http`**. The worker registers its JSON Schema at startup, reads the live value via `configuration::get` (so `${VAR:default}` placeholders in string fields expand against the process env), and hot-applies changes when the value updates.
 
-The config.yaml block below is **seed-only**: it is installed as the initial value on first boot, when no value is stored yet. After that, the configuration worker entry is the source of truth — change settings via `configuration::set` or by editing the persisted file (`./data/configuration/iii-http.yaml` with the default `fs` adapter); both propagate without an engine restart. Edits to the config.yaml block are ignored once a value is stored.
+The config.yaml block below is **seed-only**: it is installed as the initial value on first boot, when no value is stored yet. After that, the configuration worker entry is the source of truth — change settings via `configuration::set` or by editing the persisted file (`./iii-config/iii-http.yaml` with the default `fs` adapter); both propagate without an engine restart. Edits to the config.yaml block are ignored once a value is stored.
 
 ### Sample Seed Configuration
 

--- a/engine/src/workers/rest_api/api_core.rs
+++ b/engine/src/workers/rest_api/api_core.rs
@@ -18,7 +18,11 @@ use colored::Colorize;
 use dashmap::DashMap;
 use futures::Future;
 use serde_json::Value;
-use tokio::{net::TcpListener, sync::RwLock, task::AbortHandle};
+use tokio::{
+    net::TcpListener,
+    sync::{RwLock, oneshot},
+    task::AbortHandle,
+};
 use tower::limit::ConcurrencyLimitLayer;
 use tower_http::{
     cors::{Any as HTTP_Any, CorsLayer},
@@ -96,6 +100,13 @@ pub struct HttpWorker {
     pub routers_registry: Arc<DashMap<String, PathRouter>>,
     shared_routers: Arc<RwLock<Router>>,
     server_abort: Arc<StdMutex<Option<AbortHandle>>>,
+    /// Per-server graceful-shutdown trigger for the CURRENT server. Firing it
+    /// gracefully shuts that one server down — closing its listener AND its open
+    /// connections (including idle keep-alive connections a client would
+    /// otherwise reuse to keep hitting the old address). A rebind fires the
+    /// previous server's trigger so the old port is fully freed, not just
+    /// stopped from accepting new connections.
+    server_shutdown: Arc<StdMutex<Option<oneshot::Sender<()>>>>,
     /// Kept so `apply_config` can respawn the server task on host/port change.
     shutdown_rx: Arc<StdMutex<Option<tokio::sync::watch::Receiver<bool>>>>,
     /// Serializes concurrent `apply_config` runs (rapid configuration edits).
@@ -234,11 +245,15 @@ impl Worker for HttpWorker {
         // Build initial router from registry
         self.update_routes().await?;
 
-        let handle = self.spawn_server(listener, addr, shutdown_rx.clone());
+        let (handle, graceful_tx) = self.spawn_server(listener, addr, shutdown_rx.clone());
         *self
             .server_abort
             .lock()
             .expect("server_abort mutex poisoned") = Some(handle);
+        *self
+            .server_shutdown
+            .lock()
+            .expect("server_shutdown mutex poisoned") = Some(graceful_tx);
 
         // Store the receiver only once the server is live: `apply_config`
         // refuses to rebind while this is `None`, so a stray
@@ -299,6 +314,17 @@ impl Worker for HttpWorker {
             .expect("shutdown_rx mutex poisoned")
             .take();
 
+        // Gracefully close the server first (drops the listener and its open
+        // connections, idle keep-alive included), then hard-abort the task as
+        // an immediate backstop — `destroy` is a stop-now path.
+        let graceful = self
+            .server_shutdown
+            .lock()
+            .expect("server_shutdown mutex poisoned")
+            .take();
+        if let Some(graceful) = graceful {
+            let _ = graceful.send(());
+        }
         let abort = self
             .server_abort
             .lock()
@@ -312,6 +338,12 @@ impl Worker for HttpWorker {
 }
 
 const ALLOW_ORIGIN_ANY: &str = "*";
+
+/// After a host/port change the old server is gracefully shut down (which closes
+/// its listener and open connections). This is how long we then wait before
+/// hard-aborting the old server task as a safety net, so a connection that
+/// refuses to drain cannot pin the old port indefinitely.
+const OLD_SERVER_HARD_STOP_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// True for hosts that restrict the listener to the local machine
 /// ("localhost", 127.0.0.0/8, ::1). Used by the boot bind fallback to refuse
@@ -340,6 +372,7 @@ impl HttpWorker {
             // Empty router initially; updated when routes are registered.
             shared_routers: Arc::new(RwLock::new(Router::new())),
             server_abort: Arc::new(StdMutex::new(None)),
+            server_shutdown: Arc::new(StdMutex::new(None)),
             shutdown_rx: Arc::new(StdMutex::new(None)),
             apply_lock: Arc::new(tokio::sync::Mutex::new(())),
         })
@@ -402,27 +435,44 @@ impl HttpWorker {
         *self.config.write().expect("config lock poisoned") = Arc::new(config);
     }
 
-    /// Spawn the axum server task for an already-bound listener and return
-    /// its abort handle. Shared by the initial start and host/port rebinds.
+    /// Spawn the axum server task for an already-bound listener. Returns its
+    /// abort handle plus a per-server graceful-shutdown trigger. Shared by the
+    /// initial start and host/port rebinds.
+    ///
+    /// The server shuts down gracefully (closing its listener AND its open
+    /// connections) when EITHER the returned trigger fires (a targeted stop — a
+    /// rebind or `destroy`) OR the global `shutdown_rx` goes true (engine
+    /// shutdown). Graceful shutdown is what actually severs idle keep-alive
+    /// connections; a bare `abort()` would only drop the listener and leave
+    /// those connections serving the old address.
     fn spawn_server(
         &self,
         listener: TcpListener,
         addr_display: String,
         mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
-    ) -> AbortHandle {
+    ) -> (AbortHandle, oneshot::Sender<()>) {
         let hot_router = HotRouter {
             inner: self.shared_routers.clone(),
             engine: self.engine.clone(),
         };
         let make_service = MakeHotRouterService { router: hot_router };
+        let (graceful_tx, graceful_rx) = oneshot::channel::<()>();
 
         let handle = tokio::spawn(async move {
             tracing::info!("API listening on address: {}", addr_display.purple());
             let serve = axum::serve(listener, make_service).with_graceful_shutdown(async move {
-                while shutdown_rx.changed().await.is_ok() {
-                    if *shutdown_rx.borrow() {
-                        break;
-                    }
+                tokio::select! {
+                    // Targeted stop for THIS server (rebind / destroy). A dropped
+                    // sender resolves the receiver too, which also means "stop".
+                    _ = graceful_rx => {}
+                    // Global engine shutdown.
+                    _ = async {
+                        while shutdown_rx.changed().await.is_ok() {
+                            if *shutdown_rx.borrow() {
+                                break;
+                            }
+                        }
+                    } => {}
                 }
             });
             if let Err(e) = serve.await {
@@ -430,7 +480,7 @@ impl HttpWorker {
             }
         });
 
-        handle.abort_handle()
+        (handle.abort_handle(), graceful_tx)
     }
 
     /// Re-fetch the authoritative configuration and hot-apply it. The
@@ -442,10 +492,13 @@ impl HttpWorker {
     /// Same address → swap the snapshot and rebuild router layers (CORS,
     /// timeout, concurrency); global middleware is read per-request from the
     /// snapshot and needs no rebuild. Address change → bind the new listener
-    /// first (the addresses differ, so no self-conflict), then abort the old
-    /// server only once the new one is live. In-flight requests on the old
-    /// listener are aborted — same semantics as `destroy()`; a graceful drain
-    /// is a possible follow-up.
+    /// first (the addresses differ, so no self-conflict), then GRACEFULLY shut
+    /// the old server down once the new one is live. Graceful shutdown closes
+    /// the old listener AND its open connections — including idle keep-alive
+    /// connections a browser would otherwise reuse to keep hitting the old port
+    /// — so the old address is fully freed, not merely stopped from accepting
+    /// new connections. A hard abort follows after a short grace as a safety net
+    /// for a connection that refuses to drain.
     pub(super) async fn apply_config(&self) -> anyhow::Result<()> {
         let _guard = self.apply_lock.lock().await;
 
@@ -507,21 +560,38 @@ impl HttpWorker {
         self.set_config(new_config);
         self.update_routes().await?;
 
-        let new_handle = self.spawn_server(listener, new_addr.clone(), shutdown_rx);
+        let (new_handle, new_graceful) = self.spawn_server(listener, new_addr.clone(), shutdown_rx);
 
-        let previous = self
+        let prev_abort = self
             .server_abort
             .lock()
             .expect("server_abort mutex poisoned")
             .replace(new_handle);
-        if let Some(previous) = previous {
-            previous.abort();
+        let prev_graceful = self
+            .server_shutdown
+            .lock()
+            .expect("server_shutdown mutex poisoned")
+            .replace(new_graceful);
+
+        // Gracefully shut the OLD server down now that the new one is live: this
+        // closes the old listener and its open connections (idle keep-alive
+        // included), so the old port stops serving entirely.
+        if let Some(prev_graceful) = prev_graceful {
+            let _ = prev_graceful.send(());
+        }
+        // Safety net: if a connection refuses to drain, hard-abort the old
+        // server task after a grace period so it can't pin the old port forever.
+        if let Some(prev_abort) = prev_abort {
+            tokio::spawn(async move {
+                tokio::time::sleep(OLD_SERVER_HARD_STOP_GRACE).await;
+                prev_abort.abort();
+            });
         }
 
         tracing::info!(
             old = %old_addr,
             new = %new_addr,
-            "iii-http server rebound after configuration change"
+            "iii-http server rebound after configuration change; old address shutting down"
         );
         Ok(())
     }

--- a/engine/src/workers/state/configuration.rs
+++ b/engine/src/workers/state/configuration.rs
@@ -272,22 +272,22 @@ fn read_persisted_state_value_from(dir: &Path) -> Option<Value> {
     };
     let value = entry.get("value").cloned().filter(|v| !v.is_null())?;
 
-    // `expand_value` panics on a `${VAR}` placeholder with no default and no
-    // env value. At runtime that fails one bus call; here it would brick every
-    // engine start until the data file is hand-edited — so contain it and fall
-    // back to the yaml block.
-    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        crate::workers::configuration::store::expand_value(&value)
-    })) {
-        Ok(expanded) => Some(expanded),
-        Err(_) => {
-            eprintln!(
-                "persisted configuration entry {} references an environment variable with no value and no default; using the config.yaml block",
-                path.display()
-            );
-            None
-        }
+    // Expand `${VAR:default}` (with the same scalar type-coercion
+    // `configuration::get` applies) so typed fields like `port: ${HTTP_PORT:3111}`
+    // deserialize correctly. A `${VAR}` with no env value and no default can't be
+    // resolved at boot: log an ERROR and fall back to the config.yaml block rather
+    // than load a value still carrying literal `${VAR}` text. `expand_value` never
+    // panics, so no `catch_unwind` guard is needed.
+    let (expanded, missing) = crate::workers::configuration::store::expand_value(&value);
+    if !missing.is_empty() {
+        eprintln!(
+            "persisted configuration entry {} references environment variable(s) with no value and no default ({}); it will not be loaded — using the config.yaml block",
+            path.display(),
+            missing.join(", ")
+        );
+        return None;
     }
+    Some(expanded)
 }
 
 #[cfg(test)]
@@ -506,6 +506,47 @@ mod tests {
             resolve_boot_config_from(dir.path(), yaml.clone()),
             yaml,
             "malformed persisted value must fall back to the yaml block"
+        );
+    }
+
+    #[test]
+    fn boot_read_coerces_typed_placeholder() {
+        // #1916: `max_value_bytes: ${VAR:256}` must coerce to the integer 256 so
+        // StateModuleConfig deserializes, instead of arriving as the string
+        // "256" and dropping the whole persisted value back to the yaml block.
+        unsafe {
+            std::env::remove_var("STATE_BOOT_MAXBYTES");
+        }
+        let dir = tempfile::tempdir().unwrap();
+        write_entry(
+            dir.path(),
+            json!({ "max_value_bytes": "${STATE_BOOT_MAXBYTES:256}" }),
+        );
+
+        let resolved = resolve_boot_config_from(dir.path(), Some(json!({ "max_value_bytes": 1 })))
+            .expect("persisted entry present");
+        assert_eq!(resolved["max_value_bytes"], 256);
+    }
+
+    #[test]
+    fn boot_read_falls_back_when_required_var_missing_no_panic() {
+        // A `${VAR}` with no default and no env value can't be resolved at boot:
+        // the read must fall back to the yaml block — and must NOT panic (we
+        // removed the old catch_unwind guard).
+        unsafe {
+            std::env::remove_var("STATE_BOOT_MISSING");
+        }
+        let dir = tempfile::tempdir().unwrap();
+        write_entry(
+            dir.path(),
+            json!({ "max_value_bytes": "${STATE_BOOT_MISSING}" }),
+        );
+
+        let yaml = Some(json!({ "max_value_bytes": 5 }));
+        assert_eq!(
+            resolve_boot_config_from(dir.path(), yaml.clone()),
+            yaml,
+            "an unresolved required var must fall back to the yaml block without panicking"
         );
     }
 

--- a/engine/tests/http_configuration_e2e.rs
+++ b/engine/tests/http_configuration_e2e.rs
@@ -262,6 +262,201 @@ async fn port_change_rebinds_the_listener() {
     }
 }
 
+// #1916: a templated *integer* port (`port: ${VAR:NNNN}`) must coerce on read
+// and drive a real rebind, exactly like a literal integer. Pre-fix the value
+// arrived as the string "NNNN", `serde_json::from_value::<RestApiConfig>` failed,
+// and the worker silently kept its previous config — so no rebind ever happened.
+#[tokio::test]
+async fn templated_port_change_rebinds_the_listener() {
+    let _serial = PORT_SERIAL.lock().await;
+    // SAFETY: runs before the harness spawns any task; the var is scrubbed so
+    // the `${VAR:default}` default branch is what we exercise.
+    unsafe { std::env::remove_var("HTTP_CFG_E2E_PORT") };
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let port_a = free_port();
+    let port_b = free_port();
+    assert_ne!(port_a, port_b);
+
+    let _worker = start_http_worker(&harness, json!({ "host": "127.0.0.1", "port": port_a })).await;
+    tokio::net::TcpStream::connect(("127.0.0.1", port_a))
+        .await
+        .expect("initial port accepts connections");
+
+    // `set_value` panics if the set is rejected, so this also asserts that the
+    // templated port passes validation (run against the coerced integer, not
+    // the raw string).
+    set_value(
+        &harness,
+        json!({ "host": "127.0.0.1", "port": format!("${{HTTP_CFG_E2E_PORT:{port_b}}}") }),
+    )
+    .await;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port_b))
+            .await
+            .is_ok()
+        {
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("timed out waiting for rebind to templated port {port_b}");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    // The stored value keeps the placeholder verbatim for later re-evaluation.
+    let raw = harness
+        .engine
+        .call(
+            "configuration::get",
+            json!({ "id": "iii-http", "raw": true }),
+        )
+        .await
+        .expect("configuration::get raw")
+        .expect("get returns a body");
+    assert_eq!(
+        raw["value"]["port"],
+        format!("${{HTTP_CFG_E2E_PORT:{port_b}}}")
+    );
+}
+
+// Same as `port_change_rebinds_the_listener`, but the change arrives as an
+// external FILE EDIT (hot-reload via the directory watcher) rather than a
+// `configuration::set` call. Guards that the file-edit path also tears the old
+// listener down — the path behind the "old port stays bound" report.
+#[tokio::test]
+async fn port_change_via_file_edit_rebinds_and_unbinds_old_port() {
+    let _serial = PORT_SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let port_a = free_port();
+    let port_b = free_port();
+    assert_ne!(port_a, port_b);
+
+    let _worker = start_http_worker(&harness, json!({ "host": "127.0.0.1", "port": port_a })).await;
+    tokio::net::TcpStream::connect(("127.0.0.1", port_a))
+        .await
+        .expect("initial port accepts connections");
+
+    // Edit the persisted entry on disk directly. The configuration worker's
+    // watcher (started by `build_harness`) picks it up and fans out a
+    // `configuration:updated` event, which drives the same rebind path as a
+    // `set`. JSON is valid YAML, so `serde_yaml` parses this entry; `host`+`port`
+    // is a valid value (it's exactly what the worker was seeded with).
+    let path = dir.path().join("iii-http.yaml");
+    let entry = json!({
+        "id": "iii-http",
+        "name": "iii-http",
+        "description": "",
+        "value": { "host": "127.0.0.1", "port": port_b }
+    });
+    tokio::fs::write(&path, serde_json::to_string(&entry).unwrap())
+        .await
+        .expect("write the external edit");
+
+    // The new port comes up (watcher debounce ~500ms + rebind).
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port_b))
+            .await
+            .is_ok()
+        {
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("timed out waiting for hot-reload rebind to port {port_b}");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    // The old listener must be torn down.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port_a))
+            .await
+            .is_err()
+        {
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("old port {port_a} still accepting after a file-edit rebind");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+// A port change must CLOSE connections already open on the old port, not just
+// stop accepting new ones. A browser holds an HTTP keep-alive connection open
+// and reuses it on refresh; before per-server graceful shutdown, that reused
+// connection kept serving the old port. The old server is now gracefully shut
+// down on rebind, which closes its idle keep-alive connections.
+#[tokio::test]
+async fn port_change_closes_open_keepalive_connection_on_old_port() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let _serial = PORT_SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let port_a = free_port();
+    let port_b = free_port();
+    assert_ne!(port_a, port_b);
+
+    let _worker = start_http_worker(&harness, json!({ "host": "127.0.0.1", "port": port_a })).await;
+
+    // Open a keep-alive connection to the old port and complete one request, so
+    // the connection is live and idle — exactly what a browser holds open.
+    let mut conn = tokio::net::TcpStream::connect(("127.0.0.1", port_a))
+        .await
+        .expect("connect to old port");
+    conn.write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n")
+        .await
+        .expect("write request to old port");
+    let mut buf = [0u8; 4096];
+    let n = tokio::time::timeout(Duration::from_secs(5), conn.read(&mut buf))
+        .await
+        .expect("first response arrives in time")
+        .expect("read first response");
+    assert!(n > 0, "the old server answered the first request");
+
+    // Change the port (drives the same rebind path as a file edit).
+    set_value(&harness, json!({ "host": "127.0.0.1", "port": port_b })).await;
+
+    // New port comes up.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port_b))
+            .await
+            .is_ok()
+        {
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("new port {port_b} never came up");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    // The previously-open keep-alive connection to the OLD port must now be
+    // closed by the old server's graceful shutdown — a read returns EOF (0).
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        match tokio::time::timeout(Duration::from_millis(250), conn.read(&mut buf)).await {
+            Ok(Ok(0)) => break,  // EOF: server closed the keep-alive connection
+            Ok(Err(_)) => break, // connection reset/closed
+            Ok(Ok(_)) => {}      // leftover response bytes; keep reading
+            Err(_) => {}         // read timed out; not closed yet — keep waiting
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("the old keep-alive connection was not closed after the port change");
+        }
+    }
+}
+
 #[tokio::test]
 async fn env_placeholders_expand_on_read() {
     // Held for the whole test: serializes port use and also guards the


### PR DESCRIPTION
## Summary

Fixes configuration worker reliability around HTTP port changes, on-disk layout, file-based hot-reload, and env-var expansion in numeric fields.

- **`${VARIABLES}` in numeric fields** — lone placeholders like `port: ${HTTP_PORT:3111}` are env-expanded and YAML-coerced to the correct scalar type (int/bool/float), so schema validation passes instead of treating them as strings. Fixes #1916.
- **Config directory** — default store moved from `./data/configuration` → `./iii-config`. Existing entries are auto-migrated on first boot; explicit `directory:` overrides are untouched.
- **File-edit hot-reload** — direct edits to `./iii-config/*.yaml` are picked up via the fs adapter watcher (canonicalized watch path fixes macOS FSEvents on relative paths). External edits fan out the same rebind/apply path as `configuration::set`; internal writes are deduped to avoid reload loops.
- **HTTP port binding** — `iii-http` now gracefully shuts down the old listener on host/port rebind (closes idle keep-alive connections, not just the accept socket), with a hard-abort safety net so a stuck connection can’t pin the old port indefinitely.

## Test plan

- [ ] `cargo test -p iii http_configuration_e2e` — port rebind via `configuration::set` and via direct file edit
- [ ] Edit `./iii-config/iii-http.yaml` port on disk; confirm new port serves and old port stops accepting
- [ ] Set `port: ${HTTP_PORT:3111}` (or similar) in a persisted config entry; confirm it resolves to an integer
- [ ] Upgrade from an install with `./data/configuration/` entries; confirm one-time migration to `./iii-config/`
- [ ] Smoke: `iii` boots, HTTP worker listens, config changes apply without restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration files now use `./config` by default, with a one-time migration from the previous location when possible.
  * Templated values like `${VAR:default}` are now resolved more reliably, with numeric values converted automatically when appropriate.
  * HTTP server updates now rebind more gracefully, including cleaner shutdown of old listeners and open connections.

* **Bug Fixes**
  * External config edits are now validated before applying, reducing broken or invalid settings from taking effect.
  * Missing environment variables without defaults now fall back to the last valid or seed configuration instead of causing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->