### PR TITLE
fix: SSRF bypass via IPv4-mapped IPv6 addresses in url_validator

### DIFF
--- a/engine/src/invocation/url_validator.rs
+++ b/engine/src/invocation/url_validator.rs
@@ -347,6 +347,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_url_validator_blocks_ipv4_mapped_ipv6_loopback() {
+        let validator = UrlValidator::new(UrlValidatorConfig {
+            allowlist: vec!["*".to_string()],
+            block_private_ips: true,
+            require_https: false,
+        })
+        .unwrap();
+
+        let result = validator.validate("http://[::ffff:127.0.0.1]/").await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            SecurityError::PrivateIpBlocked
+        ));
+    }
+
+    #[tokio::test]
     async fn test_url_validator_blocks_private_rfc1918() {
         let validator = UrlValidator::new(UrlValidatorConfig {
             allowlist: vec!["*".to_string()],

--- a/engine/src/invocation/url_validator.rs
+++ b/engine/src/invocation/url_validator.rs
@@ -110,15 +110,16 @@ impl UrlValidator {
 
 fn is_private_ip(ip: &IpAddr) -> bool {
     match ip {
-        IpAddr::V4(ipv4) => {
-            ipv4.is_loopback()
-                || ipv4.is_private()
-                || ipv4.is_link_local()
-                || ipv4.is_broadcast()
-                || ipv4.is_documentation()
-                || ipv4.is_unspecified()
-        }
+        IpAddr::V4(ipv4) => is_private_ipv4(ipv4),
         IpAddr::V6(ipv6) => {
+            // An IPv4-mapped IPv6 address (e.g. ::ffff:169.254.169.254) routes
+            // to the underlying IPv4 address, so it has to be classified as
+            // that IPv4 address. Without this, ::ffff:127.0.0.1 and the
+            // ::ffff: form of the metadata IP pass straight through the IPv6
+            // checks below.
+            if let Some(mapped) = ipv6.to_ipv4_mapped() {
+                return is_private_ipv4(&mapped);
+            }
             ipv6.is_loopback()
                 || is_ipv6_unique_local(ipv6)
                 || is_ipv6_link_local(ipv6)
@@ -126,6 +127,15 @@ fn is_private_ip(ip: &IpAddr) -> bool {
                 || ipv6.is_multicast()
         }
     }
+}
+
+fn is_private_ipv4(ipv4: &std::net::Ipv4Addr) -> bool {
+    ipv4.is_loopback()
+        || ipv4.is_private()
+        || ipv4.is_link_local()
+        || ipv4.is_broadcast()
+        || ipv4.is_documentation()
+        || ipv4.is_unspecified()
 }
 
 fn is_ipv6_unique_local(ipv6: &std::net::Ipv6Addr) -> bool {
@@ -489,6 +499,34 @@ mod tests {
     fn test_is_private_ip_v6_public() {
         let ip: Ipv6Addr = "2001:4860:4860::8888".parse().unwrap();
         assert!(!is_private_ip(&IpAddr::V6(ip)));
+    }
+
+    // ---- IPv4-mapped IPv6 is classified by its underlying IPv4 address ----
+
+    #[test]
+    fn test_ipv4_mapped_loopback_is_private() {
+        let ip: IpAddr = "::ffff:127.0.0.1".parse().unwrap();
+        assert!(is_private_ip(&ip));
+    }
+
+    #[test]
+    fn test_ipv4_mapped_metadata_ip_is_private() {
+        // ::ffff:169.254.169.254 is the cloud metadata address in mapped form
+        let ip: IpAddr = "::ffff:169.254.169.254".parse().unwrap();
+        assert!(is_private_ip(&ip));
+    }
+
+    #[test]
+    fn test_ipv4_mapped_rfc1918_is_private() {
+        let ip: IpAddr = "::ffff:10.0.0.1".parse().unwrap();
+        assert!(is_private_ip(&ip));
+    }
+
+    // A normal public IPv6 address is still allowed through.
+    #[test]
+    fn test_global_ipv6_is_not_private() {
+        let ip: IpAddr = "2606:4700:4700::1111".parse().unwrap();
+        assert!(!is_private_ip(&ip));
     }
 
     // ---- SecurityError Display ----


### PR DESCRIPTION
## What

`is_private_ip` in `engine/src/invocation/url_validator.rs` classified IPv4 and IPv6 addresses separately. An IPv4-mapped IPv6 address like `::ffff:169.254.169.254` was being run through the IPv6 checks only, none of which catch it, so it came back as "not private."

In practice that means an attacker could reach loopback, RFC1918 ranges, or the cloud metadata endpoint by writing the address in its `::ffff:a.b.c.d` form, sidestepping the SSRF guard entirely.

## Fix

`is_private_ip` now unwraps IPv4-mapped IPv6 addresses (`Ipv6Addr::to_ipv4_mapped`, stable since 1.63) to their underlying `Ipv4Addr` and classifies that instead. The IPv4 logic was pulled into a small `is_private_ipv4` helper so both branches use the same rules.

## Tests

Added to the existing `is_private_ip` unit tests:
- `::ffff:127.0.0.1` → private (loopback)
- `::ffff:169.254.169.254` → private (metadata IP, mapped form)
- `::ffff:10.0.0.1` → private (RFC1918, mapped form)
- `2606:4700:4700::1111` → still public (control case, unaffected by this change)

Ran locally on this branch:
```
cargo test -p iii --lib url_validator
```
All 3 new cases fail against the pre-fix code and pass after. Full `url_validator` suite (36 tests) is green post-fix.

## Not in this PR

There's a second, separate gap in this file: `validate()` resolves the hostname to vet its IP, then whatever makes the actual HTTP request resolves it again — nothing pins the request to the IP that was checked, so DNS rebinding (public IP at check time, private IP at request time) still gets through. Fixing that means threading the resolved IP through to the HTTP client (e.g. `reqwest`'s `resolve()` override) and making the resolver injectable for testing. Wanted to keep this PR scoped to the mapped-address bug; happy to follow up with that one separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of private IPs when IPv4 addresses are provided in IPv6-mapped form.
  * IPv4-mapped loopback, cloud metadata, and RFC1918-mapped addresses are now consistently treated as private.
  * Public IPv6 addresses remain correctly allowed.

* **Tests**
  * Added coverage to ensure IPv4-mapped loopback is blocked when private IP blocking is enabled.
  * Expanded unit tests for private IP classification scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- [x] I license my contributions to this repository under Apache 2.0, and I have all necessary rights over the code I am contributing.