### PR TITLE
feat(python-sdk): add III.add_connection_state_listener; warn on connect-wait timeout (MOT-3969)

### DIFF
--- a/sdk/packages/python/iii/src/iii/__init__.py
+++ b/sdk/packages/python/iii/src/iii/__init__.py
@@ -5,6 +5,8 @@ from iii_helpers.queue import EnqueueResult
 from .errors import InvocationError
 from .iii import TriggerAction, register_worker
 from .iii_constants import (
+    ConnectionStateCallback,
+    IIIConnectionState,
     InitOptions,
     TelemetryOptions,
 )
@@ -24,6 +26,8 @@ __all__ = [
     # Errors
     "InvocationError",
     # Core
+    "ConnectionStateCallback",
+    "IIIConnectionState",
     "InitOptions",
     "register_worker",
     "TelemetryOptions",

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -32,6 +32,7 @@ from .format_utils import extract_request_format, extract_response_format
 from .iii_constants import (
     DEFAULT_RECONNECTION_CONFIG,
     MAX_QUEUE_SIZE,
+    ConnectionStateCallback,
     FunctionRef,
     IIIConnectionState,
     InitOptions,
@@ -202,6 +203,9 @@ class III:
         )
         self._reconnect_attempt = 0
         self._connection_state: IIIConnectionState = "disconnected"
+        # Must exist before the auto-connect below: the loop thread calls
+        # _set_connection_state as soon as connect_async starts.
+        self._connection_listeners: list[ConnectionStateCallback] = []
         self._worker_id: str | None = None
 
         # Background event loop thread
@@ -232,10 +236,15 @@ class III:
             return
         if self._connection_state == "failed":
             raise ConnectionError(f"Connection to {self._address} failed")
-        self._connected_event.wait(timeout=30)
+        connected = self._connected_event.wait(timeout=30)
         if cast(IIIConnectionState, self._connection_state) == "failed":
             raise ConnectionError(
                 f"Connection to {self._address} failed after max retries"
+            )
+        if not connected:
+            log.warning(
+                f"Timed out after 30s waiting for connection to {self._address}; "
+                "continuing to retry in background"
             )
 
     def shutdown(self) -> None:
@@ -807,6 +816,43 @@ class III:
                 self._connected_event.set()
             else:
                 self._connected_event.clear()
+            for handler in list(self._connection_listeners):
+                try:
+                    handler(state)
+                except Exception:
+                    log.exception("Connection state listener raised")
+
+    def add_connection_state_listener(
+        self, handler: ConnectionStateCallback
+    ) -> Callable[[], None]:
+        """Subscribe to connection-state transitions.
+
+        The handler is fired immediately with the current state (on the
+        caller's thread), then once per transition. Transitions fire on the
+        SDK's background event-loop thread: keep handlers fast and do not
+        call sync SDK methods from them (they would raise ``RuntimeError``).
+        Treat calls as state notifications, not edges — a state may rarely
+        be observed twice around subscription. Registering the same handler
+        twice fires it twice. Returns an idempotent unsubscribe function.
+
+        Examples:
+            >>> unsubscribe = worker.add_connection_state_listener(
+            ...     lambda state: print(f"engine link: {state}")
+            ... )
+        """
+        self._connection_listeners.append(handler)
+        try:
+            handler(self._connection_state)
+        except Exception:
+            log.exception("Connection state listener raised on initial fire")
+
+        def unsubscribe() -> None:
+            try:
+                self._connection_listeners.remove(handler)
+            except ValueError:
+                pass
+
+        return unsubscribe
 
     def get_connection_state(self) -> IIIConnectionState:
         """Return the current WebSocket connection state.
@@ -1417,14 +1463,19 @@ class TriggerAction:
 def register_worker(address: str, options: InitOptions | None = None) -> III:
     """Register the worker with a iii instance, returns a connected worker client.
 
-    Blocks until the WebSocket connection is established and ready.
+    Blocks up to 30 seconds for the WebSocket connection to be established.
+    If the engine is not reachable in time, a warning is logged and the
+    client is returned anyway — it keeps retrying in the background and
+    flushes registrations once connected. Use
+    ``add_connection_state_listener`` to observe the actual transition.
 
     Args:
         address: WebSocket URL of the III engine (e.g. ``ws://localhost:49134``).
         options: Optional configuration for worker name, timeouts, reconnection, and OTel.
 
     Returns:
-        A connected III client instance ready to use.
+        An III client instance (connected, or still connecting after the
+        30s wait timed out).
 
     Raises:
         ConnectionError: If the connection fails or exceeds max retries.

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -346,7 +346,16 @@ class III:
             )
             log.info(f"Connected to {self._address}")
             await self._on_connected()
-        except (ConnectionError, OSError, TimeoutError, asyncio.TimeoutError) as e:
+        except (
+            ConnectionError,
+            OSError,
+            TimeoutError,
+            asyncio.TimeoutError,
+            # Not an OSError: raised when the peer accepts TCP but the WS
+            # upgrade fails/stalls (the MOT-3931 zombie-VM mode). Without it
+            # the connect/reconnect task dies and retrying stops silently.
+            websockets.InvalidHandshake,
+        ) as e:
             log.warning(f"Connection failed: {e}")
             if self._running:
                 self._schedule_reconnect()
@@ -833,7 +842,8 @@ class III:
         call sync SDK methods from them (they would raise ``RuntimeError``).
         Treat calls as state notifications, not edges — a state may rarely
         be observed twice around subscription. Registering the same handler
-        twice fires it twice. Returns an idempotent unsubscribe function.
+        twice fires it twice. Returns an idempotent unsubscribe function
+        that removes only its own registration.
 
         Examples:
             >>> unsubscribe = worker.add_connection_state_listener(
@@ -846,7 +856,13 @@ class III:
         except Exception:
             log.exception("Connection state listener raised on initial fire")
 
+        unsubscribed = False
+
         def unsubscribe() -> None:
+            nonlocal unsubscribed
+            if unsubscribed:
+                return
+            unsubscribed = True
             try:
                 self._connection_listeners.remove(handler)
             except ValueError:

--- a/sdk/packages/python/iii/src/iii/types.py
+++ b/sdk/packages/python/iii/src/iii/types.py
@@ -21,6 +21,7 @@ from typing import (
 from iii_helpers.http import HttpInvocationConfig
 from pydantic import BaseModel, ConfigDict
 
+from .iii_constants import ConnectionStateCallback
 from .iii_types import (
     RegisterFunctionMessage,
     RegisterTriggerInput,
@@ -110,6 +111,8 @@ class IIIClient(Protocol):
     ) -> Any: ...
 
     def unregister_trigger_type(self, trigger_type: RegisterTriggerTypeInput | dict[str, Any]) -> None: ...
+
+    def add_connection_state_listener(self, handler: ConnectionStateCallback) -> Callable[[], None]: ...
 
     def shutdown(self) -> None: ...
 

--- a/sdk/packages/python/iii/tests/test_connection_state_listener.py
+++ b/sdk/packages/python/iii/tests/test_connection_state_listener.py
@@ -5,8 +5,11 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from iii_helpers.observability import ReconnectionConfig
+from websockets.exceptions import InvalidMessage
 
 import iii.iii as iii_module
+from iii import InitOptions
 from iii.iii import III
 
 
@@ -27,14 +30,18 @@ class FakeWebSocket:
         raise StopAsyncIteration
 
 
+def _patch_transport(monkeypatch: pytest.MonkeyPatch, connect) -> None:
+    monkeypatch.setattr(iii_module.websockets, "connect", connect)
+    monkeypatch.setattr("iii_helpers.observability.telemetry.init_otel", lambda **kwargs: None)
+    monkeypatch.setattr("iii_helpers.observability.telemetry.attach_event_loop", lambda loop: None)
+    monkeypatch.setattr(iii_module.III, "_register_worker_metadata", lambda self: None)
+
+
 def _connected_client(monkeypatch: pytest.MonkeyPatch) -> III:
     async def fake_connect(_addr: str, **kwargs: object) -> FakeWebSocket:
         return FakeWebSocket()
 
-    monkeypatch.setattr(iii_module.websockets, "connect", fake_connect)
-    monkeypatch.setattr("iii_helpers.observability.telemetry.init_otel", lambda **kwargs: None)
-    monkeypatch.setattr("iii_helpers.observability.telemetry.attach_event_loop", lambda loop: None)
-    monkeypatch.setattr(iii_module.III, "_register_worker_metadata", lambda self: None)
+    _patch_transport(monkeypatch, fake_connect)
 
     client = III("ws://fake")
     client._wait_until_connected()
@@ -84,3 +91,54 @@ def test_raising_listener_isolated_and_unsubscribe_idempotent(
 
     client.shutdown()  # fires "disconnected" into bad -> swallowed, no crash
     assert events == ["connected", "reconnecting"]
+
+
+def test_duplicate_subscription_unsubscribe_removes_only_its_own(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _connected_client(monkeypatch)
+    events: list[str] = []
+
+    unsub1 = client.add_connection_state_listener(events.append)
+    unsub2 = client.add_connection_state_listener(events.append)
+    assert events == ["connected", "connected"]
+
+    unsub1()
+    unsub1()  # second call must not remove the other registration
+    events.clear()
+    client._set_connection_state("reconnecting")
+    assert events == ["reconnecting"]
+
+    unsub2()
+    client._set_connection_state("connected")
+    assert events == ["reconnecting"]
+
+    client.shutdown()
+
+
+def test_handshake_failure_keeps_retrying(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = 0
+
+    async def flaky_connect(_addr: str, **kwargs: object) -> FakeWebSocket:
+        nonlocal attempts
+        attempts += 1
+        if attempts <= 2:
+            # Peer accepted TCP but the WS upgrade died (not an OSError):
+            # must not kill the connect/reconnect task.
+            raise InvalidMessage("did not receive a valid HTTP response")
+        return FakeWebSocket()
+
+    _patch_transport(monkeypatch, flaky_connect)
+
+    client = III(
+        "ws://fake",
+        InitOptions(reconnection_config=ReconnectionConfig(initial_delay_ms=5, max_delay_ms=10)),
+    )
+    states: list[str] = []
+    client.add_connection_state_listener(states.append)
+    client._wait_until_connected()
+    assert client.get_connection_state() == "connected"
+    assert attempts == 3
+    assert "connected" in states
+
+    client.shutdown()

--- a/sdk/packages/python/iii/tests/test_connection_state_listener.py
+++ b/sdk/packages/python/iii/tests/test_connection_state_listener.py
@@ -1,0 +1,86 @@
+"""Unit tests for III.add_connection_state_listener (no live engine needed)."""
+
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import iii.iii as iii_module
+from iii.iii import III
+
+
+class FakeWebSocket:
+    def __init__(self) -> None:
+        self.state = SimpleNamespace(name="OPEN")
+
+    async def send(self, payload: str) -> None:
+        pass
+
+    async def close(self) -> None:
+        self.state = SimpleNamespace(name="CLOSED")
+
+    def __aiter__(self) -> "FakeWebSocket":
+        return self
+
+    async def __anext__(self) -> Any:
+        raise StopAsyncIteration
+
+
+def _connected_client(monkeypatch: pytest.MonkeyPatch) -> III:
+    async def fake_connect(_addr: str, **kwargs: object) -> FakeWebSocket:
+        return FakeWebSocket()
+
+    monkeypatch.setattr(iii_module.websockets, "connect", fake_connect)
+    monkeypatch.setattr("iii_helpers.observability.telemetry.init_otel", lambda **kwargs: None)
+    monkeypatch.setattr("iii_helpers.observability.telemetry.attach_event_loop", lambda loop: None)
+    monkeypatch.setattr(iii_module.III, "_register_worker_metadata", lambda self: None)
+
+    client = III("ws://fake")
+    client._wait_until_connected()
+    time.sleep(0.05)
+    assert client.get_connection_state() == "connected"
+    return client
+
+
+def test_immediate_fire_transitions_dedup_and_shutdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _connected_client(monkeypatch)
+    events: list[str] = []
+
+    client.add_connection_state_listener(events.append)
+    assert events == ["connected"]  # fired immediately with current state
+
+    client._set_connection_state("reconnecting")
+    client._set_connection_state("connected")
+    client._set_connection_state("connected")  # same state -> no fire
+    assert events == ["connected", "reconnecting", "connected"]
+
+    client.shutdown()
+    assert events == ["connected", "reconnecting", "connected", "disconnected"]
+
+
+def test_raising_listener_isolated_and_unsubscribe_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _connected_client(monkeypatch)
+    events: list[str] = []
+
+    def bad(state: str) -> None:
+        raise RuntimeError("boom")
+
+    client.add_connection_state_listener(bad)  # immediate fire raises, is swallowed
+    unsubscribe = client.add_connection_state_listener(events.append)
+    assert events == ["connected"]
+
+    client._set_connection_state("reconnecting")
+    assert events == ["connected", "reconnecting"]  # bad didn't block delivery
+
+    unsubscribe()
+    unsubscribe()  # idempotent
+    client._set_connection_state("connected")
+    assert events == ["connected", "reconnecting"]
+
+    client.shutdown()  # fires "disconnected" into bad -> swallowed, no crash
+    assert events == ["connected", "reconnecting"]

--- a/sdk/packages/python/iii/tests/test_connection_state_listener.py
+++ b/sdk/packages/python/iii/tests/test_connection_state_listener.py
@@ -139,6 +139,11 @@ def test_handshake_failure_keeps_retrying(monkeypatch: pytest.MonkeyPatch) -> No
     client._wait_until_connected()
     assert client.get_connection_state() == "connected"
     assert attempts == 3
+    # _set_connection_state sets the connected event before dispatching
+    # listeners, so give the loop thread a bounded window to deliver.
+    deadline = time.time() + 2
+    while "connected" not in states and time.time() < deadline:
+        time.sleep(0.01)
     assert "connected" in states
 
     client.shutdown()


### PR DESCRIPTION
Fixes the SDK half of [MOT-3969](https://linear.app/motia/issue/MOT-3969/scrapling-bundle-print-worker-connected-from-an-on-connect-callback): the Python worker SDK exposed no way to observe connection transitions (`_set_connection_state` fired nothing; the `ConnectionStateCallback` type alias was dead code), so bundles printed "worker connected" unconditionally — and lied during the MOT-3931 zombie-VM repro, because `_wait_until_connected()` returns silently after its 30s timeout while the client retries in the background.

## Changes
- **`III.add_connection_state_listener(handler) -> unsubscribe`** — mirrors the browser SDK's `addConnectionStateListener`: fires immediately with the current state, then once per transition (including every reconnect). Listener exceptions are logged, never propagated into the connect/reconnect path. Listeners run on the SDK's background event-loop thread; docstring warns against calling sync SDK methods from them.
- **`_wait_until_connected` timeout is no longer silent** — logs a warning that the client is still retrying in the background; `register_worker`'s docstring now tells the truth about that path (it previously claimed to always return a connected client).
- Exports `IIIConnectionState` + `ConnectionStateCallback` (activating the previously dead alias).

## Tests
- New `tests/test_connection_state_listener.py` (no live engine needed): immediate fire, transition order, same-state dedup, raising-listener isolation, idempotent unsubscribe, shutdown firing the final `disconnected`.
- E2E: booted the scrapling bundle against this SDK with no engine (no "connected" line; timeout warning), late engine start (line appears on real connect), engine restart (line re-appears), and normal boot (unchanged output).

## Follow-up
`iii-hq/workers` PR (scrapling + hermes) consumes this API and is blocked on the `iii-sdk` 0.21.5 release.

https://claude.ai/code/session_01ENsvZiUan157BYmUUz3WW6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added connection-state listener support with immediate initial callback, ordered transition delivery, consecutive-state deduplication, and an unsubscribe function (including a “disconnected” event on shutdown).
* **Improvements**
  * Exposed connection-state types for public use and extended the client API to allow listener registration.
  * Connection startup now waits up to 30 seconds before proceeding with background retries; handshake failures now trigger the normal retry flow.
* **Bug Fixes**
  * Errors in one listener no longer prevent other listeners from receiving updates.
* **Tests**
  * Added coverage for listener behavior, unsubscribe idempotency/scope, exception isolation, and handshake-retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->