### PR TITLE
fix(docker): pre-create /app/data in engine image and add named data volume

### DIFF
--- a/engine/docker-compose.yml
+++ b/engine/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "9464:9464"    # Prometheus metrics
     volumes:
       - ./config.yaml:/app/config.yaml:ro
+      - iii_data:/app/data
     environment:
       - RUST_LOG=info
       - III_EXECUTION_CONTEXT=docker
@@ -52,5 +53,6 @@ services:
     restart: unless-stopped
 
 volumes:
+  iii_data:
   redis_data:
   rabbitmq_data:


### PR DESCRIPTION
The engine image runs as UID 65532 (distroless nonroot) but `/app` is owned by root, so the configuration worker's default `./data/configuration` path is unwritable. Pre-create `/app/data` owned by 65532 via an Alpine build stage so that a named volume mounted there inherits correct ownership.

Also adds an `iii_data` named volume to both `engine/docker-compose.yml` and the project init docker template fixture so a fresh `iii project init --docker && docker compose up` boots without manual edits.

Closes #1883


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Application data is now persisted via a dedicated named volume mounted at `/app/data` (including the provided Docker Compose setup and its template fixture).
* **Bug Fixes**
  * Improved container reliability by ensuring the image includes a pre-created data directory with the correct non-root ownership during the build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->