### PR TITLE
ci: resolve GitHub Actions pipeline warnings

### DIFF
--- a/.github/workflows/WORKFLOWS.md
+++ b/.github/workflows/WORKFLOWS.md
@@ -126,7 +126,7 @@ Publishes an alpha prerelease of every SDK (npm, pypi, crates, go), the engine b
 3. Bumps all manifests in lockstep (Cargo.toml, package.json, pyproject.toml, **Go `sdkVersion` const**) into an **ephemeral commit**
 4. Pushes **only** the `iii-alpha/v{version}` tag — never a branch, never `main`
 5. Publishes, all checking out that tag:
-   - **SDK packages** — an inline `sdk-node` job (single `pnpm -r publish` over the three node packages) plus `_py.yml`, `_rust-cargo.yml`, `_go.yml`
+   - **SDK packages** — an inline `sdk-node` job (single `pnpm -r publish` over the three node packages), `_py.yml` build jobs followed by top-level OIDC publish jobs, plus `_rust-cargo.yml` and `_go.yml`
    - **Engine binaries** — `iii` and `iii-worker` via `_rust-binary.yml`, and `iii-init` via an inline `init-build` job; all attached to a GitHub **prerelease** on the `iii-alpha/v*` tag
    - **Builtin workers + skills** — `_publish-engine-workers.yml` / `_publish-worker-skills.yml` published to the workers registry under a dedicated **`alpha`** tag (never `next`/`latest`)
 
@@ -162,7 +162,7 @@ setup (parse tag metadata, Slack notification)
   │     │           └─► homebrew-console ► _homebrew.yml (stable only)
   │     │
   │     ├─► sdk-npm ─────────────► _npm.yml
-  │     ├─► sdk-py ──────────────► _py.yml
+  │     ├─► sdk-py-build ───────► _py.yml ──► sdk-py (OIDC publish)
   │     ├─► sdk-rust ────────────► _rust-cargo.yml
   │     └─► sdk-go ──────────────► _go.yml (pushes subdir-scoped module tag)
   │
@@ -225,7 +225,7 @@ The workflow posts a sticky PR comment and publishes the `license-agreement` com
 
 ## Reusable Workflows
 
-All reusable workflows support `dry_run` mode and Slack thread notifications.
+Publish workflows support `dry_run` mode and Slack thread notifications. `_py.yml` is build-only so PyPI Trusted Publishing can run from the top-level workflow, as required by PyPI.
 
 ### `_npm.yml` — NPM Publish
 
@@ -240,11 +240,11 @@ Publishes a Node.js package to the npm registry.
 
 Uses `pnpm publish` with `--no-git-checks` and `--access public`.
 
-### `_py.yml` — PyPI Publish
+### `_py.yml` — PyPI Build
 
-Publishes a Python package to PyPI.
+Builds and validates a Python package, then uploads its distributions as a short-lived workflow artifact.
 
-Builds with `python -m build`, validates with `twine check` on dry run, publishes via `pypa/gh-action-pypi-publish`.
+The top-level `release-iii.yml` and `alpha-release.yml` workflows download that artifact and publish it with `pypa/gh-action-pypi-publish` using OIDC Trusted Publishing. Keeping the publish action in the top-level workflows is required because PyPI does not support Trusted Publishing from reusable workflows.
 
 ### `_rust-cargo.yml` — Cargo Publish
 
@@ -317,12 +317,20 @@ Publishes skill markdown for all workers with an `iii.worker.yaml` manifest and 
 |--------|---------|
 | `III_CI_APP_ID` / `III_CI_APP_PRIVATE_KEY` | GitHub App token for pushing tags, creating releases, updating homebrew-tap |
 | `NPM_TOKEN` | npm registry authentication |
-| `PYPI_API_TOKEN` | PyPI publishing |
 | `CARGO_REGISTRY_TOKEN` | crates.io publishing |
 | `DOCKERHUB_USERNAME` / `DOCKERHUB_PASSWORD` | DockerHub publishing |
 | `SLACK_BOT_TOKEN` / `SLACK_CHANNEL_ID` | Slack release notifications |
 | `SLACK_WEBHOOK_URL` | Slack Docker notifications |
 | `WORKERS_REGISTRY_API_KEY` | Workers registry publish (`_publish-engine-workers`, `_publish-worker-skills`) |
+
+## PyPI Trusted Publishers
+
+Each PyPI project (`iii-helpers`, `iii-observability`, and `iii-sdk`) must trust both top-level publishing workflows with owner `iii-hq`, repository `iii`, and no environment restriction:
+
+- `release-iii.yml`
+- `alpha-release.yml`
+
+The publish jobs request `id-token: write` directly and do not use the `PYPI_API_TOKEN` repository secret.
 
 ---
 

--- a/.github/workflows/_go.yml
+++ b/.github/workflows/_go.yml
@@ -63,7 +63,7 @@ jobs:
         if: inputs.slack_thread_ts != ''
         id: slack
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
             thread_ts: "${{ inputs.slack_thread_ts }}"
             text: ":large_yellow_circle: ${{ inputs.slack_label }}${{ inputs.dry_run == true && ' (dry run)' || '' }} — in progress"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history so we can tag
           ref: ${{ inputs.ref }}
@@ -81,7 +81,7 @@ jobs:
           # supplied only to the tag-push step below.
           persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.24'
           cache-dependency-path: ${{ inputs.package_path }}/go.sum
@@ -139,7 +139,7 @@ jobs:
       - name: Notify Slack — result
         if: always() && steps.slack.outputs.ts != ''
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         with:
           method: chat.update
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/_homebrew.yml
+++ b/.github/workflows/_homebrew.yml
@@ -79,7 +79,7 @@ jobs:
         if: inputs.slack_thread_ts != ''
         id: slack
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -100,7 +100,7 @@ jobs:
 
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.III_CI_APP_ID }}
           private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
@@ -109,7 +109,7 @@ jobs:
           permission-contents: write
 
       - name: Checkout tap repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ env.TAP_REPO }}
           token: ${{ steps.generate_token.outputs.token }}
@@ -279,7 +279,7 @@ jobs:
       - name: Notify Slack — result
         if: always() && steps.slack.outputs.ts != ''
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         with:
           method: chat.update
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/_npm.yml
+++ b/.github/workflows/_npm.yml
@@ -60,7 +60,7 @@ jobs:
         if: inputs.slack_thread_ts != ''
         id: slack
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -69,15 +69,15 @@ jobs:
             thread_ts: "${{ inputs.slack_thread_ts }}"
             text: ":large_yellow_circle: ${{ inputs.slack_label }}${{ inputs.dry_run == true && ' (dry run)' || '' }} — in progress"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           run_install: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -106,7 +106,7 @@ jobs:
       - name: Notify Slack — result
         if: always() && steps.slack.outputs.ts != ''
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         with:
           method: chat.update
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -48,11 +48,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/_publish-worker-skills.yml
+++ b/.github/workflows/_publish-worker-skills.yml
@@ -26,9 +26,9 @@ jobs:
       matrix: ${{ steps.discover.outputs.matrix }}
       has_workers: ${{ steps.discover.outputs.has_workers }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Build skills payload (${{ matrix.slug }})
         id: payload

--- a/.github/workflows/_py.yml
+++ b/.github/workflows/_py.yml
@@ -1,4 +1,4 @@
-name: PyPI Publish
+name: PyPI Build
 
 on:
   workflow_call:
@@ -12,55 +12,23 @@ on:
         required: false
         type: string
         default: ''
-      dry_run:
-        description: 'Build and validate without publishing'
-        required: false
-        type: boolean
-        default: false
-      slack_thread_ts:
-        description: 'Slack parent message timestamp for thread replies (optional)'
-        required: false
-        type: string
-        default: ''
-      slack_label:
-        description: 'Label for this step in Slack notifications (optional)'
-        required: false
-        type: string
-        default: ''
-    secrets:
-      PYPI_API_TOKEN:
+      artifact_name:
+        description: 'Workflow artifact containing the built distributions'
         required: true
-      SLACK_BOT_TOKEN:
-        required: false
-      SLACK_CHANNEL_ID:
-        required: false
+        type: string
 
 jobs:
-  publish:
-    name: Publish to PyPI
+  build:
+    name: Build distributions
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
-      - name: Notify Slack — in progress
-        if: inputs.slack_thread_ts != ''
-        id: slack
-        continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            thread_ts: "${{ inputs.slack_thread_ts }}"
-            text: ":large_yellow_circle: ${{ inputs.slack_label }}${{ inputs.dry_run == true && ' (dry run)' || '' }} — in progress"
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -72,24 +40,12 @@ jobs:
         run: python -m build
 
       - name: Validate package
-        if: inputs.dry_run == true
         run: twine check ${{ inputs.package_path }}/dist/*
 
-      - name: Publish to PyPI
-        if: inputs.dry_run != true
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Upload distributions
+        uses: actions/upload-artifact@v7
         with:
-          packages-dir: ${{ inputs.package_path }}/dist/
-          password: ${{ secrets.PYPI_API_TOKEN }}
-
-      - name: Notify Slack — result
-        if: always() && steps.slack.outputs.ts != ''
-        continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          method: chat.update
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            ts: "${{ steps.slack.outputs.ts }}"
-            text: "${{ job.status == 'success' && ':large_green_circle:' || ':red_circle:' }} ${{ inputs.slack_label }}${{ inputs.dry_run == true && ' (dry run)' || '' }} — ${{ job.status }}"
+          name: ${{ inputs.artifact_name }}
+          path: ${{ inputs.package_path }}/dist/
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/_rust-binary.yml
+++ b/.github/workflows/_rust-binary.yml
@@ -133,7 +133,7 @@ jobs:
         if: inputs.slack_thread_ts != ''
         id: slack
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -145,35 +145,20 @@ jobs:
       - name: Generate token
         if: inputs.skip_create_release != true && inputs.dry_run != true
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.III_CI_APP_ID }}
           private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         if: inputs.skip_create_release != true && inputs.dry_run != true
         with:
           token: ${{ steps.generate_token.outputs.token }}
           fetch-tags: true
 
-      - name: Compute previous stable tag
-        id: prev
-        if: inputs.skip_create_release != true && inputs.dry_run != true && inputs.tag_prefix != ''
-        env:
-          TAG_PREFIX: ${{ inputs.tag_prefix }}
-          CURRENT_TAG: ${{ inputs.tag_name }}
-        run: |
-          PREFIX="${TAG_PREFIX}v"
-          PREV_STABLE=$(git tag --list "${PREFIX}*" --sort=-v:refname \
-            | grep -E "^${PREFIX}[0-9]+\.[0-9]+\.[0-9]+\$" \
-            | grep -v "^${CURRENT_TAG}\$" \
-            | head -n 1 || true)
-          echo "previous_tag=${PREV_STABLE}" >> "$GITHUB_OUTPUT"
-          echo "::notice::Previous stable tag for release notes: ${PREV_STABLE:-<none, GitHub default>}"
-
       - name: Create GitHub Release
         if: inputs.skip_create_release != true && inputs.dry_run != true
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           token: ${{ steps.generate_token.outputs.token }}
           tag_name: ${{ inputs.tag_name }}
@@ -181,7 +166,6 @@ jobs:
           draft: false
           prerelease: ${{ inputs.is_prerelease }}
           generate_release_notes: true
-          previous_tag: ${{ steps.prev.outputs.previous_tag }}
 
   build:
     name: Build ${{ matrix.target }}
@@ -198,32 +182,32 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.III_CI_APP_ID }}
           private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Download pre-built artifact
         if: inputs.artifact_name != ''
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ inputs.artifact_dest }}
 
       - name: Download iii-init (x86_64-musl)
         if: inputs.init_artifacts == true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: iii-init-x86_64-unknown-linux-musl
           path: target/x86_64-unknown-linux-musl/release/
 
       - name: Download iii-init (aarch64-musl)
         if: inputs.init_artifacts == true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: iii-init-aarch64-unknown-linux-musl
           path: target/aarch64-unknown-linux-musl/release/
@@ -300,7 +284,7 @@ jobs:
     steps:
       - name: Update thread message
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         with:
           method: chat.update
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/_rust-cargo.yml
+++ b/.github/workflows/_rust-cargo.yml
@@ -52,7 +52,7 @@ jobs:
         if: inputs.slack_thread_ts != ''
         id: slack
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
             thread_ts: "${{ inputs.slack_thread_ts }}"
             text: ":large_yellow_circle: ${{ inputs.slack_label }}${{ inputs.dry_run == true && ' (dry run)' || '' }} — in progress"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
           # cargo publish doesn't push to git; don't leave the token in config.
@@ -80,7 +80,7 @@ jobs:
       - name: Notify Slack — result
         if: always() && steps.slack.outputs.ts != ''
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         with:
           method: chat.update
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -37,7 +37,6 @@ on:
 
 permissions:
   contents: write # prepare tag push, go tag, GitHub prerelease + binary uploads
-  id-token: write # OIDC / npm + pypi provenance (sdk-node, _py.yml)
 
 jobs:
   prepare:
@@ -52,7 +51,7 @@ jobs:
       dry_run: ${{ inputs.dry_run }}
     steps:
       - name: Checkout selected branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           # Default GITHUB_TOKEN (contents: write) is persisted in git config
@@ -119,15 +118,15 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.tag }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           run_install: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -167,8 +166,39 @@ jobs:
           --access public
           ${{ needs.prepare.outputs.dry_run == 'true' && '--dry-run' || '' }}
 
-  observability-py:
-    name: Observability Python (pypi)
+  helpers-py-build:
+    name: Helpers Python (build)
+    needs: prepare
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/_py.yml
+    with:
+      package_path: sdk/packages/python/helpers
+      ref: ${{ needs.prepare.outputs.tag }}
+      artifact_name: pypi-helpers
+
+  helpers-py:
+    name: Helpers Python (pypi)
+    needs: [prepare, helpers-py-build]
+    if: ${{ !failure() && !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: pypi-helpers
+          path: dist/
+
+      - name: Publish to PyPI
+        if: needs.prepare.outputs.dry_run != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+  observability-py-build:
+    name: Observability Python (build)
     # The shim pins iii-helpers at the release version; publish helpers first so
     # PyPI can resolve the dependency.
     needs: [prepare, helpers-py]
@@ -177,24 +207,31 @@ jobs:
     with:
       package_path: sdk/packages/python/observability
       ref: ${{ needs.prepare.outputs.tag }}
-      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
-    secrets:
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      artifact_name: pypi-observability
 
-  helpers-py:
-    name: Helpers Python (pypi)
-    needs: prepare
+  observability-py:
+    name: Observability Python (pypi)
+    needs: [prepare, observability-py-build]
     if: ${{ !failure() && !cancelled() }}
-    uses: ./.github/workflows/_py.yml
-    with:
-      package_path: sdk/packages/python/helpers
-      ref: ${{ needs.prepare.outputs.tag }}
-      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
-    secrets:
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: pypi-observability
+          path: dist/
 
-  sdk-py:
-    name: SDK Python (pypi)
+      - name: Publish to PyPI
+        if: needs.prepare.outputs.dry_run != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+  sdk-py-build:
+    name: SDK Python (build)
     # iii depends on iii-observability and iii-helpers; publish them first
     # so the package is installable from PyPI.
     needs: [prepare, observability-py, helpers-py]
@@ -203,9 +240,28 @@ jobs:
     with:
       package_path: sdk/packages/python/iii
       ref: ${{ needs.prepare.outputs.tag }}
-      dry_run: ${{ needs.prepare.outputs.dry_run == 'true' }}
-    secrets:
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      artifact_name: pypi-sdk
+
+  sdk-py:
+    name: SDK Python (pypi)
+    needs: [prepare, sdk-py-build]
+    if: ${{ !failure() && !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: pypi-sdk
+          path: dist/
+
+      - name: Publish to PyPI
+        if: needs.prepare.outputs.dry_run != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
 
   observability-rust:
     name: Observability Rust (cargo)
@@ -277,7 +333,7 @@ jobs:
       # The tag was already pushed by `prepare`; this attaches a prerelease
       # to it. Uses the default GITHUB_TOKEN (contents: write).
       - name: Create GitHub prerelease
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.prepare.outputs.tag }}
           name: iii ${{ needs.prepare.outputs.version }} (alpha)
@@ -301,7 +357,7 @@ jobs:
           - target: aarch64-unknown-linux-musl
             publish_aliases: 'aarch64-unknown-linux-gnu aarch64-apple-darwin'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.tag }}
           # Build runs checked-out code; uploads go through softprops (token
@@ -326,7 +382,7 @@ jobs:
         run: cargo build -p iii-init --target ${{ matrix.target }} --release
 
       - name: Upload init binary as workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: iii-init-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/iii-init
@@ -345,7 +401,7 @@ jobs:
 
       - name: Upload release assets
         if: needs.prepare.outputs.dry_run != 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.prepare.outputs.tag }}
           files: target/${{ matrix.target }}/release/iii-init-*.tar.gz,target/${{ matrix.target }}/release/iii-init-*.sha256

--- a/.github/workflows/bench-release.yml
+++ b/.github/workflows/bench-release.yml
@@ -21,7 +21,7 @@ jobs:
     name: Run Benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -58,7 +58,7 @@ jobs:
           alert-comment-cc-users: '@iii-hq/engine'
 
       - name: Upload raw criterion data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: criterion-data-${{ steps.meta.outputs.version }}
           path: target/criterion/
@@ -91,7 +91,7 @@ jobs:
       - name: Post to Slack
         if: always()
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/checklist-checker.yml
+++ b/.github/workflows/checklist-checker.yml
@@ -31,19 +31,19 @@ jobs:
     # build, PR-supplied actions) in this job, doing so would expose the secret to
     # untrusted contributors. Run untrusted PR code in a separate `pull_request` job.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
 
       # Mint a short-lived installation token. Unlike GITHUB_TOKEN, an App
       # installation token can write to the base repo on fork PRs, which is the
       # only kind of PR this workflow ever processes.
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ secrets.III_CI_APP_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
       engine: ${{ steps.filter.outputs.engine }}
       benches: ${{ steps.filter.outputs.benches }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -68,7 +68,7 @@ jobs:
     name: Engine Build (artifact)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -87,7 +87,7 @@ jobs:
       - name: Build iii (debug, all-features)
         run: cargo build -p iii --all-features
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: iii-binary
           path: target/debug/iii
@@ -108,7 +108,7 @@ jobs:
       github.event_name != 'pull_request' || needs.changes.outputs.engine == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Free up disk space to avoid "No space left on device" — the
       # coverage-instrumented build is large.
@@ -173,7 +173,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: engine-coverage-report
           path: |
@@ -195,7 +195,7 @@ jobs:
     if: needs.changes.outputs.benches == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -222,7 +222,7 @@ jobs:
     name: Engine Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -245,7 +245,7 @@ jobs:
     name: CLI Docs Built
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -290,7 +290,7 @@ jobs:
           --health-cmd "rabbitmq-diagnostics check_running" --health-interval 10s --health-timeout
           5s --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -321,7 +321,7 @@ jobs:
             os: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -371,7 +371,7 @@ jobs:
             os: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -428,7 +428,7 @@ jobs:
           - os: ubuntu-latest
           - os: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -450,7 +450,7 @@ jobs:
       - name: Run iii-worker tests
         run: cargo nextest run -p iii-worker --profile ci
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: junit-worker-test-${{ matrix.os }}
@@ -466,7 +466,7 @@ jobs:
     runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -504,7 +504,7 @@ jobs:
       - name: Run VM feature-gated tests
         run: cargo nextest run -p iii-worker --features integration-vm --profile ci
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: junit-worker-test-vm-linux
@@ -516,7 +516,7 @@ jobs:
     runs-on: macos-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -529,7 +529,7 @@ jobs:
       - name: Run VM feature-gated tests
         run: cargo nextest run -p iii-worker --features integration-vm --profile ci
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: junit-worker-test-vm-macos
@@ -541,7 +541,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -562,7 +562,7 @@ jobs:
       - name: Run OCI feature-gated tests
         run: cargo nextest run -p iii-worker --features integration-oci --profile ci
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: junit-worker-test-oci-linux
@@ -574,7 +574,7 @@ jobs:
     runs-on: macos-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -587,7 +587,7 @@ jobs:
       - name: Run OCI feature-gated tests
         run: cargo nextest run -p iii-worker --features integration-oci --profile ci
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: junit-worker-test-oci-macos
@@ -603,13 +603,13 @@ jobs:
     needs: engine-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           run_install: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"
@@ -630,7 +630,7 @@ jobs:
         run: pnpm --filter iii-sdk build
 
       - name: Download III binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: iii-binary
 
@@ -670,13 +670,13 @@ jobs:
     needs: engine-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           run_install: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"
@@ -694,7 +694,7 @@ jobs:
         run: pnpm --filter iii-browser-sdk test
 
       - name: Download III binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: iii-binary
 
@@ -729,13 +729,13 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "sdk/packages/python/iii/uv.lock"
@@ -753,7 +753,7 @@ jobs:
         run: uv run mypy src
 
       - name: Download III binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: iii-binary
 
@@ -784,7 +784,7 @@ jobs:
     needs: engine-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -801,7 +801,7 @@ jobs:
         run: cargo clippy -p iii-sdk --all-targets --all-features -- -D warnings
 
       - name: Download III binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: iii-binary
 
@@ -827,9 +827,9 @@ jobs:
     needs: engine-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
           cache-dependency-path: sdk/packages/go/iii/go.sum
@@ -846,7 +846,7 @@ jobs:
         run: go test -race ./...
 
       - name: Download III binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: iii-binary
 
@@ -876,13 +876,13 @@ jobs:
     name: Console Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           run_install: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "pnpm"

--- a/.github/workflows/cloudfront-functions-test.yml
+++ b/.github/workflows/cloudfront-functions-test.yml
@@ -17,9 +17,9 @@ jobs:
     timeout-minutes: 3
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -49,13 +49,13 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.III_CI_APP_ID }}
           private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
@@ -143,7 +143,7 @@ jobs:
       - name: Notify Slack — release blocked (missing docs)
         if: always() && steps.docs_check.outcome == 'failure'
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -297,7 +297,7 @@ jobs:
       - name: Generate templates token
         id: templates_token
         if: inputs.target == 'iii' && inputs.dry_run != true && inputs.prerelease == 'none'
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.III_CI_APP_ID }}
           private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
@@ -316,7 +316,7 @@ jobs:
 
       - name: Notify Slack
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -35,13 +35,13 @@ jobs:
       AWS_REGION: us-east-1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -59,7 +59,7 @@ jobs:
         run: pnpm --filter iii-presentations build
 
       - name: Configure AWS credentials (GitHub OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/docker-engine.yml
+++ b/.github/workflows/docker-engine.yml
@@ -18,6 +18,8 @@ on:
         required: true
       DOCKERHUB_PASSWORD:
         required: true
+      SLACK_WEBHOOK_URL:
+        required: false
 
 permissions:
   contents: read
@@ -62,7 +64,7 @@ jobs:
             docker_arch: arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download pre-built binary
         env:
@@ -78,22 +80,22 @@ jobs:
           mv "$BIN_NAME" "engine/iii-${{ matrix.docker_arch }}"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.DOCKERHUB_REPO }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: engine
           platforms: ${{ matrix.platform }}
@@ -108,11 +110,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.DOCKERHUB_REPO }}
           tags: |
@@ -120,7 +122,7 @@ jobs:
             type=raw,value=latest
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -146,7 +148,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -199,7 +201,7 @@ jobs:
 
       - name: Notify Slack
         if: success()
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         continue-on-error: true
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -234,7 +236,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         continue-on-error: true
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/generate-api-docs.yml
+++ b/.github/workflows/generate-api-docs.yml
@@ -36,23 +36,23 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # ── Node.js ──
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           run_install: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
 
       # ── Python ──
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
 
       # ── Rust (stable + nightly for rustdoc JSON) ──
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/install-sh.yml
+++ b/.github/workflows/install-sh.yml
@@ -29,7 +29,7 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Run shellcheck on install.sh
@@ -39,7 +39,7 @@ jobs:
     name: Unit tests (bats)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install bats-core and jq
         run: sudo apt-get update && sudo apt-get install -y bats jq
       - name: Run bats unit tests
@@ -61,7 +61,7 @@ jobs:
             os: macos-14
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install jq (macOS)
         if: startsWith(matrix.os, 'macos')
         run: brew install jq || true
@@ -82,7 +82,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: apk add --no-cache bash curl jq tar git
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Run integration tests in alpine
         env:
           CI: "true"

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Check license headers
         uses: korandoru/hawkeye@v6

--- a/.github/workflows/release-iii.yml
+++ b/.github/workflows/release-iii.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
   actions: write
   security-events: write
 
@@ -57,7 +56,7 @@ jobs:
       - name: Post initial Slack message
         id: slack
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -88,31 +87,18 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.III_CI_APP_ID }}
           private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           token: ${{ steps.generate_token.outputs.token }}
           fetch-depth: 0
 
-      - name: Compute previous stable tag
-        id: prev
-        env:
-          CURRENT_TAG: ${{ needs.setup.outputs.tag }}
-        run: |
-          PREFIX="iii/v"
-          PREV_STABLE=$(git tag --list "${PREFIX}*" --sort=-v:refname \
-            | grep -E "^${PREFIX}[0-9]+\.[0-9]+\.[0-9]+\$" \
-            | grep -v "^${CURRENT_TAG}\$" \
-            | head -n 1 || true)
-          echo "previous_tag=${PREV_STABLE}" >> "$GITHUB_OUTPUT"
-          echo "::notice::Previous stable tag for release notes: ${PREV_STABLE:-<none, GitHub default>}"
-
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           token: ${{ steps.generate_token.outputs.token }}
           tag_name: ${{ needs.setup.outputs.tag }}
@@ -120,7 +106,6 @@ jobs:
           draft: false
           prerelease: ${{ needs.setup.outputs.is_prerelease == 'true' }}
           generate_release_notes: true
-          previous_tag: ${{ steps.prev.outputs.previous_tag }}
 
   # ──────────────────────────────────────────────────────────────
   # Init Binary (cross-compiled for VM guests)
@@ -142,12 +127,12 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.III_CI_APP_ID }}
           private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           token: ${{ steps.generate_token.outputs.token }}
 
@@ -177,7 +162,7 @@ jobs:
         run: cargo build -p iii-init --target ${{ matrix.target }} --release
 
       - name: Upload init binary as workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: iii-init-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/iii-init
@@ -202,7 +187,7 @@ jobs:
 
       - name: Upload release assets
         if: needs.setup.outputs.dry_run != 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           token: ${{ steps.generate_token.outputs.token }}
           tag_name: ${{ needs.setup.outputs.tag }}
@@ -235,12 +220,12 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.III_CI_APP_ID }}
           private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           token: ${{ steps.generate_token.outputs.token }}
 
@@ -271,7 +256,7 @@ jobs:
 
       - name: Upload release assets
         if: needs.setup.outputs.dry_run != 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           token: ${{ steps.generate_token.outputs.token }}
           tag_name: ${{ needs.setup.outputs.tag }}
@@ -341,13 +326,13 @@ jobs:
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           run_install: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -358,7 +343,7 @@ jobs:
       - name: Build frontend for binary embedding
         run: pnpm --filter console-frontend build:binary
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: console-frontend-dist
           path: console/packages/console-frontend/dist-binary/
@@ -459,23 +444,63 @@ jobs:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
 
-  sdk-py:
-    name: SDK Python Publish
-    needs: [setup, create-iii-release, observability-py]
+  helpers-py-build:
+    name: Helpers Python Build
+    needs: [setup, create-iii-release]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_py.yml
     with:
-      package_path: sdk/packages/python/iii
-      dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
-      slack_thread_ts: ${{ needs.setup.outputs.slack_ts }}
-      slack_label: SDK Python (pypi)
-    secrets:
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+      package_path: sdk/packages/python/helpers
+      artifact_name: pypi-helpers
 
-  observability-py:
-    name: Observability Python Publish
+  helpers-py:
+    name: Helpers Python Publish
+    needs: [setup, create-iii-release, helpers-py-build]
+    if: ${{ !failure() && !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Notify Slack — in progress
+        if: needs.setup.outputs.slack_ts != ''
+        id: slack
+        continue-on-error: true
+        uses: slackapi/slack-github-action@v3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            thread_ts: "${{ needs.setup.outputs.slack_ts }}"
+            text: ":large_yellow_circle: Helpers Python (pypi)${{ needs.setup.outputs.dry_run == 'true' && ' (dry run)' || '' }} — in progress"
+
+      - name: Download distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: pypi-helpers
+          path: dist/
+
+      - name: Publish to PyPI
+        if: needs.setup.outputs.dry_run != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+      - name: Notify Slack — result
+        if: always() && steps.slack.outputs.ts != ''
+        continue-on-error: true
+        uses: slackapi/slack-github-action@v3
+        with:
+          method: chat.update
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            ts: "${{ steps.slack.outputs.ts }}"
+            text: "${{ job.status == 'success' && ':large_green_circle:' || ':red_circle:' }} Helpers Python (pypi)${{ needs.setup.outputs.dry_run == 'true' && ' (dry run)' || '' }} — ${{ job.status }}"
+
+  observability-py-build:
+    name: Observability Python Build
     # The shim pins iii-helpers at the release version; publish helpers first so
     # PyPI can resolve the dependency.
     needs: [setup, create-iii-release, helpers-py]
@@ -483,28 +508,108 @@ jobs:
     uses: ./.github/workflows/_py.yml
     with:
       package_path: sdk/packages/python/observability
-      dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
-      slack_thread_ts: ${{ needs.setup.outputs.slack_ts }}
-      slack_label: Observability Python (pypi)
-    secrets:
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+      artifact_name: pypi-observability
 
-  helpers-py:
-    name: Helpers Python Publish
-    needs: [setup, create-iii-release]
+  observability-py:
+    name: Observability Python Publish
+    needs: [setup, create-iii-release, observability-py-build]
+    if: ${{ !failure() && !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Notify Slack — in progress
+        if: needs.setup.outputs.slack_ts != ''
+        id: slack
+        continue-on-error: true
+        uses: slackapi/slack-github-action@v3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            thread_ts: "${{ needs.setup.outputs.slack_ts }}"
+            text: ":large_yellow_circle: Observability Python (pypi)${{ needs.setup.outputs.dry_run == 'true' && ' (dry run)' || '' }} — in progress"
+
+      - name: Download distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: pypi-observability
+          path: dist/
+
+      - name: Publish to PyPI
+        if: needs.setup.outputs.dry_run != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+      - name: Notify Slack — result
+        if: always() && steps.slack.outputs.ts != ''
+        continue-on-error: true
+        uses: slackapi/slack-github-action@v3
+        with:
+          method: chat.update
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            ts: "${{ steps.slack.outputs.ts }}"
+            text: "${{ job.status == 'success' && ':large_green_circle:' || ':red_circle:' }} Observability Python (pypi)${{ needs.setup.outputs.dry_run == 'true' && ' (dry run)' || '' }} — ${{ job.status }}"
+
+  sdk-py-build:
+    name: SDK Python Build
+    needs: [setup, create-iii-release, observability-py]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_py.yml
     with:
-      package_path: sdk/packages/python/helpers
-      dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
-      slack_thread_ts: ${{ needs.setup.outputs.slack_ts }}
-      slack_label: Helpers Python (pypi)
-    secrets:
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+      package_path: sdk/packages/python/iii
+      artifact_name: pypi-sdk
+
+  sdk-py:
+    name: SDK Python Publish
+    needs: [setup, create-iii-release, sdk-py-build]
+    if: ${{ !failure() && !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Notify Slack — in progress
+        if: needs.setup.outputs.slack_ts != ''
+        id: slack
+        continue-on-error: true
+        uses: slackapi/slack-github-action@v3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            thread_ts: "${{ needs.setup.outputs.slack_ts }}"
+            text: ":large_yellow_circle: SDK Python (pypi)${{ needs.setup.outputs.dry_run == 'true' && ' (dry run)' || '' }} — in progress"
+
+      - name: Download distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: pypi-sdk
+          path: dist/
+
+      - name: Publish to PyPI
+        if: needs.setup.outputs.dry_run != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+      - name: Notify Slack — result
+        if: always() && steps.slack.outputs.ts != ''
+        continue-on-error: true
+        uses: slackapi/slack-github-action@v3
+        with:
+          method: chat.update
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            ts: "${{ steps.slack.outputs.ts }}"
+            text: "${{ job.status == 'success' && ':large_green_circle:' || ':red_circle:' }} SDK Python (pypi)${{ needs.setup.outputs.dry_run == 'true' && ' (dry run)' || '' }} — ${{ job.status }}"
 
   sdk-rust:
     name: SDK Rust Publish
@@ -586,6 +691,7 @@ jobs:
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   # ──────────────────────────────────────────────────────────────
   # Homebrew
@@ -731,7 +837,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.III_CI_APP_ID }}
           private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
@@ -858,7 +964,7 @@ jobs:
       - name: Update Slack parent message
         if: needs.setup.outputs.slack_ts != ''
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         with:
           method: chat.update
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/skill-check.yml
+++ b/.github/workflows/skill-check.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Run iii-skill-check
         uses: iii-hq/skills-and-validation@v0.4

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -30,8 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Install dependencies

--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -33,17 +33,17 @@ jobs:
       TF_IN_AUTOMATION: 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: '1.9.8'
           terraform_wrapper: false
 
       - name: Configure AWS credentials (GitHub OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_TF_APPLY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -25,9 +25,9 @@ jobs:
       TF_IN_AUTOMATION: 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: '1.9.8'
           terraform_wrapper: false
@@ -36,7 +36,7 @@ jobs:
         run: terraform fmt -check -recursive infra/terraform/
 
       - name: Configure AWS credentials (read-only)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_READONLY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -64,7 +64,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Comment plan on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         if: github.event_name == 'pull_request'
         env:
           PLAN: ${{ steps.plan.outputs.plan }}


### PR DESCRIPTION
## Summary

- upgrade repository workflows to Node 24-compatible action majors
- split Python builds from top-level PyPI OIDC publishing and remove API-token authentication
- remove unsupported release-action inputs and wire the Docker Slack secret through the reusable workflow contract
- document the required PyPI Trusted Publisher configuration

## Root cause

The release run used action majors that target the deprecated Node 20 runtime. PyPI publishing also supplied both an API-token password and OIDC permissions, which disabled Trusted Publishing and caused attestations to be ignored.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -color`
- `git diff --check`
- built `iii-helpers`, `iii-observability`, and `iii-sdk` distributions
- `twine check` passed for all wheels and source distributions

## Deployment prerequisite

Before a non-dry-run release, configure PyPI Trusted Publishers for `iii-helpers`, `iii-observability`, and `iii-sdk`, authorizing both `release-iii.yml` and `alpha-release.yml`.