### PR TITLE
fix(iii-queue): add per-queue dispatch_timeout_ms to bound lost dispatches

### DIFF
--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -1818,6 +1818,115 @@ impl Engine {
             .remove_if(function_id, |_, owner| owner == worker_id)
             .is_some()
     }
+
+    /// Like [`EngineTrait::call`], but bounds how long the caller waits for the
+    /// invocation to complete.
+    ///
+    /// When `timeout` is `Some`, a dispatch that does not complete within the
+    /// deadline is abandoned: the pending (worker-routed) invocation is evicted
+    /// from the invocations map AND from the owning worker's in-flight set —
+    /// so a lost or never-returning worker cannot leak either entry — and a
+    /// `dispatch_timeout` error is returned. `None` preserves the unbounded
+    /// behaviour of [`EngineTrait::call`], which simply delegates here.
+    ///
+    /// The timeout does NOT cancel work already running on a worker (the WS
+    /// protocol has no cancel message): the worker keeps executing and its
+    /// eventual result is discarded, while the caller may retry the message.
+    /// In-process handlers, by contrast, ARE drop-cancelled at their next
+    /// await point. Either way, handlers invoked under a timeout must be
+    /// idempotent.
+    ///
+    /// The fn-queue consumer passes the queue's `dispatch_timeout_ms` so a lost
+    /// engine→worker dispatch is nacked back through the normal retry→DLQ path
+    /// instead of wedging the underlying broker message (RabbitMQ leaves it
+    /// `unacked` until its server-side `consumer_timeout`, ~30 min by default).
+    pub async fn call_with_timeout(
+        &self,
+        function_id: &str,
+        input: impl Serialize + Send,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Value>,
+    ) -> Result<Option<Value>, ErrorBody> {
+        let input = serde_json::to_value(input).map_err(|e| ErrorBody {
+            code: "serialization_error".into(),
+            message: e.to_string(),
+            stacktrace: None,
+        })?;
+
+        let Some(function) = self.functions.get(function_id) else {
+            return Err(ErrorBody {
+                code: "function_not_found".into(),
+                message: format!("Function {} not found", function_id),
+                stacktrace: None,
+            });
+        };
+
+        // Inject current trace context and baggage to link spans as parent-child
+        // Use the tracing span's context directly to ensure proper propagation in async code
+        let ctx = tracing::Span::current().context();
+        let traceparent = inject_traceparent_from_context(&ctx);
+        let baggage = inject_baggage_from_context(&ctx);
+
+        // Generate the invocation id up front so a timeout can evict the
+        // deferred (worker-routed) invocation from the map by id.
+        let invocation_id = Uuid::new_v4();
+        let invocation_fut = self.invocations.handle_invocation(
+            Some(invocation_id),
+            None,
+            function_id.to_string(),
+            input,
+            function,
+            traceparent,
+            baggage,
+            None,
+            metadata,
+        );
+
+        let result = match timeout {
+            Some(duration) => match tokio::time::timeout(duration, invocation_fut).await {
+                Ok(result) => result,
+                Err(_elapsed) => {
+                    // Deadline hit before the handler returned. Evict any
+                    // deferred invocation so a late (or never-arriving) worker
+                    // result cannot leak the map entry, then surface a failure
+                    // so callers route the message back through retry/DLQ.
+                    // A worker-routed dispatch is tracked in TWO places: the
+                    // engine-global map (evicted here) and the owning
+                    // worker's in-flight set (cleaned below) — the normal
+                    // completion path reconciles both, so must this one.
+                    self.invocations.remove(&invocation_id);
+                    self.worker_registry
+                        .remove_invocation_from_workers(&invocation_id)
+                        .await;
+                    tracing::warn!(
+                        function_id = %function_id,
+                        invocation_id = %invocation_id,
+                        timeout_ms = %duration.as_millis(),
+                        "Invocation exceeded dispatch timeout; abandoning dispatch"
+                    );
+                    return Err(ErrorBody {
+                        code: "dispatch_timeout".into(),
+                        message: format!(
+                            "invocation for '{}' exceeded dispatch timeout of {}ms",
+                            function_id,
+                            duration.as_millis()
+                        ),
+                        stacktrace: None,
+                    });
+                }
+            },
+            None => invocation_fut.await,
+        };
+
+        match result {
+            Ok(result) => result,
+            Err(err) => Err(ErrorBody {
+                code: "invocation_error".into(),
+                message: err.to_string(),
+                stacktrace: None,
+            }),
+        }
+    }
 }
 
 impl EngineTrait for Engine {
@@ -1833,50 +1942,10 @@ impl EngineTrait for Engine {
         input: impl Serialize + Send,
         metadata: Option<Value>,
     ) -> Result<Option<Value>, ErrorBody> {
-        let input = serde_json::to_value(input).map_err(|e| ErrorBody {
-            code: "serialization_error".into(),
-            message: e.to_string(),
-            stacktrace: None,
-        })?;
-        let function_opt = self.functions.get(function_id);
-
-        if let Some(function) = function_opt {
-            // Inject current trace context and baggage to link spans as parent-child
-            // Use the tracing span's context directly to ensure proper propagation in async code
-            let ctx = tracing::Span::current().context();
-            let traceparent = inject_traceparent_from_context(&ctx);
-            let baggage = inject_baggage_from_context(&ctx);
-
-            let result = self
-                .invocations
-                .handle_invocation(
-                    None,
-                    None,
-                    function_id.to_string(),
-                    input,
-                    function,
-                    traceparent,
-                    baggage,
-                    None,
-                    metadata,
-                )
-                .await;
-
-            match result {
-                Ok(result) => result,
-                Err(err) => Err(ErrorBody {
-                    code: "invocation_error".into(),
-                    message: err.to_string(),
-                    stacktrace: None,
-                }),
-            }
-        } else {
-            Err(ErrorBody {
-                code: "function_not_found".into(),
-                message: format!("Function {} not found", function_id),
-                stacktrace: None,
-            })
-        }
+        // Unbounded call: no dispatch deadline. See `Engine::call_with_timeout`
+        // for the bounded variant used by the fn-queue consumer.
+        self.call_with_timeout(function_id, input, None, metadata)
+            .await
     }
 
     async fn register_trigger_type(&self, trigger_type: TriggerType) {
@@ -2827,6 +2896,140 @@ mod tests {
 
         let sent = engine.send_msg(&worker, Message::Ping).await;
         assert!(!sent, "send_msg should return false on closed channels");
+    }
+
+    #[tokio::test]
+    async fn call_with_timeout_evicts_deferred_invocation_on_elapse() {
+        ensure_default_meter();
+        let engine = Engine::new();
+
+        // A handler that behaves like a worker-routed dispatch: it returns
+        // `Deferred` (so the invocation is parked in the map awaiting a result
+        // that never comes) and records the invocation id it was handed.
+        let seen_id: Arc<std::sync::Mutex<Option<uuid::Uuid>>> =
+            Arc::new(std::sync::Mutex::new(None));
+        let seen = seen_id.clone();
+        let function = crate::function::Function {
+            handler: Arc::new(
+                move |invocation_id: Option<uuid::Uuid>, _input, _session, _metadata| {
+                    let seen = seen.clone();
+                    Box::pin(async move {
+                        if let Some(id) = invocation_id {
+                            *seen.lock().unwrap() = Some(id);
+                        }
+                        FunctionResult::Deferred
+                    })
+                },
+            ),
+            _function_id: "test::deferred".to_string(),
+            _description: None,
+            request_format: None,
+            response_format: None,
+            metadata: None,
+        };
+        engine
+            .functions
+            .register_function("test::deferred".to_string(), function);
+
+        let result = engine
+            .call_with_timeout(
+                "test::deferred",
+                json!({}),
+                Some(Duration::from_millis(50)),
+                None,
+            )
+            .await;
+
+        let err = result.expect_err("a deferred invocation with no result must time out");
+        assert_eq!(err.code, "dispatch_timeout");
+
+        let id = seen_id
+            .lock()
+            .unwrap()
+            .expect("handler should have run and recorded its invocation id");
+        // The timeout path must have evicted the parked invocation from the map;
+        // a second remove therefore finds nothing.
+        assert!(
+            engine.invocations.remove(&id).is_none(),
+            "timed-out deferred invocation must be evicted from the invocations map"
+        );
+    }
+
+    #[tokio::test]
+    async fn call_with_timeout_cleans_worker_in_flight_set_on_elapse() {
+        ensure_default_meter();
+        let engine = Engine::new();
+        // Keep the receiver alive so the InvokeFunction send succeeds and the
+        // handler returns Deferred (a closed channel fails the dispatch).
+        let (tx, _rx) = mpsc::channel::<Outbound>(8);
+        let worker = WorkerConnection::new(tx);
+        engine.worker_registry.register_worker(worker.clone());
+
+        // Register the function via the worker so invocations route to it
+        // over the channel and land in the worker's in-flight set.
+        let register_msg = Message::RegisterFunction {
+            id: "wedged::worker_fn".to_string(),
+            description: None,
+            request_format: None,
+            response_format: None,
+            metadata: None,
+            invocation: None,
+        };
+        engine
+            .router_msg(&worker, &register_msg)
+            .await
+            .expect("register function should succeed");
+
+        let result = engine
+            .call_with_timeout(
+                "wedged::worker_fn",
+                json!({}),
+                Some(Duration::from_millis(50)),
+                None,
+            )
+            .await;
+        assert_eq!(
+            result.expect_err("dispatch must time out").code,
+            "dispatch_timeout"
+        );
+
+        // Both tracking structures must be reconciled on timeout: the engine
+        // map (covered above) AND the owning worker's in-flight set — a lost
+        // dispatch must not inflate `active_invocations` until disconnect.
+        assert!(
+            worker.invocations.read().await.is_empty(),
+            "timed-out invocation must be removed from the worker's in-flight set"
+        );
+    }
+
+    #[tokio::test]
+    async fn call_with_timeout_none_does_not_bound_a_completing_handler() {
+        ensure_default_meter();
+        let engine = Engine::new();
+        let function = crate::function::Function {
+            handler: Arc::new(move |_invocation_id, _input, _session, _metadata| {
+                Box::pin(async move {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    FunctionResult::Success(Some(json!({ "ok": true })))
+                })
+            }),
+            _function_id: "test::slow".to_string(),
+            _description: None,
+            request_format: None,
+            response_format: None,
+            metadata: None,
+        };
+        engine
+            .functions
+            .register_function("test::slow".to_string(), function);
+
+        let result = engine
+            .call_with_timeout("test::slow", json!({}), None, None)
+            .await;
+        assert!(
+            result.is_ok(),
+            "an unset timeout must not bound a completing handler: {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/engine/src/invocation/mod.rs
+++ b/engine/src/invocation/mod.rs
@@ -149,7 +149,7 @@ impl InvocationHandler {
 
         let invocation_fut = async {
             let (sender, receiver) = tokio::sync::oneshot::channel();
-            let invocation_id = invocation_id.unwrap_or(Uuid::new_v4());
+            let invocation_id = invocation_id.unwrap_or_else(Uuid::new_v4);
             let invocation = Invocation {
                 id: invocation_id,
                 function_id: function_id.clone(),

--- a/engine/src/worker_connections/mod.rs
+++ b/engine/src/worker_connections/mod.rs
@@ -187,6 +187,29 @@ impl WorkerConnectionRegistry {
                 .record(count, &[KeyValue::new("status", st.as_str())]);
         }
     }
+
+    /// Removes an orphaned invocation id from whichever worker's in-flight set
+    /// holds it. Used by the dispatch-timeout path, which abandons an
+    /// invocation without knowing its worker binding (the `Invocation` is
+    /// created with `worker_id: None`; routing happens deeper, in
+    /// `WorkerConnection::handle_function`). Without this, a timed-out
+    /// dispatch to a worker that never replies leaves its id in
+    /// `WorkerConnection::invocations` until disconnect, inflating
+    /// `invocation_count()`. Cold path — a linear scan over workers is fine.
+    pub async fn remove_invocation_from_workers(&self, invocation_id: &Uuid) {
+        // Snapshot the per-worker set handles first so no DashMap shard guard
+        // is held across an await.
+        let sets: Vec<_> = self
+            .workers
+            .iter()
+            .map(|w| w.value().invocations.clone())
+            .collect();
+        for set in sets {
+            if set.write().await.remove(invocation_id) {
+                return;
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]

--- a/engine/src/workers/queue/README.md
+++ b/engine/src/workers/queue/README.md
@@ -62,6 +62,7 @@ npx skills add iii-hq/iii --full-depth --skill iii-queue
 | `message_group_field` | string | Required for `fifo`. JSON field whose value determines the ordering group. |
 | `backoff_ms` | u64 | Base retry backoff in milliseconds. Exponential: `backoff_ms × 2^(attempt−1)`. Defaults to `1000`. |
 | `poll_interval_ms` | u64 | Worker poll interval in milliseconds. Defaults to `100`. |
+| `dispatch_timeout_ms` | u64 | Optional per-invocation dispatch deadline in milliseconds. If a dispatched job does not complete within it (e.g. a lost engine→worker dispatch or a worker that never returns a result), the message is nacked back through the normal retry→DLQ path instead of staying in-flight until the broker's own timeout. Unset by default (no deadline). Set it comfortably above the slowest legitimate handler runtime, and make handlers idempotent: the timeout does not cancel work already running on a worker, so a retry can overlap the original attempt. |
 
 ## Queue Modes
 

--- a/engine/src/workers/queue/adapters/builtin/adapter.rs
+++ b/engine/src/workers/queue/adapters/builtin/adapter.rs
@@ -57,6 +57,7 @@ struct FunctionHandler {
     engine: Arc<Engine>,
     function_id: String,
     condition_function_id: Option<String>,
+    dispatch_timeout: Option<std::time::Duration>,
 }
 
 #[async_trait]
@@ -86,6 +87,7 @@ impl JobHandler for FunctionHandler {
         let engine = Arc::clone(&self.engine);
         let function_id = self.function_id.clone();
         let condition_function_id = self.condition_function_id.clone();
+        let dispatch_timeout = self.dispatch_timeout;
         let data = job.data.clone();
 
         async move {
@@ -116,7 +118,9 @@ impl JobHandler for FunctionHandler {
                 }
             }
 
-            let result = engine.call(&function_id, data).await;
+            let result = engine
+                .call_with_timeout(&function_id, data, dispatch_timeout, None)
+                .await;
             match &result {
                 Ok(_) => {
                     tracing::Span::current().record("otel.status_code", "OK");
@@ -228,10 +232,13 @@ impl QueueAdapter for BuiltinQueueAdapter {
     ) {
         let internal_queue = format!("{}::{}", topic, function_id);
 
+        let dispatch_timeout = queue_config.as_ref().and_then(|c| c.dispatch_timeout());
+
         let handler: Arc<dyn JobHandler> = Arc::new(FunctionHandler {
             engine: Arc::clone(&self.engine),
             function_id: function_id.to_string(),
             condition_function_id,
+            dispatch_timeout,
         });
 
         let subscription_config = queue_config.map(|c| SubscriptionConfig {
@@ -700,7 +707,7 @@ mod tests {
             queue_mode: Some("fifo".to_string()),
             max_retries: Some(3),
             concurrency: Some(5),
-            visibility_timeout: None,
+            dispatch_timeout_ms: None,
             delay_seconds: None,
             backoff_type: None,
             backoff_delay_ms: Some(1000),
@@ -730,7 +737,7 @@ mod tests {
             queue_mode: Some("concurrent".to_string()),
             max_retries: None,
             concurrency: None,
-            visibility_timeout: None,
+            dispatch_timeout_ms: None,
             delay_seconds: None,
             backoff_type: None,
             backoff_delay_ms: None,
@@ -758,7 +765,7 @@ mod tests {
             queue_mode: Some("standard".to_string()),
             max_retries: None,
             concurrency: None,
-            visibility_timeout: None,
+            dispatch_timeout_ms: None,
             delay_seconds: None,
             backoff_type: None,
             backoff_delay_ms: None,
@@ -785,7 +792,7 @@ mod tests {
             queue_mode: None,
             max_retries: Some(5),
             concurrency: Some(10),
-            visibility_timeout: None,
+            dispatch_timeout_ms: None,
             delay_seconds: None,
             backoff_type: None,
             backoff_delay_ms: None,
@@ -832,6 +839,7 @@ mod tests {
             engine: Arc::clone(&engine),
             function_id: "queue.success".to_string(),
             condition_function_id: None,
+            dispatch_timeout: None,
         };
         success
             .handle(&job)
@@ -842,6 +850,7 @@ mod tests {
             engine,
             function_id: "queue.failure".to_string(),
             condition_function_id: None,
+            dispatch_timeout: None,
         };
         let err = failure
             .handle(&job)
@@ -863,7 +872,7 @@ mod tests {
             queue_mode: Some("fifo".to_string()),
             max_retries: Some(3),
             concurrency: Some(2),
-            visibility_timeout: None,
+            dispatch_timeout_ms: None,
             delay_seconds: None,
             backoff_type: None,
             backoff_delay_ms: Some(25),
@@ -877,7 +886,7 @@ mod tests {
             queue_mode: Some("standard".to_string()),
             max_retries: Some(2),
             concurrency: Some(1),
-            visibility_timeout: None,
+            dispatch_timeout_ms: None,
             delay_seconds: None,
             backoff_type: None,
             backoff_delay_ms: Some(10),

--- a/engine/src/workers/queue/config.rs
+++ b/engine/src/workers/queue/config.rs
@@ -102,6 +102,25 @@ pub struct FunctionQueueConfig {
     /// Defaults to 100.
     #[serde(default = "default_poll_interval_ms")]
     pub poll_interval_ms: u64,
+
+    /// Maximum time in milliseconds to wait for a dispatched invocation to
+    /// complete before the message is nacked back through the normal
+    /// retry→DLQ path. Bounds the "dispatched-but-uncompleted" case: a lost
+    /// engine→worker dispatch (or a worker that never returns a result) would
+    /// otherwise leave the message in-flight until the broker's own timeout
+    /// (e.g. RabbitMQ `consumer_timeout`, ~30 min). When unset, dispatch has
+    /// no deadline (the historical behaviour). Set it comfortably above the
+    /// slowest legitimate handler runtime.
+    ///
+    /// The timeout does not cancel work already running on a worker, so a
+    /// retry can execute concurrently with the original (still-running)
+    /// attempt, and a message can dead-letter even though an attempt
+    /// ultimately succeeded — handlers on a bounded queue must be idempotent.
+    /// In-process handlers are instead cancelled at their next await point,
+    /// which can leave partial side effects for the retry to reconcile.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 1))]
+    pub dispatch_timeout_ms: Option<u64>,
 }
 
 impl Default for FunctionQueueConfig {
@@ -115,6 +134,7 @@ impl Default for FunctionQueueConfig {
             priority_field: None,
             backoff_ms: default_backoff_ms(),
             poll_interval_ms: default_poll_interval_ms(),
+            dispatch_timeout_ms: None,
         }
     }
 }
@@ -190,6 +210,16 @@ impl QueueModuleConfig {
             if queue_config.max_priority == Some(0) {
                 anyhow::bail!(
                     "Queue '{}' has 'max_priority' 0; it must be between 1 and 255",
+                    name
+                );
+            }
+            // A 0ms dispatch timeout fires before any handler can run, so every
+            // invocation would nack immediately. The JSON schema
+            // (`range(min = 1)`) rejects this at `configuration::set`, but the
+            // `config.yaml` seed bypasses the schema, so guard here too.
+            if queue_config.dispatch_timeout_ms == Some(0) {
+                anyhow::bail!(
+                    "Queue '{}' has 'dispatch_timeout_ms' 0; it must be at least 1 (or omitted to disable)",
                     name
                 );
             }
@@ -541,6 +571,44 @@ adapter:
         assert!(config.message_group_field.is_none());
         assert_eq!(config.backoff_ms, 1000);
         assert_eq!(config.poll_interval_ms, 100);
+        // Dispatch timeout is opt-in: unset by default preserves the historical
+        // unbounded-dispatch behaviour.
+        assert!(config.dispatch_timeout_ms.is_none());
+    }
+
+    #[test]
+    fn function_queue_config_parses_dispatch_timeout_ms() {
+        // Absent -> None (opt-in, no deadline).
+        let without: FunctionQueueConfig =
+            serde_json::from_str(r#"{"max_retries": 2}"#).expect("should deserialize");
+        assert!(without.dispatch_timeout_ms.is_none());
+
+        // Present -> Some(ms).
+        let with: FunctionQueueConfig =
+            serde_json::from_str(r#"{"dispatch_timeout_ms": 5000}"#).expect("should deserialize");
+        assert_eq!(with.dispatch_timeout_ms, Some(5000));
+    }
+
+    #[test]
+    fn validate_rejects_zero_dispatch_timeout() {
+        let mut queue_configs = HashMap::new();
+        queue_configs.insert(
+            "jobs".to_string(),
+            FunctionQueueConfig {
+                dispatch_timeout_ms: Some(0),
+                ..Default::default()
+            },
+        );
+        let config = QueueModuleConfig {
+            adapter: None,
+            queue_configs,
+        };
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("jobs"), "error should name the queue: {err}");
+        assert!(
+            err.contains("dispatch_timeout_ms"),
+            "error should name the field: {err}"
+        );
     }
 
     #[test]

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -838,6 +838,12 @@ impl QueueWorker {
             config.concurrency
         };
         let max_retries = config.max_retries;
+        // Per-invocation dispatch deadline. When set, a dispatched invocation
+        // that does not complete in time is nacked back through retry→DLQ
+        // instead of wedging the broker message until its own consumer timeout.
+        let dispatch_timeout = config
+            .dispatch_timeout_ms
+            .map(std::time::Duration::from_millis);
         let mut receiver = adapter.consume_function_queue(name, prefetch).await?;
 
         let engine = self.engine.clone();
@@ -883,11 +889,14 @@ impl QueueWorker {
                         baggage.as_deref(),
                     );
 
-                    let result =
-                        AssertUnwindSafe(async { engine.call(&function_id, msg.data).await })
-                            .catch_unwind()
-                            .instrument(span)
-                            .await;
+                    let result = AssertUnwindSafe(async {
+                        engine
+                            .call_with_timeout(&function_id, msg.data, dispatch_timeout, None)
+                            .await
+                    })
+                    .catch_unwind()
+                    .instrument(span)
+                    .await;
 
                     match result {
                         Ok(Ok(_)) => {

--- a/engine/src/workers/queue/skills/SKILL.md
+++ b/engine/src/workers/queue/skills/SKILL.md
@@ -61,6 +61,6 @@ iii.registerTrigger({
 })
 ```
 
-Per-queue tuning (in `queue_configs` or `queue_config`): `max_retries` (default `3`), `concurrency` (default `10`; FIFO forces `1`), `type` (`standard` | `fifo`), `message_group_field` (required for `fifo`), `backoff_ms` (default `1000`, exponential), `poll_interval_ms` (default `100`).
+Per-queue tuning (in `queue_configs` or `queue_config`): `max_retries` (default `3`), `concurrency` (default `10`; FIFO forces `1`), `type` (`standard` | `fifo`), `message_group_field` (required for `fifo`), `backoff_ms` (default `1000`, exponential), `poll_interval_ms` (default `100`), `dispatch_timeout_ms` (optional; nacks a dispatched-but-uncompleted job back through retry→DLQ instead of leaving it in-flight until the broker timeout — does not cancel worker-side work, so bounded handlers must be idempotent).
 
 For the message payload shape, call `iii get function info` on the trigger type or handler function id.

--- a/engine/src/workers/queue/subscriber_config.rs
+++ b/engine/src/workers/queue/subscriber_config.rs
@@ -20,7 +20,14 @@ pub struct SubscriberQueueConfig {
     pub queue_mode: Option<String>,
     pub max_retries: Option<u32>,
     pub concurrency: Option<u32>,
-    pub visibility_timeout: Option<u64>,
+    /// Maximum time in milliseconds a dispatched delivery may remain
+    /// uncompleted before the engine abandons the invocation and the
+    /// delivery flows into the path's normal failure handling (nack →
+    /// retry → DLQ where the adapter supports it). Unset means the
+    /// dispatch is unbounded. The timeout does not cancel work already
+    /// running on a worker, so a retry can overlap the original attempt —
+    /// bounded handlers must be idempotent.
+    pub dispatch_timeout_ms: Option<u64>,
     pub delay_seconds: Option<u64>,
     pub backoff_type: Option<String>,
     pub backoff_delay_ms: Option<u64>,
@@ -67,8 +74,8 @@ impl SubscriberQueueConfig {
         );
         extract_field!(
             config,
-            "visibilityTimeout",
-            subscriber_config.visibility_timeout,
+            "dispatchTimeoutMs",
+            subscriber_config.dispatch_timeout_ms,
             has_any_value,
             as_u64,
             |v| v
@@ -112,6 +119,21 @@ impl SubscriberQueueConfig {
             None
         }
     }
+
+    /// Resolves `dispatch_timeout_ms` into a `Duration`, treating `0` as
+    /// invalid (unbounded) since a zero-duration dispatch timeout would
+    /// abandon every delivery immediately.
+    pub fn dispatch_timeout(&self) -> Option<std::time::Duration> {
+        match self.dispatch_timeout_ms {
+            Some(0) => {
+                tracing::warn!(
+                    "'dispatchTimeoutMs' 0 is invalid; ignoring (dispatch stays unbounded)"
+                );
+                None
+            }
+            ms => ms.map(std::time::Duration::from_millis),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -125,7 +147,7 @@ mod tests {
             "type": "fifo",
             "maxRetries": 5,
             "concurrency": 20,
-            "visibilityTimeout": 3000,
+            "dispatchTimeoutMs": 3000,
             "delaySeconds": 10,
             "backoffType": "exponential",
             "backoffDelayMs": 2000
@@ -138,7 +160,7 @@ mod tests {
         assert_eq!(subscriber_config.queue_mode, Some("fifo".to_string()));
         assert_eq!(subscriber_config.max_retries, Some(5));
         assert_eq!(subscriber_config.concurrency, Some(20));
-        assert_eq!(subscriber_config.visibility_timeout, Some(3000));
+        assert_eq!(subscriber_config.dispatch_timeout_ms, Some(3000));
         assert_eq!(subscriber_config.delay_seconds, Some(10));
         assert_eq!(
             subscriber_config.backoff_type,
@@ -193,5 +215,26 @@ mod tests {
         let config = json!("not an object");
         let result = SubscriberQueueConfig::from_value(Some(&config));
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_dispatch_timeout_filters_zero() {
+        let unset = SubscriberQueueConfig::default();
+        assert_eq!(unset.dispatch_timeout(), None);
+
+        let zero = SubscriberQueueConfig {
+            dispatch_timeout_ms: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(zero.dispatch_timeout(), None);
+
+        let bounded = SubscriberQueueConfig {
+            dispatch_timeout_ms: Some(5000),
+            ..Default::default()
+        };
+        assert_eq!(
+            bounded.dispatch_timeout(),
+            Some(std::time::Duration::from_millis(5000))
+        );
     }
 }

--- a/engine/tests/common/queue_helpers.rs
+++ b/engine/tests/common/queue_helpers.rs
@@ -347,6 +347,35 @@ pub fn register_panicking_function(
         .register_function(function_id.to_string(), function);
 }
 
+/// Registers a test function whose invocation never completes: it records the
+/// invocation in `call_count`, then awaits `std::future::pending()` forever.
+/// Simulates a lost/wedged dispatch that only a per-invocation dispatch
+/// timeout can recover.
+pub fn register_wedging_function(
+    engine: &Arc<Engine>,
+    function_id: &str,
+    call_count: Arc<AtomicU64>,
+) {
+    let function = Function {
+        handler: Arc::new(move |_invocation_id, _input, _session, _metadata| {
+            let count = call_count.clone();
+            Box::pin(async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                std::future::pending::<FunctionResult<Option<Value>, iii::protocol::ErrorBody>>()
+                    .await
+            })
+        }),
+        _function_id: function_id.to_string(),
+        _description: Some("never-completing test handler".to_string()),
+        request_format: None,
+        response_format: None,
+        metadata: None,
+    };
+    engine
+        .functions
+        .register_function(function_id.to_string(), function);
+}
+
 /// Calls `engine.call("iii::durable::publish", ...)` with a topic and data payload,
 /// mapping the result to `anyhow::Result<()>`.
 pub async fn enqueue_to_topic(engine: &Engine, topic: &str, data: Value) -> anyhow::Result<()> {

--- a/engine/tests/queue_integration.rs
+++ b/engine/tests/queue_integration.rs
@@ -9,13 +9,13 @@ use tokio::sync::Mutex;
 
 use iii::{
     engine::Engine,
-    function::{Function, FunctionResult},
     workers::{queue::QueueWorker, traits::Worker},
 };
 
 use common::queue_helpers::{
     builtin_queue_config, create_engine_with_queue, dlq_count, enqueue, register_counting_function,
     register_failing_function, register_order_recording_function, register_slow_function,
+    register_wedging_function,
 };
 
 // ---------------------------------------------------------------------------
@@ -502,5 +502,134 @@ async fn start_paused_smoke_test() {
         elapsed >= Duration::from_secs(60),
         "tokio time should have auto-advanced by 60s, but elapsed was {:?}",
         elapsed
+    );
+}
+
+/// A queue config with a single-slot `standard` queue whose invocations are
+/// bounded by `dispatch_timeout_ms`. `max_retries: 0` dead-letters on the
+/// first nack, so a timed-out dispatch lands in the DLQ immediately.
+fn dispatch_timeout_queue_config() -> Value {
+    json!({
+        "queue_configs": {
+            "wedge": {
+                "type": "standard",
+                "concurrency": 1,
+                "max_retries": 0,
+                "dispatch_timeout_ms": 200,
+                "backoff_ms": 100,
+                "poll_interval_ms": 50
+            }
+        }
+    })
+}
+
+#[tokio::test]
+async fn dispatch_timeout_wedged_handler_dead_letters() {
+    // A handler that never returns (a lost/wedged dispatch) must not pin the
+    // message forever: the per-invocation dispatch timeout nacks it back
+    // through the normal retry→DLQ path. With max_retries=0 it dead-letters on
+    // the first timeout.
+    let engine = create_engine_with_queue(dispatch_timeout_queue_config()).await;
+
+    let call_count = Arc::new(AtomicU64::new(0));
+    register_wedging_function(&engine, "test::wedged", call_count.clone());
+
+    assert_eq!(dlq_count(&engine, "wedge").await, 0);
+
+    enqueue(&engine, "wedge", "test::wedged", json!({"wedge": true}))
+        .await
+        .expect("Enqueue should succeed");
+
+    // dispatch_timeout_ms=200 → the timeout fires, nacks, and (max_retries=0)
+    // routes straight to the DLQ well within this window.
+    tokio::time::sleep(Duration::from_millis(2000)).await;
+
+    assert_eq!(
+        call_count.load(Ordering::SeqCst),
+        1,
+        "The wedged handler should have been entered exactly once"
+    );
+    assert_eq!(
+        dlq_count(&engine, "wedge").await,
+        1,
+        "The timed-out message should have been dead-lettered"
+    );
+}
+
+#[tokio::test]
+async fn dispatch_timeout_releases_concurrency_slot() {
+    // Regression test for the reported symptom: a wedged invocation permanently
+    // consuming one of the queue's concurrency slots. With concurrency=1, a
+    // second (healthy) message can only run if the first wedged dispatch's slot
+    // is released when its dispatch timeout fires.
+    let engine = create_engine_with_queue(dispatch_timeout_queue_config()).await;
+
+    let wedge_count = Arc::new(AtomicU64::new(0));
+    let ok_count = Arc::new(AtomicU64::new(0));
+    register_wedging_function(&engine, "test::wedge", wedge_count.clone());
+    register_counting_function(&engine, "test::ok", ok_count.clone());
+
+    // Wedge first, then a healthy message — both on the single-slot queue.
+    enqueue(&engine, "wedge", "test::wedge", json!({"wedge": true}))
+        .await
+        .expect("Enqueue should succeed");
+    enqueue(&engine, "wedge", "test::ok", json!({"ok": true}))
+        .await
+        .expect("Enqueue should succeed");
+
+    tokio::time::sleep(Duration::from_millis(2000)).await;
+
+    assert_eq!(
+        ok_count.load(Ordering::SeqCst),
+        1,
+        "The healthy message must run once the wedged dispatch releases the slot"
+    );
+    assert_eq!(
+        dlq_count(&engine, "wedge").await,
+        1,
+        "The wedged message should have been dead-lettered after its timeout"
+    );
+}
+
+#[tokio::test]
+async fn dispatch_timeout_unset_leaves_dispatch_unbounded() {
+    // Regression guard for backward compatibility: with dispatch_timeout_ms
+    // unset, a slow-but-completing handler must still succeed (and not be
+    // dead-lettered) — the fix preserves the historical unbounded behaviour.
+    let config = json!({
+        "queue_configs": {
+            "unbounded": {
+                "type": "standard",
+                "concurrency": 1,
+                "max_retries": 0,
+                "poll_interval_ms": 50
+            }
+        }
+    });
+    let engine = create_engine_with_queue(config).await;
+
+    let timestamps = Arc::new(Mutex::new(Vec::new()));
+    register_slow_function(
+        &engine,
+        "test::slow",
+        Duration::from_millis(400),
+        timestamps.clone(),
+    );
+
+    enqueue(&engine, "unbounded", "test::slow", json!({"k": "v"}))
+        .await
+        .expect("Enqueue should succeed");
+
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    assert_eq!(
+        timestamps.lock().await.len(),
+        1,
+        "The slow handler should have completed exactly once"
+    );
+    assert_eq!(
+        dlq_count(&engine, "unbounded").await,
+        0,
+        "No message should be dead-lettered when dispatch timeout is unset"
     );
 }


### PR DESCRIPTION
## What

Adds an opt-in per-queue `dispatch_timeout_ms` to `queue_configs` entries. When set, a fn-queue invocation that has been dispatched but not completed within the deadline is abandoned and nacked back through the normal retry→DLQ path, releasing its concurrency slot. When unset (the default), behaviour is unchanged.

- New `Engine::call_with_timeout(function_id, input, Option<Duration>)`: bounds the invocation, and on elapse evicts the abandoned invocation from **both** tracking structures — the engine-global invocations map and the owning worker's in-flight set — then returns a `dispatch_timeout` error. `EngineTrait::call` now delegates to it with `None` (no behaviour change for other callers).
- The fn-queue consumer (`QueueWorker::spawn_consumer`) dispatches through it, so a timeout lands in the existing nack→retry→DLQ arm.
- `dispatch_timeout_ms: 0` is rejected at both the JSON schema (`range(min = 1)`) and the `config.yaml` seed path (`QueueModuleConfig::validate`), mirroring the existing `concurrency`/`max_priority` guards.
- Docs (config field, README, SKILL.md) document the new knob and its caveat: the timeout does **not** cancel work already running on a worker, so a retry can overlap the original attempt — bounded handlers must be idempotent.

## Why

Fixes #1927. When the engine dequeues a fn-queue message and the engine→worker dispatch is lost (or the worker never returns a result), the message's ack/nack was gated behind an unbounded await: the fn-queue consumer awaited the invocation with no deadline, and for a worker-routed (deferred) invocation the engine parked on a oneshot that only resolves on a worker reply or a detected disconnect. A half-open connection resolves neither. Since `max_retries`/`backoff_ms`/DLQ are nack-driven, a dispatched-but-uncompleted message was never retried — it stayed `unacked` until RabbitMQ's broker `consumer_timeout` (~30 min), pinned one of the queue's `concurrency` slots the whole time, and survived worker restarts because the engine holds the AMQP consumer.

## Notes

- **Scope:** covers named fn-queues for all adapters (their consumption funnels through the single dispatch site in `queue.rs`). The topic/subscriber (`durable:subscriber`) delivery path has the same unbounded-await exposure and is tracked separately (MOT-3801), along with centralizing the deadline in `InvocationHandler` and active worker-liveness detection.
- **At-least-once semantics unchanged:** a timed-out dispatch redelivers, same as a broker-timeout redelivery today — the knob just makes recovery configurable per queue instead of fixed at ~30 min.
- Also fixes an eager `unwrap_or(Uuid::new_v4())` in `handle_invocation` that would otherwise draw a discarded UUID per invocation now that the id is generated up front.

## Test plan

- [x] `cargo test -p iii --lib` — 1900 passed (includes 3 new `call_with_timeout` unit tests: deferred-eviction from the invocations map, worker in-flight set cleanup, `None` stays unbounded)
- [x] `cargo test -p iii --test queue_integration` — 15 passed (new: wedged handler dead-letters via timeout; timeout releases the concurrency slot for a queued healthy message; unset timeout leaves a slow handler unbounded)
- [x] Config: parse/default/`Some(0)`-rejection unit tests
- [x] `cargo fmt --check`, `cargo clippy` clean on touched files
- [ ] Manual repro against a real RabbitMQ broker (docker compose) with a wedged worker — verify `messages_unacknowledged` drains at the configured deadline instead of ~30 min

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-queue dispatch timeouts for function jobs via `dispatch_timeout_ms` (JSON: `dispatchTimeoutMs`), applied to dispatched work.
* **Bug Fixes**
  * Timed-out dispatches now follow the normal retry → dead-letter path instead of staying in-flight.
  * Improved timeout cleanup so queue capacity/concurrency is freed for subsequent jobs.
  * Long-running handlers remain unaffected when timeouts are unset (bounded only when configured).
* **Tests**
  * Added integration coverage for wedged dispatch recovery, retry/dead-letter behavior, capacity freeing, and unset-timeout success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->