### PR TITLE
fix(iii-browser-sdk): export IIIReconnectionConfig and RegisterFunctionFormat

### DIFF
--- a/sdk/packages/node/iii-browser/src/index.ts
+++ b/sdk/packages/node/iii-browser/src/index.ts
@@ -1,7 +1,7 @@
 export { ChannelReader, ChannelWriter } from './channels'
 
 export { EngineFunctions, EngineTriggers } from './iii-constants'
-export type { IIIConnectionState } from './iii-constants'
+export type { IIIConnectionState, IIIReconnectionConfig } from './iii-constants'
 
 export { type InitOptions, registerWorker, TriggerAction } from './iii'
 
@@ -17,6 +17,7 @@ export type {
   OnTriggerRegistrationResult,
   OnTriggerTypeRegistrationInput,
   OnTriggerTypeRegistrationResult,
+  RegisterFunctionFormat,
   RegisterFunctionMessage,
   RegisterTriggerMessage,
   RegisterTriggerTypeMessage,


### PR DESCRIPTION
## What

Re-export two types from the `iii-browser-sdk` barrel (`index.ts`):
- `IIIReconnectionConfig`
- `RegisterFunctionFormat`

## Why

Both are already part of the public surface **by reference** but weren't nameable by consumers:
- `InitOptions.reconnectionConfig` is `Partial<IIIReconnectionConfig>` (and its doc has an `@see {@link IIIReconnectionConfig}`).
- `RegisterFunctionOptions.request_format` / `response_format` are `RegisterFunctionFormat`.

Without the re-export you can't name these types when constructing the option objects, and the generated SDK reference can't resolve them (they render as bare, unlinked names).

This was originally bundled into the docs branch (`docs/api-docs-review`) purely to make the reference resolve, then reverted from there because adding a public export is a code change, not a docs change. Splitting it out here.

## Notes

- Additive and non-breaking; the types were already defined and exported from their source modules (`iii-constants.ts`, `iii-types.ts`).
- `tsc --noEmit` passes.
- Follow-up worth considering: the Node `iii` package has the same latent gap (references `IIIReconnectionConfig` / `RegisterFunctionFormat` without exporting them). Not included here to keep this scoped to the two browser types; happy to do a companion change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public type definitions for configuring connection reconnection behavior.
  * Added the `RegisterFunctionFormat` type to the browser SDK’s exported API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->