### PR TITLE
fix: consent gate

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -11,6 +11,11 @@
     var STORAGE_KEY = 'iii_cookie_consent';
     window.iiiLoadGTM = function () {
       if (window.__iiiGTMLoaded) return;
+      try {
+        if (localStorage.getItem(STORAGE_KEY) !== 'accepted') return;
+      } catch (_) {
+        return;
+      }
       window.__iiiGTMLoaded = true;
       (function (w, d, s, l, i) {
         w[l] = w[l] || [];
@@ -23,9 +28,7 @@
         f.parentNode.insertBefore(j, f);
       })(window, document, 'script', 'dataLayer', 'GTM-N8DCTFB8');
     };
-    try {
-      if (localStorage.getItem(STORAGE_KEY) === 'accepted') window.iiiLoadGTM();
-    } catch (_) {}
+    window.iiiLoadGTM();
   })();
 </script>
 <!-- End Google Tag Manager -->
@@ -58,6 +61,11 @@
   var STORAGE_KEY = 'iii_cookie_consent';
   window.iiiLoadCommonRoomSignals = function () {
     if (typeof window.signals !== 'undefined') return;
+    try {
+      if (localStorage.getItem(STORAGE_KEY) !== 'accepted') return;
+    } catch (_) {
+      return;
+    }
     var script = document.createElement('script');
     script.src = 'https://cdn.cr-relay.com/v1/site/da18833a-8f00-4ad0-9833-6608b59a713a/signals.js';
     script.async = true;
@@ -81,9 +89,7 @@
       window.signals.form({ email: email });
     } catch (_) {}
   };
-  try {
-    if (localStorage.getItem(STORAGE_KEY) === 'accepted') window.iiiLoadCommonRoomSignals();
-  } catch (_) {}
+  window.iiiLoadCommonRoomSignals();
 })();
 </script>
 <script src="/posthog-consent.js"></script>

--- a/website/index.html
+++ b/website/index.html
@@ -5,28 +5,41 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>iii — Three primitives. Zero integration cost.</title>
 
-<!-- Google Tag Manager -->
+<!-- Google Tag Manager: loads only after analytics consent (see cookie banner below) -->
 <script>
-  (function (w, d, s, l, i) {
-    w[l] = w[l] || [];
-    w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
-    var f = d.getElementsByTagName(s)[0],
-      j = d.createElement(s),
-      dl = l != 'dataLayer' ? '&l=' + l : '';
-    j.async = true;
-    j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-    f.parentNode.insertBefore(j, f);
-  })(window, document, 'script', 'dataLayer', 'GTM-N8DCTFB8');
+  (function () {
+    var STORAGE_KEY = 'iii_cookie_consent';
+    window.iiiLoadGTM = function () {
+      if (window.__iiiGTMLoaded) return;
+      window.__iiiGTMLoaded = true;
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-N8DCTFB8');
+    };
+    try {
+      if (localStorage.getItem(STORAGE_KEY) === 'accepted') window.iiiLoadGTM();
+    } catch (_) {}
+  })();
 </script>
 <!-- End Google Tag Manager -->
 
 <!-- Analytics: thin wrapper that pushes named events to the GTM dataLayer.
-     Safe no-op if GTM is blocked. Consumers call iiiTrack(name, { ...params }). -->
+     No-op until analytics consent is accepted, and safe no-op if GTM is blocked.
+     Consumers call iiiTrack(name, { ...params }). -->
 <script>
   (function () {
+    var STORAGE_KEY = 'iii_cookie_consent';
     window.dataLayer = window.dataLayer || [];
     window.iiiTrack = function (eventName, params) {
       try {
+        if (localStorage.getItem(STORAGE_KEY) !== 'accepted') return;
         var payload = { event: eventName };
         if (params && typeof params === 'object') {
           for (var k in params) {
@@ -4531,6 +4544,7 @@
         localStorage.setItem(STORAGE_KEY, 'accepted');
       } catch (_) {}
       banner.remove();
+      if (window.iiiLoadGTM) window.iiiLoadGTM();
       if (window.iiiLoadCommonRoomSignals) window.iiiLoadCommonRoomSignals();
       if (window.iiiLoadPostHog) window.iiiLoadPostHog();
     });

--- a/website/manifesto.html
+++ b/website/manifesto.html
@@ -11,6 +11,11 @@
         var STORAGE_KEY = "iii_cookie_consent";
         window.iiiLoadGTM = function () {
           if (window.__iiiGTMLoaded) return;
+          try {
+            if (localStorage.getItem(STORAGE_KEY) !== "accepted") return;
+          } catch (_) {
+            return;
+          }
           window.__iiiGTMLoaded = true;
           (function (w, d, s, l, i) {
             w[l] = w[l] || [];
@@ -23,9 +28,7 @@
             f.parentNode.insertBefore(j, f);
           })(window, document, "script", "dataLayer", "GTM-N8DCTFB8");
         };
-        try {
-          if (localStorage.getItem(STORAGE_KEY) === "accepted") window.iiiLoadGTM();
-        } catch (_) {}
+        window.iiiLoadGTM();
       })();
     </script>
     <!-- End Google Tag Manager -->
@@ -36,6 +39,11 @@
         var STORAGE_KEY = "iii_cookie_consent";
         window.iiiLoadCommonRoomSignals = function () {
           if (typeof window.signals !== "undefined") return;
+          try {
+            if (localStorage.getItem(STORAGE_KEY) !== "accepted") return;
+          } catch (_) {
+            return;
+          }
           var script = document.createElement("script");
           script.src =
             "https://cdn.cr-relay.com/v1/site/da18833a-8f00-4ad0-9833-6608b59a713a/signals.js";
@@ -60,9 +68,7 @@
             window.signals.form({ email: email });
           } catch (_) {}
         };
-        try {
-          if (localStorage.getItem(STORAGE_KEY) === "accepted") window.iiiLoadCommonRoomSignals();
-        } catch (_) {}
+        window.iiiLoadCommonRoomSignals();
       })();
     </script>
     <script src="/posthog-consent.js"></script>

--- a/website/manifesto.html
+++ b/website/manifesto.html
@@ -5,18 +5,28 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>iii / manifesto</title>
 
-    <!-- Google Tag Manager -->
+    <!-- Google Tag Manager: loads only after analytics consent (see cookie banner below) -->
     <script>
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != "dataLayer" ? "&l=" + l : "";
-        j.async = true;
-        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-        f.parentNode.insertBefore(j, f);
-      })(window, document, "script", "dataLayer", "GTM-N8DCTFB8");
+      (function () {
+        var STORAGE_KEY = "iii_cookie_consent";
+        window.iiiLoadGTM = function () {
+          if (window.__iiiGTMLoaded) return;
+          window.__iiiGTMLoaded = true;
+          (function (w, d, s, l, i) {
+            w[l] = w[l] || [];
+            w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+            var f = d.getElementsByTagName(s)[0],
+              j = d.createElement(s),
+              dl = l != "dataLayer" ? "&l=" + l : "";
+            j.async = true;
+            j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+            f.parentNode.insertBefore(j, f);
+          })(window, document, "script", "dataLayer", "GTM-N8DCTFB8");
+        };
+        try {
+          if (localStorage.getItem(STORAGE_KEY) === "accepted") window.iiiLoadGTM();
+        } catch (_) {}
+      })();
     </script>
     <!-- End Google Tag Manager -->
 
@@ -571,6 +581,7 @@
               localStorage.setItem(STORAGE_KEY, "accepted");
             } catch (_) {}
             banner.remove();
+            if (window.iiiLoadGTM) window.iiiLoadGTM();
             if (window.iiiLoadCommonRoomSignals) window.iiiLoadCommonRoomSignals();
             if (window.iiiLoadPostHog) window.iiiLoadPostHog();
           });

--- a/website/posthog-consent.js
+++ b/website/posthog-consent.js
@@ -5,6 +5,11 @@
 
   window.iiiLoadPostHog = function () {
     if (window.__iiiPostHogLoaded) return;
+    try {
+      if (localStorage.getItem(STORAGE_KEY) !== 'accepted') return;
+    } catch (_) {
+      return;
+    }
     window.__iiiPostHogLoaded = true;
 
     !(function (t, e) {
@@ -69,7 +74,5 @@
     });
   };
 
-  try {
-    if (localStorage.getItem(STORAGE_KEY) === 'accepted') window.iiiLoadPostHog();
-  } catch (_) {}
+  window.iiiLoadPostHog();
 })();

--- a/website/privacy-policy.html
+++ b/website/privacy-policy.html
@@ -11,6 +11,11 @@
         var STORAGE_KEY = "iii_cookie_consent";
         window.iiiLoadGTM = function () {
           if (window.__iiiGTMLoaded) return;
+          try {
+            if (localStorage.getItem(STORAGE_KEY) !== "accepted") return;
+          } catch (_) {
+            return;
+          }
           window.__iiiGTMLoaded = true;
           (function (w, d, s, l, i) {
             w[l] = w[l] || [];
@@ -23,9 +28,7 @@
             f.parentNode.insertBefore(j, f);
           })(window, document, "script", "dataLayer", "GTM-N8DCTFB8");
         };
-        try {
-          if (localStorage.getItem(STORAGE_KEY) === "accepted") window.iiiLoadGTM();
-        } catch (_) {}
+        window.iiiLoadGTM();
       })();
     </script>
     <!-- End Google Tag Manager -->
@@ -36,6 +39,11 @@
         var STORAGE_KEY = "iii_cookie_consent";
         window.iiiLoadCommonRoomSignals = function () {
           if (typeof window.signals !== "undefined") return;
+          try {
+            if (localStorage.getItem(STORAGE_KEY) !== "accepted") return;
+          } catch (_) {
+            return;
+          }
           var script = document.createElement("script");
           script.src =
             "https://cdn.cr-relay.com/v1/site/da18833a-8f00-4ad0-9833-6608b59a713a/signals.js";
@@ -60,9 +68,7 @@
             window.signals.form({ email: email });
           } catch (_) {}
         };
-        try {
-          if (localStorage.getItem(STORAGE_KEY) === "accepted") window.iiiLoadCommonRoomSignals();
-        } catch (_) {}
+        window.iiiLoadCommonRoomSignals();
       })();
     </script>
     <script src="/posthog-consent.js"></script>

--- a/website/privacy-policy.html
+++ b/website/privacy-policy.html
@@ -5,18 +5,28 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>iii / privacy policy</title>
 
-    <!-- Google Tag Manager -->
+    <!-- Google Tag Manager: loads only after analytics consent (see cookie banner below) -->
     <script>
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != "dataLayer" ? "&l=" + l : "";
-        j.async = true;
-        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-        f.parentNode.insertBefore(j, f);
-      })(window, document, "script", "dataLayer", "GTM-N8DCTFB8");
+      (function () {
+        var STORAGE_KEY = "iii_cookie_consent";
+        window.iiiLoadGTM = function () {
+          if (window.__iiiGTMLoaded) return;
+          window.__iiiGTMLoaded = true;
+          (function (w, d, s, l, i) {
+            w[l] = w[l] || [];
+            w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+            var f = d.getElementsByTagName(s)[0],
+              j = d.createElement(s),
+              dl = l != "dataLayer" ? "&l=" + l : "";
+            j.async = true;
+            j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+            f.parentNode.insertBefore(j, f);
+          })(window, document, "script", "dataLayer", "GTM-N8DCTFB8");
+        };
+        try {
+          if (localStorage.getItem(STORAGE_KEY) === "accepted") window.iiiLoadGTM();
+        } catch (_) {}
+      })();
     </script>
     <!-- End Google Tag Manager -->
 
@@ -599,6 +609,7 @@
               localStorage.setItem(STORAGE_KEY, "accepted");
             } catch (_) {}
             banner.remove();
+            if (window.iiiLoadGTM) window.iiiLoadGTM();
             if (window.iiiLoadCommonRoomSignals) window.iiiLoadCommonRoomSignals();
             if (window.iiiLoadPostHog) window.iiiLoadPostHog();
           });


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

## Why

<!-- Motivation or context -->

## Notes

<!-- Anything reviewers should know (breaking changes, migration steps, etc.) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics now load only after analytics cookie consent is accepted, replacing always-on embeds across key site pages.
  * The cookie consent banner now triggers the GTM loader immediately after acceptance, before other analytics initialization.
  * Common Room and PostHog initialization were updated to self-check consent and safely no-op when storage access is blocked or consent isn’t granted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->