### PR TITLE
feat(cli): add t subcommand alias as trigger shorthand

### DIFF
--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -82,7 +82,7 @@ iii project init [OPTIONS] [NAME]
 Invoke a function on a running iii engine
 
 ```text
-iii trigger [OPTIONS] [FUNCTION_PATH] [KV]...
+iii {trigger|-t} [OPTIONS] [FUNCTION_PATH] [KV]...
 ```
 
 | Argument | Description |

--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -81,8 +81,10 @@ iii project init [OPTIONS] [NAME]
 
 Invoke a function on a running iii engine
 
+Alias: `t`
+
 ```text
-iii {trigger|-t} [OPTIONS] [FUNCTION_PATH] [KV]...
+iii trigger [OPTIONS] [FUNCTION_PATH] [KV]...
 ```
 
 | Argument | Description |

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -80,7 +80,7 @@ iii project init [OPTIONS] [NAME]
 Invoke a function on a running iii engine
 
 ```text
-iii trigger [OPTIONS] [FUNCTION_PATH] [KV]...
+iii {trigger|-t} [OPTIONS] [FUNCTION_PATH] [KV]...
 ```
 
 | Argument | Description |

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -79,8 +79,10 @@ iii project init [OPTIONS] [NAME]
 
 Invoke a function on a running iii engine
 
+Alias: `t`
+
 ```text
-iii {trigger|-t} [OPTIONS] [FUNCTION_PATH] [KV]...
+iii trigger [OPTIONS] [FUNCTION_PATH] [KV]...
 ```
 
 | Argument | Description |

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -129,7 +129,7 @@ struct Cli {
 #[derive(Subcommand, Debug)]
 enum Commands {
     /// Invoke a function on a running iii engine
-    #[command(short_flag = 't')]
+    #[command(visible_alias = "t")]
     Trigger(TriggerArgs),
 
     /// Launch the iii web console
@@ -417,9 +417,9 @@ mod tests {
     }
 
     #[test]
-    fn trigger_short_flag_parses_with_kv_pairs() {
-        let cli = Cli::try_parse_from(["iii", "-t", "my::fn", "a=10", "b=hello"])
-            .expect("should parse -t shorthand with kv args");
+    fn trigger_alias_parses_with_kv_pairs() {
+        let cli = Cli::try_parse_from(["iii", "t", "my::fn", "a=10", "b=hello"])
+            .expect("should parse t alias with kv args");
         match cli.command {
             Some(Commands::Trigger(args)) => {
                 assert_eq!(args.function_path.as_deref(), Some("my::fn"));

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -129,6 +129,7 @@ struct Cli {
 #[derive(Subcommand, Debug)]
 enum Commands {
     /// Invoke a function on a running iii engine
+    #[command(short_flag = 't')]
     Trigger(TriggerArgs),
 
     /// Launch the iii web console
@@ -410,6 +411,19 @@ mod tests {
                 assert_eq!(args.function_path.as_deref(), Some("my::fn"));
                 assert_eq!(args.kv, vec!["a=99"]);
                 assert_eq!(args.json.as_deref(), Some(r#"{"a":1,"b":2}"#));
+            }
+            _ => panic!("expected Trigger subcommand"),
+        }
+    }
+
+    #[test]
+    fn trigger_short_flag_parses_with_kv_pairs() {
+        let cli = Cli::try_parse_from(["iii", "-t", "my::fn", "a=10", "b=hello"])
+            .expect("should parse -t shorthand with kv args");
+        match cli.command {
+            Some(Commands::Trigger(args)) => {
+                assert_eq!(args.function_path.as_deref(), Some("my::fn"));
+                assert_eq!(args.kv, vec!["a=10", "b=hello"]);
             }
             _ => panic!("expected Trigger subcommand"),
         }


### PR DESCRIPTION
## Summary

Adds `t` as a subcommand alias for `trigger`, so functions can be invoked with:

```bash
iii t iii::queue::redrive queue=failing-demo
```

equivalent to `iii trigger iii::queue::redrive queue=failing-demo`.

## Changes

- `engine/src/main.rs`: `#[command(visible_alias = "t")]` on the `Trigger` variant. All trigger args (`[KV]...`, `--json`, dynamic help) work unchanged; the alias is visible in `iii --help`.
- Unit test covering `iii t my::fn a=10 b=hello` parsing.
- Regenerated `docs/next/cli-reference/index.mdx` via `scripts/generate-cli-docs.sh` and its `.skill.md` artifact via `iii-skill-render` — the trigger section now shows `Alias: \`t\``.

## Testing

- `cargo test -p iii --bin iii` — 133 passed.
- `cargo fmt --check` clean; clippy warnings in the crate are pre-existing and untouched by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shorthand alias for the `trigger` CLI command: you can now run it as `iii t <fn> ...`.
* **Documentation**
  * Updated the CLI reference pages to explicitly document the `t` alias for `iii trigger`.
* **Tests**
  * Added coverage to confirm the `t` alias correctly parses the function path and `key=value` arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->