### PR TITLE
fix(tests): sync docker-compose fixture with upstream templates (#1884)

### DIFF
--- a/engine/tests/fixtures/templates/docker/docker-compose.yml
+++ b/engine/tests/fixtures/templates/docker/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "9464:9464"    # Prometheus metrics
     volumes:
       - ./config.yaml:/app/config.yaml:ro
+    env_file: .env
     environment:
       - RUST_LOG=info
       - III_EXECUTION_CONTEXT=docker

--- a/engine/tests/project_init_e2e.rs
+++ b/engine/tests/project_init_e2e.rs
@@ -182,6 +182,12 @@ fn project_init_with_docker_flag_writes_docker_assets_with_device_id() {
         "placeholder must be substituted, got:\n{dockerfile}"
     );
 
+    let compose = std::fs::read_to_string(dir.path().join("docker-compose.yml")).unwrap();
+    assert!(
+        compose.contains("env_file: .env"),
+        "docker-compose.yml should forward .env to the iii container, got:\n{compose}"
+    );
+
     let env = std::fs::read_to_string(dir.path().join(".env")).unwrap();
     assert!(
         !env.contains("III_HOST_USER_ID"),
@@ -216,6 +222,12 @@ fn project_generate_docker_uses_existing_project_ini_device_id() {
     assert!(
         dockerfile.contains("ENV III_HOST_USER_ID=preseeded-xyz"),
         "Dockerfile should bake the existing device_id, got:\n{dockerfile}"
+    );
+
+    let compose = std::fs::read_to_string(dir.path().join("docker-compose.yml")).unwrap();
+    assert!(
+        compose.contains("env_file: .env"),
+        "docker-compose.yml should forward .env to the iii container, got:\n{compose}"
     );
 
     let env = std::fs::read_to_string(dir.path().join(".env")).unwrap();


### PR DESCRIPTION
Sync the local test fixture with the canonical docker-compose template in iii-hq/templates, which already has `env_file: .env` (iii-hq/templates#33). The `iii` service was missing `env_file: .env`, so the engine container never received `RABBITMQ_USER` / `RABBITMQ_PASS` from the generated `.env` file at runtime.

Changes:
- Add `env_file: .env` to the `iii` service in the docker-compose test fixture
- Assert `env_file: .env` is present in both e2e tests that verify generated Docker assets

- [x] I license my contributions to this repository under Apache 2.0, and I have all necessary rights over the code I am contributing.

Closes #1884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker-based project setup now includes local `.env` variables in the `iii` container.
  * End-to-end checks were updated to confirm this behavior for both Docker initialization and Docker generation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->