### PR TITLE
feat(engine): durable trigger lifecycle + relevance-ranked functions::list

### DIFF
--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -609,6 +609,18 @@ impl Engine {
             } => {
                 tracing::debug!(id = %id, trigger_type = %trigger_type, function_id = %function_id, error = ?error, "TriggerRegistrationResult");
 
+                // Synchronous-ack path: a function-path registration is
+                // awaiting this result inside the registrator proxy (see
+                // `TriggerRegistrator for WorkerConnection`), and the trigger
+                // is NOT in the registry yet — insertion happens only after
+                // the ack. The pending map lives on the acking worker's own
+                // connection, so another worker cannot spoof a result (its
+                // map has no entry for this id).
+                if let Some((_, tx)) = worker.pending_trigger_acks.remove(id) {
+                    let _ = tx.send(error.clone());
+                    return Ok(());
+                }
+
                 let Some(trigger_entry) = self.trigger_registry.triggers.get(id) else {
                     tracing::debug!(
                         trigger_id = %id,
@@ -1868,14 +1880,25 @@ impl EngineTrait for Engine {
     }
 
     async fn register_trigger_type(&self, trigger_type: TriggerType) {
-        let trigger_type_id = &trigger_type.id;
+        // Re-registration is a REPLACE, never a skip: a reloaded in-process
+        // worker re-runs `initialize()` (reload.rs) and a reconnected SDK
+        // worker replays its trigger types, and each must swap in its LIVE
+        // registrator — the registry then re-delivers the type's existing
+        // registrations to it. Keeping the old registrator strands new (and
+        // replayed) bindings on a destroyed instance or dead connection:
+        // `engine::register_trigger` succeeds but the binding lands where the
+        // live fire path never reads, so it "lands but never fires". This
+        // matches the WS `Message::RegisterTriggerType` path, which has always
+        // replaced.
         if self
             .trigger_registry
             .trigger_types
-            .contains_key(trigger_type_id)
+            .contains_key(&trigger_type.id)
         {
-            tracing::warn!(trigger_type_id = %trigger_type_id, "Trigger type already registered");
-            return;
+            tracing::info!(
+                trigger_type_id = %trigger_type.id,
+                "Trigger type re-registered; replacing registrator and re-delivering its registrations"
+            );
         }
 
         let _ = self
@@ -2854,7 +2877,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_register_trigger_type_duplicate_is_noop() {
+    async fn test_register_trigger_type_duplicate_replaces() {
+        // Re-registration must REPLACE the type (registrator included): a
+        // reloaded in-process worker or a reconnected SDK worker re-registers
+        // its types, and keeping the old registrator would strand new bindings
+        // on a destroyed instance / dead connection ("lands but never fires").
         ensure_default_meter();
         let engine = Engine::new();
         let (tx, _rx) = mpsc::channel::<Outbound>(8);
@@ -2883,7 +2910,7 @@ mod tests {
             .trigger_types
             .get("duplicate")
             .expect("trigger type should remain registered");
-        assert_eq!(trigger_type._description, "first");
+        assert_eq!(trigger_type._description, "second");
     }
 
     #[tokio::test]

--- a/engine/src/trigger.rs
+++ b/engine/src/trigger.rs
@@ -511,6 +511,88 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn re_registering_a_type_replaces_registrator_and_replays_bindings() {
+        let registry = TriggerRegistry::new();
+
+        let a = Arc::new(ControlledRegistrator::new(false, false));
+        registry
+            .register_trigger_type(TriggerType::new("cron", "gen A", Box::new(a.clone()), None))
+            .await
+            .unwrap();
+        registry
+            .register_trigger(make_trigger("t1", "cron"))
+            .await
+            .unwrap();
+        assert_eq!(a.register_count.load(Ordering::SeqCst), 1);
+
+        // Provider reload / reconnect: the type re-registers with a NEW
+        // registrator. The existing binding must be re-delivered to it, and
+        // later registrations must route to it — never to the stale one.
+        let b = Arc::new(ControlledRegistrator::new(false, false));
+        registry
+            .register_trigger_type(TriggerType::new("cron", "gen B", Box::new(b.clone()), None))
+            .await
+            .unwrap();
+        assert_eq!(
+            b.register_count.load(Ordering::SeqCst),
+            1,
+            "existing binding replayed to the new registrator"
+        );
+
+        registry
+            .register_trigger(make_trigger("t2", "cron"))
+            .await
+            .unwrap();
+        assert_eq!(b.register_count.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            a.register_count.load(Ordering::SeqCst),
+            1,
+            "stale registrator receives nothing after replacement"
+        );
+    }
+
+    #[tokio::test]
+    async fn unregister_worker_reaps_only_connection_owned_triggers() {
+        let registry = TriggerRegistry::new();
+        registry
+            .register_trigger_type(make_trigger_type("evt"))
+            .await
+            .unwrap();
+        let worker = Uuid::new_v4();
+
+        // A worker's own lifecycle binding (Message::RegisterTrigger path).
+        let mut owned = make_trigger("t_owned", "evt");
+        owned.worker_id = Some(worker);
+        registry.register_trigger(owned).await.unwrap();
+
+        // A function-path registration (engine::register_trigger): durable,
+        // no connection owner.
+        registry
+            .register_trigger(make_trigger("t_durable", "evt"))
+            .await
+            .unwrap();
+
+        registry.unregister_worker(&worker).await;
+
+        assert!(
+            !registry.triggers.contains_key("t_owned"),
+            "connection-owned binding dies with its worker"
+        );
+        assert!(
+            registry.triggers.contains_key("t_durable"),
+            "durable binding survives the owner's disconnect GC"
+        );
+
+        // Explicit unregister is the durable binding's only teardown.
+        let removed = registry
+            .unregister_trigger("t_durable".to_string(), None)
+            .await
+            .unwrap();
+        assert!(removed);
+        assert!(!registry.triggers.contains_key("t_durable"));
+    }
+
+    #[tokio::test]
     async fn test_trigger_registry_register_trigger() {
         let registry = TriggerRegistry::new();
         registry

--- a/engine/src/worker_connections/mod.rs
+++ b/engine/src/worker_connections/mod.rs
@@ -11,7 +11,7 @@ use std::{collections::HashSet, str::FromStr, sync::Arc};
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use opentelemetry::KeyValue;
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::{RwLock, mpsc, oneshot};
 use uuid::Uuid;
 
 use schemars::JsonSchema;
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     engine::Outbound,
+    protocol::ErrorBody,
     workers::{observability::metrics::get_engine_metrics, worker::rbac_session::Session},
 };
 
@@ -240,6 +241,11 @@ pub struct WorkerConnection {
     pub pid: Option<u32>,
     pub isolation: Option<String>,
     pub session: Option<Arc<Session>>,
+    /// In-flight `Message::RegisterTrigger` deliveries awaiting this worker's
+    /// `TriggerRegistrationResult` ack, keyed by trigger id. Only ownerless
+    /// (function-path) registrations wait on an entry here — see the
+    /// `TriggerRegistrator` impl in `traits.rs`.
+    pub pending_trigger_acks: Arc<DashMap<String, oneshot::Sender<Option<ErrorBody>>>>,
 }
 
 impl WorkerConnection {
@@ -262,6 +268,7 @@ impl WorkerConnection {
             pid: None,
             isolation: None,
             session: None,
+            pending_trigger_acks: Arc::new(DashMap::new()),
         }
     }
 
@@ -284,6 +291,7 @@ impl WorkerConnection {
             pid: None,
             isolation: None,
             session: Some(Arc::new(session)),
+            pending_trigger_acks: Arc::new(DashMap::new()),
         }
     }
 

--- a/engine/src/worker_connections/traits.rs
+++ b/engine/src/worker_connections/traits.rs
@@ -8,6 +8,7 @@ use std::pin::Pin;
 
 use futures::Future;
 use serde_json::Value;
+use tokio::sync::oneshot;
 use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
@@ -21,15 +22,39 @@ use crate::{
     worker_connections::WorkerConnection,
 };
 
+/// How long a function-path registration waits for the registrator worker's
+/// `TriggerRegistrationResult` before failing open (legacy / stalled workers
+/// are still covered by the late-unwind path in `router_msg`).
+const REGISTRATION_ACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 impl TriggerRegistrator for WorkerConnection {
     fn register_trigger(
         &self,
         trigger: Trigger,
     ) -> Pin<Box<dyn Future<Output = Result<(), anyhow::Error>> + Send + '_>> {
         let sender = self.channel.clone();
+        let acks = self.pending_trigger_acks.clone();
 
         Box::pin(async move {
-            sender
+            // Ownerless registrations come from the `engine::register_trigger`
+            // FUNCTION, whose invocation runs in a spawned task — awaiting the
+            // worker's ack there is safe and makes validation failures
+            // synchronous (no id-then-unwind). Connection-owned registrations
+            // (`Message::RegisterTrigger`, a worker's own lifecycle bindings)
+            // are processed INLINE in the origin connection's read loop; a
+            // worker binding its own trigger type would deadlock on its ack,
+            // so those keep fire-and-forget + late unwind.
+            let await_ack = trigger.worker_id.is_none();
+            let trigger_id = trigger.id.clone();
+            let rx = if await_ack {
+                let (tx, rx) = oneshot::channel();
+                acks.insert(trigger_id.clone(), tx);
+                Some(rx)
+            } else {
+                None
+            };
+
+            let sent = sender
                 .send(Outbound::Protocol(Message::RegisterTrigger {
                     id: trigger.id,
                     trigger_type: trigger.trigger_type,
@@ -37,15 +62,31 @@ impl TriggerRegistrator for WorkerConnection {
                     config: trigger.config,
                     metadata: trigger.metadata,
                 }))
-                .await
-                .map_err(|err| {
-                    anyhow::anyhow!(
-                        "failed to send register trigger message through worker channel: {}",
-                        err
-                    )
-                })?;
+                .await;
+            if let Err(err) = sent {
+                acks.remove(&trigger_id);
+                return Err(anyhow::anyhow!(
+                    "failed to send register trigger message through worker channel: {}",
+                    err
+                ));
+            }
 
-            Ok(())
+            let Some(rx) = rx else { return Ok(()) };
+            match tokio::time::timeout(REGISTRATION_ACK_TIMEOUT, rx).await {
+                Ok(Ok(None)) => Ok(()),
+                Ok(Ok(Some(err))) => Err(anyhow::anyhow!("{}: {}", err.code, err.message)),
+                // Ack channel dropped (connection teardown) — fail open; the
+                // disconnect GC / late-unwind own the cleanup.
+                Ok(Err(_)) => Ok(()),
+                Err(_elapsed) => {
+                    acks.remove(&trigger_id);
+                    tracing::debug!(
+                        trigger_id = %trigger_id,
+                        "no TriggerRegistrationResult within timeout; accepting registration (late unwind still applies)"
+                    );
+                    Ok(())
+                }
+            }
         })
     }
 
@@ -157,32 +198,82 @@ mod tests {
         (WorkerConnection::new(tx), rx)
     }
 
-    #[tokio::test]
-    async fn register_trigger_sends_message() {
-        let (worker, mut rx) = make_worker();
-        let trigger = Trigger {
-            id: "t1".into(),
+    fn trigger(id: &str, worker_id: Option<Uuid>) -> Trigger {
+        Trigger {
+            id: id.into(),
             trigger_type: "http".into(),
             function_id: "fn1".into(),
             config: json!({}),
-            worker_id: None,
+            worker_id,
             metadata: None,
-        };
-        worker.register_trigger(trigger).await.unwrap();
-        let msg = rx.recv().await.unwrap();
-        match msg {
-            Outbound::Protocol(Message::RegisterTrigger {
-                id,
-                trigger_type,
-                function_id,
-                ..
-            }) => {
-                assert_eq!(id, "t1");
-                assert_eq!(trigger_type, "http");
-                assert_eq!(function_id, "fn1");
-            }
-            _ => panic!("Expected RegisterTrigger message"),
         }
+    }
+
+    /// Resolve the pending ack for `id` once the delivery message lands.
+    async fn ack(
+        worker: &WorkerConnection,
+        rx: &mut mpsc::Receiver<Outbound>,
+        id: &str,
+        error: Option<ErrorBody>,
+    ) {
+        let msg = rx.recv().await.expect("RegisterTrigger delivered");
+        assert!(matches!(
+            msg,
+            Outbound::Protocol(Message::RegisterTrigger { .. })
+        ));
+        let (_, tx) = worker
+            .pending_trigger_acks
+            .remove(id)
+            .expect("pending ack entry");
+        tx.send(error).unwrap();
+    }
+
+    #[tokio::test]
+    async fn register_trigger_sends_message_and_accepts_on_ok_ack() {
+        let (worker, mut rx) = make_worker();
+        let (res, ()) = tokio::join!(
+            worker.register_trigger(trigger("t1", None)),
+            ack(&worker, &mut rx, "t1", None),
+        );
+        res.unwrap();
+        assert!(worker.pending_trigger_acks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ownerless_registration_rejects_synchronously_on_error_ack() {
+        let (worker, mut rx) = make_worker();
+        let (res, ()) = tokio::join!(
+            worker.register_trigger(trigger("t_bad", None)),
+            ack(
+                &worker,
+                &mut rx,
+                "t_bad",
+                Some(ErrorBody::new(
+                    "trigger_registration_failed",
+                    "unknown model"
+                )),
+            ),
+        );
+        let err = res.unwrap_err().to_string();
+        assert!(err.contains("unknown model"), "got: {err}");
+        assert!(worker.pending_trigger_acks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn connection_owned_registration_stays_fire_and_forget() {
+        let (worker, mut rx) = make_worker();
+        // A worker's own lifecycle binding: returns as soon as the delivery is
+        // queued, never waits on (or creates) a pending ack.
+        worker
+            .register_trigger(trigger("t_owned", Some(Uuid::new_v4())))
+            .await
+            .unwrap();
+        assert!(worker.pending_trigger_acks.is_empty());
+        let msg = rx.recv().await.unwrap();
+        assert!(matches!(
+            msg,
+            Outbound::Protocol(Message::RegisterTrigger { .. })
+        ));
     }
 
     #[tokio::test]

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -462,6 +462,23 @@ impl EngineFunctionsWorker {
             .any(|h| h.to_lowercase().contains(&lowered))
     }
 
+    /// Rank a search hit by match quality: 0 = the needle anchors the id (a
+    /// `::` segment equals it, or the id starts with it), 1 = the needle is a
+    /// substring of the id, 2 = it only matched the description. Sorting by
+    /// this keeps `state::*` above functions that merely mention "state" in
+    /// their description — models read search results top-down, and pure
+    /// alphabetical order buried the relevant hits under incidental ones.
+    fn search_rank(function_id: &str, needle_lowered: &str) -> u8 {
+        let id = function_id.to_lowercase();
+        if id.starts_with(needle_lowered) || id.split("::").any(|seg| seg == needle_lowered) {
+            0
+        } else if id.contains(needle_lowered) {
+            1
+        } else {
+            2
+        }
+    }
+
     fn config_summary(config: &Value) -> String {
         let raw = serde_json::to_string(config).unwrap_or_else(|_| "{}".to_string());
         if raw.chars().count() <= CONFIG_SUMMARY_MAX_LEN {
@@ -1169,7 +1186,21 @@ impl EngineFunctionsWorker {
             });
         }
 
-        functions.sort_by(|a, b| a.function_id.cmp(&b.function_id));
+        match input.search.as_deref().filter(|s| !s.is_empty()) {
+            // Rank by match quality so id-anchored hits (`state::get`) sort
+            // above functions that merely mention the needle in their
+            // description; alphabetical within a tier.
+            Some(search) => {
+                let needle = search.to_lowercase();
+                functions.sort_by_cached_key(|f| {
+                    (
+                        Self::search_rank(&f.function_id, &needle),
+                        f.function_id.clone(),
+                    )
+                });
+            }
+            None => functions.sort_by(|a, b| a.function_id.cmp(&b.function_id)),
+        }
 
         FunctionResult::Success(FunctionsListResult { functions })
     }
@@ -1428,11 +1459,6 @@ impl EngineFunctionsWorker {
 
         let id = uuid::Uuid::new_v4().to_string();
 
-        let worker_id = input
-            .caller_worker_id
-            .as_deref()
-            .and_then(|w| uuid::Uuid::parse_str(w).ok());
-
         // Prefix parity with the `Message::RegisterTrigger` path: a prefixed
         // session's functions are stored under `prefix::id`, so the trigger
         // must bind to the prefixed target or firing would miss the real
@@ -1449,12 +1475,20 @@ impl EngineFunctionsWorker {
         // the `Trigger` and is delivered to the handler as a distinct argument
         // at fire time (see the trigger-fire paths) — no proxy function, so
         // nothing to leak or GC, and the payload is left untouched.
+        //
+        // Ownership: deliberately NOT stamped with the caller's worker id.
+        // Function-path registrations are durable engine-side state ("when X
+        // happens, do Y"), removed only by explicit `engine::unregister_trigger`
+        // — a CLI's millisecond-lived connection or an agent proxy's restart
+        // must not reap them. A worker's own lifecycle bindings go through the
+        // `Message::RegisterTrigger` path, which keeps connection ownership and
+        // the disconnect GC.
         let trigger = Trigger {
             id: id.clone(),
             trigger_type: input.trigger_type,
             function_id,
             config: input.config,
-            worker_id,
+            worker_id: None,
             metadata: input.metadata,
         };
 
@@ -2165,6 +2199,39 @@ mod tests {
     }
 
     // ── functions_list service tests ────────────────────────────────────
+
+    #[tokio::test]
+    async fn functions_list_search_ranks_id_hits_above_description_hits() {
+        let (engine, module) = setup_engine_and_module();
+
+        // Alphabetically, coder::move sorts first — but it only matches
+        // "state" via its description and must rank LAST.
+        register_simple_function(&engine, "coder::move", Some("Move files; preserves state."));
+        register_simple_function(&engine, "restate::apply", None); // id substring
+        register_simple_function(&engine, "state::get", None); // id segment
+        register_simple_function(&engine, "unrelated::fn", None); // no match
+
+        let result = module
+            .functions_list(
+                FunctionsListInput {
+                    search: Some("state".to_string()),
+                    ..Default::default()
+                },
+                None,
+            )
+            .await;
+        match result {
+            FunctionResult::Success(result) => {
+                let ids: Vec<&str> = result
+                    .functions
+                    .iter()
+                    .map(|f| f.function_id.as_str())
+                    .collect();
+                assert_eq!(ids, vec!["state::get", "restate::apply", "coder::move"]);
+            }
+            _ => panic!("expected functions_list success"),
+        }
+    }
 
     #[tokio::test]
     async fn functions_list_filters_internal_by_default() {
@@ -3255,14 +3322,16 @@ mod tests {
         };
 
         // The trigger binds DIRECTLY to the target — no proxy function exists —
-        // and carries the metadata + worker scope.
+        // and carries the metadata. Function-path registrations are durable:
+        // the caller's connection is deliberately NOT recorded as owner, so
+        // the caller's disconnect can never reap the binding.
         let trig = engine
             .trigger_registry
             .triggers
             .get(&id)
             .expect("trigger registered");
         assert_eq!(trig.function_id, "test::target");
-        assert_eq!(trig.worker_id, Some(wid));
+        assert_eq!(trig.worker_id, None);
         assert_eq!(trig.metadata, Some(meta.clone()));
 
         // Fire the way a registrator does: metadata travels explicitly, NOT


### PR DESCRIPTION
> Stacked on #1928 (`feat/engine-register-trigger`). Until that base merges, the diff here also shows #1928's commits — the changes below are what's new on this branch (`engine/src/{engine/mod,trigger,worker_connections/mod,worker_connections/traits,workers/engine_fn/mod}.rs`).

## Durable trigger lifecycle

Registrator replacement, durable function-path bindings, and synchronous registration acks.

- **`register_trigger_type` replaces the registrator and replays bindings.** Re-registration now swaps in the new registrator and replays existing bindings to it. Previously a stale registrator kept the type, so after a provider reloaded, new bindings landed but never fired.
- **`engine::register_trigger` (function path) bindings are durable.** We stop stamping the caller's connection as owner. These bindings are engine-side state removed only by an explicit `engine::unregister_trigger`, so a CLI's millisecond-lived connection or an agent proxy restart no longer reaps them. A worker's own lifecycle bindings (`Message::RegisterTrigger`) still keep connection ownership and disconnect GC.
- **Ownerless registrations ack synchronously.** The `WorkerConnection` registrator awaits the worker's `TriggerRegistrationResult` (10s fail-open timeout) so a validation failure rejects the call synchronously instead of returning an id and unwinding later. The pending-ack map lives on the acking connection, which also blocks cross-worker spoofing. Connection-owned registrations keep fire-and-forget delivery — they're processed inline in the origin connection's read loop, where awaiting a self-binding ack would deadlock.

## Relevance-ranked `functions::list` search

Search hits were sorted alphabetically, so a function that merely mentions the needle in its description (`coder::move` for "state") outranked every `state::*` function. Models read results top-down — small local models especially anchor on the first entries — so relevant hits got buried.

Now ranked by match quality: id-anchored matches first (a `::` segment equals the needle, or the id starts with it), id substrings second, description-only matches last; alphabetical within each tier. No filtering change — the same functions return, just reordered. Listing without a search term stays pure alphabetical.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results are now ranked more intelligently, surfacing better matches higher when you search for functions.
  * Trigger registration now supports smoother re-registration, keeping the latest version active and replaying existing bindings.

* **Bug Fixes**
  * Improved handling of trigger registration acknowledgements so successful, failed, and timed-out registrations are processed more reliably.
  * Worker cleanup now preserves durable triggers while removing only worker-owned ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->