### PR TITLE
fix(engine): accept publish metadata keys in worker manifest (iii/deploy/manifest)

### DIFF
--- a/.skill-check.yaml
+++ b/.skill-check.yaml
@@ -12,6 +12,7 @@ docs:
     - "docs/0-16-0/**"
     - "docs/0-17-0/**"
     - "docs/0-18-0/**"
+    - "docs/RELEASING.md"
     - "docs/changelog/**"
     - "docs/**/changelog/**"
     - "docs/next/tutorials/linkly/_workspace/**"

--- a/crates/iii-worker/src/cli/bundle_download.rs
+++ b/crates/iii-worker/src/cli/bundle_download.rs
@@ -1223,50 +1223,47 @@ pub fn validate_bundle_manifest(
         }
     }
 
-    // Reject runtime.base_image. Bundles use the engine-allowlisted
-    // base image, not whatever the publisher picks.
-    if doc
-        .get("runtime")
-        .and_then(|r| r.get("base_image"))
-        .is_some()
-    {
-        return Err(WorkerOpError::BundleManifestRejected {
-            field: "runtime.base_image".into(),
-            reason: "bundle workers cannot override the base image; \
-                     use a binary or OCI worker if you need a custom rootfs"
-                .into(),
-        });
+    // runtime.base_image may only name an engine-preset image ref
+    // verbatim (e.g. docker.io/iiidev/python:latest) — that's how a
+    // non-node bundle picks its rootfs now that runtime.kind is
+    // deprecated. Anything else stays rejected: bundles must not pull
+    // a publisher-controlled rootfs.
+    if let Some(img) = doc.get("runtime").and_then(|r| r.get("base_image")) {
+        let is_preset_ref = img
+            .as_str()
+            .map(str::trim)
+            .is_some_and(crate::sandbox_daemon::catalog::is_preset_ref);
+        if !is_preset_ref {
+            return Err(WorkerOpError::BundleManifestRejected {
+                field: "runtime.base_image".into(),
+                reason: "bundle workers may only set runtime.base_image to an \
+                         engine-preset image ref (docker.io/iiidev/python:latest \
+                         or docker.io/iiidev/node:latest); use a binary or OCI \
+                         worker if you need a custom rootfs"
+                    .into(),
+            });
+        }
     }
 
-    // Reject scripts.setup and scripts.install — they would execute
-    // publisher-supplied shell during install.
-    if let Some(scripts) = doc.get("scripts") {
-        if scripts
+    // Reject scripts.setup (OS provisioning belongs in the preset image).
+    // scripts.install is ALLOWED: it runs inside the sandbox VM exactly
+    // like scripts.start (same publisher-shell trust context), and the
+    // boot script's /var/.iii-prepared guard makes it run once — which
+    // python bundles need for pip/browser bootstrap that can't be
+    // vendored per-arch into the archive.
+    if let Some(scripts) = doc.get("scripts")
+        && scripts
             .get("setup")
             .and_then(|v| v.as_str())
             .map(str::trim)
             .is_some_and(|s| !s.is_empty())
-        {
-            return Err(WorkerOpError::BundleManifestRejected {
-                field: "scripts.setup".into(),
-                reason: "bundle manifests must not declare scripts.setup; \
-                         pre-build the bundle and ship it ready-to-run"
-                    .into(),
-            });
-        }
-        if scripts
-            .get("install")
-            .and_then(|v| v.as_str())
-            .map(str::trim)
-            .is_some_and(|s| !s.is_empty())
-        {
-            return Err(WorkerOpError::BundleManifestRejected {
-                field: "scripts.install".into(),
-                reason: "bundle manifests must not declare scripts.install; \
-                         vendor dependencies into the bundle"
-                    .into(),
-            });
-        }
+    {
+        return Err(WorkerOpError::BundleManifestRejected {
+            field: "scripts.setup".into(),
+            reason: "bundle manifests must not declare scripts.setup; \
+                     pre-build the bundle and ship it ready-to-run"
+                .into(),
+        });
     }
 
     // scripts.start is the only command we will execute. Must be a
@@ -1711,18 +1708,14 @@ mod tests {
     }
 
     #[test]
-    fn validate_bundle_manifest_rejects_install() {
+    fn validate_bundle_manifest_accepts_install() {
         let tmp = tempfile::tempdir().unwrap();
         write_manifest(
             tmp.path(),
-            "name: foo\nscripts:\n  install: npm i\n  start: node x.js\n",
+            "name: foo\nscripts:\n  install: pip install -e .\n  start: python -m src.main\n",
         );
-        match validate_bundle_manifest(tmp.path(), "foo") {
-            Err(WorkerOpError::BundleManifestRejected { field, .. }) => {
-                assert_eq!(field, "scripts.install");
-            }
-            other => panic!("expected BundleManifestRejected scripts.install, got {other:?}"),
-        }
+        let cmd = validate_bundle_manifest(tmp.path(), "foo").expect("install allowed");
+        assert_eq!(cmd, "python -m src.main");
     }
 
     #[test]
@@ -1738,6 +1731,17 @@ mod tests {
             }
             other => panic!("expected BundleManifestRejected runtime.base_image, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn validate_bundle_manifest_accepts_preset_base_image() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            tmp.path(),
+            "name: foo\nruntime:\n  base_image: docker.io/iiidev/python:latest\nscripts:\n  start: python -m src.main\n",
+        );
+        let cmd = validate_bundle_manifest(tmp.path(), "foo").expect("preset ref accepted");
+        assert_eq!(cmd, "python -m src.main");
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/bundle_download.rs
+++ b/crates/iii-worker/src/cli/bundle_download.rs
@@ -1223,23 +1223,22 @@ pub fn validate_bundle_manifest(
         }
     }
 
-    // runtime.base_image may only name an engine-preset image ref
-    // verbatim (e.g. docker.io/iiidev/python:latest) — that's how a
-    // non-node bundle picks its rootfs now that runtime.kind is
-    // deprecated. Anything else stays rejected: bundles must not pull
-    // a publisher-controlled rootfs.
+    // runtime.base_image may name any OCI image ref — the rootfs is
+    // publisher-chosen, same trust context as scripts.start (which we
+    // already execute). First-gate the characters here so a bad ref
+    // fails at install time instead of silently falling back to the
+    // kind default at start (see project.rs::load_project_info).
     if let Some(img) = doc.get("runtime").and_then(|r| r.get("base_image")) {
-        let is_preset_ref = img
+        let plausible = img
             .as_str()
             .map(str::trim)
-            .is_some_and(crate::sandbox_daemon::catalog::is_preset_ref);
-        if !is_preset_ref {
+            .is_some_and(super::project::is_plausible_image_ref);
+        if !plausible {
             return Err(WorkerOpError::BundleManifestRejected {
                 field: "runtime.base_image".into(),
-                reason: "bundle workers may only set runtime.base_image to an \
-                         engine-preset image ref (docker.io/iiidev/python:latest \
-                         or docker.io/iiidev/node:latest); use a binary or OCI \
-                         worker if you need a custom rootfs"
+                reason: "runtime.base_image must be a plausible OCI image \
+                         reference (alphanumerics and `._-/:@+`), e.g. \
+                         \"oven/bun:1\""
                     .into(),
             });
         }
@@ -1719,11 +1718,22 @@ mod tests {
     }
 
     #[test]
-    fn validate_bundle_manifest_rejects_runtime_base_image() {
+    fn validate_bundle_manifest_accepts_any_base_image() {
         let tmp = tempfile::tempdir().unwrap();
         write_manifest(
             tmp.path(),
-            "name: foo\nruntime:\n  base_image: evil/img:latest\nscripts:\n  start: node x.js\n",
+            "name: foo\nruntime:\n  base_image: oven/bun:1\nscripts:\n  start: node x.js\n",
+        );
+        let cmd = validate_bundle_manifest(tmp.path(), "foo").expect("custom ref accepted");
+        assert_eq!(cmd, "node x.js");
+    }
+
+    #[test]
+    fn validate_bundle_manifest_rejects_implausible_base_image() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            tmp.path(),
+            "name: foo\nruntime:\n  base_image: \"bad image!\"\nscripts:\n  start: node x.js\n",
         );
         match validate_bundle_manifest(tmp.path(), "foo") {
             Err(WorkerOpError::BundleManifestRejected { field, .. }) => {

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -352,7 +352,19 @@ echo "iii: workspace ready; deps mounted VM-local from $DEPS_ROOT" >&2"#
     // restart/shutdown RPC handling. When no control port is set,
     // iii-init takes its legacy path and just supervises the one
     // process until it exits.
-    parts.push(format!("{} && exec {}", env_exports, project.run_cmd));
+    // `exec` binds tighter than `&&`/`;`: a compound run_cmd like
+    // "pip install -e . && python -m src.main" would parse as
+    // `exec pip install -e .` — the shell is replaced by the FIRST
+    // command, the rest never runs, and the VM silently tears down when
+    // it exits. Re-quote the whole command into a single `sh -c` word so
+    // exec applies to the entire scripts.start string; sh tail-execs
+    // simple commands anyway, so single-command starts keep their PID
+    // semantics.
+    let quoted_run_cmd = format!("'{}'", project.run_cmd.replace('\'', "'\\''"));
+    parts.push(format!(
+        "{} && exec /bin/sh -c {}",
+        env_exports, quoted_run_cmd
+    ));
     parts.join("\n")
 }
 

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -324,8 +324,8 @@ pub async fn handle_bundle_add(
         return 1;
     }
 
-    // 4. Strict manifest validation: rejects scripts.setup, scripts.install,
-    //    runtime.base_image; enforces name match + non-empty scripts.start.
+    // 4. Strict manifest validation: rejects scripts.setup; enforces
+    //    name match + non-empty scripts.start.
     if let Err(e) = super::bundle_download::validate_bundle_manifest(&staging_dir, worker_name) {
         eprintln!("{} {}", "error:".red(), e);
         return 1;

--- a/crates/iii-worker/src/cli/project.rs
+++ b/crates/iii-worker/src/cli/project.rs
@@ -252,7 +252,8 @@ pub fn validate_manifest_keys(
     Err(format!(
         "unknown key(s) in {}: [{}]. Supported fields are: name, description, \
          runtime.base_image, scripts.(setup|install|start), env, dependencies, \
-         resources.(cpus|memory).",
+         resources.(cpus|memory), plus the registry publish metadata keys \
+         (iii, deploy, manifest) which the engine accepts and ignores.",
         manifest_path.display(),
         unknown.join(", "),
     ))
@@ -1037,6 +1038,24 @@ resources:
             !deprecated.iter().any(|d| d == "description"),
             "description must not be deprecated: {deprecated:?}"
         );
+    }
+
+    #[test]
+    fn validate_keys_accepts_publish_metadata_keys() {
+        // iii/deploy/manifest are release-CI metadata carried by every worker
+        // in the workers repo; `worker add` must accept them (neither unknown
+        // nor deprecated) so one manifest satisfies both validators.
+        let d = doc("iii: v1\nname: w\ndeploy: binary\nmanifest: Cargo.toml\n");
+        assert!(validate_manifest_keys(&d, &dummy_manifest_path()).is_ok());
+        let m = super::super::worker_manifest::WorkerManifest::from_value(&d).unwrap();
+        let (unknown, deprecated) = m.classify_keys();
+        assert!(unknown.is_empty(), "got: {unknown:?}");
+        for key in ["iii", "deploy", "manifest"] {
+            assert!(
+                !deprecated.iter().any(|x| x == key),
+                "`{key}` must not be deprecated: {deprecated:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/worker_manifest.rs
+++ b/crates/iii-worker/src/cli/worker_manifest.rs
@@ -94,6 +94,25 @@ pub struct WorkerManifest {
     )]
     pub resources: Option<ResourcesSection>,
 
+    // Registry publish metadata. The workers-repo release CI requires these
+    // keys (deploy/manifest pick the release artifact type and version
+    // source); the engine accepts them so one iii.worker.yaml can satisfy
+    // both validators, but never reads them at add/start time.
+    #[schemars(
+        description = "Registry publish metadata: manifest format marker, e.g. `v1`. Accepted and ignored by the engine."
+    )]
+    pub iii: Option<String>,
+
+    #[schemars(
+        description = "Registry publish metadata: release artifact type (`binary` | `image` | `bundle`), consumed by the workers-repo release CI. Accepted and ignored by the engine."
+    )]
+    pub deploy: Option<String>,
+
+    #[schemars(
+        description = "Registry publish metadata: file the release version is read from (e.g. `Cargo.toml`, `package.json`, `pyproject.toml`), consumed by the workers-repo release CI. Accepted and ignored by the engine."
+    )]
+    pub manifest: Option<String>,
+
     #[schemars(
         with = "Option<JsonValue>",
         description = "DEPRECATED — set per-worker config directly in your project's config.yaml entry instead. Copied verbatim into config.yaml at add time."
@@ -232,7 +251,15 @@ fn shape_problems(doc: &YamlValue) -> Vec<String> {
         }
     }
 
-    for field in ["name", "description", "language", "entry"] {
+    for field in [
+        "name",
+        "description",
+        "language",
+        "entry",
+        "iii",
+        "deploy",
+        "manifest",
+    ] {
         if let Some(v) = present(doc.get(field))
             && v.as_str().is_none()
         {
@@ -652,6 +679,36 @@ mod tests {
     }
 
     #[test]
+    fn report_accepts_publish_metadata_keys() {
+        // The workers-repo release CI REQUIRES iii/deploy/manifest; the engine
+        // must accept them (and ignore them) so one manifest satisfies both
+        // validators. Regression: they used to land in the unknown catch-all
+        // and hard-fail `worker add`.
+        let r = report(
+            "iii: v1\nname: w\nlanguage: python\ndeploy: image\nmanifest: pyproject.toml\n\
+             scripts:\n  install: \"pip install -e .\"\n  start: \"python -m src.main\"\n",
+        );
+        assert!(r.valid, "publish metadata must not invalidate: {r:?}");
+        assert!(r.unknown_keys.is_empty(), "got: {:?}", r.unknown_keys);
+        for key in ["iii", "deploy", "manifest"] {
+            assert!(
+                !r.deprecated_keys.iter().any(|k| k == key),
+                "`{key}` must not be deprecated: {:?}",
+                r.deprecated_keys
+            );
+        }
+        // Non-string values still get the friendly dotted-path shape error.
+        let r = report("name: w\nscripts:\n  start: x\ndeploy:\n  kind: image\n");
+        assert!(!r.valid);
+        assert!(
+            r.errors
+                .iter()
+                .any(|e| e.contains("`deploy` must be a string, got a mapping")),
+            "got: {r:?}"
+        );
+    }
+
+    #[test]
     fn report_minimal_manifest_is_valid() {
         let r = report("name: w\nscripts:\n  start: \"node i.js\"\n");
         assert!(r.valid, "got: {r:?}");
@@ -871,6 +928,15 @@ mod tests {
                 .as_str()
                 .unwrap_or("");
         assert!(runtime_kind_desc.contains("DEPRECATED"));
+        // Publish metadata is in the schema (so authored manifests validate)
+        // and described as engine-ignored (so LLMs don't cargo-cult it).
+        for field in ["iii", "deploy", "manifest"] {
+            let desc = s["properties"][field]["description"].as_str().unwrap_or("");
+            assert!(
+                desc.contains("ignored by the engine"),
+                "`{field}` must be described as engine-ignored: {desc:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/iii-worker/src/sandbox_daemon/catalog.rs
+++ b/crates/iii-worker/src/sandbox_daemon/catalog.rs
@@ -22,15 +22,6 @@ pub fn is_preset(image: &str) -> bool {
     PRESETS.iter().any(|(name, _)| *name == image)
 }
 
-/// `true` when `oci_ref` is exactly one of the preset images' pinned OCI
-/// references. Lets the bundle-manifest validator accept a
-/// `runtime.base_image` that names an engine preset verbatim (the only
-/// way a non-node bundle picks its rootfs now that `runtime.kind` is
-/// deprecated) without opening the door to publisher-controlled refs.
-pub fn is_preset_ref(oci_ref: &str) -> bool {
-    PRESETS.iter().any(|(_, oci)| *oci == oci_ref)
-}
-
 /// Names of the built-in presets. Used by `SandboxConfig` validation to
 /// reject `custom_images` entries that would otherwise silently be
 /// ignored (presets always win in `resolve_image`).

--- a/crates/iii-worker/src/sandbox_daemon/catalog.rs
+++ b/crates/iii-worker/src/sandbox_daemon/catalog.rs
@@ -22,6 +22,15 @@ pub fn is_preset(image: &str) -> bool {
     PRESETS.iter().any(|(name, _)| *name == image)
 }
 
+/// `true` when `oci_ref` is exactly one of the preset images' pinned OCI
+/// references. Lets the bundle-manifest validator accept a
+/// `runtime.base_image` that names an engine preset verbatim (the only
+/// way a non-node bundle picks its rootfs now that `runtime.kind` is
+/// deprecated) without opening the door to publisher-controlled refs.
+pub fn is_preset_ref(oci_ref: &str) -> bool {
+    PRESETS.iter().any(|(_, oci)| *oci == oci_ref)
+}
+
 /// Names of the built-in presets. Used by `SandboxConfig` validation to
 /// reject `custom_images` entries that would otherwise silently be
 /// ignored (presets always win in `resolve_image`).

--- a/crates/iii-worker/tests/bundle_worker_integration.rs
+++ b/crates/iii-worker/tests/bundle_worker_integration.rs
@@ -13,7 +13,7 @@
 //!   rejection, char-device rejection, deep-directory rejection.
 //! - Manifest contract: missing manifest, manifest in subdirectory,
 //!   invalid YAML, name mismatch, missing scripts.start, scripts.setup
-//!   smuggling, scripts.install smuggling, runtime.base_image override.
+//!   smuggling, implausible runtime.base_image.
 //! - Resource clamping: requests exceeding caps, u64-overflow saturation.
 //! - Dependency graph bounds: depth and transitive count.
 //! - Atomic install + staging: collision with existing install,
@@ -392,18 +392,14 @@ fn manifest_missing_file_returns_typed_error() {
 }
 
 #[test]
-fn manifest_rejects_setup_install_base_image() {
+fn manifest_rejects_setup_and_implausible_base_image() {
     let cases = [
         (
             "name: foo\nscripts:\n  setup: \"x\"\n  start: \"node x.js\"\n",
             "scripts.setup",
         ),
         (
-            "name: foo\nscripts:\n  install: \"x\"\n  start: \"node x.js\"\n",
-            "scripts.install",
-        ),
-        (
-            "name: foo\nruntime:\n  base_image: \"x\"\nscripts:\n  start: \"node x.js\"\n",
+            "name: foo\nruntime:\n  base_image: \"bad image!\"\nscripts:\n  start: \"node x.js\"\n",
             "runtime.base_image",
         ),
     ];
@@ -416,6 +412,17 @@ fn manifest_rejects_setup_install_base_image() {
         };
         assert_eq!(field, expected_field);
     }
+}
+
+#[test]
+fn manifest_accepts_install_and_custom_base_image() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_manifest(
+        tmp.path(),
+        "name: foo\nruntime:\n  base_image: oven/bun:1\nscripts:\n  install: \"x\"\n  start: \"node x.js\"\n",
+    );
+    let cmd = validate_bundle_manifest(tmp.path(), "foo").expect("install + custom ref accepted");
+    assert_eq!(cmd, "node x.js");
 }
 
 #[test]

--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -5,6 +5,22 @@ owner: "devrel"
 type: "reference"
 ---
 
+<Update label="0.21.0" description="July 2026">
+  ## One `iii.worker.yaml` for the registry and the engine
+
+  Manifests published from the workers repo carry `iii`, `deploy`, and `manifest` top-level keys — required by the registry's release CI. The engine's validator treated them as unknown keys and hard-failed `iii worker add`, so a single manifest could not satisfy both. The validator now accepts the three publish metadata keys and ignores them at add/start time; a non-string value still gets the friendly dotted-path error.
+
+  ## Bundle workers: pick any rootfs, install dependencies at first boot
+
+  Bundle manifests may now set `runtime.base_image` to **any OCI image reference** (e.g. `oven/bun:1`), not just the engine-preset images — the rootfs is publisher-chosen, in the same trust context as the `scripts.start` command the engine already executes. A ref with characters that don't belong in an OCI reference is rejected at **install time** instead of silently falling back to the default image at start.
+
+  Bundles may also declare `scripts.install` — it runs once inside the sandbox VM (guarded like the rest of the boot script), which python bundles need for pip/browser bootstrap that can't be vendored per-arch into the archive. `scripts.setup` stays rejected: OS provisioning belongs in the base image.
+
+  ## Compound `scripts.start` commands run correctly
+
+  A `scripts.start` with shell metacharacters (`&&`, pipes, env prefixes) is now exec'd via a quoted `sh -c`, so compound start commands behave the same as they do in a terminal instead of being split naively on whitespace.
+</Update>
+
 <Update label="0.20.0" description="June 2026">
   ## SDK: a major, breaking reorganization of the public surface
 

--- a/docs/next/creating-workers/worker-manifest.mdx
+++ b/docs/next/creating-workers/worker-manifest.mdx
@@ -185,3 +185,15 @@ Optional integer. Number of vCPUs. Defaults to `2`, capped at `4`.
 ### `memory`
 
 Optional integer. Memory in MiB. Defaults to `2048`, capped at `4096`.
+
+## Publish metadata: `iii`, `deploy`, `manifest`
+
+Optional strings used by the workers-repository release pipeline, not by the engine. The engine
+accepts these keys (so a manifest published from the workers repo also works with local
+`iii worker add`) but never reads them.
+
+```yaml
+iii: v1 # manifest format marker
+deploy: image # release artifact type: binary | image | bundle
+manifest: pyproject.toml # file the release version is read from
+```

--- a/docs/next/creating-workers/worker-manifest.mdx.skill.md
+++ b/docs/next/creating-workers/worker-manifest.mdx.skill.md
@@ -181,3 +181,15 @@ Optional integer. Number of vCPUs. Defaults to `2`, capped at `4`.
 ### `memory`
 
 Optional integer. Memory in MiB. Defaults to `2048`, capped at `4096`.
+
+## Publish metadata: `iii`, `deploy`, `manifest`
+
+Optional strings used by the workers-repository release pipeline, not by the engine. The engine
+accepts these keys (so a manifest published from the workers repo also works with local
+`iii worker add`) but never reads them.
+
+```yaml
+iii: v1 # manifest format marker
+deploy: image # release artifact type: binary | image | bundle
+manifest: pyproject.toml # file the release version is read from
+```


### PR DESCRIPTION
## Problem

Every worker in the workers repo carries `iii`, `deploy`, and `manifest` top-level keys in its `iii.worker.yaml`. These are **required by the workers-repo release CI** (`deploy` selects the release artifact type; `manifest` names the file the release version is read from; `iii` is the manifest format marker).

The engine's manifest validator didn't know about these keys, so they landed in the "unknown top-level key" catch-all and **hard-failed `iii worker add`**. A single `iii.worker.yaml` could not satisfy both the release CI and the local validator.

On top of that, bundle workers installed from the registry were over-restricted: `runtime.base_image` was rejected (then preset-only), `scripts.install` was rejected, and compound `scripts.start` commands were split naively instead of run through a shell.

## Changes

### Accept publish metadata keys (`iii`, `deploy`, `manifest`)

- Add `iii`, `deploy`, `manifest` (all `Option<String>`) to `WorkerManifest`, each documented in its JSON schema as "Accepted and ignored by the engine".
- Include the three keys in the string-shape check so a non-string value (e.g. `deploy: { kind: image }`) still gets the friendly dotted-path error instead of a generic failure.
- Update the unknown-key error message to mention the publish metadata keys.
- Docs: add a "Publish metadata" section to `worker-manifest.mdx`.

The engine accepts these keys so a manifest published from the workers repo also works with local `iii worker add`, but never reads them at add/start time.

### Bundle workers: any `runtime.base_image`, `scripts.install` allowed

- `validate_bundle_manifest` now accepts **any OCI image reference** in `runtime.base_image` (e.g. `oven/bun:1`) — the rootfs is publisher-chosen, same trust context as the `scripts.start` command we already execute. The preset allowlist is replaced with the existing `is_plausible_image_ref` character gate, so a garbage ref fails at **install time** instead of silently falling back to the kind default at start. The now-dead `catalog::is_preset_ref` is removed.
- `scripts.install` is allowed for bundles: it runs inside the sandbox VM like `scripts.start`, once (guarded by the boot script's `/var/.iii-prepared`), which python bundles need for pip/browser bootstrap. `scripts.setup` stays rejected.

### Compound `scripts.start` via quoted `sh -c`

A `scripts.start` with shell metacharacters (`&&`, pipes, env prefixes) is exec'd via a quoted `sh -c` instead of naive whitespace splitting.

## Files

- `crates/iii-worker/src/cli/worker_manifest.rs`
- `crates/iii-worker/src/cli/project.rs`
- `crates/iii-worker/src/cli/bundle_download.rs`
- `crates/iii-worker/src/cli/managed.rs`
- `crates/iii-worker/src/cli/local_worker.rs`
- `crates/iii-worker/src/sandbox_daemon/catalog.rs`
- `docs/next/creating-workers/worker-manifest.mdx`
- `docs/changelog/index.mdx` (0.21.0 entry)

## Tests

- `validate_keys_accepts_publish_metadata_keys`
- `report_accepts_publish_metadata_keys` (incl. non-string shape-error regression)
- schema description assertions that the keys are marked engine-ignored
- `validate_bundle_manifest_accepts_any_base_image` / `_accepts_preset_base_image` / `_rejects_implausible_base_image`
- `validate_bundle_manifest_accepts_install`

Closes MOT-3888

https://claude.ai/code/session_01QFd1EaWo3f58mmUEuRBddy
