### PR TITLE
feat(observability): live pending spans and traces UX

### DIFF
--- a/crates/iii-worker/src/cli/download.rs
+++ b/crates/iii-worker/src/cli/download.rs
@@ -84,20 +84,18 @@ pub async fn stream_response_to_path(
     use futures::StreamExt as _;
     use tokio::io::AsyncWriteExt as _;
 
-    if let Some(prefix) = opts.allowed_content_type_prefix {
-        if let Some(ct) = response
+    if let Some(prefix) = opts.allowed_content_type_prefix
+        && let Some(ct) = response
             .headers()
             .get(reqwest::header::CONTENT_TYPE)
             .and_then(|v| v.to_str().ok())
-        {
-            if !ct.to_ascii_lowercase().starts_with(prefix) {
-                return Err(DownloadError::UnexpectedContentType {
-                    url: opts.url_for_logs.to_string(),
-                    content_type: ct.to_string(),
-                    expected_prefix: prefix.to_string(),
-                });
-            }
-        }
+        && !ct.to_ascii_lowercase().starts_with(prefix)
+    {
+        return Err(DownloadError::UnexpectedContentType {
+            url: opts.url_for_logs.to_string(),
+            content_type: ct.to_string(),
+            expected_prefix: prefix.to_string(),
+        });
     }
 
     if let Some(len) = response.content_length()
@@ -263,7 +261,7 @@ pub fn validate_archive_url_for_ssrf(url_str: &str) -> Result<(), SsrfError> {
 /// compile on stable. The conditions mirror RFC 6890 / 3927 / 1918 /
 /// 4291 / 5737 / 3849.
 fn ip_is_non_routable(ip: std::net::IpAddr) -> Option<&'static str> {
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use std::net::{IpAddr, Ipv6Addr};
     match ip {
         IpAddr::V4(v4) => {
             if v4.is_loopback() {
@@ -329,7 +327,7 @@ fn ip_is_non_routable(ip: std::net::IpAddr) -> Option<&'static str> {
             }
             // IPv4-mapped IPv6 (::ffff:0:0/96): recurse on the embedded v4.
             if let Some(mapped) = v6.to_ipv4_mapped() {
-                let _ = Ipv4Addr::from(mapped); // type-check
+                let _ = mapped; // type-check
                 return ip_is_non_routable(IpAddr::V4(mapped));
             }
             // IPv4-compatible (::a.b.c.d/96, deprecated) and IPv4-in-IPv6.

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -521,7 +521,7 @@ impl WorkerActivationLock {
         match nix::fcntl::Flock::lock(file, nix::fcntl::FlockArg::LockExclusiveNonblock) {
             Ok(lock) => {
                 use std::io::Write as _;
-                let _ = (&*lock).set_len(0);
+                let _ = &lock.set_len(0);
                 let _ = writeln!(&*lock, "pid={}", std::process::id());
                 Ok(Self { _lock: lock })
             }
@@ -3494,7 +3494,7 @@ pub async fn handle_worker_list() -> i32 {
     // pidfile signal-0 check or because we just saw it in `ps`). Dead disk-only
     // entries are stale runtime state, not what the user is asking about.
     let candidate_names: std::collections::BTreeSet<String> =
-        disk_names.into_iter().chain(ps_names.into_iter()).collect();
+        disk_names.into_iter().chain(ps_names).collect();
     let orphan_names: Vec<String> = candidate_names
         .into_iter()
         .filter(|n| !config_set.contains(n.as_str()))

--- a/crates/iii-worker/src/cli/worker_manager_daemon.rs
+++ b/crates/iii-worker/src/cli/worker_manager_daemon.rs
@@ -604,7 +604,7 @@ fn register_validate(iii: &IIIClient) {
     let _ = iii.register_function("worker::validate", describe_op(rf, "worker::validate"));
 }
 
-fn sink_ref<'a>(sink: &'a Arc<IIIEventSink>) -> &'a dyn EventSink {
+fn sink_ref(sink: &Arc<IIIEventSink>) -> &dyn EventSink {
     // `IIIEventSink` is the only mutating-op sink today, but the
     // orchestrators take `&dyn EventSink` — this helper makes the
     // coercion site explicit at every call site.

--- a/crates/iii-worker/src/core/project.rs
+++ b/crates/iii-worker/src/core/project.rs
@@ -43,8 +43,7 @@ impl ProjectOperationLock {
         match nix::fcntl::Flock::lock(file, nix::fcntl::FlockArg::LockExclusiveNonblock) {
             Ok(lock) => {
                 let marker = format!("pid={}\n", std::process::id());
-                (&*lock)
-                    .set_len(0)
+                lock.set_len(0)
                     .and_then(|_| (&*lock).write_all(marker.as_bytes()))
                     .map_err(|source| WorkerOpError::LockIo { path, source })?;
                 Ok(Self { _lock: lock })

--- a/engine/src/invocation/mod.rs
+++ b/engine/src/invocation/mod.rs
@@ -449,7 +449,10 @@ mod tests {
             crate::telemetry::inject_baggage_from_context(&rewritten).expect("baggage header");
         assert!(header.contains("iii.function.id=child::fn"));
         assert!(!header.contains("iii.function.id=parent::fn"));
-        assert!(header.contains("iii.session.id=s-1"), "other entries preserved");
+        assert!(
+            header.contains("iii.session.id=s-1"),
+            "other entries preserved"
+        );
     }
 
     #[test]

--- a/engine/src/invocation/mod.rs
+++ b/engine/src/invocation/mod.rs
@@ -96,10 +96,10 @@ impl InvocationHandler {
         //     volume. Suppressed by default; re-enable with
         //     `III_OTEL_TRACE_BUILTINS=true`.
         //   - Worker-routed (non-builtin) functions are executed by an external
-        //     worker that emits its OWN `call <fn>` span (service = that
-        //     worker). The engine's span would be a cross-service duplicate of
-        //     the same logical invocation, so suppress it and let the worker's
-        //     span be the canonical one.
+        //     worker that emits its own handler span (`execute <fn>`, INTERNAL,
+        //     service = that worker). An engine-side `call` span would wrap the
+        //     same logical invocation as a cross-service duplicate, so suppress
+        //     it and let the worker's span be the canonical one.
         let suppress_span = if is_builtin {
             !crate::workers::telemetry::trace_builtins_enabled()
         } else {
@@ -139,10 +139,18 @@ impl InvocationHandler {
         //     trace; attaching it nests the fan-out under the writer (e.g.
         //     `approval::resolve` → state write → `turn::on_approval`).
         let dispatch_cx = if traceparent.is_some() || baggage.is_some() {
-            Some(crate::telemetry::extract_context(
-                traceparent.as_deref(),
-                baggage.as_deref(),
-            ))
+            let cx = crate::telemetry::extract_context(traceparent.as_deref(), baggage.as_deref());
+            // The caller's baggage names the CALLER; rewrite `iii.function.id`
+            // to the function being invoked so worker-side spans are attributed
+            // to their owning function (mirrors the enqueue boundary in
+            // `engine/mod.rs` and the `fn_queue` consumer in `queue.rs`).
+            // Built-ins execute in-process under the caller's identity and are
+            // left untouched.
+            Some(if is_builtin {
+                cx
+            } else {
+                crate::telemetry::with_function_id_baggage(&cx, &function_id)
+            })
         } else {
             None
         };
@@ -426,6 +434,22 @@ mod tests {
         let id = Uuid::new_v4();
         // Should not panic.
         handler.halt_invocation(&id);
+    }
+
+    #[test]
+    fn dispatch_baggage_rewrite_names_the_target_function() {
+        // `handle_invocation` rewrites `iii.function.id` in the dispatch
+        // context for non-builtin targets (extract → rewrite → inject is the
+        // exact path the worker-bound baggage header takes), so worker-side
+        // spans are attributed to the function they serve — not the caller.
+        let caller = "iii.session.id=s-1,iii.function.id=parent::fn";
+        let cx = crate::telemetry::extract_context(None, Some(caller));
+        let rewritten = crate::telemetry::with_function_id_baggage(&cx, "child::fn");
+        let header =
+            crate::telemetry::inject_baggage_from_context(&rewritten).expect("baggage header");
+        assert!(header.contains("iii.function.id=child::fn"));
+        assert!(!header.contains("iii.function.id=parent::fn"));
+        assert!(header.contains("iii.session.id=s-1"), "other entries preserved");
     }
 
     #[test]

--- a/engine/src/logging.rs
+++ b/engine/src/logging.rs
@@ -411,6 +411,13 @@ fn otel_config_from_module(
     if let Some(max_spans) = module_config.memory_max_spans {
         otel_cfg.memory_max_spans = max_spans;
     }
+    // Re-derive rather than override: the mode-aware default (memory → on)
+    // must be computed against the exporter resolved just above, not the one
+    // `OtelConfig::default()` saw before this block applied the yaml config.
+    otel_cfg.live_spans = crate::workers::observability::otel::resolve_live_spans(
+        module_config.live_spans,
+        &otel_cfg.exporter,
+    );
 
     otel_cfg
 }

--- a/engine/src/workers/observability/README.md
+++ b/engine/src/workers/observability/README.md
@@ -98,6 +98,7 @@ engine restart. Memory-backed stores are unaffected.
 | `endpoint`                  | string      | OTLP collector base endpoint. Defaults to `"http://localhost:4317"`. Env: `OTEL_EXPORTER_OTLP_ENDPOINT`.                                                                     |
 | `sampling_ratio`            | number      | Global trace sampling ratio (`0.0`–`1.0`). Defaults to `1.0`. Env: `OTEL_TRACES_SAMPLER_ARG`.                                                                                |
 | `memory_max_spans`          | number      | Max spans to keep in memory. Defaults to `1000`. Env: `OTEL_MEMORY_MAX_SPANS`.                                                                                               |
+| `live_spans`                | boolean     | Mirror spans into the in-memory store at start as pending snapshots (see [Live (pending) spans](#live-pending-spans)). Defaults to `true` for `exporter: memory`, `false` otherwise — set it to opt in with `both` in production. Ignored for `otlp`-only. Restart-tier. Env: `OTEL_LIVE_SPANS`. |
 | `metrics_enabled`           | boolean     | Whether metrics collection is enabled. Defaults to `false`. Env: `OTEL_METRICS_ENABLED`.                                                                                     |
 | `metrics_exporter`          | string      | Metrics exporter: `memory` or `otlp`. Defaults to `memory`. Env: `OTEL_METRICS_EXPORTER`.                                                                                    |
 | `metrics_retention_seconds` | number      | How long to retain metrics in memory. Defaults to `3600`. Env: `OTEL_METRICS_RETENTION_SECONDS`.                                                                             |
@@ -215,6 +216,35 @@ All logging functions accept: `message` (string, required), `data` (object), `tr
 | `engine::traces::tree`  | Retrieve a trace as a hierarchical span tree. Parameters: `trace_id` (required).                                                                                                                                        |
 | `engine::traces::clear` | Clear all stored trace spans from memory.                                                                                                                                                                               |
 
+### Live (pending) spans
+
+With the `memory` exporter (the local-dev default), spans are additionally mirrored into the
+in-memory store the moment they **start**. This is on by default for `memory` only; a `both`
+setup — the production shape that also exports OTLP — opts in explicitly with `live_spans: true`
+(or `OTEL_LIVE_SPANS=true`), and `otlp`-only can never mirror (engine finals don't land in the
+memory store there, so pending snapshots would never be replaced). A live snapshot is marked
+`pending: true` with `end_time_unix_nano: 0` and carries the attributes known at creation (span
+macro fields plus baggage-stamped `iii.*` attributes); attributes recorded later, like
+`otel.status_code`, are absent, so pending spans read `status: "unset"`. When the span closes, the
+final span **replaces the snapshot in place** — same storage position, one entry per span id.
+
+This is what lets live trace views show in-progress work: engine-side parent spans (`trigger <fn>`,
+`enqueue`, builtin `call <fn>`) become visible while the work under them is still running, traces
+appear in list views as soon as they start, and the trace trigger / devtools streams tick on span
+start as well as close. Worker (SDK) spans still arrive only when they close — they are ingested
+over OTLP, which has no notion of an unfinished span.
+
+Consumers of the Traces API should treat `pending: true` (or `end_time_unix_nano == 0`) as
+"still running": duration filters and sorts already measure such spans as duration-so-far, and
+`engine::metrics::list` excludes them from latency statistics. The `pending` field is only
+serialized when true, so the wire shape of finished spans is unchanged.
+
+**OTEL compliance:** pending snapshots exist ONLY in the in-memory store and the `iii:devtools:*`
+streams fed from it. The OTLP export path (both the engine exporter and the SDK-span forwarder) is
+untouched and only ever ships complete spans — `end_time_unix_nano` is semantically required on the
+OTLP wire, and nothing partial ever reaches it. Spans that never close (e.g. a leaked guard) remain
+pending until buffer eviction; they are a dev-store artifact, not exported data.
+
 ### Metrics API
 
 | Function                | Description                                                                                                                                                 |
@@ -270,9 +300,11 @@ Log entry payload fields: `timestamp_unix_nano`, `observed_timestamp_unix_nano`,
 Register a function to react to span activity in the in-memory trace store, so any client — a worker
 or the web console — can refresh reactively instead of polling. The trigger is a **coalesced "traces
 changed" tick**, not a per-span feed: span activity is debounced (~300ms) and the handler receives
-the distinct affected trace ids for the window. Re-read details via `engine::traces::list` /
-`engine::traces::tree`. Requires the memory exporter (`exporter: memory` or `both`); with the
-OTLP-only exporter there is no in-memory store and trace triggers stay dormant.
+the distinct affected trace ids for the window. With `live_spans` on, the tick also fires when spans
+**start** (pending snapshots land in the store), not just when they close. Re-read details via
+`engine::traces::list` / `engine::traces::tree`. Requires the memory exporter (`exporter: memory` or
+`both`); in OTLP-only mode engine spans never land in the store, so the trigger only ever sees
+OTLP-ingested SDK spans there.
 
 Engine-internal spans and the trigger's **own delivery spans** are excluded from firing it —
 delivering a trigger via `engine.call` is itself instrumented as a span, so without this exclusion

--- a/engine/src/workers/observability/config.rs
+++ b/engine/src/workers/observability/config.rs
@@ -255,6 +255,15 @@ pub struct ObservabilityWorkerConfig {
     #[schemars(range(min = 1))]
     pub memory_max_spans: Option<usize>,
 
+    /// Mirror spans into the in-memory store at start as `pending` snapshots
+    /// so live trace views show in-progress work. Defaults to on for the
+    /// "memory" exporter (local dev) and off otherwise — set `true` to opt in
+    /// with "both" in production. Ignored for "otlp"-only (no in-memory
+    /// finals to replace pendings); never affects OTLP output either way.
+    /// Restart-tier: the span processor set is fixed at provider build.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub live_spans: Option<bool>,
+
     /// Whether OpenTelemetry metrics export is enabled
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metrics_enabled: Option<bool>,
@@ -349,6 +358,7 @@ impl Default for ObservabilityWorkerConfig {
             sampling_ratio: None,
             sampling: None,
             memory_max_spans: None,
+            live_spans: None,
             metrics_retention_seconds: None,
             metrics_max_count: None,
             logs_max_count: None,
@@ -528,6 +538,7 @@ mod tests {
             "sampling_ratio",
             "sampling",
             "memory_max_spans",
+            "live_spans",
             "metrics_enabled",
             "metrics_exporter",
             "metrics_retention_seconds",

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -41,6 +41,10 @@ use crate::{
 pub struct TracesListInput {
     /// Filter by specific trace ID
     trace_id: Option<String>,
+    /// Filter to a specific set of trace IDs (ignored when `trace_id` is set;
+    /// used by grouped views to expand one group's members in a single call).
+    #[serde(default)]
+    trace_ids: Option<Vec<String>>,
     /// Pagination offset (default: 0)
     offset: Option<usize>,
     /// Pagination limit (default: 100)
@@ -67,6 +71,11 @@ pub struct TracesListInput {
     sort_order: Option<String>,
     /// Filter by span attributes (array of [key, value] pairs, AND logic, exact match)
     attributes: Option<Vec<Vec<String>>>,
+    /// Exclude listed rows whose own attributes match ANY [key, value] pair
+    /// (OR logic, exact match). Applied to the root/row span itself — hiding
+    /// a function hides traces rooted at it, not traces that merely call it.
+    #[serde(default)]
+    exclude_attributes: Option<Vec<Vec<String>>>,
     /// Include internal engine traces (engine.* functions). Defaults to false.
     #[serde(default)]
     include_internal: Option<bool>,
@@ -99,11 +108,18 @@ pub struct TracesGroupByInput {
     /// Include engine-internal spans. Defaults to false, matching `traces::list`.
     #[serde(default)]
     include_internal: Option<bool>,
+    /// Attribute whose value becomes each group's human-readable `label`
+    /// (e.g. group by `iii.session.id` with label `iii.session.name`). The
+    /// newest group member carrying the attribute wins, so renames surface.
+    #[serde(default)]
+    label_attribute: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct TraceGroup {
     pub value: String,
+    /// Display label resolved from `label_attribute`, when requested and present.
+    pub label: Option<String>,
     pub trace_ids: Vec<String>,
     pub span_count: u32,
     pub first_seen_ms: u64,
@@ -149,6 +165,33 @@ pub struct TracesTreeResult {
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct TracesGroupByResult {
     pub groups: Vec<TraceGroup>,
+}
+
+/// Generic trace-tag namespace: `iii.tag.<key>` span attributes (stamped via
+/// OTel baggage; see the SDK `BaggageSpanProcessor` allowed prefixes).
+const TRACE_TAG_PREFIX: &str = "iii.tag.";
+
+/// Identity attributes surfaced alongside `iii.tag.*` as trace-level tags.
+const TRACE_TAG_EXACT_KEYS: &[&str] = &["iii.session.id", "iii.session.name", "iii.message.id"];
+
+/// Merge trace-level tags from every span of a trace. Worker-set baggage
+/// never lands on the engine-side root `call` span (it starts before the
+/// handler runs), so listing roots alone would miss these; the row instead
+/// carries the union, newest span winning on key conflicts (e.g. renames).
+fn collect_trace_tags(
+    trace_spans: &[otel::StoredSpan],
+) -> std::collections::BTreeMap<String, String> {
+    let mut spans: Vec<&otel::StoredSpan> = trace_spans.iter().collect();
+    spans.sort_by_key(|s| s.start_time_unix_nano);
+    let mut tags = std::collections::BTreeMap::new();
+    for span in spans {
+        for (k, v) in &span.attributes {
+            if k.starts_with(TRACE_TAG_PREFIX) || TRACE_TAG_EXACT_KEYS.contains(&k.as_str()) {
+                tags.insert(k.clone(), v.clone());
+            }
+        }
+    }
+    tags
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -1934,13 +1977,22 @@ impl ObservabilityWorker {
     ) -> FunctionResult<TracesListResult, ErrorBody> {
         match otel::get_span_storage() {
             Some(storage) => {
-                let all_spans = match input.trace_id {
-                    Some(trace_id) => storage.get_spans_by_trace_id(&trace_id),
-                    None => storage.get_spans(),
+                let all_spans = if let Some(ref trace_id) = input.trace_id {
+                    storage.get_spans_by_trace_id(trace_id)
+                } else if let Some(ref trace_ids) = input.trace_ids {
+                    trace_ids
+                        .iter()
+                        .flat_map(|id| storage.get_spans_by_trace_id(id))
+                        .collect()
+                } else {
+                    storage.get_spans()
                 };
 
                 let include_internal = input.include_internal.unwrap_or(false);
                 let search_all = input.search_all_spans.unwrap_or(false);
+                // One "now" for the whole listing — pending spans measure
+                // duration-so-far / activity against it.
+                let now_ns = otel::now_unix_nanos();
 
                 // Pre-compute trace IDs that have any span matching the name filter
                 let name_matched_trace_ids: Option<std::collections::HashSet<String>> =
@@ -2016,6 +2068,19 @@ impl ObservabilityWorker {
                         true
                     })
                     .filter(|s| {
+                        // Row-level exclusion (e.g. the console's hidden
+                        // functions): drop rows matching ANY [key, value] pair.
+                        let Some(ref excl) = input.exclude_attributes else {
+                            return true;
+                        };
+                        !excl.iter().any(|pair| {
+                            pair.len() == 2
+                                && s.attributes
+                                    .iter()
+                                    .any(|(k, v)| k == &pair[0] && v == &pair[1])
+                        })
+                    })
+                    .filter(|s| {
                         if let Some(ref sn) = input.service_name
                             && !s.service_name.to_lowercase().contains(&sn.to_lowercase())
                         {
@@ -2041,9 +2106,12 @@ impl ObservabilityWorker {
                         {
                             return false;
                         }
-                        let duration_ns =
-                            s.end_time_unix_nano.saturating_sub(s.start_time_unix_nano);
-                        let duration_ms: f64 = duration_ns as f64 / 1_000_000.0;
+                        // Pending (in-flight) spans measure duration-so-far
+                        // and count as active "now" for the time window — a
+                        // span running for 10s legitimately matches
+                        // `min_duration_ms: 5000`, and an end sentinel of 0
+                        // must not drop it from "recent" views.
+                        let duration_ms: f64 = s.duration_ns(now_ns) as f64 / 1_000_000.0;
                         if let Some(min) = input.min_duration_ms
                             && duration_ms < min
                         {
@@ -2056,7 +2124,7 @@ impl ObservabilityWorker {
                         }
                         if let Some(start) = input.start_time {
                             let start_ns = start * 1_000_000;
-                            if s.end_time_unix_nano < start_ns {
+                            if s.effective_end_ns(now_ns) < start_ns {
                                 return false;
                             }
                         }
@@ -2106,10 +2174,8 @@ impl ObservabilityWorker {
                         // span `duration_ms`) uses the `_ms` suffix, so callers
                         // reasonably pass either spelling.
                         "duration" | "duration_ms" => {
-                            let da =
-                                a.end_time_unix_nano.saturating_sub(a.start_time_unix_nano) as f64;
-                            let db =
-                                b.end_time_unix_nano.saturating_sub(b.start_time_unix_nano) as f64;
+                            let da = a.duration_ns(now_ns) as f64;
+                            let db = b.duration_ns(now_ns) as f64;
                             da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
                         }
                         "service_name" => a.service_name.cmp(&b.service_name),
@@ -2128,7 +2194,23 @@ impl ObservabilityWorker {
                 FunctionResult::Success(TracesListResult {
                     spans: spans
                         .into_iter()
-                        .map(|s| serde_json::to_value(s).unwrap_or(Value::Null))
+                        .map(|s| {
+                            // Attach trace-level tags to the returned page only
+                            // (per-row index lookup, bounded by `limit`).
+                            let tags = collect_trace_tags(
+                                &storage.get_spans_by_trace_id(&s.trace_id),
+                            );
+                            let mut value = serde_json::to_value(s).unwrap_or(Value::Null);
+                            if !tags.is_empty()
+                                && let Value::Object(ref mut map) = value
+                            {
+                                map.insert(
+                                    "trace_tags".to_string(),
+                                    serde_json::to_value(tags).unwrap_or(Value::Null),
+                                );
+                            }
+                            value
+                        })
                         .collect(),
                     total,
                     offset,
@@ -2205,6 +2287,9 @@ impl ObservabilityWorker {
                 let include_internal = input.include_internal.unwrap_or(false);
                 let since_ns = input.since_ms.map(|ms| ms.saturating_mul(1_000_000));
                 let limit = input.limit.unwrap_or(100) as usize;
+                // Pending spans count as active "now" for the window and for
+                // last_seen (their end sentinel is 0).
+                let now_ns = otel::now_unix_nanos();
 
                 struct GroupBuilder {
                     trace_ids: std::collections::HashSet<String>,
@@ -2212,6 +2297,8 @@ impl ObservabilityWorker {
                     first_seen_ns: u64,
                     last_seen_ns: u64,
                     error_count: u32,
+                    label: Option<String>,
+                    label_seen_at_ns: u64,
                 }
                 let mut groups: std::collections::HashMap<String, GroupBuilder> =
                     std::collections::HashMap::new();
@@ -2227,7 +2314,7 @@ impl ObservabilityWorker {
                         }
                     }
                     if let Some(min_ns) = since_ns
-                        && span.end_time_unix_nano < min_ns
+                        && span.effective_end_ns(now_ns) < min_ns
                     {
                         continue;
                     }
@@ -2242,15 +2329,27 @@ impl ObservabilityWorker {
                         trace_ids: std::collections::HashSet::new(),
                         span_count: 0,
                         first_seen_ns: span.start_time_unix_nano,
-                        last_seen_ns: span.end_time_unix_nano,
+                        last_seen_ns: span.effective_end_ns(now_ns),
                         error_count: 0,
+                        label: None,
+                        label_seen_at_ns: 0,
                     });
                     entry.trace_ids.insert(span.trace_id.clone());
                     entry.span_count += 1;
                     entry.first_seen_ns = entry.first_seen_ns.min(span.start_time_unix_nano);
-                    entry.last_seen_ns = entry.last_seen_ns.max(span.end_time_unix_nano);
+                    entry.last_seen_ns = entry.last_seen_ns.max(span.effective_end_ns(now_ns));
                     if is_error {
                         entry.error_count += 1;
+                    }
+                    // Newest span carrying the label attribute wins, so e.g.
+                    // session renames surface on the group heading.
+                    if let Some(ref label_key) = input.label_attribute
+                        && span.start_time_unix_nano >= entry.label_seen_at_ns
+                        && let Some((_, label)) =
+                            span.attributes.iter().find(|(k, _)| k == label_key)
+                    {
+                        entry.label = Some(label.clone());
+                        entry.label_seen_at_ns = span.start_time_unix_nano;
                     }
                 }
 
@@ -2266,6 +2365,7 @@ impl ObservabilityWorker {
                         trace_ids.sort();
                         TraceGroup {
                             value,
+                            label: b.label,
                             trace_ids,
                             span_count: b.span_count,
                             first_seen_ms: first_ms,
@@ -3606,6 +3706,7 @@ mod tests {
             instrumentation_scope_version: None,
             flags: None,
             trace_state: None,
+            pending: false,
         }
     }
 
@@ -4954,6 +5055,43 @@ mod tests {
         let bare = make_span("t", "s", None, "n", "svc", 1, 2, "ok", vec![]);
         assert!(!is_internal_span(&bare));
         assert_eq!(span_function_id(&bare), None);
+    }
+
+    #[test]
+    fn pending_internal_span_is_still_filtered_from_trigger_feed() {
+        // Loop-safety regression: a live (pending) snapshot of an internal
+        // wrapper span carries its `iii.function.kind=internal` creation attr,
+        // so the trace-trigger subscriber's `is_internal_span` post-filter
+        // excludes it exactly like the final span — pending snapshots must not
+        // re-fire the feed that produced them.
+        let mut pending_wrapper = make_span(
+            "t",
+            "s",
+            None,
+            "stream_triggers",
+            "iii",
+            1,
+            0,
+            "unset",
+            vec![("iii.function.kind", "internal")],
+        );
+        pending_wrapper.pending = true;
+        assert!(is_internal_span(&pending_wrapper));
+
+        // Same for a pending engine::* builtin call span.
+        let mut pending_builtin = make_span(
+            "t",
+            "s2",
+            None,
+            "call engine::traces::list",
+            "iii",
+            1,
+            0,
+            "unset",
+            vec![("function_id", "engine::traces::list")],
+        );
+        pending_builtin.pending = true;
+        assert!(is_internal_span(&pending_builtin));
     }
 
     // =========================================================================
@@ -6342,6 +6480,7 @@ mod tests {
 
         let input = TracesListInput {
             trace_id: None,
+            trace_ids: None,
             offset: Some(0),
             limit: Some(10),
             service_name: None,
@@ -6354,6 +6493,7 @@ mod tests {
             sort_by: None,
             sort_order: None,
             attributes: None,
+            exclude_attributes: None,
             include_internal: Some(false),
             search_all_spans: None,
         };
@@ -6424,6 +6564,7 @@ mod tests {
 
         let base_input = || TracesListInput {
             trace_id: None,
+            trace_ids: None,
             offset: Some(0),
             limit: Some(10),
             service_name: None,
@@ -6436,6 +6577,7 @@ mod tests {
             sort_by: None,
             sort_order: None,
             attributes: None,
+            exclude_attributes: None,
             include_internal: Some(false),
             search_all_spans: None,
         };
@@ -6550,6 +6692,7 @@ mod tests {
         let traces_result = module
             .list_traces(TracesListInput {
                 trace_id: None,
+                trace_ids: None,
                 offset: Some(0),
                 limit: Some(10),
                 service_name: Some("svc".to_string()),
@@ -6562,6 +6705,7 @@ mod tests {
                 sort_by: Some("name".to_string()),
                 sort_order: Some("asc".to_string()),
                 attributes: Some(vec![vec!["http.method".to_string(), "GET".to_string()]]),
+                exclude_attributes: None,
                 include_internal: Some(false),
                 search_all_spans: None,
             })
@@ -6768,6 +6912,7 @@ mod tests {
         let result = module
             .list_traces(TracesListInput {
                 trace_id: None,
+                trace_ids: None,
                 offset: Some(0),
                 limit: Some(10),
                 service_name: None,
@@ -6783,6 +6928,7 @@ mod tests {
                     "iii.message.id".to_string(),
                     "M-target".to_string(),
                 ]]),
+                exclude_attributes: None,
                 include_internal: Some(true),
                 search_all_spans: Some(true),
             })
@@ -6849,6 +6995,7 @@ mod tests {
         let result_root_only = module
             .list_traces(TracesListInput {
                 trace_id: None,
+                trace_ids: None,
                 offset: Some(0),
                 limit: Some(10),
                 service_name: None,
@@ -6861,6 +7008,7 @@ mod tests {
                 sort_by: None,
                 sort_order: None,
                 attributes: None,
+                exclude_attributes: None,
                 include_internal: Some(true),
                 search_all_spans: Some(false),
             })
@@ -6878,6 +7026,7 @@ mod tests {
         let result_all = module
             .list_traces(TracesListInput {
                 trace_id: None,
+                trace_ids: None,
                 offset: Some(0),
                 limit: Some(10),
                 service_name: None,
@@ -6890,6 +7039,7 @@ mod tests {
                 sort_by: None,
                 sort_order: None,
                 attributes: None,
+                exclude_attributes: None,
                 include_internal: Some(true),
                 search_all_spans: Some(true),
             })
@@ -6948,6 +7098,7 @@ mod tests {
         let result = module
             .list_traces(TracesListInput {
                 trace_id: None,
+                trace_ids: None,
                 offset: Some(0),
                 limit: Some(10),
                 service_name: None,
@@ -6963,6 +7114,7 @@ mod tests {
                     "iii.message.id".to_string(),
                     "M-target".to_string(),
                 ]]),
+                exclude_attributes: None,
                 include_internal: Some(true),
                 search_all_spans: Some(false),
             })
@@ -7068,6 +7220,7 @@ mod tests {
                 since_ms: None,
                 limit: Some(100),
                 include_internal: Some(true),
+                label_attribute: None,
             })
             .await;
 
@@ -7140,6 +7293,7 @@ mod tests {
                 since_ms: Some(2000),
                 limit: Some(100),
                 include_internal: Some(true),
+                label_attribute: None,
             })
             .await;
 
@@ -7189,6 +7343,7 @@ mod tests {
                 since_ms: None,
                 limit: Some(2),
                 include_internal: Some(true),
+                label_attribute: None,
             })
             .await;
 
@@ -7263,6 +7418,7 @@ mod tests {
                 since_ms: None,
                 limit: Some(100),
                 include_internal: None,
+                label_attribute: None,
             })
             .await;
 
@@ -7278,6 +7434,329 @@ mod tests {
                 assert_eq!(groups[0]["value"], "M-user");
             }
             _ => panic!("expected group_traces_by success"),
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_traces_group_by_label_attribute_newest_wins() {
+        reset_observability_test_state();
+
+        let engine = Arc::new(Engine::new());
+        let module = make_test_module(engine.clone());
+
+        let span_storage = otel::get_span_storage().expect("span storage should exist");
+        span_storage.clear();
+        span_storage.add_spans(vec![
+            // Session S-1 renamed between turns: the newest span's name wins.
+            make_span(
+                "trace-A",
+                "A1",
+                None,
+                "turn-1",
+                "harness",
+                1_000_000_000,
+                2_000_000_000,
+                "OK",
+                vec![("iii.session.id", "S-1"), ("iii.session.name", "untitled")],
+            ),
+            make_span(
+                "trace-B",
+                "B1",
+                None,
+                "turn-2",
+                "harness",
+                3_000_000_000,
+                4_000_000_000,
+                "OK",
+                vec![
+                    ("iii.session.id", "S-1"),
+                    ("iii.session.name", "refactor auth"),
+                ],
+            ),
+            // Session S-2 has no name attribute anywhere: label stays null.
+            make_span(
+                "trace-C",
+                "C1",
+                None,
+                "turn-3",
+                "harness",
+                5_000_000_000,
+                6_000_000_000,
+                "OK",
+                vec![("iii.session.id", "S-2")],
+            ),
+        ]);
+
+        let result = module
+            .group_traces_by(TracesGroupByInput {
+                attribute: "iii.session.id".to_string(),
+                since_ms: None,
+                limit: Some(100),
+                include_internal: Some(true),
+                label_attribute: Some("iii.session.name".to_string()),
+            })
+            .await;
+
+        match result {
+            FunctionResult::Success(value) => {
+                let value = serde_json::to_value(&value).unwrap();
+                let groups = value["groups"].as_array().expect("groups array");
+                assert_eq!(groups.len(), 2);
+                // Sorted by first_seen_ms DESC: S-2 first, then S-1.
+                assert_eq!(groups[0]["value"], "S-2");
+                assert!(groups[0]["label"].is_null());
+                assert_eq!(groups[1]["value"], "S-1");
+                assert_eq!(groups[1]["label"], "refactor auth");
+            }
+            _ => panic!("expected group_traces_by success"),
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_list_traces_exclude_attributes_hides_matching_roots() {
+        reset_observability_test_state();
+
+        let module = make_test_module(Arc::new(Engine::new()));
+        let span_storage = otel::get_span_storage().expect("span storage should exist");
+        span_storage.clear();
+        span_storage.add_spans(vec![
+            make_span(
+                "t-noisy",
+                "n1",
+                None,
+                "call ui::subscribe",
+                "engine",
+                1_000_000_000,
+                1_100_000_000,
+                "OK",
+                vec![("function_id", "ui::subscribe")],
+            ),
+            make_span(
+                "t-kept",
+                "k1",
+                None,
+                "call harness::turn",
+                "engine",
+                2_000_000_000,
+                2_100_000_000,
+                "OK",
+                vec![("function_id", "harness::turn")],
+            ),
+            // The excluded function appearing INSIDE a trace must not hide it
+            // (root-match only).
+            make_span(
+                "t-kept-2",
+                "k2",
+                None,
+                "call other::fn",
+                "engine",
+                3_000_000_000,
+                3_200_000_000,
+                "OK",
+                vec![("function_id", "other::fn")],
+            ),
+            make_span(
+                "t-kept-2",
+                "k2-child",
+                Some("k2"),
+                "call ui::subscribe",
+                "engine",
+                3_050_000_000,
+                3_100_000_000,
+                "OK",
+                vec![("function_id", "ui::subscribe")],
+            ),
+        ]);
+
+        let result = module
+            .list_traces(TracesListInput {
+                trace_id: None,
+                trace_ids: None,
+                offset: None,
+                limit: None,
+                service_name: None,
+                name: None,
+                status: None,
+                min_duration_ms: None,
+                max_duration_ms: None,
+                start_time: None,
+                end_time: None,
+                sort_by: None,
+                sort_order: None,
+                attributes: None,
+                exclude_attributes: Some(vec![vec![
+                    "function_id".to_string(),
+                    "ui::subscribe".to_string(),
+                ]]),
+                include_internal: Some(true),
+                search_all_spans: None,
+            })
+            .await;
+
+        match result {
+            FunctionResult::Success(value) => {
+                let value = serde_json::to_value(&value).unwrap();
+                let spans = value["spans"].as_array().expect("spans array");
+                let trace_ids: Vec<&str> = spans
+                    .iter()
+                    .map(|s| s["trace_id"].as_str().unwrap())
+                    .collect();
+                assert_eq!(
+                    trace_ids,
+                    vec!["t-kept", "t-kept-2"],
+                    "root matching the excluded pair is hidden; a child match is not"
+                );
+            }
+            _ => panic!("expected list_traces success"),
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_list_traces_trace_ids_filters_to_requested_set() {
+        reset_observability_test_state();
+
+        let module = make_test_module(Arc::new(Engine::new()));
+        let span_storage = otel::get_span_storage().expect("span storage should exist");
+        span_storage.clear();
+        span_storage.add_spans(vec![
+            make_span("t-1", "s1", None, "op-1", "svc", 1_000_000_000, 1_100_000_000, "OK", vec![]),
+            make_span("t-2", "s2", None, "op-2", "svc", 2_000_000_000, 2_100_000_000, "OK", vec![]),
+            make_span("t-3", "s3", None, "op-3", "svc", 3_000_000_000, 3_100_000_000, "OK", vec![]),
+        ]);
+
+        let result = module
+            .list_traces(TracesListInput {
+                trace_id: None,
+                trace_ids: Some(vec!["t-1".to_string(), "t-3".to_string()]),
+                offset: None,
+                limit: None,
+                service_name: None,
+                name: None,
+                status: None,
+                min_duration_ms: None,
+                max_duration_ms: None,
+                start_time: None,
+                end_time: None,
+                sort_by: None,
+                sort_order: None,
+                attributes: None,
+                exclude_attributes: None,
+                include_internal: Some(true),
+                search_all_spans: None,
+            })
+            .await;
+
+        match result {
+            FunctionResult::Success(value) => {
+                let value = serde_json::to_value(&value).unwrap();
+                let spans = value["spans"].as_array().expect("spans array");
+                let trace_ids: Vec<&str> = spans
+                    .iter()
+                    .map(|s| s["trace_id"].as_str().unwrap())
+                    .collect();
+                assert_eq!(trace_ids, vec!["t-1", "t-3"]);
+            }
+            _ => panic!("expected list_traces success"),
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_list_traces_merges_trace_tags_from_child_spans() {
+        reset_observability_test_state();
+
+        let module = make_test_module(Arc::new(Engine::new()));
+        let span_storage = otel::get_span_storage().expect("span storage should exist");
+        span_storage.clear();
+        // Engine-side root has no baggage-derived attributes (it starts before
+        // the worker handler stamps baggage); children carry them.
+        span_storage.add_spans(vec![
+            make_span(
+                "t-turn",
+                "root",
+                None,
+                "call harness::turn",
+                "engine",
+                1_000_000_000,
+                2_000_000_000,
+                "OK",
+                vec![("function_id", "harness::turn")],
+            ),
+            make_span(
+                "t-turn",
+                "child-1",
+                Some("root"),
+                "call session::messages",
+                "session-manager",
+                1_100_000_000,
+                1_200_000_000,
+                "OK",
+                vec![
+                    ("iii.session.id", "S-1"),
+                    ("iii.session.name", "untitled"),
+                    ("iii.tag.message", "fix the login bug"),
+                ],
+            ),
+            // Newer child carries the renamed session: it wins the merge.
+            make_span(
+                "t-turn",
+                "child-2",
+                Some("root"),
+                "call router::chat",
+                "llm-router",
+                1_300_000_000,
+                1_900_000_000,
+                "OK",
+                vec![
+                    ("iii.session.id", "S-1"),
+                    ("iii.session.name", "refactor auth"),
+                    ("iii.message.id", "turn-9"),
+                ],
+            ),
+        ]);
+
+        let result = module
+            .list_traces(TracesListInput {
+                trace_id: None,
+                trace_ids: None,
+                offset: None,
+                limit: None,
+                service_name: None,
+                name: None,
+                status: None,
+                min_duration_ms: None,
+                max_duration_ms: None,
+                start_time: None,
+                end_time: None,
+                sort_by: None,
+                sort_order: None,
+                attributes: None,
+                exclude_attributes: None,
+                include_internal: Some(true),
+                search_all_spans: None,
+            })
+            .await;
+
+        match result {
+            FunctionResult::Success(value) => {
+                let value = serde_json::to_value(&value).unwrap();
+                let spans = value["spans"].as_array().expect("spans array");
+                assert_eq!(spans.len(), 1, "one root row expected");
+                let tags = &spans[0]["trace_tags"];
+                assert_eq!(tags["iii.tag.message"], "fix the login bug");
+                assert_eq!(tags["iii.session.id"], "S-1");
+                assert_eq!(
+                    tags["iii.session.name"], "refactor auth",
+                    "newest span's value wins on key conflict"
+                );
+                assert_eq!(tags["iii.message.id"], "turn-9");
+                // Non-tag attributes must not leak into trace_tags.
+                assert!(tags.get("function_id").is_none());
+            }
+            _ => panic!("expected list_traces success"),
         }
     }
 

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -2197,9 +2197,8 @@ impl ObservabilityWorker {
                         .map(|s| {
                             // Attach trace-level tags to the returned page only
                             // (per-row index lookup, bounded by `limit`).
-                            let tags = collect_trace_tags(
-                                &storage.get_spans_by_trace_id(&s.trace_id),
-                            );
+                            let tags =
+                                collect_trace_tags(&storage.get_spans_by_trace_id(&s.trace_id));
                             let mut value = serde_json::to_value(s).unwrap_or(Value::Null);
                             if !tags.is_empty()
                                 && let Value::Object(ref mut map) = value
@@ -7622,9 +7621,39 @@ mod tests {
         let span_storage = otel::get_span_storage().expect("span storage should exist");
         span_storage.clear();
         span_storage.add_spans(vec![
-            make_span("t-1", "s1", None, "op-1", "svc", 1_000_000_000, 1_100_000_000, "OK", vec![]),
-            make_span("t-2", "s2", None, "op-2", "svc", 2_000_000_000, 2_100_000_000, "OK", vec![]),
-            make_span("t-3", "s3", None, "op-3", "svc", 3_000_000_000, 3_100_000_000, "OK", vec![]),
+            make_span(
+                "t-1",
+                "s1",
+                None,
+                "op-1",
+                "svc",
+                1_000_000_000,
+                1_100_000_000,
+                "OK",
+                vec![],
+            ),
+            make_span(
+                "t-2",
+                "s2",
+                None,
+                "op-2",
+                "svc",
+                2_000_000_000,
+                2_100_000_000,
+                "OK",
+                vec![],
+            ),
+            make_span(
+                "t-3",
+                "s3",
+                None,
+                "op-3",
+                "svc",
+                3_000_000_000,
+                3_100_000_000,
+                "OK",
+                vec![],
+            ),
         ]);
 
         let result = module

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -19,13 +19,13 @@ use super::sampler::AdvancedSampler;
 use opentelemetry::propagation::{TextMapCompositePropagator, TextMapPropagator};
 use opentelemetry::{
     Context, KeyValue, global,
-    trace::{TraceContextExt, TracerProvider as _},
+    trace::{Span as _, TraceContextExt, TracerProvider as _},
 };
 use opentelemetry_sdk::{
     Resource,
     error::OTelSdkResult,
     propagation::{BaggagePropagator, TraceContextPropagator},
-    trace::{RandomIdGenerator, Sampler, SdkTracerProvider, SpanData, SpanExporter},
+    trace::{RandomIdGenerator, Sampler, SdkTracerProvider, SpanData, SpanExporter, SpanProcessor},
 };
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::Serialize;
@@ -145,6 +145,31 @@ pub struct OtelConfig {
     pub sampling_ratio: f64,
     /// Maximum spans to keep in memory. Used for Memory and Both exporters.
     pub memory_max_spans: usize,
+    /// Mirror spans into the in-memory store at start as `pending` snapshots
+    /// (`LiveSpanProcessor`), so live trace views show in-progress work.
+    /// Resolved by [`resolve_live_spans`]: on by default for the Memory
+    /// exporter (local dev), opt-in for Both (production), never effective
+    /// for Otlp-only. Restart-tier.
+    pub live_spans: bool,
+}
+
+/// `OTEL_LIVE_SPANS` env override for live-span mirroring.
+fn env_live_spans() -> Option<bool> {
+    env::var("OTEL_LIVE_SPANS")
+        .ok()
+        .map(|v| v == "true" || v == "1")
+}
+
+/// Resolve the live-spans switch: explicit config > `OTEL_LIVE_SPANS` env >
+/// mode-aware default. The default is ON only for the `memory` exporter (the
+/// local-dev mode where live trace views matter); `both` — the production
+/// shape that also exports OTLP — stays off unless explicitly enabled, and
+/// `otlp`-only can never mirror (engine finals don't land in the memory
+/// store there, so pendings would never be replaced).
+pub fn resolve_live_spans(explicit: Option<bool>, exporter: &ExporterType) -> bool {
+    explicit
+        .or_else(env_live_spans)
+        .unwrap_or(matches!(exporter, ExporterType::Memory))
 }
 
 impl Default for OtelConfig {
@@ -217,6 +242,8 @@ impl Default for OtelConfig {
             })
             .unwrap_or(DEFAULT_MEMORY_MAX_SPANS);
 
+        let live_spans = resolve_live_spans(global_cfg.and_then(|c| c.live_spans), &exporter);
+
         Self {
             enabled,
             service_name,
@@ -226,6 +253,7 @@ impl Default for OtelConfig {
             endpoint,
             sampling_ratio,
             memory_max_spans,
+            live_spans,
         }
     }
 }
@@ -365,6 +393,14 @@ pub struct StoredSpan {
     /// caller propagated a non-empty `tracestate` alongside `traceparent`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trace_state: Option<String>,
+    /// True while the span is in progress — a live snapshot taken by
+    /// `LiveSpanProcessor::on_start`, replaced in place by the final span when
+    /// it closes (`InMemorySpanStorage::add_spans`). Pending spans exist ONLY
+    /// in the in-memory store and the `iii:devtools:*` streams; they are never
+    /// exported via OTLP, where `end_time_unix_nano` is semantically required.
+    /// By convention `end_time_unix_nano == 0` while pending.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub pending: bool,
 }
 
 impl StoredSpan {
@@ -464,8 +500,35 @@ impl StoredSpan {
                 let ts = span.span_context.trace_state().header();
                 if ts.is_empty() { None } else { Some(ts) }
             },
+            pending: false,
         }
     }
+
+    /// Effective end for time math: a pending span is active "now", so time
+    /// filters and durations must not read its `end_time_unix_nano == 0`
+    /// sentinel literally.
+    pub fn effective_end_ns(&self, now_ns: u64) -> u64 {
+        if self.pending {
+            now_ns
+        } else {
+            self.end_time_unix_nano
+        }
+    }
+
+    /// Duration so far for pending spans, final duration otherwise.
+    pub fn duration_ns(&self, now_ns: u64) -> u64 {
+        self.effective_end_ns(now_ns)
+            .saturating_sub(self.start_time_unix_nano)
+    }
+}
+
+/// Nanoseconds since the UNIX epoch, for `StoredSpan::effective_end_ns` /
+/// `duration_ns`. Compute once per request so one listing sees one "now".
+pub fn now_unix_nanos() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as u64
 }
 
 /// In-memory span storage with circular buffer and broadcast channel.
@@ -476,9 +539,45 @@ pub struct InMemorySpanStorage {
     max_spans: std::sync::atomic::AtomicUsize,
     /// Secondary index: trace_id -> set of span indices for O(1) trace lookups
     spans_by_trace_id: RwLock<HashMap<String, HashSet<usize>>>,
+    /// span_ids currently stored as pending (live snapshots awaiting their
+    /// final span). Gates the replace-scan in `add_spans` so the hot append
+    /// path (OTLP ingest, exporters) stays O(1) when no pending predecessor
+    /// exists. Lock order everywhere: `spans` → `spans_by_trace_id` → this.
+    pending_span_ids: RwLock<HashSet<String>>,
     /// Broadcast of every span as it lands, driving the `trace` trigger
     /// fan-out. Mirrors `InMemoryLogStorage`'s log broadcast.
     tx: broadcast::Sender<StoredSpan>,
+}
+
+/// Evict oldest spans until `len < max_spans`, maintaining the trace index
+/// (shift-down on every pop) and purging evicted ids from the pending set.
+/// Callers hold all three storage locks (see the lock-order note above).
+fn evict_to_capacity(
+    spans: &mut VecDeque<StoredSpan>,
+    index: &mut HashMap<String, HashSet<usize>>,
+    pending: &mut HashSet<String>,
+    max_spans: usize,
+) {
+    // Loop converges after a shrink
+    while spans.len() >= max_spans
+        && let Some(old) = spans.pop_front()
+    {
+        pending.remove(&old.span_id);
+        // Remove from index and shift all indices down
+        if let Some(set) = index.get_mut(&old.trace_id) {
+            set.remove(&0);
+            *set = set.iter().filter_map(|&i| i.checked_sub(1)).collect();
+            if set.is_empty() {
+                index.remove(&old.trace_id);
+            }
+        }
+        // Also shift indices for all other trace_ids
+        for (trace_id, set) in index.iter_mut() {
+            if trace_id != &old.trace_id {
+                *set = set.iter().filter_map(|&i| i.checked_sub(1)).collect();
+            }
+        }
+    }
 }
 
 impl std::fmt::Debug for InMemorySpanStorage {
@@ -501,6 +600,7 @@ impl InMemorySpanStorage {
             spans: RwLock::new(VecDeque::with_capacity(max_spans)),
             max_spans: std::sync::atomic::AtomicUsize::new(max_spans),
             spans_by_trace_id: RwLock::new(HashMap::new()),
+            pending_span_ids: RwLock::new(HashSet::new()),
             tx,
         }
     }
@@ -515,8 +615,11 @@ impl InMemorySpanStorage {
         let mut spans = self.spans.write().unwrap();
         if spans.len() > max {
             let mut index = self.spans_by_trace_id.write().unwrap();
+            let mut pending = self.pending_span_ids.write().unwrap();
             let excess = spans.len() - max;
-            spans.drain(..excess);
+            for old in spans.drain(..excess) {
+                pending.remove(&old.span_id);
+            }
             index.clear();
             for (idx, span) in spans.iter().enumerate() {
                 index.entry(span.trace_id.clone()).or_default().insert(idx);
@@ -527,31 +630,31 @@ impl InMemorySpanStorage {
     pub fn add_spans(&self, new_spans: Vec<StoredSpan>) {
         let mut spans = self.spans.write().unwrap();
         let mut index = self.spans_by_trace_id.write().unwrap();
+        let mut pending = self.pending_span_ids.write().unwrap();
 
         let max_spans = self
             .max_spans
             .load(std::sync::atomic::Ordering::Relaxed)
             .max(1);
         for span in new_spans {
-            // Evict oldest if at capacity (loop converges after a shrink)
-            while spans.len() >= max_spans
-                && let Some(old) = spans.pop_front()
+            // A final span replacing its live (pending) snapshot overwrites in
+            // place: same idx, same trace_id, so neither index changes. The set
+            // gate keeps the scan off the hot append path, and pending spans
+            // are by construction recent, so scan from the back. The reverse
+            // never happens — a pending snapshot must not overwrite a final
+            // (`on_start` always precedes `on_end`, and OTLP-ingested worker
+            // spans are never pending).
+            if pending.remove(&span.span_id)
+                && let Some(slot) = spans.iter_mut().rev().find(|s| s.span_id == span.span_id)
             {
-                // Remove from index and shift all indices down
-                if let Some(set) = index.get_mut(&old.trace_id) {
-                    set.remove(&0);
-                    *set = set.iter().filter_map(|&i| i.checked_sub(1)).collect();
-                    if set.is_empty() {
-                        index.remove(&old.trace_id);
-                    }
-                }
-                // Also shift indices for all other trace_ids
-                for (trace_id, set) in index.iter_mut() {
-                    if trace_id != &old.trace_id {
-                        *set = set.iter().filter_map(|&i| i.checked_sub(1)).collect();
-                    }
-                }
+                let _ = self.tx.send(span.clone());
+                *slot = span;
+                continue;
             }
+            // A tracked pending whose slot was already evicted falls through
+            // and appends as a fresh span.
+
+            evict_to_capacity(&mut spans, &mut index, &mut pending, max_spans);
 
             let idx = spans.len();
             let trace_id = span.trace_id.clone();
@@ -565,6 +668,31 @@ impl InMemorySpanStorage {
             spans.push_back(span);
             index.entry(trace_id).or_default().insert(idx);
         }
+    }
+
+    /// Record an in-progress span snapshot (`LiveSpanProcessor::on_start`).
+    /// Appends + broadcasts exactly like `add_spans` and marks the id pending
+    /// so the final span replaces it in place when it closes. Pending spans
+    /// live ONLY in this store and the streams fed from it — the OTLP export
+    /// path never sees them.
+    pub fn add_pending_span(&self, span: StoredSpan) {
+        debug_assert!(span.pending && span.end_time_unix_nano == 0);
+        let mut spans = self.spans.write().unwrap();
+        let mut index = self.spans_by_trace_id.write().unwrap();
+        let mut pending = self.pending_span_ids.write().unwrap();
+
+        let max_spans = self
+            .max_spans
+            .load(std::sync::atomic::Ordering::Relaxed)
+            .max(1);
+        evict_to_capacity(&mut spans, &mut index, &mut pending, max_spans);
+
+        let idx = spans.len();
+        let trace_id = span.trace_id.clone();
+        pending.insert(span.span_id.clone());
+        let _ = self.tx.send(span.clone());
+        spans.push_back(span);
+        index.entry(trace_id).or_default().insert(idx);
     }
 
     pub fn get_spans(&self) -> Vec<StoredSpan> {
@@ -587,8 +715,10 @@ impl InMemorySpanStorage {
     pub fn clear(&self) {
         let mut spans = self.spans.write().unwrap();
         let mut index = self.spans_by_trace_id.write().unwrap();
+        let mut pending = self.pending_span_ids.write().unwrap();
         spans.clear();
         index.clear();
+        pending.clear();
     }
 
     /// Subscribe to a broadcast of every span as it lands in storage. Drives
@@ -614,9 +744,12 @@ impl InMemorySpanStorage {
             return (0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         }
 
-        // Calculate duration in milliseconds for each span
+        // Calculate duration in milliseconds for each span. In-flight
+        // (pending) spans are excluded — their duration isn't known yet, and
+        // counting them as 0/partial would drag down min/percentiles.
         let mut durations: Vec<f64> = spans
             .iter()
+            .filter(|span| !span.pending)
             .map(|span| {
                 let duration_nanos = span
                     .end_time_unix_nano
@@ -703,6 +836,68 @@ impl SpanExporter for InMemorySpanExporter {
 
     fn shutdown_with_timeout(&mut self, _timeout: std::time::Duration) -> OTelSdkResult {
         // Nothing to clean up for in-memory storage
+        Ok(())
+    }
+}
+
+/// Mirrors spans into the in-memory store at START (as `pending` snapshots) so
+/// live trace views can render in-progress work — most importantly the
+/// engine-side parent spans (`trigger <fn>`, `enqueue`, `call <fn>`) that
+/// otherwise only land after everything under them has finished.
+///
+/// The final span still arrives exclusively via the exporter path on close and
+/// replaces the snapshot in place (`InMemorySpanStorage::add_spans`). The OTLP
+/// export path is untouched: no partial spans ever reach the wire, where the
+/// proto documents `end_time_unix_nano` as semantically required.
+///
+/// Registered when `live_spans` resolves on (see [`resolve_live_spans`]:
+/// default for the `memory` exporter, explicit opt-in for `both`) — and never
+/// in OTLP-only mode, where engine finals don't land in memory storage and
+/// pendings would never be replaced.
+#[derive(Debug)]
+pub struct LiveSpanProcessor {
+    storage: Arc<InMemorySpanStorage>,
+    service_name: String,
+}
+
+impl LiveSpanProcessor {
+    pub fn new(storage: Arc<InMemorySpanStorage>, service_name: String) -> Self {
+        Self {
+            storage,
+            service_name,
+        }
+    }
+}
+
+impl SpanProcessor for LiveSpanProcessor {
+    fn on_start(&self, span: &mut opentelemetry_sdk::trace::Span, _cx: &Context) {
+        // RecordOnly spans are recorded but never exported (the exporter-side
+        // processors skip !is_sampled on_end) — skip them here too, or their
+        // pendings would never be finalized. Covers sampled-out spans as well.
+        if !span.span_context().is_sampled() {
+            return;
+        }
+        // None for non-recording spans.
+        let Some(data) = span.exported_data() else {
+            return;
+        };
+        let mut stored = StoredSpan::from_span_data(&data, &self.service_name);
+        stored.pending = true;
+        // The SDK initializes end_time = start_time at build; zero is the
+        // live-span sentinel (see the `StoredSpan::pending` docs).
+        stored.end_time_unix_nano = 0;
+        self.storage.add_pending_span(stored);
+    }
+
+    // MUST stay a no-op: the final span lands via the exporter path; replacing
+    // the pending here as well would race it and duplicate the span.
+    fn on_end(&self, _span: SpanData) {}
+
+    fn force_flush(&self) -> OTelSdkResult {
+        Ok(())
+    }
+
+    fn shutdown_with_timeout(&self, _timeout: std::time::Duration) -> OTelSdkResult {
         Ok(())
     }
 }
@@ -987,6 +1182,9 @@ where
                         Arc::new(InMemorySpanStorage::new(config.memory_max_spans));
                     let _ = IN_MEMORY_STORAGE.set(memory_storage);
 
+                    // No LiveSpanProcessor here: in OTLP-only mode engine
+                    // finals never land in memory storage, so pending
+                    // snapshots would never be replaced.
                     SdkTracerProvider::builder()
                         .with_span_processor(
                             iii_helpers::observability::BaggageSpanProcessor::default(),
@@ -1004,14 +1202,25 @@ where
                         "Failed to create OTLP exporter, falling back to memory-only mode"
                     );
                     // Fall back to memory-only mode
-                    let exporter = InMemorySpanExporter::new(
-                        config.memory_max_spans,
+                    let memory_storage =
+                        Arc::new(InMemorySpanStorage::new(config.memory_max_spans));
+                    if IN_MEMORY_STORAGE.set(memory_storage.clone()).is_err() {
+                        tracing::debug!("In-memory span storage already initialized");
+                    }
+                    let exporter = InMemorySpanExporter::with_storage(
+                        memory_storage.clone(),
                         config.service_name.clone(),
                     );
-                    SdkTracerProvider::builder()
-                        .with_span_processor(
-                            iii_helpers::observability::BaggageSpanProcessor::default(),
-                        )
+                    let mut builder = SdkTracerProvider::builder().with_span_processor(
+                        iii_helpers::observability::BaggageSpanProcessor::default(),
+                    );
+                    if config.live_spans {
+                        builder = builder.with_span_processor(LiveSpanProcessor::new(
+                            memory_storage,
+                            config.service_name.clone(),
+                        ));
+                    }
+                    builder
                         .with_simple_exporter(exporter)
                         .with_sampler(sampler)
                         .with_id_generator(RandomIdGenerator::default())
@@ -1021,11 +1230,30 @@ where
             }
         }
         ExporterType::Memory => {
-            let exporter =
-                InMemorySpanExporter::new(config.memory_max_spans, config.service_name.clone());
+            // Create the storage explicitly (rather than via
+            // `InMemorySpanExporter::new`) so the LiveSpanProcessor is
+            // guaranteed to share the exact storage the exporter writes to,
+            // even when the global slot was already taken by a prior init.
+            let memory_storage = Arc::new(InMemorySpanStorage::new(config.memory_max_spans));
+            if IN_MEMORY_STORAGE.set(memory_storage.clone()).is_err() {
+                tracing::debug!("In-memory span storage already initialized");
+            }
+            let exporter = InMemorySpanExporter::with_storage(
+                memory_storage.clone(),
+                config.service_name.clone(),
+            );
 
-            SdkTracerProvider::builder()
-                .with_span_processor(iii_helpers::observability::BaggageSpanProcessor::default())
+            let mut builder = SdkTracerProvider::builder()
+                .with_span_processor(iii_helpers::observability::BaggageSpanProcessor::default());
+            if config.live_spans {
+                // After BaggageSpanProcessor, so pending snapshots carry the
+                // baggage-stamped attributes.
+                builder = builder.with_span_processor(LiveSpanProcessor::new(
+                    memory_storage,
+                    config.service_name.clone(),
+                ));
+            }
+            builder
                 .with_simple_exporter(exporter)
                 .with_sampler(sampler)
                 .with_id_generator(RandomIdGenerator::default())
@@ -1047,14 +1275,22 @@ where
                     // Create tee exporter that sends to both
                     let tee_exporter = TeeSpanExporter::new(
                         otlp_exporter,
-                        memory_storage,
+                        memory_storage.clone(),
                         config.service_name.clone(),
                     );
 
-                    SdkTracerProvider::builder()
-                        .with_span_processor(
-                            iii_helpers::observability::BaggageSpanProcessor::default(),
-                        )
+                    let mut builder = SdkTracerProvider::builder().with_span_processor(
+                        iii_helpers::observability::BaggageSpanProcessor::default(),
+                    );
+                    if config.live_spans {
+                        // Pending snapshots feed ONLY the memory side; the
+                        // OTLP half of the tee still sees spans on close only.
+                        builder = builder.with_span_processor(LiveSpanProcessor::new(
+                            memory_storage,
+                            config.service_name.clone(),
+                        ));
+                    }
+                    builder
                         .with_batch_exporter(tee_exporter)
                         .with_sampler(sampler)
                         .with_id_generator(RandomIdGenerator::default())
@@ -1069,13 +1305,19 @@ where
                     );
                     // Fall back to memory-only with our already-created storage
                     let exporter = InMemorySpanExporter::with_storage(
-                        memory_storage,
+                        memory_storage.clone(),
                         config.service_name.clone(),
                     );
-                    SdkTracerProvider::builder()
-                        .with_span_processor(
-                            iii_helpers::observability::BaggageSpanProcessor::default(),
-                        )
+                    let mut builder = SdkTracerProvider::builder().with_span_processor(
+                        iii_helpers::observability::BaggageSpanProcessor::default(),
+                    );
+                    if config.live_spans {
+                        builder = builder.with_span_processor(LiveSpanProcessor::new(
+                            memory_storage,
+                            config.service_name.clone(),
+                        ));
+                    }
+                    builder
                         .with_simple_exporter(exporter)
                         .with_sampler(sampler)
                         .with_id_generator(RandomIdGenerator::default())
@@ -1244,7 +1486,7 @@ pub fn extract_context_with_state(
 }
 
 /// Baggage key the `BaggageSpanProcessor` copies onto every span as the
-/// `iii.function.id` attribute (see the SDK observability crate allowlist).
+/// `iii.function.id` attribute (baggage entries copy to spans unconditionally).
 const FUNCTION_ID_BAGGAGE_KEY: &str = "iii.function.id";
 
 /// Return a context identical to `cx` but with the `iii.function.id` baggage
@@ -2076,6 +2318,8 @@ pub async fn ingest_otlp_json(json_str: &str) -> anyhow::Result<()> {
                         flags: span.flags,
                         // OTLP-ingested spans don't currently carry tracestate.
                         trace_state: None,
+                        // Worker spans arrive only when closed — never pending.
+                        pending: false,
                     };
 
                     stored_spans.push(stored_span);
@@ -4634,6 +4878,7 @@ mod tests {
             instrumentation_scope_version: None,
             flags: None,
             trace_state: None,
+            pending: false,
         }
     }
 
@@ -4729,6 +4974,246 @@ mod tests {
         assert!(storage.get_spans_by_trace_id("t2").is_empty());
     }
 
+    // ==========================================================================
+    // Pending (live) span tests
+    // ==========================================================================
+
+    /// Pending-span variant of `make_stored_span` (end sentinel 0).
+    fn make_pending_span(trace_id: &str, span_id: &str, name: &str, start_ns: u64) -> StoredSpan {
+        let mut span = make_stored_span(trace_id, span_id, name, start_ns, 0);
+        span.pending = true;
+        span.status = "unset".to_string();
+        span
+    }
+
+    #[test]
+    fn pending_span_replaced_in_place_by_final() {
+        let storage = InMemorySpanStorage::new(10);
+
+        storage.add_spans(vec![make_stored_span("t1", "a", "op-a", 1_000, 2_000)]);
+        storage.add_pending_span(make_pending_span("t1", "p", "op-p", 3_000));
+        storage.add_spans(vec![make_stored_span("t1", "b", "op-b", 4_000, 5_000)]);
+        assert_eq!(storage.pending_span_ids.read().unwrap().len(), 1);
+
+        // Final arrives: replaces the pending snapshot at its original position.
+        storage.add_spans(vec![make_stored_span("t1", "p", "op-p", 3_000, 9_000)]);
+
+        let spans = storage.get_spans();
+        assert_eq!(spans.len(), 3, "replace, not append");
+        assert_eq!(spans[1].span_id, "p", "position preserved");
+        assert!(!spans[1].pending);
+        assert_eq!(spans[1].end_time_unix_nano, 9_000);
+        assert!(storage.pending_span_ids.read().unwrap().is_empty());
+        assert_eq!(storage.get_spans_by_trace_id("t1").len(), 3);
+
+        // The id is no longer pending-tracked: a duplicate final appends
+        // (unchanged pre-existing behavior for duplicate finals).
+        storage.add_spans(vec![make_stored_span("t1", "p", "op-p", 3_000, 9_500)]);
+        assert_eq!(storage.get_spans().len(), 4);
+    }
+
+    #[test]
+    fn pending_span_evicted_before_final_appends_fresh() {
+        let storage = InMemorySpanStorage::new(2);
+
+        storage.add_pending_span(make_pending_span("t1", "p", "op-p", 1_000));
+        storage.add_spans(vec![
+            make_stored_span("t2", "a", "op-a", 2_000, 3_000),
+            // Third insert evicts the oldest (the pending snapshot).
+            make_stored_span("t3", "b", "op-b", 4_000, 5_000),
+        ]);
+        assert!(storage.pending_span_ids.read().unwrap().is_empty());
+
+        // The late final no longer has a pending predecessor — plain append.
+        storage.add_spans(vec![make_stored_span("t1", "p", "op-p", 1_000, 6_000)]);
+        let spans = storage.get_spans();
+        assert_eq!(spans.len(), 2);
+        let last = spans.last().unwrap();
+        assert_eq!(last.span_id, "p");
+        assert!(!last.pending);
+        assert_eq!(last.end_time_unix_nano, 6_000);
+    }
+
+    #[test]
+    fn set_max_spans_and_clear_purge_pending_ids() {
+        let storage = InMemorySpanStorage::new(10);
+        storage.add_pending_span(make_pending_span("t1", "p1", "op", 1_000));
+        storage.add_pending_span(make_pending_span("t2", "p2", "op", 2_000));
+
+        storage.set_max_spans(1); // drains p1
+        assert_eq!(storage.len(), 1);
+        let pending: Vec<String> = storage
+            .pending_span_ids
+            .read()
+            .unwrap()
+            .iter()
+            .cloned()
+            .collect();
+        assert_eq!(pending, vec!["p2".to_string()]);
+
+        storage.clear();
+        assert!(storage.pending_span_ids.read().unwrap().is_empty());
+    }
+
+    #[test]
+    fn performance_metrics_exclude_pending_spans() {
+        let storage = InMemorySpanStorage::new(10);
+        let base = 1_000_000_000u64;
+        storage.add_spans(vec![
+            make_stored_span("t1", "s1", "op1", base, base + 10_000_000),
+            make_stored_span("t2", "s2", "op2", base, base + 30_000_000),
+        ]);
+        // An in-flight span must not drag the statistics toward 0.
+        storage.add_pending_span(make_pending_span("t3", "p", "op-p", base));
+
+        let (avg, _p50, _p95, _p99, min, max) = storage.calculate_performance_metrics();
+        assert_eq!(min, 10.0);
+        assert_eq!(max, 30.0);
+        assert_eq!(avg, 20.0);
+    }
+
+    #[test]
+    fn effective_end_and_duration_treat_pending_as_active_now() {
+        let now = 10_000u64;
+        let done = make_stored_span("t", "s", "op", 1_000, 2_000);
+        assert_eq!(done.effective_end_ns(now), 2_000);
+        assert_eq!(done.duration_ns(now), 1_000);
+
+        let live = make_pending_span("t", "p", "op", 1_000);
+        assert_eq!(live.effective_end_ns(now), now);
+        assert_eq!(live.duration_ns(now), 9_000);
+    }
+
+    #[test]
+    #[serial]
+    fn live_spans_defaults_on_for_memory_exporter_only() {
+        temp_env::with_vars([("OTEL_LIVE_SPANS", None::<&str>)], || {
+            // Mode-aware default: local-dev memory mode mirrors live spans;
+            // production shapes (both/otlp) don't unless asked to.
+            assert!(resolve_live_spans(None, &ExporterType::Memory));
+            assert!(!resolve_live_spans(None, &ExporterType::Both));
+            assert!(!resolve_live_spans(None, &ExporterType::Otlp));
+            // Explicit config beats the mode default in either direction.
+            assert!(resolve_live_spans(Some(true), &ExporterType::Both));
+            assert!(!resolve_live_spans(Some(false), &ExporterType::Memory));
+        });
+        // The env var opts a production (both) setup in…
+        temp_env::with_vars([("OTEL_LIVE_SPANS", Some("true"))], || {
+            assert!(resolve_live_spans(None, &ExporterType::Both));
+        });
+        // …or a memory setup out, and explicit config still wins over it.
+        temp_env::with_vars([("OTEL_LIVE_SPANS", Some("false"))], || {
+            assert!(!resolve_live_spans(None, &ExporterType::Memory));
+            assert!(resolve_live_spans(Some(true), &ExporterType::Both));
+        });
+    }
+
+    #[test]
+    fn pending_field_serialized_only_when_true() {
+        let done = make_stored_span("t", "s", "op", 1, 2);
+        let json = serde_json::to_value(&done).unwrap();
+        assert!(
+            json.get("pending").is_none(),
+            "wire shape of finished spans must be unchanged"
+        );
+
+        let live = make_pending_span("t", "p", "op", 1);
+        let json = serde_json::to_value(&live).unwrap();
+        assert_eq!(json["pending"], serde_json::Value::Bool(true));
+        assert_eq!(json["end_time_unix_nano"], 0);
+    }
+
+    /// Test stand-in for the OTLP exporter: captures what would go on the wire.
+    #[derive(Debug, Clone)]
+    struct CapturingExporter(Arc<std::sync::Mutex<Vec<SpanData>>>);
+
+    impl SpanExporter for CapturingExporter {
+        fn export(
+            &self,
+            batch: Vec<SpanData>,
+        ) -> impl std::future::Future<Output = OTelSdkResult> + Send {
+            self.0.lock().unwrap().extend(batch);
+            async { Ok(()) }
+        }
+    }
+
+    #[test]
+    fn live_span_processor_mirrors_pending_and_wire_stays_clean() {
+        use opentelemetry::trace::{Span as _, Tracer as _, TracerProvider as _};
+
+        let storage = Arc::new(InMemorySpanStorage::new(100));
+        let wire = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let provider = SdkTracerProvider::builder()
+            .with_span_processor(iii_helpers::observability::BaggageSpanProcessor::default())
+            .with_span_processor(LiveSpanProcessor::new(storage.clone(), "test-svc".into()))
+            // Memory side (final replaces pending) + wire stand-in (OTLP path).
+            .with_simple_exporter(InMemorySpanExporter::with_storage(
+                storage.clone(),
+                "test-svc".into(),
+            ))
+            .with_simple_exporter(CapturingExporter(wire.clone()))
+            .build();
+        let tracer = provider.tracer("test");
+
+        let mut span = tracer
+            .span_builder("call fn::x")
+            .with_attributes([KeyValue::new("function_id", "fn::x")])
+            .start(&tracer);
+
+        {
+            let stored = storage.get_spans();
+            assert_eq!(stored.len(), 1, "pending snapshot lands at start");
+            assert!(stored[0].pending);
+            assert_eq!(stored[0].end_time_unix_nano, 0);
+            assert_eq!(stored[0].name, "call fn::x");
+            assert!(
+                stored[0]
+                    .attributes
+                    .iter()
+                    .any(|(k, v)| k == "function_id" && v == "fn::x"),
+                "creation attributes present on the pending snapshot"
+            );
+            assert!(wire.lock().unwrap().is_empty(), "nothing exported at start");
+        }
+
+        span.end();
+
+        let stored = storage.get_spans();
+        assert_eq!(stored.len(), 1, "final replaced the pending snapshot");
+        assert!(!stored[0].pending);
+        assert!(stored[0].end_time_unix_nano > 0);
+
+        let exported = wire.lock().unwrap();
+        assert_eq!(exported.len(), 1, "exactly one span on the wire");
+        let end_ns = exported[0]
+            .end_time
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+        assert!(end_ns > 0, "no unfinished span ever reaches the wire");
+    }
+
+    #[test]
+    fn live_span_processor_skips_sampled_out_spans() {
+        use opentelemetry::trace::{Tracer as _, TracerProvider as _};
+
+        let storage = Arc::new(InMemorySpanStorage::new(100));
+        let provider = SdkTracerProvider::builder()
+            .with_sampler(Sampler::AlwaysOff)
+            .with_span_processor(LiveSpanProcessor::new(storage.clone(), "test-svc".into()))
+            .with_simple_exporter(InMemorySpanExporter::with_storage(
+                storage.clone(),
+                "test-svc".into(),
+            ))
+            .build();
+        let tracer = provider.tracer("test");
+
+        let span = tracer.start("dropped");
+        drop(span);
+
+        assert!(storage.get_spans().is_empty(), "sampled-out spans leave no pending");
+    }
+
     #[test]
     fn test_span_storage_len_and_is_empty() {
         let storage = InMemorySpanStorage::new(10);
@@ -4815,6 +5300,7 @@ mod tests {
             endpoint: "http://localhost:4317".to_string(),
             sampling_ratio: 1.0,
             memory_max_spans: 100,
+            live_spans: true,
         };
 
         let sampler = build_sampler(&config);
@@ -4833,6 +5319,7 @@ mod tests {
             endpoint: "http://localhost:4317".to_string(),
             sampling_ratio: 0.0,
             memory_max_spans: 100,
+            live_spans: true,
         };
 
         let sampler = build_sampler(&config);
@@ -4850,6 +5337,7 @@ mod tests {
             endpoint: "http://localhost:4317".to_string(),
             sampling_ratio: 0.5,
             memory_max_spans: 100,
+            live_spans: true,
         };
 
         let sampler = build_sampler(&config);

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -5211,7 +5211,10 @@ mod tests {
         let span = tracer.start("dropped");
         drop(span);
 
-        assert!(storage.get_spans().is_empty(), "sampled-out spans leave no pending");
+        assert!(
+            storage.get_spans().is_empty(),
+            "sampled-out spans leave no pending"
+        );
     }
 
     #[test]

--- a/engine/tests/observability_configuration_e2e.rs
+++ b/engine/tests/observability_configuration_e2e.rs
@@ -740,6 +740,7 @@ fn make_span(i: u64) -> iii::workers::observability::otel::StoredSpan {
         instrumentation_scope_version: None,
         flags: None,
         trace_state: None,
+        pending: false,
     }
 }
 

--- a/sdk/packages/node/helpers/src/observability/index.ts
+++ b/sdk/packages/node/helpers/src/observability/index.ts
@@ -3,7 +3,6 @@ export { executeTracedRequest } from './http-instrumentation'
 export type { TracedFetchInit } from './http-instrumentation'
 export {
   BaggageSpanProcessor,
-  DEFAULT_ALLOWLIST,
   currentSpanId,
   currentSpanIsRecording,
   currentTraceId,

--- a/sdk/packages/node/helpers/src/observability/telemetry-system/baggage-span-processor.ts
+++ b/sdk/packages/node/helpers/src/observability/telemetry-system/baggage-span-processor.ts
@@ -1,24 +1,20 @@
 // Baggage -> span attribute processor.
+//
+// Copies EVERY baggage entry onto every span started in its scope,
+// unconditionally — the same contract as the upstream OTel contrib
+// BaggageSpanProcessor. There is deliberately no key filtering here: a
+// filtering policy baked into worker binaries has to be kept in lockstep
+// across every SDK language and every deployed worker, and a stale binary
+// silently drops newer keys. Which attributes *mean* something (e.g. the
+// `iii.tag.*` trace-tag namespace, `iii.session.*`) is a query-side
+// convention owned by the engine's traces API, where it can evolve without
+// touching workers.
 
 import type { Context } from '@opentelemetry/api'
 import { propagation } from '@opentelemetry/api'
 import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-base'
 
-/** DEFAULT_ALLOWLIST drift across languages would break worker chains;
- * lockstep tests in each SDK pin this constant at CI time. */
-export const DEFAULT_ALLOWLIST: readonly string[] = [
-  'iii.session.id',
-  'iii.message.id',
-  'iii.function.id',
-] as const
-
 export class BaggageSpanProcessor implements SpanProcessor {
-  private readonly allowlist: readonly string[]
-
-  constructor(allowlist: readonly string[] = DEFAULT_ALLOWLIST) {
-    this.allowlist = allowlist
-  }
-
   onStart(span: Span, parentContext: Context): void {
     // NoOp guard: skip allocation when sampler drops the span.
     if (!span.isRecording()) {
@@ -30,11 +26,8 @@ export class BaggageSpanProcessor implements SpanProcessor {
       return
     }
 
-    for (const key of this.allowlist) {
-      const entry = baggage.getEntry(key)
-      if (entry) {
-        span.setAttribute(key, entry.value)
-      }
+    for (const [key, entry] of baggage.getAllEntries()) {
+      span.setAttribute(key, entry.value)
     }
   }
 

--- a/sdk/packages/node/helpers/src/observability/telemetry-system/index.ts
+++ b/sdk/packages/node/helpers/src/observability/telemetry-system/index.ts
@@ -46,7 +46,7 @@ import { parseIntegerEnv, resolveFlushIntervalMs } from './utils'
 // Re-export everything from submodules
 export * from './types'
 export * from './context'
-export { BaggageSpanProcessor, DEFAULT_ALLOWLIST } from './baggage-span-processor'
+export { BaggageSpanProcessor } from './baggage-span-processor'
 export {
   currentSpanIsRecording,
   recordSpanEvent,

--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -372,11 +372,13 @@ class Sdk implements IIIClient {
             const parentContext = extractContext(traceparent, baggage)
 
             // INTERNAL and named `execute` (not `call`/`trigger`): the engine
-            // already emits the SERVER `call <fn>` span for this hop AND a
-            // `trigger <fn>` span from fire_triggers. Reusing either name would
-            // duplicate an engine span under the worker's service. `execute` is
-            // unique, so the worker handler span reads as a clean internal child
-            // of the engine's call span (and is collapsible by a single rule).
+            // suppresses its own `call <fn>` span for worker-routed functions
+            // (this span is the canonical one for the invocation) but still
+            // emits engine-side wrappers like `trigger <fn>` from fire_triggers
+            // and `call <fn>` for builtins. Reusing those names would read as
+            // duplicate engine spans under the worker's service. `execute` is
+            // unique, so the worker handler span reads as a clean internal
+            // child (and is collapsible by a single rule).
             return context.with(parentContext, () =>
               withSpan(`execute ${functionId}`, { kind: SpanKind.INTERNAL }, async () => await runHandler()),
             )

--- a/sdk/packages/node/iii/tests/baggage-span-processor.test.ts
+++ b/sdk/packages/node/iii/tests/baggage-span-processor.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@opentelemetry/sdk-trace-base'
 import { describe, expect, it } from 'vitest'
 
-import { BaggageSpanProcessor, DEFAULT_ALLOWLIST } from '@iii-dev/helpers/observability'
+import { BaggageSpanProcessor } from '@iii-dev/helpers/observability'
 
 function buildTestProvider(processor: BaggageSpanProcessor) {
   const exporter = new InMemorySpanExporter()
@@ -34,24 +34,30 @@ function firstSpanAttr(exporter: InMemorySpanExporter, key: string): AttributeVa
 }
 
 describe('BaggageSpanProcessor', () => {
-  it('copies default allowlist from baggage to attributes', () => {
+  it('copies every baggage entry to attributes', () => {
+    // No key policy: which attributes *mean* something (`iii.tag.*`,
+    // `iii.session.*`) is a query-side convention owned by the engine's
+    // traces API — a filtering policy baked into worker binaries would
+    // silently drop newer keys from any worker running an older SDK.
     const { tracer, exporter } = buildTestProvider(new BaggageSpanProcessor())
 
-    withBaggage(
-      {
-        'iii.session.id': 'S-1',
-        'iii.message.id': 'M-1',
-        'iii.function.id': 'auth::set_token',
-      },
-      () => {
-        const span = tracer.startSpan('inner')
-        span.end()
-      },
-    )
+    const entries = {
+      'iii.session.id': 'S-1',
+      'iii.session.name': 'refactor auth',
+      'iii.message.id': 'M-1',
+      'iii.function.id': 'auth::set_token',
+      'iii.tag.message': 'fix the login bug',
+      // Non-iii baggage is a first-class tag source too.
+      'tenant.id': 't-42',
+    }
+    withBaggage(entries, () => {
+      const span = tracer.startSpan('inner')
+      span.end()
+    })
 
-    expect(firstSpanAttr(exporter, 'iii.session.id')).toBe('S-1')
-    expect(firstSpanAttr(exporter, 'iii.message.id')).toBe('M-1')
-    expect(firstSpanAttr(exporter, 'iii.function.id')).toBe('auth::set_token')
+    for (const [key, value] of Object.entries(entries)) {
+      expect(firstSpanAttr(exporter, key), key).toBe(value)
+    }
   })
 
   it('missing baggage entry means attribute not set', () => {
@@ -65,48 +71,6 @@ describe('BaggageSpanProcessor', () => {
     expect(firstSpanAttr(exporter, 'iii.message.id')).toBe('M-only')
     expect(firstSpanAttr(exporter, 'iii.session.id')).toBeUndefined()
     expect(firstSpanAttr(exporter, 'iii.function.id')).toBeUndefined()
-  })
-
-  it('baggage entries not in allowlist are dropped', () => {
-    const { tracer, exporter } = buildTestProvider(new BaggageSpanProcessor())
-
-    withBaggage(
-      {
-        'iii.message.id': 'M',
-        'tenant.id': 't-42',
-        'debug.feature_flag': 'on',
-      },
-      () => {
-        const span = tracer.startSpan('inner')
-        span.end()
-      },
-    )
-
-    expect(firstSpanAttr(exporter, 'iii.message.id')).toBe('M')
-    expect(firstSpanAttr(exporter, 'tenant.id')).toBeUndefined()
-    expect(firstSpanAttr(exporter, 'debug.feature_flag')).toBeUndefined()
-  })
-
-  it('custom allowlist is honored', () => {
-    const { tracer, exporter } = buildTestProvider(
-      new BaggageSpanProcessor(['tenant.id', 'iii.message.id']),
-    )
-
-    withBaggage(
-      {
-        'tenant.id': 't-1',
-        'iii.message.id': 'M',
-        'iii.session.id': 'S-not-copied',
-      },
-      () => {
-        const span = tracer.startSpan('inner')
-        span.end()
-      },
-    )
-
-    expect(firstSpanAttr(exporter, 'tenant.id')).toBe('t-1')
-    expect(firstSpanAttr(exporter, 'iii.message.id')).toBe('M')
-    expect(firstSpanAttr(exporter, 'iii.session.id')).toBeUndefined()
   })
 
   it('empty parent context produces no attributes', () => {
@@ -139,14 +103,5 @@ describe('BaggageSpanProcessor', () => {
     )
 
     expect(exporter.getFinishedSpans()).toHaveLength(0)
-  })
-
-  it('default allowlist matches the Rust SDK and harness contract', () => {
-    // DEFAULT_ALLOWLIST drift across languages would break worker chains.
-    expect([...DEFAULT_ALLOWLIST]).toEqual([
-      'iii.session.id',
-      'iii.message.id',
-      'iii.function.id',
-    ])
   })
 })

--- a/sdk/packages/python/helpers/src/iii_helpers/observability/__init__.py
+++ b/sdk/packages/python/helpers/src/iii_helpers/observability/__init__.py
@@ -1,6 +1,6 @@
 """iii_helpers.observability: shared OTel + Logger primitives."""
 
-from .baggage_span_processor import DEFAULT_ALLOWLIST, BaggageSpanProcessor
+from .baggage_span_processor import BaggageSpanProcessor
 from .http_instrumentation import execute_traced_request
 from .logger import Logger
 from .payload import (
@@ -32,7 +32,6 @@ from .telemetry_types import OtelConfig
 
 __all__ = [
     "BaggageSpanProcessor",
-    "DEFAULT_ALLOWLIST",
     "Logger",
     "OtelConfig",
     "REDACTED_PLACEHOLDER",

--- a/sdk/packages/python/helpers/src/iii_helpers/observability/baggage_span_processor.py
+++ b/sdk/packages/python/helpers/src/iii_helpers/observability/baggage_span_processor.py
@@ -1,36 +1,34 @@
-"""Baggage -> span attribute processor."""
+"""Baggage -> span attribute processor.
+
+Copies EVERY baggage entry onto every span started in its scope,
+unconditionally -- the same contract as the upstream OTel contrib
+``BaggageSpanProcessor``. There is deliberately no key filtering here: a
+filtering policy baked into worker binaries has to be kept in lockstep
+across every SDK language and every deployed worker, and a stale binary
+silently drops newer keys. Which attributes *mean* something (e.g. the
+``iii.tag.*`` trace-tag namespace, ``iii.session.*``) is a query-side
+convention owned by the engine's traces API, where it can evolve without
+touching workers.
+"""
 
 from __future__ import annotations
-
-from typing import Sequence
 
 from opentelemetry import baggage
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 
-#: DEFAULT_ALLOWLIST drift across languages would break worker chains;
-#: lockstep tests in each SDK pin this constant at CI time.
-DEFAULT_ALLOWLIST: tuple[str, ...] = (
-    "iii.session.id",
-    "iii.message.id",
-    "iii.function.id",
-)
-
 
 class BaggageSpanProcessor(SpanProcessor):
-
-    def __init__(self, allowlist: Sequence[str] = DEFAULT_ALLOWLIST) -> None:
-        self._allowlist: tuple[str, ...] = tuple(allowlist)
 
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
         # NoOp guard: skip allocation when sampler drops the span.
         if not span.is_recording():
             return
 
-        for key in self._allowlist:
-            value = baggage.get_baggage(key, parent_context)
-            if value is not None:
-                span.set_attribute(key, str(value))
+        for key, value in baggage.get_all(parent_context).items():
+            if value is None:
+                continue
+            span.set_attribute(key, str(value))
 
     def on_end(self, span: ReadableSpan) -> None:  # noqa: ARG002
         pass

--- a/sdk/packages/python/iii/tests/test_baggage_span_processor.py
+++ b/sdk/packages/python/iii/tests/test_baggage_span_processor.py
@@ -10,10 +10,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
 )
 from opentelemetry.sdk.trace.sampling import ALWAYS_OFF
 
-from iii_helpers.observability import (
-    DEFAULT_ALLOWLIST,
-    BaggageSpanProcessor,
-)
+from iii_helpers.observability import BaggageSpanProcessor
 
 
 def _build_test_provider(
@@ -40,26 +37,35 @@ def _first_span_attr(exporter: InMemorySpanExporter, key: str) -> object | None:
     return spans[0].attributes.get(key) if spans[0].attributes else None
 
 
-def test_copies_default_allowlist_from_baggage_to_attributes() -> None:
+def test_copies_every_baggage_entry_to_attributes() -> None:
+    """No key policy: baggage copies to span attributes unconditionally.
+
+    Which attributes *mean* something (`iii.tag.*`, `iii.session.*`) is a
+    query-side convention owned by the engine's traces API — a filtering
+    policy baked into worker binaries would silently drop newer keys from
+    any worker running an older SDK.
+    """
     provider, exporter = _build_test_provider(BaggageSpanProcessor())
     tracer = provider.get_tracer("test")
 
-    token = _attach_baggage(
-        {
-            "iii.session.id": "S-1",
-            "iii.message.id": "M-1",
-            "iii.function.id": "auth::set_token",
-        }
-    )
+    entries = {
+        "iii.session.id": "S-1",
+        "iii.session.name": "refactor auth",
+        "iii.message.id": "M-1",
+        "iii.function.id": "auth::set_token",
+        "iii.tag.message": "fix the login bug",
+        # Non-iii baggage is a first-class tag source too.
+        "tenant.id": "t-42",
+    }
+    token = _attach_baggage(entries)
     try:
         with tracer.start_as_current_span("inner"):
             pass
     finally:
         context.detach(token)
 
-    assert _first_span_attr(exporter, "iii.session.id") == "S-1"
-    assert _first_span_attr(exporter, "iii.message.id") == "M-1"
-    assert _first_span_attr(exporter, "iii.function.id") == "auth::set_token"
+    for key, value in entries.items():
+        assert _first_span_attr(exporter, key) == value, key
 
 
 def test_missing_baggage_entry_means_attribute_not_set() -> None:
@@ -76,51 +82,6 @@ def test_missing_baggage_entry_means_attribute_not_set() -> None:
     assert _first_span_attr(exporter, "iii.message.id") == "M-only"
     assert _first_span_attr(exporter, "iii.session.id") is None
     assert _first_span_attr(exporter, "iii.function.id") is None
-
-
-def test_baggage_entries_not_in_allowlist_are_dropped() -> None:
-    provider, exporter = _build_test_provider(BaggageSpanProcessor())
-    tracer = provider.get_tracer("test")
-
-    token = _attach_baggage(
-        {
-            "iii.message.id": "M",
-            "tenant.id": "t-42",
-            "debug.feature_flag": "on",
-        }
-    )
-    try:
-        with tracer.start_as_current_span("inner"):
-            pass
-    finally:
-        context.detach(token)
-
-    assert _first_span_attr(exporter, "iii.message.id") == "M"
-    assert _first_span_attr(exporter, "tenant.id") is None
-    assert _first_span_attr(exporter, "debug.feature_flag") is None
-
-
-def test_custom_allowlist_is_honored() -> None:
-    processor = BaggageSpanProcessor(allowlist=["tenant.id", "iii.message.id"])
-    provider, exporter = _build_test_provider(processor)
-    tracer = provider.get_tracer("test")
-
-    token = _attach_baggage(
-        {
-            "tenant.id": "t-1",
-            "iii.message.id": "M",
-            "iii.session.id": "S-not-copied",
-        }
-    )
-    try:
-        with tracer.start_as_current_span("inner"):
-            pass
-    finally:
-        context.detach(token)
-
-    assert _first_span_attr(exporter, "tenant.id") == "t-1"
-    assert _first_span_attr(exporter, "iii.message.id") == "M"
-    assert _first_span_attr(exporter, "iii.session.id") is None
 
 
 def test_empty_parent_context_produces_no_attributes() -> None:
@@ -151,12 +112,3 @@ def test_noop_guard_skips_processing_when_sampled_out() -> None:
         context.detach(token)
 
     assert exporter.get_finished_spans() == ()
-
-
-def test_default_allowlist_matches_other_sdks() -> None:
-    """DEFAULT_ALLOWLIST drift across languages would break worker chains."""
-    assert tuple(DEFAULT_ALLOWLIST) == (
-        "iii.session.id",
-        "iii.message.id",
-        "iii.function.id",
-    )

--- a/sdk/packages/rust/helpers/src/observability/mod.rs
+++ b/sdk/packages/rust/helpers/src/observability/mod.rs
@@ -7,7 +7,7 @@ pub mod telemetry;
 pub use opentelemetry;
 
 pub use self::logger::Logger;
-pub use self::telemetry::baggage_span_processor::{BaggageSpanProcessor, DEFAULT_ALLOWLIST};
+pub use self::telemetry::baggage_span_processor::BaggageSpanProcessor;
 pub use self::telemetry::context::{
     CapturedContext, capture_otel_context, current_span_id, current_trace_id, extract_baggage,
     extract_context, extract_traceparent, get_all_baggage, get_baggage_entry, inject_baggage,

--- a/sdk/packages/rust/helpers/src/observability/telemetry/baggage_span_processor.rs
+++ b/sdk/packages/rust/helpers/src/observability/telemetry/baggage_span_processor.rs
@@ -1,4 +1,19 @@
 //! Baggage -> span attribute processor.
+//!
+//! Copies EVERY baggage entry onto every span started in its scope,
+//! unconditionally — the same contract as the upstream OTel contrib
+//! `BaggageSpanProcessor`. There is deliberately no key filtering here:
+//! a filtering policy baked into worker binaries has to be kept in
+//! lockstep across every SDK language and every deployed worker, and a
+//! stale binary silently drops newer keys. Which attributes *mean*
+//! something (e.g. the `iii.tag.*` trace-tag namespace, `iii.session.*`)
+//! is a query-side convention owned by the engine's traces API, where it
+//! can evolve without touching workers.
+//!
+//! Baggage in the iii ecosystem is set by iii code (turn identity, trace
+//! tags, function routing), so span attributes stay bounded by what
+//! callers deliberately stamp; W3C propagator limits bound what can
+//! arrive from outside.
 
 use opentelemetry::baggage::BaggageExt;
 use opentelemetry::trace::Span as _;
@@ -6,32 +21,13 @@ use opentelemetry::{Context, KeyValue};
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::trace::{Span, SpanData, SpanProcessor};
 
-/// DEFAULT_ALLOWLIST drift across languages would break worker chains;
-/// lockstep tests in each SDK pin this constant at CI time.
-pub const DEFAULT_ALLOWLIST: &[&str] = &["iii.session.id", "iii.message.id", "iii.function.id"];
-
-#[derive(Debug, Clone)]
-pub struct BaggageSpanProcessor {
-    allowlist: Vec<&'static str>,
-}
+#[derive(Debug, Clone, Default)]
+pub struct BaggageSpanProcessor;
 
 impl BaggageSpanProcessor {
     #[must_use]
     pub fn new() -> Self {
-        Self::default()
-    }
-
-    #[must_use]
-    pub const fn with_allowlist(keys: Vec<&'static str>) -> Self {
-        Self { allowlist: keys }
-    }
-}
-
-impl Default for BaggageSpanProcessor {
-    fn default() -> Self {
-        Self {
-            allowlist: DEFAULT_ALLOWLIST.to_vec(),
-        }
+        Self
     }
 }
 
@@ -42,14 +38,11 @@ impl SpanProcessor for BaggageSpanProcessor {
             return;
         }
 
-        let baggage = cx.baggage();
-        for key in &self.allowlist {
-            if let Some(value) = baggage.get(*key) {
-                span.set_attribute(KeyValue::new(
-                    (*key).to_string(),
-                    value.as_str().to_string(),
-                ));
-            }
+        for (key, (value, _meta)) in cx.baggage().iter() {
+            span.set_attribute(KeyValue::new(
+                key.as_str().to_string(),
+                value.as_str().to_string(),
+            ));
         }
     }
 
@@ -98,13 +91,17 @@ mod tests {
     }
 
     #[test]
-    fn copies_default_allowlist_from_baggage_to_attributes() {
+    fn copies_every_baggage_entry_to_attributes() {
         let (tracer, exporter) = build_test_provider(BaggageSpanProcessor::default());
 
         let cx = Context::new().with_baggage(vec![
             KeyValue::new("iii.session.id", "S-1"),
+            KeyValue::new("iii.session.name", "refactor auth"),
             KeyValue::new("iii.message.id", "M-1"),
             KeyValue::new("iii.function.id", "auth::set_token"),
+            KeyValue::new("iii.tag.message", "fix the login bug"),
+            // No key policy: non-iii baggage is a first-class tag source too.
+            KeyValue::new("tenant.id", "t-42"),
         ]);
 
         let span = tracer
@@ -112,18 +109,20 @@ mod tests {
             .start_with_context(&tracer, &cx);
         drop(span);
 
-        assert_eq!(
-            first_span_attr(&exporter, "iii.session.id").as_deref(),
-            Some("S-1"),
-        );
-        assert_eq!(
-            first_span_attr(&exporter, "iii.message.id").as_deref(),
-            Some("M-1"),
-        );
-        assert_eq!(
-            first_span_attr(&exporter, "iii.function.id").as_deref(),
-            Some("auth::set_token"),
-        );
+        for (key, expected) in [
+            ("iii.session.id", "S-1"),
+            ("iii.session.name", "refactor auth"),
+            ("iii.message.id", "M-1"),
+            ("iii.function.id", "auth::set_token"),
+            ("iii.tag.message", "fix the login bug"),
+            ("tenant.id", "t-42"),
+        ] {
+            assert_eq!(
+                first_span_attr(&exporter, key).as_deref(),
+                Some(expected),
+                "baggage key {key} must be copied",
+            );
+        }
     }
 
     #[test]
@@ -140,57 +139,6 @@ mod tests {
         assert_eq!(
             first_span_attr(&exporter, "iii.message.id").as_deref(),
             Some("M-only"),
-        );
-        assert!(first_span_attr(&exporter, "iii.session.id").is_none());
-        assert!(first_span_attr(&exporter, "iii.function.id").is_none());
-    }
-
-    #[test]
-    fn baggage_entries_not_in_allowlist_are_dropped() {
-        let (tracer, exporter) = build_test_provider(BaggageSpanProcessor::default());
-
-        let cx = Context::new().with_baggage(vec![
-            KeyValue::new("iii.message.id", "M"),
-            KeyValue::new("tenant.id", "t-42"),
-            KeyValue::new("debug.feature_flag", "on"),
-        ]);
-
-        let span = tracer
-            .span_builder("inner")
-            .start_with_context(&tracer, &cx);
-        drop(span);
-
-        assert_eq!(
-            first_span_attr(&exporter, "iii.message.id").as_deref(),
-            Some("M"),
-        );
-        assert!(first_span_attr(&exporter, "tenant.id").is_none());
-        assert!(first_span_attr(&exporter, "debug.feature_flag").is_none());
-    }
-
-    #[test]
-    fn custom_allowlist_is_honored() {
-        let processor = BaggageSpanProcessor::with_allowlist(vec!["tenant.id", "iii.message.id"]);
-        let (tracer, exporter) = build_test_provider(processor);
-
-        let cx = Context::new().with_baggage(vec![
-            KeyValue::new("tenant.id", "t-1"),
-            KeyValue::new("iii.message.id", "M"),
-            KeyValue::new("iii.session.id", "S-not-copied"),
-        ]);
-
-        let span = tracer
-            .span_builder("inner")
-            .start_with_context(&tracer, &cx);
-        drop(span);
-
-        assert_eq!(
-            first_span_attr(&exporter, "tenant.id").as_deref(),
-            Some("t-1"),
-        );
-        assert_eq!(
-            first_span_attr(&exporter, "iii.message.id").as_deref(),
-            Some("M"),
         );
         assert!(first_span_attr(&exporter, "iii.session.id").is_none());
     }
@@ -230,15 +178,6 @@ mod tests {
         assert!(
             spans.is_empty(),
             "AlwaysOff sampler should drop the span; no export expected"
-        );
-    }
-
-    #[test]
-    fn default_allowlist_matches_harness_baggage_write_set() {
-        // DEFAULT_ALLOWLIST drift across languages would break worker chains.
-        assert_eq!(
-            DEFAULT_ALLOWLIST,
-            &["iii.session.id", "iii.message.id", "iii.function.id"],
         );
     }
 }

--- a/sdk/packages/rust/helpers/src/observability/telemetry/baggage_span_processor.rs
+++ b/sdk/packages/rust/helpers/src/observability/telemetry/baggage_span_processor.rs
@@ -92,7 +92,7 @@ mod tests {
 
     #[test]
     fn copies_every_baggage_entry_to_attributes() {
-        let (tracer, exporter) = build_test_provider(BaggageSpanProcessor::default());
+        let (tracer, exporter) = build_test_provider(BaggageSpanProcessor);
 
         let cx = Context::new().with_baggage(vec![
             KeyValue::new("iii.session.id", "S-1"),
@@ -127,7 +127,7 @@ mod tests {
 
     #[test]
     fn missing_baggage_entry_means_attribute_not_set() {
-        let (tracer, exporter) = build_test_provider(BaggageSpanProcessor::default());
+        let (tracer, exporter) = build_test_provider(BaggageSpanProcessor);
 
         let cx = Context::new().with_baggage(vec![KeyValue::new("iii.message.id", "M-only")]);
 
@@ -145,7 +145,7 @@ mod tests {
 
     #[test]
     fn empty_parent_context_produces_no_attributes() {
-        let (tracer, exporter) = build_test_provider(BaggageSpanProcessor::default());
+        let (tracer, exporter) = build_test_provider(BaggageSpanProcessor);
 
         let span = tracer.start("inner");
         drop(span);
@@ -159,7 +159,7 @@ mod tests {
         let exporter = InMemorySpanExporter::default();
         let provider = SdkTracerProvider::builder()
             .with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOff)
-            .with_span_processor(BaggageSpanProcessor::default())
+            .with_span_processor(BaggageSpanProcessor)
             .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
             .build();
         let tracer = provider.tracer("test");

--- a/sdk/packages/rust/helpers/src/observability/telemetry/mod.rs
+++ b/sdk/packages/rust/helpers/src/observability/telemetry/mod.rs
@@ -314,7 +314,7 @@ pub async fn init_otel(config: OtelConfig) -> bool {
 
     let tracer_provider = SdkTracerProvider::builder()
         .with_resource(resource.clone())
-        .with_span_processor(baggage_span_processor::BaggageSpanProcessor::default())
+        .with_span_processor(baggage_span_processor::BaggageSpanProcessor)
         .with_span_processor(span_processor)
         .build();
 

--- a/sdk/packages/rust/iii/tests/payload_capture.rs
+++ b/sdk/packages/rust/iii/tests/payload_capture.rs
@@ -14,7 +14,7 @@ static SERIAL: Mutex<()> = Mutex::new(());
 fn install_test_provider() -> (InMemorySpanExporter, SdkTracerProvider) {
     let exporter = InMemorySpanExporter::default();
     let provider = SdkTracerProvider::builder()
-        .with_span_processor(BaggageSpanProcessor::default())
+        .with_span_processor(BaggageSpanProcessor)
         .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
         .build();
     opentelemetry::global::set_tracer_provider(provider.clone());

--- a/sdk/packages/rust/iii/tests/span_ops_api.rs
+++ b/sdk/packages/rust/iii/tests/span_ops_api.rs
@@ -16,7 +16,7 @@ static SERIAL: Mutex<()> = Mutex::new(());
 fn install_test_provider() -> (InMemorySpanExporter, SdkTracerProvider) {
     let exporter = InMemorySpanExporter::default();
     let provider = SdkTracerProvider::builder()
-        .with_span_processor(BaggageSpanProcessor::default())
+        .with_span_processor(BaggageSpanProcessor)
         .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
         .build();
     opentelemetry::global::set_tracer_provider(provider.clone());


### PR DESCRIPTION
## Summary

Trace views only showed work after spans finished, which made long-running invocations look idle and hid engine-side parents until workers completed. This PR adds live (pending) span snapshots for the in-memory store and tightens traces API + baggage behavior so devtools can render in-progress traces with useful grouping and tags.

## What changed

- **Live spans (`live_spans`)** — Engine mirrors spans into memory at start as `pending` snapshots (default on for `exporter: memory`, opt-in for `both`). Final spans replace them in place on close. OTLP export is unchanged — only complete spans leave the engine.
- **Traces API UX** — `engine::traces::list` / `group_by` support pending spans (duration-so-far, active time windows), `trace_ids` batch lookup, `exclude_attributes` row filtering, `label_attribute` for group headings, and merged `trace_tags` from `iii.tag.*` / session attrs across the trace.
- **Baggage → attributes** — SDK `BaggageSpanProcessor` copies all baggage entries unconditionally (allowlist removed). Tag semantics live in the engine queries, not worker binaries.
- **Attribution & naming** — Dispatch rewrites `iii.function.id` to the invoked function for worker routes; worker handler spans are `execute <fn>` (INTERNAL) instead of `call <fn>`.

## Test plan

- [ ] With `exporter: memory`, start a long invocation and confirm traces appear immediately as pending, then finalize in place
- [ ] Confirm OTLP / `both` still export only finished spans; pending stays memory-only
- [ ] Verify grouped traces show `label_attribute` (e.g. session name) and `trace_tags` on list rows
- [ ] Confirm worker spans carry the target function’s `iii.function.id`, not the caller’s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `live_spans` to observability to mirror in-progress spans as pending snapshots (memory/both exporters), including live start-trigger behavior.
  * Trace list and grouping now support bulk `trace_ids`, attribute exclusion, and optional group labeling.
  * Trace details now include merged `trace_tags` per span.
* **Bug Fixes**
  * Improved handling of pending spans for duration/time-window filtering and sorting.
  * Updated invocation context propagation so `iii.function.id` matches the invoked function for non-builtin calls.
* **Changes**
  * Baggage-to-span attributes now copy all baggage entries (no allowlist), and the previous allowlist exports were removed.
  * Updated observability documentation for the new `live_spans` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->