### PR TITLE
fix(engine,iii-worker): restore iii-queue as an opt-in engine builtin

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -400,6 +400,7 @@ jobs:
           - { worker: iii-http, worker_dir: engine/src/workers/rest_api }
           - { worker: iii-stream, worker_dir: engine/src/workers/stream }
           - { worker: iii-state, worker_dir: engine/src/workers/state }
+          - { worker: iii-queue, worker_dir: engine/src/workers/queue }
           - { worker: iii-pubsub, worker_dir: engine/src/workers/pubsub }
           - { worker: iii-cron, worker_dir: engine/src/workers/cron }
           - { worker: iii-observability, worker_dir: engine/src/workers/observability }

--- a/.github/workflows/release-iii.yml
+++ b/.github/workflows/release-iii.yml
@@ -663,6 +663,8 @@ jobs:
             worker_dir: engine/src/workers/stream
           - worker: iii-state
             worker_dir: engine/src/workers/state
+          - worker: iii-queue
+            worker_dir: engine/src/workers/queue
           - worker: iii-pubsub
             worker_dir: engine/src/workers/pubsub
           - worker: iii-cron

--- a/crates/iii-worker/src/cli/builtin_defaults.rs
+++ b/crates/iii-worker/src/cli/builtin_defaults.rs
@@ -5,10 +5,11 @@
 // See LICENSE and PATENTS files for details.
 
 /// Configurable builtin workers: enabled by default and have a default YAML config.
-pub const BUILTIN_NAMES: [&str; 6] = [
+pub const BUILTIN_NAMES: [&str; 7] = [
     "iii-http",
     "iii-stream",
     "iii-state",
+    "iii-queue",
     "iii-pubsub",
     "iii-cron",
     "iii-sandbox",
@@ -50,6 +51,7 @@ pub fn resolve_builtin_version(requested: Option<&str>) -> &str {
 const HTTP_MANIFEST: &str = include_str!("../../../../engine/src/workers/rest_api/iii.worker.yaml");
 const STREAM_MANIFEST: &str = include_str!("../../../../engine/src/workers/stream/iii.worker.yaml");
 const STATE_MANIFEST: &str = include_str!("../../../../engine/src/workers/state/iii.worker.yaml");
+const QUEUE_MANIFEST: &str = include_str!("../../../../engine/src/workers/queue/iii.worker.yaml");
 const PUBSUB_MANIFEST: &str = include_str!("../../../../engine/src/workers/pubsub/iii.worker.yaml");
 const CRON_MANIFEST: &str = include_str!("../../../../engine/src/workers/cron/iii.worker.yaml");
 
@@ -58,6 +60,7 @@ fn manifest_for_builtin(name: &str) -> Option<&'static str> {
         "iii-http" => Some(HTTP_MANIFEST),
         "iii-stream" => Some(STREAM_MANIFEST),
         "iii-state" => Some(STATE_MANIFEST),
+        "iii-queue" => Some(QUEUE_MANIFEST),
         "iii-pubsub" => Some(PUBSUB_MANIFEST),
         "iii-cron" => Some(CRON_MANIFEST),
         _ => None,

--- a/engine/src/workers/queue/iii.worker.yaml
+++ b/engine/src/workers/queue/iii.worker.yaml
@@ -1,0 +1,8 @@
+iii: v1
+name: iii-queue
+type: engine
+description: Async job processing with named queues, retries, and dead-letter support.
+repo: https://github.com/iii-hq/iii
+config:
+  adapter:
+    name: builtin

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -1298,6 +1298,17 @@ impl ConfigurableWorker for QueueWorker {
     }
 }
 
+// Opt-in only: the standalone `queue` worker owns queue runtime behavior by
+// default (see MOT-3944). This registration exists so an explicit `iii-queue`
+// entry in config.yaml (written by `iii worker add iii-queue`) still boots the
+// in-engine implementation instead of being silently ignored.
+crate::register_worker!(
+    "iii-queue",
+    QueueWorker,
+    description = "Async job processing with named queues, retries, and dead-letter support.",
+    enabled_by_default = false
+);
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/tests/iii_queue_optin_registration.rs
+++ b/engine/tests/iii_queue_optin_registration.rs
@@ -1,0 +1,32 @@
+use serde_json::json;
+
+use iii::{EngineBuilder, engine::EngineTrait};
+
+/// An explicit `iii-queue` worker entry (what `iii worker add iii-queue`
+/// writes into config.yaml) must boot the in-engine queue worker and register
+/// the caller-facing queue/DLQ functions.
+#[tokio::test]
+async fn explicit_iii_queue_entry_registers_queue_functions() {
+    let builder = EngineBuilder::new()
+        .add_worker("iii-engine-functions", None)
+        .add_worker("iii-observability", None)
+        .add_worker("iii-queue", None)
+        .build()
+        .await
+        .expect("engine build should succeed");
+    let engine = builder.engine();
+
+    let result = engine
+        .call("engine::queue::list_topics", json!({}))
+        .await
+        .expect("engine::queue::list_topics should be registered and callable")
+        .expect("list_topics should return a value");
+    assert!(result.is_array(), "unexpected shape: {result:?}");
+
+    let dlq = engine
+        .call("engine::queue::dlq_topics", json!({}))
+        .await
+        .expect("engine::queue::dlq_topics should be registered and callable")
+        .expect("dlq_topics should return a value");
+    assert!(dlq.is_array(), "unexpected shape: {dlq:?}");
+}


### PR DESCRIPTION
## What

Restores the `iii-queue` engine builtin removed by #1950, as **opt-in** (`enabled_by_default = false`):

- `engine/src/workers/queue/queue.rs` — re-adds the `register_worker!("iii-queue", QueueWorker, ...)` block so an explicit `iii-queue` entry in config.yaml boots the in-engine implementation again instead of being silently ignored.
- `engine/src/workers/queue/iii.worker.yaml` — restores the engine-type manifest (needed by the publish pipeline and the CLI embed).
- `crates/iii-worker/src/cli/builtin_defaults.rs` — restores `iii-queue` in `BUILTIN_NAMES` + the embedded manifest, so `iii worker add iii-queue` resolves locally without the registry.
- `.github/workflows/release-iii.yml` / `alpha-release.yml` — restores the `iii-queue` publish-matrix rows so the next release publishes a working engine-type registry entry.
- `engine/tests/iii_queue_optin_registration.rs` — new regression test: engine booted with an explicit `iii-queue` entry registers `engine::queue::list_topics` / `engine::queue::dlq_topics` and they respond.

## Why

MOT-3944 (#1950, shipped in 0.21.5) retired the in-engine queue worker, but users following existing docs still run `iii worker add iii-queue`: the registry resolves the stale 0.21.4 engine-type entry, the config entry is silently dropped by 0.21.5+ engines, `iii worker status` reports "not registered", and `engine::queue::*` calls fail with "Function not found" (user report on 0.21.6).

With this change the standalone `queue` worker still owns queue behavior by default — default config continues to exclude `iii-queue` and `test_default_config_excludes_retired_iii_queue_worker` still passes — but the legacy name works again when explicitly configured.

## Notes

- Only helps engines built from this change onward (0.21.7+); it cannot fix 0.21.5/0.21.6 binaries already installed. A registry-side compatibility alias for those versions is being handled separately.
- Stale docs pointing at `iii worker add iii-queue` (`docs/creating-workers/queues.mdx`, `skills/iii-getting-started/SKILL.md`, queue README install section) still need their own fix.
- Verified: `cargo check -p iii -p iii-worker` clean; `workers::config` (70), `workers::queue` (163), `builtin_functions_e2e` (7), `queue_integration` (12), `queue_configuration_e2e` (12) all pass plus the new regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `iii-queue` worker for asynchronous job processing with retries and dead-letter support.
  * Queue functionality can be explicitly enabled and configured with built-in defaults.
  * The worker is now included in alpha and standard release publishing.

* **Tests**
  * Added coverage verifying queue topic and dead-letter queue APIs return valid results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->