### PR TITLE
fix(ci): authenticate iii CLI install against GitHub API in publish-engine-workers

### DIFF
--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -69,6 +69,9 @@ jobs:
         env:
           VERSION_INPUT: ${{ inputs.version }}
           RELEASE_TAG_INPUT: ${{ inputs.release_tag }}
+          # install.sh queries the GitHub releases API; unauthenticated calls
+          # share a 60/hr per-IP limit that hosted runners routinely exhaust.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           curl -fsSL https://install.iii.dev/iii/main/install.sh -o /tmp/install-iii.sh


### PR DESCRIPTION
## Summary

Release runs intermittently fail at the **Install iii CLI** step of `_publish-engine-workers.yml` with:

```
error: GitHub API rate limit hit (unauthenticated: 60/hr). Retry later, or set $GITHUB_TOKEN ...
```

Example failure: [Release iii → POST /publish (configuration)](https://github.com/iii-hq/iii/actions/runs/28862843610/job/85608438938)

`install.sh` resolves the release through the GitHub API, and hosted runners share an unauthenticated 60 req/hr per-IP limit, so failures depend on runner IP luck. The script already sends `Authorization: Bearer $GITHUB_TOKEN` when the variable is set — the workflow just never passed it.

## Change

Pass `GITHUB_TOKEN: ${{ github.token }}` to the install step env. This is the only workflow step that fetches `install.iii.dev` without a token.

## Test plan

- [ ] `Release iii` workflow's publish jobs install the CLI without hitting the rate limit on the next release run

https://claude.ai/code/session_01Vjb6USUNMhHqPCQ8EXVesS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow to use authenticated GitHub access during installation steps, reducing the chance of rate-limit issues on hosted runners.
  * Added clarifying notes to make the release process easier to understand and maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->