### PR TITLE
feat(observability): making observability worker a required one

### DIFF
--- a/crates/iii-worker/src/cli/builtin_defaults.rs
+++ b/crates/iii-worker/src/cli/builtin_defaults.rs
@@ -5,14 +5,13 @@
 // See LICENSE and PATENTS files for details.
 
 /// Configurable builtin workers: enabled by default and have a default YAML config.
-pub const BUILTIN_NAMES: [&str; 8] = [
+pub const BUILTIN_NAMES: [&str; 7] = [
     "iii-http",
     "iii-stream",
     "iii-state",
     "iii-queue",
     "iii-pubsub",
     "iii-cron",
-    "iii-observability",
     "iii-sandbox",
 ];
 
@@ -21,11 +20,14 @@ pub const BUILTIN_NAMES: [&str; 8] = [
 pub const OPTIONAL_BUILTIN_NAMES: [&str; 2] = ["iii-exec", "iii-bridge"];
 
 /// Internal builtin workers that are always present and never user-configured.
-pub const MANDATORY_BUILTIN_NAMES: [&str; 4] = [
+/// Defaults live in Rust (`ObservabilityWorkerConfig::default`, etc.), not in
+/// a `config:` block written into `config.yaml`.
+pub const MANDATORY_BUILTIN_NAMES: [&str; 5] = [
     "iii-worker-manager",
     "iii-telemetry",
     "iii-engine-functions",
     "iii-http-functions",
+    "iii-observability",
 ];
 
 /// Returns true if the name is any engine builtin (configurable, optional, or mandatory).
@@ -52,8 +54,6 @@ const STATE_MANIFEST: &str = include_str!("../../../../engine/src/workers/state/
 const QUEUE_MANIFEST: &str = include_str!("../../../../engine/src/workers/queue/iii.worker.yaml");
 const PUBSUB_MANIFEST: &str = include_str!("../../../../engine/src/workers/pubsub/iii.worker.yaml");
 const CRON_MANIFEST: &str = include_str!("../../../../engine/src/workers/cron/iii.worker.yaml");
-const OBSERVABILITY_MANIFEST: &str =
-    include_str!("../../../../engine/src/workers/observability/iii.worker.yaml");
 
 fn manifest_for_builtin(name: &str) -> Option<&'static str> {
     match name {
@@ -63,7 +63,6 @@ fn manifest_for_builtin(name: &str) -> Option<&'static str> {
         "iii-queue" => Some(QUEUE_MANIFEST),
         "iii-pubsub" => Some(PUBSUB_MANIFEST),
         "iii-cron" => Some(CRON_MANIFEST),
-        "iii-observability" => Some(OBSERVABILITY_MANIFEST),
         _ => None,
     }
 }
@@ -167,11 +166,14 @@ mod tests {
     }
 
     #[test]
-    fn observability_default_uses_engine_version_placeholder() {
-        let yaml = get_builtin_default("iii-observability").unwrap();
-
-        assert!(yaml.contains("service_version: ${SERVICE_VERSION:__III_ENGINE_VERSION__}"));
-        assert!(!yaml.contains("service_version: 0.2.0"));
+    fn observability_is_mandatory_without_yaml_default() {
+        // Defaults live in ObservabilityWorkerConfig::default(); the
+        // iii.worker.yaml no longer carries a config: block, so
+        // get_builtin_default must not invent one for config.yaml.
+        assert!(MANDATORY_BUILTIN_NAMES.contains(&"iii-observability"));
+        assert!(!BUILTIN_NAMES.contains(&"iii-observability"));
+        assert!(get_builtin_default("iii-observability").is_none());
+        assert!(is_any_builtin("iii-observability"));
     }
 
     #[test]
@@ -267,27 +269,6 @@ mod tests {
         assert_eq!(
             adapter[&Value::String("name".into())],
             Value::String("local".into())
-        );
-    }
-
-    #[test]
-    fn observability_default_uses_memory_exporter() {
-        let yaml = get_builtin_default("iii-observability").unwrap();
-        let val: Value = serde_yaml::from_str(&yaml).unwrap();
-        let map = val.as_mapping().unwrap();
-
-        assert_eq!(map[&Value::String("enabled".into())], Value::Bool(true));
-        assert_eq!(
-            map[&Value::String("exporter".into())],
-            Value::String("memory".into())
-        );
-        assert_eq!(
-            map[&Value::String("metrics_exporter".into())],
-            Value::String("memory".into())
-        );
-        assert_eq!(
-            map[&Value::String("logs_exporter".into())],
-            Value::String("memory".into())
         );
     }
 

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -26,7 +26,9 @@
 use colored::Colorize;
 
 use super::binary_download;
-use super::builtin_defaults::{get_builtin_default, is_any_builtin, resolve_builtin_version};
+use super::builtin_defaults::{
+    MANDATORY_BUILTIN_NAMES, get_builtin_default, is_any_builtin, resolve_builtin_version,
+};
 use super::config_file::ResolvedWorkerType;
 use super::lifecycle::build_container_spec;
 use super::registry::{
@@ -61,7 +63,7 @@ async fn fire_worker_telemetry(name: &str, version: &str) {
     )
     .await
     {
-        Ok(Ok(resp)) if resp.status().as_u16() == 204 => {}
+        Ok(Ok(resp)) if matches!(resp.status().as_u16(), 200 | 204) => {}
         Ok(Ok(resp)) => {
             eprintln!(
                 "  {} telemetry for {} returned unexpected status {}",
@@ -1762,6 +1764,19 @@ pub async fn handle_managed_add(
 
     // Shorthand name — resolve via API
     let (name, version) = parse_worker_input(image_or_name);
+
+    // Mandatory builtins are always injected by the engine with Rust defaults;
+    // they must not be written into config.yaml via `iii worker add`.
+    if MANDATORY_BUILTIN_NAMES.contains(&name.as_str()) {
+        if !brief {
+            eprintln!(
+                "  {} '{}' is a mandatory engine worker (always on; configure via the configuration worker, not config.yaml).",
+                "info:".cyan(),
+                name.bold()
+            );
+        }
+        return 0;
+    }
 
     // Check for engine-builtin workers first (no network needed).
     if let Some(default_yaml) = get_builtin_default(&name) {

--- a/engine/src/logging.rs
+++ b/engine/src/logging.rs
@@ -425,10 +425,11 @@ fn otel_config_from_module(
 /// Resolve the authoritative boot configuration for the `iii-observability`
 /// worker:
 ///
-/// 1. yaml entry with a config block → that block;
-/// 2. yaml entry without a config block → built-in defaults (enabled);
-/// 3. no yaml entry → `None` (observability stays off unless env-enabled,
-///    exactly as before — a stray persisted file must not switch it on).
+/// 1. persisted configuration-worker entry (when file-backed) → that value;
+/// 2. yaml entry with a config block → that block;
+/// 3. yaml entry without a config block, or no yaml entry → built-in
+///    [`ObservabilityWorkerConfig::default`] (the worker is mandatory and
+///    always auto-injected, same pattern as `configuration`).
 ///
 /// When the configuration worker uses the file-backed adapter and a
 /// persisted `iii-observability` entry exists, its value REPLACES the yaml
@@ -436,6 +437,9 @@ fn otel_config_from_module(
 /// seed-only after first boot). This is what lets restart-tier fields
 /// (trace exporter wiring, resource identity, log format) edited through
 /// `configuration::set` take effect at the next engine start.
+///
+/// Returned values have `${VAR:default}` placeholders expanded so the live
+/// OTEL global never carries template strings.
 ///
 /// Runs before any tracing subscriber exists, so diagnostics use stdio.
 fn resolve_boot_observability_config(
@@ -461,7 +465,7 @@ fn resolve_boot_observability_config(
                 println!(
                     "Using persisted iii-observability configuration entry (config.yaml block is seed-only)"
                 );
-                return Some(stored_cfg.normalized());
+                return Some(stored_cfg.normalized().with_env_expanded());
             }
             Err(err) => eprintln!(
                 "persisted iii-observability configuration is invalid ({err}); using the config.yaml block"
@@ -469,24 +473,26 @@ fn resolve_boot_observability_config(
         }
     }
 
-    // No persisted entry: first boot. Fall back to the config.yaml block when
-    // present; otherwise leave the global unset (the auto-injected worker
-    // seeds its own defaults in `from_config`) — exactly the prior behavior
-    // for engines that never declared the worker.
-    let entry = entry?;
-    let yaml_base: ObservabilityWorkerConfig = match &entry.config {
-        Some(value) => match serde_json::from_value(value.clone()) {
-            Ok(parsed) => parsed,
-            Err(err) => {
-                eprintln!(
-                    "iii-observability config block in config.yaml is invalid ({err}); using built-in defaults"
-                );
-                ObservabilityWorkerConfig::default()
-            }
+    // No persisted entry: first boot. Prefer the config.yaml block when
+    // present; otherwise use built-in defaults — the worker is mandatory
+    // and always injected, so there is no "observability off" first-boot
+    // path anymore.
+    let yaml_base: ObservabilityWorkerConfig = match entry {
+        Some(entry) => match &entry.config {
+            Some(value) => match serde_json::from_value(value.clone()) {
+                Ok(parsed) => parsed,
+                Err(err) => {
+                    eprintln!(
+                        "iii-observability config block in config.yaml is invalid ({err}); using built-in defaults"
+                    );
+                    ObservabilityWorkerConfig::default()
+                }
+            },
+            None => ObservabilityWorkerConfig::default(),
         },
         None => ObservabilityWorkerConfig::default(),
     };
-    Some(yaml_base.normalized())
+    Some(yaml_base.normalized().with_env_expanded())
 }
 
 /// Read the persisted `iii-observability` configuration value written by the
@@ -1459,16 +1465,25 @@ mod tests {
     }
 
     #[test]
-    fn boot_merge_returns_none_on_true_first_boot() {
-        // No yaml entry and no persisted file: leave the global unset so the
-        // auto-injected worker seeds its own defaults.
+    fn boot_merge_uses_defaults_on_true_first_boot() {
+        // No yaml entry and no persisted file: the mandatory worker still
+        // boots with ObservabilityWorkerConfig::default().
         let dir = tempfile::tempdir().unwrap();
         let mut cfg = boot_cfg_with_dir(dir.path(), serde_json::json!({}));
         cfg.workers.remove(0); // drop the iii-observability yaml entry
 
-        assert!(
-            resolve_boot_observability_config(&cfg).is_none(),
-            "no yaml entry and no persisted file is a true first boot"
+        let resolved = resolve_boot_observability_config(&cfg).expect("defaults apply");
+        assert_eq!(resolved.enabled, Some(true));
+        assert_eq!(resolved.service_name.as_deref(), Some("iii"));
+        assert_eq!(
+            resolved.memory_max_spans,
+            Some(1_000_000),
+            "built-in defaults match the former iii.worker.yaml block"
+        );
+        // service_version template is expanded for the live OTEL global
+        assert_eq!(
+            resolved.service_version.as_deref(),
+            Some(env!("CARGO_PKG_VERSION"))
         );
     }
 

--- a/engine/src/workers/observability/config.rs
+++ b/engine/src/workers/observability/config.rs
@@ -340,29 +340,40 @@ pub struct ObservabilityWorkerConfig {
 }
 
 impl Default for ObservabilityWorkerConfig {
+    /// Built-in defaults used when the worker is auto-injected with no
+    /// `config:` block (mandatory registration) and as the
+    /// `configuration::register` seed on first boot. Mirrors the former
+    /// `iii.worker.yaml` config block so removing that block is not a
+    /// behavior change.
+    ///
+    /// `service_version` keeps the `${SERVICE_VERSION:__III_ENGINE_VERSION__}`
+    /// template so the configuration worker expands it on every
+    /// `configuration::get` (and boot reads that go through the same
+    /// expander). Callers that publish this value into the live OTEL
+    /// global must expand it first.
     fn default() -> Self {
         Self {
             enabled: Some(true),
             service_name: Some("iii".to_string()),
+            service_version: Some("${SERVICE_VERSION:__III_ENGINE_VERSION__}".to_string()),
             exporter: Some(OtelExporterType::Memory),
+            memory_max_spans: Some(1_000_000),
             metrics_enabled: Some(true),
             metrics_exporter: Some(MetricsExporterType::Memory),
+            metrics_retention_seconds: Some(3600),
+            metrics_max_count: Some(10_000),
             logs_enabled: Some(true),
             logs_exporter: Some(LogsExporterType::Memory),
+            logs_max_count: Some(1000),
+            logs_retention_seconds: Some(3600),
             logs_console_output: true,
             logs_sampling_ratio: 1.0,
-            // All other fields left as None/empty — resolved at runtime
-            service_version: None,
+            sampling_ratio: Some(1.0),
+            // Optional / advanced fields left unset
             service_namespace: None,
             endpoint: None,
-            sampling_ratio: None,
             sampling: None,
-            memory_max_spans: None,
             live_spans: None,
-            metrics_retention_seconds: None,
-            metrics_max_count: None,
-            logs_max_count: None,
-            logs_retention_seconds: None,
             logs_batch_size: None,
             logs_flush_interval_ms: None,
             alerts: Vec::new(),
@@ -374,6 +385,22 @@ impl Default for ObservabilityWorkerConfig {
 }
 
 impl ObservabilityWorkerConfig {
+    /// Expand `${VAR:default}` placeholders (including the
+    /// `__III_ENGINE_VERSION__` sentinel) the same way `configuration::get`
+    /// does. Used when publishing this config into the live OTEL global —
+    /// the seed passed to `configuration::register` keeps the template form
+    /// so later reads re-expand against the process env.
+    pub fn with_env_expanded(self) -> Self {
+        let Ok(value) = serde_json::to_value(&self) else {
+            return self;
+        };
+        let (expanded, _missing) = crate::workers::configuration::store::expand_value(&value);
+        match serde_json::from_value::<Self>(expanded) {
+            Ok(parsed) => parsed.normalized(),
+            Err(_) => self,
+        }
+    }
+
     /// Clamp out-of-range top-level values into safe bounds.
     ///
     /// The JSON Schema rejects out-of-range values at `configuration::set`
@@ -617,9 +644,27 @@ mod tests {
         );
         assert!(!obj.contains_key("alerts"), "empty vecs must not serialize");
         assert!(obj.contains_key("enabled"));
+        assert_eq!(
+            obj.get("service_version").and_then(|v| v.as_str()),
+            Some("${SERVICE_VERSION:__III_ENGINE_VERSION__}"),
+            "default seed keeps the env template for configuration::register"
+        );
+        assert_eq!(
+            obj.get("memory_max_spans").and_then(|v| v.as_u64()),
+            Some(1_000_000)
+        );
         // Round-trips through the schema validator (all serialized fields valid).
         let parsed: ObservabilityWorkerConfig = serde_json::from_value(value).unwrap();
         assert_eq!(parsed, ObservabilityWorkerConfig::default());
+    }
+
+    #[test]
+    fn with_env_expanded_resolves_engine_version_sentinel() {
+        let expanded = ObservabilityWorkerConfig::default().with_env_expanded();
+        assert_eq!(
+            expanded.service_version.as_deref(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
     }
 
     #[test]

--- a/engine/src/workers/observability/configuration.rs
+++ b/engine/src/workers/observability/configuration.rs
@@ -7,14 +7,16 @@
 //! Integration with the builtin `configuration` worker.
 //!
 //! The `iii-observability` worker registers its config schema under the id
-//! `iii-observability`, seeds it from the config.yaml block only when no
-//! value is stored yet, reads the live value (with `${VAR:default}`
-//! expansion), and hot-applies `configuration:updated` events per field tier
-//! (live globals, storage limits, sampler/alerts/level/collapse swaps, log
-//! exporter task rebuilds). After first boot the configuration worker entry
-//! is the runtime source of truth; the config.yaml block is seed-only —
-//! restart-tier fields (trace exporter wiring, resource identity, log
-//! format) are read from the persisted entry at the next engine start.
+//! `iii-observability`, seeds it from the config.yaml block (or
+//! [`ObservabilityWorkerConfig::default`] when auto-injected with no block)
+//! only when no value is stored yet, reads the live value (with
+//! `${VAR:default}` expansion), and hot-applies `configuration:updated`
+//! events per field tier (live globals, storage limits, sampler/alerts/
+//! level/collapse swaps, log exporter task rebuilds). After first boot the
+//! configuration worker entry is the runtime source of truth; the
+//! config.yaml block is seed-only — restart-tier fields (trace exporter
+//! wiring, resource identity, log format) are read from the persisted
+//! entry at the next engine start.
 
 use anyhow::anyhow;
 use serde_json::{Value, json};
@@ -39,9 +41,9 @@ pub(super) const CONFIG_BUS_TIMEOUT: std::time::Duration = std::time::Duration::
 const APPLY_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Register the `iii-observability` configuration entry: schema and metadata
-/// refresh on every boot; `initial_value` (the config.yaml seed, or built-in
-/// defaults) is included only when nothing is stored yet, so runtime edits
-/// survive engine restarts.
+/// refresh on every boot; `initial_value` (the config.yaml seed, or
+/// [`ObservabilityWorkerConfig::default`]) is included only when nothing is
+/// stored yet, so runtime edits survive engine restarts.
 ///
 /// Makes unbounded bus calls — callers must wrap the call in
 /// `tokio::time::timeout(CONFIG_BUS_TIMEOUT, ...)`.

--- a/engine/src/workers/observability/iii.worker.yaml
+++ b/engine/src/workers/observability/iii.worker.yaml
@@ -3,19 +3,3 @@ name: iii-observability
 type: engine
 description: OpenTelemetry-based traces, metrics, logs, alerts, and sampling.
 repo: https://github.com/iii-hq/iii
-config:
-  enabled: true
-  service_name: iii
-  service_version: ${SERVICE_VERSION:__III_ENGINE_VERSION__}
-  exporter: memory
-  memory_max_spans: 1000000
-  metrics_enabled: true
-  metrics_exporter: memory
-  metrics_retention_seconds: 3600
-  metrics_max_count: 10000
-  logs_enabled: true
-  logs_exporter: memory
-  logs_max_count: 1000
-  logs_retention_seconds: 3600
-  logs_console_output: true
-  sampling_ratio: 1.0

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -673,10 +673,12 @@ pub struct BaggageGetAllInput {}
 /// It sets the global OTEL configuration from YAML before logging is initialized.
 #[derive(Clone)]
 pub struct ObservabilityWorker {
-    /// The config.yaml block passed to `create()` (or built-in defaults).
+    /// The config.yaml block passed to `create()`, or
+    /// [`config::ObservabilityWorkerConfig::default`] when auto-injected.
     /// Used as the seed for first-time `configuration::register` and as the
     /// fetch fallback; the configuration worker entry is the runtime source
-    /// of truth afterwards.
+    /// of truth afterwards. May still contain `${VAR:default}` templates —
+    /// the live OTEL global is published with those expanded.
     _config: config::ObservabilityWorkerConfig,
     triggers: Arc<OtelLogTriggers>,
     trace_triggers: Arc<OtelTraceTriggers>,
@@ -1000,11 +1002,13 @@ impl ObservabilityWorker {
         };
         let otel_config = otel_config.normalized();
 
-        // Seed the global OTEL config so logging can use it. On the serve
-        // path the global is already populated during logging init (from the
-        // persisted configuration entry or this same yaml block); first-set
-        // semantics keep that value authoritative.
-        if !otel::set_otel_config(otel_config.clone()) {
+        // Seed the global OTEL config so logging can use it. Expand
+        // `${VAR:default}` placeholders for the live snapshot; `_config`
+        // keeps the template form so first-boot `configuration::register`
+        // can seed it. On the serve path the global is already populated
+        // during logging init; first-set semantics keep that value
+        // authoritative.
+        if !otel::set_otel_config(otel_config.clone().with_env_expanded()) {
             tracing::debug!(
                 "ObservabilityWorker created with the global config already set; keeping it"
             );


### PR DESCRIPTION
## Summary
- Make `iii-observability` a mandatory engine worker (always injected), like `configuration`
- Move defaults into `ObservabilityWorkerConfig::default()` and drop the `config:` block from `iii.worker.yaml`, so `iii worker add` no longer writes observability into `config.yaml`
- Expand `${VAR:default}` (including `__III_ENGINE_VERSION__`) when publishing the live OTEL config; keep the template form for `configuration::register` seeding

## Test plan
- [ ] `cargo test -p iii --lib -- logging::tests::boot_merge workers::observability::config::tests workers::observability::configuration::tests`
- [ ] `cargo test -p iii-worker --lib -- cli::builtin_defaults`
- [ ] Boot with no `iii-observability` entry in `config.yaml` and confirm defaults apply / `./config/iii-observability.yaml` is seeded
- [ ] Confirm `iii worker add iii-observability` is a no-op (does not write a `config:` block)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `iii-observability` now uses built-in defaults automatically and no longer relies on a YAML config block.
  * Observability settings are now expanded from environment-style placeholders before being applied at runtime.
  * Telemetry download requests now succeed on both `200` and `204` responses.

* **Bug Fixes**
  * First boot now always gets a valid observability configuration instead of leaving it unset.
  * Default observability values are now applied consistently, including service version and logging/metrics settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->