### PR TITLE
fix(iii-worker): worker CLI operation fixes (remove, status, clear, update, logs, sandbox)

### DIFF
--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -61,9 +61,9 @@ pub enum Commands {
         no_wait: bool,
     },
 
-    /// Remove one or more workers from config.yaml. The engine's file watcher
-    /// tears down any running sandbox. Artifacts under ~/.iii/managed/{name}/
-    /// remain; use `iii worker clear {name}` to delete them.
+    /// Remove one or more workers from config.yaml and iii.lock. The engine's
+    /// file watcher tears down any running sandbox. Artifacts under
+    /// ~/.iii/managed/{name}/ remain; use `iii worker clear {name}` to delete them.
     Remove {
         /// Worker names to remove (e.g., "pdfkit")
         #[arg(value_name = "WORKER", required = true, num_args = 1..)]

--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -74,14 +74,16 @@ pub enum Commands {
         yes: bool,
     },
 
-    /// Re-download a worker (equivalent to `add --force`; pass `--reset-config` to also reset
-    /// its config.yaml entry to registry defaults)
+    /// Re-download a worker (like `add --force`, but returns immediately instead of waiting
+    /// for the worker to report ready; pass `--reset-config` to also reset its config.yaml
+    /// entry to registry defaults)
     Reinstall {
         #[command(flatten)]
         args: AddArgs,
     },
 
-    /// Update workers in iii.lock to their latest allowed version
+    /// Update workers pinned in iii.lock to the latest version published in the registry,
+    /// rewriting config.yaml and iii.lock
     Update {
         /// Optional worker name to update. If omitted, updates every worker in iii.lock.
         #[arg(value_name = "WORKER")]
@@ -100,7 +102,9 @@ pub enum Commands {
         yes: bool,
     },
 
-    /// Start a previously stopped managed worker container.
+    /// Start a previously stopped managed worker container. If the worker has no
+    /// local artifacts (e.g. after `iii worker clear`), it is fetched from the
+    /// registry first.
     /// By default waits up to 120s for the worker to report ready before returning.
     /// Workers will continue to start after 120s, see `iii worker status` and `iii worker logs` for
     /// tracking workers.
@@ -139,7 +143,8 @@ pub enum Commands {
         yes: bool,
     },
 
-    /// Restart a managed worker: stop if running, then start.
+    /// Restart a managed worker: stop if running, then start (same start path as
+    /// `iii worker start`, including the registry fetch for missing local artifacts).
     /// By default waits up to 120s for the worker to report ready (same as start).
     Restart {
         /// Worker name to restart
@@ -171,7 +176,8 @@ pub enum Commands {
         frozen: bool,
     },
 
-    /// Verify the worker's manifest (iii.worker.yaml) is valid.
+    /// Verify config.yaml and iii.lock agree: every managed worker in config.yaml
+    /// must be pinned in iii.lock for this platform.
     Verify {
         /// Also check dependency declarations against locked versions.
         #[arg(long)]
@@ -180,7 +186,7 @@ pub enum Commands {
 
     /// Show detailed status of one worker (config, sandbox, process, logs).
     /// By default refreshes live in place until the worker reaches a success
-    /// or failure state.
+    /// or failure state; exits immediately when the engine is not running.
     Status {
         /// Worker name
         #[arg(value_name = "WORKER")]
@@ -191,7 +197,8 @@ pub enum Commands {
         no_watch: bool,
     },
 
-    /// Show logs from a managed worker container
+    /// Show logs from a managed worker container. Logs are read from the
+    /// local log files under ~/.iii/logs/{name}/.
     Logs {
         /// Worker name
         #[arg(value_name = "WORKER")]
@@ -200,14 +207,6 @@ pub enum Commands {
         /// Follow log output
         #[arg(long, short)]
         follow: bool,
-
-        /// Engine host address
-        #[arg(long, default_value = "localhost")]
-        address: String,
-
-        /// Engine WebSocket port
-        #[arg(long, default_value_t = DEFAULT_PORT)]
-        port: u16,
     },
 
     /// Scaffold a NEW standalone worker repo from scratch.
@@ -404,8 +403,7 @@ pub enum SandboxCmd {
         #[arg(long, value_name = "NAME")]
         name: Option<String>,
 
-        /// Enable guest network access. Default follows the engine's
-        /// sandbox policy (typically disabled).
+        /// Enable guest network access (disabled unless this flag is passed).
         #[arg(long)]
         network: bool,
 

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -1297,6 +1297,25 @@ fn read_lockfile_or_default(
     }
 }
 
+/// Delete `worker_name` from `iii.lock`. Returns `Ok(true)` when an entry
+/// was removed and the lockfile rewritten, `Ok(false)` when there was
+/// nothing to do (no lockfile, or the worker wasn't pinned — local and
+/// builtin workers never are). Without this, `iii worker sync` keeps
+/// replaying the removed worker's artifacts and a bare `iii worker update`
+/// re-resolves it as a lock root, reinstalling it into config.yaml.
+fn remove_lock_entry(worker_name: &str) -> Result<bool, String> {
+    let lock_path = super::lockfile::lockfile_path();
+    if !lock_path.exists() {
+        return Ok(false);
+    }
+    let mut lockfile = super::lockfile::WorkerLockfile::read_from(lock_path)?;
+    if lockfile.workers.remove(worker_name).is_none() {
+        return Ok(false);
+    }
+    lockfile.write_to(lock_path)?;
+    Ok(true)
+}
+
 fn write_engine_lock_entry(worker_name: &str, version: &str) -> Result<(), String> {
     let lock_path = super::lockfile::lockfile_path();
     let mut lockfile = read_lockfile_or_default(lock_path)?;
@@ -2124,12 +2143,38 @@ pub async fn handle_managed_remove(worker_name: &str, brief: bool) -> i32 {
         );
         return 1;
     }
+    // Snapshot config.yaml so the config and lockfile edits commit together:
+    // a worker left in iii.lock after leaving config.yaml gets resurrected by
+    // `iii worker update` and replayed by `iii worker sync`.
+    let config_snapshot = match ConfigYamlSnapshot::capture() {
+        Ok(snapshot) => snapshot,
+        Err(e) => {
+            eprintln!("{} {}", "error:".red(), e);
+            return 1;
+        }
+    };
     if let Err(e) = super::config_file::remove_worker(worker_name) {
         eprintln!("{} {}", "error:".red(), e);
         return 1;
     }
+    let removed_from_lock = match remove_lock_entry(worker_name) {
+        Ok(removed) => removed,
+        Err(e) => {
+            eprintln!("{} {}", "error:".red(), e);
+            config_snapshot.restore_after_failure();
+            return 1;
+        }
+    };
     if brief {
         eprintln!("        {} {}", "✓".green(), worker_name.bold());
+    } else if removed_from_lock {
+        eprintln!(
+            "  {} {} removed from {} and {}",
+            "✓".green(),
+            worker_name.bold(),
+            "config.yaml".dimmed(),
+            "iii.lock".dimmed(),
+        );
     } else {
         eprintln!(
             "  {} {} removed from {}",
@@ -5746,6 +5791,93 @@ dependencies:
             let rc = handle_worker_update(None).await;
 
             assert_eq!(rc, 0);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_managed_remove_removes_worker_from_lockfile() {
+        in_temp_dir_async(|_| async move {
+            std::fs::write(
+                "config.yaml",
+                "workers:\n  - name: pdfkit\n  - name: keeper\n",
+            )
+            .unwrap();
+            let mut lock = cli_lockfile::WorkerLockfile::default();
+            for name in ["pdfkit", "keeper"] {
+                lock.workers.insert(
+                    name.to_string(),
+                    cli_lockfile::LockedWorker {
+                        version: "1.0.0".to_string(),
+                        worker_type: cli_lockfile::LockedWorkerType::Binary,
+                        dependencies: Default::default(),
+                        source: locked_binary_source(
+                            binary_download::current_target(),
+                            &format!("https://workers.iii.dev/{name}.tar.gz"),
+                            "a".repeat(64),
+                        ),
+                    },
+                );
+            }
+            lock.write_to(cli_lockfile::lockfile_path()).unwrap();
+
+            let rc = handle_managed_remove("pdfkit", false).await;
+
+            assert_eq!(rc, 0);
+            let config = std::fs::read_to_string("config.yaml").unwrap();
+            assert!(!config.contains("pdfkit"));
+            let lock =
+                cli_lockfile::WorkerLockfile::read_from(cli_lockfile::lockfile_path()).unwrap();
+            assert!(!lock.workers.contains_key("pdfkit"));
+            assert!(lock.workers.contains_key("keeper"));
+            // Regression: before the lockfile prune, `iii worker update pdfkit`
+            // still resolved the removed worker and reinstalled it.
+            assert_eq!(handle_worker_update(Some("pdfkit")).await, 1);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_managed_remove_leaves_lockfile_alone_for_unpinned_worker() {
+        in_temp_dir_async(|_| async move {
+            // Local/builtin workers live in config.yaml but are never pinned
+            // in iii.lock; removing one must not disturb other pins.
+            std::fs::write("config.yaml", "workers:\n  - name: local-w\n").unwrap();
+            let mut lock = cli_lockfile::WorkerLockfile::default();
+            lock.workers.insert(
+                "keeper".to_string(),
+                cli_lockfile::LockedWorker {
+                    version: "1.0.0".to_string(),
+                    worker_type: cli_lockfile::LockedWorkerType::Engine,
+                    dependencies: Default::default(),
+                    source: None,
+                },
+            );
+            lock.write_to(cli_lockfile::lockfile_path()).unwrap();
+
+            let rc = handle_managed_remove("local-w", false).await;
+
+            assert_eq!(rc, 0);
+            let lock =
+                cli_lockfile::WorkerLockfile::read_from(cli_lockfile::lockfile_path()).unwrap();
+            assert!(lock.workers.contains_key("keeper"));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_managed_remove_restores_config_when_lockfile_is_malformed() {
+        in_temp_dir_async(|_| async move {
+            let config = "workers:\n  - name: pdfkit\n";
+            std::fs::write("config.yaml", config).unwrap();
+            std::fs::write("iii.lock", "not: [valid").unwrap();
+
+            let rc = handle_managed_remove("pdfkit", false).await;
+
+            // The lockfile edit failed, so the config removal must roll back
+            // rather than leave config.yaml and iii.lock disagreeing.
+            assert_eq!(rc, 1);
+            assert_eq!(std::fs::read_to_string("config.yaml").unwrap(), config);
         })
         .await;
     }

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -618,6 +618,25 @@ pub async fn handle_worker_sync(frozen: bool) -> i32 {
         return handle_worker_verify(false).await;
     }
 
+    // Acquire the operation lock BEFORE reading iii.lock. Reading first
+    // left a TOCTOU window: sync snapshots the lockfile, a concurrent
+    // update commits a new one, then sync acquires the lock and installs
+    // artifacts from the stale snapshot while iii.lock on disk says
+    // otherwise. (The --frozen path above stays outside the lock: it is
+    // read-only and lockfile writes are atomic renames, so its reads are
+    // always self-consistent.)
+    let _operation_lock =
+        match crate::core::ProjectOperationLock::acquire(std::path::Path::new(".")) {
+            Ok(lock) => lock,
+            Err(e) => {
+                eprintln!(
+                    "{} another iii worker operation is active ({e}). Wait for it to finish.",
+                    "error:".red()
+                );
+                return 1;
+            }
+        };
+
     let lock_path = super::lockfile::lockfile_path();
     let lockfile = match super::lockfile::WorkerLockfile::read_from(lock_path) {
         Ok(lockfile) => lockfile,
@@ -642,18 +661,6 @@ pub async fn handle_worker_sync(frozen: bool) -> i32 {
         return 1;
     }
     let skipped_unmanaged = skipped_unmanaged_config_workers(&lockfile, &config_names);
-
-    let _operation_lock =
-        match crate::core::ProjectOperationLock::acquire(std::path::Path::new(".")) {
-            Ok(lock) => lock,
-            Err(e) => {
-                eprintln!(
-                    "{} another iii worker operation is active ({e}). Wait for it to finish.",
-                    "error:".red()
-                );
-                return 1;
-            }
-        };
 
     match replay_lockfile(&lockfile).await {
         Ok(mut summary) => {
@@ -2173,6 +2180,21 @@ pub async fn handle_managed_remove(worker_name: &str, brief: bool) -> i32 {
         );
         return 1;
     }
+    // Same mutual exclusion as sync/update: remove edits config.yaml AND
+    // iii.lock, so racing an update's lockfile read-modify-write could
+    // silently write the removed worker's pin back, and the snapshot
+    // rollback below could wipe a concurrent add's config.yaml append.
+    let _operation_lock =
+        match crate::core::ProjectOperationLock::acquire(std::path::Path::new(".")) {
+            Ok(lock) => lock,
+            Err(e) => {
+                eprintln!(
+                    "{} another iii worker operation is active ({e}). Wait for it to finish.",
+                    "error:".red()
+                );
+                return 1;
+            }
+        };
     // Snapshot config.yaml so the config and lockfile edits commit together:
     // a worker left in iii.lock after leaving config.yaml gets resurrected by
     // `iii worker update` and replayed by `iii worker sync`.
@@ -2286,7 +2308,9 @@ fn clear_single_worker(worker_name: &str) -> i32 {
 /// Prompts the user for confirmation before clearing all artifacts.
 /// Returns `true` if the user confirms with "y".
 fn confirm_clear() -> bool {
-    confirm_prompt("  This will remove all downloaded workers and images. Continue? [y/N] ")
+    confirm_prompt(
+        "  This will remove all downloaded workers, images, and managed VM state. Continue? [y/N] ",
+    )
 }
 
 fn clear_all_workers(skip_confirm: bool) -> i32 {
@@ -2337,8 +2361,25 @@ fn clear_all_workers(skip_confirm: bool) -> i32 {
             }
             return None;
         }
-        total_freed += dir_size(&entry.path());
-        let _ = std::fs::remove_dir_all(entry.path());
+        // Legacy binary workers can be a bare FILE at ~/.iii/workers/{name}
+        // (see delete_worker_artifacts); remove_dir_all fails on those with
+        // NotADirectory. Branch on the entry's own (non-following) file
+        // type, and count the entry as cleared — and its bytes as freed —
+        // only when the deletion actually succeeded.
+        let path = entry.path();
+        let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+        let (bytes, removed) = if is_dir {
+            (dir_size(&path), std::fs::remove_dir_all(&path))
+        } else {
+            let len = std::fs::symlink_metadata(&path)
+                .map(|m| m.len())
+                .unwrap_or(0);
+            (len, std::fs::remove_file(&path))
+        };
+        if removed.is_err() {
+            return None;
+        }
+        total_freed += bytes;
         Some(name)
     };
 
@@ -6427,6 +6468,35 @@ dependencies:
         });
     }
 
+    #[test]
+    fn clear_all_workers_removes_legacy_single_file_binary() {
+        // Legacy binary workers are a bare FILE at ~/.iii/workers/{name}.
+        // remove_dir_all fails on those with NotADirectory, so the old code
+        // left the file on disk while still reporting it cleared and its
+        // bytes freed. The wipe-all path must branch on file type.
+        in_temp_dir(|dir| {
+            let _env_guard = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let home = dir.join("home");
+            std::fs::create_dir_all(&home).unwrap();
+            let _home_guard = set_env_var_for_test("HOME", &home);
+
+            let workers = home.join(".iii/workers");
+            std::fs::create_dir_all(&workers).unwrap();
+            let legacy_file = workers.join("legacy-file-worker");
+            std::fs::write(&legacy_file, "fake binary bytes").unwrap();
+
+            let rc = clear_all_workers(true);
+
+            assert_eq!(rc, 0);
+            assert!(
+                !legacy_file.exists(),
+                "legacy single-file binary artifact must be removed"
+            );
+        });
+    }
+
     #[tokio::test]
     async fn handle_worker_update_without_lockfile_says_nothing_to_update() {
         in_temp_dir_async(|_| async move {
@@ -6436,6 +6506,41 @@ dependencies:
             // A named update without a lockfile is the same failure as
             // "name not pinned".
             assert_eq!(handle_worker_update(Some("ghost")).await, 1);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_worker_sync_fails_when_operation_lock_is_held() {
+        in_temp_dir_async(|dir| async move {
+            // The lock must be acquired BEFORE sync reads its iii.lock
+            // snapshot — reading first left a TOCTOU window where sync could
+            // replay a snapshot a concurrent update had already replaced. A
+            // held lock therefore has to fail sync even when iii.lock is
+            // perfectly readable.
+            cli_lockfile::WorkerLockfile::default()
+                .write_to(cli_lockfile::lockfile_path())
+                .unwrap();
+            let _held = crate::core::ProjectOperationLock::acquire(&dir).unwrap();
+
+            assert_eq!(handle_worker_sync(false).await, 1);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_managed_remove_fails_when_operation_lock_is_held() {
+        in_temp_dir_async(|dir| async move {
+            // Remove edits config.yaml + iii.lock, so it must respect the
+            // same operation mutex as sync/update — otherwise a concurrent
+            // update's lockfile read-modify-write can resurrect the removed
+            // worker's pin.
+            let config = "workers:\n  - name: pdfkit\n";
+            std::fs::write("config.yaml", config).unwrap();
+            let _held = crate::core::ProjectOperationLock::acquire(&dir).unwrap();
+
+            assert_eq!(handle_managed_remove("pdfkit", false).await, 1);
+            assert_eq!(std::fs::read_to_string("config.yaml").unwrap(), config);
         })
         .await;
     }

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -1074,6 +1074,36 @@ pub async fn handle_worker_update(worker_name: Option<&str>) -> i32 {
     }
 
     let lock_path = super::lockfile::lockfile_path();
+    if !lock_path.exists() {
+        // No lockfile: for a named update this is the same failure as
+        // "name not pinned" below; for a bare update it's the same outcome
+        // as an empty lockfile — nothing pinned, nothing to do. Surfacing
+        // the raw ENOENT here made a fresh project look broken.
+        if let Some(name) = worker_name {
+            eprintln!("{} Worker '{}' is not in iii.lock", "error:".red(), name);
+            return 1;
+        }
+        eprintln!(
+            "  No iii.lock here; nothing to update. Install a worker first with `iii worker add <name>`."
+        );
+        return 0;
+    }
+
+    // Same mutual exclusion as sync: update rewrites config.yaml and
+    // iii.lock per resolved root, and a concurrent update/sync would race
+    // the read-modify-write (last writer silently wins).
+    let _operation_lock =
+        match crate::core::ProjectOperationLock::acquire(std::path::Path::new(".")) {
+            Ok(lock) => lock,
+            Err(e) => {
+                eprintln!(
+                    "{} another iii worker operation is active ({e}). Wait for it to finish.",
+                    "error:".red()
+                );
+                return 1;
+            }
+        };
+
     let lockfile = match super::lockfile::WorkerLockfile::read_from(lock_path) {
         Ok(lockfile) => lockfile,
         Err(e) => {
@@ -2263,8 +2293,9 @@ fn clear_all_workers(skip_confirm: bool) -> i32 {
     let home = dirs::home_dir().unwrap_or_default();
     let workers_dir = home.join(".iii/workers");
     let images_dir = home.join(".iii/images");
+    let managed_dir = home.join(".iii/managed");
 
-    if !workers_dir.exists() && !images_dir.exists() {
+    if !workers_dir.exists() && !images_dir.exists() && !managed_dir.exists() {
         eprintln!("  Nothing to clear.");
         return 0;
     }
@@ -2276,33 +2307,64 @@ fn clear_all_workers(skip_confirm: bool) -> i32 {
 
     let mut skipped: Vec<String> = Vec::new();
     let mut total_freed: u64 = 0;
-    let mut worker_count: u32 = 0;
+    // Unique worker names cleared across ~/.iii/workers and ~/.iii/managed —
+    // a binary worker can have artifacts in both, and counting it twice
+    // would inflate the tally.
+    let mut cleared_workers: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut image_count: u32 = 0;
+
+    // Deletes one artifact dir entry after the shared guards: valid worker
+    // name, resolved path stays under `base`, worker not currently running.
+    let mut clear_entry = |entry: &std::fs::DirEntry,
+                           base: &std::path::Path,
+                           skipped: &mut Vec<String>|
+     -> Option<String> {
+        let name = entry.file_name().to_string_lossy().to_string();
+        // Skip entries with invalid names (e.g. symlinks with path traversal)
+        if super::registry::validate_worker_name(&name).is_err() {
+            return None;
+        }
+        // Verify resolved path stays under the artifact base dir
+        if let Ok(resolved) = entry.path().canonicalize()
+            && let Ok(base) = base.canonicalize()
+            && !resolved.starts_with(&base)
+        {
+            return None;
+        }
+        if is_worker_running(&name) {
+            if !skipped.contains(&name) {
+                skipped.push(name);
+            }
+            return None;
+        }
+        total_freed += dir_size(&entry.path());
+        let _ = std::fs::remove_dir_all(entry.path());
+        Some(name)
+    };
 
     // Clear binary workers
     if workers_dir.exists()
         && let Ok(entries) = std::fs::read_dir(&workers_dir)
     {
         for entry in entries.flatten() {
-            let name = entry.file_name().to_string_lossy().to_string();
-            // Skip entries with invalid names (e.g. symlinks with path traversal)
-            if super::registry::validate_worker_name(&name).is_err() {
-                continue;
+            if let Some(name) = clear_entry(&entry, &workers_dir, &mut skipped) {
+                cleared_workers.insert(name);
             }
-            // Verify resolved path stays under workers_dir
-            if let Ok(resolved) = entry.path().canonicalize()
-                && let Ok(base) = workers_dir.canonicalize()
-                && !resolved.starts_with(&base)
-            {
-                continue;
+        }
+    }
+
+    // Clear managed VM state (~/.iii/managed/{name}): rootfs clones, dep
+    // caches, and the `.iii-prepared` marker. The per-worker path
+    // (`delete_worker_artifacts`) already removes this dir — a stale
+    // prepared marker silently skips the in-VM dependency reinstall on the
+    // next boot (MOT-3585) — so the wipe-all path must cover it too.
+    if managed_dir.exists()
+        && let Ok(entries) = std::fs::read_dir(&managed_dir)
+    {
+        for entry in entries.flatten() {
+            if let Some(name) = clear_entry(&entry, &managed_dir, &mut skipped) {
+                cleared_workers.insert(name);
             }
-            if is_worker_running(&name) {
-                skipped.push(name);
-                continue;
-            }
-            total_freed += dir_size(&entry.path());
-            let _ = std::fs::remove_dir_all(entry.path());
-            worker_count += 1;
         }
     }
 
@@ -2350,7 +2412,7 @@ fn clear_all_workers(skip_confirm: bool) -> i32 {
     eprintln!(
         "  {} Cleared {} worker(s) and {} image(s) ({:.1} MB freed)",
         "✓".green(),
-        worker_count,
+        cleared_workers.len(),
         image_count,
         total_freed as f64 / 1_048_576.0,
     );
@@ -3820,12 +3882,7 @@ async fn follow_single_log(path: &std::path::Path) -> i32 {
     0
 }
 
-pub async fn handle_managed_logs(
-    worker_name: &str,
-    follow: bool,
-    _address: &str,
-    _port: u16,
-) -> i32 {
+pub async fn handle_managed_logs(worker_name: &str, follow: bool) -> i32 {
     if let Err(e) = super::registry::validate_worker_name(worker_name) {
         eprintln!("{} {}", "error:".red(), e);
         return 1;
@@ -3919,8 +3976,24 @@ pub async fn handle_managed_logs(
             0
         }
         Err(_) => {
-            eprintln!("{} No logs found for '{}'", "error:".red(), worker_name);
-            1
+            // No log files anywhere. A known worker that simply hasn't
+            // produced logs yet is informational (exit 0, matching the
+            // "No logs available" branches above); a name with no config
+            // entry and no artifacts is a probable typo (exit 1).
+            let known = super::config_file::worker_exists(worker_name)
+                || home.join(".iii/managed").join(worker_name).is_dir()
+                || home.join(".iii/workers").join(worker_name).exists();
+            if known {
+                eprintln!("  No logs available for {} yet", worker_name.bold());
+                0
+            } else {
+                eprintln!(
+                    "{} No logs found for '{}'. Run `iii worker list` to see known workers.",
+                    "error:".red(),
+                    worker_name,
+                );
+                1
+            }
         }
     }
 }
@@ -6314,6 +6387,92 @@ dependencies:
     fn delete_worker_artifacts_nothing_to_delete() {
         let freed = delete_worker_artifacts("__iii_test_no_artifacts_exist__");
         assert_eq!(freed, 0);
+    }
+
+    #[test]
+    fn clear_all_workers_removes_managed_vm_state() {
+        // Regression: `iii worker clear` (no name) only wiped ~/.iii/workers
+        // and ~/.iii/images, leaving every ~/.iii/managed/{name} dir — and
+        // with it the `.iii-prepared` marker whose staleness silently skips
+        // the in-VM dependency reinstall (MOT-3585). The wipe-all path must
+        // cover the same dirs as `clear <name>`.
+        in_temp_dir(|dir| {
+            let _env_guard = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let home = dir.join("home");
+            std::fs::create_dir_all(&home).unwrap();
+            let _home_guard = set_env_var_for_test("HOME", &home);
+
+            // A binary worker with artifacts in BOTH dirs (must count once)
+            // and a local-path worker with managed state only.
+            let binary_dir = home.join(".iii/workers/clear-all-bin");
+            std::fs::create_dir_all(&binary_dir).unwrap();
+            std::fs::write(binary_dir.join("blob"), "bytes").unwrap();
+            let managed_bin = home.join(".iii/managed/clear-all-bin");
+            std::fs::create_dir_all(managed_bin.join("var")).unwrap();
+            std::fs::write(managed_bin.join("var/.iii-prepared"), "").unwrap();
+            let managed_local = home.join(".iii/managed/clear-all-local");
+            std::fs::create_dir_all(managed_local.join("var")).unwrap();
+            std::fs::write(managed_local.join("var/.iii-prepared"), "").unwrap();
+
+            let rc = clear_all_workers(true);
+
+            assert_eq!(rc, 0);
+            assert!(!binary_dir.exists(), "binary artifacts must be cleared");
+            assert!(
+                !managed_bin.exists() && !managed_local.exists(),
+                "managed VM state must be cleared by the wipe-all path too"
+            );
+        });
+    }
+
+    #[tokio::test]
+    async fn handle_worker_update_without_lockfile_says_nothing_to_update() {
+        in_temp_dir_async(|_| async move {
+            // Bare update on a fresh project is not an error — there is
+            // nothing pinned. It used to surface a raw ENOENT and exit 1.
+            assert_eq!(handle_worker_update(None).await, 0);
+            // A named update without a lockfile is the same failure as
+            // "name not pinned".
+            assert_eq!(handle_worker_update(Some("ghost")).await, 1);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_worker_update_fails_when_operation_lock_is_held() {
+        in_temp_dir_async(|dir| async move {
+            cli_lockfile::WorkerLockfile::default()
+                .write_to(cli_lockfile::lockfile_path())
+                .unwrap();
+            let _held = crate::core::ProjectOperationLock::acquire(&dir).unwrap();
+
+            // Update mutates config.yaml + iii.lock per root; racing another
+            // update/sync must be excluded like sync already is.
+            assert_eq!(handle_worker_update(None).await, 1);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn handle_managed_logs_no_logs_exit_code_depends_on_worker_being_known() {
+        in_temp_dir_async(|dir| async move {
+            let _env_guard = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let home = dir.join("home");
+            std::fs::create_dir_all(&home).unwrap();
+            let _home_guard = set_env_var_for_test("HOME", &home);
+            std::fs::write("config.yaml", "workers:\n  - name: quiet-w\n").unwrap();
+
+            // Known worker with no logs yet: informational, exit 0 (matches
+            // the "No logs available" branches for empty log files).
+            assert_eq!(handle_managed_logs("quiet-w", false).await, 0);
+            // Unknown name with no artifacts: probable typo, exit 1.
+            assert_eq!(handle_managed_logs("ghost-w", false).await, 1);
+        })
+        .await;
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/sandbox.rs
+++ b/crates/iii-worker/src/cli/sandbox.rs
@@ -29,6 +29,20 @@ fn connect(port: u16) -> IIIClient {
     register_worker(&format!("ws://127.0.0.1:{port}"), InitOptions::default())
 }
 
+/// Fail fast when no engine is listening on `port`, with a hint the raw
+/// trigger error doesn't carry. Checked BEFORE `preflight_pull_if_preset`
+/// so `sandbox create python` with no engine errors in milliseconds
+/// instead of pulling a multi-hundred-MiB preset image first.
+fn engine_down(port: u16) -> bool {
+    if super::managed::is_engine_running_on(port) {
+        return false;
+    }
+    eprintln!(
+        "error: engine not running on port {port} — start it with `iii` in another terminal, then re-run"
+    );
+    true
+}
+
 /// Pre-pull a preset image into the unified rootfs cache so
 /// `pull_and_extract_rootfs`'s "Pulling image layers..." + layer-extract
 /// progress bar renders directly on the user's terminal.
@@ -108,6 +122,9 @@ pub async fn handle_run(image: String, cmd: Vec<String>, cpus: u32, memory: u32,
         }
     };
 
+    if engine_down(port) {
+        return 1;
+    }
     preflight_pull_if_preset(&image).await;
     let iii = connect(port);
 
@@ -212,6 +229,9 @@ pub async fn handle_create(
     env: Vec<String>,
     port: u16,
 ) -> i32 {
+    if engine_down(port) {
+        return 1;
+    }
     preflight_pull_if_preset(&image).await;
     let iii = connect(port);
 
@@ -240,22 +260,31 @@ pub async fn handle_create(
         })
         .await
     {
-        Ok(resp) => {
-            let sandbox_id = resp
-                .get("sandbox_id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            // On a TTY, leave a one-line "ready" breadcrumb on stderr so the
-            // user sees what actually happened before the uuid appears. On a
-            // pipe, stderr is silent and the uuid goes straight to stdout so
-            // `SB=$(iii worker sandbox create ...)` still works unchanged.
-            if std::io::IsTerminal::is_terminal(&std::io::stderr()) {
-                let elapsed = started_at.elapsed().as_millis() as f64 / 1000.0;
-                eprintln!("✓ sandbox ready in {elapsed:.1}s");
+        Ok(resp) => match resp
+            .get("sandbox_id")
+            .and_then(|v| v.as_str())
+            .filter(|id| !id.is_empty())
+        {
+            Some(sandbox_id) => {
+                // On a TTY, leave a one-line "ready" breadcrumb on stderr so the
+                // user sees what actually happened before the uuid appears. On a
+                // pipe, stderr is silent and the uuid goes straight to stdout so
+                // `SB=$(iii worker sandbox create ...)` still works unchanged.
+                if std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+                    let elapsed = started_at.elapsed().as_millis() as f64 / 1000.0;
+                    eprintln!("✓ sandbox ready in {elapsed:.1}s");
+                }
+                println!("{sandbox_id}");
+                0
             }
-            println!("{sandbox_id}");
-            0
-        }
+            // Exiting 0 with an empty stdout here would hand
+            // `SB=$(iii worker sandbox create ...)` scripts an empty id
+            // with a success status. Mirror handle_run's hard error.
+            None => {
+                eprintln!("error: sandbox::create returned no sandbox_id");
+                1
+            }
+        },
         Err(e) => {
             eprintln!("error: {}", handler_error_message(&e));
             1

--- a/crates/iii-worker/src/cli/status.rs
+++ b/crates/iii-worker/src/cli/status.rs
@@ -388,6 +388,16 @@ impl WorkerStatus {
         )
     }
 
+    /// Terminal condition for the untimed `iii worker status` watch: wait
+    /// terminality plus `EngineDown`. With no engine, the phase cannot
+    /// progress on its own, so an untimed watch would spin forever. The
+    /// timed `--wait` loops keep polling through `EngineDown` instead — an
+    /// engine restarting mid-`add` is expected to come back before the
+    /// timeout.
+    pub fn is_terminal_for_watch(&self) -> bool {
+        self.is_terminal_for_wait() || matches!(self.phase, Phase::EngineDown)
+    }
+
     /// Same as [`Self::headline`] but appends a live spinner glyph and an
     /// elapsed-seconds counter. The plain `headline` is used for one-shot
     /// snapshots; this variant is what live `--watch` and `--wait` print so
@@ -480,19 +490,27 @@ impl WorkerStatus {
         // download), suppress the hint — the worker is plainly making
         // progress and a "may have failed" warning would directly
         // contradict the `tail:` row right above it.
-        if matches!(self.phase, Phase::Queued)
+        if matches!(self.phase, Phase::Queued | Phase::Booting)
             && p.elapsed >= Duration::from_secs(30)
             && !self.log_recently_updated(Duration::from_secs(10))
         {
+            // Booting covers the "prepared but VM not running" window, which
+            // is also what a deliberately stopped worker looks like (stop
+            // removes the pidfile but keeps the prepared marker). After 30s
+            // of silence that's the likelier story — say so instead of
+            // spinning on "booting VM" indefinitely.
+            let hint = if matches!(self.phase, Phase::Booting) {
+                "VM not running — if this worker was stopped, start it with `iii worker start {name}`"
+            } else {
+                "still queued, no log activity — check `iii worker logs {name} -f` (engine may have failed to spawn it)"
+            };
             let insert_at = out.len().saturating_sub(1);
             out.insert(
                 insert_at,
                 format!(
                     "{:>12}  {}",
                     "hint:".yellow(),
-                    "still queued, no log activity — check `iii worker logs {name} -f` (engine may have failed to spawn it)"
-                        .replace("{name}", &self.name)
-                        .dimmed()
+                    hint.replace("{name}", &self.name).dimmed()
                 ),
             );
         }
@@ -790,18 +808,23 @@ pub async fn handle_worker_status(worker_name: &str, watch: bool) -> i32 {
         for line in status.render() {
             eprintln!("{}", line);
         }
-        return match status.phase {
-            Phase::Ready => 0,
-            Phase::NotInConfig => 1,
-            _ => 0,
-        };
+        return status_exit_code(&status.phase);
     }
 
-    // --watch: live-redraw with no timeout (Ctrl-C to abort).
+    // --watch: live-redraw until a watch-terminal phase (Ready /
+    // NotInConfig / Failed / EngineDown) or Ctrl-C.
     let final_status = watch_until_ready(worker_name, None, port).await;
-    match final_status.phase {
+    status_exit_code(&final_status.phase)
+}
+
+/// Exit code for `iii worker status`: 0 only when the worker is Ready or
+/// still progressing; 1 when it can't be Ready without user action (not in
+/// config, failed, or no engine to run it). Keeps `iii worker status -- ...`
+/// usable in scripts as a readiness probe.
+fn status_exit_code(phase: &Phase) -> i32 {
+    match phase {
         Phase::Ready => 0,
-        Phase::NotInConfig => 1,
+        Phase::NotInConfig | Phase::Failed | Phase::EngineDown => 1,
         _ => 0,
     }
 }
@@ -810,8 +833,10 @@ pub async fn handle_worker_status(worker_name: &str, watch: bool) -> i32 {
 /// terminal wait phase (Ready / NotInConfig / Failed), `timeout` elapses, or
 /// the process is killed.
 ///
-/// `timeout = None` means "wait forever" (used by `--watch`); `Some(d)` is
-/// used by `--wait` so the CLI doesn't hang on a stuck VM. `port` is the
+/// `timeout = None` means "watch until a watch-terminal phase, including
+/// EngineDown" (used by `iii worker status`); `Some(d)` is used by `--wait`
+/// so the CLI doesn't hang on a stuck VM while still polling through an
+/// engine restart. `port` is the
 /// engine's `iii-worker-manager` port — each probe re-checks it so the
 /// "engine: running/stopped" line reflects the correct engine even when
 /// the user runs on a non-default port.
@@ -890,7 +915,14 @@ pub async fn watch_until_ready(
             eprintln!("{}", line);
         }
 
-        if status.is_terminal_for_wait() {
+        let terminal = match timeout {
+            // Untimed watch (`iii worker status`): also stop on EngineDown —
+            // nothing progresses without an engine, and the help text
+            // promises the watch ends.
+            None => status.is_terminal_for_watch(),
+            Some(_) => status.is_terminal_for_wait(),
+        };
+        if terminal {
             break status;
         }
         if let Some(t) = timeout
@@ -1035,6 +1067,50 @@ mod tests {
 
         not_in.phase = Phase::Failed;
         assert!(not_in.is_terminal_for_wait());
+    }
+
+    /// Regression: the untimed `iii worker status` watch spun forever with
+    /// the engine down, because EngineDown was not wait-terminal and the
+    /// watch used the wait predicate. The watch predicate must include
+    /// EngineDown while leaving the wait predicate untouched (an engine
+    /// restart mid-`add --wait` is expected to come back).
+    #[test]
+    fn engine_down_is_terminal_for_watch_but_not_for_wait() {
+        let mut status = WorkerStatus {
+            name: "t".into(),
+            phase: Phase::EngineDown,
+            engine_running: false,
+            worker_type: Some("local"),
+            worker_path: None,
+            managed_dir_exists: true,
+            prepared: true,
+            pid: None,
+            alive: false,
+            engine_registered: None,
+            logs_dir: None,
+            logs_last_modified: None,
+        };
+        assert!(status.is_terminal_for_watch());
+        assert!(!status.is_terminal_for_wait());
+
+        // Non-terminal boot phases stay non-terminal for both.
+        for phase in [Phase::Queued, Phase::Preparing, Phase::Booting] {
+            status.phase = phase;
+            assert!(!status.is_terminal_for_watch());
+        }
+    }
+
+    /// `iii worker status` exit codes: 0 only for Ready or a phase that can
+    /// still progress on its own; 1 when readiness needs user action.
+    #[test]
+    fn status_exit_code_flags_unready_terminal_states() {
+        assert_eq!(status_exit_code(&Phase::Ready), 0);
+        assert_eq!(status_exit_code(&Phase::Queued), 0);
+        assert_eq!(status_exit_code(&Phase::Preparing), 0);
+        assert_eq!(status_exit_code(&Phase::Booting), 0);
+        assert_eq!(status_exit_code(&Phase::NotInConfig), 1);
+        assert_eq!(status_exit_code(&Phase::Failed), 1);
+        assert_eq!(status_exit_code(&Phase::EngineDown), 1);
     }
 
     /// Regression: `truncate_visible` must count VISIBLE columns and

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -476,12 +476,7 @@ async fn async_main() -> anyhow::Result<()> {
         Commands::Logs {
             worker_name,
             follow,
-            address,
-            port,
-        } => {
-            iii_worker::cli::managed::handle_managed_logs(&worker_name, follow, &address, port)
-                .await
-        }
+        } => iii_worker::cli::managed::handle_managed_logs(&worker_name, follow).await,
         Commands::Init(args) => iii_worker::cli::init::run(args).await,
         Commands::Exec(args) => {
             let handler = iii_worker::cli::shell_client::handle_managed_exec;

--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -138,17 +138,17 @@ iii worker <COMMAND>
 | [`exec`](#iii-worker-exec) | Run a command inside a running worker's VM. Pipes stdin/stdout/ stderr through and returns the child's exit code. Pass `-t` for an interactive PTY |
 | [`init`](#iii-worker-init) | Scaffold a NEW standalone worker repo from scratch. To install an EXISTING worker, use `iii worker add` |
 | [`list`](#iii-worker-list) | List all workers and their status |
-| [`logs`](#iii-worker-logs) | Show logs from a managed worker container |
-| [`reinstall`](#iii-worker-reinstall) | Re-download a worker (equivalent to `add --force`; pass `--reset-config` to also reset its config.yaml entry to registry defaults) |
+| [`logs`](#iii-worker-logs) | Show logs from a managed worker container. Logs are read from the local log files under ~/.iii/logs/\{name\}/ |
+| [`reinstall`](#iii-worker-reinstall) | Re-download a worker (like `add --force`, but returns immediately instead of waiting for the worker to report ready; pass `--reset-config` to also reset its config.yaml entry to registry defaults) |
 | [`remove`](#iii-worker-remove) | Remove one or more workers from config.yaml and iii.lock. The engine's file watcher tears down any running sandbox. Artifacts under ~/.iii/managed/\{name\}/ remain; use `iii worker clear {name}` to delete them |
-| [`restart`](#iii-worker-restart) | Restart a managed worker: stop if running, then start. By default waits up to 120s for the worker to report ready (same as start) |
+| [`restart`](#iii-worker-restart) | Restart a managed worker: stop if running, then start (same start path as `iii worker start`, including the registry fetch for missing local artifacts). By default waits up to 120s for the worker to report ready (same as start) |
 | [`sandbox`](#iii-worker-sandbox) | Manage ephemeral sandboxes (create/exec/stop short-lived VMs) |
-| [`start`](#iii-worker-start) | Start a previously stopped managed worker container. By default waits up to 120s for the worker to report ready before returning. Workers will continue to start after 120s, see `iii worker status` and `iii worker logs` for tracking workers |
-| [`status`](#iii-worker-status) | Show detailed status of one worker (config, sandbox, process, logs). By default refreshes live in place until the worker reaches a success or failure state |
+| [`start`](#iii-worker-start) | Start a previously stopped managed worker container. If the worker has no local artifacts (e.g. after `iii worker clear`), it is fetched from the registry first. By default waits up to 120s for the worker to report ready before returning. Workers will continue to start after 120s, see `iii worker status` and `iii worker logs` for tracking workers |
+| [`status`](#iii-worker-status) | Show detailed status of one worker (config, sandbox, process, logs). By default refreshes live in place until the worker reaches a success or failure state; exits immediately when the engine is not running |
 | [`stop`](#iii-worker-stop) | Stop a managed worker container. Stop is treated as a routine, reversible action; running `iii worker start <name>` brings the worker back up |
 | [`sync`](#iii-worker-sync) | Install registry-managed workers exactly from iii.lock |
-| [`update`](#iii-worker-update) | Update workers in iii.lock to their latest allowed version |
-| [`verify`](#iii-worker-verify) | Verify the worker's manifest (iii.worker.yaml) is valid |
+| [`update`](#iii-worker-update) | Update workers pinned in iii.lock to the latest version published in the registry, rewriting config.yaml and iii.lock |
+| [`verify`](#iii-worker-verify) | Verify config.yaml and iii.lock agree: every managed worker in config.yaml must be pinned in iii.lock for this platform |
 
 ### `iii worker add`
 
@@ -235,7 +235,7 @@ iii worker list
 
 ### `iii worker logs`
 
-Show logs from a managed worker container
+Show logs from a managed worker container. Logs are read from the local log files under ~/.iii/logs/\{name\}/
 
 ```text
 iii worker logs [OPTIONS] <WORKER>
@@ -248,12 +248,10 @@ iii worker logs [OPTIONS] <WORKER>
 | Option | Description |
 | ------ | ----------- |
 | `-f, --follow` | Follow log output |
-| `--address <ADDRESS>` | Engine host address [default: localhost] |
-| `--port <PORT>` | Engine WebSocket port [default: 49134] |
 
 ### `iii worker reinstall`
 
-Re-download a worker (equivalent to `add --force`; pass `--reset-config` to also reset its config.yaml entry to registry defaults)
+Re-download a worker (like `add --force`, but returns immediately instead of waiting for the worker to report ready; pass `--reset-config` to also reset its config.yaml entry to registry defaults)
 
 ```text
 iii worker reinstall [OPTIONS] <WORKER[@VERSION]|PATH>...
@@ -285,7 +283,7 @@ iii worker remove [OPTIONS] <WORKER>...
 
 ### `iii worker restart`
 
-Restart a managed worker: stop if running, then start. By default waits up to 120s for the worker to report ready (same as start)
+Restart a managed worker: stop if running, then start (same start path as `iii worker start`, including the registry fetch for missing local artifacts). By default waits up to 120s for the worker to report ready (same as start)
 
 ```text
 iii worker restart [OPTIONS] <WORKER>
@@ -329,7 +327,7 @@ iii worker sandbox create [OPTIONS] <IMAGE>
 | `--memory <MEMORY>` | Memory in MiB allocated to the sandbox VM [default: 512] |
 | `--idle-timeout <SECS>` | Auto-stop the sandbox after this many seconds of exec inactivity. Omit to use the engine's default |
 | `--name <NAME>` | Human-readable label for the sandbox (shown in `list`) |
-| `--network` | Enable guest network access. Default follows the engine's sandbox policy (typically disabled) |
+| `--network` | Enable guest network access (disabled unless this flag is passed) |
 | `-e, --env <KEY=VALUE>` | Set an environment variable inside the guest. Repeatable, `KEY=VALUE` form; entries without `=` are silently skipped |
 | `--port <PORT>` | Engine WebSocket port [default: 49134] |
 
@@ -451,7 +449,7 @@ iii worker sandbox upload [OPTIONS] <SANDBOX_ID> <LOCAL_PATH> <REMOTE_PATH>
 
 ### `iii worker start`
 
-Start a previously stopped managed worker container. By default waits up to 120s for the worker to report ready before returning. Workers will continue to start after 120s, see `iii worker status` and `iii worker logs` for tracking workers
+Start a previously stopped managed worker container. If the worker has no local artifacts (e.g. after `iii worker clear`), it is fetched from the registry first. By default waits up to 120s for the worker to report ready before returning. Workers will continue to start after 120s, see `iii worker status` and `iii worker logs` for tracking workers
 
 ```text
 iii worker start [OPTIONS] <WORKER>
@@ -469,7 +467,7 @@ iii worker start [OPTIONS] <WORKER>
 
 ### `iii worker status`
 
-Show detailed status of one worker (config, sandbox, process, logs). By default refreshes live in place until the worker reaches a success or failure state
+Show detailed status of one worker (config, sandbox, process, logs). By default refreshes live in place until the worker reaches a success or failure state; exits immediately when the engine is not running
 
 ```text
 iii worker status [OPTIONS] <WORKER>
@@ -513,7 +511,7 @@ iii worker sync [OPTIONS]
 
 ### `iii worker update`
 
-Update workers in iii.lock to their latest allowed version
+Update workers pinned in iii.lock to the latest version published in the registry, rewriting config.yaml and iii.lock
 
 ```text
 iii worker update [WORKER]
@@ -525,7 +523,7 @@ iii worker update [WORKER]
 
 ### `iii worker verify`
 
-Verify the worker's manifest (iii.worker.yaml) is valid
+Verify config.yaml and iii.lock agree: every managed worker in config.yaml must be pinned in iii.lock for this platform
 
 ```text
 iii worker verify [OPTIONS]

--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -140,7 +140,7 @@ iii worker <COMMAND>
 | [`list`](#iii-worker-list) | List all workers and their status |
 | [`logs`](#iii-worker-logs) | Show logs from a managed worker container |
 | [`reinstall`](#iii-worker-reinstall) | Re-download a worker (equivalent to `add --force`; pass `--reset-config` to also reset its config.yaml entry to registry defaults) |
-| [`remove`](#iii-worker-remove) | Remove one or more workers from config.yaml. The engine's file watcher tears down any running sandbox. Artifacts under ~/.iii/managed/\{name\}/ remain; use `iii worker clear {name}` to delete them |
+| [`remove`](#iii-worker-remove) | Remove one or more workers from config.yaml and iii.lock. The engine's file watcher tears down any running sandbox. Artifacts under ~/.iii/managed/\{name\}/ remain; use `iii worker clear {name}` to delete them |
 | [`restart`](#iii-worker-restart) | Restart a managed worker: stop if running, then start. By default waits up to 120s for the worker to report ready (same as start) |
 | [`sandbox`](#iii-worker-sandbox) | Manage ephemeral sandboxes (create/exec/stop short-lived VMs) |
 | [`start`](#iii-worker-start) | Start a previously stopped managed worker container. By default waits up to 120s for the worker to report ready before returning. Workers will continue to start after 120s, see `iii worker status` and `iii worker logs` for tracking workers |
@@ -269,7 +269,7 @@ iii worker reinstall [OPTIONS] <WORKER[@VERSION]|PATH>...
 
 ### `iii worker remove`
 
-Remove one or more workers from config.yaml. The engine's file watcher tears down any running sandbox. Artifacts under ~/.iii/managed/\{name\}/ remain; use `iii worker clear {name}` to delete them
+Remove one or more workers from config.yaml and iii.lock. The engine's file watcher tears down any running sandbox. Artifacts under ~/.iii/managed/\{name\}/ remain; use `iii worker clear {name}` to delete them
 
 ```text
 iii worker remove [OPTIONS] <WORKER>...

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -136,17 +136,17 @@ iii worker <COMMAND>
 | [`exec`](#iii-worker-exec) | Run a command inside a running worker's VM. Pipes stdin/stdout/ stderr through and returns the child's exit code. Pass `-t` for an interactive PTY |
 | [`init`](#iii-worker-init) | Scaffold a NEW standalone worker repo from scratch. To install an EXISTING worker, use `iii worker add` |
 | [`list`](#iii-worker-list) | List all workers and their status |
-| [`logs`](#iii-worker-logs) | Show logs from a managed worker container |
-| [`reinstall`](#iii-worker-reinstall) | Re-download a worker (equivalent to `add --force`; pass `--reset-config` to also reset its config.yaml entry to registry defaults) |
+| [`logs`](#iii-worker-logs) | Show logs from a managed worker container. Logs are read from the local log files under ~/.iii/logs/\{name\}/ |
+| [`reinstall`](#iii-worker-reinstall) | Re-download a worker (like `add --force`, but returns immediately instead of waiting for the worker to report ready; pass `--reset-config` to also reset its config.yaml entry to registry defaults) |
 | [`remove`](#iii-worker-remove) | Remove one or more workers from config.yaml and iii.lock. The engine's file watcher tears down any running sandbox. Artifacts under ~/.iii/managed/\{name\}/ remain; use `iii worker clear {name}` to delete them |
-| [`restart`](#iii-worker-restart) | Restart a managed worker: stop if running, then start. By default waits up to 120s for the worker to report ready (same as start) |
+| [`restart`](#iii-worker-restart) | Restart a managed worker: stop if running, then start (same start path as `iii worker start`, including the registry fetch for missing local artifacts). By default waits up to 120s for the worker to report ready (same as start) |
 | [`sandbox`](#iii-worker-sandbox) | Manage ephemeral sandboxes (create/exec/stop short-lived VMs) |
-| [`start`](#iii-worker-start) | Start a previously stopped managed worker container. By default waits up to 120s for the worker to report ready before returning. Workers will continue to start after 120s, see `iii worker status` and `iii worker logs` for tracking workers |
-| [`status`](#iii-worker-status) | Show detailed status of one worker (config, sandbox, process, logs). By default refreshes live in place until the worker reaches a success or failure state |
+| [`start`](#iii-worker-start) | Start a previously stopped managed worker container. If the worker has no local artifacts (e.g. after `iii worker clear`), it is fetched from the registry first. By default waits up to 120s for the worker to report ready before returning. Workers will continue to start after 120s, see `iii worker status` and `iii worker logs` for tracking workers |
+| [`status`](#iii-worker-status) | Show detailed status of one worker (config, sandbox, process, logs). By default refreshes live in place until the worker reaches a success or failure state; exits immediately when the engine is not running |
 | [`stop`](#iii-worker-stop) | Stop a managed worker container. Stop is treated as a routine, reversible action; running `iii worker start <name>` brings the worker back up |
 | [`sync`](#iii-worker-sync) | Install registry-managed workers exactly from iii.lock |
-| [`update`](#iii-worker-update) | Update workers in iii.lock to their latest allowed version |
-| [`verify`](#iii-worker-verify) | Verify the worker's manifest (iii.worker.yaml) is valid |
+| [`update`](#iii-worker-update) | Update workers pinned in iii.lock to the latest version published in the registry, rewriting config.yaml and iii.lock |
+| [`verify`](#iii-worker-verify) | Verify config.yaml and iii.lock agree: every managed worker in config.yaml must be pinned in iii.lock for this platform |
 
 ### `iii worker add`
 
@@ -233,7 +233,7 @@ iii worker list
 
 ### `iii worker logs`
 
-Show logs from a managed worker container
+Show logs from a managed worker container. Logs are read from the local log files under ~/.iii/logs/\{name\}/
 
 ```text
 iii worker logs [OPTIONS] <WORKER>
@@ -246,12 +246,10 @@ iii worker logs [OPTIONS] <WORKER>
 | Option | Description |
 | ------ | ----------- |
 | `-f, --follow` | Follow log output |
-| `--address <ADDRESS>` | Engine host address [default: localhost] |
-| `--port <PORT>` | Engine WebSocket port [default: 49134] |
 
 ### `iii worker reinstall`
 
-Re-download a worker (equivalent to `add --force`; pass `--reset-config` to also reset its config.yaml entry to registry defaults)
+Re-download a worker (like `add --force`, but returns immediately instead of waiting for the worker to report ready; pass `--reset-config` to also reset its config.yaml entry to registry defaults)
 
 ```text
 iii worker reinstall [OPTIONS] <WORKER[@VERSION]|PATH>...
@@ -283,7 +281,7 @@ iii worker remove [OPTIONS] <WORKER>...
 
 ### `iii worker restart`
 
-Restart a managed worker: stop if running, then start. By default waits up to 120s for the worker to report ready (same as start)
+Restart a managed worker: stop if running, then start (same start path as `iii worker start`, including the registry fetch for missing local artifacts). By default waits up to 120s for the worker to report ready (same as start)
 
 ```text
 iii worker restart [OPTIONS] <WORKER>
@@ -327,7 +325,7 @@ iii worker sandbox create [OPTIONS] <IMAGE>
 | `--memory <MEMORY>` | Memory in MiB allocated to the sandbox VM [default: 512] |
 | `--idle-timeout <SECS>` | Auto-stop the sandbox after this many seconds of exec inactivity. Omit to use the engine's default |
 | `--name <NAME>` | Human-readable label for the sandbox (shown in `list`) |
-| `--network` | Enable guest network access. Default follows the engine's sandbox policy (typically disabled) |
+| `--network` | Enable guest network access (disabled unless this flag is passed) |
 | `-e, --env <KEY=VALUE>` | Set an environment variable inside the guest. Repeatable, `KEY=VALUE` form; entries without `=` are silently skipped |
 | `--port <PORT>` | Engine WebSocket port [default: 49134] |
 
@@ -449,7 +447,7 @@ iii worker sandbox upload [OPTIONS] <SANDBOX_ID> <LOCAL_PATH> <REMOTE_PATH>
 
 ### `iii worker start`
 
-Start a previously stopped managed worker container. By default waits up to 120s for the worker to report ready before returning. Workers will continue to start after 120s, see `iii worker status` and `iii worker logs` for tracking workers
+Start a previously stopped managed worker container. If the worker has no local artifacts (e.g. after `iii worker clear`), it is fetched from the registry first. By default waits up to 120s for the worker to report ready before returning. Workers will continue to start after 120s, see `iii worker status` and `iii worker logs` for tracking workers
 
 ```text
 iii worker start [OPTIONS] <WORKER>
@@ -467,7 +465,7 @@ iii worker start [OPTIONS] <WORKER>
 
 ### `iii worker status`
 
-Show detailed status of one worker (config, sandbox, process, logs). By default refreshes live in place until the worker reaches a success or failure state
+Show detailed status of one worker (config, sandbox, process, logs). By default refreshes live in place until the worker reaches a success or failure state; exits immediately when the engine is not running
 
 ```text
 iii worker status [OPTIONS] <WORKER>
@@ -511,7 +509,7 @@ iii worker sync [OPTIONS]
 
 ### `iii worker update`
 
-Update workers in iii.lock to their latest allowed version
+Update workers pinned in iii.lock to the latest version published in the registry, rewriting config.yaml and iii.lock
 
 ```text
 iii worker update [WORKER]
@@ -523,7 +521,7 @@ iii worker update [WORKER]
 
 ### `iii worker verify`
 
-Verify the worker's manifest (iii.worker.yaml) is valid
+Verify config.yaml and iii.lock agree: every managed worker in config.yaml must be pinned in iii.lock for this platform
 
 ```text
 iii worker verify [OPTIONS]

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -138,7 +138,7 @@ iii worker <COMMAND>
 | [`list`](#iii-worker-list) | List all workers and their status |
 | [`logs`](#iii-worker-logs) | Show logs from a managed worker container |
 | [`reinstall`](#iii-worker-reinstall) | Re-download a worker (equivalent to `add --force`; pass `--reset-config` to also reset its config.yaml entry to registry defaults) |
-| [`remove`](#iii-worker-remove) | Remove one or more workers from config.yaml. The engine's file watcher tears down any running sandbox. Artifacts under ~/.iii/managed/\{name\}/ remain; use `iii worker clear {name}` to delete them |
+| [`remove`](#iii-worker-remove) | Remove one or more workers from config.yaml and iii.lock. The engine's file watcher tears down any running sandbox. Artifacts under ~/.iii/managed/\{name\}/ remain; use `iii worker clear {name}` to delete them |
 | [`restart`](#iii-worker-restart) | Restart a managed worker: stop if running, then start. By default waits up to 120s for the worker to report ready (same as start) |
 | [`sandbox`](#iii-worker-sandbox) | Manage ephemeral sandboxes (create/exec/stop short-lived VMs) |
 | [`start`](#iii-worker-start) | Start a previously stopped managed worker container. By default waits up to 120s for the worker to report ready before returning. Workers will continue to start after 120s, see `iii worker status` and `iii worker logs` for tracking workers |
@@ -267,7 +267,7 @@ iii worker reinstall [OPTIONS] <WORKER[@VERSION]|PATH>...
 
 ### `iii worker remove`
 
-Remove one or more workers from config.yaml. The engine's file watcher tears down any running sandbox. Artifacts under ~/.iii/managed/\{name\}/ remain; use `iii worker clear {name}` to delete them
+Remove one or more workers from config.yaml and iii.lock. The engine's file watcher tears down any running sandbox. Artifacts under ~/.iii/managed/\{name\}/ remain; use `iii worker clear {name}` to delete them
 
 ```text
 iii worker remove [OPTIONS] <WORKER>...

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -3886,6 +3886,25 @@ mod tests {
         }
     }
 
+    struct OtelConfigTestGuard(Option<Arc<config::ObservabilityWorkerConfig>>);
+
+    impl OtelConfigTestGuard {
+        fn install(config: config::ObservabilityWorkerConfig) -> Self {
+            Self(otel::update_otel_config(config))
+        }
+    }
+
+    impl Drop for OtelConfigTestGuard {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(previous) => {
+                    otel::update_otel_config((*previous).clone());
+                }
+                None => otel::clear_otel_config_for_test(),
+            }
+        }
+    }
+
     fn make_number_metric(
         name: &str,
         value: f64,
@@ -7935,13 +7954,15 @@ mod tests {
     #[serial]
     async fn test_initialize_returns_ok_when_disabled() {
         reset_observability_test_state();
+        let config = config::ObservabilityWorkerConfig {
+            enabled: Some(false),
+            ..config::ObservabilityWorkerConfig::default()
+        };
+        let _config_guard = OtelConfigTestGuard::install(config.clone());
         let engine = Arc::new(Engine::new());
         let (shutdown_tx, _) = tokio::sync::watch::channel(false);
         let worker = ObservabilityWorker {
-            _config: config::ObservabilityWorkerConfig {
-                enabled: Some(false),
-                ..config::ObservabilityWorkerConfig::default()
-            },
+            _config: config,
             triggers: Arc::new(OtelLogTriggers::new()),
             trace_triggers: Arc::new(OtelTraceTriggers::new()),
             engine: engine.clone(),
@@ -7975,13 +7996,15 @@ mod tests {
     #[serial]
     async fn test_initialize_defaults_to_enabled_when_none() {
         reset_observability_test_state();
+        let config = config::ObservabilityWorkerConfig {
+            enabled: None,
+            ..config::ObservabilityWorkerConfig::default()
+        };
+        let _config_guard = OtelConfigTestGuard::install(config.clone());
         let engine = Arc::new(Engine::new());
         let (shutdown_tx, _) = tokio::sync::watch::channel(false);
         let worker = ObservabilityWorker {
-            _config: config::ObservabilityWorkerConfig {
-                enabled: None,
-                ..config::ObservabilityWorkerConfig::default()
-            },
+            _config: config,
             triggers: Arc::new(OtelLogTriggers::new()),
             trace_triggers: Arc::new(OtelTraceTriggers::new()),
             engine: engine.clone(),
@@ -8015,13 +8038,15 @@ mod tests {
     #[serial]
     async fn test_start_background_tasks_returns_ok_when_disabled() {
         reset_observability_test_state();
+        let config = config::ObservabilityWorkerConfig {
+            enabled: Some(false),
+            ..config::ObservabilityWorkerConfig::default()
+        };
+        let _config_guard = OtelConfigTestGuard::install(config.clone());
         let engine = Arc::new(Engine::new());
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
         let worker = ObservabilityWorker {
-            _config: config::ObservabilityWorkerConfig {
-                enabled: Some(false),
-                ..config::ObservabilityWorkerConfig::default()
-            },
+            _config: config,
             triggers: Arc::new(OtelLogTriggers::new()),
             trace_triggers: Arc::new(OtelTraceTriggers::new()),
             engine: engine.clone(),


### PR DESCRIPTION
## Summary

Fixes from a full audit of the `iii worker` CLI surface (every operation except `add` was traced end-to-end and exercised live against a built binary). Each fix below is covered by regression tests — 9 new tests, full suite green.

## Fixes by operation

### `remove` — stale iii.lock entry resurrected removed workers
`iii worker remove` only rewrote `config.yaml`, leaving the worker pinned in `iii.lock` forever. Nothing in the codebase ever deleted lock entries, so a bare `iii worker update` re-resolved the removed worker as a lock root and reinstalled it, and `iii worker sync` kept replaying its artifacts. Remove now deletes the lock entry alongside the config entry, and rolls back `config.yaml` if the lockfile edit fails so the two files never disagree.

### `status` — default watch hung forever
The default (watch) mode only terminated on `Ready`/`NotInConfig`/`Failed`, but `Failed` was unreachable and `EngineDown` isn't terminal — so `iii worker status <name>` with the engine down (or after `iii worker stop`) spun until Ctrl-C, contradicting its own help text. Now:
- the untimed status watch also terminates on `EngineDown` (new `is_terminal_for_watch`); timed `--wait` loops keep polling through engine restarts as before
- exit code is 1 for `EngineDown`/`Failed`/`NotInConfig`, making `status` usable as a scriptable readiness probe (previously 0 for everything except `NotInConfig`)
- after 30s stuck in `Booting` with no log activity, a hint explains the worker is probably just stopped and how to start it

### `clear` (all) — left `~/.iii/managed` behind
`clear <name>` deletes `~/.iii/managed/{name}` specifically because a stale `.iii-prepared` marker silently skips the in-VM dependency reinstall (MOT-3585) — but the wipe-all path only cleared `~/.iii/workers` and `~/.iii/images`, reintroducing exactly that hazard. Clear-all now covers the managed dir with the same guards (name validation, path containment, running-worker skip), and workers with artifacts in both dirs count once in the freed tally.

### `update` — lockfile race + raw ENOENT
- now acquires the same `ProjectOperationLock` as `sync`; previously two concurrent updates (or an update racing a sync) did unsynchronized read-modify-writes of `iii.lock` where the last writer silently won
- a missing `iii.lock` now prints "nothing to update — install a worker first with `iii worker add <name>`" (exit 0; exit 1 for a named worker, same as "not pinned") instead of a raw `No such file or directory`

### `logs` — dead flags and inconsistent exit codes
- `--address`/`--port` were documented as engine parameters but never read (logs always come from local files) — removed
- "no logs" previously exited 0 or 1 depending on which files happened to exist; now a known worker without logs exits 0 ("No logs available yet") and an unknown name exits 1 with a `iii worker list` hint

### `sandbox` — 204 MiB pull before noticing the engine is down; empty-id success
- `create`/`run` now fail fast with "engine not running on port N — start it with `iii`" *before* the preset-image preflight pull; previously `sandbox create python` with no engine downloaded the full image and then failed opaquely
- `create` treated a daemon response without `sandbox_id` as success, printing an empty line with exit 0 and silently breaking `SB=$(iii worker sandbox create ...)` scripts; it now errors like `run` already did

### Help texts corrected to match behavior
- `update`: claimed "latest **allowed** version" — no version-range logic exists; it resolves `latest`
- `verify`: claimed to validate `iii.worker.yaml` — it actually checks config.yaml ↔ iii.lock consistency
- `reinstall`: claimed equivalence with `add --force` — it hard-codes no-wait
- `start`/`restart`: now document the registry auto-install for missing local artifacts
- `sandbox --network`: described a nonexistent engine-level policy default
- the generated CLI reference (`docs/next/cli-reference/`) is regenerated accordingly

## Testing

- 9 new regression tests (lock-entry removal + rollback, watch-vs-wait terminality, status exit codes, clear-all managed state, update lock contention, update missing-lockfile, logs exit codes)
- full `iii-worker` suite green (936 lib tests + integration suites)
- verified live against a built binary: status exits ~1s/code 1 where it hung, sandbox create errors in milliseconds where it pulled 204 MiB, remove cleans both files end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved managed worker update/remove/clear to prevent `iii.lock`/`config.yaml` mismatches, remove lock entries safely, and avoid races.
  - Refined `iii worker logs` to use local log files with correct exit codes for known vs unknown workers.
  - Updated `iii worker status` watch/`--wait` behavior to terminate appropriately when the engine is down and improved early-boot hints.
  - Made `iii worker start`/`create` fail fast when the engine isn’t running; hardened `sandbox create` when sandbox id is missing.
- **Documentation**
  - Refreshed CLI reference wording for worker subcommands and clarified guest networking for `sandbox create --network`.
- **Tests**
  - Added regression coverage for managed remove rollback/wipe, and logs/status exit-code behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->