### PR TITLE
fix(engine): idle-timeout accepted worker WS sockets that never complete the upgrade (MOT-3967)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2703,6 +2703,8 @@ dependencies = [
  "glob",
  "hex",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "iana-time-zone",
  "iii",
  "iii-clap-docs",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -115,6 +115,12 @@ http-body-util = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 
 axum = { version = "0.8", features = ["ws", "macros"] }
+# Both already in the tree via axum; declared directly so the worker WS
+# listener can serve connections with an http1 header-read deadline
+# (MOT-3967) — axum::serve exposes no timer, so stalled pre-upgrade
+# sockets would otherwise leak fds.
+hyper = { version = "1", features = ["http1", "server"] }
+hyper-util = { version = "0.1", features = ["tokio", "service"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = "0.8"

--- a/engine/src/workers/worker/mod.rs
+++ b/engine/src/workers/worker/mod.rs
@@ -10,8 +10,10 @@ pub mod rbac_session;
 pub mod ws_handler;
 
 use std::{
+    io,
     net::SocketAddr,
     sync::{Arc, Mutex as StdMutex},
+    time::Duration,
 };
 
 use axum::{
@@ -22,10 +24,16 @@ use axum::{
     routing::get,
 };
 use colored::Colorize;
+use hyper::server::conn::http1;
+use hyper_util::{
+    rt::{TokioIo, TokioTimer},
+    service::TowerToHyperService,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::{net::TcpListener, task::AbortHandle};
+use tower::Service as _;
 
 use crate::{
     engine::Engine,
@@ -34,6 +42,11 @@ use crate::{
 };
 
 pub const DEFAULT_PORT: u16 = 49134;
+
+/// Default deadline for an accepted TCP connection to complete its HTTP
+/// request (the WS upgrade). Generous for a handshake that normally takes
+/// milliseconds; the point is bounding it at all (MOT-3967).
+pub const DEFAULT_HANDSHAKE_TIMEOUT_MS: u64 = 10_000;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default, JsonSchema)]
 pub struct CreateChannelInput {
@@ -59,6 +72,11 @@ pub struct WorkerManagerConfig {
     #[serde(default)]
     pub middleware_function_id: Option<String>,
     pub rbac: Option<rbac_config::RbacConfig>,
+    /// Deadline in milliseconds for an accepted TCP connection to complete
+    /// its HTTP request (the WS upgrade). Sockets that stall pre-upgrade
+    /// are closed and logged instead of leaking the fd (MOT-3967).
+    #[serde(default = "default_handshake_timeout_ms")]
+    pub handshake_timeout_ms: u64,
 }
 
 fn default_port() -> u16 {
@@ -69,6 +87,10 @@ fn default_host() -> String {
     "0.0.0.0".to_string()
 }
 
+fn default_handshake_timeout_ms() -> u64 {
+    DEFAULT_HANDSHAKE_TIMEOUT_MS
+}
+
 impl Default for WorkerManagerConfig {
     fn default() -> Self {
         Self {
@@ -76,6 +98,7 @@ impl Default for WorkerManagerConfig {
             host: default_host(),
             middleware_function_id: None,
             rbac: None,
+            handshake_timeout_ms: default_handshake_timeout_ms(),
         }
     }
 }
@@ -130,6 +153,7 @@ impl Worker for WorkerManager {
             .route("/ws/channels/{channel_id}", get(channel_ws_upgrade))
             .with_state(state);
 
+        let handshake_timeout = Duration::from_millis(config.handshake_timeout_ms);
         let handle = tokio::spawn(async move {
             let shutdown = async move {
                 tokio::select! {
@@ -145,15 +169,54 @@ impl Worker for WorkerManager {
                     } => {}
                 }
             };
+            tokio::pin!(shutdown);
 
-            if let Err(e) = axum::serve(
-                listener,
-                app.into_make_service_with_connect_info::<SocketAddr>(),
-            )
-            .with_graceful_shutdown(shutdown)
-            .await
-            {
-                tracing::error!(error = %e, "WorkerManager server exited with error");
+            // Serve connections manually instead of via `axum::serve`:
+            // hyper's `header_read_timeout` is the handshake deadline that
+            // reaps sockets stalling before the WS upgrade completes
+            // (MOT-3967), and axum::serve exposes neither it nor the timer
+            // it requires. Established WS sessions are unaffected — the
+            // deadline only bounds reading request headers.
+            let mut make_service = app.into_make_service_with_connect_info::<SocketAddr>();
+            loop {
+                let (stream, peer) = tokio::select! {
+                    res = listener.accept() => match res {
+                        Ok(conn) => conn,
+                        Err(err) => {
+                            // ECONNABORTED/RESET are normal client churn;
+                            // anything else (e.g. EMFILE) gets a pause so
+                            // the accept loop doesn't spin.
+                            if !is_connection_error(&err) {
+                                tracing::warn!(error = ?err, "worker listener accept error");
+                                tokio::time::sleep(Duration::from_secs(1)).await;
+                            }
+                            continue;
+                        }
+                    },
+                    _ = &mut shutdown => break,
+                };
+                let service = match make_service.call(peer).await {
+                    Ok(service) => service,
+                    Err(infallible) => match infallible {},
+                };
+                tokio::spawn(async move {
+                    let conn = http1::Builder::new()
+                        .timer(TokioTimer::new())
+                        .header_read_timeout(handshake_timeout)
+                        .serve_connection(TokioIo::new(stream), TowerToHyperService::new(service))
+                        .with_upgrades();
+                    if let Err(err) = conn.await {
+                        if err.is_timeout() {
+                            tracing::warn!(
+                                peer = %peer,
+                                timeout_ms = handshake_timeout.as_millis() as u64,
+                                "closed worker socket: WS upgrade not completed within handshake deadline"
+                            );
+                        } else {
+                            tracing::debug!(peer = %peer, error = ?err, "worker connection error");
+                        }
+                    }
+                });
             }
         });
 
@@ -188,6 +251,18 @@ pub struct AppState {
     pub engine: Arc<Engine>,
     pub config: Arc<WorkerManagerConfig>,
     pub(crate) shutdown_rx: tokio::sync::watch::Receiver<bool>,
+}
+
+/// Accept errors caused by the remote end (mirrors `axum::serve`'s internal
+/// accept loop) — these are normal churn and don't warrant a warning or a
+/// pause of the accept loop.
+fn is_connection_error(e: &io::Error) -> bool {
+    matches!(
+        e.kind(),
+        io::ErrorKind::ConnectionRefused
+            | io::ErrorKind::ConnectionAborted
+            | io::ErrorKind::ConnectionReset
+    )
 }
 
 async fn shutdown_signal() -> anyhow::Result<()> {
@@ -276,6 +351,7 @@ mod tests {
         assert_eq!(config.host, "0.0.0.0");
         assert!(config.middleware_function_id.is_none());
         assert!(config.rbac.is_none());
+        assert_eq!(config.handshake_timeout_ms, DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     #[test]
@@ -286,5 +362,6 @@ mod tests {
         assert_eq!(config.host, "0.0.0.0");
         assert!(config.middleware_function_id.is_none());
         assert!(config.rbac.is_none());
+        assert_eq!(config.handshake_timeout_ms, DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 }

--- a/engine/src/workers/worker/mod.rs
+++ b/engine/src/workers/worker/mod.rs
@@ -171,6 +171,12 @@ impl Worker for WorkerManager {
             };
             tokio::pin!(shutdown);
 
+            // Fans shutdown out to every spawned connection task, mirroring
+            // what axum::serve did internally: sent when the accept loop
+            // exits, and if this task is aborted (`destroy()`), the dropped
+            // sender wakes subscribers the same way.
+            let (conn_shutdown_tx, _) = tokio::sync::watch::channel(false);
+
             // Serve connections manually instead of via `axum::serve`:
             // hyper's `header_read_timeout` is the handshake deadline that
             // reaps sockets stalling before the WS upgrade completes
@@ -199,25 +205,53 @@ impl Worker for WorkerManager {
                     Ok(service) => service,
                     Err(infallible) => match infallible {},
                 };
+                let mut conn_shutdown_rx = conn_shutdown_tx.subscribe();
                 tokio::spawn(async move {
                     let conn = http1::Builder::new()
                         .timer(TokioTimer::new())
                         .header_read_timeout(handshake_timeout)
                         .serve_connection(TokioIo::new(stream), TowerToHyperService::new(service))
                         .with_upgrades();
-                    if let Err(err) = conn.await {
-                        if err.is_timeout() {
-                            tracing::warn!(
-                                peer = %peer,
-                                timeout_ms = handshake_timeout.as_millis() as u64,
-                                "closed worker socket: WS upgrade not completed within handshake deadline"
-                            );
-                        } else {
-                            tracing::debug!(peer = %peer, error = ?err, "worker connection error");
+                    tokio::pin!(conn);
+                    // Completes on shutdown send or sender drop (abort).
+                    let conn_shutdown = async move {
+                        while conn_shutdown_rx.changed().await.is_ok() {
+                            if *conn_shutdown_rx.borrow() {
+                                break;
+                            }
+                        }
+                    };
+                    tokio::pin!(conn_shutdown);
+                    let mut graceful_sent = false;
+                    loop {
+                        tokio::select! {
+                            res = conn.as_mut() => {
+                                if let Err(err) = res {
+                                    if err.is_timeout() {
+                                        tracing::warn!(
+                                            peer = %peer,
+                                            timeout_ms = handshake_timeout.as_millis() as u64,
+                                            "closed worker socket: WS upgrade not completed within handshake deadline"
+                                        );
+                                    } else {
+                                        tracing::debug!(peer = %peer, error = ?err, "worker connection error");
+                                    }
+                                }
+                                break;
+                            }
+                            // Close idle keep-alive connections immediately
+                            // and mark in-flight ones close-after-response,
+                            // then keep polling the connection to completion.
+                            _ = &mut conn_shutdown, if !graceful_sent => {
+                                conn.as_mut().graceful_shutdown();
+                                graceful_sent = true;
+                            }
                         }
                     }
                 });
             }
+
+            let _ = conn_shutdown_tx.send(true);
         });
 
         *self

--- a/engine/tests/rbac_infrastructure_e2e.rs
+++ b/engine/tests/rbac_infrastructure_e2e.rs
@@ -66,6 +66,7 @@ fn session_with(
             host: "127.0.0.1".to_string(),
             middleware_function_id: middleware,
             rbac: Some(rbac),
+            ..Default::default()
         }),
         ip_address: "127.0.0.1".to_string(),
         session_id: Uuid::new_v4(),

--- a/engine/tests/worker_ws_handshake_timeout_test.rs
+++ b/engine/tests/worker_ws_handshake_timeout_test.rs
@@ -1,0 +1,141 @@
+//! Regression tests for MOT-3967: the engine used to accept a TCP socket
+//! on the worker WS port and wait indefinitely for the HTTP upgrade
+//! request. A client that stalled pre-upgrade (observed: a TSI data stall)
+//! held its fd forever — an invisible leak (fd 16 held for 8+ minutes in
+//! the MOT-3857/MOT-3931 evidence chain).
+//!
+//! Fix: the worker listener serves each accepted connection through
+//! hyper's http1 builder with a `header_read_timeout` handshake deadline
+//! (`WorkerManagerConfig::handshake_timeout_ms`). Sockets that don't
+//! complete the upgrade in time are closed and logged; established WS
+//! sessions are unaffected (the deadline disarms once headers are read).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use iii::engine::Engine;
+use iii::workers::traits::Worker;
+use iii::workers::worker::WorkerManager;
+use serde_json::json;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Handshake deadline used by these tests. Short so the suite stays fast,
+/// long enough that a healthy local WS upgrade (sub-millisecond) never
+/// trips it.
+const HANDSHAKE_TIMEOUT_MS: u64 = 300;
+
+/// Boots a `WorkerManager` on a random port with a sub-second handshake
+/// deadline and returns the port + engine handle. Mirrors the pattern in
+/// `otel_ws_no_worker_registration_test.rs`.
+async fn spawn_engine() -> (u16, Arc<Engine>) {
+    // Pre-bind to discover an available port so the test avoids racing
+    // against CI parallelism on 49134.
+    let probe = TcpListener::bind("127.0.0.1:0").await.expect("bind probe");
+    let port = probe.local_addr().expect("local_addr").port();
+    drop(probe);
+
+    let engine = Arc::new(Engine::new());
+    let config = json!({
+        "port": port,
+        "host": "127.0.0.1",
+        "handshake_timeout_ms": HANDSHAKE_TIMEOUT_MS,
+    });
+    let worker = WorkerManager::create(engine.clone(), Some(config))
+        .await
+        .expect("create WorkerManager");
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    worker
+        .start_background_tasks(shutdown_rx, shutdown_tx)
+        .await
+        .expect("start WorkerManager");
+
+    // Give the listener task a moment to start serving.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    (port, engine)
+}
+
+/// Asserts the server closes `stream` (read returns EOF) within 2s —
+/// i.e. well within a few multiples of the 300ms handshake deadline.
+/// Pre-fix, the read never completes and the outer timeout elapses.
+async fn assert_server_closes(mut stream: TcpStream, what: &str) {
+    let mut buf = [0u8; 512];
+    let deadline = Duration::from_secs(2);
+    tokio::time::timeout(deadline, async {
+        loop {
+            match stream.read(&mut buf).await {
+                // EOF: server closed the connection. Reset also counts as
+                // closed — either way the fd is reclaimed server-side.
+                Ok(0) | Err(_) => break,
+                // Ignore any bytes the server writes (e.g. an HTTP 408).
+                Ok(_) => continue,
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!("server did not close {what} within {deadline:?} (fd leak: MOT-3967 regression)")
+    });
+}
+
+#[tokio::test]
+async fn stalled_socket_is_closed_at_handshake_deadline() {
+    let (port, _engine) = spawn_engine().await;
+    let addr = format!("127.0.0.1:{port}");
+
+    // Case 1: TCP connect, then total silence — the observed MOT-3967
+    // failure mode (client never sends the upgrade request).
+    let silent = TcpStream::connect(&addr).await.expect("connect silent");
+    assert_server_closes(silent, "a zero-byte stalled socket").await;
+
+    // Case 2: partial request headers, then stall.
+    let mut partial = TcpStream::connect(&addr).await.expect("connect partial");
+    partial
+        .write_all(b"GET / HTTP/1.1\r\nHost: x\r\n")
+        .await
+        .expect("write partial headers");
+    assert_server_closes(partial, "a partial-header stalled socket").await;
+
+    // The listener must stay healthy after reaping stalled sockets: a
+    // well-behaved WS client still connects.
+    let (ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/"))
+        .await
+        .expect("WS connect should still succeed after stalled sockets were reaped");
+    drop(ws);
+}
+
+#[tokio::test]
+async fn established_ws_session_survives_handshake_timeout() {
+    let (port, engine) = spawn_engine().await;
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}/"))
+        .await
+        .expect("connect to /");
+
+    // Wait for the registry entry that proves handle_worker registered
+    // the session (same idiom as otel_ws_no_worker_registration_test).
+    tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            if engine.worker_registry.list_workers().len() == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("`/` should register a worker within 500ms");
+
+    // Sit well past the handshake deadline. The deadline only bounds the
+    // pre-upgrade phase; an established session must not be reaped.
+    tokio::time::sleep(Duration::from_millis(HANDSHAKE_TIMEOUT_MS * 3)).await;
+
+    assert_eq!(
+        engine.worker_registry.list_workers().len(),
+        1,
+        "established WS session must survive past the handshake deadline"
+    );
+
+    let _ = ws.close(None).await;
+}

--- a/engine/tests/worker_ws_handshake_timeout_test.rs
+++ b/engine/tests/worker_ws_handshake_timeout_test.rs
@@ -13,22 +13,32 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures_util::{SinkExt, StreamExt};
 use iii::engine::Engine;
 use iii::workers::traits::Worker;
 use iii::workers::worker::WorkerManager;
 use serde_json::json;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::tungstenite::Message as WsMessage;
 
 /// Handshake deadline used by these tests. Short so the suite stays fast,
 /// long enough that a healthy local WS upgrade (sub-millisecond) never
 /// trips it.
 const HANDSHAKE_TIMEOUT_MS: u64 = 300;
 
-/// Boots a `WorkerManager` on a random port with a sub-second handshake
-/// deadline and returns the port + engine handle. Mirrors the pattern in
-/// `otel_ws_no_worker_registration_test.rs`.
-async fn spawn_engine() -> (u16, Arc<Engine>) {
+/// Boots a `WorkerManager` on a random port and returns the port, engine
+/// handle, and a clone of the engine-wide shutdown sender. Mirrors the
+/// pattern in `otel_ws_no_worker_registration_test.rs`.
+async fn spawn_engine_with(
+    handshake_timeout_ms: u64,
+) -> (u16, Arc<Engine>, tokio::sync::watch::Sender<bool>) {
+    // Without a meter, `register_worker` panics after inserting into the
+    // registry — the detached handler task dies while the registry row
+    // (and any len()-based assertion) survives. Initialize it so upgraded
+    // sessions actually stay alive in this standalone test binary.
+    iii::workers::observability::metrics::ensure_default_meter();
+
     // Pre-bind to discover an available port so the test avoids racing
     // against CI parallelism on 49134.
     let probe = TcpListener::bind("127.0.0.1:0").await.expect("bind probe");
@@ -39,7 +49,7 @@ async fn spawn_engine() -> (u16, Arc<Engine>) {
     let config = json!({
         "port": port,
         "host": "127.0.0.1",
-        "handshake_timeout_ms": HANDSHAKE_TIMEOUT_MS,
+        "handshake_timeout_ms": handshake_timeout_ms,
     });
     let worker = WorkerManager::create(engine.clone(), Some(config))
         .await
@@ -47,13 +57,20 @@ async fn spawn_engine() -> (u16, Arc<Engine>) {
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     worker
-        .start_background_tasks(shutdown_rx, shutdown_tx)
+        .start_background_tasks(shutdown_rx, shutdown_tx.clone())
         .await
         .expect("start WorkerManager");
 
     // Give the listener task a moment to start serving.
     tokio::time::sleep(Duration::from_millis(150)).await;
 
+    (port, engine, shutdown_tx)
+}
+
+/// Boots a `WorkerManager` with the sub-second handshake deadline used by
+/// the deadline tests.
+async fn spawn_engine() -> (u16, Arc<Engine>) {
+    let (port, engine, _shutdown_tx) = spawn_engine_with(HANDSHAKE_TIMEOUT_MS).await;
     (port, engine)
 }
 
@@ -107,6 +124,36 @@ async fn stalled_socket_is_closed_at_handshake_deadline() {
 }
 
 #[tokio::test]
+async fn shutdown_closes_idle_keepalive_connections_promptly() {
+    // Long handshake deadline so a prompt graceful close is clearly
+    // distinguishable from the deadline reaping the connection.
+    let (port, _engine, shutdown_tx) = spawn_engine_with(5_000).await;
+
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .expect("connect");
+
+    // Complete a normal (non-upgrade) request; the connection then idles
+    // in keep-alive awaiting the next request.
+    stream
+        .write_all(b"GET /nope HTTP/1.1\r\nHost: x\r\n\r\n")
+        .await
+        .expect("write request");
+    let mut buf = [0u8; 1024];
+    let n = tokio::time::timeout(Duration::from_secs(1), stream.read(&mut buf))
+        .await
+        .expect("HTTP response within 1s")
+        .expect("read response");
+    assert!(n > 0, "expected an HTTP response, got EOF");
+
+    // Engine-wide shutdown must propagate to this idle connection promptly
+    // (well before the 5s handshake deadline would reap it), matching the
+    // per-connection graceful shutdown axum::serve used to provide.
+    shutdown_tx.send(true).expect("flip shutdown watch");
+    assert_server_closes(stream, "an idle keep-alive connection after shutdown").await;
+}
+
+#[tokio::test]
 async fn established_ws_session_survives_handshake_timeout() {
     let (port, engine) = spawn_engine().await;
 
@@ -136,6 +183,28 @@ async fn established_ws_session_survives_handshake_timeout() {
         1,
         "established WS session must survive past the handshake deadline"
     );
+
+    // The registry row alone can outlive a dead handler task (a panic after
+    // the registry insert leaves the row behind), so prove the session is
+    // truly alive end-to-end: `handle_worker` answers WS pings with pongs.
+    ws.send(WsMessage::Ping(b"mot-3967".to_vec().into()))
+        .await
+        .expect("send ping on established session");
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            match ws.next().await {
+                Some(Ok(WsMessage::Pong(payload))) => {
+                    assert_eq!(payload.as_ref(), b"mot-3967");
+                    break;
+                }
+                // Skip protocol frames like the WorkerRegistered text message.
+                Some(Ok(_)) => continue,
+                other => panic!("session died instead of answering ping: {other:?}"),
+            }
+        }
+    })
+    .await
+    .expect("no pong within 1s: WS session is not alive after the handshake deadline");
 
     let _ = ws.close(None).await;
 }


### PR DESCRIPTION
## What

Adds a handshake deadline on the worker WS listener (default port 49134, including RBAC-gated listener instances): accepted TCP sockets that don't complete their HTTP request (the WS upgrade) within `handshake_timeout_ms` (new `iii-worker-manager` config field, default 10s) are closed and logged. Serving moves from `axum::serve` to a manual accept loop using hyper's http1 builder with `header_read_timeout` plus per-connection graceful-shutdown propagation (axum parity).

## Why

Fixes MOT-3967: the engine accepted a socket on the worker port and waited indefinitely for the upgrade; a stalled client leaked the fd invisibly (MOT-3857/MOT-3931 evidence chain: fd 16 held 8+ minutes with no WS session). `axum::serve` exposes neither hyper's header-read timeout nor the timer it requires, and hyper-util's auto builder never bounds its version-sniff read — hence the http1-only manual loop (every client of this port is an http1 WS client).

## Notes

- Behavior changes, all intended: the worker port no longer negotiates h2 (nothing used it); idle keep-alive sockets are reaped by the same deadline and now close immediately on shutdown. Established WS sessions are unaffected — the deadline only bounds reading request headers.
- Verified end-to-end: integration tests cover zero-byte stall, partial-header stall, listener health after reaping, session survival past the deadline (real ping/pong), and prompt close of idle connections on shutdown. Also verified against a live engine: lsof shows the fd held while stalled, closed at the deadline, reclaimed; SIGTERM exits cleanly through the new loop.
- Local full suite (`--no-fail-fast`): every integration suite green; remaining failures are pre-existing (RabbitMQ suite needs Docker; a few lib tests have global-state/timing isolation issues, notably `engine/config/` seed residue breaking the stream-bind test — fails on `main` too).
- Follow-ups (out of scope): the REST (`api_core.rs`) and stream (`stream.rs`) listeners share the unhardened `axum::serve` pattern but are h2-facing and need a different shape; channel WS sessions have no shutdown wiring (pre-existing).

Fixes MOT-3967

https://claude.ai/code/session_01PdbhbeksBGLosymTjFZ2sc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable timeout for worker WebSocket handshakes, with a default value applied automatically.
  * Worker connections now shut down gracefully when the engine stops.

* **Bug Fixes**
  * Stalled or incomplete WebSocket connection attempts are now closed instead of remaining open indefinitely.
  * Established WebSocket sessions remain active beyond the handshake timeout.
  * Improved handling and logging of connection and handshake errors.

* **Tests**
  * Added coverage for stalled connections, partial requests, shutdown behavior, and active WebSocket sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->