### PR TITLE
fix(browser-sdk): generate invocation UUIDs in insecure contexts

### DIFF
--- a/sdk/packages/node/iii-browser/src/iii.ts
+++ b/sdk/packages/node/iii-browser/src/iii.ts
@@ -30,7 +30,7 @@ import type {
   Trigger,
   TriggerTypeRef,
 } from './types'
-import { isChannelRef } from './utils'
+import { isChannelRef, randomUUID } from './utils'
 
 /** @internal */
 export type TelemetryOptions = {
@@ -179,7 +179,7 @@ class Sdk implements ISdk {
    * ```
    */
   registerTrigger = (trigger: Omit<RegisterTriggerMessage, 'message_type' | 'id'>): Trigger => {
-    const id = crypto.randomUUID()
+    const id = randomUUID()
     const fullTrigger: RegisterTriggerMessage = {
       ...trigger,
       id,
@@ -333,7 +333,7 @@ class Sdk implements ISdk {
       return undefined as TOutput
     }
 
-    const invocation_id = crypto.randomUUID()
+    const invocation_id = randomUUID()
 
     return new Promise<TOutput>((resolve, reject) => {
       const timeout = setTimeout(() => {

--- a/sdk/packages/node/iii-browser/src/utils.ts
+++ b/sdk/packages/node/iii-browser/src/utils.ts
@@ -80,3 +80,21 @@ const extractRefsRecursive = (
     extractRefsRecursive(value, path, refs)
   }
 }
+
+/**
+ * Generate an RFC 4122 v4 UUID.
+ *
+ * `crypto.randomUUID` is only defined in secure contexts (https / localhost),
+ * so pages served over plain http from a LAN address would throw on every
+ * invocation. Fall back to building the UUID from `crypto.getRandomValues`,
+ * which is available in insecure contexts and uses the same CSPRNG. The
+ * engine parses invocation ids as UUIDs, so the fallback must be a real one.
+ */
+export function randomUUID(): string {
+  if (typeof crypto.randomUUID === 'function') return crypto.randomUUID()
+  const bytes = crypto.getRandomValues(new Uint8Array(16))
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}

--- a/sdk/packages/node/iii-browser/tests/utils.test.ts
+++ b/sdk/packages/node/iii-browser/tests/utils.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { randomUUID } from '../src/utils'
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+describe('randomUUID', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns a v4 UUID when crypto.randomUUID is available', () => {
+    expect(randomUUID()).toMatch(UUID_V4)
+  })
+
+  it('returns a v4 UUID in insecure contexts where crypto.randomUUID is undefined', () => {
+    // Browsers only expose crypto.randomUUID in secure contexts (https /
+    // localhost); getRandomValues is always available.
+    vi.stubGlobal('crypto', {
+      getRandomValues: crypto.getRandomValues.bind(crypto),
+    })
+    expect(typeof crypto.randomUUID).toBe('undefined')
+    expect(randomUUID()).toMatch(UUID_V4)
+  })
+
+  it('generates unique ids', () => {
+    vi.stubGlobal('crypto', {
+      getRandomValues: crypto.getRandomValues.bind(crypto),
+    })
+    const ids = new Set(Array.from({ length: 1000 }, () => randomUUID()))
+    expect(ids.size).toBe(1000)
+  })
+})


### PR DESCRIPTION
## Problem

The console (and any `iii-browser` consumer) breaks when served over plain `http://` from a non-localhost address — e.g. `http://<lan-ip>:3113`. Every `trigger()` call and `registerTrigger()` throws `TypeError: crypto.randomUUID is not a function`, because `crypto.randomUUID` is only defined in secure contexts (https / localhost).

The visible symptom: the console shows the **"install the harness worker"** setup screen and an empty model list even when the engine, harness, and providers are all healthy — the `engine::workers::list` probe fails client-side before it ever reaches the engine.

## Fix

Add a `randomUUID()` helper in `utils.ts` that uses `crypto.randomUUID` when present and otherwise builds an RFC 4122 v4 UUID from `crypto.getRandomValues` (available in insecure contexts, same CSPRNG). Both call sites in `iii.ts` (`registerTrigger`, invocation ids) now use it.

The fallback keeps the strict UUID format because the engine parses invocation ids as UUIDs and silently drops frames that don't parse (`json decode error: UUID parsing failed`).

## Test plan

- [x] `vitest run` — 54 tests pass
- [x] New `tests/utils.test.ts`: valid v4 UUID with and without `crypto.randomUUID` (simulated insecure context), uniqueness over 1000 ids
- [x] `npm run build` (tsdown) passes
- [x] Manually reproduced against a live engine: invocation with a well-formed v4 UUID from an insecure-origin page returns results; non-UUID ids are dropped by the engine

https://claude.ai/code/session_01Teg1GKop3sPUs9YvS3LqRm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when generating unique identifiers in browser environments where the preferred cryptographic UUID API is unavailable.
  * Trigger registrations and function invocations now consistently receive valid, unique UUIDs.

* **Tests**
  * Added coverage for UUID formatting, fallback generation, and uniqueness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->