### PR TITLE
test(engine): cover both queue providers; fix builtin trigger attribution

### DIFF
--- a/engine/src/trigger.rs
+++ b/engine/src/trigger.rs
@@ -62,6 +62,13 @@ pub struct TriggerType {
     pub call_response_format: Option<Value>,
     pub registrator: Box<dyn TriggerRegistrator>,
     pub worker_id: Option<Uuid>,
+    /// Worker name that owns this trigger type when it was registered
+    /// in-process (`worker_id: None`) by a worker whose name differs from the
+    /// `KNOWN_TRIGGER_TYPE_PROVIDERS` entry. `durable:subscriber` maps to the
+    /// standalone `queue` worker there (install guidance), but the opt-in
+    /// `iii-queue` builtin registers the same type and must attribute to
+    /// itself in `engine::workers::info`.
+    pub owner_name: Option<String>,
 }
 
 impl TriggerType {
@@ -83,7 +90,13 @@ impl TriggerType {
             call_response_format,
             registrator,
             worker_id,
+            owner_name: None,
         }
+    }
+
+    pub fn with_owner_name(mut self, owner_name: impl Into<String>) -> Self {
+        self.owner_name = Some(owner_name.into());
+        self
     }
 
     pub fn with_trigger_request_format<T: schemars::JsonSchema>(mut self) -> Self {

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -592,6 +592,9 @@ impl EngineFunctionsWorker {
         {
             return name;
         }
+        if let Some(name) = tt.owner_name.as_deref() {
+            return name.to_string();
+        }
         if let Some(name) = known_trigger_type_provider(&tt.id) {
             return name.to_string();
         }
@@ -3265,6 +3268,73 @@ mod tests {
             }
             _ => panic!("expected success"),
         }
+    }
+
+    /// Both queue providers must attribute correctly: the opt-in `iii-queue`
+    /// builtin registers `durable:subscriber` in-process with an explicit
+    /// owner name, while the standalone `queue` worker registers it over a
+    /// WS connection (Uuid attribution). The static provider table remains
+    /// the fallback naming the standalone worker.
+    #[tokio::test]
+    async fn durable_subscriber_attribution_covers_both_queue_providers() {
+        let (engine, module) = setup_engine_and_module();
+
+        // In-process registration with owner_name (the iii-queue builtin).
+        let builtin_tt = crate::trigger::TriggerType::new(
+            "durable:subscriber",
+            "Queue core module",
+            Box::new(module.clone()),
+            None,
+        )
+        .with_owner_name("iii-queue");
+        assert_eq!(
+            module.owner_name_for_trigger_type(&builtin_tt),
+            "iii-queue",
+            "in-process owner_name must win over the static provider table"
+        );
+
+        // WS registration by a connected worker named `queue` (the standalone
+        // worker): Uuid attribution wins over both owner_name and the table.
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let conn = crate::worker_connections::WorkerConnection::new(tx);
+        let conn_id = conn.id;
+        engine.worker_registry.register_worker(conn);
+        engine.worker_registry.update_worker_metadata(
+            &conn_id,
+            "rust".to_string(),
+            Some("1.0.0".to_string()),
+            Some("queue".to_string()),
+            None,
+            Some("linux".to_string()),
+            None,
+            None,
+            None,
+        );
+        let ws_tt = crate::trigger::TriggerType::new(
+            "durable:subscriber",
+            "Queue core module",
+            Box::new(module.clone()),
+            Some(conn_id),
+        );
+        assert_eq!(
+            module.owner_name_for_trigger_type(&ws_tt),
+            "queue",
+            "WS-registered trigger types attribute to the connected worker"
+        );
+
+        // No owner_name, no worker_id: the table names the standalone worker
+        // (install guidance for the default path).
+        let bare_tt = crate::trigger::TriggerType::new(
+            "durable:subscriber",
+            "Queue core module",
+            Box::new(module.clone()),
+            None,
+        );
+        assert_eq!(
+            module.owner_name_for_trigger_type(&bare_tt),
+            "queue",
+            "table fallback must keep naming the standalone queue worker"
+        );
     }
 
     #[test]

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -1115,12 +1115,17 @@ impl Worker for QueueWorker {
         tracing::info!("Initializing QueueModule");
         self.config_snapshot().validate()?;
 
+        // Attribute the in-process registration to this worker by name: the
+        // static provider table maps `durable:subscriber` to the standalone
+        // `queue` worker (install guidance), which is not this deployment's
+        // provider when the opt-in builtin is active.
         let trigger_type = TriggerType::new(
             "durable:subscriber",
             "Queue core module",
             Box::new(self.clone()),
             None,
-        );
+        )
+        .with_owner_name("iii-queue");
 
         let _ = self.engine.register_trigger_type(trigger_type).await;
 

--- a/engine/tests/iii_queue_optin_registration.rs
+++ b/engine/tests/iii_queue_optin_registration.rs
@@ -1,12 +1,16 @@
-use serde_json::json;
+mod common;
 
-use iii::{EngineBuilder, engine::EngineTrait};
+use std::sync::Arc;
+use std::time::Duration;
 
-/// An explicit `iii-queue` worker entry (what `iii worker add iii-queue`
-/// writes into config.yaml) must boot the in-engine queue worker and register
-/// the caller-facing queue/DLQ functions.
-#[tokio::test]
-async fn explicit_iii_queue_entry_registers_queue_functions() {
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
+
+use iii::{EngineBuilder, engine::EngineTrait, trigger::Trigger};
+
+use common::queue_helpers::{enqueue_to_topic, register_payload_capturing_function};
+
+async fn boot_optin_iii_queue() -> Arc<iii::engine::Engine> {
     let builder = EngineBuilder::new()
         .add_worker("iii-engine-functions", None)
         .add_worker("iii-observability", None)
@@ -14,7 +18,15 @@ async fn explicit_iii_queue_entry_registers_queue_functions() {
         .build()
         .await
         .expect("engine build should succeed");
-    let engine = builder.engine();
+    builder.engine().clone()
+}
+
+/// An explicit `iii-queue` worker entry (what `iii worker add iii-queue`
+/// writes into config.yaml) must boot the in-engine queue worker and register
+/// the caller-facing queue/DLQ functions.
+#[tokio::test]
+async fn explicit_iii_queue_entry_registers_queue_functions() {
+    let engine = boot_optin_iii_queue().await;
 
     let result = engine
         .call("engine::queue::list_topics", json!({}))
@@ -29,4 +41,96 @@ async fn explicit_iii_queue_entry_registers_queue_functions() {
         .expect("engine::queue::dlq_topics should be registered and callable")
         .expect("dlq_topics should return a value");
     assert!(dlq.is_array(), "unexpected shape: {dlq:?}");
+}
+
+/// The opt-in builtin registers `durable:subscriber` in-process, so discovery
+/// must attribute the trigger type to `iii-queue` — not to the standalone
+/// `queue` worker that the static provider table names for install guidance.
+/// This is what the release publish pipeline reads (`engine::workers::info`)
+/// when building the iii-queue registry payload.
+#[tokio::test]
+async fn explicit_iii_queue_entry_attributes_durable_subscriber_to_itself() {
+    let engine = boot_optin_iii_queue().await;
+
+    let triggers = engine
+        .call("engine::triggers::list", json!({}))
+        .await
+        .expect("engine::triggers::list should be callable")
+        .expect("triggers::list should return a value");
+    let durable = triggers["triggers"]
+        .as_array()
+        .expect("triggers should be an array")
+        .iter()
+        .find(|t| t["id"] == "durable:subscriber")
+        .unwrap_or_else(|| panic!("durable:subscriber not registered: {triggers:?}"))
+        .clone();
+    assert_eq!(
+        durable["worker_name"], "iii-queue",
+        "durable:subscriber must attribute to the opt-in builtin"
+    );
+
+    let info = engine
+        .call("engine::workers::info", json!({"name": "iii-queue"}))
+        .await
+        .expect("engine::workers::info should be callable")
+        .expect("workers::info should return a value");
+    let type_ids: Vec<&str> = info["trigger_types"]
+        .as_array()
+        .expect("trigger_types should be an array")
+        .iter()
+        .filter_map(|t| t["id"].as_str())
+        .collect();
+    assert!(
+        type_ids.contains(&"durable:subscriber"),
+        "workers::info for iii-queue must roll up durable:subscriber, got {type_ids:?}"
+    );
+}
+
+/// Queue behavior must work as it did pre-retirement when the builtin is
+/// explicitly configured: a `durable:subscriber` trigger binds and messages
+/// published to its topic are delivered to the bound function.
+#[tokio::test]
+async fn explicit_iii_queue_entry_delivers_durable_subscriber_messages() {
+    let engine = boot_optin_iii_queue().await;
+
+    let captured: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+    register_payload_capturing_function(&engine, "test::optin_handler", captured.clone());
+
+    let topic = format!("optin-e2e-{}", uuid::Uuid::new_v4());
+    engine
+        .trigger_registry
+        .register_trigger(Trigger {
+            id: format!("trig-{}", uuid::Uuid::new_v4()),
+            trigger_type: "durable:subscriber".to_string(),
+            function_id: "test::optin_handler".to_string(),
+            config: json!({
+                "topic": &topic,
+                "queue_config": { "poll_interval_ms": 50 }
+            }),
+            worker_id: None,
+            metadata: None,
+        })
+        .await
+        .expect("durable:subscriber trigger should register against the opt-in builtin");
+
+    enqueue_to_topic(&engine, &topic, json!({"msg": "hello from iii-queue"}))
+        .await
+        .expect("publish to topic should succeed");
+
+    // Poll instead of a fixed sleep: consumer startup is asynchronous.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if !captured.lock().await.is_empty() {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "message was not delivered to the durable:subscriber handler within 5s"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    let payloads = captured.lock().await;
+    assert_eq!(payloads.len(), 1, "expected exactly one delivery");
+    assert_eq!(payloads[0]["msg"], "hello from iii-queue");
 }


### PR DESCRIPTION
## What

Follow-up to #1967 — coverage guaranteeing both queue providers keep working, plus the one attribution gap the restore left open:

- `TriggerType` gains an optional `owner_name` that in-process registrators can set; `owner_name_for_trigger_type` prefers worker-Uuid (WS workers), then `owner_name`, then the static provider table. Only the `iii-queue` builtin sets it.
- Unit test covering all three attribution paths for `durable:subscriber`: the in-process builtin (`iii-queue`), a WS-connected worker named `queue` (standalone), and the bare table fallback (still names `queue` for install guidance).
- Integration tests through the real opt-in boot path (`EngineBuilder` with an explicit `iii-queue` entry): queue/DLQ functions registered; `durable:subscriber` attributed to `iii-queue` in `engine::triggers::list` and rolled up by `engine::workers::info`; and a `durable:subscriber` trigger binds and delivers a published message end-to-end.

## Why

The `KNOWN_TRIGGER_TYPE_PROVIDERS` table maps `durable:subscriber` to the standalone `queue` worker — correct for install guidance, and deliberately not reverted. But the opt-in builtin registers the type in-process (`worker_id: None`), so it fell through to the table and was attributed to a worker that doesn't exist in that deployment: `engine::workers::info { name: "iii-queue" }` omitted the trigger type, and the restored release publish job would have shipped an `iii-queue` registry entry with an empty `triggers` list.

We support both names going forward: `queue` (standalone worker, default) and `iii-queue` (opt-in builtin) — this pins that contract with tests on both sides.

## Notes

- The missing-provider guidance path is untouched: `missing_durable_subscriber_points_to_standalone_queue_worker` still passes, pointing users at `iii worker add queue`.
- Verified: new integration suite (3 tests), `trigger`/`engine_fn` unit tests (115), `workers::queue` (163), `queue_integration` (2), `queue_e2e_happy_path` (12) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved attribution for `durable:subscriber` triggers, ensuring they are associated with the correct queue worker across registration methods.
  - Corrected trigger ownership details for in-process registrations.

- **New Features**
  - Enhanced opt-in queue registration for durable subscribers.
  - Added validation that messages published to subscribed topics are delivered successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->