### PR TITLE
opt-in ping_interval_secs keepalive on the listener

### DIFF
--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -1474,6 +1474,11 @@ impl Engine {
         tracing::debug!(peer = %peer, "Worker connected via WebSocket");
         let (mut ws_tx, mut ws_rx) = socket.split();
 
+        let ping_interval = config
+            .ping_interval_secs
+            .filter(|secs| *secs > 0)
+            .map(std::time::Duration::from_secs);
+
         let session =
             match rbac_session::handle_session(peer, Arc::new(self.clone()), config, uri, headers)
                 .await
@@ -1534,9 +1539,31 @@ impl Engine {
         self.fire_triggers(TRIGGER_WORKERS_AVAILABLE, workers_data)
             .await;
 
+        let mut last_inbound = tokio::time::Instant::now();
+        let mut ping_timer = tokio::time::interval(
+            ping_interval.unwrap_or(std::time::Duration::from_secs(3600)),
+        );
+        ping_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        ping_timer.tick().await;
+
         loop {
             tokio::select! {
+                _ = ping_timer.tick(), if ping_interval.is_some() => {
+                    let interval = ping_interval.expect("guarded by is_some");
+                    if last_inbound.elapsed() >= interval * 2 {
+                        tracing::info!(
+                            peer = %peer,
+                            worker_id = %worker.id,
+                            "No inbound frames for two ping intervals — closing unresponsive worker connection"
+                        );
+                        break;
+                    }
+                    if tx.send(Outbound::Raw(WsMessage::Ping(Vec::new().into()))).await.is_err() {
+                        break;
+                    }
+                }
                 frame = ws_rx.next() => {
+                    last_inbound = tokio::time::Instant::now();
                     match frame {
                         Some(Ok(WsMessage::Text(text))) => {
                             if text.trim().is_empty() {

--- a/engine/src/workers/worker/mod.rs
+++ b/engine/src/workers/worker/mod.rs
@@ -59,6 +59,8 @@ pub struct WorkerManagerConfig {
     #[serde(default)]
     pub middleware_function_id: Option<String>,
     pub rbac: Option<rbac_config::RbacConfig>,
+    #[serde(default)]
+    pub ping_interval_secs: Option<u64>,
 }
 
 fn default_port() -> u16 {
@@ -76,6 +78,7 @@ impl Default for WorkerManagerConfig {
             host: default_host(),
             middleware_function_id: None,
             rbac: None,
+            ping_interval_secs: None,
         }
     }
 }

--- a/engine/tests/rbac_infrastructure_e2e.rs
+++ b/engine/tests/rbac_infrastructure_e2e.rs
@@ -66,6 +66,7 @@ fn session_with(
             host: "127.0.0.1".to_string(),
             middleware_function_id: middleware,
             rbac: Some(rbac),
+            ping_interval_secs: None,
         }),
         ip_address: "127.0.0.1".to_string(),
         session_id: Uuid::new_v4(),

--- a/engine/tests/worker_manager_ping_keepalive_e2e.rs
+++ b/engine/tests/worker_manager_ping_keepalive_e2e.rs
@@ -1,0 +1,139 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! E2E tests for the opt-in `ping_interval_secs` keepalive on the
+//! worker-manager listener: unresponsive connections are closed after two
+//! silent intervals, responsive ones stay, and the default (unset) keeps
+//! the previous no-ping behavior.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use iii::engine::Engine;
+use iii::workers::traits::Worker;
+use iii::workers::worker::WorkerManager;
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+
+async fn spawn_engine(mut config: Value) -> (u16, Arc<Engine>) {
+    iii::workers::observability::metrics::ensure_default_meter();
+
+    let probe = TcpListener::bind("127.0.0.1:0").await.expect("bind probe");
+    let port = probe.local_addr().expect("local_addr").port();
+    drop(probe);
+
+    config["port"] = json!(port);
+    config["host"] = json!("127.0.0.1");
+
+    let engine = Arc::new(Engine::new());
+    let worker = WorkerManager::create(engine.clone(), Some(config))
+        .await
+        .expect("create WorkerManager");
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    worker
+        .start_background_tasks(shutdown_rx, shutdown_tx)
+        .await
+        .expect("start WorkerManager");
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    (port, engine)
+}
+
+async fn wait_for_workers(engine: &Engine, expected: usize, timeout: Duration) -> bool {
+    tokio::time::timeout(timeout, async {
+        loop {
+            if engine.worker_registry.list_workers().len() == expected {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .is_ok()
+}
+
+#[tokio::test]
+async fn unresponsive_connection_is_closed_when_ping_enabled() {
+    let (port, engine) = spawn_engine(json!({ "ping_interval_secs": 1 })).await;
+
+    let (ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{}/", port))
+        .await
+        .expect("connect");
+
+    assert!(
+        wait_for_workers(&engine, 1, Duration::from_millis(500)).await,
+        "connection should register a worker"
+    );
+
+    // Never read from the socket: tungstenite only replies to pings while the
+    // stream is being polled, so this client stays silent like a dead peer.
+    assert!(
+        wait_for_workers(&engine, 0, Duration::from_secs(4)).await,
+        "silent connection should be reaped after two ping intervals"
+    );
+
+    drop(ws);
+}
+
+#[tokio::test]
+async fn responsive_connection_stays_open_when_ping_enabled() {
+    let (port, engine) = spawn_engine(json!({ "ping_interval_secs": 1 })).await;
+
+    let (ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{}/", port))
+        .await
+        .expect("connect");
+
+    assert!(
+        wait_for_workers(&engine, 1, Duration::from_millis(500)).await,
+        "connection should register a worker"
+    );
+
+    // Poll the stream continuously: tungstenite answers server pings with
+    // pongs automatically, which is what browsers do per RFC 6455.
+    let reader = tokio::spawn(async move {
+        let mut ws = ws;
+        while let Some(msg) = ws.next().await {
+            if msg.is_err() {
+                break;
+            }
+        }
+    });
+
+    tokio::time::sleep(Duration::from_millis(3500)).await;
+    assert_eq!(
+        engine.worker_registry.list_workers().len(),
+        1,
+        "responsive connection must survive multiple ping intervals"
+    );
+
+    reader.abort();
+}
+
+#[tokio::test]
+async fn no_pings_and_no_reaping_when_disabled() {
+    let (port, engine) = spawn_engine(json!({})).await;
+
+    let (ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{}/", port))
+        .await
+        .expect("connect");
+
+    assert!(
+        wait_for_workers(&engine, 1, Duration::from_millis(500)).await,
+        "connection should register a worker"
+    );
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    assert_eq!(
+        engine.worker_registry.list_workers().len(),
+        1,
+        "without ping_interval_secs a silent connection must stay registered"
+    );
+
+    drop(ws);
+}


### PR DESCRIPTION
The worker-manager listener has no active liveness mechanism: the engine
only answers Ping frames, never initiates them, and a connection whose
peer died without FIN/RST (suspended device, NAT-dropped path) lingers in
the worker and trigger registries until a write to it exhausts TCP
retransmissions.

Add an opt-in `ping_interval_secs` to WorkerManagerConfig. When set, the
listener sends a WebSocket Ping frame to each connection every interval
and closes connections that produce no inbound frame (Pong included —
browsers and WS libraries auto-reply per RFC 6455) for two consecutive
intervals. Unset keeps the previous behavior unchanged.

- [x] I license my contributions to this repository under Apache 2.0, and I have all necessary rights over the code I am contributing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional WebSocket keepalive checks for worker connections, with configurable ping intervals.
  * Connections now stay alive during normal activity and are closed only after extended inactivity.

* **Bug Fixes**
  * Improved handling of unresponsive worker connections to prevent stale sessions from lingering.
  * Preserved existing behavior when keepalive checks are not configured.

* **Tests**
  * Added end-to-end coverage for silent, responsive, and disabled keepalive scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->