### PR TITLE
feat(engine): honor W3C tracestate on inbound HTTP and surface distributed traces

### DIFF
--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -26,8 +26,8 @@ use crate::{
     protocol::{ErrorBody, Message},
     services::{Service, ServicesRegistry},
     telemetry::{
-        ingest_otlp_json, ingest_otlp_logs, ingest_otlp_metrics, inject_baggage_from_context,
-        inject_traceparent_from_context,
+        ingest_otlp_json, ingest_otlp_logs, ingest_otlp_metrics,
+        inject_baggage_from_context, inject_traceparent_from_context,
     },
     trigger::{Trigger, TriggerRegistry, TriggerType},
     worker_connections::{RuntimeWorkerInfo, WorkerConnection, WorkerConnectionRegistry},

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -26,8 +26,8 @@ use crate::{
     protocol::{ErrorBody, Message},
     services::{Service, ServicesRegistry},
     telemetry::{
-        ingest_otlp_json, ingest_otlp_logs, ingest_otlp_metrics,
-        inject_baggage_from_context, inject_traceparent_from_context,
+        ingest_otlp_json, ingest_otlp_logs, ingest_otlp_metrics, inject_baggage_from_context,
+        inject_traceparent_from_context,
     },
     trigger::{Trigger, TriggerRegistry, TriggerType},
     worker_connections::{RuntimeWorkerInfo, WorkerConnection, WorkerConnectionRegistry},

--- a/engine/src/invocation/mod.rs
+++ b/engine/src/invocation/mod.rs
@@ -121,7 +121,7 @@ impl InvocationHandler {
                 // Tag internal vs user functions for filtering
                 "iii.function.kind" = if is_builtin { "internal" } else { "user" },
             )
-            .with_parent_headers(traceparent.as_deref(), baggage.as_deref())
+            .with_parent_headers(traceparent.as_deref(), None, baggage.as_deref())
         };
 
         // Run the dispatch under the caller's OTel context whenever one was

--- a/engine/src/telemetry.rs
+++ b/engine/src/telemetry.rs
@@ -19,27 +19,39 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 /// Extension trait for `tracing::Span` to simplify setting parent context from HTTP headers.
 ///
 /// This trait provides a fluent API for setting the parent context of a span using
-/// W3C Trace Context (`traceparent`) and Baggage headers.
+/// W3C Trace Context (`traceparent` + `tracestate`) and Baggage headers.
 ///
 /// # Example
 /// ```ignore
 /// use crate::telemetry::SpanExt;
 ///
 /// let span = tracing::info_span!("my_operation")
-///     .with_parent_headers(traceparent.as_deref(), baggage.as_deref());
+///     .with_parent_headers(traceparent.as_deref(), tracestate.as_deref(), baggage.as_deref());
 /// ```
 pub trait SpanExt {
-    /// Sets the parent context of this span from optional traceparent and baggage headers.
+    /// Sets the parent context of this span from optional W3C trace-context and baggage headers.
     ///
-    /// If either `traceparent` or `baggage` is provided, the span's parent context will be
-    /// set using the extracted context. If both are `None`, the span is returned unchanged.
-    fn with_parent_headers(self, traceparent: Option<&str>, baggage: Option<&str>) -> Self;
+    /// If any of `traceparent`, `tracestate`, or `baggage` is provided, the span's parent
+    /// context is set using the extracted context. `tracestate` is only meaningful alongside
+    /// a valid `traceparent` (it is ignored without one, per the W3C spec). If all are `None`,
+    /// the span is returned unchanged.
+    fn with_parent_headers(
+        self,
+        traceparent: Option<&str>,
+        tracestate: Option<&str>,
+        baggage: Option<&str>,
+    ) -> Self;
 }
 
 impl SpanExt for Span {
-    fn with_parent_headers(self, traceparent: Option<&str>, baggage: Option<&str>) -> Self {
-        if traceparent.is_some() || baggage.is_some() {
-            let parent_context = extract_context(traceparent, baggage);
+    fn with_parent_headers(
+        self,
+        traceparent: Option<&str>,
+        tracestate: Option<&str>,
+        baggage: Option<&str>,
+    ) -> Self {
+        if traceparent.is_some() || tracestate.is_some() || baggage.is_some() {
+            let parent_context = extract_context_with_state(traceparent, tracestate, baggage);
             let tp_owned = traceparent.map(|s| s.to_string());
             let parent_trace_id = parent_context.span().span_context().trace_id();
             let parent_valid = parent_context.span().span_context().is_valid();
@@ -90,7 +102,18 @@ mod tests {
         let span = tracing::info_span!("telemetry-test");
         let _span = span.with_parent_headers(
             Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"),
+            None,
             Some("user_id=123"),
+        );
+    }
+
+    #[test]
+    fn span_ext_accepts_w3c_tracestate_header() {
+        let span = tracing::info_span!("telemetry-test");
+        let _span = span.with_parent_headers(
+            Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"),
+            Some("congo=t61rcWkgMzE,rojo=00f067aa0ba902b7"),
+            None,
         );
     }
 }

--- a/engine/src/telemetry.rs
+++ b/engine/src/telemetry.rs
@@ -11,6 +11,8 @@
 
 pub use crate::workers::observability::otel::*;
 
+use opentelemetry::trace::TraceContextExt;
+use opentelemetry::KeyValue;
 use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
@@ -38,7 +40,42 @@ impl SpanExt for Span {
     fn with_parent_headers(self, traceparent: Option<&str>, baggage: Option<&str>) -> Self {
         if traceparent.is_some() || baggage.is_some() {
             let parent_context = extract_context(traceparent, baggage);
-            let _ = self.set_parent(parent_context);
+            let tp_owned = traceparent.map(|s| s.to_string());
+            let parent_trace_id = parent_context.span().span_context().trace_id();
+            let parent_valid = parent_context.span().span_context().is_valid();
+            match self.set_parent(parent_context) {
+                Ok(()) => {
+                    tracing::debug!(
+                        traceparent = tp_owned.as_deref().unwrap_or("(none)"),
+                        parent_trace_id = %parent_trace_id,
+                        parent_context_valid = parent_valid,
+                        "with_parent_headers: successfully set parent context"
+                    );
+                    // Record an event on this span so it shows up in OTel export
+                    self.add_event(
+                        "traceparent.propagated",
+                        vec![
+                            KeyValue::new("parent.trace_id", format!("{parent_trace_id}")),
+                            KeyValue::new("traceparent", tp_owned.as_deref().unwrap_or("(none)").to_string()),
+                        ],
+                    );
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        traceparent = tp_owned.as_deref().unwrap_or("(none)"),
+                        parent_trace_id = %parent_trace_id,
+                        error = %err,
+                        "with_parent_headers: failed to set parent context"
+                    );
+                    self.add_event(
+                        "traceparent.set_parent_failed",
+                        vec![
+                            KeyValue::new("error", err.to_string()),
+                            KeyValue::new("traceparent", tp_owned.as_deref().unwrap_or("(none)").to_string()),
+                        ],
+                    );
+                }
+            }
         }
         self
     }

--- a/engine/src/telemetry.rs
+++ b/engine/src/telemetry.rs
@@ -11,8 +11,8 @@
 
 pub use crate::workers::observability::otel::*;
 
-use opentelemetry::trace::TraceContextExt;
 use opentelemetry::KeyValue;
+use opentelemetry::trace::TraceContextExt;
 use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
@@ -68,7 +68,10 @@ impl SpanExt for Span {
                         "traceparent.propagated",
                         vec![
                             KeyValue::new("parent.trace_id", format!("{parent_trace_id}")),
-                            KeyValue::new("traceparent", tp_owned.as_deref().unwrap_or("(none)").to_string()),
+                            KeyValue::new(
+                                "traceparent",
+                                tp_owned.as_deref().unwrap_or("(none)").to_string(),
+                            ),
                         ],
                     );
                 }
@@ -83,7 +86,10 @@ impl SpanExt for Span {
                         "traceparent.set_parent_failed",
                         vec![
                             KeyValue::new("error", err.to_string()),
-                            KeyValue::new("traceparent", tp_owned.as_deref().unwrap_or("(none)").to_string()),
+                            KeyValue::new(
+                                "traceparent",
+                                tp_owned.as_deref().unwrap_or("(none)").to_string(),
+                            ),
                         ],
                     );
                 }

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -1976,10 +1976,25 @@ impl ObservabilityWorker {
                         None
                     };
 
+                // A span is a trace root when it has no parent OR its parent is
+                // absent from the store. The latter covers traces that entered
+                // iii from an external caller via an incoming `traceparent`: the
+                // server span's parent is the remote caller's span, which lives
+                // in another service and is never stored here. Without this,
+                // root-only listing hides every distributed trace. Mirrors
+                // `build_span_tree`'s dangling-parent handling.
+                let present_span_ids: std::collections::HashSet<String> =
+                    all_spans.iter().map(|s| s.span_id.clone()).collect();
+
                 let mut filtered: Vec<_> = all_spans
                     .into_iter()
                     // Root-only by default; `search_all_spans` widens to children too.
-                    .filter(|s| search_all || s.parent_span_id.is_none())
+                    .filter(|s| {
+                        search_all
+                            || s.parent_span_id
+                                .as_ref()
+                                .is_none_or(|p| !present_span_ids.contains(p))
+                    })
                     .filter(|s| {
                         // Exclude internal engine traces unless explicitly requested
                         if !include_internal {
@@ -6280,6 +6295,76 @@ mod tests {
             }
             _ => panic!("expected baggage_get_all to succeed"),
         }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_list_traces_treats_dangling_remote_parent_as_root() {
+        reset_observability_test_state();
+
+        let module = make_test_module(Arc::new(Engine::new()));
+        let span_storage = otel::get_span_storage().expect("span storage should exist");
+        span_storage.clear();
+
+        // A trace that entered iii from an external caller: the server span's
+        // parent is the remote caller's span id, which is never stored here.
+        // Its child (parent present in the store) is NOT a root.
+        span_storage.add_spans(vec![
+            make_span(
+                "t-remote",
+                "s-http",
+                Some("remoteparent0001"),
+                "POST /x",
+                "iii-engine",
+                1_000_000_000,
+                1_100_000_000,
+                "OK",
+                vec![],
+            ),
+            make_span(
+                "t-remote",
+                "s-child",
+                Some("s-http"),
+                "execute fn",
+                "worker",
+                1_010_000_000,
+                1_090_000_000,
+                "OK",
+                vec![],
+            ),
+        ]);
+
+        let input = TracesListInput {
+            trace_id: None,
+            offset: Some(0),
+            limit: Some(10),
+            service_name: None,
+            name: None,
+            status: None,
+            min_duration_ms: None,
+            max_duration_ms: None,
+            start_time: None,
+            end_time: None,
+            sort_by: None,
+            sort_order: None,
+            attributes: None,
+            include_internal: Some(false),
+            search_all_spans: None,
+        };
+
+        let spans = match module.list_traces(input).await {
+            FunctionResult::Success(v) => {
+                serde_json::to_value(&v).unwrap()["spans"]
+                    .as_array()
+                    .expect("spans array")
+                    .clone()
+            }
+            _ => panic!("expected list_traces success"),
+        };
+
+        // Only the dangling-parent server span surfaces as a root.
+        assert_eq!(spans.len(), 1, "dangling-parent span must be a root");
+        assert_eq!(spans[0]["name"].as_str().unwrap(), "POST /x");
     }
 
     #[tokio::test]

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -6359,12 +6359,10 @@ mod tests {
         };
 
         let spans = match module.list_traces(input).await {
-            FunctionResult::Success(v) => {
-                serde_json::to_value(&v).unwrap()["spans"]
-                    .as_array()
-                    .expect("spans array")
-                    .clone()
-            }
+            FunctionResult::Success(v) => serde_json::to_value(&v).unwrap()["spans"]
+                .as_array()
+                .expect("spans array")
+                .clone(),
             _ => panic!("expected list_traces success"),
         };
 

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -891,18 +891,25 @@ fn corrected_detail_spans(
 }
 
 fn build_span_tree(spans: Vec<otel::StoredSpan>) -> Vec<SpanTreeNode> {
+    // Span ids present in this set. A span whose parent is NOT present is a
+    // local trace root — covers traces entering iii from an external caller via
+    // an incoming `traceparent`, whose server span points at the remote caller's
+    // span (never stored here). Without this the whole subtree is orphaned and
+    // the trace detail view renders nothing.
+    let present_ids: std::collections::HashSet<String> =
+        spans.iter().map(|s| s.span_id.clone()).collect();
     let mut children_map: HashMap<String, Vec<otel::StoredSpan>> = HashMap::new();
     let mut roots: Vec<otel::StoredSpan> = Vec::new();
 
     for span in spans {
         match &span.parent_span_id {
-            Some(parent_id) => {
+            Some(parent_id) if present_ids.contains(parent_id) => {
                 children_map
                     .entry(parent_id.clone())
                     .or_default()
                     .push(span);
             }
-            None => roots.push(span),
+            _ => roots.push(span),
         }
     }
 
@@ -5310,11 +5317,10 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_build_span_tree_orphan_child() {
-        // A child whose parent is not in the span list becomes an orphan
-        // The current implementation only puts spans with None parent in roots.
-        // Orphan children (with parent_span_id set but parent not in list) are
-        // not treated as roots; they go into children_map but never get collected.
+    fn test_build_span_tree_orphan_child_becomes_root() {
+        // A span whose parent_span_id is set but absent from the span list is a
+        // local trace root (e.g. the server span of a trace that entered iii via
+        // an incoming `traceparent`, whose parent lives in the remote caller).
         let orphan = make_span(
             "t1",
             "s2",
@@ -5329,8 +5335,8 @@ mod tests {
 
         let tree = build_span_tree(vec![orphan]);
 
-        // Since the span has a parent_span_id, it won't appear as a root
-        assert!(tree.is_empty());
+        assert_eq!(tree.len(), 1, "orphan with missing parent must be a root");
+        assert_eq!(tree[0].span.name, "orphan");
     }
 
     // =========================================================================

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -3583,6 +3583,7 @@ mod tests {
             instrumentation_scope_name: None,
             instrumentation_scope_version: None,
             flags: None,
+            trace_state: None,
         }
     }
 

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -5841,7 +5841,10 @@ mod tests {
         };
 
         let stored = StoredSpan::from_span_data(&make(span_context), "svc");
-        assert_eq!(stored.trace_state.as_deref(), Some(trace_state.header().as_str()));
+        assert_eq!(
+            stored.trace_state.as_deref(),
+            Some(trace_state.header().as_str())
+        );
 
         // A span with no tracestate omits the field rather than emitting "".
         let empty_sc = SpanContext::new(

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -1194,9 +1194,27 @@ where
 /// Combine trace context and baggage extraction into a single context.
 /// This extracts both traceparent and baggage headers into a unified context.
 pub fn extract_context(traceparent: Option<&str>, baggage: Option<&str>) -> Context {
+    extract_context_with_state(traceparent, None, baggage)
+}
+
+/// Like [`extract_context`] but also honors the W3C `tracestate` header.
+///
+/// `tracestate` is the companion header to `traceparent` in the W3C Trace
+/// Context spec; it carries vendor-specific trace data that must travel
+/// alongside the trace id. The `TraceContextPropagator` only populates a
+/// `SpanContext`'s `TraceState` when both headers are present in the carrier,
+/// so a bare `traceparent` would silently drop any incoming `tracestate`.
+pub fn extract_context_with_state(
+    traceparent: Option<&str>,
+    tracestate: Option<&str>,
+    baggage: Option<&str>,
+) -> Context {
     let mut carrier: HashMap<String, String> = HashMap::new();
     if let Some(tp) = traceparent {
         carrier.insert("traceparent".to_string(), tp.to_string());
+    }
+    if let Some(ts) = tracestate {
+        carrier.insert("tracestate".to_string(), ts.to_string());
     }
     if let Some(bg) = baggage {
         carrier.insert("baggage".to_string(), bg.to_string());
@@ -6779,6 +6797,27 @@ mod tests {
         assert_eq!(format!("{:032x}", sc.trace_id()), SAMPLE_TRACE_ID_HEX);
         assert_eq!(format!("{:016x}", sc.span_id()), SAMPLE_SPAN_ID_HEX);
         assert!(sc.is_remote(), "extracted parent must be flagged remote");
+    }
+
+    #[test]
+    fn extract_context_with_state_carries_w3c_tracestate() {
+        let tracestate = "congo=t61rcWkgMzE,rojo=00f067aa0ba902b7";
+        let cx = extract_context_with_state(Some(SAMPLE_TRACEPARENT), Some(tracestate), None);
+        let span_ref = cx.span();
+        let sc = span_ref.span_context();
+        assert!(sc.is_valid());
+        assert_eq!(format!("{:032x}", sc.trace_id()), SAMPLE_TRACE_ID_HEX);
+        // The W3C `TraceContextPropagator` only populates `TraceState` when both
+        // `traceparent` and `tracestate` are present, so this also guards the
+        // companion-header wiring.
+        assert_eq!(sc.trace_state().header(), tracestate);
+    }
+
+    #[test]
+    fn extract_context_without_tracestate_has_empty_trace_state() {
+        let cx = extract_context_with_state(Some(SAMPLE_TRACEPARENT), None, None);
+        let span_ref = cx.span();
+        assert!(span_ref.span_context().trace_state().header().is_empty());
     }
 
     #[test]

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -361,6 +361,10 @@ pub struct StoredSpan {
     /// W3C trace flags (e.g., sampled=1)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub flags: Option<u32>,
+    /// W3C `tracestate` header carried by this span's context. Present when the
+    /// caller propagated a non-empty `tracestate` alongside `traceparent`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_state: Option<String>,
 }
 
 impl StoredSpan {
@@ -456,6 +460,10 @@ impl StoredSpan {
             instrumentation_scope_name: None,
             instrumentation_scope_version: None,
             flags: Some(span.span_context.trace_flags().to_u8() as u32),
+            trace_state: {
+                let ts = span.span_context.trace_state().header();
+                if ts.is_empty() { None } else { Some(ts) }
+            },
         }
     }
 }
@@ -2058,6 +2066,8 @@ pub async fn ingest_otlp_json(json_str: &str) -> anyhow::Result<()> {
                         instrumentation_scope_name: scope_name.clone(),
                         instrumentation_scope_version: scope_version.clone(),
                         flags: span.flags,
+                        // OTLP-ingested spans don't currently carry tracestate.
+                        trace_state: None,
                     };
 
                     stored_spans.push(stored_span);
@@ -4515,6 +4525,7 @@ mod tests {
             instrumentation_scope_name: None,
             instrumentation_scope_version: None,
             flags: None,
+            trace_state: None,
         }
     }
 
@@ -5792,6 +5803,56 @@ mod tests {
         assert_eq!(spans[0].status, "ok");
         assert_eq!(spans[0].attributes.len(), 1);
         assert_eq!(spans[0].attributes[0].0, "key");
+    }
+
+    #[test]
+    fn stored_span_from_span_data_carries_tracestate() {
+        use opentelemetry::trace::{SpanContext, SpanKind, Status, TraceFlags, TraceState};
+        use opentelemetry::{InstrumentationScope, SpanId, TraceId};
+        use opentelemetry_sdk::trace::{SpanEvents, SpanLinks};
+        use std::borrow::Cow;
+        use std::time::{Duration, UNIX_EPOCH};
+
+        let trace_state = "congo=t61rcWkgMzE,rojo=00f067aa0ba902b7"
+            .parse::<TraceState>()
+            .unwrap();
+        let span_context = SpanContext::new(
+            TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap(),
+            SpanId::from_hex("b7ad6b7169203331").unwrap(),
+            TraceFlags::SAMPLED,
+            true,
+            trace_state.clone(),
+        );
+
+        let make = |sc: SpanContext| SpanData {
+            span_context: sc,
+            parent_span_id: SpanId::INVALID,
+            parent_span_is_remote: false,
+            span_kind: SpanKind::Server,
+            name: Cow::Borrowed("HTTP"),
+            start_time: UNIX_EPOCH + Duration::from_secs(1000),
+            end_time: UNIX_EPOCH + Duration::from_secs(1001),
+            attributes: vec![],
+            dropped_attributes_count: 0,
+            events: SpanEvents::default(),
+            links: SpanLinks::default(),
+            status: Status::Ok,
+            instrumentation_scope: InstrumentationScope::builder("test").build(),
+        };
+
+        let stored = StoredSpan::from_span_data(&make(span_context), "svc");
+        assert_eq!(stored.trace_state.as_deref(), Some(trace_state.header().as_str()));
+
+        // A span with no tracestate omits the field rather than emitting "".
+        let empty_sc = SpanContext::new(
+            TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap(),
+            SpanId::from_hex("b7ad6b7169203331").unwrap(),
+            TraceFlags::SAMPLED,
+            true,
+            TraceState::NONE,
+        );
+        let stored_empty = StoredSpan::from_span_data(&make(empty_sc), "svc");
+        assert_eq!(stored_empty.trace_state, None);
     }
 
     // =========================================================================

--- a/engine/src/workers/queue/adapters/bridge.rs
+++ b/engine/src/workers/queue/adapters/bridge.rs
@@ -199,7 +199,11 @@ impl QueueAdapter for BridgeAdapter {
                         "messaging.operation.type" = "process",
                         otel.status_code = tracing::field::Empty,
                     )
-                    .with_parent_headers(traceparent.as_deref(), None, baggage.as_deref());
+                    .with_parent_headers(
+                        traceparent.as_deref(),
+                        None,
+                        baggage.as_deref(),
+                    );
 
                     async move {
                         if let Some(condition_path) = condition_function_id {

--- a/engine/src/workers/queue/adapters/bridge.rs
+++ b/engine/src/workers/queue/adapters/bridge.rs
@@ -199,7 +199,7 @@ impl QueueAdapter for BridgeAdapter {
                         "messaging.operation.type" = "process",
                         otel.status_code = tracing::field::Empty,
                     )
-                    .with_parent_headers(traceparent.as_deref(), baggage.as_deref());
+                    .with_parent_headers(traceparent.as_deref(), None, baggage.as_deref());
 
                     async move {
                         if let Some(condition_path) = condition_function_id {

--- a/engine/src/workers/queue/adapters/builtin/adapter.rs
+++ b/engine/src/workers/queue/adapters/builtin/adapter.rs
@@ -81,7 +81,7 @@ impl JobHandler for FunctionHandler {
             "baggage.queue" = %job.queue,
             otel.status_code = tracing::field::Empty,
         )
-        .with_parent_headers(job.traceparent.as_deref(), job.baggage.as_deref());
+        .with_parent_headers(job.traceparent.as_deref(), None, job.baggage.as_deref());
 
         let engine = Arc::clone(&self.engine);
         let function_id = self.function_id.clone();

--- a/engine/src/workers/queue/adapters/rabbitmq/worker.rs
+++ b/engine/src/workers/queue/adapters/rabbitmq/worker.rs
@@ -203,7 +203,7 @@ impl Worker {
             queue = %job.topic,
             otel.status_code = tracing::field::Empty,
         )
-        .with_parent_headers(job.traceparent.as_deref(), job.baggage.as_deref());
+        .with_parent_headers(job.traceparent.as_deref(), None, job.baggage.as_deref());
 
         async {
             let engine = Arc::clone(&self.engine);

--- a/engine/src/workers/queue/adapters/redis_adapter.rs
+++ b/engine/src/workers/queue/adapters/redis_adapter.rs
@@ -267,7 +267,7 @@ impl QueueAdapter for RedisAdapter {
                     queue = %topic_for_span,
                     otel.status_code = tracing::field::Empty,
                 )
-                .with_parent_headers(traceparent.as_deref(), baggage.as_deref());
+                .with_parent_headers(traceparent.as_deref(), None, baggage.as_deref());
 
                 tokio::spawn(
                     async move {

--- a/engine/src/workers/queue/adapters/redis_adapter.rs
+++ b/engine/src/workers/queue/adapters/redis_adapter.rs
@@ -267,7 +267,11 @@ impl QueueAdapter for RedisAdapter {
                     queue = %topic_for_span,
                     otel.status_code = tracing::field::Empty,
                 )
-                .with_parent_headers(traceparent.as_deref(), None, baggage.as_deref());
+                .with_parent_headers(
+                    traceparent.as_deref(),
+                    None,
+                    baggage.as_deref(),
+                );
 
                 tokio::spawn(
                     async move {

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -866,7 +866,7 @@ impl QueueWorker {
                         "messaging.operation.type" = "process",
                         otel.status_code = tracing::field::Empty,
                     )
-                    .with_parent_headers(traceparent.as_deref(), baggage.as_deref());
+                    .with_parent_headers(traceparent.as_deref(), None, baggage.as_deref());
 
                     let result =
                         AssertUnwindSafe(async { engine.call(&function_id, msg.data).await })

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -866,7 +866,11 @@ impl QueueWorker {
                         "messaging.operation.type" = "process",
                         otel.status_code = tracing::field::Empty,
                     )
-                    .with_parent_headers(traceparent.as_deref(), None, baggage.as_deref());
+                    .with_parent_headers(
+                        traceparent.as_deref(),
+                        None,
+                        baggage.as_deref(),
+                    );
 
                     let result =
                         AssertUnwindSafe(async { engine.call(&function_id, msg.data).await })

--- a/engine/src/workers/rest_api/views.rs
+++ b/engine/src/workers/rest_api/views.rs
@@ -19,6 +19,7 @@ use tracing::Instrument;
 
 use crate::{
     condition::check_condition,
+    telemetry::SpanExt,
     workers::rest_api::types::{HttpRequest, HttpResponse},
     workers::worker::channels::ChannelItem,
 };
@@ -310,6 +311,27 @@ pub async fn dynamic_handler(
         format!("{}://{}{}?{}", url_scheme, host, actual_path, query_string)
     };
 
+    // Extract W3C traceparent and baggage headers from the incoming HTTP
+    // request and use `set_parent` (via `with_parent_headers`) AFTER
+    // `info_span!()` to link this span as a child of the caller's trace.
+    //
+    // We explicitly do NOT use `OtelContext::attach()` before `info_span!()`
+    // because `tracing-opentelemetry`'s `parent_context()` only reads
+    // `Context::current()` for *contextual* spans (`is_contextual() == true`).
+    // A top-level HTTP handler has no active tracing span, so the span is
+    // non-contextual and the attached context is silently ignored, creating
+    // a new root trace. `set_parent` replaces the `parent_cx` in the
+    // `OtelData::Builder` state directly and works regardless of
+    // `is_contextual()`.
+    let tp = headers
+        .get("traceparent")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let bg = headers
+        .get("baggage")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
     let span = tracing::info_span!(
         "HTTP",
         otel.name = %format!("{} {}", method, registered_path),
@@ -327,7 +349,8 @@ pub async fn dynamic_handler(
         "http.request.body.size" = %request_body_size,
         "http.response.status_code" = tracing::field::Empty,
         "iii.function.kind" = tracing::field::Empty,
-    );
+    )
+    .with_parent_headers(tp.as_deref(), bg.as_deref());
 
     async move {
         tracing::debug!("Registered route path: {}", registered_path);

--- a/engine/src/workers/rest_api/views.rs
+++ b/engine/src/workers/rest_api/views.rs
@@ -126,6 +126,8 @@ fn extract_path_params(registered_path: &str, actual_path: &str) -> HashMap<Stri
 
 const SENSITIVE_HEADERS: &[&str] = &[
     "authorization",
+    // W3C baggage often carries user/session metadata; redact it from logs.
+    "baggage",
     "cookie",
     "set-cookie",
     "x-api-key",
@@ -311,9 +313,12 @@ pub async fn dynamic_handler(
         format!("{}://{}{}?{}", url_scheme, host, actual_path, query_string)
     };
 
-    // Extract W3C traceparent and baggage headers from the incoming HTTP
-    // request and use `set_parent` (via `with_parent_headers`) AFTER
-    // `info_span!()` to link this span as a child of the caller's trace.
+    // Extract the W3C trace-context (`traceparent` + `tracestate`) and baggage
+    // headers from the incoming HTTP request and use `set_parent` (via
+    // `with_parent_headers`) AFTER `info_span!()` to link this span as a child
+    // of the caller's trace. `tracestate` is the companion header to
+    // `traceparent` (https://www.w3.org/TR/trace-context/) and carries
+    // vendor-specific state that must travel with the trace id.
     //
     // We explicitly do NOT use `OtelContext::attach()` before `info_span!()`
     // because `tracing-opentelemetry`'s `parent_context()` only reads
@@ -325,6 +330,10 @@ pub async fn dynamic_handler(
     // `is_contextual()`.
     let tp = headers
         .get("traceparent")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let ts = headers
+        .get("tracestate")
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
     let bg = headers
@@ -350,7 +359,7 @@ pub async fn dynamic_handler(
         "http.response.status_code" = tracing::field::Empty,
         "iii.function.kind" = tracing::field::Empty,
     )
-    .with_parent_headers(tp.as_deref(), bg.as_deref());
+    .with_parent_headers(tp.as_deref(), ts.as_deref(), bg.as_deref());
 
     async move {
         tracing::debug!("Registered route path: {}", registered_path);
@@ -1012,6 +1021,18 @@ mod tests {
     }
 
     #[test]
+    fn test_sanitize_headers_redacts_baggage() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("baggage"),
+            HeaderValue::from_static("user_id=123,session_id=abc"),
+        );
+
+        let sanitized = sanitize_headers_for_logging(&headers);
+        assert_eq!(sanitized.get("baggage").unwrap(), "[REDACTED]");
+    }
+
+    #[test]
     fn test_sanitize_headers_preserves_safe() {
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -1480,8 +1501,9 @@ mod tests {
 
     #[test]
     fn test_sensitive_headers_list_is_complete() {
-        assert_eq!(SENSITIVE_HEADERS.len(), 10);
+        assert_eq!(SENSITIVE_HEADERS.len(), 11);
         assert!(SENSITIVE_HEADERS.contains(&"authorization"));
+        assert!(SENSITIVE_HEADERS.contains(&"baggage"));
         assert!(SENSITIVE_HEADERS.contains(&"cookie"));
         assert!(SENSITIVE_HEADERS.contains(&"set-cookie"));
         assert!(SENSITIVE_HEADERS.contains(&"x-api-key"));

--- a/engine/tests/observability_configuration_e2e.rs
+++ b/engine/tests/observability_configuration_e2e.rs
@@ -739,6 +739,7 @@ fn make_span(i: u64) -> iii::workers::observability::otel::StoredSpan {
         instrumentation_scope_name: None,
         instrumentation_scope_version: None,
         flags: None,
+        trace_state: None,
     }
 }
 


### PR DESCRIPTION
## What

Completes W3C trace-context propagation for inbound HTTP requests and makes the
resulting distributed traces visible in the console.

Builds on #1769 (propagate `traceparent`) with:

- **Honor `tracestate` on inbound HTTP** — `traceparent`'s W3C companion header.
  `extract_context` only seeded `traceparent` into the propagation carrier, so
  `TraceContextPropagator` silently dropped any incoming `tracestate`. The HTTP
  boundary (`rest_api/views.rs`) now reads `tracestate` and forwards it through
  `SpanExt::with_parent_headers`. Non-HTTP callers pass `None` (the engine
  protocol does not carry `tracestate` across hops — boundary-only by design).
- **Redact `baggage` in header logs** — baggage often carries user/session
  metadata; it's now treated as sensitive in `sanitize_headers_for_logging`.
- **Expose span `tracestate` in the traces API** — `StoredSpan` dropped the
  span's own `tracestate` (only links carried it), so the honored value was
  invisible to `engine::traces::list` and the console.
- **Surface distributed traces in `traces::list` and `traces::tree`** — both
  treated a span as a trace root only when `parent_span_id` was `None`. A trace
  entering iii via an incoming `traceparent` has a server span whose parent is
  the remote caller's span (never stored here), so the whole trace was hidden
  from the list and the detail view rendered "No span data available". Both now
  treat a span as a root when its parent is absent from the store.

## Why

Without `tracestate`, iii silently drops vendor trace state on the server span,
breaking distributed traces that rely on it. The observability gaps meant a
correctly-propagated trace was invisible in the console, so the feature was
effectively unusable for its main purpose (end-to-end observability of requests
entering iii from an upstream service).

## Notes

- Verified end-to-end: a `curl` carrying `traceparent` + `tracestate` + `baggage`
  produces an engine HTTP span under the caller's trace id, carrying the
  `tracestate`, propagated to the worker span in the same trace, and visible in
  the console trace list and detail tree.
- Unit tests added: tracestate extraction, empty-state default, baggage
  redaction, `StoredSpan` tracestate, and dangling-remote-parent roots in both
  `traces::list` and `build_span_tree`.
- Boundary-only scope: full multi-hop `tracestate` propagation (protocol +
  queue jobs + SDKs) is intentionally out of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved trace-context propagation across requests and background jobs, including support for additional tracing metadata.
  * Trace listings now include spans with missing parents as root spans, making externally started traces easier to view.

* **Bug Fixes**
  * Preserved trace context more reliably when linking spans.
  * Sensitive request headers now redact baggage values in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->