### PR TITLE
feat: recoverable triggers

### DIFF
--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -727,6 +727,18 @@ impl Engine {
                     trigger_type.call_request_format = Some(fmt.clone());
                 }
 
+                // Sweep intents whose owning worker is gone before the drain
+                // below can replay them. Concurrent disconnect cleanups can
+                // leak a dead worker's intent into `pending_triggers` (the
+                // provider's cleanup parks it after the owner's cleanup
+                // already purged its intents); this is the one moment such a
+                // leak becomes visible, so drop them here rather than deliver
+                // a binding nothing owns.
+                self.trigger_registry.pending_triggers.retain(|_, t| {
+                    t.worker_id
+                        .is_none_or(|id| self.worker_registry.get_worker(&id).is_some())
+                });
+
                 let _ = self
                     .trigger_registry
                     .register_trigger_type(trigger_type)
@@ -3720,6 +3732,9 @@ mod tests {
         let engine = Engine::new();
         let (tx, _rx) = mpsc::channel::<Outbound>(8);
         let worker = WorkerConnection::new(tx);
+        // The intent's owner must be a connected worker, or the dead-owner
+        // sweep at type registration reaps it before the drain.
+        engine.worker_registry.register_worker(worker.clone());
 
         // Bad sequencing: the trigger arrives before its type's provider.
         let msg = Message::RegisterTrigger {
@@ -3823,6 +3838,132 @@ mod tests {
         assert!(
             provider_rx.try_recv().is_err(),
             "provider must not receive a dead worker's trigger"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_unregistering_a_parked_trigger_prevents_replay_on_type_return() {
+        ensure_default_meter();
+        let engine = Engine::new();
+
+        // Worker A provides trigger type X.
+        let (a_tx, _a_rx) = mpsc::channel::<Outbound>(8);
+        let worker_a = WorkerConnection::new(a_tx);
+        engine.worker_registry.register_worker(worker_a.clone());
+        let tt_msg = Message::RegisterTriggerType {
+            id: "type_x".to_string(),
+            description: "provided by worker A".to_string(),
+            trigger_request_format: None,
+            call_request_format: None,
+        };
+        engine
+            .router_msg(&worker_a, &tt_msg)
+            .await
+            .expect("RegisterTriggerType should succeed");
+
+        // Worker B binds type_x -> b::echo.
+        let (b_tx, _b_rx) = mpsc::channel::<Outbound>(8);
+        let worker_b = WorkerConnection::new(b_tx);
+        engine.worker_registry.register_worker(worker_b.clone());
+        let reg_msg = Message::RegisterTrigger {
+            id: "trig-b-echo".to_string(),
+            trigger_type: "type_x".to_string(),
+            function_id: "b::echo".to_string(),
+            config: serde_json::json!({}),
+            metadata: None,
+        };
+        engine
+            .router_msg(&worker_b, &reg_msg)
+            .await
+            .expect("RegisterTrigger should succeed at protocol level");
+        assert!(engine.trigger_registry.triggers.contains_key("trig-b-echo"));
+
+        // Worker A disconnects: B's binding is parked, not dropped.
+        engine.cleanup_worker(&worker_a).await;
+        assert!(
+            engine
+                .trigger_registry
+                .pending_triggers
+                .contains_key("trig-b-echo"),
+            "binding should be parked while its type's provider is away"
+        );
+
+        // B explicitly unregisters the parked binding: dropping the intent
+        // is the whole unregister.
+        let unreg_msg = Message::UnregisterTrigger {
+            id: "trig-b-echo".to_string(),
+            trigger_type: Some("type_x".to_string()),
+        };
+        engine
+            .router_msg(&worker_b, &unreg_msg)
+            .await
+            .expect("UnregisterTrigger should succeed");
+        assert!(engine.trigger_registry.pending_triggers.is_empty());
+
+        // Worker A returns with the type: the unregistered binding must not
+        // be resurrected or delivered.
+        let (a2_tx, mut a2_rx) = mpsc::channel::<Outbound>(8);
+        let worker_a2 = WorkerConnection::new(a2_tx);
+        engine.worker_registry.register_worker(worker_a2.clone());
+        engine
+            .router_msg(&worker_a2, &tt_msg)
+            .await
+            .expect("RegisterTriggerType should succeed");
+
+        assert!(engine.trigger_registry.triggers.is_empty());
+        assert!(engine.trigger_registry.pending_triggers.is_empty());
+        assert!(
+            a2_rx.try_recv().is_err(),
+            "returning provider must not receive an unregistered binding"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_leaked_dead_owner_pending_intent_is_swept_on_type_registration() {
+        ensure_default_meter();
+        let engine = Engine::new();
+
+        // Simulate the concurrent-disconnect leak: a provider's cleanup can
+        // park another worker's binding after that worker's own cleanup
+        // already purged its intents, leaving an intent owned by a worker
+        // that is no longer connected.
+        let dead_worker = uuid::Uuid::new_v4();
+        engine.trigger_registry.pending_triggers.insert(
+            "trig-leaked".to_string(),
+            crate::trigger::Trigger {
+                id: "trig-leaked".to_string(),
+                trigger_type: "type_x".to_string(),
+                function_id: "b::echo".to_string(),
+                config: serde_json::json!({}),
+                worker_id: Some(dead_worker),
+                metadata: None,
+            },
+        );
+
+        // A provider registers the type: the leaked intent must be swept at
+        // the drain, never delivered as a binding nothing owns.
+        let (provider_tx, mut provider_rx) = mpsc::channel::<Outbound>(8);
+        let provider = WorkerConnection::new(provider_tx);
+        engine.worker_registry.register_worker(provider.clone());
+        let tt_msg = Message::RegisterTriggerType {
+            id: "type_x".to_string(),
+            description: "arrives after the leak".to_string(),
+            trigger_request_format: None,
+            call_request_format: None,
+        };
+        engine
+            .router_msg(&provider, &tt_msg)
+            .await
+            .expect("RegisterTriggerType should succeed");
+
+        assert!(
+            engine.trigger_registry.pending_triggers.is_empty(),
+            "leaked dead-owner intent should be swept"
+        );
+        assert!(engine.trigger_registry.triggers.is_empty());
+        assert!(
+            provider_rx.try_recv().is_err(),
+            "provider must not receive a dead worker's leaked intent"
         );
     }
 

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -828,25 +828,17 @@ impl Engine {
                     })
                     .await
                 {
-                    Ok(()) => {
+                    // A Deferred outcome is not an error: the intent is
+                    // parked engine-side and activates when the trigger type
+                    // registers, so no failure ack goes to the worker.
+                    Ok(_) => {
                         crate::workers::telemetry::collector::track_trigger_registered();
                     }
                     Err(err) => {
-                        let error_body = match &err {
-                            crate::trigger::RegisterTriggerError::UnknownBuiltin { .. }
-                            | crate::trigger::RegisterTriggerError::Unknown { .. } => {
-                                crate::protocol::ErrorBody::new(
-                                    "trigger_type_not_found",
-                                    err.to_string(),
-                                )
-                            }
-                            crate::trigger::RegisterTriggerError::Other(_) => {
-                                crate::protocol::ErrorBody::new(
-                                    "trigger_registration_failed",
-                                    err.to_string(),
-                                )
-                            }
-                        };
+                        let error_body = crate::protocol::ErrorBody::new(
+                            "trigger_registration_failed",
+                            err.to_string(),
+                        );
                         let result_msg = Message::TriggerRegistrationResult {
                             id: reg_trigger_id,
                             trigger_type: reg_trigger_type,
@@ -3687,7 +3679,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_register_trigger_unknown_builtin_sends_install_hint() {
+    async fn test_register_trigger_unknown_type_defers_without_error_ack() {
         ensure_default_meter();
         let engine = Engine::new();
         let (tx, mut rx) = mpsc::channel::<Outbound>(8);
@@ -3695,7 +3687,7 @@ mod tests {
 
         let msg = Message::RegisterTrigger {
             id: "trig-1".to_string(),
-            trigger_type: "http".to_string(),
+            trigger_type: "totally-made-up".to_string(),
             function_id: "fn-1".to_string(),
             config: serde_json::json!({}),
             metadata: None,
@@ -3706,67 +3698,73 @@ mod tests {
             .await
             .expect("RegisterTrigger should succeed at protocol level");
 
-        let outbound = rx
-            .try_recv()
-            .expect("engine should emit TriggerRegistrationResult on failure");
-        let Outbound::Protocol(Message::TriggerRegistrationResult {
-            id,
-            trigger_type,
-            function_id,
-            error,
-        }) = outbound
-        else {
-            panic!("expected TriggerRegistrationResult, got {:?}", outbound);
-        };
-        assert_eq!(id, "trig-1");
-        assert_eq!(trigger_type, "http");
-        assert_eq!(function_id, "fn-1");
-        let err = error.expect("error should be populated");
-        assert_eq!(err.code, "trigger_type_not_found");
-        assert!(err.message.contains("iii-http"), "msg: {}", err.message);
+        // Deferral is not a failure: no TriggerRegistrationResult goes back
+        // to the worker; the intent is parked engine-side instead.
         assert!(
-            err.message.contains("iii worker add"),
-            "msg: {}",
-            err.message
+            rx.try_recv().is_err(),
+            "no error ack should be sent for a deferred registration"
         );
+        assert!(
+            engine
+                .trigger_registry
+                .pending_triggers
+                .contains_key("trig-1"),
+            "intent should be parked in pending_triggers"
+        );
+        assert!(!engine.trigger_registry.triggers.contains_key("trig-1"));
     }
 
     #[tokio::test]
-    async fn test_register_trigger_unknown_type_recommends_workers_directory() {
+    async fn test_deferred_trigger_activates_when_provider_registers_type() {
         ensure_default_meter();
         let engine = Engine::new();
-        let (tx, mut rx) = mpsc::channel::<Outbound>(8);
+        let (tx, _rx) = mpsc::channel::<Outbound>(8);
         let worker = WorkerConnection::new(tx);
 
+        // Bad sequencing: the trigger arrives before its type's provider.
         let msg = Message::RegisterTrigger {
-            id: "trig-2".to_string(),
-            trigger_type: "totally-made-up".to_string(),
-            function_id: "fn-2".to_string(),
+            id: "trig-early".to_string(),
+            trigger_type: "late_type".to_string(),
+            function_id: "fn-1".to_string(),
             config: serde_json::json!({}),
             metadata: None,
         };
-
         engine
             .router_msg(&worker, &msg)
             .await
             .expect("RegisterTrigger should succeed at protocol level");
+        assert!(
+            engine
+                .trigger_registry
+                .pending_triggers
+                .contains_key("trig-early")
+        );
 
-        let outbound = rx.try_recv().expect("engine should emit a result");
-        let Outbound::Protocol(Message::TriggerRegistrationResult { error, .. }) = outbound else {
-            panic!("expected TriggerRegistrationResult");
+        // The provider shows up and registers the type: the parked intent
+        // is activated and forwarded to the provider.
+        let (provider_tx, mut provider_rx) = mpsc::channel::<Outbound>(8);
+        let provider = WorkerConnection::new(provider_tx);
+        let tt_msg = Message::RegisterTriggerType {
+            id: "late_type".to_string(),
+            description: "arrives after its triggers".to_string(),
+            trigger_request_format: None,
+            call_request_format: None,
         };
-        let err = error.expect("error should be populated");
-        assert_eq!(err.code, "trigger_type_not_found");
-        assert!(
-            err.message.contains("totally-made-up"),
-            "msg should name the missing type: {}",
-            err.message
-        );
-        assert!(
-            err.message.contains("https://workers.iii.dev/"),
-            "msg should recommend the workers directory: {}",
-            err.message
-        );
+        engine
+            .router_msg(&provider, &tt_msg)
+            .await
+            .expect("RegisterTriggerType should succeed");
+
+        assert!(engine.trigger_registry.pending_triggers.is_empty());
+        assert!(engine.trigger_registry.triggers.contains_key("trig-early"));
+
+        let outbound = provider_rx
+            .try_recv()
+            .expect("provider should receive the recovered trigger");
+        let Outbound::Protocol(Message::RegisterTrigger { id, .. }) = outbound else {
+            panic!("expected RegisterTrigger, got {:?}", outbound);
+        };
+        assert_eq!(id, "trig-early");
     }
 
     // =========================================================================

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -3767,6 +3767,65 @@ mod tests {
         assert_eq!(id, "trig-early");
     }
 
+    #[tokio::test]
+    async fn test_cleanup_worker_drops_its_pending_trigger_intents() {
+        ensure_default_meter();
+        let engine = Engine::new();
+        let (tx, _rx) = mpsc::channel::<Outbound>(8);
+        let worker = WorkerConnection::new(tx);
+        engine.worker_registry.register_worker(worker.clone());
+
+        // The message path stamps the trigger with the origin connection as
+        // owner, so the parked intent is connection-owned.
+        let msg = Message::RegisterTrigger {
+            id: "trig-orphan".to_string(),
+            trigger_type: "never_registered".to_string(),
+            function_id: "fn-1".to_string(),
+            config: serde_json::json!({}),
+            metadata: None,
+        };
+        engine
+            .router_msg(&worker, &msg)
+            .await
+            .expect("RegisterTrigger should succeed at protocol level");
+        assert!(
+            engine
+                .trigger_registry
+                .pending_triggers
+                .contains_key("trig-orphan")
+        );
+
+        // The worker disconnects while its registration is still parked: the
+        // intent must be reaped with the connection, exactly like a live
+        // connection-owned binding would be.
+        engine.cleanup_worker(&worker).await;
+        assert!(
+            engine.trigger_registry.pending_triggers.is_empty(),
+            "pending intent should be reaped with its worker"
+        );
+
+        // A provider for the type arriving later must find nothing to
+        // deliver — the dead worker's intent must not be resurrected.
+        let (provider_tx, mut provider_rx) = mpsc::channel::<Outbound>(8);
+        let provider = WorkerConnection::new(provider_tx);
+        let tt_msg = Message::RegisterTriggerType {
+            id: "never_registered".to_string(),
+            description: "arrives after the owner died".to_string(),
+            trigger_request_format: None,
+            call_request_format: None,
+        };
+        engine
+            .router_msg(&provider, &tt_msg)
+            .await
+            .expect("RegisterTriggerType should succeed");
+
+        assert!(engine.trigger_registry.triggers.is_empty());
+        assert!(
+            provider_rx.try_recv().is_err(),
+            "provider must not receive a dead worker's trigger"
+        );
+    }
+
     // =========================================================================
     // router_msg: RegisterService
     // =========================================================================

--- a/engine/src/trigger.rs
+++ b/engine/src/trigger.rs
@@ -259,7 +259,22 @@ impl TriggerRegistry {
 
         for trigger_type_id in worker_trigger_type_ids {
             tracing::debug!(trigger_type_id = %trigger_type_id, "Removing trigger type");
-            self.trigger_types.remove(&trigger_type_id);
+            // The entry may have been replaced by a new provider between the
+            // snapshot above and now (worker restart: the replacement can
+            // register before the old connection's cleanup runs). Only remove
+            // it if it still belongs to the disconnecting worker — and only
+            // then are its bindings orphaned; a replaced type keeps firing.
+            let removed = self
+                .trigger_types
+                .remove_if(&trigger_type_id, |_, tt| tt.worker_id == Some(*worker_id))
+                .is_some();
+            if !removed {
+                tracing::debug!(
+                    trigger_type_id = %trigger_type_id,
+                    "Trigger type already replaced by another worker; leaving it"
+                );
+                continue;
+            }
             tracing::debug!(trigger_type_id = %trigger_type_id, "Trigger type removed");
 
             // Bindings from other owners that reference the departed type are
@@ -274,6 +289,13 @@ impl TriggerRegistry {
                 .map(|pair| pair.value().clone())
                 .collect();
             for trigger in orphaned {
+                // Park only when this call is the one that removed the
+                // binding: a concurrent owner-disconnect cleanup may have
+                // already reaped it, and parking it anyway would resurrect a
+                // dead worker's binding as a pending intent.
+                if self.triggers.remove(&trigger.id).is_none() {
+                    continue;
+                }
                 tracing::warn!(
                     "{} Trigger {} (type {}, function {}) is disabled: its trigger type was unregistered. It will be re-registered automatically when the trigger type returns.",
                     "[DISABLED]".yellow(),
@@ -281,7 +303,6 @@ impl TriggerRegistry {
                     trigger.trigger_type.purple(),
                     trigger.function_id.purple(),
                 );
-                self.triggers.remove(&trigger.id);
                 self.pending_triggers.insert(trigger.id.clone(), trigger);
             }
         }
@@ -299,6 +320,19 @@ impl TriggerRegistry {
             trigger_type_id.purple()
         );
 
+        // Publish the type BEFORE any replay so every concurrent path
+        // observes the new generation first:
+        //  * a concurrent `register_trigger` that misses the pending drain
+        //    finds the type on its post-park re-check, so an intent can never
+        //    be stranded in pending while the type is available (see
+        //    `register_trigger`);
+        //  * a stale disconnect cleanup of the previous provider now fails
+        //    its ownership check (see `unregister_worker`) instead of parking
+        //    bindings this registration is about to replay — which would
+        //    deliver them twice.
+        self.trigger_types
+            .insert(trigger_type_id.clone(), trigger_type);
+
         let matching_triggers: Vec<Trigger> = self
             .triggers
             .iter()
@@ -306,31 +340,27 @@ impl TriggerRegistry {
             .map(|pair| pair.value().clone())
             .collect();
 
-        for trigger in matching_triggers {
-            let result = trigger_type
-                .registrator
-                .replay_trigger(trigger.clone())
-                .await;
-            if let Err(err) = result {
-                tracing::error!(error = %err, "Error registering trigger");
-            }
-        }
-
-        // Insert the type BEFORE draining pending intents: a concurrent
-        // `register_trigger` that misses the drain then finds the type on its
-        // post-park re-check, so an intent can never be stranded in pending
-        // while the type is available (see `register_trigger`).
-        self.trigger_types
-            .insert(trigger_type_id.clone(), trigger_type);
-
-        let pending: Vec<String> = self
-            .pending_triggers
-            .iter()
-            .filter(|pair| pair.value().trigger_type == trigger_type_id)
-            .map(|pair| pair.key().clone())
-            .collect();
-
+        // Re-fetch instead of using the inserted value: if an even newer
+        // generation replaced the entry in the meantime, replay must route to
+        // that one.
         if let Some(trigger_type) = self.trigger_types.get(&trigger_type_id) {
+            for trigger in matching_triggers {
+                let result = trigger_type
+                    .registrator
+                    .replay_trigger(trigger.clone())
+                    .await;
+                if let Err(err) = result {
+                    tracing::error!(error = %err, "Error registering trigger");
+                }
+            }
+
+            let pending: Vec<String> = self
+                .pending_triggers
+                .iter()
+                .filter(|pair| pair.value().trigger_type == trigger_type_id)
+                .map(|pair| pair.key().clone())
+                .collect();
+
             for trigger_id in pending {
                 // `remove` claims the intent, so a concurrent drain of the
                 // same type cannot activate it twice.
@@ -714,6 +744,79 @@ mod tests {
             .unwrap();
         assert!(removed);
         assert!(!registry.triggers.contains_key("t_durable"));
+    }
+
+    /// Provider restart where the replacement registers concurrently with the
+    /// old connection's cleanup. Whatever the interleave: the replacement
+    /// type entry must survive (ownership-checked removal), the binding must
+    /// never be lost (it ends live or parked, in exactly one bucket), and the
+    /// stale generation must receive nothing after replacement.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn stale_cleanup_racing_a_replacement_never_clobbers_or_loses_bindings() {
+        for _ in 0..100 {
+            let registry = Arc::new(TriggerRegistry::new());
+            let old_worker = Uuid::new_v4();
+
+            let a = Arc::new(ControlledRegistrator::new(false, false));
+            registry
+                .register_trigger_type(TriggerType::new(
+                    "evt",
+                    "gen A",
+                    Box::new(a.clone()),
+                    Some(old_worker),
+                ))
+                .await
+                .unwrap();
+
+            let mut binding = make_trigger("t1", "evt");
+            binding.worker_id = Some(Uuid::new_v4());
+            registry.register_trigger(binding).await.unwrap();
+            assert_eq!(a.register_count.load(Ordering::SeqCst), 1);
+
+            let b = Arc::new(ControlledRegistrator::new(false, false));
+            let new_worker = Uuid::new_v4();
+            let replacement =
+                TriggerType::new("evt", "gen B", Box::new(b.clone()), Some(new_worker));
+
+            let cleanup = {
+                let registry = registry.clone();
+                tokio::spawn(async move { registry.unregister_worker(&old_worker).await })
+            };
+            let reregister = {
+                let registry = registry.clone();
+                tokio::spawn(
+                    async move { registry.register_trigger_type(replacement).await.unwrap() },
+                )
+            };
+            let (r1, r2) = tokio::join!(cleanup, reregister);
+            r1.unwrap();
+            r2.unwrap();
+
+            let tt = registry
+                .trigger_types
+                .get("evt")
+                .expect("replacement type survives the stale cleanup");
+            assert_eq!(tt.worker_id, Some(new_worker));
+            drop(tt);
+
+            let live = registry.triggers.contains_key("t1");
+            let parked = registry.pending_triggers.contains_key("t1");
+            assert!(
+                live ^ parked,
+                "binding must end in exactly one bucket (live: {live}, parked: {parked})"
+            );
+            if live {
+                assert!(
+                    b.register_count.load(Ordering::SeqCst) >= 1,
+                    "a live binding was delivered to the replacement generation"
+                );
+            }
+            assert_eq!(
+                a.register_count.load(Ordering::SeqCst),
+                1,
+                "stale generation receives nothing after replacement"
+            );
+        }
     }
 
     #[tokio::test]

--- a/engine/src/trigger.rs
+++ b/engine/src/trigger.rs
@@ -37,21 +37,15 @@ pub fn known_trigger_type_provider(trigger_type_id: &str) -> Option<&'static str
         .map(|(_, worker)| *worker)
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum RegisterTriggerError {
-    #[error(
-        "Trigger type \"{trigger_type}\" not found — worker {worker} is missing. Run: iii worker add {worker}"
-    )]
-    UnknownBuiltin {
-        trigger_type: String,
-        worker: &'static str,
-    },
-    #[error(
-        "Trigger type \"{trigger_type}\" not found. Search for a worker that provides this trigger type at https://workers.iii.dev/"
-    )]
-    Unknown { trigger_type: String },
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
+/// Outcome of [`TriggerRegistry::register_trigger`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegisterTriggerOutcome {
+    /// The trigger type was available and the binding is live.
+    Registered,
+    /// The trigger type is not (yet) available. The registration intent is
+    /// parked in [`TriggerRegistry::pending_triggers`] and will be activated
+    /// automatically when the trigger type registers.
+    Deferred,
 }
 
 pub struct TriggerType {
@@ -161,6 +155,18 @@ pub trait TriggerRegistrator: Send + Sync {
         &self,
         trigger: Trigger,
     ) -> Pin<Box<dyn Future<Output = Result<(), anyhow::Error>> + Send + '_>>;
+    /// Re-deliver an already-accepted binding (type re-registration replay,
+    /// pending-intent recovery). Defaults to `register_trigger`. Registrators
+    /// whose register path blocks on an ack from the provider worker
+    /// (`WorkerConnection`) must override this to fire-and-forget: replay
+    /// runs inline on that provider's own read loop, so awaiting its ack
+    /// stalls the connection until the timeout.
+    fn replay_trigger(
+        &self,
+        trigger: Trigger,
+    ) -> Pin<Box<dyn Future<Output = Result<(), anyhow::Error>> + Send + '_>> {
+        self.register_trigger(trigger)
+    }
     fn unregister_trigger(
         &self,
         trigger: Trigger,
@@ -195,6 +201,12 @@ impl std::hash::Hash for Trigger {
 pub struct TriggerRegistry {
     pub trigger_types: Arc<DashMap<String, TriggerType>>,
     pub triggers: Arc<DashMap<String, Trigger>>,
+    /// Registration intents whose trigger type is not currently available:
+    /// either it never registered, or its provider worker disconnected. These
+    /// bindings are disabled (they never fire) until the trigger type
+    /// (re)registers, at which point they are activated and moved into
+    /// `triggers`. Keyed by trigger id, like `triggers`.
+    pub pending_triggers: Arc<DashMap<String, Trigger>>,
 }
 
 impl TriggerRegistry {
@@ -202,6 +214,7 @@ impl TriggerRegistry {
         Self {
             trigger_types: Arc::new(DashMap::new()),
             triggers: Arc::new(DashMap::new()),
+            pending_triggers: Arc::new(DashMap::new()),
         }
     }
 
@@ -239,10 +252,38 @@ impl TriggerRegistry {
             tracing::debug!(trigger_id = trigger.id, "Trigger removed");
         }
 
+        // Connection-owned intents die with their worker, same as live
+        // connection-owned bindings above.
+        self.pending_triggers
+            .retain(|_, trigger| trigger.worker_id != Some(*worker_id));
+
         for trigger_type_id in worker_trigger_type_ids {
             tracing::debug!(trigger_type_id = %trigger_type_id, "Removing trigger type");
             self.trigger_types.remove(&trigger_type_id);
             tracing::debug!(trigger_type_id = %trigger_type_id, "Trigger type removed");
+
+            // Bindings from other owners that reference the departed type are
+            // now orphaned: nothing can fire them. Park them as pending
+            // intents so they are re-activated when the type (re)registers —
+            // a provider worker restart must not silently drop everyone
+            // else's bindings.
+            let orphaned: Vec<Trigger> = self
+                .triggers
+                .iter()
+                .filter(|pair| pair.value().trigger_type == trigger_type_id)
+                .map(|pair| pair.value().clone())
+                .collect();
+            for trigger in orphaned {
+                tracing::warn!(
+                    "{} Trigger {} (type {}, function {}) is disabled: its trigger type was unregistered. It will be re-registered automatically when the trigger type returns.",
+                    "[DISABLED]".yellow(),
+                    trigger.id.purple(),
+                    trigger.trigger_type.purple(),
+                    trigger.function_id.purple(),
+                );
+                self.triggers.remove(&trigger.id);
+                self.pending_triggers.insert(trigger.id.clone(), trigger);
+            }
         }
     }
 
@@ -268,43 +309,124 @@ impl TriggerRegistry {
         for trigger in matching_triggers {
             let result = trigger_type
                 .registrator
-                .register_trigger(trigger.clone())
+                .replay_trigger(trigger.clone())
                 .await;
             if let Err(err) = result {
                 tracing::error!(error = %err, "Error registering trigger");
             }
         }
 
+        // Insert the type BEFORE draining pending intents: a concurrent
+        // `register_trigger` that misses the drain then finds the type on its
+        // post-park re-check, so an intent can never be stranded in pending
+        // while the type is available (see `register_trigger`).
         self.trigger_types
-            .insert(trigger_type.id.clone(), trigger_type);
+            .insert(trigger_type_id.clone(), trigger_type);
+
+        let pending: Vec<String> = self
+            .pending_triggers
+            .iter()
+            .filter(|pair| pair.value().trigger_type == trigger_type_id)
+            .map(|pair| pair.key().clone())
+            .collect();
+
+        if let Some(trigger_type) = self.trigger_types.get(&trigger_type_id) {
+            for trigger_id in pending {
+                // `remove` claims the intent, so a concurrent drain of the
+                // same type cannot activate it twice.
+                let Some((_, trigger)) = self.pending_triggers.remove(&trigger_id) else {
+                    continue;
+                };
+                self.activate_pending_trigger(&trigger_type, trigger).await;
+            }
+        }
 
         Ok(())
     }
 
-    pub async fn register_trigger(&self, trigger: Trigger) -> Result<(), RegisterTriggerError> {
+    /// Activate a claimed pending intent against its now-available trigger
+    /// type. On registrator failure the intent is parked again so the next
+    /// type (re)registration retries it.
+    async fn activate_pending_trigger(&self, trigger_type: &TriggerType, trigger: Trigger) -> bool {
+        match trigger_type
+            .registrator
+            .replay_trigger(trigger.clone())
+            .await
+        {
+            Ok(()) => {
+                tracing::info!(
+                    "{} Trigger {} (type {}, function {}) recovered from pending",
+                    "[REGISTERED]".green(),
+                    trigger.id.purple(),
+                    trigger.trigger_type.purple(),
+                    trigger.function_id.purple(),
+                );
+                self.triggers.insert(trigger.id.clone(), trigger);
+                true
+            }
+            Err(err) => {
+                tracing::error!(
+                    error = %err,
+                    trigger_id = %trigger.id,
+                    trigger_type = %trigger.trigger_type,
+                    "Error registering pending trigger; it stays pending"
+                );
+                self.pending_triggers.insert(trigger.id.clone(), trigger);
+                false
+            }
+        }
+    }
+
+    /// Human-readable warning for a registration intent that had to be
+    /// parked because its trigger type is not available.
+    fn pending_trigger_warning(trigger: &Trigger) -> String {
+        let base = format!(
+            "{} Trigger {} (function {}) was NOT activated: trigger type {} is not registered. It will be registered automatically when the trigger type becomes available.",
+            "[PENDING]".yellow(),
+            trigger.id.purple(),
+            trigger.function_id.purple(),
+            trigger.trigger_type.purple().bold(),
+        );
+        match known_trigger_type_provider(&trigger.trigger_type) {
+            Some(worker_name) => format!(
+                "{} If this persists, the {} worker is missing — run: {}",
+                base,
+                worker_name.cyan().bold(),
+                format!("iii worker add {}", worker_name).green().bold()
+            ),
+            None => format!(
+                "{} If this persists, search for a worker that provides this trigger type at {}",
+                base,
+                "https://workers.iii.dev/".cyan().bold()
+            ),
+        }
+    }
+
+    pub async fn register_trigger(
+        &self,
+        trigger: Trigger,
+    ) -> Result<RegisterTriggerOutcome, anyhow::Error> {
         let trigger_type_id = trigger.trigger_type.clone();
         let Some(trigger_type) = self.trigger_types.get(&trigger_type_id) else {
-            if let Some(worker_name) = known_trigger_type_provider(&trigger_type_id) {
-                tracing::error!(
-                    "Trigger type {} requires the {} worker, which is not active in your project.\n\n  To fix this, run:\n\n    {}\n",
-                    trigger_type_id.purple().bold(),
-                    worker_name.cyan().bold(),
-                    format!("iii worker add {}", worker_name).green().bold()
-                );
-                return Err(RegisterTriggerError::UnknownBuiltin {
-                    trigger_type: trigger_type_id,
-                    worker: worker_name,
-                });
+            // Park the intent instead of failing: workers may connect in any
+            // order, and a binding that arrives before its trigger type's
+            // provider must survive until the provider shows up.
+            tracing::warn!("{}", Self::pending_trigger_warning(&trigger));
+            self.pending_triggers
+                .insert(trigger.id.clone(), trigger.clone());
+
+            // Close the park/drain race: if the type registered between the
+            // lookup above and the park, its pending drain may have already
+            // run. Re-check and activate the intent ourselves — claiming it
+            // via `remove` so we never double-activate with a drain.
+            if let Some(trigger_type) = self.trigger_types.get(&trigger_type_id)
+                && let Some((_, parked)) = self.pending_triggers.remove(&trigger.id)
+                && self.activate_pending_trigger(&trigger_type, parked).await
+            {
+                return Ok(RegisterTriggerOutcome::Registered);
             }
 
-            tracing::error!(
-                "Trigger type {} not found. Search for a worker that provides this trigger type at {}",
-                trigger_type_id.purple().bold(),
-                "https://workers.iii.dev/".cyan().bold()
-            );
-            return Err(RegisterTriggerError::Unknown {
-                trigger_type: trigger_type_id,
-            });
+            return Ok(RegisterTriggerOutcome::Deferred);
         };
 
         if let Err(err) = trigger_type
@@ -313,23 +435,27 @@ impl TriggerRegistry {
             .await
         {
             tracing::error!(error = %err, "Error registering trigger");
-            return Err(RegisterTriggerError::Other(err));
+            return Err(err);
         }
 
         drop(trigger_type);
 
         tracing::debug!(trigger = %trigger.id, worker_id = %trigger.worker_id.unwrap_or_default(), "Registering trigger");
 
+        // A live registration supersedes any parked intent with the same id.
+        self.pending_triggers.remove(&trigger.id);
         self.triggers.insert(trigger.id.clone(), trigger);
 
-        Ok(())
+        Ok(RegisterTriggerOutcome::Registered)
     }
 
     /// Unregister a trigger by id. Idempotent: returns `Ok(false)` when no
     /// trigger with this id exists (rather than erroring), so callers can treat
-    /// double-unregister as a no-op. On a registrator error the registry entry
-    /// is left in place (registry and registrator stay consistent) and the
-    /// error is propagated. Returns `Ok(true)` when a trigger was removed.
+    /// double-unregister as a no-op. A parked pending intent counts as
+    /// existing: unregistering it drops the intent and returns `Ok(true)`.
+    /// On a registrator error the registry entry is left in place (registry
+    /// and registrator stay consistent) and the error is propagated. Returns
+    /// `Ok(true)` when a trigger was removed.
     pub async fn unregister_trigger(
         &self,
         id: String,
@@ -342,7 +468,9 @@ impl TriggerRegistry {
         );
 
         let Some(trigger_entry) = self.triggers.get(&id) else {
-            return Ok(false);
+            // A parked intent has no live registration to tear down —
+            // dropping it from the pending bucket is the whole unregister.
+            return Ok(self.pending_triggers.remove(&id).is_some());
         };
         let trigger = trigger_entry.value().clone();
         drop(trigger_entry);
@@ -604,51 +732,251 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_trigger_registry_register_trigger_missing_type() {
+    async fn test_trigger_registry_register_trigger_missing_type_defers() {
         let registry = TriggerRegistry::new();
-        // No trigger type registered -- should fail.
+        // No trigger type registered -- the intent is parked, not dropped.
         let trigger = make_trigger("t1", "nonexistent");
         let result = registry.register_trigger(trigger).await;
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("\"nonexistent\" not found"),
-            "Expected unknown-type message, got: {err_msg}"
-        );
-        assert!(
-            err_msg.contains("https://workers.iii.dev/"),
-            "Expected workers directory recommendation, got: {err_msg}"
-        );
+        assert!(matches!(result, Ok(RegisterTriggerOutcome::Deferred)));
         assert!(registry.triggers.is_empty());
+        assert!(registry.pending_triggers.contains_key("t1"));
+    }
+
+    #[test]
+    fn pending_warning_names_missing_builtin_worker() {
+        let msg = TriggerRegistry::pending_trigger_warning(&make_trigger("t1", "http"));
+        assert!(
+            msg.contains("iii worker add iii-http"),
+            "Expected hint with 'iii worker add iii-http', got: {msg}"
+        );
+    }
+
+    #[test]
+    fn pending_warning_for_durable_subscriber_points_to_standalone_queue_worker() {
+        let msg =
+            TriggerRegistry::pending_trigger_warning(&make_trigger("t1", "durable:subscriber"));
+        assert!(
+            msg.contains("iii worker add queue"),
+            "expected standalone queue installation hint, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn pending_warning_for_unknown_type_points_to_workers_directory() {
+        let msg = TriggerRegistry::pending_trigger_warning(&make_trigger("t1", "nonexistent"));
+        assert!(
+            msg.contains("https://workers.iii.dev/"),
+            "Expected workers directory recommendation, got: {msg}"
+        );
     }
 
     #[tokio::test]
-    async fn test_trigger_registry_register_trigger_missing_builtin_worker() {
+    async fn deferred_trigger_activates_when_type_registers() {
         let registry = TriggerRegistry::new();
-        let trigger = make_trigger("t1", "http");
-        let result = registry.register_trigger(trigger).await;
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("iii worker add iii-http"),
-            "Expected hint with 'iii worker add iii-http', got: {err_msg}"
-        );
-        assert!(registry.triggers.is_empty());
-    }
 
-    #[tokio::test]
-    async fn missing_durable_subscriber_points_to_standalone_queue_worker() {
-        let registry = TriggerRegistry::new();
         let result = registry
-            .register_trigger(make_trigger("t1", "durable:subscriber"))
+            .register_trigger(make_trigger("t1", "webhook"))
             .await;
+        assert!(matches!(result, Ok(RegisterTriggerOutcome::Deferred)));
+        assert!(registry.pending_triggers.contains_key("t1"));
+        assert!(!registry.triggers.contains_key("t1"));
 
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("iii worker add queue"),
-            "expected standalone queue installation hint, got: {err_msg}"
+        let registrator = Arc::new(ControlledRegistrator::new(false, false));
+        registry
+            .register_trigger_type(TriggerType::new(
+                "webhook",
+                "Webhook",
+                Box::new(Arc::clone(&registrator)),
+                None,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            registrator.register_count.load(Ordering::SeqCst),
+            1,
+            "parked intent delivered to the registrator when the type arrives"
         );
+        assert!(registry.pending_triggers.is_empty());
+        assert!(registry.triggers.contains_key("t1"));
+    }
+
+    #[tokio::test]
+    async fn pending_trigger_that_fails_activation_stays_pending_and_retries() {
+        let registry = TriggerRegistry::new();
+        registry
+            .register_trigger(make_trigger("t1", "webhook"))
+            .await
+            .unwrap();
+
+        let failing = Arc::new(ControlledRegistrator::new(true, false));
+        registry
+            .register_trigger_type(TriggerType::new(
+                "webhook",
+                "gen A",
+                Box::new(Arc::clone(&failing)),
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(failing.register_count.load(Ordering::SeqCst), 1);
+        assert!(
+            registry.pending_triggers.contains_key("t1"),
+            "failed activation keeps the intent parked"
+        );
+        assert!(!registry.triggers.contains_key("t1"));
+
+        // The next (re)registration of the type retries the parked intent.
+        let healthy = Arc::new(ControlledRegistrator::new(false, false));
+        registry
+            .register_trigger_type(TriggerType::new(
+                "webhook",
+                "gen B",
+                Box::new(Arc::clone(&healthy)),
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(healthy.register_count.load(Ordering::SeqCst), 1);
+        assert!(registry.pending_triggers.is_empty());
+        assert!(registry.triggers.contains_key("t1"));
+    }
+
+    #[tokio::test]
+    async fn provider_disconnect_parks_other_owners_bindings_until_type_returns() {
+        let registry = TriggerRegistry::new();
+        let provider = Uuid::new_v4();
+
+        let gen_a = Arc::new(ControlledRegistrator::new(false, false));
+        registry
+            .register_trigger_type(TriggerType::new(
+                "evt",
+                "gen A",
+                Box::new(Arc::clone(&gen_a)),
+                Some(provider),
+            ))
+            .await
+            .unwrap();
+
+        // A durable binding (engine::register_trigger path) and another
+        // worker's binding, both against the provider's type.
+        registry
+            .register_trigger(make_trigger("t_durable", "evt"))
+            .await
+            .unwrap();
+        let other_worker = Uuid::new_v4();
+        let mut other = make_trigger("t_other", "evt");
+        other.worker_id = Some(other_worker);
+        registry.register_trigger(other).await.unwrap();
+
+        // Provider restarts: its type goes away, the surviving bindings are
+        // parked (disabled), not dropped.
+        registry.unregister_worker(&provider).await;
+        assert!(registry.trigger_types.is_empty());
         assert!(registry.triggers.is_empty());
+        assert!(registry.pending_triggers.contains_key("t_durable"));
+        assert!(registry.pending_triggers.contains_key("t_other"));
+
+        // Provider reconnects and re-registers the type: both bindings
+        // come back to life.
+        let gen_b = Arc::new(ControlledRegistrator::new(false, false));
+        registry
+            .register_trigger_type(TriggerType::new(
+                "evt",
+                "gen B",
+                Box::new(Arc::clone(&gen_b)),
+                Some(Uuid::new_v4()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(gen_b.register_count.load(Ordering::SeqCst), 2);
+        assert!(registry.pending_triggers.is_empty());
+        assert!(registry.triggers.contains_key("t_durable"));
+        assert!(registry.triggers.contains_key("t_other"));
+    }
+
+    #[tokio::test]
+    async fn unregister_worker_drops_its_own_pending_intents() {
+        let registry = TriggerRegistry::new();
+        let worker = Uuid::new_v4();
+
+        let mut owned = make_trigger("t_owned", "missing-type");
+        owned.worker_id = Some(worker);
+        registry.register_trigger(owned).await.unwrap();
+        registry
+            .register_trigger(make_trigger("t_durable", "missing-type"))
+            .await
+            .unwrap();
+        assert_eq!(registry.pending_triggers.len(), 2);
+
+        registry.unregister_worker(&worker).await;
+
+        assert!(
+            !registry.pending_triggers.contains_key("t_owned"),
+            "connection-owned intent dies with its worker"
+        );
+        assert!(
+            registry.pending_triggers.contains_key("t_durable"),
+            "durable intent survives another worker's disconnect"
+        );
+    }
+
+    #[tokio::test]
+    async fn unregister_trigger_drops_pending_intent() {
+        let registry = TriggerRegistry::new();
+        registry
+            .register_trigger(make_trigger("t1", "missing-type"))
+            .await
+            .unwrap();
+        assert!(registry.pending_triggers.contains_key("t1"));
+
+        let removed = registry.unregister_trigger("t1".to_string(), None).await;
+        assert!(matches!(removed, Ok(true)));
+        assert!(registry.pending_triggers.is_empty());
+
+        // Its type arriving later must not resurrect the dropped intent.
+        let registrator = Arc::new(ControlledRegistrator::new(false, false));
+        registry
+            .register_trigger_type(TriggerType::new(
+                "missing-type",
+                "now present",
+                Box::new(Arc::clone(&registrator)),
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(registrator.register_count.load(Ordering::SeqCst), 0);
+        assert!(registry.triggers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn live_registration_supersedes_parked_intent_with_same_id() {
+        let registry = TriggerRegistry::new();
+        registry
+            .register_trigger(make_trigger("t1", "webhook"))
+            .await
+            .unwrap();
+        assert!(registry.pending_triggers.contains_key("t1"));
+
+        let registrator = Arc::new(ControlledRegistrator::new(false, false));
+        registry
+            .register_trigger_type(TriggerType::new(
+                "evt",
+                "other type",
+                Box::new(Arc::clone(&registrator)),
+                None,
+            ))
+            .await
+            .unwrap();
+
+        // Re-registering the same id against an available type replaces the
+        // parked intent instead of leaving a stale duplicate behind.
+        registry
+            .register_trigger(make_trigger("t1", "evt"))
+            .await
+            .unwrap();
+        assert!(registry.pending_triggers.is_empty());
+        assert_eq!(registry.triggers.get("t1").unwrap().trigger_type, "evt");
     }
 
     #[tokio::test]

--- a/engine/src/trigger.rs
+++ b/engine/src/trigger.rs
@@ -919,6 +919,79 @@ mod tests {
             registry.pending_triggers.contains_key("t_durable"),
             "durable intent survives another worker's disconnect"
         );
+
+        // The type arriving later must not resurrect the dropped intent —
+        // only the surviving durable one may activate.
+        let registrator = Arc::new(ControlledRegistrator::new(false, false));
+        registry
+            .register_trigger_type(TriggerType::new(
+                "missing-type",
+                "now present",
+                Box::new(Arc::clone(&registrator)),
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(registrator.register_count.load(Ordering::SeqCst), 1);
+        assert!(registry.triggers.contains_key("t_durable"));
+        assert!(!registry.triggers.contains_key("t_owned"));
+        assert!(registry.pending_triggers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn owner_disconnect_while_parked_drops_the_disabled_binding() {
+        // Full lifecycle chain: a live binding is parked because its type's
+        // provider disconnected ([DISABLED]); then the binding's OWNER
+        // disconnects while it is parked. The intent must die with its owner
+        // and must NOT come back when the provider returns.
+        let registry = TriggerRegistry::new();
+        let provider = Uuid::new_v4();
+        let owner = Uuid::new_v4();
+
+        let gen_a = Arc::new(ControlledRegistrator::new(false, false));
+        registry
+            .register_trigger_type(TriggerType::new(
+                "evt",
+                "gen A",
+                Box::new(Arc::clone(&gen_a)),
+                Some(provider),
+            ))
+            .await
+            .unwrap();
+
+        let mut owned = make_trigger("t_owned", "evt");
+        owned.worker_id = Some(owner);
+        registry.register_trigger(owned).await.unwrap();
+
+        // Provider restarts: the owner's binding is parked, not dropped.
+        registry.unregister_worker(&provider).await;
+        assert!(registry.pending_triggers.contains_key("t_owned"));
+
+        // The owner disconnects while its binding is still parked.
+        registry.unregister_worker(&owner).await;
+        assert!(
+            registry.pending_triggers.is_empty(),
+            "parked intent dies with its owning worker"
+        );
+
+        // Provider returns: nothing may be re-delivered.
+        let gen_b = Arc::new(ControlledRegistrator::new(false, false));
+        registry
+            .register_trigger_type(TriggerType::new(
+                "evt",
+                "gen B",
+                Box::new(Arc::clone(&gen_b)),
+                Some(Uuid::new_v4()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            gen_b.register_count.load(Ordering::SeqCst),
+            0,
+            "dead owner's binding must not be resurrected"
+        );
+        assert!(registry.triggers.is_empty());
+        assert!(registry.pending_triggers.is_empty());
     }
 
     #[tokio::test]

--- a/engine/src/worker_connections/traits.rs
+++ b/engine/src/worker_connections/traits.rs
@@ -90,6 +90,40 @@ impl TriggerRegistrator for WorkerConnection {
         })
     }
 
+    /// Fire-and-forget re-delivery. Replay/recovery runs inline on THIS
+    /// worker's read loop (`router_msg` handling its `RegisterTriggerType`),
+    /// so awaiting the ack like `register_trigger` does for ownerless
+    /// triggers would stall the connection until the timeout — the ack can
+    /// only be read once the loop is free again. Failures are still handled:
+    /// the worker's `TriggerRegistrationResult` takes the late-unwind path in
+    /// `router_msg`, which removes the trigger from the registry.
+    fn replay_trigger(
+        &self,
+        trigger: Trigger,
+    ) -> Pin<Box<dyn Future<Output = Result<(), anyhow::Error>> + Send + '_>> {
+        let sender = self.channel.clone();
+
+        Box::pin(async move {
+            sender
+                .send(Outbound::Protocol(Message::RegisterTrigger {
+                    id: trigger.id,
+                    trigger_type: trigger.trigger_type,
+                    function_id: trigger.function_id,
+                    config: trigger.config,
+                    metadata: trigger.metadata,
+                }))
+                .await
+                .map_err(|err| {
+                    anyhow::anyhow!(
+                        "failed to send register trigger message through worker channel: {}",
+                        err
+                    )
+                })?;
+
+            Ok(())
+        })
+    }
+
     fn unregister_trigger(
         &self,
         trigger: Trigger,
@@ -266,6 +300,25 @@ mod tests {
         // queued, never waits on (or creates) a pending ack.
         worker
             .register_trigger(trigger("t_owned", Some(Uuid::new_v4())))
+            .await
+            .unwrap();
+        assert!(worker.pending_trigger_acks.is_empty());
+        let msg = rx.recv().await.unwrap();
+        assert!(matches!(
+            msg,
+            Outbound::Protocol(Message::RegisterTrigger { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn replay_trigger_is_fire_and_forget_even_for_ownerless_triggers() {
+        let (worker, mut rx) = make_worker();
+        // Replay runs inline on this worker's read loop, so it must return as
+        // soon as the delivery is queued — no pending ack, no timeout — even
+        // for ownerless (durable) triggers that DO await an ack on the
+        // register_trigger path.
+        worker
+            .replay_trigger(trigger("t_replayed", None))
             .await
             .unwrap();
         assert!(worker.pending_trigger_acks.is_empty());

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -3732,14 +3732,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn register_trigger_fn_unknown_type_fails_without_registering() {
+    async fn register_trigger_fn_unknown_type_defers_and_activates_later() {
         let (engine, module) = setup_engine_and_module();
         register_simple_function(&engine, "test::target", None);
 
         let result = module
             .register_trigger_fn(
                 RegisterTriggerInput {
-                    trigger_type: "no-such-type".to_string(),
+                    trigger_type: "test-type".to_string(),
                     function_id: "test::target".to_string(),
                     config: serde_json::json!({}),
                     metadata: None,
@@ -3748,9 +3748,18 @@ mod tests {
                 None,
             )
             .await;
-        assert!(matches!(result, FunctionResult::Failure(_)));
-
-        // A failed bind leaves no trigger behind.
+        // Registering ahead of the trigger type's provider succeeds and
+        // returns a usable id: the intent is parked, not live.
+        let id = match result {
+            FunctionResult::Success(r) => r.id,
+            _ => panic!("expected deferred register success"),
+        };
         assert!(engine.trigger_registry.triggers.is_empty());
+        assert!(engine.trigger_registry.pending_triggers.contains_key(&id));
+
+        // Once the type registers, the parked intent goes live.
+        register_test_trigger_type(&engine, &module).await;
+        assert!(engine.trigger_registry.pending_triggers.is_empty());
+        assert!(engine.trigger_registry.triggers.contains_key(&id));
     }
 }

--- a/sdk/packages/node/iii/tests/trigger-fault-tolerance.test.ts
+++ b/sdk/packages/node/iii/tests/trigger-fault-tolerance.test.ts
@@ -96,9 +96,9 @@ describe('Trigger fault tolerance (deferred registration)', () => {
   })
 
   it('parks a trigger registered before its type exists and activates it when the provider arrives', async () => {
-    const TRIGGER_TYPE_ID = `test.deferred.node.${RUN}`
-    const CONSUMER_FN = `test.deferred.node.${RUN}.consumer`
-    const FIRE_FN = `test.deferred.node.${RUN}.fire`
+    const TRIGGER_TYPE_ID = `test::deferred-node-${RUN}`
+    const CONSUMER_FN = `test::deferred-node-${RUN}::consumer`
+    const FIRE_FN = `test::deferred-node-${RUN}::fire`
 
     // The engine must not error-ack a deferred registration — the SDK would
     // log it as "[iii] Trigger registration failed".
@@ -134,9 +134,9 @@ describe('Trigger fault tolerance (deferred registration)', () => {
   })
 
   it('re-registers another worker’s trigger after the provider stops and starts again', async () => {
-    const TRIGGER_TYPE_ID = `test.provider-restart.node.${RUN}`
-    const CONSUMER_FN = `test.provider-restart.node.${RUN}.consumer`
-    const FIRE_FN = `test.provider-restart.node.${RUN}.fire`
+    const TRIGGER_TYPE_ID = `test::provider-restart-node-${RUN}`
+    const CONSUMER_FN = `test::provider-restart-node-${RUN}::consumer`
+    const FIRE_FN = `test::provider-restart-node-${RUN}::fire`
 
     let provider = createProvider(TRIGGER_TYPE_ID, FIRE_FN)
     await sleep(300)

--- a/sdk/packages/node/iii/tests/trigger-fault-tolerance.test.ts
+++ b/sdk/packages/node/iii/tests/trigger-fault-tolerance.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TriggerAction, registerWorker } from '../src/index'
+import type { IIIClient } from '../src/types'
+import type { TriggerConfig } from '../src/triggers'
+import { engineWsUrl, sleep } from './utils'
+
+/**
+ * Fault tolerance to bad worker sequencing: the engine parks trigger
+ * registrations whose trigger type is not (yet) available and activates them
+ * when the type's provider shows up — including when the provider restarts.
+ *
+ * The suite shares one long-running engine, so every id carries a per-run
+ * suffix: a parked intent left behind by a crashed previous run must never be
+ * re-activated into this run's spies.
+ */
+const RUN = crypto.randomUUID().slice(0, 8)
+const TRIGGER_CONFIG = { tag: 'fault-tolerance' }
+
+type TestTriggerConfig = { tag: string }
+
+type ProviderHarness = {
+  sdk: IIIClient
+  bindings: Map<string, TriggerConfig<TestTriggerConfig>>
+  registerTriggerSpy: ReturnType<typeof vi.fn>
+  fire: (payload: Record<string, unknown>) => Promise<unknown>
+}
+
+describe('Trigger fault tolerance (deferred registration)', () => {
+  const clients: IIIClient[] = []
+
+  function createProvider(triggerTypeId: string, fireFnId: string): ProviderHarness {
+    const bindings = new Map<string, TriggerConfig<TestTriggerConfig>>()
+    const registerTriggerSpy = vi.fn(async (cfg: TriggerConfig<TestTriggerConfig>) => {
+      bindings.set(cfg.id, cfg)
+    })
+
+    const sdk = registerWorker(engineWsUrl, {
+      reconnectionConfig: { maxRetries: 3, initialDelayMs: 100, maxDelayMs: 1000 },
+    })
+    clients.push(sdk)
+
+    sdk.registerTriggerType(
+      { id: triggerTypeId, description: 'Node SDK fault-tolerance test trigger type' },
+      {
+        registerTrigger: registerTriggerSpy,
+        unregisterTrigger: async (cfg) => {
+          bindings.delete(cfg.id)
+        },
+      },
+    )
+
+    sdk.registerFunction(fireFnId, async (payload: Record<string, unknown>) => {
+      for (const binding of bindings.values()) {
+        await sdk.trigger({
+          function_id: binding.function_id,
+          payload,
+          action: TriggerAction.Void(),
+        })
+      }
+      return { fired: bindings.size }
+    })
+
+    return {
+      sdk,
+      bindings,
+      registerTriggerSpy,
+      fire: (payload) => sdk.trigger({ function_id: fireFnId, payload }),
+    }
+  }
+
+  function createConsumer(
+    triggerTypeId: string,
+    consumerFnId: string,
+  ): { sdk: IIIClient; handlerSpy: ReturnType<typeof vi.fn> } {
+    const handlerSpy = vi.fn(async (payload: Record<string, unknown>) => ({ ok: true, payload }))
+    const sdk = registerWorker(engineWsUrl, {
+      reconnectionConfig: { maxRetries: 3, initialDelayMs: 100, maxDelayMs: 1000 },
+    })
+    clients.push(sdk)
+
+    sdk.registerFunction(consumerFnId, handlerSpy)
+    sdk.registerTrigger({
+      type: triggerTypeId,
+      function_id: consumerFnId,
+      config: TRIGGER_CONFIG,
+    })
+
+    return { sdk, handlerSpy }
+  }
+
+  afterEach(async () => {
+    while (clients.length > 0) {
+      await clients.pop()?.shutdown()
+    }
+    vi.restoreAllMocks()
+  })
+
+  it('parks a trigger registered before its type exists and activates it when the provider arrives', async () => {
+    const TRIGGER_TYPE_ID = `test.deferred.node.${RUN}`
+    const CONSUMER_FN = `test.deferred.node.${RUN}.consumer`
+    const FIRE_FN = `test.deferred.node.${RUN}.fire`
+
+    // The engine must not error-ack a deferred registration — the SDK would
+    // log it as "[iii] Trigger registration failed".
+    const consoleErrorSpy = vi.spyOn(console, 'error')
+
+    // Bad sequencing: the consumer binds to a trigger type whose provider
+    // has not connected yet.
+    const { handlerSpy } = createConsumer(TRIGGER_TYPE_ID, CONSUMER_FN)
+    await sleep(400)
+
+    const registrationFailures = consoleErrorSpy.mock.calls
+      .map((args) => args.join(' '))
+      .filter((msg) => msg.includes('Trigger registration failed') && msg.includes(TRIGGER_TYPE_ID))
+    expect(registrationFailures).toEqual([])
+
+    // The provider shows up late and registers the trigger type: the parked
+    // registration must be delivered to it.
+    const provider = createProvider(TRIGGER_TYPE_ID, FIRE_FN)
+    await sleep(500)
+
+    expect(provider.registerTriggerSpy).toHaveBeenCalledTimes(1)
+    expect(provider.registerTriggerSpy.mock.calls[0][0]).toMatchObject({
+      function_id: CONSUMER_FN,
+      config: TRIGGER_CONFIG,
+    })
+
+    // End to end: firing the recovered binding invokes the consumer.
+    await provider.fire({ n: 1 })
+    await sleep(400)
+
+    expect(handlerSpy).toHaveBeenCalledTimes(1)
+    expect(handlerSpy.mock.calls[0][0]).toMatchObject({ n: 1 })
+  })
+
+  it('re-registers another worker’s trigger after the provider stops and starts again', async () => {
+    const TRIGGER_TYPE_ID = `test.provider-restart.node.${RUN}`
+    const CONSUMER_FN = `test.provider-restart.node.${RUN}.consumer`
+    const FIRE_FN = `test.provider-restart.node.${RUN}.fire`
+
+    let provider = createProvider(TRIGGER_TYPE_ID, FIRE_FN)
+    await sleep(300)
+
+    const { handlerSpy } = createConsumer(TRIGGER_TYPE_ID, CONSUMER_FN)
+    await sleep(400)
+
+    expect(provider.registerTriggerSpy).toHaveBeenCalledTimes(1)
+    const boundTriggerId = provider.registerTriggerSpy.mock.calls[0][0].id as string
+
+    // Stop the provider: its trigger type is unregistered and the consumer's
+    // binding is disabled (parked) engine-side.
+    await provider.sdk.shutdown()
+    clients.splice(clients.indexOf(provider.sdk), 1)
+    await sleep(400)
+
+    // Start the provider again: the engine re-delivers the parked binding to
+    // the fresh registrator.
+    provider = createProvider(TRIGGER_TYPE_ID, FIRE_FN)
+    await sleep(500)
+
+    expect(provider.registerTriggerSpy).toHaveBeenCalledTimes(1)
+    expect(provider.registerTriggerSpy.mock.calls[0][0]).toMatchObject({
+      id: boundTriggerId,
+      function_id: CONSUMER_FN,
+      config: TRIGGER_CONFIG,
+    })
+
+    // The recovered binding still fires the consumer's function.
+    await provider.fire({ n: 2 })
+    await sleep(400)
+
+    expect(handlerSpy).toHaveBeenCalledTimes(1)
+    expect(handlerSpy.mock.calls[0][0]).toMatchObject({ n: 2 })
+  })
+})


### PR DESCRIPTION
## Summary

Makes trigger registration resilient to bad worker sequencing and provider restarts. When a trigger type is missing, the engine parks the registration intent instead of failing, then activates it when the type registers or re-registers.

## Problem

`RegisterTrigger` currently fails if the trigger type does not exist yet. That makes startup order fragile: consumers can lose bindings if they connect before providers, and provider restarts drop other workers' bindings.

## Solution

- **Missing trigger type:** park intent in `pending_triggers`, log `[PENDING]`, return success (no error ack to worker)
- **Trigger type registers:** drain matching pending intents and activate them
- **Provider disconnects:** move live bindings to `pending_triggers`, log `[DISABLED]`, recover on re-register
- **`replay_trigger`:** fire-and-forget re-delivery on `WorkerConnection` to avoid deadlocks during inline replay

## Test plan

- [ ] `cargo test -p iii` (trigger registry + engine tests)
- [ ] `cd sdk/packages/node/iii && pnpm test trigger-fault-tolerance`
- [ ] Manual: consumer before provider → binding recovers when provider connects
- [ ] Manual: provider restart → bindings disabled then recovered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trigger registrations are now deferred when the required trigger type isn’t available, and parked until the provider/type arrives.
  * Added trigger replay behavior to recover parked bindings, including after provider reconnection.
* **Bug Fixes**
  * Prevented incorrect error acknowledgements for temporarily unknown/unavailable trigger types.
  * Ensured pending/parked triggers are properly cleaned up on worker disconnect and when triggers are unregistered; avoid replaying stale/dead-owner intents.
* **Tests**
  * Added Node SDK integration coverage for deferred activation, reconnection recovery, and correct cleanup/replay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->