### PR TITLE
fix(queue): apply per-subscriber retry tuning in the builtin adapter

### DIFF
--- a/engine/src/builtins/queue.rs
+++ b/engine/src/builtins/queue.rs
@@ -209,6 +209,7 @@ pub struct BuiltinQueue {
     pubsub: Arc<BuiltInPubSubLite>,
     config: QueueConfig,
     subscriptions: Arc<RwLock<HashMap<String, JoinHandle<()>>>>,
+    subscription_configs: Arc<RwLock<HashMap<String, SubscriptionConfig>>>,
 }
 
 impl BuiltinQueue {
@@ -222,6 +223,7 @@ impl BuiltinQueue {
             pubsub,
             config,
             subscriptions: Arc::new(RwLock::new(HashMap::new())),
+            subscription_configs: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -491,6 +493,19 @@ impl BuiltinQueue {
         Ok(())
     }
 
+    /// Overlays per-subscriber retry tuning onto a job's publish-time
+    /// defaults. Jobs are stamped with the global config at push time; the
+    /// subscriber's own maxRetries/backoffDelayMs must win at retry time so
+    /// tuning also applies to jobs enqueued before the subscriber connected
+    /// or rebuilt from storage.
+    async fn apply_subscription_overrides(&self, job: &mut Job) {
+        let configs = self.subscription_configs.read().await;
+        if let Some(cfg) = configs.get(&job.queue) {
+            job.max_attempts = cfg.effective_max_attempts(job.max_attempts);
+            job.backoff_delay_ms = cfg.effective_backoff_ms(job.backoff_delay_ms);
+        }
+    }
+
     pub async fn nack(&self, queue: &str, job_id: &str, error: &str) -> anyhow::Result<()> {
         let job_key = self.job_key(queue, job_id);
         let job_value = self.kv_store.get_job(&job_key).await;
@@ -503,6 +518,7 @@ impl BuiltinQueue {
         };
 
         let mut job: Job = serde_json::from_value(job_value)?;
+        self.apply_subscription_overrides(&mut job).await;
         job.increment_attempts();
 
         if job.is_exhausted() {
@@ -601,6 +617,18 @@ impl BuiltinQueue {
             .and_then(|c| c.mode)
             .unwrap_or(self.config.mode);
 
+        if let Some(cfg) = &config {
+            // Recorded so nack/inline-retry can apply per-subscriber retry
+            // tuning to jobs stamped with global defaults at publish time.
+            // ponytail: keyed by queue, last subscriber wins; entries are kept
+            // on unsubscribe so a sibling subscription on the same queue
+            // keeps its tuning.
+            self.subscription_configs
+                .write()
+                .await
+                .insert(queue.to_string(), cfg.clone());
+        }
+
         let task_handle = match effective_mode {
             QueueMode::Fifo => {
                 let concurrency = config
@@ -636,7 +664,6 @@ impl BuiltinQueue {
                     Arc::new(self.clone()),
                     queue.to_string(),
                     handler,
-                    config,
                     effective_concurrency,
                 );
                 tokio::spawn(async move {
@@ -839,6 +866,7 @@ impl Clone for BuiltinQueue {
             pubsub: Arc::clone(&self.pubsub),
             config: self.config.clone(),
             subscriptions: Arc::clone(&self.subscriptions),
+            subscription_configs: Arc::clone(&self.subscription_configs),
         }
     }
 }
@@ -853,6 +881,8 @@ async fn process_job_with_inline_retry(
     mut job: Job,
     group_id_for_logging: Option<&str>,
 ) {
+    queue_impl.apply_subscription_overrides(&mut job).await;
+
     loop {
         match handler.handle(&job).await {
             Ok(()) => {
@@ -915,7 +945,6 @@ impl Worker {
         queue_impl: Arc<BuiltinQueue>,
         queue_name: String,
         handler: Arc<dyn JobHandler>,
-        _subscription_config: Option<SubscriptionConfig>,
         concurrency: u32,
     ) -> Self {
         Self {
@@ -2819,5 +2848,205 @@ mod tests {
         // Pop moves from waiting to active, depth should stay same
         let _job = queue.pop("test_queue").await;
         assert_eq!(queue.queue_depth("test_queue").await, 2);
+    }
+
+    // =========================================================================
+    // Per-subscriber retry tuning (MOT-3947)
+    // =========================================================================
+
+    struct FailCounter {
+        invocations: Arc<RwLock<u32>>,
+    }
+
+    #[async_trait]
+    impl JobHandler for FailCounter {
+        async fn handle(&self, _job: &Job) -> Result<(), String> {
+            *self.invocations.write().await += 1;
+            Err("intentional failure".to_string())
+        }
+    }
+
+    async fn wait_for_dlq(queue: &BuiltinQueue, name: &str) {
+        for _ in 0..200 {
+            if queue.dlq_count(name).await >= 1 {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        panic!("timed out waiting for job to reach the DLQ on {name}");
+    }
+
+    #[tokio::test]
+    async fn test_subscription_max_attempts_applied_concurrent() {
+        let kv_store = make_queue_kv(None);
+        let pubsub = Arc::new(BuiltInPubSubLite::new(None));
+        // Global default: 3 attempts, 1s backoff.
+        let queue = BuiltinQueue::new(kv_store, pubsub, QueueConfig::default());
+
+        let invocations = Arc::new(RwLock::new(0));
+        let handler = Arc::new(FailCounter {
+            invocations: Arc::clone(&invocations),
+        });
+
+        queue
+            .subscribe(
+                "tuned_concurrent_q",
+                handler,
+                Some(SubscriptionConfig {
+                    concurrency: None,
+                    max_attempts: Some(1),
+                    backoff_ms: Some(1),
+                    mode: None,
+                }),
+            )
+            .await;
+
+        queue
+            .push("tuned_concurrent_q", serde_json::json!({}), None, None)
+            .await;
+
+        wait_for_dlq(&queue, "tuned_concurrent_q").await;
+        assert_eq!(
+            *invocations.read().await,
+            1,
+            "subscriber max_attempts=1 must yield exactly one invocation"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_subscription_max_attempts_applied_fifo() {
+        let kv_store = make_queue_kv(None);
+        let pubsub = Arc::new(BuiltInPubSubLite::new(None));
+        let queue = BuiltinQueue::new(kv_store, pubsub, QueueConfig::default());
+
+        let invocations = Arc::new(RwLock::new(0));
+        let handler = Arc::new(FailCounter {
+            invocations: Arc::clone(&invocations),
+        });
+
+        queue
+            .subscribe(
+                "tuned_fifo_q",
+                handler,
+                Some(SubscriptionConfig {
+                    concurrency: None,
+                    max_attempts: Some(2),
+                    backoff_ms: Some(1),
+                    mode: Some(QueueMode::Fifo),
+                }),
+            )
+            .await;
+
+        queue
+            .push("tuned_fifo_q", serde_json::json!({}), None, None)
+            .await;
+
+        wait_for_dlq(&queue, "tuned_fifo_q").await;
+        assert_eq!(
+            *invocations.read().await,
+            2,
+            "subscriber max_attempts=2 must yield exactly two invocations"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_nack_honors_subscription_max_attempts() {
+        let kv_store = make_queue_kv(None);
+        let pubsub = Arc::new(BuiltInPubSubLite::new(None));
+        let queue = BuiltinQueue::new(kv_store, pubsub, QueueConfig::default());
+
+        queue.subscription_configs.write().await.insert(
+            "nack_max_q".to_string(),
+            SubscriptionConfig {
+                concurrency: None,
+                max_attempts: Some(1),
+                backoff_ms: None,
+                mode: None,
+            },
+        );
+
+        queue
+            .push("nack_max_q", serde_json::json!({}), None, None)
+            .await;
+        let job = queue.pop("nack_max_q").await.unwrap();
+        // Publish time stamps the global default; the subscription must win.
+        assert_eq!(job.max_attempts, 3);
+
+        queue.nack("nack_max_q", &job.id, "err").await.unwrap();
+        assert_eq!(
+            queue.dlq_count("nack_max_q").await,
+            1,
+            "first failure must exhaust the job when subscription max_attempts=1"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_nack_honors_subscription_backoff() {
+        let kv_store = make_queue_kv(None);
+        let pubsub = Arc::new(BuiltInPubSubLite::new(None));
+        // Global default backoff: 1000ms.
+        let queue = BuiltinQueue::new(kv_store.clone(), pubsub, QueueConfig::default());
+
+        queue.subscription_configs.write().await.insert(
+            "nack_backoff_q".to_string(),
+            SubscriptionConfig {
+                concurrency: None,
+                max_attempts: Some(5),
+                backoff_ms: Some(5),
+                mode: None,
+            },
+        );
+
+        queue
+            .push("nack_backoff_q", serde_json::json!({}), None, None)
+            .await;
+        let job = queue.pop("nack_backoff_q").await.unwrap();
+
+        let before = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        queue.nack("nack_backoff_q", &job.id, "err").await.unwrap();
+
+        let job_key = queue.job_key("nack_backoff_q", &job.id);
+        let stored: Job =
+            serde_json::from_value(kv_store.get_job(&job_key).await.unwrap()).unwrap();
+        let process_at = stored.process_at.unwrap();
+        assert!(
+            process_at < before + 500,
+            "retry must use the subscription backoff (5ms), not the 1000ms default; got +{}ms",
+            process_at.saturating_sub(before)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_registers_retry_config() {
+        let kv_store = make_queue_kv(None);
+        let pubsub = Arc::new(BuiltInPubSubLite::new(None));
+        let queue = BuiltinQueue::new(kv_store, pubsub, QueueConfig::default());
+
+        let handle = queue
+            .subscribe(
+                "register_cfg_q",
+                Arc::new(TestHandler { should_fail: false }),
+                Some(SubscriptionConfig {
+                    concurrency: None,
+                    max_attempts: Some(7),
+                    backoff_ms: Some(9),
+                    mode: None,
+                }),
+            )
+            .await;
+
+        {
+            let configs = queue.subscription_configs.read().await;
+            let cfg = configs
+                .get("register_cfg_q")
+                .expect("subscribe must record the subscription config");
+            assert_eq!(cfg.max_attempts, Some(7));
+            assert_eq!(cfg.backoff_ms, Some(9));
+        }
+
+        queue.unsubscribe(handle).await;
     }
 }

--- a/engine/src/workers/queue/adapters/builtin/adapter.rs
+++ b/engine/src/workers/queue/adapters/builtin/adapter.rs
@@ -191,6 +191,21 @@ pub fn make_adapter(engine: Arc<Engine>, config: Option<Value>) -> QueueAdapterF
     })
 }
 
+/// Maps the user-facing subscriber `queue_config` onto the builtin queue's
+/// subscription config. `maxRetries` counts retries after the initial
+/// attempt, while `max_attempts` is the total number of attempts.
+fn to_subscription_config(c: SubscriberQueueConfig) -> SubscriptionConfig {
+    SubscriptionConfig {
+        concurrency: c.concurrency,
+        max_attempts: c.max_retries.map(|r| r.saturating_add(1)),
+        backoff_ms: c.backoff_delay_ms,
+        mode: c.queue_mode.as_ref().map(|m| match m.as_str() {
+            "fifo" => QueueMode::Fifo,
+            _ => QueueMode::Concurrent,
+        }),
+    }
+}
+
 #[async_trait]
 impl QueueAdapter for BuiltinQueueAdapter {
     async fn enqueue(
@@ -234,15 +249,7 @@ impl QueueAdapter for BuiltinQueueAdapter {
             condition_function_id,
         });
 
-        let subscription_config = queue_config.map(|c| SubscriptionConfig {
-            concurrency: c.concurrency,
-            max_attempts: c.max_retries,
-            backoff_ms: c.backoff_delay_ms,
-            mode: c.queue_mode.as_ref().map(|m| match m.as_str() {
-                "fifo" => QueueMode::Fifo,
-                _ => QueueMode::Concurrent,
-            }),
-        });
+        let subscription_config = queue_config.map(to_subscription_config);
 
         let handle = self
             .queue
@@ -707,20 +714,11 @@ mod tests {
             max_priority: None,
         };
 
-        let subscription_config = Some(config).map(|c| SubscriptionConfig {
-            concurrency: c.concurrency,
-            max_attempts: c.max_retries,
-            backoff_ms: c.backoff_delay_ms,
-            mode: c.queue_mode.as_ref().map(|m| match m.as_str() {
-                "fifo" => QueueMode::Fifo,
-                _ => QueueMode::Concurrent,
-            }),
-        });
-
-        let sub_config = subscription_config.unwrap();
+        let sub_config = to_subscription_config(config);
         assert_eq!(sub_config.mode, Some(QueueMode::Fifo));
         assert_eq!(sub_config.concurrency, Some(5));
-        assert_eq!(sub_config.max_attempts, Some(3));
+        // maxRetries: 3 = 3 retries after the initial attempt = 4 total attempts
+        assert_eq!(sub_config.max_attempts, Some(4));
         assert_eq!(sub_config.backoff_ms, Some(1000));
     }
 
@@ -737,18 +735,10 @@ mod tests {
             max_priority: None,
         };
 
-        let subscription_config = Some(config).map(|c| SubscriptionConfig {
-            concurrency: c.concurrency,
-            max_attempts: c.max_retries,
-            backoff_ms: c.backoff_delay_ms,
-            mode: c.queue_mode.as_ref().map(|m| match m.as_str() {
-                "fifo" => QueueMode::Fifo,
-                _ => QueueMode::Concurrent,
-            }),
-        });
-
-        let sub_config = subscription_config.unwrap();
+        let sub_config = to_subscription_config(config);
         assert_eq!(sub_config.mode, Some(QueueMode::Concurrent));
+        // Absent maxRetries must stay absent so the global default applies.
+        assert_eq!(sub_config.max_attempts, None);
     }
 
     #[test]
@@ -765,17 +755,7 @@ mod tests {
             max_priority: None,
         };
 
-        let subscription_config = Some(config).map(|c| SubscriptionConfig {
-            concurrency: c.concurrency,
-            max_attempts: c.max_retries,
-            backoff_ms: c.backoff_delay_ms,
-            mode: c.queue_mode.as_ref().map(|m| match m.as_str() {
-                "fifo" => QueueMode::Fifo,
-                _ => QueueMode::Concurrent,
-            }),
-        });
-
-        let sub_config = subscription_config.unwrap();
+        let sub_config = to_subscription_config(config);
         assert_eq!(sub_config.mode, Some(QueueMode::Concurrent));
     }
 
@@ -792,21 +772,12 @@ mod tests {
             max_priority: None,
         };
 
-        let subscription_config = Some(config).map(|c| SubscriptionConfig {
-            concurrency: c.concurrency,
-            max_attempts: c.max_retries,
-            backoff_ms: c.backoff_delay_ms,
-            mode: c.queue_mode.as_ref().map(|m| match m.as_str() {
-                "fifo" => QueueMode::Fifo,
-                _ => QueueMode::Concurrent,
-            }),
-        });
-
-        let sub_config = subscription_config.unwrap();
+        let sub_config = to_subscription_config(config);
         // When queue_mode is None, mode should also be None (inherits global default)
         assert_eq!(sub_config.mode, None);
         assert_eq!(sub_config.concurrency, Some(10));
-        assert_eq!(sub_config.max_attempts, Some(5));
+        // maxRetries: 5 = 5 retries after the initial attempt = 6 total attempts
+        assert_eq!(sub_config.max_attempts, Some(6));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Makes the builtin queue adapter honor per-subscriber retry tuning (`queue_config.maxRetries` / `queue_config.backoffDelayMs`) on `durable:subscriber` triggers. Previously every failing delivery got exactly 3 attempts with the default 1s-base exponential backoff regardless of configuration.

## Why

Fixes MOT-3947. The config was parsed (`subscriber_config.rs`) and mapped into `SubscriptionConfig` (`adapters/builtin/adapter.rs`), but never applied: jobs were stamped with the global defaults at publish time, `BuiltinQueue::subscribe` read only `mode` and `concurrency`, the Concurrent `Worker` discarded the config (`_subscription_config`), and both retry paths (`nack` and the FIFO inline-retry loop) read only the job's own stamped fields. `effective_max_attempts()` / `effective_backoff_ms()` existed but were only referenced by a unit test.

## Notes

**How it works now:** `BuiltinQueue` records each subscription's config (keyed by internal queue, which is per topic+function). At retry-decision time — `nack()` for Concurrent workers and the inline-retry loop for FIFO/grouped-FIFO workers — the subscriber's effective `max_attempts`/`backoff_ms` are overlaid onto the job's publish-time defaults. Applying at retry time (not publish time) means tuning also covers jobs enqueued before the subscriber connected or rebuilt from storage.

**Semantics (please review):** `maxRetries: N` = N retries *after* the initial attempt, i.e. N+1 total attempts; `maxRetries: 0` fails straight to the DLQ after one attempt. This matches the RabbitMQ adapter's per-message retry counting (`attempt < max_retries`, attempt starting at 0). The previous (dead) mapping treated `maxRetries` as total attempts.

**Not covered (follow-ups):** trigger-level flat `max_retries`/`backoff_ms` are still dropped in the shared `register_trigger` for all adapters (`queue_config` is the canonical interface); the queue worker docs should be updated to re-document the tuning fields with the semantics above; the ticket's related minor findings (`redriven` field name in `discard_message`, DLQ dropped on last-unsubscribe, Python `EnqueueResult`) are separate issues.

## Test plan

- [x] TDD: 5 new tests in `builtins/queue.rs` watched failing first, then passing — end-to-end Concurrent and FIFO subscriber tests asserting exact handler invocation counts via DLQ arrival, deterministic nack-level tests for max-attempts and backoff override, and subscribe-records-config
- [x] 4 adapter mapping tests now exercise the extracted `to_subscription_config()` production fn (previously asserted against inline copies of the mapping closure) with the new N+1 expectations
- [x] Full engine suite: 1928 passed; 3 failures are pre-existing parallelism flakes in `builtins::kv`/observability that pass in isolation and are untouched by this change
- [x] `cargo fmt` clean; no clippy warnings in touched files
- [ ] Re-verify the original repro from the Node/Python/Rust SDKs against a built engine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription-specific retry settings now apply consistently to queued jobs.
  * Configure maximum retry attempts and retry delays independently for each queue subscription.
  * Retry behavior is supported consistently in both concurrent and FIFO processing modes.

* **Bug Fixes**
  * Jobs now honor updated subscription retry settings even when queued before subscription or restored from storage.
  * Exhausted jobs are moved to the dead-letter queue according to the configured attempt limit.
  * Retry counts now correctly account for the initial processing attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->