### PR TITLE
fix: dx issues

### DIFF
--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -19,11 +19,21 @@ pub struct AddArgs {
     #[arg(value_name = "WORKER[@VERSION]|PATH", required = true, num_args = 1..)]
     pub worker_names: Vec<String>,
 
-    /// Discard the worker's config.yaml entry and recreate it from registry
-    /// defaults. Plain `add --force` would otherwise keep the entry. Only
-    /// takes effect together with --force on add.
+    /// Discard the worker's config.yaml entry and recreate it fresh
+    /// (dropping any hand-written config block). Plain `add --force` would
+    /// otherwise keep the entry. Only takes effect together with --force on
+    /// add.
     #[arg(long)]
     pub reset_config: bool,
+
+    /// Install through a RUNNING iii engine instead of editing the config
+    /// file in the current directory: connects to HOST[:PORT] (ex.
+    /// `localhost:49134`; port defaults to 49134, ws:// URLs also accepted)
+    /// and invokes its worker::add. The engine applies the add in ITS
+    /// project directory, so this works from any folder and with engines on
+    /// non-default ports.
+    #[arg(long, value_name = "HOST[:PORT]")]
+    pub host: Option<String>,
 }
 
 #[derive(Parser, Debug)]

--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -20,18 +20,19 @@ pub struct AddArgs {
     pub worker_names: Vec<String>,
 
     /// Discard the worker's config.yaml entry and recreate it fresh
-    /// (dropping any hand-written config block). Plain `add --force` would
-    /// otherwise keep the entry. Only takes effect together with --force on
-    /// add.
+    /// (dropping any hand-written config block), instead of keeping the
+    /// existing entry. With `add`, takes effect only together with --force;
+    /// `reinstall` applies force automatically.
     #[arg(long)]
     pub reset_config: bool,
 
     /// Install through a RUNNING iii engine instead of editing the config
     /// file in the current directory: connects to HOST[:PORT] (ex.
-    /// `localhost:49134`; port defaults to 49134, ws:// URLs also accepted)
-    /// and invokes its worker::add. The engine applies the add in ITS
-    /// project directory, so this works from any folder and with engines on
-    /// non-default ports.
+    /// `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are
+    /// also accepted and used as-is) and invokes its worker::add. The
+    /// engine applies the add in ITS project directory, so this works from
+    /// any folder and with engines on non-default ports. Local worker PATHs
+    /// resolve on the engine host.
     #[arg(long, value_name = "HOST[:PORT]")]
     pub host: Option<String>,
 }

--- a/crates/iii-worker/src/cli/config_file.rs
+++ b/crates/iii-worker/src/cli/config_file.rs
@@ -4,14 +4,40 @@
 // This software is patent protected. We welcome discussions - reach out at team@iii.dev
 // See LICENSE and PATENTS files for details.
 
-//! Helpers to read/append/remove worker entries from `config.yaml` while
-//! preserving existing formatting and comments.
+//! Helpers to read/append/remove worker entries from the project config
+//! file (`config.yaml` by default) while preserving existing formatting and
+//! comments.
 
 use regex::Regex;
 use std::path::Path;
 use std::sync::LazyLock;
 
 pub(crate) const CONFIG_FILE: &str = "config.yaml";
+
+/// Project config file this process reads and edits.
+///
+/// Resolution order:
+/// 1. `III_CONFIG_PATH` — set by the engine on every process it spawns
+///    (worker-ops daemon, sandbox daemon, `iii worker start` children) so
+///    they target the engine's ACTUAL config file. Without it, an engine
+///    started with `--config config.yml` (or from a different directory)
+///    and this code silently operate on two different files.
+/// 2. `./config.yaml` — the historical default for direct CLI use.
+pub(crate) fn config_path() -> std::path::PathBuf {
+    match std::env::var_os("III_CONFIG_PATH") {
+        Some(p) if !p.is_empty() => std::path::PathBuf::from(p),
+        _ => std::path::PathBuf::from(CONFIG_FILE),
+    }
+}
+
+/// File name of [`config_path`] for user-facing messages ("config.yaml"
+/// unless the engine handed us a custom name).
+pub fn config_display_name() -> String {
+    config_path()
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| CONFIG_FILE.to_string())
+}
 
 /// Resolve the engine's effective `iii-worker-manager` port from config.yaml.
 ///
@@ -29,7 +55,7 @@ pub(crate) const CONFIG_FILE: &str = "config.yaml";
 ///   uses `DEFAULT_PORT` engine-side too)
 /// - the entry has no `config.port` field, or the port is not a u16
 pub fn manager_port() -> u16 {
-    let path = Path::new(CONFIG_FILE);
+    let path = config_path();
     if !path.exists() {
         return super::app::DEFAULT_PORT;
     }
@@ -74,7 +100,7 @@ pub(crate) fn manager_port_from(content: &str) -> u16 {
 /// `upper_size_gib` knob — changing the size means regenerating the golden via
 /// `vendor/regen-golden.sh`.
 pub fn rootfs_mode() -> Option<String> {
-    let content = std::fs::read_to_string(Path::new(CONFIG_FILE)).ok()?;
+    let content = std::fs::read_to_string(config_path()).ok()?;
     rootfs_mode_from(&content)
 }
 
@@ -438,7 +464,7 @@ fn deep_merge(a: serde_json::Value, b: serde_json::Value) -> serde_json::Value {
 
 /// Returns `true` if `config.yaml` contains an entry for `name`.
 pub fn worker_exists(name: &str) -> bool {
-    let path = Path::new(CONFIG_FILE);
+    let path = config_path();
     if !path.exists() {
         return false;
     }
@@ -473,11 +499,11 @@ pub fn append_worker_with_path(
     config_yaml: Option<&str>,
 ) -> Result<(), String> {
     super::registry::validate_worker_name(name)?;
-    let path = Path::new(CONFIG_FILE);
+    let path = config_path();
 
     let mut content = if path.exists() {
-        std::fs::read_to_string(path)
-            .map_err(|e| format!("failed to read {}: {}", CONFIG_FILE, e))?
+        std::fs::read_to_string(&path)
+            .map_err(|e| format!("failed to read {}: {}", path.display(), e))?
     } else {
         String::new()
     };
@@ -491,7 +517,7 @@ pub fn append_worker_with_path(
                 let merged = merge_yaml_configs(incoming, &existing);
                 return append_to_content_with_fields(
                     &mut content,
-                    path,
+                    &path,
                     name,
                     None,
                     Some(worker_path),
@@ -500,7 +526,7 @@ pub fn append_worker_with_path(
             }
             return append_to_content_with_fields(
                 &mut content,
-                path,
+                &path,
                 name,
                 None,
                 Some(worker_path),
@@ -511,7 +537,7 @@ pub fn append_worker_with_path(
 
     append_to_content_with_fields(
         &mut content,
-        path,
+        &path,
         name,
         None,
         Some(worker_path),
@@ -521,7 +547,7 @@ pub fn append_worker_with_path(
 
 /// Returns the `worker_path:` value for a named worker in `config.yaml`, if present.
 pub fn get_worker_path(name: &str) -> Option<String> {
-    let path = Path::new(CONFIG_FILE);
+    let path = config_path();
     let content = std::fs::read_to_string(path).ok()?;
     extract_worker_path(&content, name)
 }
@@ -532,12 +558,12 @@ fn append_worker_impl(
     config_yaml: Option<&str>,
 ) -> Result<(), String> {
     super::registry::validate_worker_name(name)?;
-    let path = Path::new(CONFIG_FILE);
+    let path = config_path();
 
     // Read existing content or start from scratch.
     let mut content = if path.exists() {
-        std::fs::read_to_string(path)
-            .map_err(|e| format!("failed to read {}: {}", CONFIG_FILE, e))?
+        std::fs::read_to_string(&path)
+            .map_err(|e| format!("failed to read {}: {}", path.display(), e))?
     } else {
         String::new()
     };
@@ -553,15 +579,15 @@ fn append_worker_impl(
         if let Some(existing) = existing_config {
             if let Some(incoming) = config_yaml {
                 let merged = merge_yaml_configs(incoming, &existing);
-                return append_to_content(&mut content, path, name, image, Some(&merged));
+                return append_to_content(&mut content, &path, name, image, Some(&merged));
             }
             // No new config from registry — keep existing as-is.
-            return append_to_content(&mut content, path, name, image, Some(&existing));
+            return append_to_content(&mut content, &path, name, image, Some(&existing));
         }
         // Worker existed but had no config — use incoming.
     }
 
-    append_to_content(&mut content, path, name, image, config_yaml)
+    append_to_content(&mut content, &path, name, image, config_yaml)
 }
 
 /// Low-level: appends a worker entry to `content` and writes to `path`.
@@ -628,8 +654,8 @@ fn append_to_content_with_fields(
     new_content.push_str(&entry);
     new_content.push_str(suffix);
 
-    std::fs::write(path, &new_content)
-        .map_err(|e| format!("failed to write {}: {}", CONFIG_FILE, e))?;
+    std::fs::write(&path, &new_content)
+        .map_err(|e| format!("failed to write {}: {}", path.display(), e))?;
 
     *content = new_content;
 
@@ -638,7 +664,7 @@ fn append_to_content_with_fields(
 
 /// Returns the `image:` value for a named worker in `config.yaml`, if present.
 pub fn get_worker_image(name: &str) -> Option<String> {
-    let path = Path::new(CONFIG_FILE);
+    let path = config_path();
     let content = std::fs::read_to_string(path).ok()?;
     extract_image(&content, name)
 }
@@ -677,7 +703,7 @@ fn resolve_worker_type_from_content(content: &str, name: &str) -> ResolvedWorker
 /// practice; if they do, the bundle install wins and a re-add replaces it
 /// in place (`atomic_install`).
 pub fn resolve_worker_type(name: &str) -> ResolvedWorkerType {
-    let path = std::path::Path::new(CONFIG_FILE);
+    let path = config_path();
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
         Err(_) => return check_install_fallback(name),
@@ -841,7 +867,7 @@ fn expand_env_vars(yaml_content: &str) -> Result<String, String> {
 /// on a top-level `${X}`, iii-worker is never invoked — so the
 /// scoping divergence is invisible.
 pub fn get_worker_config_as_env(name: &str) -> std::collections::HashMap<String, String> {
-    let path = Path::new(CONFIG_FILE);
+    let path = config_path();
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
         Err(_) => return std::collections::HashMap::new(),
@@ -909,7 +935,7 @@ fn flatten_value_to_env(
 pub fn get_worker_start_info(
     name: &str,
 ) -> Option<(String, std::collections::HashMap<String, String>)> {
-    let path = Path::new(CONFIG_FILE);
+    let path = config_path();
     let content = std::fs::read_to_string(path).ok()?;
 
     // Extract image
@@ -959,29 +985,29 @@ pub fn get_worker_start_info(
 
 /// Removes the named worker entry from `config.yaml`.
 pub fn remove_worker(name: &str) -> Result<(), String> {
-    let path = Path::new(CONFIG_FILE);
+    let path = config_path();
     if !path.exists() {
-        return Err(format!("{} not found", CONFIG_FILE));
+        return Err(format!("{} not found", path.display()));
     }
 
-    let content = std::fs::read_to_string(path)
-        .map_err(|e| format!("failed to read {}: {}", CONFIG_FILE, e))?;
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| format!("failed to read {}: {}", path.display(), e))?;
 
     if !worker_exists_in(&content, name) {
-        return Err(format!("Worker '{}' not found in {}", name, CONFIG_FILE));
+        return Err(format!("Worker '{}' not found in {}", name, path.display()));
     }
 
     let new_content = remove_worker_from(&content, name);
 
-    std::fs::write(path, &new_content)
-        .map_err(|e| format!("failed to write {}: {}", CONFIG_FILE, e))?;
+    std::fs::write(&path, &new_content)
+        .map_err(|e| format!("failed to write {}: {}", path.display(), e))?;
 
     Ok(())
 }
 
 /// Returns all worker names listed under `workers:` in `config.yaml`.
 pub fn list_worker_names() -> Vec<String> {
-    let path = Path::new(CONFIG_FILE);
+    let path = config_path();
     if !path.exists() {
         return Vec::new();
     }
@@ -995,15 +1021,15 @@ pub fn list_worker_names() -> Vec<String> {
 
 /// Returns worker names from `config.yaml`, surfacing read/parse failures.
 pub fn list_worker_names_result() -> Result<Vec<String>, String> {
-    let path = Path::new(CONFIG_FILE);
+    let path = config_path();
     if !path.exists() {
         return Ok(Vec::new());
     }
 
-    let content = std::fs::read_to_string(path)
-        .map_err(|e| format!("failed to read {}: {}", CONFIG_FILE, e))?;
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| format!("failed to read {}: {}", path.display(), e))?;
     serde_yaml::from_str::<serde_yaml::Value>(&content)
-        .map_err(|e| format!("failed to parse {}: {}", CONFIG_FILE, e))?;
+        .map_err(|e| format!("failed to parse {}: {}", path.display(), e))?;
 
     Ok(list_worker_names_from_content(&content))
 }
@@ -1410,6 +1436,40 @@ mod tests {
     }
 
     #[test]
+    fn test_append_into_engine_starter_config_shape() {
+        // The engine's missing-file bootstrap (EngineConfig::starter_config_yaml)
+        // writes header comments + an empty `workers: []` list. The first
+        // `iii worker add` must turn that into a real list without breaking
+        // the YAML or dropping the comments.
+        let mut content = "\
+# iii engine configuration.
+# Add workers with `iii worker add <name>`; a running engine reloads on save.
+# Configure workers at runtime through the configuration worker (configuration::set).
+workers: []
+"
+        .to_string();
+        let path = std::path::Path::new("/tmp/test-starter-config-shape.yaml");
+
+        append_to_content_with_fields(&mut content, path, "iii-http", None, None, None).unwrap();
+
+        assert!(content.starts_with("# iii engine configuration."));
+        assert!(!content.contains("workers: []"));
+        let parsed: serde_yaml::Value =
+            serde_yaml::from_str(&content).expect("output should be valid YAML");
+        let workers = parsed
+            .get("workers")
+            .and_then(|w| w.as_sequence())
+            .expect("`workers` should be a sequence");
+        assert_eq!(workers.len(), 1);
+        assert_eq!(
+            workers[0].get("name").and_then(|n| n.as_str()),
+            Some("iii-http")
+        );
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn test_normalize_empty_workers_list_strips_inline_marker() {
         assert_eq!(normalize_empty_workers_list("workers: []\n"), "workers:\n");
         assert_eq!(normalize_empty_workers_list("workers: []"), "workers:");
@@ -1748,6 +1808,82 @@ workers:
         let result = f();
         std::env::set_current_dir(&prior).expect("restore cwd");
         result
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // III_CONFIG_PATH — the engine exports it to spawned processes so this
+    // module targets the engine's actual config file, not ./config.yaml.
+    // These tests hold BOTH the crate-wide TEST_HOME_LOCK (other modules'
+    // config-reading tests serialize on it) and this module's ENV_LOCK,
+    // because the env override redirects every reader in the process.
+    // ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn config_path_defaults_to_config_yaml() {
+        let _home = crate::cli::test_support::lock_home();
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::unset("III_CONFIG_PATH");
+        assert_eq!(config_path(), std::path::PathBuf::from("config.yaml"));
+        assert_eq!(config_display_name(), "config.yaml");
+    }
+
+    #[test]
+    fn config_path_honors_env_override() {
+        let _home = crate::cli::test_support::lock_home();
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::set("III_CONFIG_PATH", "/srv/proj/config.yml");
+        assert_eq!(
+            config_path(),
+            std::path::PathBuf::from("/srv/proj/config.yml")
+        );
+        assert_eq!(config_display_name(), "config.yml");
+    }
+
+    #[test]
+    fn config_path_ignores_empty_env_override() {
+        let _home = crate::cli::test_support::lock_home();
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::set("III_CONFIG_PATH", "");
+        assert_eq!(config_path(), std::path::PathBuf::from("config.yaml"));
+    }
+
+    #[test]
+    fn worker_ops_follow_env_override_to_a_custom_file_name() {
+        let _cwd = CWD_LOCK.lock().unwrap();
+        let _home = crate::cli::test_support::lock_home();
+        let _env_lock = ENV_LOCK.lock().unwrap();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let custom = dir.path().join("config.yml");
+        std::fs::write(
+            &custom,
+            "workers:\n  - name: iii-worker-manager\n    config:\n      port: 50123\n",
+        )
+        .expect("write config.yml");
+        let _g = EnvGuard::set("III_CONFIG_PATH", custom.to_str().unwrap());
+
+        // Reads resolve against the override…
+        assert!(worker_exists("iii-worker-manager"));
+        assert_eq!(manager_port(), 50123);
+        assert_eq!(list_worker_names(), vec!["iii-worker-manager".to_string()]);
+
+        // …and so do writes: append + remove mutate config.yml, and no
+        // config.yaml appears anywhere.
+        append_worker("added-via-env", None).expect("append");
+        let content = std::fs::read_to_string(&custom).expect("read config.yml");
+        assert!(content.contains("- name: added-via-env"));
+        remove_worker("added-via-env").expect("remove");
+        let content = std::fs::read_to_string(&custom).expect("read config.yml");
+        assert!(!content.contains("added-via-env"));
+        assert!(
+            !dir.path().join("config.yaml").exists(),
+            "no config.yaml must be created when III_CONFIG_PATH points elsewhere"
+        );
+
+        // ProjectCtx (op outcome reporting) follows the same override, so
+        // `worker::add` outcomes name the file that was actually edited.
+        let ctx = crate::core::ProjectCtx::open_unlocked(dir.path().to_path_buf());
+        assert_eq!(ctx.config_path(), custom);
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -714,20 +714,13 @@ pub async fn handle_local_add(
         return 1;
     }
 
-    // 6. Extract default config from the single manifest doc read in step 3a
-    //     (no re-read — also closes the read-then-write window for `config:`).
-    let config_yaml = manifest_doc
-        .as_ref()
-        .and_then(|doc| doc.get("config").cloned())
-        .and_then(|v| serde_yaml::to_string(&v).ok());
-
-    // 7. Append to config.yaml with worker_path
+    // 6. Append to config.yaml with worker_path. Bare entry — no `config:`
+    //    block: workers own their configuration through the configuration
+    //    worker, so the manifest's `config:` defaults are not copied into
+    //    the project config file (a hand-written block there still wins via
+    //    the append merge).
     let abs_path_str = project_path.to_string_lossy();
-    if let Err(e) = super::config_file::append_worker_with_path(
-        &worker_name,
-        &abs_path_str,
-        config_yaml.as_deref(),
-    ) {
+    if let Err(e) = super::config_file::append_worker_with_path(&worker_name, &abs_path_str, None) {
         eprintln!(
             "{} Failed to update config.yaml: {}\n  \
              Fix: check that config.yaml is writable and valid YAML.",

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -173,9 +173,11 @@ pub async fn handle_binary_add(
         }
     }
 
-    let config_yaml = binary_config_yaml(&response.config);
-
-    if let Err(e) = super::config_file::append_worker(worker_name, config_yaml.as_deref()) {
+    // Bare `- name:` entry — no `config:` block. Workers receive their
+    // configuration through the configuration worker (Rust/worker defaults
+    // seed the store on first boot); a copied registry default here would
+    // only be re-imported on the next engine restart and then stripped.
+    if let Err(e) = super::config_file::append_worker(worker_name, None) {
         eprintln!("{} {}", "error:".red(), e);
         return 1;
     }
@@ -417,33 +419,6 @@ pub async fn handle_bundle_add(
         eprintln!("        {} {}", "✓".green(), worker_name.bold());
     }
     0
-}
-
-fn binary_config_yaml(config: &serde_json::Value) -> Option<String> {
-    let config = match config {
-        serde_json::Value::Null => return None,
-        serde_json::Value::Object(map) if map.is_empty() => return None,
-        serde_json::Value::Object(map) => map.get("config").unwrap_or(config),
-        _ => config,
-    };
-
-    match config {
-        serde_json::Value::Null => None,
-        serde_json::Value::Object(map) if map.is_empty() => None,
-        _ => {
-            let yaml = serde_yaml::to_string(config).unwrap_or_default();
-            let yaml = yaml
-                .strip_prefix("---\n")
-                .unwrap_or(&yaml)
-                .trim_end()
-                .to_string();
-            if yaml.is_empty() || yaml == "{}" || yaml == "null" {
-                None
-            } else {
-                Some(yaml)
-            }
-        }
-    }
 }
 
 pub async fn handle_managed_add_many(worker_names: &[String], wait: bool) -> i32 {
@@ -1292,27 +1267,31 @@ struct ConfigYamlSnapshot {
 
 impl ConfigYamlSnapshot {
     fn capture() -> Result<Self, String> {
-        let path = std::path::Path::new("config.yaml");
+        let path = super::config_file::config_path();
         if !path.exists() {
             return Ok(Self { content: None });
         }
 
-        let content = std::fs::read_to_string(path)
-            .map_err(|e| format!("failed to read config.yaml before graph install: {e}"))?;
+        let content = std::fs::read_to_string(&path).map_err(|e| {
+            format!(
+                "failed to read {} before graph install: {e}",
+                path.display()
+            )
+        })?;
         Ok(Self {
             content: Some(content),
         })
     }
 
     fn restore(&self) -> Result<(), String> {
-        let path = std::path::Path::new("config.yaml");
+        let path = super::config_file::config_path();
         match &self.content {
-            Some(content) => std::fs::write(path, content)
-                .map_err(|e| format!("failed to restore config.yaml: {e}")),
-            None => match std::fs::remove_file(path) {
+            Some(content) => std::fs::write(&path, content)
+                .map_err(|e| format!("failed to restore {}: {e}", path.display())),
+            None => match std::fs::remove_file(&path) {
                 Ok(()) => Ok(()),
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-                Err(e) => Err(format!("failed to remove config.yaml: {e}")),
+                Err(e) => Err(format!("failed to remove {}: {e}", path.display())),
             },
         }
     }
@@ -1497,11 +1476,11 @@ async fn handle_resolved_graph_add(graph: &ResolvedWorkerGraph, brief: bool) -> 
             "engine" => {
                 // Engine workers are baked into the iii binary — nothing to
                 // download. Telemetry still fires for them below, alongside
-                // every other resolved worker type.
-                let config_yaml = binary_config_yaml(&node.config);
-                if let Err(e) =
-                    super::config_file::append_worker(&node.name, config_yaml.as_deref())
-                {
+                // every other resolved worker type. Bare `- name:` entry:
+                // workers own their configuration through the configuration
+                // worker, so registry config defaults are not copied into
+                // the project config file.
+                if let Err(e) = super::config_file::append_worker(&node.name, None) {
                     eprintln!("{} {}", "error:".red(), e);
                     config_snapshot.restore_after_failure();
                     return 1;
@@ -1838,11 +1817,18 @@ pub async fn handle_managed_add(
     if let Some(default_yaml) = get_builtin_default(&name) {
         let builtin_version = resolve_builtin_version(version.as_deref());
         let already_exists = super::config_file::worker_exists(&name);
-        if let Err(e) = persist_engine_worker_config_and_lock(
-            &name,
-            builtin_version,
-            Some(default_yaml.as_str()),
-        ) {
+        // Bare `- name:` entry: builtins boot with their Rust defaults and
+        // own their configuration through the configuration worker, so the
+        // add must not copy a default `config:` block into the project
+        // config file (it would only be re-imported on the next engine
+        // restart). iii-sandbox is the exception — its daemon consumes
+        // `config:` directly at spawn and fails closed without it, and the
+        // image allowlist is an operator security surface that belongs in
+        // the file.
+        let config_yaml = (name == "iii-sandbox").then_some(default_yaml);
+        if let Err(e) =
+            persist_engine_worker_config_and_lock(&name, builtin_version, config_yaml.as_deref())
+        {
             eprintln!("{} {}", "error:".red(), e);
             return 1;
         }
@@ -1855,17 +1841,17 @@ pub async fn handle_managed_add(
         } else {
             if already_exists {
                 eprintln!(
-                    "\n  {} Worker {} updated in {} (merged with builtin defaults)",
+                    "\n  {} Worker {} updated in {}",
                     "✓".green(),
                     name.bold(),
-                    "config.yaml".dimmed(),
+                    super::config_file::config_display_name().dimmed(),
                 );
             } else {
                 eprintln!(
                     "\n  {} Worker {} added to {}",
                     "✓".green(),
                     name.bold(),
-                    "config.yaml".dimmed(),
+                    super::config_file::config_display_name().dimmed(),
                 );
             }
 
@@ -2045,42 +2031,12 @@ async fn handle_oci_pull_and_add(name: &str, image_ref: &str, brief: bool) -> i3
         }
     }
 
-    // Extract OCI env vars from the pulled image rootfs and write as config:
-    let rootfs_dir = image_cache_dir(image_ref);
-    let oci_env = super::worker_manager::oci::read_oci_env(&rootfs_dir);
-    let config_yaml = if oci_env.is_empty() {
-        None
-    } else {
-        // Filter out generic system env vars (PATH, HOME, etc.)
-        let filtered: Vec<_> = oci_env
-            .iter()
-            .filter(|(k, _)| !matches!(k.as_str(), "PATH" | "HOME" | "HOSTNAME" | "LANG" | "TERM"))
-            .collect();
-        if filtered.is_empty() {
-            None
-        } else {
-            let config_map: serde_json::Map<String, serde_json::Value> = filtered
-                .iter()
-                .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
-                .collect();
-            let yaml_str =
-                serde_yaml::to_string(&serde_json::Value::Object(config_map)).unwrap_or_default();
-            // serde_yaml adds a leading `---\n`, strip it for embedding
-            let yaml_str = yaml_str
-                .strip_prefix("---\n")
-                .unwrap_or(&yaml_str)
-                .trim_end();
-            if yaml_str.is_empty() {
-                None
-            } else {
-                Some(yaml_str.to_string())
-            }
-        }
-    };
-
-    if let Err(e) =
-        super::config_file::append_worker_with_image(name, image_ref, config_yaml.as_deref())
-    {
+    // Bare `name:` + `image:` entry — no `config:` block. The image's own
+    // env vars are re-read from the cached OCI config at every boot
+    // (`worker_manager/libkrun.rs`), and user-supplied config flows through
+    // the configuration worker; copying the image env here only froze it
+    // into the project config file.
+    if let Err(e) = super::config_file::append_worker_with_image(name, image_ref, None) {
         eprintln!("{} Failed to update config.yaml: {}", "error:".red(), e);
         return 1;
     }
@@ -3408,11 +3364,14 @@ async fn wait_for_ready(worker_name: &str, port: u16) {
             eprintln!(
                 "  {} not ready after {:.0}s.\n  \
                  Keep watching: iii worker status {}\n  \
-                 Check logs:    iii worker logs {} -f",
+                 Check logs:    iii worker logs {} -f\n  \
+                 Engine running in a different directory or port? Target it \
+                 directly: iii worker add {} --host <host:port>",
                 "⚠".yellow(),
                 elapsed.as_secs_f64(),
                 worker_name,
-                worker_name
+                worker_name,
+                worker_name,
             );
         }
     }
@@ -4042,7 +4001,6 @@ pub async fn handle_managed_logs(worker_name: &str, follow: bool) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
     use std::sync::Mutex;
 
     static CWD_LOCK: Mutex<()> = Mutex::new(());
@@ -4088,11 +4046,6 @@ mod tests {
         std::env::set_current_dir(&dir_path).unwrap();
         let _cwd_guard = CwdGuard(original);
         f(dir_path);
-    }
-
-    #[test]
-    fn binary_config_yaml_omits_empty_registry_config() {
-        assert_eq!(binary_config_yaml(&serde_json::json!({})), None);
     }
 
     #[test]
@@ -4149,17 +4102,6 @@ mod tests {
             restore.rollback();
             WorkerActivationLock::acquire(name).expect("acquire after rollback must succeed");
         });
-    }
-
-    #[test]
-    fn binary_config_yaml_returns_none_for_null_json() {
-        assert_eq!(binary_config_yaml(&serde_json::Value::Null), None);
-    }
-
-    #[test]
-    fn binary_config_yaml_returns_none_for_inner_null() {
-        let wrapped = serde_json::json!({ "config": null });
-        assert_eq!(binary_config_yaml(&wrapped), None);
     }
 
     use crate::cli::lockfile as cli_lockfile;
@@ -5994,58 +5936,6 @@ dependencies:
             assert_eq!(std::fs::read_to_string("config.yaml").unwrap(), config);
         })
         .await;
-    }
-
-    #[test]
-    fn binary_config_yaml_extracts_wrapped_registry_config() {
-        let config = serde_json::json!({
-            "name": "image-resize",
-            "config": {
-                "width": 200,
-                "strategy": "scale-to-fit"
-            }
-        });
-
-        let yaml = binary_config_yaml(&config).expect("wrapped config should render");
-
-        assert!(yaml.contains("width: 200"));
-        assert!(yaml.contains("strategy: scale-to-fit"));
-        assert!(!yaml.contains("name: image-resize"));
-    }
-
-    #[test]
-    fn binary_config_yaml_accepts_plain_registry_config() {
-        let config = serde_json::json!({
-            "width": 200,
-            "strategy": "scale-to-fit"
-        });
-
-        let yaml = binary_config_yaml(&config).expect("plain config should render");
-
-        assert!(yaml.contains("width: 200"));
-        assert!(yaml.contains("strategy: scale-to-fit"));
-    }
-
-    #[tokio::test]
-    async fn read_new_bytes_picks_up_appended_content() {
-        let dir = tempfile::tempdir().unwrap();
-        let log = dir.path().join("test.log");
-        std::fs::write(&log, "line1\nline2\n").unwrap();
-
-        let initial_len = file_len(&log);
-        assert_eq!(initial_len, 12); // "line1\nline2\n"
-
-        // No new bytes → offset unchanged
-        let offset = read_new_bytes(&log, initial_len, false).await;
-        assert_eq!(offset, initial_len);
-
-        // Append new content
-        let mut f = std::fs::OpenOptions::new().append(true).open(&log).unwrap();
-        write!(f, "line3\nline4\n").unwrap();
-        drop(f);
-
-        let offset = read_new_bytes(&log, initial_len, false).await;
-        assert_eq!(offset, file_len(&log));
     }
 
     #[tokio::test]

--- a/crates/iii-worker/src/cli/mod.rs
+++ b/crates/iii-worker/src/cli/mod.rs
@@ -24,6 +24,7 @@ pub mod overlay;
 pub mod pidfile;
 pub mod project;
 pub mod registry;
+pub mod remote_ops;
 pub mod rootfs;
 pub mod rootfs_cache;
 pub mod sandbox;

--- a/crates/iii-worker/src/cli/remote_ops.rs
+++ b/crates/iii-worker/src/cli/remote_ops.rs
@@ -87,6 +87,34 @@ fn probe_authority(url: &str) -> Option<String> {
     (has_port && !auth.is_empty()).then(|| auth.to_string())
 }
 
+/// True when the `--host` value targets this machine (localhost / 127.x /
+/// ::1). Gates the client-side cwd-absolutization of local worker paths:
+/// `WorkerSource::Local` paths resolve on the ENGINE host by contract (see
+/// the schema on `core::types::WorkerSource`), so rewriting them against
+/// the CLI's cwd is only correct when both are the same machine — the
+/// engine-in-another-directory case `--host` primarily exists for.
+/// Unparseable values return false (`handle_remote_add` rejects them with
+/// a real error before any path matters).
+pub fn host_is_loopback(host: &str) -> bool {
+    let Ok(url) = host_to_ws_url(host) else {
+        return false;
+    };
+    let Some(rest) = url.split_once("://").map(|(_, r)| r) else {
+        return false;
+    };
+    let auth = rest.split(['/', '?']).next().unwrap_or(rest);
+    // Strip the port: bracketed IPv6 keeps everything inside `[...]`,
+    // otherwise drop the last `:segment`.
+    let host_part = if let Some(inner) = auth.strip_prefix('[') {
+        inner.split_once(']').map(|(h, _)| h).unwrap_or(inner)
+    } else {
+        auth.rsplit_once(':').map(|(h, _)| h).unwrap_or(auth)
+    };
+    host_part.eq_ignore_ascii_case("localhost")
+        || host_part.starts_with("127.")
+        || host_part == "::1"
+}
+
 /// Fail fast when nothing listens at the target: without this, a wrong
 /// `--host` sits silent until the trigger timeout while the SDK retries the
 /// connection in the background — exactly the hang this flag exists to fix.
@@ -301,6 +329,30 @@ mod tests {
         assert!(host_to_ws_url(":49134").is_err());
         assert!(host_to_ws_url("http://engine:49134").is_err());
         assert!(host_to_ws_url("[::1").is_err());
+    }
+
+    #[test]
+    fn host_is_loopback_matches_local_targets() {
+        assert!(host_is_loopback("localhost"));
+        assert!(host_is_loopback("LOCALHOST:49134"));
+        assert!(host_is_loopback("127.0.0.1"));
+        assert!(host_is_loopback("127.1.2.3:5000"));
+        assert!(host_is_loopback("[::1]"));
+        assert!(host_is_loopback("[::1]:49134"));
+        assert!(host_is_loopback("ws://localhost:49134"));
+        assert!(host_is_loopback("ws://127.0.0.1"));
+    }
+
+    #[test]
+    fn host_is_loopback_rejects_remote_and_invalid_targets() {
+        assert!(!host_is_loopback("engine.internal"));
+        assert!(!host_is_loopback("10.0.0.7:49134"));
+        assert!(!host_is_loopback("wss://engine.example.com"));
+        assert!(!host_is_loopback("ws://[2001:db8::1]:49134"));
+        // Unparseable values are not loopback; handle_remote_add rejects
+        // them with a real error before any path handling matters.
+        assert!(!host_is_loopback(""));
+        assert!(!host_is_loopback("localhost:notaport"));
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/remote_ops.rs
+++ b/crates/iii-worker/src/cli/remote_ops.rs
@@ -1,0 +1,339 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! `iii worker add --host <engine>`: route the add through a RUNNING iii
+//! engine's `worker::add` trigger (served by its iii-worker-ops daemon)
+//! instead of editing a config file relative to the CLI's cwd.
+//!
+//! The engine host applies the op against ITS project — config file,
+//! artifacts, locks — so the CLI can run from any directory (or machine)
+//! that can reach the engine. Without `--host`, `iii worker add` edits the
+//! config file in the current directory and only a same-directory engine
+//! picks the change up.
+
+use colored::Colorize;
+
+use crate::core::{AddOptions, AddOutcome};
+
+/// Turn a `--host` value into an engine WebSocket URL.
+///
+/// Accepted shapes: `host`, `host:port`, `[v6addr]`, `[v6addr]:port`, and
+/// full `ws://` / `wss://` URLs (passed through untouched). A missing port
+/// defaults to the engine's default WS port.
+pub fn host_to_ws_url(host: &str) -> Result<String, String> {
+    let trimmed = host.trim();
+    if trimmed.is_empty() {
+        return Err("--host cannot be empty".to_string());
+    }
+    if trimmed.starts_with("ws://") || trimmed.starts_with("wss://") {
+        return Ok(trimmed.to_string());
+    }
+    if trimmed.contains("://") {
+        return Err(format!(
+            "unsupported scheme in --host '{trimmed}' (use host[:port], ws:// or wss://)"
+        ));
+    }
+
+    // Bracketed IPv6: `[::1]` or `[::1]:49134`.
+    if let Some(rest) = trimmed.strip_prefix('[') {
+        let Some((addr, tail)) = rest.split_once(']') else {
+            return Err(format!("unclosed '[' in --host '{trimmed}'"));
+        };
+        if addr.is_empty() {
+            return Err(format!("empty IPv6 address in --host '{trimmed}'"));
+        }
+        let port = match tail.strip_prefix(':') {
+            Some(p) => parse_port(p, trimmed)?,
+            None if tail.is_empty() => super::app::DEFAULT_PORT,
+            _ => return Err(format!("invalid --host '{trimmed}'")),
+        };
+        return Ok(format!("ws://[{addr}]:{port}"));
+    }
+
+    match trimmed.rsplit_once(':') {
+        Some((h, p)) => {
+            if h.is_empty() {
+                return Err(format!("missing host in --host '{trimmed}'"));
+            }
+            if h.contains(':') {
+                return Err(format!("IPv6 addresses need brackets: --host '[{h}]:{p}'"));
+            }
+            let port = parse_port(p, trimmed)?;
+            Ok(format!("ws://{h}:{port}"))
+        }
+        None => Ok(format!("ws://{}:{}", trimmed, super::app::DEFAULT_PORT)),
+    }
+}
+
+fn parse_port(p: &str, host: &str) -> Result<u16, String> {
+    p.parse::<u16>()
+        .map_err(|_| format!("invalid port '{p}' in --host '{host}'"))
+}
+
+/// `host:port` authority of a ws/wss URL, for the TCP reachability probe.
+/// `None` when the URL has no explicit port (full-URL passthrough) — the
+/// probe is skipped and the trigger timeout is the backstop.
+fn probe_authority(url: &str) -> Option<String> {
+    let rest = url.split_once("://")?.1;
+    let auth = rest.split(['/', '?']).next().unwrap_or(rest);
+    let has_port = if let Some(bracket_end) = auth.rfind(']') {
+        auth[bracket_end..].contains(':')
+    } else {
+        auth.contains(':')
+    };
+    (has_port && !auth.is_empty()).then(|| auth.to_string())
+}
+
+/// Fail fast when nothing listens at the target: without this, a wrong
+/// `--host` sits silent until the trigger timeout while the SDK retries the
+/// connection in the background — exactly the hang this flag exists to fix.
+async fn check_engine_reachable(url: &str) -> Result<(), String> {
+    let Some(authority) = probe_authority(url) else {
+        return Ok(());
+    };
+    let connect = tokio::net::TcpStream::connect(authority.clone());
+    match tokio::time::timeout(std::time::Duration::from_secs(5), connect).await {
+        Ok(Ok(_)) => Ok(()),
+        Ok(Err(e)) => Err(format!("cannot reach an iii engine at {url}: {e}")),
+        Err(_) => Err(format!(
+            "cannot reach an iii engine at {url}: connect timed out"
+        )),
+    }
+}
+
+/// Human-readable message from a failed `worker::*` trigger. The daemon
+/// packs a `{ type, code, message, details }` envelope into
+/// `Error::Remote.message`; prefer its `message` field over raw JSON.
+fn remote_error_message(e: &iii_sdk::Error) -> String {
+    match e {
+        iii_sdk::Error::Remote { code, message, .. } => {
+            let human = serde_json::from_str::<serde_json::Value>(message)
+                .ok()
+                .and_then(|v| {
+                    v.get("message")
+                        .and_then(|m| m.as_str())
+                        .map(|m| m.to_string())
+                })
+                .unwrap_or_else(|| message.clone());
+            format!("[{code}] {human}")
+        }
+        iii_sdk::Error::Timeout => {
+            "engine call timed out — the install may still be running server-side; \
+             poll worker::status before retrying"
+                .to_string()
+        }
+        other => other.to_string(),
+    }
+}
+
+/// Install workers through the engine at `host`. `adds` pairs the
+/// user-facing label (the argv token) with the fully-built options shipped
+/// to `worker::add`. Returns a process exit code.
+pub async fn handle_remote_add(host: &str, adds: Vec<(String, AddOptions)>) -> i32 {
+    let url = match host_to_ws_url(host) {
+        Ok(url) => url,
+        Err(e) => {
+            eprintln!("{} {}", "error:".red(), e);
+            return 2;
+        }
+    };
+
+    if let Err(e) = check_engine_reachable(&url).await {
+        eprintln!(
+            "{} {}\n  Start the engine there first (`iii`), or fix --host.",
+            "error:".red(),
+            e
+        );
+        return 1;
+    }
+
+    let iii = iii_sdk::register_worker(
+        &url,
+        iii_sdk::InitOptions {
+            // Attributable in the engine console instead of an anonymous
+            // `<hostname>:<pid>` connection.
+            metadata: Some(iii_sdk::runtime::WorkerMetadata {
+                name: "iii-cli".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    );
+
+    // Keep the client-side deadline aligned with the daemon's advertised
+    // worker::add budget (downloads + optional 120s ready-wait).
+    let (timeout_ms, _) = super::worker_manager_daemon::op_metadata("worker::add");
+
+    let total = adds.len();
+    let mut fail_count = 0usize;
+    for (i, (label, opts)) in adds.into_iter().enumerate() {
+        if total > 1 {
+            eprintln!("  [{}/{}] Adding {}...", i + 1, total, label.bold());
+        }
+        let waited = opts.wait;
+        let payload = match serde_json::to_value(&opts) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!(
+                    "{} cannot encode add request for '{label}': {e}",
+                    "error:".red()
+                );
+                fail_count += 1;
+                continue;
+            }
+        };
+
+        let spinner = super::spinner::Spinner::start(format!("Installing {label} via {url}..."));
+        let result = iii
+            .trigger(iii_sdk::protocol::TriggerRequest {
+                function_id: "worker::add".to_string(),
+                payload,
+                action: None,
+                timeout_ms: Some(timeout_ms),
+            })
+            .await;
+
+        match result {
+            Ok(value) => match serde_json::from_value::<AddOutcome>(value) {
+                Ok(outcome) => {
+                    let version = outcome
+                        .version
+                        .as_deref()
+                        .map(|v| format!(" v{v}"))
+                        .unwrap_or_default();
+                    spinner.finish_ok(format!(
+                        "{}{} installed via {} (engine config: {})",
+                        outcome.name.bold(),
+                        version,
+                        url,
+                        outcome.config_path.display(),
+                    ));
+                    if !waited {
+                        eprintln!(
+                            "  boots in the background — poll worker::status {{\"name\":\"{}\"}} on the engine",
+                            outcome.name
+                        );
+                    }
+                }
+                Err(e) => {
+                    // The op succeeded server-side; only the outcome decode
+                    // failed (likely a version skew). Say so instead of
+                    // claiming a failed install.
+                    spinner.finish_ok(format!(
+                        "{} installed via {} (unrecognized outcome shape: {e})",
+                        label.bold(),
+                        url,
+                    ));
+                }
+            },
+            Err(e) => {
+                let msg = remote_error_message(&e);
+                spinner.finish_err(format!("{label}: {msg}"));
+                if msg.contains("not found") && msg.contains("worker::add") {
+                    eprintln!(
+                        "  The engine at {url} does not expose worker::add — its \
+                         iii-worker-ops daemon isn't running (older engine, or \
+                         IIIWORKER_DISABLE_BUILTIN_DAEMONS set)."
+                    );
+                }
+                fail_count += 1;
+            }
+        }
+    }
+
+    iii.shutdown_async().await;
+    if fail_count == 0 { 0 } else { 1 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_host_gets_default_port() {
+        assert_eq!(
+            host_to_ws_url("localhost").unwrap(),
+            format!("ws://localhost:{}", crate::cli::app::DEFAULT_PORT)
+        );
+    }
+
+    #[test]
+    fn host_port_passes_through() {
+        assert_eq!(
+            host_to_ws_url("localhost:49134").unwrap(),
+            "ws://localhost:49134"
+        );
+        assert_eq!(
+            host_to_ws_url("10.0.0.7:5000").unwrap(),
+            "ws://10.0.0.7:5000"
+        );
+    }
+
+    #[test]
+    fn full_ws_urls_pass_through_untouched() {
+        assert_eq!(
+            host_to_ws_url("ws://engine.internal:49134").unwrap(),
+            "ws://engine.internal:49134"
+        );
+        assert_eq!(
+            host_to_ws_url("wss://engine.example.com").unwrap(),
+            "wss://engine.example.com"
+        );
+    }
+
+    #[test]
+    fn ipv6_hosts_require_and_accept_brackets() {
+        assert_eq!(host_to_ws_url("[::1]").unwrap(), {
+            format!("ws://[::1]:{}", crate::cli::app::DEFAULT_PORT)
+        });
+        assert_eq!(host_to_ws_url("[::1]:5000").unwrap(), "ws://[::1]:5000");
+        assert!(host_to_ws_url("::1").is_err());
+    }
+
+    #[test]
+    fn invalid_hosts_are_rejected() {
+        assert!(host_to_ws_url("").is_err());
+        assert!(host_to_ws_url("localhost:notaport").is_err());
+        assert!(host_to_ws_url("localhost:70000").is_err());
+        assert!(host_to_ws_url(":49134").is_err());
+        assert!(host_to_ws_url("http://engine:49134").is_err());
+        assert!(host_to_ws_url("[::1").is_err());
+    }
+
+    #[test]
+    fn probe_authority_extracts_host_port() {
+        assert_eq!(
+            probe_authority("ws://localhost:49134").as_deref(),
+            Some("localhost:49134")
+        );
+        assert_eq!(
+            probe_authority("ws://[::1]:49134").as_deref(),
+            Some("[::1]:49134")
+        );
+        // No explicit port → probe skipped.
+        assert_eq!(probe_authority("wss://engine.example.com"), None);
+    }
+
+    #[test]
+    fn remote_error_message_prefers_envelope_message() {
+        let e = iii_sdk::Error::Remote {
+            code: "W110".into(),
+            message: r#"{"type":"WorkerOpError","code":"W110","message":"Worker 'pdfkit' not found","details":{"name":"pdfkit"}}"#.into(),
+            stacktrace: None,
+        };
+        assert_eq!(remote_error_message(&e), "[W110] Worker 'pdfkit' not found");
+    }
+
+    #[test]
+    fn remote_error_message_falls_back_to_raw() {
+        let e = iii_sdk::Error::Remote {
+            code: "X1".into(),
+            message: "plain text".into(),
+            stacktrace: None,
+        };
+        assert_eq!(remote_error_message(&e), "[X1] plain text");
+    }
+}

--- a/crates/iii-worker/src/core/project.rs
+++ b/crates/iii-worker/src/core/project.rs
@@ -95,9 +95,17 @@ impl ProjectCtx {
         Self { root, lock: None }
     }
 
-    /// First existing candidate (`iii.config.yaml` then `config.yaml`);
-    /// falls back to the canonical name when neither exists yet.
+    /// The project config file. `III_CONFIG_PATH` wins when set — the
+    /// engine exports it to every process it spawns so ops target (and
+    /// report) the engine's ACTUAL config file, whatever its name. Otherwise
+    /// the first existing candidate (`iii.config.yaml` then `config.yaml`),
+    /// falling back to the canonical name when neither exists yet.
     pub fn config_path(&self) -> PathBuf {
+        if let Some(p) = std::env::var_os("III_CONFIG_PATH")
+            && !p.is_empty()
+        {
+            return PathBuf::from(p);
+        }
         for name in CONFIG_CANDIDATES {
             let candidate = self.root.join(name);
             if candidate.exists() {

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -129,7 +129,7 @@ async fn async_main() -> anyhow::Result<()> {
                         (
                             name.clone(),
                             AddOptions {
-                                source: remote_source_for_cli(name),
+                                source: remote_source_for_cli(name, host),
                                 force,
                                 reset_config: args.reset_config,
                                 wait: !no_wait,
@@ -246,7 +246,7 @@ async fn async_main() -> anyhow::Result<()> {
                         (
                             name.clone(),
                             AddOptions {
-                                source: remote_source_for_cli(name),
+                                source: remote_source_for_cli(name, host),
                                 force: true,
                                 reset_config: args.reset_config,
                                 wait: false,
@@ -679,16 +679,27 @@ fn parse_source_for_cli(input: &str) -> iii_worker::core::WorkerSource {
     iii_worker::core::WorkerSource::Registry { name, version }
 }
 
-/// Source for a `--host` add. Same parse as the local path, except relative
-/// local paths are resolved against the CLI's cwd before shipping: the
-/// engine-side daemon resolves paths in ITS working directory, which is the
-/// very mismatch `--host` exists to bridge.
-fn remote_source_for_cli(input: &str) -> iii_worker::core::WorkerSource {
+/// Source for a `--host` add. Same parse as the local path, with one
+/// adjustment: `WorkerSource::Local` paths resolve on the ENGINE host by
+/// contract, so when the target is loopback (same machine — the
+/// engine-in-another-directory case `--host` primarily fixes) relative
+/// paths are absolutized against the CLI's cwd. For a non-loopback target
+/// the path is shipped verbatim — rewriting it against a cwd the engine
+/// machine has never seen would silently break the documented semantics —
+/// and a one-line note reminds the user where it resolves.
+fn remote_source_for_cli(input: &str, host: &str) -> iii_worker::core::WorkerSource {
     let mut source = parse_source_for_cli(input);
-    if let iii_worker::core::WorkerSource::Local { path } = &mut source
-        && let Ok(abs) = std::path::absolute(&*path)
-    {
-        *path = abs;
+    if let iii_worker::core::WorkerSource::Local { path } = &mut source {
+        if iii_worker::cli::remote_ops::host_is_loopback(host) {
+            if let Ok(abs) = std::path::absolute(&*path) {
+                *path = abs;
+            }
+        } else {
+            eprintln!(
+                "  note: local path '{}' resolves on the engine host, not this machine",
+                path.display()
+            );
+        }
     }
     source
 }

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -118,6 +118,29 @@ async fn async_main() -> anyhow::Result<()> {
             use iii_worker::cli::stderr_sink::StderrSink;
             use iii_worker::core::{AddOptions, ProjectCtx, add as core_add};
 
+            // --host: route the add through the target engine's worker::add
+            // trigger. The engine host edits ITS config file and installs
+            // artifacts there — nothing in the CLI's cwd is touched.
+            if let Some(host) = args.host.as_deref() {
+                let adds = args
+                    .worker_names
+                    .iter()
+                    .map(|name| {
+                        (
+                            name.clone(),
+                            AddOptions {
+                                source: remote_source_for_cli(name),
+                                force,
+                                reset_config: args.reset_config,
+                                wait: !no_wait,
+                            },
+                        )
+                    })
+                    .collect();
+                let rc = iii_worker::cli::remote_ops::handle_remote_add(host, adds).await;
+                std::process::exit(rc);
+            }
+
             let total = args.worker_names.len();
             let brief = total > 1;
             let mut fail_count = 0usize;
@@ -213,6 +236,27 @@ async fn async_main() -> anyhow::Result<()> {
             use iii_worker::cli::host_shim::CliHostShim;
             use iii_worker::cli::stderr_sink::StderrSink;
             use iii_worker::core::{AddOptions, ProjectCtx, add as core_add};
+
+            // Reinstall is `add --force`; same --host routing as Add.
+            if let Some(host) = args.host.as_deref() {
+                let adds = args
+                    .worker_names
+                    .iter()
+                    .map(|name| {
+                        (
+                            name.clone(),
+                            AddOptions {
+                                source: remote_source_for_cli(name),
+                                force: true,
+                                reset_config: args.reset_config,
+                                wait: false,
+                            },
+                        )
+                    })
+                    .collect();
+                let rc = iii_worker::cli::remote_ops::handle_remote_add(host, adds).await;
+                std::process::exit(rc);
+            }
 
             let mut fail_count = 0usize;
             for name in &args.worker_names {
@@ -633,4 +677,18 @@ fn parse_source_for_cli(input: &str) -> iii_worker::core::WorkerSource {
         None => (input.to_string(), None),
     };
     iii_worker::core::WorkerSource::Registry { name, version }
+}
+
+/// Source for a `--host` add. Same parse as the local path, except relative
+/// local paths are resolved against the CLI's cwd before shipping: the
+/// engine-side daemon resolves paths in ITS working directory, which is the
+/// very mismatch `--host` exists to bridge.
+fn remote_source_for_cli(input: &str) -> iii_worker::core::WorkerSource {
+    let mut source = parse_source_for_cli(input);
+    if let iii_worker::core::WorkerSource::Local { path } = &mut source
+        && let Ok(abs) = std::path::absolute(&*path)
+    {
+        *path = abs;
+    }
+    source
 }

--- a/crates/iii-worker/tests/config_force_integration.rs
+++ b/crates/iii-worker/tests/config_force_integration.rs
@@ -45,7 +45,9 @@ async fn handle_managed_add_force_reset_config_clears_overrides() {
         )
         .unwrap();
 
-        // Force with reset_config should clear user overrides and re-apply defaults
+        // Force with reset_config should clear user overrides, leaving a
+        // bare entry (defaults live in Rust and flow through the
+        // configuration worker — they are no longer written into the file)
         let exit_code =
             iii_worker::cli::managed::handle_managed_add("iii-http", false, true, true, false)
                 .await;
@@ -53,8 +55,11 @@ async fn handle_managed_add_force_reset_config_clears_overrides() {
 
         let content = std::fs::read_to_string("config.yaml").unwrap();
         assert!(content.contains("- name: iii-http"));
-        // Builtin defaults should be present
-        assert!(content.contains("default_timeout"));
+        // No config block re-created
+        assert!(
+            !content.contains("default_timeout"),
+            "reset must not re-write builtin defaults, got:\n{content}"
+        );
         // User override should NOT be preserved (reset_config wipes it)
         assert!(!content.contains("custom_key"));
     })

--- a/crates/iii-worker/tests/config_managed_integration.rs
+++ b/crates/iii-worker/tests/config_managed_integration.rs
@@ -63,12 +63,14 @@ async fn handle_managed_add_builtin_creates_config() {
 
         let content = std::fs::read_to_string("config.yaml").unwrap();
         assert!(content.contains("- name: iii-http"));
-        assert!(content.contains("config:"));
-        assert!(content.contains("port: 3111"));
-        assert!(content.contains("host: 127.0.0.1"));
-        assert!(content.contains("default_timeout: 30000"));
-        assert!(content.contains("concurrency_request_limit: 1024"));
-        assert!(content.contains("allowed_origins"));
+        // Bare entry: builtins boot with Rust defaults and are configured
+        // through the configuration worker, so `add` must not copy a
+        // default config block into config.yaml anymore.
+        assert!(
+            !content.contains("config:"),
+            "builtin add must not write a config block, got:\n{content}"
+        );
+        assert!(!content.contains("port: 3111"));
         let lockfile = iii_worker::cli::lockfile::WorkerLockfile::read_from(
             iii_worker::cli::lockfile::lockfile_path(),
         )
@@ -103,7 +105,6 @@ async fn handle_managed_add_builtin_accepts_explicit_version() {
 
         let content = std::fs::read_to_string("config.yaml").unwrap();
         assert!(content.contains("- name: iii-http"));
-        assert!(content.contains("port: 3111"));
         let lockfile = iii_worker::cli::lockfile::WorkerLockfile::read_from(
             iii_worker::cli::lockfile::lockfile_path(),
         )
@@ -132,9 +133,13 @@ async fn handle_managed_add_builtin_merges_existing() {
         // User override preserved
         assert!(content.contains("9999"));
         assert!(content.contains("custom_key"));
-        // Builtin defaults filled in
-        assert!(content.contains("default_timeout"));
-        assert!(content.contains("concurrency_request_limit"));
+        // Re-adding must NOT inject builtin defaults into the file anymore —
+        // defaults live in Rust and flow through the configuration worker.
+        assert!(
+            !content.contains("default_timeout"),
+            "re-add must not inject builtin defaults, got:\n{content}"
+        );
+        assert!(!content.contains("concurrency_request_limit"));
     })
     .await;
 }

--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -19,9 +19,8 @@ iii [OPTIONS] [COMMAND]
 
 | Option | Description |
 | ------ | ----------- |
-| `-c, --config <CONFIG>` | Path to the config file [default: config.yaml] |
+| `-c, --config <CONFIG>` | Path to the config file [default: config.yaml]. When the file does not exist, `iii` offers to create it with an empty workers list (and creates it without asking in non-interactive sessions) |
 | `-v, --version` | Print version and exit |
-| `--use-default-config` | Run with built-in defaults instead of a config file. Cannot be combined with `--config` |
 | `--no-update-check` | Disable background update and security advisory checks |
 
 **Subcommands:**
@@ -164,7 +163,8 @@ iii worker add [OPTIONS] <WORKER[@VERSION]|PATH>...
 
 | Option | Description |
 | ------ | ----------- |
-| `--reset-config` | Discard the worker's config.yaml entry and recreate it from registry defaults. Plain `add --force` would otherwise keep the entry. Only takes effect together with `--force` on add |
+| `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block). Plain `add --force` would otherwise keep the entry. Only takes effect together with `--force` on add |
+| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134, ws:// URLs also accepted) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports |
 | `-f, --force` | Force re-download: delete existing artifacts before adding |
 | `--no-wait` | Don't block waiting for the engine to finish booting the worker |
 
@@ -263,7 +263,8 @@ iii worker reinstall [OPTIONS] <WORKER[@VERSION]|PATH>...
 
 | Option | Description |
 | ------ | ----------- |
-| `--reset-config` | Discard the worker's config.yaml entry and recreate it from registry defaults. Plain `add --force` would otherwise keep the entry. Only takes effect together with `--force` on add |
+| `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block). Plain `add --force` would otherwise keep the entry. Only takes effect together with `--force` on add |
+| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134, ws:// URLs also accepted) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports |
 
 ### `iii worker remove`
 

--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -163,8 +163,8 @@ iii worker add [OPTIONS] <WORKER[@VERSION]|PATH>...
 
 | Option | Description |
 | ------ | ----------- |
-| `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block). Plain `add --force` would otherwise keep the entry. Only takes effect together with `--force` on add |
-| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134, ws:// URLs also accepted) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports |
+| `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block), instead of keeping the existing entry. With `add`, takes effect only together with `--force`; `reinstall` applies force automatically |
+| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host |
 | `-f, --force` | Force re-download: delete existing artifacts before adding |
 | `--no-wait` | Don't block waiting for the engine to finish booting the worker |
 
@@ -263,8 +263,8 @@ iii worker reinstall [OPTIONS] <WORKER[@VERSION]|PATH>...
 
 | Option | Description |
 | ------ | ----------- |
-| `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block). Plain `add --force` would otherwise keep the entry. Only takes effect together with `--force` on add |
-| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134, ws:// URLs also accepted) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports |
+| `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block), instead of keeping the existing entry. With `add`, takes effect only together with `--force`; `reinstall` applies force automatically |
+| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host |
 
 ### `iii worker remove`
 

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -17,9 +17,8 @@ iii [OPTIONS] [COMMAND]
 
 | Option | Description |
 | ------ | ----------- |
-| `-c, --config <CONFIG>` | Path to the config file [default: config.yaml] |
+| `-c, --config <CONFIG>` | Path to the config file [default: config.yaml]. When the file does not exist, `iii` offers to create it with an empty workers list (and creates it without asking in non-interactive sessions) |
 | `-v, --version` | Print version and exit |
-| `--use-default-config` | Run with built-in defaults instead of a config file. Cannot be combined with `--config` |
 | `--no-update-check` | Disable background update and security advisory checks |
 
 **Subcommands:**
@@ -162,7 +161,8 @@ iii worker add [OPTIONS] <WORKER[@VERSION]|PATH>...
 
 | Option | Description |
 | ------ | ----------- |
-| `--reset-config` | Discard the worker's config.yaml entry and recreate it from registry defaults. Plain `add --force` would otherwise keep the entry. Only takes effect together with `--force` on add |
+| `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block). Plain `add --force` would otherwise keep the entry. Only takes effect together with `--force` on add |
+| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134, ws:// URLs also accepted) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports |
 | `-f, --force` | Force re-download: delete existing artifacts before adding |
 | `--no-wait` | Don't block waiting for the engine to finish booting the worker |
 
@@ -261,7 +261,8 @@ iii worker reinstall [OPTIONS] <WORKER[@VERSION]|PATH>...
 
 | Option | Description |
 | ------ | ----------- |
-| `--reset-config` | Discard the worker's config.yaml entry and recreate it from registry defaults. Plain `add --force` would otherwise keep the entry. Only takes effect together with `--force` on add |
+| `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block). Plain `add --force` would otherwise keep the entry. Only takes effect together with `--force` on add |
+| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134, ws:// URLs also accepted) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports |
 
 ### `iii worker remove`
 

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -161,8 +161,8 @@ iii worker add [OPTIONS] <WORKER[@VERSION]|PATH>...
 
 | Option | Description |
 | ------ | ----------- |
-| `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block). Plain `add --force` would otherwise keep the entry. Only takes effect together with `--force` on add |
-| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134, ws:// URLs also accepted) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports |
+| `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block), instead of keeping the existing entry. With `add`, takes effect only together with `--force`; `reinstall` applies force automatically |
+| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host |
 | `-f, --force` | Force re-download: delete existing artifacts before adding |
 | `--no-wait` | Don't block waiting for the engine to finish booting the worker |
 
@@ -261,8 +261,8 @@ iii worker reinstall [OPTIONS] <WORKER[@VERSION]|PATH>...
 
 | Option | Description |
 | ------ | ----------- |
-| `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block). Plain `add --force` would otherwise keep the entry. Only takes effect together with `--force` on add |
-| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134, ws:// URLs also accepted) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports |
+| `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block), instead of keeping the existing entry. With `add`, takes effect only together with `--force`; `reinstall` applies force automatically |
+| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host |
 
 ### `iii worker remove`
 

--- a/docs/next/tutorials/incremental-adoption/overview.mdx
+++ b/docs/next/tutorials/incremental-adoption/overview.mdx
@@ -15,8 +15,9 @@ runs on iii without ever needing a full cutover.
 
 ## Prerequisites
 
-- A running iii engine ([install](../../install), then `iii --use-default-config` for a scratch
-  instance; see [Default configuration](../../using-iii/engine#default-configuration)).
+- A running iii engine ([install](../../install), then run `iii` in a scratch directory and let it
+  create a `config.yaml` — add the workers each step needs with `iii worker add`; see
+  [Default configuration](../../using-iii/engine#default-configuration)).
 - An existing service you want to migrate, reachable over HTTP.
 - The SDK for the language your service is written in (TypeScript, Python, or Rust).
 

--- a/docs/next/tutorials/incremental-adoption/overview.mdx
+++ b/docs/next/tutorials/incremental-adoption/overview.mdx
@@ -16,7 +16,7 @@ runs on iii without ever needing a full cutover.
 ## Prerequisites
 
 - A running iii engine ([install](../../install), then run `iii` in a scratch directory and let it
-  create a `config.yaml` — add the workers each step needs with `iii worker add`; see
+  create a `config.yaml`, then add the workers each step needs with `iii worker add`; see
   [Default configuration](../../using-iii/engine#default-configuration)).
 - An existing service you want to migrate, reachable over HTTP.
 - The SDK for the language your service is written in (TypeScript, Python, or Rust).

--- a/docs/next/tutorials/incremental-adoption/overview.mdx.skill.md
+++ b/docs/next/tutorials/incremental-adoption/overview.mdx.skill.md
@@ -13,8 +13,9 @@ runs on iii without ever needing a full cutover.
 
 ## Prerequisites
 
-- A running iii engine ([install](../../install), then `iii --use-default-config` for a scratch
-  instance; see [Default configuration](../../using-iii/engine#default-configuration)).
+- A running iii engine ([install](../../install), then run `iii` in a scratch directory and let it
+  create a `config.yaml` — add the workers each step needs with `iii worker add`; see
+  [Default configuration](../../using-iii/engine#default-configuration)).
 - An existing service you want to migrate, reachable over HTTP.
 - The SDK for the language your service is written in (TypeScript, Python, or Rust).
 

--- a/docs/next/tutorials/incremental-adoption/overview.mdx.skill.md
+++ b/docs/next/tutorials/incremental-adoption/overview.mdx.skill.md
@@ -14,7 +14,7 @@ runs on iii without ever needing a full cutover.
 ## Prerequisites
 
 - A running iii engine ([install](../../install), then run `iii` in a scratch directory and let it
-  create a `config.yaml` — add the workers each step needs with `iii worker add`; see
+  create a `config.yaml`, then add the workers each step needs with `iii worker add`; see
   [Default configuration](../../using-iii/engine#default-configuration)).
 - An existing service you want to migrate, reachable over HTTP.
 - The SDK for the language your service is written in (TypeScript, Python, or Rust).

--- a/docs/next/using-iii/cli.mdx
+++ b/docs/next/using-iii/cli.mdx
@@ -32,7 +32,8 @@ command.
 | `iii update`  | Update iii and its managed binaries. See [Updating iii itself](#updating-iii).                                    |
 
 Running `iii` with no subcommand starts the engine from `./config.yaml` (or the path passed to
-`--config`); pass `--use-default-config` to start with the built-in defaults instead.
+`--config`). When the file doesn't exist yet, `iii` offers to create it with an empty workers list
+(and creates it without asking in non-interactive sessions); add workers with `iii worker add`.
 
 ## Managing iii Cloud deployments
 

--- a/docs/next/using-iii/cli.mdx.skill.md
+++ b/docs/next/using-iii/cli.mdx.skill.md
@@ -30,7 +30,8 @@ command.
 | `iii update`  | Update iii and its managed binaries. See [Updating iii itself](#updating-iii).                                    |
 
 Running `iii` with no subcommand starts the engine from `./config.yaml` (or the path passed to
-`--config`); pass `--use-default-config` to start with the built-in defaults instead.
+`--config`). When the file doesn't exist yet, `iii` offers to create it with an empty workers list
+(and creates it without asking in non-interactive sessions); add workers with `iii worker add`.
 
 ## Managing iii Cloud deployments
 

--- a/docs/next/using-iii/engine.mdx
+++ b/docs/next/using-iii/engine.mdx
@@ -14,8 +14,8 @@ Think of the engine like a router, it receives requests, routes them to workers,
 ## Engine configuration
 
 The iii engine starts from a `config.yaml` file at your project root. Pass `--config <path>` to
-point at a different file, or `--use-default-config` to start with a default set of workers (handy
-for first-run and scratch work).
+point at a different file. When the file doesn't exist yet, `iii` offers to create it (handy for
+first-run and scratch work) — non-interactive sessions create it without asking.
 
 ```bash
 iii --config config.yaml
@@ -24,8 +24,9 @@ iii --config config.yaml
 ## Configuration file structure
 
 `config.yaml` has a single top-level key, `workers:`, that lists the workers the engine should load.
-Each entry has a `name` (a registry slug or local worker name) and a `config` block whose shape is
-defined by that worker and is read once, as a first-boot seed.
+Each entry has a `name` (a registry slug or local worker name) and, optionally, a `config` block
+whose shape is defined by that worker and is read once, as a first-boot seed. A bare `- name:`
+entry — what `iii worker add` writes — boots the worker with its built-in defaults.
 
 ```yaml
 workers:
@@ -86,6 +87,10 @@ workers:
 
 ## Default configuration
 
-Run `iii --use-default-config` to start the engine with a default set of workers without writing a
-`config.yaml`. Useful for first-run and scratch work. Once you need to customize ports, adapters, or
-the set of workers, switch to a real `config.yaml`.
+Run `iii` in a directory with no `config.yaml` and it offers to create one (in non-interactive
+sessions — containers, CI — it creates the file without asking). The created file starts with an
+**empty** `workers:` list: the engine boots with just its internal services (the WebSocket listener
+SDK workers connect to, the configuration worker, observability), and you opt into everything else
+with `iii worker add <name>` — the engine watches the file and picks new workers up live. Workers
+boot with their built-in defaults; customize ports, adapters, or credentials at runtime through the
+configuration worker, or by adding a `config:` block to an entry by hand.

--- a/docs/next/using-iii/engine.mdx
+++ b/docs/next/using-iii/engine.mdx
@@ -92,5 +92,6 @@ sessions — containers, CI — it creates the file without asking). The created
 **empty** `workers:` list: the engine boots with just its internal services (the WebSocket listener
 SDK workers connect to, the configuration worker, observability), and you opt into everything else
 with `iii worker add <name>` — the engine watches the file and picks new workers up live. Workers
-boot with their built-in defaults; customize ports, adapters, or credentials at runtime through the
-configuration worker, or by adding a `config:` block to an entry by hand.
+boot with their built-in defaults. Customize ports, adapters, or credentials at runtime through the
+configuration worker or the persisted per-worker config file under `./config/`. To seed the initial
+configuration instead, add a `config:` block to an entry before the worker's first boot.

--- a/docs/next/using-iii/engine.mdx
+++ b/docs/next/using-iii/engine.mdx
@@ -15,7 +15,7 @@ Think of the engine like a router, it receives requests, routes them to workers,
 
 The iii engine starts from a `config.yaml` file at your project root. Pass `--config <path>` to
 point at a different file. When the file doesn't exist yet, `iii` offers to create it (handy for
-first-run and scratch work) — non-interactive sessions create it without asking.
+first-run and scratch work); non-interactive sessions create it without asking.
 
 ```bash
 iii --config config.yaml
@@ -26,7 +26,7 @@ iii --config config.yaml
 `config.yaml` has a single top-level key, `workers:`, that lists the workers the engine should load.
 Each entry has a `name` (a registry slug or local worker name) and, optionally, a `config` block
 whose shape is defined by that worker and is read once, as a first-boot seed. A bare `- name:`
-entry — what `iii worker add` writes — boots the worker with its built-in defaults.
+entry (what `iii worker add` writes) boots the worker with its built-in defaults.
 
 ```yaml
 workers:
@@ -87,11 +87,11 @@ workers:
 
 ## Default configuration
 
-Run `iii` in a directory with no `config.yaml` and it offers to create one (in non-interactive
-sessions — containers, CI — it creates the file without asking). The created file starts with an
-**empty** `workers:` list: the engine boots with just its internal services (the WebSocket listener
+Run `iii` in a directory with no `config.yaml` and it offers to create one (non-interactive
+sessions such as containers and CI create the file without asking). The created file starts with an
+**empty** `workers:` list: the engine boots with its internal services (the WebSocket listener
 SDK workers connect to, the configuration worker, observability), and you opt into everything else
-with `iii worker add <name>` — the engine watches the file and picks new workers up live. Workers
+with `iii worker add <name>`; the engine watches the file and picks new workers up live. Workers
 boot with their built-in defaults. Customize ports, adapters, or credentials at runtime through the
 configuration worker or the persisted per-worker config file under `./config/`. To seed the initial
 configuration instead, add a `config:` block to an entry before the worker's first boot.

--- a/docs/next/using-iii/engine.mdx.skill.md
+++ b/docs/next/using-iii/engine.mdx.skill.md
@@ -84,5 +84,6 @@ sessions — containers, CI — it creates the file without asking). The created
 **empty** `workers:` list: the engine boots with just its internal services (the WebSocket listener
 SDK workers connect to, the configuration worker, observability), and you opt into everything else
 with `iii worker add <name>` — the engine watches the file and picks new workers up live. Workers
-boot with their built-in defaults; customize ports, adapters, or credentials at runtime through the
-configuration worker, or by adding a `config:` block to an entry by hand.
+boot with their built-in defaults. Customize ports, adapters, or credentials at runtime through the
+configuration worker or the persisted per-worker config file under `./config/`. To seed the initial
+configuration instead, add a `config:` block to an entry before the worker's first boot.

--- a/docs/next/using-iii/engine.mdx.skill.md
+++ b/docs/next/using-iii/engine.mdx.skill.md
@@ -6,8 +6,8 @@
 ## Engine configuration
 
 The iii engine starts from a `config.yaml` file at your project root. Pass `--config <path>` to
-point at a different file, or `--use-default-config` to start with a default set of workers (handy
-for first-run and scratch work).
+point at a different file. When the file doesn't exist yet, `iii` offers to create it (handy for
+first-run and scratch work) — non-interactive sessions create it without asking.
 
 ```bash
 iii --config config.yaml
@@ -16,8 +16,9 @@ iii --config config.yaml
 ## Configuration file structure
 
 `config.yaml` has a single top-level key, `workers:`, that lists the workers the engine should load.
-Each entry has a `name` (a registry slug or local worker name) and a `config` block whose shape is
-defined by that worker and is read once, as a first-boot seed.
+Each entry has a `name` (a registry slug or local worker name) and, optionally, a `config` block
+whose shape is defined by that worker and is read once, as a first-boot seed. A bare `- name:`
+entry — what `iii worker add` writes — boots the worker with its built-in defaults.
 
 ```yaml
 workers:
@@ -78,6 +79,10 @@ workers:
 
 ## Default configuration
 
-Run `iii --use-default-config` to start the engine with a default set of workers without writing a
-`config.yaml`. Useful for first-run and scratch work. Once you need to customize ports, adapters, or
-the set of workers, switch to a real `config.yaml`.
+Run `iii` in a directory with no `config.yaml` and it offers to create one (in non-interactive
+sessions — containers, CI — it creates the file without asking). The created file starts with an
+**empty** `workers:` list: the engine boots with just its internal services (the WebSocket listener
+SDK workers connect to, the configuration worker, observability), and you opt into everything else
+with `iii worker add <name>` — the engine watches the file and picks new workers up live. Workers
+boot with their built-in defaults; customize ports, adapters, or credentials at runtime through the
+configuration worker, or by adding a `config:` block to an entry by hand.

--- a/docs/next/using-iii/engine.mdx.skill.md
+++ b/docs/next/using-iii/engine.mdx.skill.md
@@ -7,7 +7,7 @@
 
 The iii engine starts from a `config.yaml` file at your project root. Pass `--config <path>` to
 point at a different file. When the file doesn't exist yet, `iii` offers to create it (handy for
-first-run and scratch work) — non-interactive sessions create it without asking.
+first-run and scratch work); non-interactive sessions create it without asking.
 
 ```bash
 iii --config config.yaml
@@ -18,7 +18,7 @@ iii --config config.yaml
 `config.yaml` has a single top-level key, `workers:`, that lists the workers the engine should load.
 Each entry has a `name` (a registry slug or local worker name) and, optionally, a `config` block
 whose shape is defined by that worker and is read once, as a first-boot seed. A bare `- name:`
-entry — what `iii worker add` writes — boots the worker with its built-in defaults.
+entry (what `iii worker add` writes) boots the worker with its built-in defaults.
 
 ```yaml
 workers:
@@ -79,11 +79,11 @@ workers:
 
 ## Default configuration
 
-Run `iii` in a directory with no `config.yaml` and it offers to create one (in non-interactive
-sessions — containers, CI — it creates the file without asking). The created file starts with an
-**empty** `workers:` list: the engine boots with just its internal services (the WebSocket listener
+Run `iii` in a directory with no `config.yaml` and it offers to create one (non-interactive
+sessions such as containers and CI create the file without asking). The created file starts with an
+**empty** `workers:` list: the engine boots with its internal services (the WebSocket listener
 SDK workers connect to, the configuration worker, observability), and you opt into everything else
-with `iii worker add <name>` — the engine watches the file and picks new workers up live. Workers
+with `iii worker add <name>`; the engine watches the file and picks new workers up live. Workers
 boot with their built-in defaults. Customize ports, adapters, or credentials at runtime through the
 configuration worker or the persisted per-worker config file under `./config/`. To seed the initial
 configuration instead, add a `config:` block to an entry before the worker's first boot.

--- a/docs/next/using-iii/workers.mdx
+++ b/docs/next/using-iii/workers.mdx
@@ -66,7 +66,8 @@ The registry contains many workers that encapsulate common services. See
 
 <Note>
   You need iii [installed](../install) and [running](./engine) before adding a worker. To spin up a
-  temporary iii instance for testing, run `iii --use-default-config` (see [Default
+  temporary iii instance for testing, run `iii` in a scratch directory — when no `config.yaml`
+  exists yet it creates one with an empty workers list, ready for `iii worker add` (see [Default
   configuration](./engine#default-configuration)).
 </Note>
 
@@ -86,10 +87,23 @@ iii worker add ghcr.io/org/worker:tag # Pulls and adds a worker from a Docker or
 The worker is added to `config.yaml` and started automatically. To force a redownload of an existing
 worker, use `iii worker reinstall <name>` (equivalent to `add --force`).
 
-`iii worker add` also writes the worker's default `config:` block. That block seeds the worker's
-settings once, on its first boot; from then on, runtime settings are managed through the
-[configuration worker](./configuration), not `config.yaml`. The settings remain editable as local
-files under `./config/`; see [Configuration](./configuration).
+`iii worker add` writes a bare `- name:` entry — no `config:` block. Workers boot with their
+built-in defaults and manage runtime settings through the
+[configuration worker](./configuration), whose entries are editable as local files under
+`./config/`. A `config:` block you write into `config.yaml` by hand still works as a one-time
+first-boot seed, and re-adding a worker preserves it. (`iii-sandbox` is the one exception: its add
+writes the sandbox `config:` block, because the image allowlist is enforced from the file.)
+
+By default `iii worker add` edits the config file in the **current directory**, so run it from the
+same folder as the engine it should affect. To install into an engine running elsewhere (a
+different directory, machine, or a non-default port), pass `--host`:
+
+```bash
+iii worker add pdfkit --host localhost:49134
+```
+
+With `--host` the CLI calls the engine's `worker::add` trigger and the engine applies the install
+in its own project directory — nothing in your current folder is touched.
 
 <Note>
   `iii worker add` downloads worker images from remote repositories (the iii registry or an OCI

--- a/docs/next/using-iii/workers.mdx
+++ b/docs/next/using-iii/workers.mdx
@@ -66,7 +66,7 @@ The registry contains many workers that encapsulate common services. See
 
 <Note>
   You need iii [installed](../install) and [running](./engine) before adding a worker. To spin up a
-  temporary iii instance for testing, run `iii` in a scratch directory — when no `config.yaml`
+  temporary iii instance for testing, run `iii` in a scratch directory: when no `config.yaml`
   exists yet it creates one with an empty workers list, ready for `iii worker add` (see [Default
   configuration](./engine#default-configuration)).
 </Note>
@@ -87,7 +87,7 @@ iii worker add ghcr.io/org/worker:tag # Pulls and adds a worker from a Docker or
 The worker is added to `config.yaml` and started automatically. To force a redownload of an existing
 worker, use `iii worker reinstall <name>` (equivalent to `add --force`).
 
-`iii worker add` writes a bare `- name:` entry — no `config:` block. Workers boot with their
+`iii worker add` writes a bare `- name:` entry with no `config:` block. Workers boot with their
 built-in defaults and manage runtime settings through the
 [configuration worker](./configuration), whose entries are editable as local files under
 `./config/`. A `config:` block you write into `config.yaml` by hand still works as a one-time
@@ -103,7 +103,7 @@ iii worker add pdfkit --host localhost:49134
 ```
 
 With `--host` the CLI calls the engine's `worker::add` trigger and the engine applies the install
-in its own project directory — nothing in your current folder is touched.
+in its own project directory; nothing in your current folder is touched.
 
 <Note>
   `iii worker add` downloads worker images from remote repositories (the iii registry or an OCI

--- a/docs/next/using-iii/workers.mdx.skill.md
+++ b/docs/next/using-iii/workers.mdx.skill.md
@@ -51,7 +51,7 @@ The registry contains many workers that encapsulate common services. See
 
 <Note>
   You need iii [installed](../install) and [running](./engine) before adding a worker. To spin up a
-  temporary iii instance for testing, run `iii` in a scratch directory — when no `config.yaml`
+  temporary iii instance for testing, run `iii` in a scratch directory: when no `config.yaml`
   exists yet it creates one with an empty workers list, ready for `iii worker add` (see [Default
   configuration](./engine#default-configuration)).
 </Note>
@@ -72,7 +72,7 @@ iii worker add ghcr.io/org/worker:tag # Pulls and adds a worker from a Docker or
 The worker is added to `config.yaml` and started automatically. To force a redownload of an existing
 worker, use `iii worker reinstall <name>` (equivalent to `add --force`).
 
-`iii worker add` writes a bare `- name:` entry — no `config:` block. Workers boot with their
+`iii worker add` writes a bare `- name:` entry with no `config:` block. Workers boot with their
 built-in defaults and manage runtime settings through the
 [configuration worker](./configuration), whose entries are editable as local files under
 `./config/`. A `config:` block you write into `config.yaml` by hand still works as a one-time
@@ -88,7 +88,7 @@ iii worker add pdfkit --host localhost:49134
 ```
 
 With `--host` the CLI calls the engine's `worker::add` trigger and the engine applies the install
-in its own project directory — nothing in your current folder is touched.
+in its own project directory; nothing in your current folder is touched.
 
 <Note>
   `iii worker add` downloads worker images from remote repositories (the iii registry or an OCI

--- a/docs/next/using-iii/workers.mdx.skill.md
+++ b/docs/next/using-iii/workers.mdx.skill.md
@@ -51,7 +51,8 @@ The registry contains many workers that encapsulate common services. See
 
 <Note>
   You need iii [installed](../install) and [running](./engine) before adding a worker. To spin up a
-  temporary iii instance for testing, run `iii --use-default-config` (see [Default
+  temporary iii instance for testing, run `iii` in a scratch directory — when no `config.yaml`
+  exists yet it creates one with an empty workers list, ready for `iii worker add` (see [Default
   configuration](./engine#default-configuration)).
 </Note>
 
@@ -71,10 +72,23 @@ iii worker add ghcr.io/org/worker:tag # Pulls and adds a worker from a Docker or
 The worker is added to `config.yaml` and started automatically. To force a redownload of an existing
 worker, use `iii worker reinstall <name>` (equivalent to `add --force`).
 
-`iii worker add` also writes the worker's default `config:` block. That block seeds the worker's
-settings once, on its first boot; from then on, runtime settings are managed through the
-[configuration worker](./configuration), not `config.yaml`. The settings remain editable as local
-files under `./config/`; see [Configuration](./configuration).
+`iii worker add` writes a bare `- name:` entry — no `config:` block. Workers boot with their
+built-in defaults and manage runtime settings through the
+[configuration worker](./configuration), whose entries are editable as local files under
+`./config/`. A `config:` block you write into `config.yaml` by hand still works as a one-time
+first-boot seed, and re-adding a worker preserves it. (`iii-sandbox` is the one exception: its add
+writes the sandbox `config:` block, because the image allowlist is enforced from the file.)
+
+By default `iii worker add` edits the config file in the **current directory**, so run it from the
+same folder as the engine it should affect. To install into an engine running elsewhere (a
+different directory, machine, or a non-default port), pass `--host`:
+
+```bash
+iii worker add pdfkit --host localhost:49134
+```
+
+With `--host` the CLI calls the engine's `worker::add` trigger and the engine applies the install
+in its own project directory — nothing in your current folder is touched.
 
 <Note>
   `iii worker add` downloads worker images from remote repositories (the iii registry or an OCI

--- a/engine/src/cli/exec.rs
+++ b/engine/src/cli/exec.rs
@@ -19,7 +19,11 @@ use super::error::ExecError;
 ///
 /// IMPORTANT: All iii output (progress bars, update notifications) MUST be
 /// flushed before calling this function.
-pub fn run_binary(binary_path: &Path, args: &[String]) -> Result<i32, ExecError> {
+pub fn run_binary(
+    binary_path: &Path,
+    args: &[String],
+    envs: &[(String, String)],
+) -> Result<i32, ExecError> {
     if !binary_path.exists() {
         return Err(ExecError::BinaryNotFound {
             path: binary_path.display().to_string(),
@@ -31,12 +35,12 @@ pub fn run_binary(binary_path: &Path, args: &[String]) -> Result<i32, ExecError>
 
     #[cfg(unix)]
     {
-        run_binary_unix(binary_path, args)
+        run_binary_unix(binary_path, args, envs)
     }
 
     #[cfg(windows)]
     {
-        run_binary_windows(binary_path, args)
+        run_binary_windows(binary_path, args, envs)
     }
 }
 
@@ -55,11 +59,18 @@ fn flush_output() {
 /// entirely. The child binary inherits the terminal, PID, and all file
 /// descriptors. This is NOT shell invocation -- no injection risk.
 #[cfg(unix)]
-fn run_binary_unix(binary_path: &Path, args: &[String]) -> Result<i32, ExecError> {
+fn run_binary_unix(
+    binary_path: &Path,
+    args: &[String],
+    envs: &[(String, String)],
+) -> Result<i32, ExecError> {
     use std::os::unix::process::CommandExt;
 
     // .exec() replaces the current process image (only returns on error)
-    let err = std::process::Command::new(binary_path).args(args).exec();
+    let err = std::process::Command::new(binary_path)
+        .args(args)
+        .envs(envs.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        .exec();
 
     Err(ExecError::SpawnFailed {
         binary: binary_path.display().to_string(),
@@ -69,9 +80,14 @@ fn run_binary_unix(binary_path: &Path, args: &[String]) -> Result<i32, ExecError
 
 /// Windows: Spawn the binary as a child process with inherited stdio.
 #[cfg(windows)]
-fn run_binary_windows(binary_path: &Path, args: &[String]) -> Result<i32, ExecError> {
+fn run_binary_windows(
+    binary_path: &Path,
+    args: &[String],
+    envs: &[(String, String)],
+) -> Result<i32, ExecError> {
     let status = std::process::Command::new(binary_path)
         .args(args)
+        .envs(envs.iter().map(|(k, v)| (k.as_str(), v.as_str())))
         .stdin(std::process::Stdio::inherit())
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit())
@@ -91,7 +107,7 @@ mod tests {
 
     #[test]
     fn test_binary_not_found() {
-        let result = run_binary(&PathBuf::from("/nonexistent/binary"), &[]);
+        let result = run_binary(&PathBuf::from("/nonexistent/binary"), &[], &[]);
         assert!(result.is_err());
         match result.unwrap_err() {
             ExecError::BinaryNotFound { path } => {

--- a/engine/src/cli/mod.rs
+++ b/engine/src/cli/mod.rs
@@ -20,7 +20,12 @@ pub mod update;
 use colored::Colorize;
 
 /// Handle dispatching a command to a managed binary.
-pub async fn handle_dispatch(command: &str, args: &[String], no_update_check: bool) -> i32 {
+pub async fn handle_dispatch(
+    command: &str,
+    args: &[String],
+    no_update_check: bool,
+    envs: &[(String, String)],
+) -> i32 {
     // Resolve command to binary spec
     let (spec, binary_subcommand) = match registry::resolve_command(command) {
         Ok(result) => result,
@@ -164,7 +169,7 @@ pub async fn handle_dispatch(command: &str, args: &[String], no_update_check: bo
     child_args.extend_from_slice(args);
 
     // Execute the binary (replaces process on Unix)
-    match exec::run_binary(&binary_path, &child_args) {
+    match exec::run_binary(&binary_path, &child_args, envs) {
         Ok(code) => code,
         Err(e) => {
             eprintln!("{} {}", "error:".red(), e);

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -235,6 +235,12 @@ pub struct Engine {
     /// ExternalWorkerProcess::spawn` so externally-spawned workers connect
     /// back to the actual configured port, not a hardcoded DEFAULT_PORT.
     worker_manager_port: Arc<std::sync::OnceLock<u16>>,
+    /// Absolute path of the config file this engine was built from, when
+    /// file-backed. Set once by `EngineBuilder::build`. Handed to spawned
+    /// worker processes as `III_CONFIG_PATH` so `iii-worker` reads/edits
+    /// the SAME file the engine watches (a non-default name like
+    /// `config.yml` otherwise silently splits the two).
+    config_path: Arc<std::sync::OnceLock<std::path::PathBuf>>,
 }
 
 fn resolve_registration_id(worker: &WorkerConnection, id: &str) -> String {
@@ -270,6 +276,7 @@ impl Engine {
             external_function_owners: Arc::new(DashMap::new()),
             active_scope,
             worker_manager_port: Arc::new(std::sync::OnceLock::new()),
+            config_path: Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -290,6 +297,19 @@ impl Engine {
     /// drift mid-lifetime.
     pub fn set_worker_manager_port(&self, port: u16) {
         let _ = self.worker_manager_port.set(port);
+    }
+
+    /// Absolute config file path when the engine is file-backed; `None` for
+    /// programmatic/in-memory configs. See the field doc for why spawned
+    /// workers need it.
+    pub fn config_path(&self) -> Option<&std::path::Path> {
+        self.config_path.get().map(|p| p.as_path())
+    }
+
+    /// Records the config file path. Called once by `EngineBuilder::build`;
+    /// later calls are ignored (OnceLock semantics).
+    pub fn set_config_path(&self, path: std::path::PathBuf) {
+        let _ = self.config_path.set(path);
     }
 
     pub fn upsert_runtime_worker(&self, worker: RuntimeWorkerInfo) {

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -96,18 +96,18 @@ struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
 
-    /// Path to the config file.
-    #[arg(short, long, default_value = "config.yaml")]
-    config: String,
+    /// Path to the config file [default: config.yaml]. When the file does
+    /// not exist, `iii` offers to create it with an empty workers list (and
+    /// creates it without asking in non-interactive sessions).
+    // Option (not default_value) so subcommand dispatch can tell "user chose
+    // this file" from "clap default" — only an explicit choice is forwarded
+    // to `iii worker …` as III_CONFIG_PATH.
+    #[arg(short, long)]
+    config: Option<String>,
 
     /// Print version and exit.
     #[arg(short = 'v', long)]
     version: bool,
-
-    /// Run with built-in defaults instead of a config file.
-    /// Cannot be combined with --config.
-    #[arg(long, conflicts_with = "config")]
-    use_default_config: bool,
 
     /// Disable background update and security advisory checks.
     #[arg(long)]
@@ -195,10 +195,6 @@ enum Commands {
     },
 }
 
-fn should_init_logging_from_engine_config(cli: &Cli) -> bool {
-    cli.use_default_config
-}
-
 fn passthrough_command_path(command: &str, args: &[String]) -> String {
     match args.first() {
         Some(arg) if !arg.starts_with('-') => format!("{command} {arg}"),
@@ -235,24 +231,88 @@ fn cli_usage_command_path(cli: &Cli) -> String {
     }
 }
 
-async fn run_serve(cli: &Cli) -> anyhow::Result<()> {
-    let config = if cli.use_default_config {
-        EngineConfig::default_config()
-    } else {
-        EngineConfig::config_file(&cli.config)?
+/// Make sure the config file exists before the engine loads it.
+///
+/// Missing file: on an interactive terminal, ask before writing (running
+/// `iii` in the wrong directory shouldn't silently litter a config.yaml
+/// there); headless sessions (containers, CI, service managers) create it
+/// without asking so `iii` keeps booting unattended. Returns `false` when
+/// the user declined — the caller aborts without creating anything.
+fn ensure_config_file(path: &str) -> anyhow::Result<bool> {
+    use std::io::{IsTerminal, Write};
+
+    if std::path::Path::new(path).exists() {
+        return Ok(true);
+    }
+
+    let dir = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    if std::io::stdin().is_terminal() && std::io::stderr().is_terminal() {
+        eprint!(
+            "No {} found in {}. Create it and start the engine? [Y/n] ",
+            path,
+            dir.display()
+        );
+        let _ = std::io::stderr().flush();
+        let mut answer = String::new();
+        std::io::stdin().read_line(&mut answer)?;
+        let answer = answer.trim().to_lowercase();
+        if !(answer.is_empty() || answer == "y" || answer == "yes") {
+            return Ok(false);
+        }
+    }
+
+    std::fs::write(path, EngineConfig::starter_config_yaml())
+        .map_err(|e| anyhow::anyhow!("failed to create config file '{}': {}", path, e))?;
+    eprintln!(
+        "Created {}. Add workers with `iii worker add <name>` — the engine picks them up live.",
+        path
+    );
+    Ok(true)
+}
+
+/// Effective config file path: the explicit `--config` value, or the
+/// `config.yaml` default.
+fn config_path_of(cli: &Cli) -> &str {
+    cli.config.as_deref().unwrap_or("config.yaml")
+}
+
+/// Env vars for a dispatched `iii worker …` child. An explicit `--config`
+/// is forwarded as III_CONFIG_PATH (absolutized — the child keeps our cwd,
+/// but everything IT spawns may not) so `iii -c config.yml worker add x`
+/// edits the same file the engine reads. Without an explicit flag the
+/// child keeps its own default (and any user-exported III_CONFIG_PATH).
+fn worker_dispatch_envs(cli: &Cli) -> Vec<(String, String)> {
+    let Some(ref config) = cli.config else {
+        return Vec::new();
     };
-
-    if should_init_logging_from_engine_config(cli) {
-        logging::init_log_from_engine_config(&config);
+    let path = std::path::Path::new(config);
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
     } else {
-        logging::init_log_from_config(Some(&cli.config));
+        std::env::current_dir()
+            .map(|cwd| cwd.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    };
+    vec![("III_CONFIG_PATH".to_string(), abs.display().to_string())]
+}
+
+async fn run_serve(cli: &Cli) -> anyhow::Result<()> {
+    let config_path = config_path_of(cli);
+    if !ensure_config_file(config_path)? {
+        eprintln!(
+            "Aborted. Run `iii` from your project directory, or pass --config <path> to an existing config file."
+        );
+        std::process::exit(1);
     }
 
-    let mut builder = EngineBuilder::new().with_config(config);
-    if !cli.use_default_config {
-        builder = builder.with_config_path(&cli.config);
-    }
-    let engine = builder.build().await?;
+    let config = EngineConfig::config_file(config_path)?;
+    logging::init_log_from_config(Some(config_path));
+
+    let engine = EngineBuilder::new()
+        .with_config(config)
+        .with_config_path(config_path)
+        .build()
+        .await?;
     engine.serve().await?;
     Ok(())
 }
@@ -314,15 +374,19 @@ async fn main() -> anyhow::Result<()> {
             Err(cli_trigger::TriggerCliError::Other(e)) => Err(e),
         },
         Some(Commands::Console { args }) => {
-            let exit_code = cli::handle_dispatch("console", args, cli_args.no_update_check).await;
+            let exit_code =
+                cli::handle_dispatch("console", args, cli_args.no_update_check, &[]).await;
             std::process::exit(exit_code);
         }
         Some(Commands::Cloud { args }) => {
-            let exit_code = cli::handle_dispatch("cloud", args, cli_args.no_update_check).await;
+            let exit_code =
+                cli::handle_dispatch("cloud", args, cli_args.no_update_check, &[]).await;
             std::process::exit(exit_code);
         }
         Some(Commands::Worker { args }) => {
-            let exit_code = cli::handle_dispatch("worker", args, cli_args.no_update_check).await;
+            let envs = worker_dispatch_envs(&cli_args);
+            let exit_code =
+                cli::handle_dispatch("worker", args, cli_args.no_update_check, &envs).await;
             std::process::exit(exit_code);
         }
         Some(Commands::Project(args)) => {
@@ -456,9 +520,15 @@ mod tests {
     }
 
     #[test]
-    fn use_default_config_uses_engine_config_for_logging() {
-        let cli = Cli::try_parse_from(["iii", "--use-default-config"]).unwrap();
-        assert!(should_init_logging_from_engine_config(&cli));
+    fn use_default_config_is_no_longer_a_flag() {
+        // `--use-default-config` was removed: `iii` now creates config.yaml
+        // when it's missing, so a file-less mode flag has nothing to do and
+        // only bypassed the config.yaml setup (worker add, reload watcher).
+        let result = Cli::try_parse_from(["iii", "--use-default-config"]);
+        assert!(
+            result.is_err(),
+            "--use-default-config should no longer parse"
+        );
     }
 
     #[test]
@@ -891,6 +961,23 @@ mod tests {
     fn config_flag_still_works_before_subcommand() {
         let cli = Cli::try_parse_from(["iii", "--config", "foo.yaml", "worker", "add", "x"])
             .expect("config before subcommand should still parse");
-        assert_eq!(cli.config, "foo.yaml");
+        assert_eq!(cli.config.as_deref(), Some("foo.yaml"));
+        // An explicit --config is forwarded to the dispatched `iii worker`
+        // child as an absolute III_CONFIG_PATH so both sides edit the same
+        // file even when it isn't named config.yaml.
+        let envs = worker_dispatch_envs(&cli);
+        assert_eq!(envs.len(), 1);
+        assert_eq!(envs[0].0, "III_CONFIG_PATH");
+        assert!(std::path::Path::new(&envs[0].1).is_absolute());
+        assert!(envs[0].1.ends_with("foo.yaml"));
+    }
+
+    #[test]
+    fn default_config_is_not_forwarded_to_worker_dispatch() {
+        // Without an explicit --config the child keeps its own default and
+        // any user-exported III_CONFIG_PATH stays in effect.
+        let cli = Cli::try_parse_from(["iii", "worker", "list"]).unwrap();
+        assert!(cli.config.is_none());
+        assert!(worker_dispatch_envs(&cli).is_empty());
     }
 }

--- a/engine/src/workers/config.rs
+++ b/engine/src/workers/config.rs
@@ -89,7 +89,7 @@ impl EngineConfig {
             if e.kind() == std::io::ErrorKind::NotFound {
                 anyhow::anyhow!(
                     "Config file not found: '{}'.\n\
-                     Hint: create a config.yaml or pass --use-default-config to run with defaults.",
+                     Hint: create the file, or start `iii` again — it offers to create a missing config file for you.",
                     path
                 )
             } else {
@@ -113,6 +113,22 @@ impl EngineConfig {
         };
         cfg.ensure_builtin_daemons();
         cfg
+    }
+
+    /// YAML content written when `iii` starts in a directory that has no
+    /// config file yet. Deliberately minimal: an EMPTY `workers:` list.
+    /// Mandatory engine workers (configuration, iii-worker-manager, …) are
+    /// always injected by `build()` and never need an entry; everything
+    /// else is opt-in via `iii worker add <name>`, which appends entries
+    /// here. Written as `workers: []` (not a bare `workers:` key) because
+    /// the strict EngineConfig parser rejects a null list; the worker-add
+    /// append path normalizes the `[]` away before inserting entries.
+    pub fn starter_config_yaml() -> String {
+        "# iii engine configuration.\n\
+         # Add workers with `iii worker add <name>`; a running engine reloads on save.\n\
+         # Configure workers at runtime through the configuration worker (configuration::set).\n\
+         workers: []\n"
+            .to_string()
     }
 
     /// Inject KNOWN_EXTERNAL daemons (e.g. `iii-worker-ops` for the
@@ -339,7 +355,7 @@ impl WorkerRegistry {
 
         // 3. Legacy: external worker (iii.toml + iii_workers/)
         if image.is_none()
-            && let Some(info) = super::external::resolve_external_module(name)
+            && let Some(mut info) = super::external::resolve_external_module(name)
         {
             tracing::info!(
                 "Resolved '{}' as external worker '{}' ({})",
@@ -347,6 +363,15 @@ impl WorkerRegistry {
                 info.name,
                 info.binary_path.display()
             );
+            // Same-file contract: daemons that edit the project config file
+            // (worker-ops) must target the engine's ACTUAL config file —
+            // their built-in ./config.yaml default silently breaks custom
+            // config file names. The engine WS URL travels separately via
+            // III_ENGINE_URL, exported by ExternalWorker::spawn (MOT-3970).
+            if let Some(path) = engine.config_path() {
+                info.env
+                    .push(("III_CONFIG_PATH".to_string(), path.display().to_string()));
+            }
             let module =
                 super::external::ExternalWorker::new(info, config, engine.worker_manager_port());
             return Ok(Box::new(ExternalProcessWorker::new(Box::new(module))));
@@ -360,10 +385,14 @@ impl WorkerRegistry {
         //    back to DEFAULT_PORT via `worker_manager_port()`.
         let port = engine.worker_manager_port();
         tracing::info!(worker = %name, port = port, "Starting external worker via iii-worker");
-        let process =
-            super::registry_worker::ExternalWorkerProcess::spawn(name, port, config.as_ref())
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to start worker '{}': {}", name, e))?;
+        let process = super::registry_worker::ExternalWorkerProcess::spawn(
+            name,
+            port,
+            config.as_ref(),
+            engine.config_path(),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to start worker '{}': {}", name, e))?;
         Ok(Box::new(
             super::registry_worker::ExternalWorkerWrapper::new(process),
         ))
@@ -595,8 +624,8 @@ impl EngineBuilder {
 
     /// Records the path of the config file this engine was built from so that
     /// reload-time code can re-read and re-apply it. When set, `serve()` watches
-    /// this file for changes and reloads automatically. When unset (e.g. running
-    /// with `--use-default-config`), file watching is disabled.
+    /// this file for changes and reloads automatically. When unset (programmatic
+    /// in-memory configs), file watching is disabled.
     pub fn with_config_path(mut self, path: impl Into<String>) -> Self {
         self.config_path = Some(path.into());
         self
@@ -686,6 +715,22 @@ impl EngineBuilder {
             .map(|c| c.port)
             .unwrap_or(super::worker::DEFAULT_PORT);
         self.engine.set_worker_manager_port(resolved_port);
+
+        // Publish the absolute config path so worker-spawning code can hand
+        // it to child processes (III_CONFIG_PATH). Absolutized because the
+        // CLI default is the bare relative name "config.yaml" and children
+        // may resolve it from a different cwd.
+        if let Some(ref path) = self.config_path {
+            let abs = std::path::Path::new(path);
+            let abs = if abs.is_absolute() {
+                abs.to_path_buf()
+            } else {
+                std::env::current_dir()
+                    .map(|cwd| cwd.join(abs))
+                    .unwrap_or_else(|_| abs.to_path_buf())
+            };
+            self.engine.set_config_path(abs);
+        }
 
         for entry in workers {
             tracing::debug!("Creating worker: {}", entry.name);
@@ -892,7 +937,7 @@ impl EngineBuilder {
             tracing::info!("reload: watching {} for changes", path);
             Some(watcher)
         } else {
-            tracing::info!("reload: no config file to watch (--use-default-config)");
+            tracing::info!("reload: no config file to watch (running with in-memory config)");
             None
         };
 
@@ -2427,5 +2472,85 @@ workers:
             49199,
             "second set_worker_manager_port must be a no-op"
         );
+    }
+
+    #[tokio::test]
+    async fn engine_builder_publishes_absolute_config_path() {
+        // Spawned workers receive III_CONFIG_PATH from `Engine::config_path`;
+        // a relative path (the CLI default is the bare "config.yaml") would
+        // resolve against the CHILD's cwd and defeat the whole handshake.
+        let builder = EngineBuilder::new()
+            .with_config(EngineConfig {
+                modules: Vec::new(),
+                workers: Vec::new(),
+            })
+            .with_config_path("config.yaml")
+            .build()
+            .await
+            .expect("build with relative config path");
+
+        let path = builder
+            .engine()
+            .config_path()
+            .expect("config path must be published on the engine")
+            .to_path_buf();
+        assert!(
+            path.is_absolute(),
+            "published config path must be absolute, got {}",
+            path.display()
+        );
+        assert!(
+            path.ends_with("config.yaml"),
+            "published config path must keep the file name, got {}",
+            path.display()
+        );
+
+        builder.destroy().await.expect("destroy engine");
+    }
+
+    #[test]
+    fn engine_config_path_is_none_for_in_memory_configs() {
+        assert!(Engine::new().config_path().is_none());
+    }
+
+    #[test]
+    fn starter_config_yaml_has_an_empty_workers_list() {
+        let yaml = EngineConfig::starter_config_yaml();
+
+        // Must parse under the strict EngineConfig schema — this is why the
+        // file says `workers: []` and not a bare `workers:` key (serde
+        // rejects a null list).
+        let cfg: EngineConfig =
+            serde_yaml::from_str(&yaml).expect("starter config must parse as EngineConfig");
+
+        // Deliberately empty: mandatory engine workers are injected by
+        // build(), and everything else is opt-in via `iii worker add`.
+        assert!(
+            cfg.workers.is_empty(),
+            "starter file must not pre-list any workers, got {:?}",
+            cfg.workers
+        );
+        assert!(cfg.modules.is_empty());
+    }
+
+    #[tokio::test]
+    async fn starter_config_boots_and_accepts_appended_workers() {
+        // End-to-end shape check on the created file: it must build into a
+        // working engine as-is, and `iii worker add`'s append helper must be
+        // able to turn the empty `workers: []` marker into a real list (the
+        // normalize path in iii-worker's config_file.rs relies on this exact
+        // content shape; this pins the engine side of that contract).
+        let cfg: EngineConfig = serde_yaml::from_str(&EngineConfig::starter_config_yaml())
+            .expect("starter config must parse");
+        let builder = EngineBuilder::new()
+            .with_config(cfg)
+            .build()
+            .await
+            .expect("an empty starter config must boot (mandatory workers injected)");
+        assert_eq!(
+            builder.engine().worker_manager_port(),
+            super::super::worker::DEFAULT_PORT,
+        );
+        builder.destroy().await.expect("destroy engine");
     }
 }

--- a/engine/src/workers/external.rs
+++ b/engine/src/workers/external.rs
@@ -116,6 +116,7 @@ pub fn resolve_external_module_in(base_dir: &Path, class: &str) -> Option<Extern
             name: binary_name_candidate,
             binary_path,
             extra_args: hit.args.iter().map(|s| (*s).to_string()).collect(),
+            env: Vec::new(),
         });
     }
 
@@ -160,6 +161,7 @@ pub fn resolve_external_module_in(base_dir: &Path, class: &str) -> Option<Extern
         name: binary_name,
         binary_path,
         extra_args: vec![],
+        env: Vec::new(),
     })
 }
 
@@ -170,6 +172,10 @@ pub struct ExternalWorkerInfo {
     /// Empty for conventional iii_workers/<binary> resolution; populated
     /// when the worker was matched via KNOWN_EXTERNAL.
     pub extra_args: Vec<String>,
+    /// Extra environment variables set on the child (e.g. `III_CONFIG_PATH`
+    /// so daemons that edit the project config file target the engine's
+    /// actual file, not a hardcoded ./config.yaml).
+    pub env: Vec<(String, String)>,
 }
 
 /// A worker implementation backed by an external binary from `iii_workers/`.
@@ -191,6 +197,7 @@ pub struct ExternalWorker {
     /// (sandbox-daemon, worker-manager-daemon) connect back to THIS engine
     /// instead of their hardcoded ws://127.0.0.1:49134 default (MOT-3970).
     worker_manager_port: u16,
+    env: Vec<(String, String)>,
     config: Option<Value>,
     child: Arc<Mutex<Option<Child>>>,
     config_file: Arc<Mutex<Option<PathBuf>>>,
@@ -226,6 +233,7 @@ impl ExternalWorker {
             binary_path: info.binary_path,
             extra_args: info.extra_args,
             worker_manager_port,
+            env: info.env,
             config,
             child: Arc::new(Mutex::new(None)),
             config_file: Arc::new(Mutex::new(None)),
@@ -256,6 +264,9 @@ impl ExternalWorker {
         }
         if let Some(path) = config_path {
             cmd.arg("--config").arg(path);
+        }
+        for (key, value) in &self.env {
+            cmd.env(key, value);
         }
         // Pipe stdio instead of inheriting the engine's TTY fds. External
         // workers (notably iii-sandbox) load libkrun, which raws the host
@@ -890,6 +901,7 @@ mod tests {
             name: "test-worker".to_string(),
             binary_path: PathBuf::from("/tmp/test-worker"),
             extra_args: vec![],
+            env: Vec::new(),
         };
         let module = ExternalWorker::new(info, None, crate::workers::worker::DEFAULT_PORT);
         assert_eq!(module.name, "test-worker");
@@ -904,6 +916,7 @@ mod tests {
             name: "configured-worker".to_string(),
             binary_path: PathBuf::from("/tmp/configured-worker"),
             extra_args: vec![],
+            env: Vec::new(),
         };
         let module = ExternalWorker::new(
             info,
@@ -919,6 +932,7 @@ mod tests {
             name: "my-worker".to_string(),
             binary_path: PathBuf::from("/tmp/my-worker"),
             extra_args: vec![],
+            env: Vec::new(),
         };
         let module = ExternalWorker::new(info, None, crate::workers::worker::DEFAULT_PORT);
         assert_eq!(module.name(), "ExternalWorker(my-worker)");
@@ -930,6 +944,7 @@ mod tests {
             name: "test-worker".to_string(),
             binary_path: PathBuf::from("/tmp/test-worker"),
             extra_args: vec![],
+            env: Vec::new(),
         };
         let module = ExternalWorker::new(info, None, crate::workers::worker::DEFAULT_PORT);
         let name1 = module.name();
@@ -946,6 +961,7 @@ mod tests {
             name: "clone-test".to_string(),
             binary_path: PathBuf::from("/tmp/clone-test"),
             extra_args: vec![],
+            env: Vec::new(),
         };
         let module = ExternalWorker::new(info, None, crate::workers::worker::DEFAULT_PORT);
         let cloned = module.clone();
@@ -962,6 +978,7 @@ mod tests {
             name: "init-test".to_string(),
             binary_path: PathBuf::from("/tmp/init-test"),
             extra_args: vec![],
+            env: Vec::new(),
         };
         let module = ExternalWorker::new(info, None, crate::workers::worker::DEFAULT_PORT);
         assert!(module.initialize().await.is_ok());
@@ -973,6 +990,7 @@ mod tests {
             name: "destroy-test".to_string(),
             binary_path: PathBuf::from("/tmp/destroy-test"),
             extra_args: vec![],
+            env: Vec::new(),
         };
         let module = ExternalWorker::new(info, None, crate::workers::worker::DEFAULT_PORT);
         // destroy on a fresh module (no spawned child) should succeed
@@ -985,6 +1003,7 @@ mod tests {
             name: "cleanup-test".to_string(),
             binary_path: PathBuf::from("/tmp/cleanup-test"),
             extra_args: vec![],
+            env: Vec::new(),
         };
         let module = ExternalWorker::new(info, None, crate::workers::worker::DEFAULT_PORT);
 
@@ -1018,6 +1037,7 @@ mod tests {
             name: "unit-test".into(),
             binary_path: PathBuf::from("/tmp/fake"),
             extra_args: vec![],
+            env: Vec::new(),
         };
         assert!(info.extra_args.is_empty());
     }
@@ -1164,6 +1184,7 @@ mod tests {
             name: "probe".into(),
             binary_path: fixture,
             extra_args: vec!["first-arg".into(), "second-arg".into()],
+            env: vec![("III_PROBE_EXTRA_ENV".into(), "probe-env-value".into())],
         };
 
         // Distinctive port: the assertion below proves the child received
@@ -1221,6 +1242,12 @@ mod tests {
             assert!(
                 env_line.contains("engine_url=ws://127.0.0.1:50123"),
                 "child must see this engine's actual WS URL, not a default; got: {env_line:?}"
+            );
+            // Info-declared env vars (e.g. III_CONFIG_PATH in production)
+            // must reach the child.
+            assert!(
+                env_line.contains("extra_env=probe-env-value"),
+                "child must see ExternalWorkerInfo.env vars; got: {env_line:?}"
             );
         }
     }

--- a/engine/src/workers/external.rs
+++ b/engine/src/workers/external.rs
@@ -1289,6 +1289,7 @@ mod tests {
             name: "respawn-probe".into(),
             binary_path: fixture,
             extra_args: vec![],
+            env: Vec::new(),
         };
         // config: None — the builtin daemon path MOT-3857 is about.
         let worker = ExternalWorker::new(info, None, crate::workers::worker::DEFAULT_PORT);
@@ -1355,6 +1356,7 @@ mod tests {
             name: "destroy-probe".into(),
             binary_path: fixture,
             extra_args: vec![],
+            env: Vec::new(),
         };
         let worker = ExternalWorker::new(info, None, crate::workers::worker::DEFAULT_PORT);
 

--- a/engine/src/workers/registry_worker.rs
+++ b/engine/src/workers/registry_worker.rs
@@ -246,7 +246,17 @@ impl ExternalWorkerProcess {
     /// behavior; when it runs on a non-default port (e.g. SDK integration
     /// tests with multiple `iii-worker-manager` entries), the spawned worker
     /// no longer silently connects to the wrong port.
-    pub async fn spawn(name: &str, port: u16, config: Option<&Value>) -> Result<Self, String> {
+    ///
+    /// `engine_config_path` is the engine's absolute config file path when
+    /// file-backed; exported as `III_CONFIG_PATH` so the spawned
+    /// `iii-worker start` resolves worker type/config from the SAME file the
+    /// engine watches even when the file isn't `./config.yaml`.
+    pub async fn spawn(
+        name: &str,
+        port: u16,
+        config: Option<&Value>,
+        engine_config_path: Option<&std::path::Path>,
+    ) -> Result<Self, String> {
         let worker_binary = resolve_iii_worker_binary()
             .ok_or_else(|| {
                 "iii-worker binary not found. Install with `iii update worker` or place in ~/.local/bin/".to_string()
@@ -310,6 +320,12 @@ impl ExternalWorkerProcess {
         // iii` left every managed worker running: this path — not
         // external.rs — is how production workers are spawned.
         cmd.env("III_ENGINE_PID", std::process::id().to_string());
+        // Same-file contract: the spawned `iii-worker start` (and everything
+        // it detaches — VM boot, source watcher restarts) must read the
+        // engine's actual config file, not assume ./config.yaml in its cwd.
+        if let Some(path) = engine_config_path {
+            cmd.env("III_CONFIG_PATH", path);
+        }
 
         let child = cmd
             .spawn()

--- a/engine/src/workers/reload.rs
+++ b/engine/src/workers/reload.rs
@@ -350,7 +350,7 @@ impl ReloadManager {
         let path = match config_path {
             Some(p) => p,
             None => {
-                tracing::info!("reload: ignored, running with --use-default-config");
+                tracing::info!("reload: ignored, running with in-memory config (no file)");
                 return Ok(());
             }
         };

--- a/engine/tests/cli_args.rs
+++ b/engine/tests/cli_args.rs
@@ -1,59 +1,95 @@
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 fn iii_bin() -> Command {
     Command::new(env!("CARGO_BIN_EXE_iii"))
 }
 
-#[test]
-fn test_conflicting_flags_exits_with_error() {
-    let output = iii_bin()
-        .args(["--use-default-config", "-c", "some.yaml"])
-        .output()
-        .expect("failed to execute");
-    assert!(
-        !output.status.success(),
-        "Should fail with conflicting flags"
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("cannot be used with") || stderr.contains("conflict"),
-        "Should mention conflict, got: {}",
-        stderr
-    );
+/// Spawn the engine in `dir`, wait for it to create `file_name`, then kill it.
+/// Returns whether the file appeared within the deadline. The engine may fail
+/// later (e.g. port already bound by a concurrent test) — irrelevant here, the
+/// config file is written before any listener binds.
+fn spawn_and_wait_for_config(dir: &std::path::Path, args: &[&str], file_name: &str) -> bool {
+    let mut child = iii_bin()
+        .args(args)
+        .current_dir(dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn iii");
+
+    let config_path = dir.join(file_name);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    let mut created = false;
+    while std::time::Instant::now() < deadline {
+        if config_path.exists() {
+            created = true;
+            break;
+        }
+        // A crashed child will never create the file; stop early.
+        if let Ok(Some(_)) = child.try_wait() {
+            created = config_path.exists();
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    created
 }
 
 #[test]
-fn test_missing_default_config_exits_with_error() {
-    // Run in a temp dir where config.yaml doesn't exist
-    let dir = tempfile::tempdir().unwrap();
-    let output = iii_bin()
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to execute");
-    assert!(
-        !output.status.success(),
-        "Should fail when config.yaml is missing"
-    );
-    // Check stderr or stdout for the helpful message
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let combined = format!("{}{}", stderr, stdout);
-    assert!(
-        combined.contains("Config file not found") || combined.contains("config.yaml"),
-        "Should mention missing config file, got: {}",
-        combined
-    );
-}
-
-#[test]
-fn test_use_default_config_flag_is_accepted() {
-    // Run with --use-default-config and --version to verify clap accepts the flag
+fn test_use_default_config_flag_is_rejected() {
+    // `--use-default-config` was removed: `iii` now creates config.yaml when
+    // it's missing instead of offering a file-less mode that broke the
+    // config.yaml setup (worker add, reload watcher).
     let output = iii_bin()
         .args(["--use-default-config", "--version"])
         .output()
         .expect("failed to execute");
     assert!(
-        output.status.success(),
-        "Should accept --use-default-config flag"
+        !output.status.success(),
+        "--use-default-config should no longer be accepted"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unexpected argument") || stderr.contains("--use-default-config"),
+        "Should reject the removed flag, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_missing_default_config_is_created_headless() {
+    // Non-interactive session (stdin is not a TTY): a missing config.yaml is
+    // created instead of aborting the boot.
+    let dir = tempfile::tempdir().unwrap();
+    assert!(
+        spawn_and_wait_for_config(dir.path(), &[], "config.yaml"),
+        "engine should create config.yaml when it is missing"
+    );
+    let content = std::fs::read_to_string(dir.path().join("config.yaml")).unwrap();
+    assert!(
+        content.contains("workers: []"),
+        "created config should declare an empty workers list, got: {}",
+        content
+    );
+    // Deliberately empty: no workers are pre-listed; users opt in via
+    // `iii worker add <name>`.
+    assert!(
+        !content.contains("- name:"),
+        "created config must not pre-list any workers, got: {}",
+        content
+    );
+}
+
+#[test]
+fn test_missing_explicit_config_is_created_headless() {
+    // The same creation flow applies to a custom --config name, so setups
+    // using e.g. config.yml work end to end.
+    let dir = tempfile::tempdir().unwrap();
+    assert!(
+        spawn_and_wait_for_config(dir.path(), &["--config", "config.yml"], "config.yml"),
+        "engine should create the file named by --config when it is missing"
     );
 }

--- a/engine/tests/cli_integration.rs
+++ b/engine/tests/cli_integration.rs
@@ -50,9 +50,18 @@ fn help_flag_shows_all_subcommands() {
     assert!(stdout.contains("worker"), "help should list worker");
     assert!(stdout.contains("project"), "help should list project");
     assert!(stdout.contains("update"), "help should list update");
+    // "create" was replaced by `iii project init --template` — it must not
+    // come back as a SUBCOMMAND. The word may legitimately appear in option
+    // descriptions (the --config help says `iii` offers to create the file),
+    // so check the subcommand-line pattern rather than a raw substring.
+    let create_subcommand_lines: Vec<&str> = stdout
+        .lines()
+        .filter(|l| l.trim_start().starts_with("create ") || l.trim() == "create")
+        .collect();
     assert!(
-        !stdout.contains(" create "),
-        "help should NOT list create (replaced by `iii project init --template`)"
+        create_subcommand_lines.is_empty(),
+        "help should NOT list create as a subcommand (replaced by `iii project init --template`), found: {:?}",
+        create_subcommand_lines
     );
 }
 

--- a/engine/tests/fixtures/argv_probe.sh
+++ b/engine/tests/fixtures/argv_probe.sh
@@ -6,8 +6,8 @@
 {
   printf '%s\n' "$*"
   if [ -e "/dev/fd/${III_LIFELINE_FD:-999}" ]; then lifeline_open=yes; else lifeline_open=no; fi
-  printf 'engine_pid=%s lifeline_fd=%s lifeline_open=%s engine_url=%s\n' \
+  printf 'engine_pid=%s lifeline_fd=%s lifeline_open=%s engine_url=%s extra_env=%s\n' \
     "${III_ENGINE_PID:-unset}" "${III_LIFELINE_FD:-unset}" "$lifeline_open" \
-    "${III_ENGINE_URL:-unset}"
+    "${III_ENGINE_URL:-unset}" "${III_PROBE_EXTRA_ENV:-unset}"
 } > "$ARGV_LOG"
 sleep 30


### PR DESCRIPTION
## Problem

Several DX issues around `iii` startup and `iii worker add` made the worker workflow fragile unless everything ran from one directory, with the default file name, on the default port:

- `iii worker add` edits `config.yaml` **in the CLI's cwd**. Run from any other folder it wrote to a file no engine was watching, then hung for 120s waiting for a worker that would never boot.
- Worker ops hardcoded the name `config.yaml` — engines started with `--config config.yml` (or any custom path) silently split into two files.
- `add` copied each worker's default `config:` block into `config.yaml`. Workers are configured live through the configuration worker, so those blocks only took effect after a full engine restart (legacy first-boot seeding).
- The `iii-worker-ops` daemon hardcoded `ws://127.0.0.1:49134`; engines on any other port got a daemon stuck in a reconnect loop spamming connectivity warnings.
- `iii` refused to start without a `config.yaml`, and the escape hatch `--use-default-config` ran file-less — which broke the config setup (`worker add`, reload watcher) entirely.

## Solution

- **`iii` runs without a pre-existing config file.** On a TTY it asks before creating (`No config.yaml found in <dir>. Create it and start the engine? [Y/n]`); non-interactive sessions (containers, CI) create it without asking. Works for `--config <custom-name>` too. The created file is deliberately minimal — no pre-listed workers, you opt in with `iii worker add`:

  ```yaml
  # iii engine configuration.
  # Add workers with `iii worker add <name>`; a running engine reloads on save.
  # Configure workers at runtime through the configuration worker (configuration::set).
  workers: []
  ```

- **`--use-default-config` is removed** (breaking). The created starter file replaces it, keeping the reload watcher and worker ops functional.
- **`iii worker add --host <host[:port]>`** (and `reinstall`) installs through a *running* engine by invoking its `worker::add` trigger — the engine applies the change in **its** project directory, so the command works from any folder, machine, or port (`iii worker add pdfkit --host localhost:49134`). Unreachable hosts fail fast instead of hanging; the local-path timeout message now points at `--host`.
- **`III_CONFIG_PATH` handshake:** the engine exports its absolutized config path to every process it spawns (worker-ops daemon, sandbox daemon, `iii worker start` children, and `iii --config x.yml worker …` dispatch). All worker-op reads/writes resolve through it, so custom config names work end to end.
- **Correct engine URL for daemons:** landed on main as MOT-3970 (#1974) while this PR was in review — the engine exports `III_ENGINE_URL` to spawned daemons and their `--engine` args read it. This PR rebased onto that mechanism and adds `III_CONFIG_PATH` on top.
- **`add` writes bare `- name:` entries** — no `config:` blocks (registry/binary/OCI/local/builtin alike). Hand-written blocks are preserved on re-add. Exception: `iii-sandbox` keeps its block, since its daemon is fail-closed on it and the image allowlist is an operator security surface.

## Verification

Live e2e: engine started with `--config config.yml` on port 49177; `iii worker add iii-queue --host localhost:49177` from an unrelated directory appended a bare entry to the engine's `config.yml`, the engine hot-reloaded and registered the worker, and nothing in the CLI's cwd was touched. Fresh-dir boot auto-created the empty starter file and a follow-up `iii worker add iii-state` populated it live. Docs + generated CLI reference updated.

## Testing this branch from source

`iii worker …` subcommands are **dispatched to the separately installed `iii-worker` binary** (`~/.local/bin/iii-worker` first, then PATH) — `make build` compiles it but does not install it, so a rebuilt `iii` on PATH will still run your previously installed release `iii-worker`, which predates `--host` and fails with `error: unexpected argument '--host' found`. Install the branch worker binary too:

```bash
make install-iii-worker   # builds and installs iii-worker to ~/.local/bin
```

> **Breaking:** `--use-default-config` no longer parses. Scripts using it should just run `iii` (the config file is created on first run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--host` support for installing or reinstalling workers through a running engine, including custom ports and WebSocket URLs.
  * Added automatic config-file creation when the selected file is missing.
  * Added support for selecting project configuration through the `III_CONFIG_PATH` environment variable.
  * Worker entries now use built-in defaults unless an optional initial configuration block is provided.

* **Bug Fixes**
  * Improved remote connection checks, timeout guidance, and user-friendly error messages.

* **Documentation**
  * Updated CLI, engine, and worker documentation to reflect the new configuration and remote installation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->