### PR TITLE
fix(iii-worker): make `iii worker list`/`status` reflect engine truth (MOT-3931)

### DIFF
--- a/crates/iii-worker/src/cli/host_shim.rs
+++ b/crates/iii-worker/src/cli/host_shim.rs
@@ -299,6 +299,104 @@ fn strip_ansi(s: &str) -> String {
     out
 }
 
+/// What the engine reports via `engine::workers::list`: every non-disconnected
+/// identifier (worker-reported `name` and engine-side `id` — in-process
+/// builtins carry the config entry name as `id`) plus per-identifier versions.
+pub(crate) struct EngineWorkerSnapshot {
+    pub(crate) names: std::collections::HashSet<String>,
+    pub(crate) versions: std::collections::HashMap<String, String>,
+}
+
+/// A held connection to the engine for repeated snapshot queries (e.g. the
+/// `iii worker status` watch loop). One connect/disconnect pair per probe
+/// lifetime — connecting per query would fire the engine's workers-available
+/// triggers on every poll.
+pub(crate) struct EngineProbe {
+    iii: iii_sdk::IIIClient,
+}
+
+impl EngineProbe {
+    pub(crate) fn connect(port: u16) -> Self {
+        let iii = iii_sdk::register_worker(
+            &format!("ws://127.0.0.1:{port}"),
+            iii_sdk::InitOptions {
+                // Identify the transient connection so it's attributable in
+                // the engine console instead of an anonymous
+                // `<hostname>:<pid>`.
+                metadata: Some(iii_sdk::runtime::WorkerMetadata {
+                    name: "iii-cli".to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+        Self { iii }
+    }
+
+    pub(crate) async fn snapshot(&self) -> Option<EngineWorkerSnapshot> {
+        use iii_sdk::protocol::TriggerRequest;
+        let result = self
+            .iii
+            .trigger(TriggerRequest {
+                function_id: "engine::workers::list".to_string(),
+                payload: serde_json::json!({}),
+                action: None,
+                // The engine is local; a short deadline keeps callers snappy
+                // when the port is open but the engine is wedged.
+                timeout_ms: Some(3_000),
+            })
+            .await;
+        parse_engine_worker_snapshot(&result.ok()?)
+    }
+
+    /// Non-joining shutdown: `shutdown()` joins the connection thread, which
+    /// parks forever inside connect_async() when the port is open but the WS
+    /// handshake never completes (wedged engine, port squatter). The thread
+    /// leaks; the process is a short-lived CLI (or the daemon, where a leak
+    /// per wedged-engine event is bounded).
+    pub(crate) async fn close(self) {
+        self.iii.shutdown_async().await;
+    }
+}
+
+/// One-shot: ask the engine what's actually connected/registered. `None`
+/// when the engine is unreachable, the call times out, or RBAC denies the
+/// discovery function — callers fall back to local pidfile/ps heuristics
+/// (MOT-3931: those heuristics alone made `iii worker list` report dead VMs
+/// as running).
+async fn engine_worker_snapshot(port: u16) -> Option<EngineWorkerSnapshot> {
+    let probe = EngineProbe::connect(port);
+    let snap = probe.snapshot().await;
+    probe.close().await;
+    snap
+}
+
+/// Pure parser for the `engine::workers::list` result. Exposed for testing.
+fn parse_engine_worker_snapshot(value: &serde_json::Value) -> Option<EngineWorkerSnapshot> {
+    let workers = value.get("workers")?.as_array()?;
+    let mut names = std::collections::HashSet::new();
+    let mut versions = std::collections::HashMap::new();
+    for w in workers {
+        if w.get("status").and_then(|v| v.as_str()) == Some("disconnected") {
+            continue;
+        }
+        let version = w.get("version").and_then(|v| v.as_str());
+        for key in ["name", "id"] {
+            if let Some(n) = w.get(key).and_then(|v| v.as_str())
+                && !n.is_empty()
+            {
+                names.insert(n.to_string());
+                if let Some(ver) = version {
+                    versions
+                        .entry(n.to_string())
+                        .or_insert_with(|| ver.to_string());
+                }
+            }
+        }
+    }
+    Some(EngineWorkerSnapshot { names, versions })
+}
+
 #[async_trait]
 impl WorkerHostShim for CliHostShim {
     async fn add(
@@ -552,25 +650,70 @@ impl WorkerHostShim for CliHostShim {
         };
 
         let engine_running = is_engine_running();
+        // Engine truth: what's actually connected/registered right now.
+        // `None` = engine down or query failed; local signals only.
+        let engine = if engine_running {
+            // Outer deadline as a backstop over the SDK's own trigger
+            // timeout: list must never hang on a half-up engine.
+            tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                engine_worker_snapshot(crate::cli::config_file::manager_port()),
+            )
+            .await
+            .ok()
+            .flatten()
+        } else {
+            None
+        };
 
         let mut workers = Vec::with_capacity(config_names.len() + orphan_names.len());
 
         for name in &config_names {
-            // Mirrors handle_worker_list's status logic: a worker counts as
-            // running if its own pidfile/ps match is alive, OR if it's a
-            // config-only / engine-builtin entry and the engine is up
-            // (those workers run inside the engine process, not standalone).
+            // `is_worker_running` is identity-checked (pidfile PID must map
+            // to this worker in the process table), so a live hit is a real
+            // local process — but a live process is NOT a serving worker: a
+            // VM can sit booting (or stuck reconnecting) for minutes. When
+            // the engine answered, connected/registered is the only signal
+            // that earns "running"; a live-but-unregistered process is
+            // "starting" (MOT-3931: list must not say running for a worker
+            // the engine can't see).
             let worker_running = is_worker_running(name);
-            let alive = worker_running
-                || (matches!(
-                    crate::cli::config_file::resolve_worker_type(name),
-                    crate::cli::config_file::ResolvedWorkerType::Config
-                ) && engine_running);
+            let (alive, status) = match &engine {
+                Some(snap) => {
+                    let connected = snap.names.contains(name.as_str());
+                    let status = if connected {
+                        "running"
+                    } else if worker_running {
+                        "starting"
+                    } else {
+                        "stopped"
+                    };
+                    (connected, Some(status.to_string()))
+                }
+                // Engine unreachable: config-only / engine-builtin entries
+                // run inside the engine process, so the port probe is the
+                // only signal available for them. status stays None —
+                // consumers fall back to the `running` bool.
+                None => (
+                    worker_running
+                        || (matches!(
+                            crate::cli::config_file::resolve_worker_type(name),
+                            crate::cli::config_file::ResolvedWorkerType::Config
+                        ) && engine_running),
+                    None,
+                ),
+            };
             let pid = find_worker_pid_from_ps(name);
+            let version = version_for(name).or_else(|| {
+                engine
+                    .as_ref()
+                    .and_then(|snap| snap.versions.get(name.as_str()).cloned())
+            });
             workers.push(WorkerEntry {
                 name: name.clone(),
-                version: version_for(name),
+                version,
                 running: alive,
+                status,
                 pid,
             });
         }
@@ -581,6 +724,7 @@ impl WorkerHostShim for CliHostShim {
                 name: name.clone(),
                 version: version_for(name),
                 running: true, // orphan filter already requires alive
+                status: None,
                 pid,
             });
         }
@@ -785,6 +929,38 @@ fn dir_size(path: &std::path::Path) -> u64 {
 mod tests {
     use super::*;
     use crate::core::error::WorkerOpErrorKind;
+
+    #[test]
+    fn engine_snapshot_parses_names_ids_versions_and_skips_disconnected() {
+        let value = serde_json::json!({
+            "workers": [
+                // WS worker: matchable by self-reported name.
+                {"name": "scrapling", "id": "b1e2...", "status": "connected", "version": "0.2.3"},
+                // In-process builtin: matchable by engine-side id.
+                {"name": "state", "id": "iii-state", "status": "available", "version": "0.21.2"},
+                // Disconnected workers must not read as running.
+                {"name": "ghost", "id": "dead...", "status": "disconnected", "version": "1.0.0"},
+                {"name": null, "id": "anon", "status": "connected"},
+            ]
+        });
+        let snap = parse_engine_worker_snapshot(&value).unwrap();
+        assert!(snap.names.contains("scrapling"));
+        assert!(snap.names.contains("iii-state"));
+        assert!(snap.names.contains("state"));
+        assert!(snap.names.contains("anon"));
+        assert!(!snap.names.contains("ghost"));
+        assert_eq!(
+            snap.versions.get("scrapling").map(String::as_str),
+            Some("0.2.3")
+        );
+        assert_eq!(
+            snap.versions.get("iii-state").map(String::as_str),
+            Some("0.21.2")
+        );
+        assert!(snap.versions.get("anon").is_none());
+        // Not a list result at all → None, caller falls back.
+        assert!(parse_engine_worker_snapshot(&serde_json::json!({"nope": 1})).is_none());
+    }
 
     /// Shared across every test that swaps fd 2 — fd 2 is process-
     /// global, so a per-test local `static` Mutex (one per function)

--- a/crates/iii-worker/src/cli/host_shim.rs
+++ b/crates/iii-worker/src/cli/host_shim.rs
@@ -371,6 +371,21 @@ async fn engine_worker_snapshot(port: u16) -> Option<EngineWorkerSnapshot> {
     snap
 }
 
+/// Status derivation for a config worker when the engine answered. Engine
+/// truth wins: only a connected/registered worker is "running". A live local
+/// process the engine can't see is "starting" — booting, or wedged mid-
+/// connect (MOT-3931: this state used to read as "running"). Returns
+/// `(running, status)`.
+fn engine_status_for(connected: bool, worker_running: bool) -> (bool, &'static str) {
+    if connected {
+        (true, "running")
+    } else if worker_running {
+        (false, "starting")
+    } else {
+        (false, "stopped")
+    }
+}
+
 /// Pure parser for the `engine::workers::list` result. Exposed for testing.
 fn parse_engine_worker_snapshot(value: &serde_json::Value) -> Option<EngineWorkerSnapshot> {
     let workers = value.get("workers")?.as_array()?;
@@ -680,15 +695,9 @@ impl WorkerHostShim for CliHostShim {
             let worker_running = is_worker_running(name);
             let (alive, status) = match &engine {
                 Some(snap) => {
-                    let connected = snap.names.contains(name.as_str());
-                    let status = if connected {
-                        "running"
-                    } else if worker_running {
-                        "starting"
-                    } else {
-                        "stopped"
-                    };
-                    (connected, Some(status.to_string()))
+                    let (alive, status) =
+                        engine_status_for(snap.names.contains(name.as_str()), worker_running);
+                    (alive, Some(status.to_string()))
                 }
                 // Engine unreachable: config-only / engine-builtin entries
                 // run inside the engine process, so the port probe is the
@@ -929,6 +938,18 @@ fn dir_size(path: &std::path::Path) -> u64 {
 mod tests {
     use super::*;
     use crate::core::error::WorkerOpErrorKind;
+
+    #[test]
+    fn engine_status_mapping_is_engine_truth_first() {
+        // Connected wins regardless of local process signals (builtins have
+        // no local process at all).
+        assert_eq!(engine_status_for(true, true), (true, "running"));
+        assert_eq!(engine_status_for(true, false), (true, "running"));
+        // The MOT-3931 lie: process alive but engine can't see it — that is
+        // "starting", never "running".
+        assert_eq!(engine_status_for(false, true), (false, "starting"));
+        assert_eq!(engine_status_for(false, false), (false, "stopped"));
+    }
 
     #[test]
     fn engine_snapshot_parses_names_ids_versions_and_skips_disconnected() {

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -2343,13 +2343,25 @@ pub async fn kill_stale_worker(worker_name: &str) {
                 use nix::sys::signal::{Signal, kill};
                 use nix::unistd::Pid;
                 let p = Pid::from_raw(pid as i32);
-                // Only kill if process is still alive.
+                // Only kill if the process is still alive AND is not a
+                // recycled PID now hosting an unrelated process. watch.pid
+                // points at a watcher helper the argv matcher can't name,
+                // so identity is only enforced for the worker pidfiles.
                 if kill(p, None).is_ok() {
-                    tracing::info!(worker = %worker_name, pid, "Killing stale worker process");
-                    let _ = kill(p, Signal::SIGTERM);
-                    // Brief wait then force-kill.
-                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                    let _ = kill(p, Signal::SIGKILL);
+                    let is_watch_pid =
+                        pid_file.file_name().and_then(|f| f.to_str()) == Some("watch.pid");
+                    if !is_watch_pid && pid_identity_matches(pid, worker_name) == Some(false) {
+                        tracing::warn!(
+                            worker = %worker_name, pid,
+                            "pidfile PID belongs to an unrelated process (recycled); not killing"
+                        );
+                    } else {
+                        tracing::info!(worker = %worker_name, pid, "Killing stale worker process");
+                        let _ = kill(p, Signal::SIGTERM);
+                        // Brief wait then force-kill.
+                        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                        let _ = kill(p, Signal::SIGKILL);
+                    }
                 }
             }
             #[cfg(not(unix))]
@@ -2359,6 +2371,30 @@ pub async fn kill_stale_worker(worker_name: &str) {
         }
         if existed {
             let _ = tokio::fs::remove_file(pid_file).await;
+        }
+    }
+
+    // Pidfile-less leftovers: a VM whose pidfile was lost (crash, manual
+    // cleanup, overlapping engine restarts) is invisible to the pass above
+    // but must still die before a new instance shares
+    // `~/.iii/managed/{worker_name}` (MOT-3931 duplicate-VM race).
+    #[cfg(unix)]
+    {
+        use nix::sys::signal::{Signal, kill};
+        use nix::unistd::Pid;
+        let leftovers = find_worker_pids_from_ps(worker_name);
+        if !leftovers.is_empty() {
+            tracing::info!(
+                worker = %worker_name, pids = ?leftovers,
+                "Killing pidfile-less worker process(es)"
+            );
+            for pid in &leftovers {
+                let _ = kill(Pid::from_raw(*pid as i32), Signal::SIGTERM);
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            for pid in &leftovers {
+                let _ = kill(Pid::from_raw(*pid as i32), Signal::SIGKILL);
+            }
         }
     }
 }
@@ -2526,8 +2562,9 @@ fn collect_processes() -> Vec<(u32, String)> {
 }
 
 /// From a single process's `argv`-joined cmdline, return the worker name it
-/// represents (if any). Shared between name discovery and PID lookup so both
-/// match against the exact same recognition rules.
+/// represents (if any). Shared between name discovery, PID lookup, and the
+/// pidfile identity cross-check so all match against the exact same
+/// recognition rules.
 fn extract_worker_name_from_cmdline(
     cmdline: &str,
     workers_prefix: &std::path::Path,
@@ -2545,19 +2582,38 @@ fn extract_worker_name_from_cmdline(
         return Some(name.to_string());
     }
 
-    // Pattern 2: iii-worker __vm-boot --pid-file <...>/managed/{name}/vm.pid
+    // Pattern 2: iii-worker __vm-boot with a path under ~/.iii/managed/{name}
+    // in either `--pid-file <...>/managed/{name}/vm.pid` or
+    // `--rootfs <...>/managed/{name}`. The `--rootfs` fallback matters for VMs
+    // booted by older builds whose dev boot path didn't pass `--pid-file`.
     if exe_path.file_name().and_then(|s| s.to_str()) == Some("iii-worker")
         && tokens.next() == Some("__vm-boot")
     {
         let rest: Vec<&str> = tokens.collect();
         for i in 0..rest.len().saturating_sub(1) {
-            if rest[i] == "--pid-file"
-                && let Ok(rel) = std::path::Path::new(rest[i + 1]).strip_prefix(managed_prefix)
-                && let Some(name) = rel.iter().next().and_then(|c| c.to_str())
-                && !name.is_empty()
-            {
-                return Some(name.to_string());
+            let flag = rest[i];
+            if flag != "--pid-file" && flag != "--rootfs" {
+                continue;
             }
+            let Ok(rel) = std::path::Path::new(rest[i + 1]).strip_prefix(managed_prefix) else {
+                continue;
+            };
+            let mut components = rel.iter();
+            let Some(name) = components.next().and_then(|c| c.to_str()) else {
+                continue;
+            };
+            if name.is_empty() {
+                continue;
+            }
+            // `--rootfs` only counts when it IS the managed dir: legacy-cache
+            // sandbox VMs boot with `--rootfs ~/.iii/managed/<preset>/rootfs`
+            // and must not be claimed as worker `<preset>` (worker dev VMs
+            // pass the managed dir itself). `--pid-file` is always
+            // `{name}/vm.pid`, so the extra component is expected there.
+            if flag == "--rootfs" && components.next().is_some() {
+                continue;
+            }
+            return Some(name.to_string());
         }
     }
     None
@@ -2597,7 +2653,107 @@ fn find_worker_pid_in_processes(
     })
 }
 
-/// Returns `true` if the worker has a valid PID file and the process is alive.
+/// Every live PID whose cmdline resolves to `name` — plural sibling of
+/// [`find_worker_pid_from_ps`] for callers that must handle duplicate VMs
+/// (e.g. two overlapping boots of the same managed worker).
+pub fn find_worker_pids_from_ps(name: &str) -> Vec<u32> {
+    let processes = collect_processes();
+    if processes.is_empty() {
+        return Vec::new();
+    }
+    let home = dirs::home_dir().unwrap_or_default();
+    let workers_prefix = home.join(".iii/workers");
+    let managed_prefix = home.join(".iii/managed");
+    processes
+        .iter()
+        .filter_map(|(pid, cmdline)| {
+            match extract_worker_name_from_cmdline(cmdline, &workers_prefix, &managed_prefix) {
+                Some(n) if n == name => Some(*pid),
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+/// One process's argv-joined cmdline, by PID. Cheap single-PID lookup — NOT a
+/// full process-table scan — because the identity cross-check runs on every
+/// `is_worker_running` call (list loops, status --watch ticks).
+#[cfg(target_os = "linux")]
+fn process_cmdline(pid: u32) -> Option<String> {
+    let bytes = std::fs::read(format!("/proc/{pid}/cmdline")).ok()?;
+    if bytes.is_empty() {
+        // Zombies and kernel threads have an empty cmdline: identity can't
+        // be judged, only liveness (which the caller already checked).
+        return None;
+    }
+    let line = String::from_utf8_lossy(&bytes).replace('\0', " ");
+    let trimmed = line.trim_end().to_string();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
+#[cfg(target_os = "macos")]
+fn process_cmdline(pid: u32) -> Option<String> {
+    let output = std::process::Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "args="])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let line = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!line.is_empty()).then_some(line)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn process_cmdline(_pid: u32) -> Option<String> {
+    None
+}
+
+/// Identity cross-check for a pidfile PID. `Some(true)` when `pid`'s cmdline
+/// says it runs `worker_name`, `Some(false)` when it demonstrably hosts
+/// something else (the PID number was recycled by an unrelated process),
+/// `None` when the cmdline can't be read so identity can't be judged.
+fn pid_identity_matches(pid: u32, worker_name: &str) -> Option<bool> {
+    let cmdline = process_cmdline(pid)?;
+    let home = dirs::home_dir().unwrap_or_default();
+    let workers_prefix = home.join(".iii/workers");
+    let managed_prefix = home.join(".iii/managed");
+    Some(cmdline_matches_worker(
+        &cmdline,
+        worker_name,
+        &workers_prefix,
+        &managed_prefix,
+    ))
+}
+
+/// Pure form of [`pid_identity_matches`]. Deliberately MORE lenient than the
+/// discovery matcher: identity asks "could this PID be worker N?", and a
+/// false veto makes a live worker read as stopped AND unkillable by
+/// `kill_stale_worker`. Beyond the discovery patterns, accept any argv token
+/// exactly equal to `~/.iii/workers/{name}` — an interpreter-wrapped binary
+/// worker (`#!/bin/sh` payload) runs as `/bin/sh ~/.iii/workers/{name} ...`,
+/// where argv[0] is the interpreter.
+fn cmdline_matches_worker(
+    cmdline: &str,
+    worker_name: &str,
+    workers_prefix: &std::path::Path,
+    managed_prefix: &std::path::Path,
+) -> bool {
+    if extract_worker_name_from_cmdline(cmdline, workers_prefix, managed_prefix).as_deref()
+        == Some(worker_name)
+    {
+        return true;
+    }
+    let worker_path = workers_prefix.join(worker_name);
+    cmdline
+        .split_whitespace()
+        .any(|tok| std::path::Path::new(tok) == worker_path)
+}
+
+/// Returns `true` if the worker has a valid PID file, the process is alive,
+/// and — when the process table is readable — the PID actually belongs to
+/// this worker. A stale pidfile whose PID number has been recycled by an
+/// unrelated process must not read as alive (MOT-3931).
 pub fn is_worker_running(worker_name: &str) -> bool {
     let home = dirs::home_dir().unwrap_or_default();
     let oci_pid = home.join(".iii/managed").join(worker_name).join("vm.pid");
@@ -2610,7 +2766,12 @@ pub fn is_worker_running(worker_name: &str) -> bool {
             {
                 use nix::sys::signal::kill;
                 use nix::unistd::Pid;
-                if kill(Pid::from_raw(pid as i32), None).is_ok() {
+                if kill(Pid::from_raw(pid as i32), None).is_ok()
+                    // `Some(false)` = the PID is alive but demonstrably not
+                    // this worker (recycled). `None` = can't enumerate
+                    // processes; fall back to trusting the pidfile.
+                    && pid_identity_matches(pid, worker_name) != Some(false)
+                {
                     return true;
                 }
             }
@@ -3478,128 +3639,6 @@ async fn start_binary_worker(
     }
 }
 
-pub async fn handle_worker_list() -> i32 {
-    let config_names = super::config_file::list_worker_names();
-
-    // Discovery union: on-disk PID files + on-disk managed dirs + live process
-    // table (catches workers whose pidfiles were removed but the process kept
-    // running -- the actual repro from the user's bug report).
-    let disk_names = discover_disk_worker_names();
-    let ps_names = discover_running_worker_names_from_ps();
-    let ps_set: std::collections::HashSet<String> = ps_names.iter().cloned().collect();
-    let config_set: std::collections::HashSet<&str> =
-        config_names.iter().map(String::as_str).collect();
-
-    // Orphan = not in current ./config.yaml AND demonstrably alive (either via
-    // pidfile signal-0 check or because we just saw it in `ps`). Dead disk-only
-    // entries are stale runtime state, not what the user is asking about.
-    let candidate_names: std::collections::BTreeSet<String> =
-        disk_names.into_iter().chain(ps_names).collect();
-    let orphan_names: Vec<String> = candidate_names
-        .into_iter()
-        .filter(|n| !config_set.contains(n.as_str()))
-        .filter(|n| ps_set.contains(n) || is_worker_running(n))
-        .collect();
-
-    if config_names.is_empty() && orphan_names.is_empty() {
-        eprintln!("  No workers. Use `iii worker add` to get started.");
-        return 0;
-    }
-
-    let engine_running = is_engine_running();
-
-    eprintln!();
-    eprintln!(
-        "  {:25} {:10} {}",
-        "NAME".bold(),
-        "TYPE".bold(),
-        "STATUS".bold()
-    );
-    eprintln!(
-        "  {:25} {:10} {}",
-        "----".dimmed(),
-        "----".dimmed(),
-        "------".dimmed()
-    );
-
-    for name in &config_names {
-        let worker_type = worker_list_type_label(name);
-
-        let running = if is_worker_running(name) {
-            "running".green().to_string()
-        } else if matches!(worker_type, "config" | "engine") && engine_running {
-            "running".green().to_string()
-        } else {
-            "stopped".dimmed().to_string()
-        };
-
-        eprintln!("  {:25} {:10} {}", name, worker_type.dimmed(), running);
-    }
-
-    // Orphans: alive on this machine but absent from the current ./config.yaml.
-    // The TYPE column is inferred from the on-disk evidence we found the worker
-    // through (managed dir vs binary pidfile/exe). Falls back to "?" only when
-    // a worker was discovered solely via `ps` and no on-disk artifact remains.
-    for name in &orphan_names {
-        let home = dirs::home_dir().unwrap_or_default();
-        let worker_type = resolve_orphan_type(
-            name,
-            &home.join(".iii/managed"),
-            &home.join(".iii/pids"),
-            &home.join(".iii/workers"),
-        );
-        eprintln!(
-            "  {:25} {:10} {}",
-            name,
-            worker_type.dimmed(),
-            "orphan".yellow()
-        );
-    }
-
-    eprintln!();
-    0
-}
-
-fn worker_list_type_label(name: &str) -> &'static str {
-    worker_list_type_label_from_resolved(name, super::config_file::resolve_worker_type(name))
-}
-
-fn worker_list_type_label_from_resolved(name: &str, resolved: ResolvedWorkerType) -> &'static str {
-    match resolved {
-        ResolvedWorkerType::Local { .. } => "local",
-        ResolvedWorkerType::Oci { .. } => "oci",
-        ResolvedWorkerType::Bundle { .. } => "bundle",
-        ResolvedWorkerType::Binary { .. } => "binary",
-        ResolvedWorkerType::Config if is_any_builtin(name) => "engine",
-        ResolvedWorkerType::Config => "config",
-    }
-}
-
-/// Infers the TYPE label for an orphan worker from on-disk evidence alone.
-///
-/// We can't rebuild the `ResolvedWorkerType` enum without a config entry, but
-/// we can tell `managed` (OCI/VM/local-path -- shares a directory shape) from
-/// `binary` (single executable + sidecar pidfile) just from where the artifact
-/// lives. Returns "?" when only a `ps` match exists and every artifact has been
-/// cleaned up under it -- the honest answer.
-///
-/// Path arguments are injected to keep the function unit-testable against a
-/// tempdir without an env override.
-fn resolve_orphan_type(
-    name: &str,
-    managed_dir: &std::path::Path,
-    pids_dir: &std::path::Path,
-    workers_dir: &std::path::Path,
-) -> &'static str {
-    if managed_dir.join(name).is_dir() {
-        return "managed";
-    }
-    if pids_dir.join(format!("{}.pid", name)).is_file() || workers_dir.join(name).is_file() {
-        return "binary";
-    }
-    "?"
-}
-
 /// Pick the log directory with the most recently modified, non-empty log file.
 /// Returns `None` when no candidate contains any usable log content.
 fn file_len(path: &std::path::Path) -> u64 {
@@ -3853,54 +3892,6 @@ mod tests {
     #[test]
     fn binary_config_yaml_omits_empty_registry_config() {
         assert_eq!(binary_config_yaml(&serde_json::json!({})), None);
-    }
-
-    #[test]
-    fn worker_list_type_label_marks_configured_builtin_as_engine() {
-        assert_eq!(
-            worker_list_type_label_from_resolved("iii-stream", ResolvedWorkerType::Config),
-            "engine"
-        );
-    }
-
-    #[test]
-    fn worker_list_type_label_keeps_non_builtin_config_as_config() {
-        assert_eq!(
-            worker_list_type_label_from_resolved("custom-config-only", ResolvedWorkerType::Config),
-            "config"
-        );
-    }
-
-    #[test]
-    fn worker_list_type_label_preserves_local_oci_and_binary_labels() {
-        assert_eq!(
-            worker_list_type_label_from_resolved(
-                "local-dev",
-                ResolvedWorkerType::Local {
-                    worker_path: "./worker".to_string(),
-                },
-            ),
-            "local"
-        );
-        assert_eq!(
-            worker_list_type_label_from_resolved(
-                "external-image",
-                ResolvedWorkerType::Oci {
-                    image: "ghcr.io/acme/external:1".to_string(),
-                    env: std::collections::HashMap::new(),
-                },
-            ),
-            "oci"
-        );
-        assert_eq!(
-            worker_list_type_label_from_resolved(
-                "downloaded-worker",
-                ResolvedWorkerType::Binary {
-                    binary_path: std::path::PathBuf::from("/tmp/downloaded-worker"),
-                },
-            ),
-            "binary"
-        );
     }
 
     #[test]
@@ -5935,10 +5926,10 @@ dependencies:
    \n\
 /usr/bin/python\n\
 /h/.local/bin/iii-worker __serve\n\
-/h/.local/bin/iii-worker __vm-boot --rootfs /h/.iii/managed/x/rootfs\n\
+/h/.local/bin/iii-worker __vm-boot --rootfs /elsewhere/rootfs\n\
 /h/.local/bin/iii-worker __vm-boot --pid-file\n\
 /h/.local/bin/iii-worker __vm-boot --pid-file /elsewhere/vm.pid\n";
-        // No `--pid-file <path>` matching managed prefix → no orphans found.
+        // No `--pid-file`/`--rootfs` path under the managed prefix → no orphans found.
         let names = discover_running_worker_names_from_ps_output(ps, &workers, &managed);
         assert!(names.is_empty(), "got unexpected names: {names:?}");
     }
@@ -5998,60 +5989,70 @@ dependencies:
     }
 
     #[test]
-    fn resolve_orphan_type_managed_takes_priority() {
-        let tmp = tempfile::tempdir().unwrap();
-        let managed = tmp.path().join("managed");
-        let pids = tmp.path().join("pids");
-        let workers = tmp.path().join("workers");
-        std::fs::create_dir_all(managed.join("dual")).unwrap();
-        std::fs::create_dir_all(&pids).unwrap();
-        std::fs::write(pids.join("dual.pid"), "1").unwrap();
-        // managed/ wins because the directory shape carries more information
-        // (rootfs, logs, etc.) than a bare pidfile.
+    fn vm_boot_without_pid_file_is_recognized_via_rootfs() {
+        // Dev/bundle VMs booted by older builds have no `--pid-file` in argv;
+        // the `--rootfs <managed dir>` fallback must still name them
+        // (MOT-3931: permanent PID "-" / orphan-discovery blind spot).
+        let workers = std::path::PathBuf::from("/h/.iii/workers");
+        let managed = std::path::PathBuf::from("/h/.iii/managed");
+        let processes = vec![(
+            36134,
+            "/h/.local/bin/iii-worker __vm-boot --rootfs /h/.iii/managed/scrapling \
+             --rootfs-lower /h/.iii/cache/base.erofs --control-sock \
+             /h/.iii/managed/scrapling/control.sock --network"
+                .to_string(),
+        )];
         assert_eq!(
-            resolve_orphan_type("dual", &managed, &pids, &workers),
-            "managed"
+            find_worker_pid_in_processes(&processes, "scrapling", &workers, &managed),
+            Some(36134)
+        );
+        // Legacy-cache sandbox VMs boot with `--rootfs .../managed/<preset>/rootfs`
+        // (a SUBDIR of a managed path) and must NOT be claimed as a worker —
+        // `iii worker stop`/`start` would kill a live sandbox.
+        let sandbox = vec![(
+            500,
+            "/h/.local/bin/iii-worker __vm-boot --rootfs /h/.iii/managed/python/rootfs --network"
+                .to_string(),
+        )];
+        assert_eq!(
+            find_worker_pid_in_processes(&sandbox, "python", &workers, &managed),
+            None
         );
     }
 
     #[test]
-    fn resolve_orphan_type_binary_via_pidfile() {
-        let tmp = tempfile::tempdir().unwrap();
-        let managed = tmp.path().join("managed");
-        let pids = tmp.path().join("pids");
-        let workers = tmp.path().join("workers");
-        std::fs::create_dir_all(&pids).unwrap();
-        std::fs::write(pids.join("img-resize.pid"), "1234").unwrap();
-        assert_eq!(
-            resolve_orphan_type("img-resize", &managed, &pids, &workers),
-            "binary"
-        );
-    }
-
-    #[test]
-    fn resolve_orphan_type_binary_via_workers_executable() {
-        let tmp = tempfile::tempdir().unwrap();
-        let managed = tmp.path().join("managed");
-        let pids = tmp.path().join("pids");
-        let workers = tmp.path().join("workers");
-        std::fs::create_dir_all(&workers).unwrap();
-        std::fs::write(workers.join("img-resize"), b"#!/bin/sh\n").unwrap();
-        // No pidfile, only the executable -- still recognisable as binary.
-        assert_eq!(
-            resolve_orphan_type("img-resize", &managed, &pids, &workers),
-            "binary"
-        );
-    }
-
-    #[test]
-    fn resolve_orphan_type_unknown_when_only_ps_evidence() {
-        let tmp = tempfile::tempdir().unwrap();
-        let managed = tmp.path().join("managed");
-        let pids = tmp.path().join("pids");
-        let workers = tmp.path().join("workers");
-        // Nothing on disk under any of the three roots: a worker that is alive
-        // in ps but has had every artifact cleaned up. Honest answer is "?".
-        assert_eq!(resolve_orphan_type("ghost", &managed, &pids, &workers), "?");
+    fn cmdline_identity_rejects_recycled_pid_but_tolerates_interpreters() {
+        let workers = std::path::PathBuf::from("/h/.iii/workers");
+        let managed = std::path::PathBuf::from("/h/.iii/managed");
+        // Recycled PID hosting an unrelated process → no match.
+        assert!(!cmdline_matches_worker(
+            "/usr/bin/spotify",
+            "todo",
+            &workers,
+            &managed
+        ));
+        // VM-boot argv designating this worker.
+        let vm = "/h/.local/bin/iii-worker __vm-boot --pid-file /h/.iii/managed/todo/vm.pid";
+        assert!(cmdline_matches_worker(vm, "todo", &workers, &managed));
+        // Same argv, different worker name → mismatch.
+        assert!(!cmdline_matches_worker(vm, "other", &workers, &managed));
+        // Interpreter-wrapped binary worker: argv[0] is the interpreter, the
+        // workers-dir path appears as a later token. Identity must tolerate
+        // this (discovery does not) or the worker becomes invisible AND
+        // unkillable.
+        assert!(cmdline_matches_worker(
+            "/bin/sh /h/.iii/workers/todo --port 3111",
+            "todo",
+            &workers,
+            &managed
+        ));
+        // A path merely *under* the worker's dir is a different token.
+        assert!(!cmdline_matches_worker(
+            "tail -f /h/.iii/workers/todo.log",
+            "todo",
+            &workers,
+            &managed
+        ));
     }
 
     #[test]
@@ -6506,6 +6507,11 @@ dependencies:
 
     #[test]
     fn image_cache_dir_deterministic_hash() {
+        // Hold the HOME lock: the two calls must observe the same HOME, and
+        // concurrent tests legitimately override it under this lock.
+        let _guard = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Same ref always produces same path
         let a = image_cache_dir("ghcr.io/org/worker:1.0");
         let b = image_cache_dir("ghcr.io/org/worker:1.0");
@@ -6519,6 +6525,9 @@ dependencies:
 
     #[test]
     fn image_cache_dir_under_iii_images() {
+        let _guard = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let dir = image_cache_dir("test:latest");
         let path_str = dir.to_string_lossy();
         assert!(path_str.contains(".iii/images/") || path_str.contains(".iii\\images\\"));

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -2360,7 +2360,15 @@ pub async fn kill_stale_worker(worker_name: &str) {
                         let _ = kill(p, Signal::SIGTERM);
                         // Brief wait then force-kill.
                         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                        let _ = kill(p, Signal::SIGKILL);
+                        // Re-check before the force-kill: the PID may have
+                        // exited on SIGTERM and been recycled by an
+                        // unrelated process during the grace window. `None`
+                        // (already dead, or a watch.pid whose argv we can't
+                        // name) falls through to a harmless SIGKILL of a
+                        // dead/zombie pid.
+                        if is_watch_pid || pid_identity_matches(pid, worker_name) != Some(false) {
+                            let _ = kill(p, Signal::SIGKILL);
+                        }
                     }
                 }
             }
@@ -2392,7 +2400,14 @@ pub async fn kill_stale_worker(worker_name: &str) {
                 let _ = kill(Pid::from_raw(*pid as i32), Signal::SIGTERM);
             }
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-            for pid in &leftovers {
+            // Re-scan before the force-kill: a PID from the first snapshot
+            // may have exited during the grace window and been recycled by
+            // an unrelated process. Force-kill only PIDs present in BOTH
+            // snapshots — the fresh scan alone could pick up a
+            // concurrently-started sibling this pass must not touch.
+            let survivors: std::collections::HashSet<u32> =
+                find_worker_pids_from_ps(worker_name).into_iter().collect();
+            for pid in leftovers.iter().filter(|p| survivors.contains(p)) {
                 let _ = kill(Pid::from_raw(*pid as i32), Signal::SIGKILL);
             }
         }

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -2637,6 +2637,25 @@ fn discover_running_worker_names_from_ps_output(
     names.into_iter().collect()
 }
 
+/// Pure form of [`find_worker_pids_from_ps`]: every PID whose cmdline
+/// resolves to `name`, in process-table order. Exposed for testing.
+fn find_worker_pids_in_processes(
+    processes: &[(u32, String)],
+    name: &str,
+    workers_prefix: &std::path::Path,
+    managed_prefix: &std::path::Path,
+) -> Vec<u32> {
+    processes
+        .iter()
+        .filter_map(|(pid, cmdline)| {
+            match extract_worker_name_from_cmdline(cmdline, workers_prefix, managed_prefix) {
+                Some(n) if n == name => Some(*pid),
+                _ => None,
+            }
+        })
+        .collect()
+}
+
 /// Pure parser used by [`find_worker_pid_from_ps`]. Returns the first PID
 /// whose cmdline resolves to `name`. Exposed for testing.
 fn find_worker_pid_in_processes(
@@ -2645,12 +2664,9 @@ fn find_worker_pid_in_processes(
     workers_prefix: &std::path::Path,
     managed_prefix: &std::path::Path,
 ) -> Option<u32> {
-    processes.iter().find_map(|(pid, cmdline)| {
-        match extract_worker_name_from_cmdline(cmdline, workers_prefix, managed_prefix) {
-            Some(n) if n == name => Some(*pid),
-            _ => None,
-        }
-    })
+    find_worker_pids_in_processes(processes, name, workers_prefix, managed_prefix)
+        .first()
+        .copied()
 }
 
 /// Every live PID whose cmdline resolves to `name` — plural sibling of
@@ -2664,15 +2680,7 @@ pub fn find_worker_pids_from_ps(name: &str) -> Vec<u32> {
     let home = dirs::home_dir().unwrap_or_default();
     let workers_prefix = home.join(".iii/workers");
     let managed_prefix = home.join(".iii/managed");
-    processes
-        .iter()
-        .filter_map(|(pid, cmdline)| {
-            match extract_worker_name_from_cmdline(cmdline, &workers_prefix, &managed_prefix) {
-                Some(n) if n == name => Some(*pid),
-                _ => None,
-            }
-        })
-        .collect()
+    find_worker_pids_in_processes(&processes, name, &workers_prefix, &managed_prefix)
 }
 
 /// One process's argv-joined cmdline, by PID. Cheap single-PID lookup — NOT a
@@ -6018,6 +6026,42 @@ dependencies:
             find_worker_pid_in_processes(&sandbox, "python", &workers, &managed),
             None
         );
+    }
+
+    #[test]
+    fn find_worker_pids_collects_duplicate_vms() {
+        // MOT-3931 duplicate-VM race in miniature: two overlapping boots of
+        // the same worker (one old-build via --rootfs, one new via
+        // --pid-file). kill_stale_worker's sweep needs BOTH; the singular
+        // lookup keeps first-match semantics.
+        let workers = std::path::PathBuf::from("/h/.iii/workers");
+        let managed = std::path::PathBuf::from("/h/.iii/managed");
+        let processes = vec![
+            (10, "/usr/bin/zsh".to_string()),
+            (
+                41,
+                "/h/.local/bin/iii-worker __vm-boot --pid-file /h/.iii/managed/todo/vm.pid"
+                    .to_string(),
+            ),
+            (
+                42,
+                "/h/.local/bin/iii-worker __vm-boot --rootfs /h/.iii/managed/todo".to_string(),
+            ),
+            (
+                43,
+                "/h/.local/bin/iii-worker __vm-boot --pid-file /h/.iii/managed/other/vm.pid"
+                    .to_string(),
+            ),
+        ];
+        assert_eq!(
+            find_worker_pids_in_processes(&processes, "todo", &workers, &managed),
+            vec![41, 42]
+        );
+        assert_eq!(
+            find_worker_pid_in_processes(&processes, "todo", &workers, &managed),
+            Some(41)
+        );
+        assert!(find_worker_pids_in_processes(&processes, "ghost", &workers, &managed).is_empty());
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/status.rs
+++ b/crates/iii-worker/src/cli/status.rs
@@ -201,6 +201,12 @@ pub struct WorkerStatus {
     /// from phase so the render can distinguish "alive, deps still
     /// installing" (Preparing) from "stale pidfile" (dead).
     pub alive: bool,
+    /// Engine truth: is a worker with this name connected/registered with
+    /// the engine right now? `None` when the engine wasn't asked (down, or
+    /// query failed). A live VM process whose worker never registered
+    /// (wedged handshake, stuck boot) is `Some(false)` — the case where
+    /// every local signal lies (MOT-3931).
+    pub engine_registered: Option<bool>,
     pub logs_dir: Option<std::path::PathBuf>,
     pub logs_last_modified: Option<SystemTime>,
 }
@@ -228,6 +234,7 @@ impl WorkerStatus {
                 prepared: false,
                 pid: None,
                 alive: false,
+                engine_registered: None,
                 logs_dir: None,
                 logs_last_modified: None,
             };
@@ -302,8 +309,25 @@ impl WorkerStatus {
             prepared,
             pid,
             alive: running,
+            engine_registered: None,
             logs_dir,
             logs_last_modified,
+        }
+    }
+
+    /// Overlay engine truth onto a locally-derived status. A `Ready` verdict
+    /// built from pidfiles and markers is a lie when the engine has no
+    /// worker registered under this name (VM alive but its connection never
+    /// completed — MOT-3931); downgrade it to `Booting` so `--wait` keeps
+    /// waiting and the render says why.
+    pub(crate) fn apply_engine_truth(
+        &mut self,
+        snap: &crate::cli::host_shim::EngineWorkerSnapshot,
+    ) {
+        let registered = snap.names.contains(&self.name);
+        self.engine_registered = Some(registered);
+        if !registered && self.phase == Phase::Ready {
+            self.phase = Phase::Booting;
         }
     }
 
@@ -676,6 +700,25 @@ impl WorkerStatus {
         };
         out.push(process_line);
 
+        // Engine truth, when the engine was asked. A live process the engine
+        // can't see is the one state every local signal gets wrong.
+        match self.engine_registered {
+            Some(true) => out.push(format!(
+                "{:>12}  {} {}",
+                "worker:".dimmed(),
+                "registered".green(),
+                "(connected to engine)".dimmed()
+            )),
+            Some(false) => out.push(format!(
+                "{:>12}  {} {}",
+                "worker:".dimmed(),
+                "not registered".red(),
+                "(engine has no worker under this name — booting, or its connection is stuck)"
+                    .dimmed()
+            )),
+            None => {}
+        }
+
         let logs_line = match (&self.logs_dir, self.logs_last_modified) {
             (Some(_), Some(_)) => format!(
                 "{:>12}  {} {}",
@@ -736,7 +779,14 @@ pub(crate) fn read_pid(name: &str) -> Option<u32> {
 pub async fn handle_worker_status(worker_name: &str, watch: bool) -> i32 {
     let port = super::config_file::manager_port();
     if !watch {
-        let status = WorkerStatus::probe_on(worker_name, port);
+        let mut status = WorkerStatus::probe_on(worker_name, port);
+        if status.engine_running {
+            let probe = super::host_shim::EngineProbe::connect(port);
+            if let Some(snap) = probe.snapshot().await {
+                status.apply_engine_truth(&snap);
+            }
+            probe.close().await;
+        }
         for line in status.render() {
             eprintln!("{}", line);
         }
@@ -787,8 +837,28 @@ pub async fn watch_until_ready(
     // stat() calls + a TCP probe of the engine port), so faster polling
     // also tightens reaction time on phase transitions.
     let poll_interval = Duration::from_millis(200);
-    loop {
-        let status = WorkerStatus::probe_on(worker_name, port);
+    // One held engine connection for the whole watch session (connecting per
+    // tick would fire the engine's workers-available triggers 5×/s). The
+    // snapshot refreshes every 5th tick (~1s); in between, the last snapshot
+    // still applies — registration state doesn't flap at 200ms granularity.
+    let mut engine_probe: Option<super::host_shim::EngineProbe> = None;
+    let mut last_snap: Option<super::host_shim::EngineWorkerSnapshot> = None;
+    let final_status = loop {
+        let mut status = WorkerStatus::probe_on(worker_name, port);
+        if status.engine_running {
+            if engine_probe.is_none() {
+                engine_probe = Some(super::host_shim::EngineProbe::connect(port));
+            }
+            if tick % 5 == 0
+                && let Some(probe) = &engine_probe
+                && let Some(snap) = probe.snapshot().await
+            {
+                last_snap = Some(snap);
+            }
+        }
+        if let Some(snap) = &last_snap {
+            status.apply_engine_truth(snap);
+        }
         let progress = WatchProgress {
             tick,
             elapsed: started.elapsed(),
@@ -821,17 +891,21 @@ pub async fn watch_until_ready(
         }
 
         if status.is_terminal_for_wait() {
-            return status;
+            break status;
         }
         if let Some(t) = timeout
             && started.elapsed() >= t
         {
-            return status;
+            break status;
         }
 
         tick = tick.wrapping_add(1);
         tokio::time::sleep(poll_interval).await;
+    };
+    if let Some(probe) = engine_probe {
+        probe.close().await;
     }
+    final_status
 }
 
 /// Truncate a single line to `max` characters, suffixing `…` if cut.
@@ -935,6 +1009,7 @@ mod tests {
             prepared: true,
             pid: Some(42),
             alive: true,
+            engine_registered: None,
             logs_dir: None,
             logs_last_modified: None,
         };
@@ -1028,6 +1103,7 @@ mod tests {
             prepared: false,
             pid: None,
             alive: false,
+            engine_registered: None,
             logs_dir: Some(logs_dir),
             logs_last_modified: Some(SystemTime::now()),
         };
@@ -1069,6 +1145,7 @@ mod tests {
             prepared: false,
             pid: None,
             alive: false,
+            engine_registered: None,
             logs_dir: None,
             logs_last_modified: None,
         };
@@ -1129,6 +1206,7 @@ mod tests {
             prepared: true,
             pid: Some(123),
             alive: true,
+            engine_registered: None,
             logs_dir: Some(std::path::PathBuf::from("/tmp/logs")),
             logs_last_modified: Some(SystemTime::now()),
         };
@@ -1153,6 +1231,7 @@ mod tests {
             prepared: false,
             pid: None,
             alive: false,
+            engine_registered: None,
             logs_dir: None,
             logs_last_modified: None,
         };
@@ -1182,6 +1261,7 @@ mod tests {
             prepared: false,
             pid: Some(16795),
             alive: true,
+            engine_registered: None,
             logs_dir: None,
             logs_last_modified: None,
         };
@@ -1219,6 +1299,7 @@ mod tests {
             prepared: false,
             pid: Some(48350),
             alive: true,
+            engine_registered: None,
             logs_dir: None,
             logs_last_modified: None,
         };
@@ -1264,6 +1345,7 @@ mod tests {
             prepared: false,
             pid: Some(16795),
             alive: true,
+            engine_registered: None,
             logs_dir: None,
             logs_last_modified: None,
         };
@@ -1278,6 +1360,61 @@ mod tests {
             "process row must NOT call a live pid stale, got:\n{}",
             text
         );
+    }
+
+    #[test]
+    fn apply_engine_truth_downgrades_unregistered_ready_and_renders_row() {
+        // MOT-3931 live repro: VM alive, all local signals say Ready, but
+        // the engine has no worker registered under this name (connection
+        // wedged mid-handshake). Ready must downgrade to Booting and the
+        // render must say why.
+        let mut s = WorkerStatus {
+            name: "scrapling".into(),
+            phase: Phase::Ready,
+            engine_running: true,
+            worker_type: Some("bundle"),
+            worker_path: None,
+            managed_dir_exists: true,
+            prepared: false,
+            pid: Some(59049),
+            alive: true,
+            engine_registered: None,
+            logs_dir: None,
+            logs_last_modified: None,
+        };
+        let snap = crate::cli::host_shim::EngineWorkerSnapshot {
+            names: ["iii-state".to_string()].into_iter().collect(),
+            versions: Default::default(),
+        };
+        s.apply_engine_truth(&snap);
+        assert_eq!(s.phase, Phase::Booting);
+        assert_eq!(s.engine_registered, Some(false));
+        let text = s.render().join("\n");
+        assert!(
+            text.contains("not registered"),
+            "render must flag the unregistered worker, got:\n{}",
+            text
+        );
+
+        // Registered worker: Ready stays Ready, row says registered.
+        let mut ok = WorkerStatus {
+            name: "iii-state".into(),
+            phase: Phase::Ready,
+            engine_running: true,
+            worker_type: Some("config"),
+            worker_path: None,
+            managed_dir_exists: false,
+            prepared: false,
+            pid: None,
+            alive: false,
+            engine_registered: None,
+            logs_dir: None,
+            logs_last_modified: None,
+        };
+        ok.apply_engine_truth(&snap);
+        assert_eq!(ok.phase, Phase::Ready);
+        assert_eq!(ok.engine_registered, Some(true));
+        assert!(ok.render().join("\n").contains("registered"));
     }
 
     /// Regression for the classifier bug where binary workers reported
@@ -1365,6 +1502,7 @@ mod tests {
             prepared: false,
             pid: None,
             alive: false,
+            engine_registered: None,
             logs_dir: None,
             logs_last_modified: None,
         };
@@ -1766,24 +1904,31 @@ mod tests {
         .unwrap();
 
         // Binary worker is detected by presence of the binary file under
-        // ~/.iii/workers/{name}. Staging an empty file is enough for the
-        // classifier — we don't execute it.
+        // ~/.iii/workers/{name}. Since is_worker_running now cross-checks
+        // the pidfile PID against the process table (a recycled PID must
+        // not read as alive — MOT-3931), the pidfile has to point at a REAL
+        // process whose executable lives under the workers dir. Copy a
+        // harmless sleeper there and run it.
         let workers_dir = tmp.path().join(".iii/workers");
         std::fs::create_dir_all(&workers_dir).unwrap();
-        std::fs::write(workers_dir.join(name), b"").unwrap();
+        let worker_bin = workers_dir.join(name);
+        std::fs::copy("/bin/sleep", &worker_bin).unwrap();
+        let mut child = std::process::Command::new(&worker_bin)
+            .arg("30")
+            .spawn()
+            .expect("spawn sleeper as fake binary worker");
 
         let pids = tmp.path().join(".iii/pids");
         std::fs::create_dir_all(&pids).unwrap();
-        // Write OUR pid so kill(pid, 0) succeeds on the alive check.
-        std::fs::write(
-            pids.join(format!("{}.pid", name)),
-            std::process::id().to_string(),
-        )
-        .unwrap();
+        std::fs::write(pids.join(format!("{}.pid", name)), child.id().to_string()).unwrap();
 
         let s = WorkerStatus::probe(name);
-        assert_eq!(s.pid, Some(std::process::id()));
-        assert!(s.alive, "is_worker_running must see our live pidfile");
+        let alive_seen = s.alive;
+        let pid_seen = s.pid;
+        let _ = child.kill();
+        let _ = child.wait();
+        assert_eq!(pid_seen, Some(child.id()));
+        assert!(alive_seen, "is_worker_running must see our live pidfile");
         assert_eq!(
             s.worker_type,
             Some("binary"),

--- a/crates/iii-worker/src/cli/status.rs
+++ b/crates/iii-worker/src/cli/status.rs
@@ -1922,7 +1922,14 @@ mod tests {
         std::fs::create_dir_all(&pids).unwrap();
         std::fs::write(pids.join(format!("{}.pid", name)), child.id().to_string()).unwrap();
 
-        let s = WorkerStatus::probe(name);
+        // `spawn()` returns pre-exec; on Linux the identity check reads the
+        // parent's argv until exec completes. Poll briefly.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let mut s = WorkerStatus::probe(name);
+        while !s.alive && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(25));
+            s = WorkerStatus::probe(name);
+        }
         let alive_seen = s.alive;
         let pid_seen = s.pid;
         let _ = child.kill();

--- a/crates/iii-worker/src/cli/worker_manager/libkrun.rs
+++ b/crates/iii-worker/src/cli/worker_manager/libkrun.rs
@@ -130,6 +130,7 @@ pub async fn run_dev(
         env.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
     let control_sock = rootfs.join("control.sock");
     let shell_sock = rootfs.join("shell.sock");
+    let pid_file = rootfs.join("vm.pid");
 
     let mut cmd = tokio::process::Command::new(&self_exe);
     cmd.arg("__vm-boot");
@@ -146,6 +147,7 @@ pub async fn run_dev(
         exec_path,
         vcpus,
         ram_mib,
+        &pid_file,
         &control_sock,
         &shell_sock,
         &env_pairs,
@@ -223,7 +225,6 @@ pub async fn run_dev(
             // Hardened writer: O_NOFOLLOW + 0o600 on Unix so a symlink
             // pre-planted at vm.pid can't redirect our write to a
             // sensitive file. Matches the watch.pid hardening.
-            let pid_file = rootfs.join("vm.pid");
             let pid = child.id().unwrap_or(0);
             if pid > 0
                 && let Err(e) = crate::cli::pidfile::write_pid_file_strict(&pid_file, pid)
@@ -367,6 +368,7 @@ fn vm_boot_args_dev(
     exec_path: &str,
     vcpus: u32,
     ram_mib: u32,
+    pid_file: &Path,
     control_sock: &Path,
     shell_sock: &Path,
     env: &[(String, String)],
@@ -385,6 +387,12 @@ fn vm_boot_args_dev(
     out.push(OsString::from(vcpus.to_string()));
     out.push(OsString::from("--ram"));
     out.push(OsString::from(ram_mib.to_string()));
+    // `--pid-file` must be in argv (not just written post-spawn by the
+    // parent): it's how `extract_worker_name_from_cmdline` recognizes this
+    // VM in `ps`, and how `__vm-boot` knows to clean the pidfile on exit.
+    // Matching `vm_boot_args_oci`.
+    out.push(OsString::from("--pid-file"));
+    out.push(pid_file.as_os_str().to_owned());
     out.push(OsString::from("--control-sock"));
     out.push(control_sock.as_os_str().to_owned());
     out.push(OsString::from("--shell-sock"));
@@ -1027,6 +1035,7 @@ mod tests {
             "/bin/sh",
             2,
             2048,
+            Path::new("/tmp/vm.pid"),
             Path::new("/tmp/control.sock"),
             Path::new("/tmp/shell.sock"),
             &env,
@@ -1040,6 +1049,7 @@ mod tests {
         assert_eq!(parsed.workdir, "/workspace");
         assert_eq!(parsed.vcpus, 2);
         assert_eq!(parsed.ram, 2048);
+        assert_eq!(parsed.pid_file.as_deref(), Some("/tmp/vm.pid"));
         assert_eq!(parsed.control_sock.as_deref(), Some("/tmp/control.sock"));
         assert_eq!(parsed.shell_sock.as_deref(), Some("/tmp/shell.sock"));
         assert_eq!(parsed.env, vec!["III_URL=ws://localhost:3111".to_string()]);

--- a/crates/iii-worker/src/cli/worker_manager_daemon.rs
+++ b/crates/iii-worker/src/cli/worker_manager_daemon.rs
@@ -942,7 +942,14 @@ mod tests {
         std::fs::create_dir_all(&pids).unwrap();
         std::fs::write(pids.join(format!("{name}.pid")), child.id().to_string()).unwrap();
 
-        let s = build_status(name).await.unwrap();
+        // `spawn()` returns pre-exec; on Linux the identity check reads the
+        // parent's argv until exec completes. Poll briefly.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let mut s = build_status(name).await.unwrap();
+        while !s.running && std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            s = build_status(name).await.unwrap();
+        }
         let _ = child.kill();
         let _ = child.wait();
 

--- a/crates/iii-worker/src/cli/worker_manager_daemon.rs
+++ b/crates/iii-worker/src/cli/worker_manager_daemon.rs
@@ -929,17 +929,22 @@ mod tests {
         .unwrap();
         let workers_dir = tmp.path().join(".iii/workers");
         std::fs::create_dir_all(&workers_dir).unwrap();
-        std::fs::write(workers_dir.join(name), b"").unwrap();
+        // is_worker_running cross-checks the pidfile PID against the process
+        // table (recycled PIDs must not read as alive — MOT-3931), so the
+        // pidfile must point at a real process running from the workers dir.
+        let worker_bin = workers_dir.join(name);
+        std::fs::copy("/bin/sleep", &worker_bin).unwrap();
+        let mut child = std::process::Command::new(&worker_bin)
+            .arg("30")
+            .spawn()
+            .expect("spawn sleeper as fake binary worker");
         let pids = tmp.path().join(".iii/pids");
         std::fs::create_dir_all(&pids).unwrap();
-        // Our own pid makes the kill(pid, 0) liveness check succeed.
-        std::fs::write(
-            pids.join(format!("{name}.pid")),
-            std::process::id().to_string(),
-        )
-        .unwrap();
+        std::fs::write(pids.join(format!("{name}.pid")), child.id().to_string()).unwrap();
 
         let s = build_status(name).await.unwrap();
+        let _ = child.kill();
+        let _ = child.wait();
 
         assert!(s.installed);
         assert_eq!(s.worker_type, "binary");

--- a/crates/iii-worker/src/core/types.rs
+++ b/crates/iii-worker/src/core/types.rs
@@ -357,6 +357,11 @@ pub struct WorkerEntry {
     pub version: Option<String>,
     #[schemars(description = "Whether the worker is currently running.")]
     pub running: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(
+        description = "Engine-truth status when the engine was reachable: \"running\" (connected/registered with the engine), \"starting\" (local process alive but not registered with the engine — booting, or stuck), \"stopped\". Null when the engine couldn't be asked; fall back to `running`."
+    )]
+    pub status: Option<String>,
     #[schemars(
         description = "Process id when discoverable via ps. Null for engine builtins or when the pid wasn't recoverable."
     )]

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -438,10 +438,16 @@ async fn async_main() -> anyhow::Result<()> {
                                 .pid
                                 .map(|p| p.to_string())
                                 .unwrap_or_else(|| "-".to_string());
-                            let status = if w.running {
-                                "running".green().to_string()
-                            } else {
-                                "stopped".dimmed().to_string()
+                            // Engine-truth status when present ("running" /
+                            // "starting" / "stopped"); fall back to the
+                            // process-signal bool when the engine couldn't
+                            // be asked.
+                            let status = match w.status.as_deref() {
+                                Some("running") => "running".green().to_string(),
+                                Some("starting") => "starting".yellow().to_string(),
+                                Some(other) => other.dimmed().to_string(),
+                                None if w.running => "running".green().to_string(),
+                                None => "stopped".dimmed().to_string(),
                             };
                             eprintln!(
                                 "  {:25} {:10} {:10} {}",

--- a/crates/iii-worker/tests/worker_list_discovery_integration.rs
+++ b/crates/iii-worker/tests/worker_list_discovery_integration.rs
@@ -118,7 +118,15 @@ fn is_worker_running_true_for_alive_pid() {
     let pid = child.id();
     std::fs::write(pids_dir.join("alive-worker.pid"), pid.to_string()).unwrap();
 
-    let running = is_worker_running("alive-worker");
+    // `spawn()` returns between fork and exec; on Linux /proc/<pid>/cmdline
+    // shows the PARENT's argv until exec completes, so the identity check
+    // can transiently miss the sleeper. Poll briefly instead of probing once.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut running = is_worker_running("alive-worker");
+    while !running && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(25));
+        running = is_worker_running("alive-worker");
+    }
     let _ = child.kill();
     let _ = child.wait();
     assert!(
@@ -189,10 +197,37 @@ async fn kill_stale_worker_sweeps_pidfile_less_process() {
     // Deliberately NO pidfile anywhere: the pidfile pass can't see this
     // process; only the argv sweep can.
 
+    // `spawn()` returns pre-exec; wait until the sleeper's real argv is
+    // visible to the ps matcher so the sweep can actually see it.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while find_worker_pid_from_ps("sweep-me") != Some(child.id())
+        && std::time::Instant::now() < deadline
+    {
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+    assert_eq!(
+        find_worker_pid_from_ps("sweep-me"),
+        Some(child.id()),
+        "fixture: sleeper never became visible to the ps matcher"
+    );
+
     kill_stale_worker("sweep-me").await;
 
     // The sweep SIGTERMs then SIGKILLs; either way the child must be gone.
-    let status = child.wait().expect("reap swept child");
+    // Bounded reap so a regressed sweep can't hang the suite for the
+    // sleeper's full 30s.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("try_wait swept child") {
+            break status;
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("ps sweep did not kill the pidfile-less worker process within 10s");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    };
     assert!(
         !status.success(),
         "pidfile-less worker process must be killed by the ps sweep, got {status:?}"

--- a/crates/iii-worker/tests/worker_list_discovery_integration.rs
+++ b/crates/iii-worker/tests/worker_list_discovery_integration.rs
@@ -89,22 +89,37 @@ fn discover_disk_worker_names_finds_managed_and_pids() {
 }
 
 /// `is_worker_running` must return `true` when the pidfile holds a PID that
-/// is actually alive. The current test process's PID is the simplest
-/// guaranteed-alive sentinel, exercising the real signal-0 path.
+/// is actually alive AND belongs to this worker. Since the identity
+/// cross-check (MOT-3931: recycled PIDs must not read as alive) inspects the
+/// process's argv, the pidfile has to point at a real process running from
+/// `~/.iii/workers/{name}` — a copied `/bin/sleep` is the simplest such
+/// sentinel, exercising the real signal-0 + identity path.
 #[test]
 fn is_worker_running_true_for_alive_pid() {
     let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let tmp = tempfile::tempdir().unwrap();
     let _home = HomeGuard::new(tmp.path());
 
+    let workers_dir = tmp.path().join(".iii/workers");
+    std::fs::create_dir_all(&workers_dir).unwrap();
+    let worker_bin = workers_dir.join("alive-worker");
+    std::fs::copy("/bin/sleep", &worker_bin).unwrap();
+    let mut child = std::process::Command::new(&worker_bin)
+        .arg("30")
+        .spawn()
+        .expect("spawn sleeper as fake binary worker");
+
     let pids_dir = tmp.path().join(".iii/pids");
     std::fs::create_dir_all(&pids_dir).unwrap();
-    let my_pid = std::process::id();
-    std::fs::write(pids_dir.join("alive-worker.pid"), my_pid.to_string()).unwrap();
+    let pid = child.id();
+    std::fs::write(pids_dir.join("alive-worker.pid"), pid.to_string()).unwrap();
 
+    let running = is_worker_running("alive-worker");
+    let _ = child.kill();
+    let _ = child.wait();
     assert!(
-        is_worker_running("alive-worker"),
-        "expected alive-worker (pid {my_pid}, this process) to be detected as running"
+        running,
+        "expected alive-worker (pid {pid}, live sleeper) to be detected as running"
     );
 }
 

--- a/crates/iii-worker/tests/worker_list_discovery_integration.rs
+++ b/crates/iii-worker/tests/worker_list_discovery_integration.rs
@@ -4,19 +4,23 @@
 // This software is patent protected. We welcome discussions - reach out at team@iii.dev
 // See LICENSE and PATENTS files for details.
 
-//! Integration tests for orphan-worker discovery in `iii worker list`.
+//! Integration tests for orphan-worker discovery in `iii worker list` and
+//! the stale-worker lifecycle guards.
 //!
 //! These tests exercise the public discovery functions
-//! ([`discover_disk_worker_names`], [`discover_running_worker_names_from_ps`])
-//! and the liveness check ([`is_worker_running`]) against a real filesystem
-//! tree under a temporary HOME, using the current test process's PID as a
-//! known-alive sentinel. This is the regression coverage for the bug where
-//! `iii worker list` missed workers whose project folders had moved or whose
-//! PID files had been removed while the process kept running.
+//! ([`discover_disk_worker_names`], [`discover_running_worker_names_from_ps`]),
+//! the liveness check ([`is_worker_running`]), and [`kill_stale_worker`]
+//! against a real filesystem tree under a temporary HOME, spawning copied
+//! `/bin/sleep` processes as known-alive sentinels (the identity cross-check
+//! inspects real argv, so a bare PID is no longer enough). This is the
+//! regression coverage for the bug where `iii worker list` missed workers
+//! whose project folders had moved or whose PID files had been removed while
+//! the process kept running (and its inverse: recycled PIDs reading as
+//! alive — MOT-3931).
 
 use iii_worker::cli::managed::{
     discover_disk_worker_names, discover_running_worker_names_from_ps, find_worker_pid_from_ps,
-    is_worker_running,
+    is_worker_running, kill_stale_worker,
 };
 use std::sync::Mutex;
 
@@ -120,6 +124,78 @@ fn is_worker_running_true_for_alive_pid() {
     assert!(
         running,
         "expected alive-worker (pid {pid}, live sleeper) to be detected as running"
+    );
+}
+
+/// MOT-3931: a pidfile whose PID number has been recycled by an UNRELATED
+/// process must not get that process killed. `kill_stale_worker` must skip
+/// the kill (identity mismatch) while still reaping the stale pidfile.
+#[tokio::test]
+async fn kill_stale_worker_spares_recycled_pid() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::new(tmp.path());
+
+    // Decoy: a live process that is NOT this worker — a sleeper running from
+    // outside ~/.iii/workers and ~/.iii/managed. Its PID lands in the
+    // worker's pidfile, simulating PID reuse after a crash left the pidfile
+    // behind.
+    let decoy_bin = tmp.path().join("decoy-sleep");
+    std::fs::copy("/bin/sleep", &decoy_bin).unwrap();
+    let mut decoy = std::process::Command::new(&decoy_bin)
+        .arg("30")
+        .spawn()
+        .expect("spawn decoy sleeper");
+
+    let pids_dir = tmp.path().join(".iii/pids");
+    std::fs::create_dir_all(&pids_dir).unwrap();
+    let pidfile = pids_dir.join("recycled-worker.pid");
+    std::fs::write(&pidfile, decoy.id().to_string()).unwrap();
+
+    kill_stale_worker("recycled-worker").await;
+
+    // try_wait() == Ok(None) means the child is still running.
+    let alive = decoy.try_wait().unwrap().is_none();
+    let _ = decoy.kill();
+    let _ = decoy.wait();
+    assert!(
+        alive,
+        "kill_stale_worker must not kill an unrelated process behind a recycled PID"
+    );
+    assert!(
+        !pidfile.exists(),
+        "the stale pidfile must still be reaped even when the kill is skipped"
+    );
+}
+
+/// MOT-3931 duplicate-VM guard: a live worker process whose pidfile was lost
+/// (crash, manual cleanup, overlapping restarts) must still die before a new
+/// instance shares its runtime dirs. The ps sweep finds it by argv and kills
+/// it.
+#[tokio::test]
+async fn kill_stale_worker_sweeps_pidfile_less_process() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::new(tmp.path());
+
+    let workers_dir = tmp.path().join(".iii/workers");
+    std::fs::create_dir_all(&workers_dir).unwrap();
+    let worker_bin = workers_dir.join("sweep-me");
+    std::fs::copy("/bin/sleep", &worker_bin).unwrap();
+    let mut child = std::process::Command::new(&worker_bin)
+        .arg("30")
+        .spawn()
+        .expect("spawn sleeper as pidfile-less worker");
+    // Deliberately NO pidfile anywhere: the pidfile pass can't see this
+    // process; only the argv sweep can.
+
+    kill_stale_worker("sweep-me").await;
+
+    // The sweep SIGTERMs then SIGKILLs; either way the child must be gone.
+    let status = child.wait().expect("reap swept child");
+    assert!(
+        !status.success(),
+        "pidfile-less worker process must be killed by the ps sweep, got {status:?}"
     );
 }
 


### PR DESCRIPTION
Fixes [MOT-3931](https://linear.app/motia/issue/MOT-3931): `iii worker list` STATUS was untrustworthy — bundle/VM workers never got a PID, dead or still-booting VMs showed `running`, and engine restarts left orphaned duplicate VMs.

## What changed

**1. `list` asks the engine what's actually connected** (`host_shim.rs`)
- When the engine port is up, a transient SDK client calls `engine::workers::list` (3s trigger deadline + 5s outer timeout; non-joining `shutdown_async` so a wedged WS handshake can't hang the CLI).
- New `WorkerEntry.status`: `running` = connected/registered with the engine, `starting` (yellow) = local process alive but not registered (booting, or stuck), `stopped` = neither. Matching is by summary `name` OR `id` (in-process builtins carry the config name as `id`).
- VERSION now falls back to the engine-reported version — builtins no longer show `-`.
- When the engine can't be asked, the old local heuristics remain as fallback.

**2. `status` overlays the same engine truth** (`status.rs`)
- A locally-Ready worker the engine can't see downgrades to `Booting`, with a new row: `worker: registered (connected to engine)` / `not registered (…booting, or its connection is stuck)`.
- The `--watch`/`--wait` loop holds one engine connection for the whole session (snapshot refresh ~1s) instead of connecting per tick, so polling doesn't fire `workers-available` triggers. `add --wait` now waits for actual registration, not just a live pid.

**3. Dev/bundle VMs get `--pid-file` in argv** (`libkrun.rs`)
- `vm_boot_args_dev` now matches `vm_boot_args_oci` — fixes the permanent PID `-` and the ps orphan-discovery blind spot, and gives dev VMs `__vm-boot`'s on-exit pidfile cleanup.
- The shared argv matcher also accepts `--rootfs <managed dir>` (VMs booted by older builds), but only the managed dir itself — legacy-cache sandbox VMs (`…/managed/<preset>/rootfs`) are never claimed as workers.

**4. Pidfile PIDs are identity-checked** (`managed.rs`)
- `is_worker_running` cross-checks the PID's cmdline via a cheap single-PID lookup (no full ps scan), so a recycled PID can't read as alive. Identity is deliberately more lenient than discovery (tolerates interpreter-wrapped binaries) so a live worker can't become invisible *and* unkillable.

**5. `kill_stale_worker` hardened**
- Identity-guards its kills (no more SIGKILLing a recycled PID's innocent process) and sweeps all argv-matched pidfile-less leftovers, so two VMs never share `~/.iii/managed/{name}` after rapid engine restarts.

**6. Deleted dead `handle_worker_list` + helpers** — `main.rs` routes `Commands::List` through `CliHostShim`; the dead copy carried the old lying heuristic.

## Verification

- 1416 tests pass (lib + integration), fmt + clippy clean.
- Verified live against a real wedged bundle worker (VM alive, engine has no such worker): `list` → `starting`, `status` → `booting` + `worker: not registered`, PID column populated via the `--rootfs` matcher for a VM booted by an older build.
- Root-cause evidence for the underlying guest↔engine reconnect stall (TSI data stall + missing SDK handshake deadlines) posted on [MOT-3857](https://linear.app/motia/issue/MOT-3857).

## Known trade-offs

- Each `list`/`status` invocation opens one transient engine connection (same pattern as the sandbox CLI); it appears briefly as `iii-cli` and fires the engine's connect/disconnect triggers once.
- Workers that self-report a name different from their config name read as `starting` while connected — setting the SDK worker name (as scrapling does) resolves it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worker listing/status now incorporates engine registration truth (“registered” vs “not registered”) to better reflect startup vs ready.
  * Worker list output can now enrich versions from live engine data when local version info is missing.
* **Bug Fixes**
  * Improved detection of running workers to prevent false positives from recycled PIDs; safer stale-worker cleanup, including better handling of pidfile-less leftovers.
  * Worker list status rendering now prefers explicit status values and falls back to running/stopped only when needed.
* **Tests**
  * Expanded integration/regression coverage for engine-aware status behavior and stale-worker lifecycle safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->