### PR TITLE
fix(node-sdk): bound WebSocket connects and detect half-open sockets (MOT-3968)

### DIFF
--- a/sdk/packages/node/helpers/src/observability/telemetry-system/connection.ts
+++ b/sdk/packages/node/helpers/src/observability/telemetry-system/connection.ts
@@ -38,7 +38,8 @@ export class SharedEngineConnection {
     this.state = 'connecting'
 
     try {
-      this.ws = new WebSocket(this.wsUrl)
+      // 10s handshake cap, parity with iii-sdk / Rust SDK (MOT-3857/MOT-3968)
+      this.ws = new WebSocket(this.wsUrl, { handshakeTimeout: 10000 })
 
       this.ws.on('open', () => {
         this.connecting = false

--- a/sdk/packages/node/iii/src/channels.ts
+++ b/sdk/packages/node/iii/src/channels.ts
@@ -1,5 +1,6 @@
 import { Readable, Writable } from 'node:stream'
 import { WebSocket } from 'ws'
+import { WS_HANDSHAKE_TIMEOUT_MS } from './iii-constants'
 import type { StreamChannelRef } from './iii-types'
 
 /**
@@ -112,7 +113,7 @@ export class ChannelWriter {
       return
     }
     this.wsReady = false
-    this.ws = new WebSocket(this.url)
+    this.ws = new WebSocket(this.url, { handshakeTimeout: WS_HANDSHAKE_TIMEOUT_MS })
 
     this.ws.on('open', () => {
       this.wsReady = true
@@ -243,7 +244,7 @@ export class ChannelReader {
   private ensureConnected(): void {
     if (this.connected) return
     this.connected = true
-    this.ws = new WebSocket(this.url)
+    this.ws = new WebSocket(this.url, { handshakeTimeout: WS_HANDSHAKE_TIMEOUT_MS })
 
     this.ws.on('open', () => {
       ;(this.ws as unknown as { binaryType: string }).binaryType = 'nodebuffer'

--- a/sdk/packages/node/iii/src/iii-constants.ts
+++ b/sdk/packages/node/iii/src/iii-constants.ts
@@ -70,3 +70,12 @@ export const DEFAULT_BRIDGE_RECONNECTION_CONFIG: IIIReconnectionConfig = {
 
 /** Default invocation timeout in milliseconds */
 export const DEFAULT_INVOCATION_TIMEOUT_MS = 30000
+
+/** WebSocket opening-handshake timeout in ms (parity with Rust SDK connect_timeout, MOT-3857) */
+export const WS_HANDSHAKE_TIMEOUT_MS = 10000
+
+/** Client keepalive ping cadence in ms (parity with Rust SDK ping_interval) */
+export const WS_PING_INTERVAL_MS = 20000
+
+/** Force reconnect after this long with no inbound frame (parity with Rust SDK idle_timeout) */
+export const WS_IDLE_TIMEOUT_MS = 60000

--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -10,6 +10,9 @@ import {
   EngineFunctions,
   type IIIConnectionState,
   type IIIReconnectionConfig,
+  WS_HANDSHAKE_TIMEOUT_MS,
+  WS_IDLE_TIMEOUT_MS,
+  WS_PING_INTERVAL_MS,
 } from './iii-constants'
 import type { HttpInvocationConfig } from '@iii-dev/helpers/http'
 import {
@@ -131,6 +134,8 @@ class Sdk implements IIIClient {
   private workerDescription?: string
   private workerId?: string
   private reconnectTimeout?: NodeJS.Timeout
+  private heartbeatInterval?: NodeJS.Timeout
+  private lastRxAt = 0
   private metricsReportingEnabled: boolean
   private invocationTimeoutMs: number
   private reconnectionConfig: IIIReconnectionConfig
@@ -585,8 +590,10 @@ class Sdk implements IIIClient {
     // Shutdown OpenTelemetry
     await shutdownOtel()
 
-    // Clear reconnection timeout
+    // Clear reconnection timeout and keepalive heartbeat (shutdown never
+    // reaches onSocketClose: listeners are removed before close() below)
     this.clearReconnectTimeout()
+    this.stopHeartbeat()
 
     // Reject all pending invocations
     for (const [_id, invocation] of this.invocations) {
@@ -631,7 +638,10 @@ class Sdk implements IIIClient {
     }
 
     this.setConnectionState('connecting')
-    this.ws = new WebSocket(this.address, { headers: this.options?.headers })
+    this.ws = new WebSocket(this.address, {
+      headers: this.options?.headers,
+      handshakeTimeout: WS_HANDSHAKE_TIMEOUT_MS,
+    })
     this.ws.on('open', this.onSocketOpen.bind(this))
     this.ws.on('close', this.onSocketClose.bind(this))
     this.ws.on('error', this.onSocketError.bind(this))
@@ -641,6 +651,26 @@ class Sdk implements IIIClient {
     if (this.reconnectTimeout) {
       clearTimeout(this.reconnectTimeout)
       this.reconnectTimeout = undefined
+    }
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat()
+    this.lastRxAt = Date.now()
+    this.heartbeatInterval = setInterval(() => {
+      if (Date.now() - this.lastRxAt >= WS_IDLE_TIMEOUT_MS) {
+        this.logError(`No inbound data for ${WS_IDLE_TIMEOUT_MS}ms, terminating connection to force reconnect`)
+        this.ws?.terminate() // 'close' fires -> onSocketClose stops the heartbeat and schedules reconnect
+      } else if (this.ws && this.isOpen()) {
+        this.ws.ping()
+      }
+    }, WS_PING_INTERVAL_MS)
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval)
+      this.heartbeatInterval = undefined
     }
   }
 
@@ -704,6 +734,7 @@ class Sdk implements IIIClient {
   }
 
   private onSocketClose(): void {
+    this.stopHeartbeat()
     this.ws?.removeAllListeners()
     this.ws?.terminate()
     this.ws = undefined
@@ -719,6 +750,15 @@ class Sdk implements IIIClient {
     this.setConnectionState('connected')
 
     this.ws?.on('message', this.onMessage.bind(this))
+
+    // Reset the idle deadline on any inbound frame (message/ping/pong), Rust SDK parity
+    const touch = () => {
+      this.lastRxAt = Date.now()
+    }
+    this.ws?.on('message', touch)
+    this.ws?.on('ping', touch)
+    this.ws?.on('pong', touch)
+    this.startHeartbeat()
 
     this.triggerTypes.forEach(({ message }) => {
       this.sendMessage(MessageType.RegisterTriggerType, message, true)

--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -135,7 +135,7 @@ class Sdk implements IIIClient {
   private workerId?: string
   private reconnectTimeout?: NodeJS.Timeout
   private heartbeatInterval?: NodeJS.Timeout
-  private lastRxAt = 0
+  private idleTimeout?: NodeJS.Timeout
   private metricsReportingEnabled: boolean
   private invocationTimeoutMs: number
   private reconnectionConfig: IIIReconnectionConfig
@@ -656,12 +656,15 @@ class Sdk implements IIIClient {
 
   private startHeartbeat(): void {
     this.stopHeartbeat()
-    this.lastRxAt = Date.now()
+    // Dedicated deadline, refresh()ed on every inbound frame, so it fires
+    // exactly WS_IDLE_TIMEOUT_MS after the last frame instead of on the next
+    // ping tick (which could add up to a full WS_PING_INTERVAL_MS of delay).
+    this.idleTimeout = setTimeout(() => {
+      this.logError(`No inbound data for ${WS_IDLE_TIMEOUT_MS}ms, terminating connection to force reconnect`)
+      this.ws?.terminate() // 'close' fires -> onSocketClose stops the heartbeat and schedules reconnect
+    }, WS_IDLE_TIMEOUT_MS)
     this.heartbeatInterval = setInterval(() => {
-      if (Date.now() - this.lastRxAt >= WS_IDLE_TIMEOUT_MS) {
-        this.logError(`No inbound data for ${WS_IDLE_TIMEOUT_MS}ms, terminating connection to force reconnect`)
-        this.ws?.terminate() // 'close' fires -> onSocketClose stops the heartbeat and schedules reconnect
-      } else if (this.ws && this.isOpen()) {
+      if (this.ws && this.isOpen()) {
         this.ws.ping()
       }
     }, WS_PING_INTERVAL_MS)
@@ -671,6 +674,10 @@ class Sdk implements IIIClient {
     if (this.heartbeatInterval) {
       clearInterval(this.heartbeatInterval)
       this.heartbeatInterval = undefined
+    }
+    if (this.idleTimeout) {
+      clearTimeout(this.idleTimeout)
+      this.idleTimeout = undefined
     }
   }
 
@@ -753,7 +760,7 @@ class Sdk implements IIIClient {
 
     // Reset the idle deadline on any inbound frame (message/ping/pong), Rust SDK parity
     const touch = () => {
-      this.lastRxAt = Date.now()
+      this.idleTimeout?.refresh()
     }
     this.ws?.on('message', touch)
     this.ws?.on('ping', touch)

--- a/sdk/packages/node/iii/tests/connection-handshake-timeout.test.ts
+++ b/sdk/packages/node/iii/tests/connection-handshake-timeout.test.ts
@@ -1,0 +1,62 @@
+import { type AddressInfo, createServer, type Socket } from 'node:net'
+import { expect, it } from 'vitest'
+import { WS_HANDSHAKE_TIMEOUT_MS } from '../src/iii-constants'
+import { registerWorker } from '../src/index'
+
+// Real `ws` transport, no mock and no engine: a raw TCP listener that accepts
+// connections but never answers the WebSocket upgrade. The SDK must abandon
+// the attempt after WS_HANDSHAKE_TIMEOUT_MS and re-enter reconnect backoff,
+// observable as a second connection reaching the listener. Complements the
+// fake-timer suite in connection-heartbeat.test.ts, which pins the SDK-side
+// logic but replaces the transport. Takes ~10s of real time by design.
+
+it('abandons a stalled handshake after WS_HANDSHAKE_TIMEOUT_MS and retries', async () => {
+  const connectionTimes: number[] = []
+  const clientSockets = new Set<Socket>()
+  let resolveSecond: (() => void) | undefined
+  const secondConnection = new Promise<void>((resolve) => {
+    resolveSecond = resolve
+  })
+
+  const server = createServer((socket) => {
+    clientSockets.add(socket)
+    socket.on('close', () => clientSockets.delete(socket))
+    connectionTimes.push(Date.now())
+    if (connectionTimes.length === 2) {
+      resolveSecond?.()
+    }
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const port = (server.address() as AddressInfo).port
+
+  const sdk = registerWorker(`ws://127.0.0.1:${port}`, {
+    otel: { enabled: false },
+    reconnectionConfig: { initialDelayMs: 100, jitterFactor: 0, maxRetries: 1 },
+  })
+
+  let guard: NodeJS.Timeout | undefined
+  try {
+    await Promise.race([
+      secondConnection,
+      new Promise((_, reject) => {
+        guard = setTimeout(() => reject(new Error('no retry within 15s — handshake timeout never fired')), 15_000)
+      }),
+    ])
+
+    expect(connectionTimes).toHaveLength(2)
+    // The retry must come after the handshake timeout, not from an instant
+    // connect failure such as ECONNREFUSED.
+    expect(connectionTimes[1] - connectionTimes[0]).toBeGreaterThanOrEqual(WS_HANDSHAKE_TIMEOUT_MS - 500)
+  } finally {
+    if (guard) {
+      clearTimeout(guard)
+    }
+    await sdk.shutdown()
+    // The stalled sockets never close on their own and would wedge
+    // server.close(), which waits for every accepted connection to end.
+    for (const socket of clientSockets) {
+      socket.destroy()
+    }
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
+}, 20_000)

--- a/sdk/packages/node/iii/tests/connection-heartbeat.test.ts
+++ b/sdk/packages/node/iii/tests/connection-heartbeat.test.ts
@@ -1,0 +1,170 @@
+import { EventEmitter } from 'node:events'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Inline mock for the 'ws' module, following channel-writer-readiness.test.ts.
+// Records constructor options so handshakeTimeout can be asserted, counts
+// pings, and mirrors the real socket's terminate() -> 'close' transition so
+// the Sdk's heartbeat/reconnect wiring can be driven with fake timers.
+// ---------------------------------------------------------------------------
+
+const sockets: MockWebSocket[] = []
+
+class MockWebSocket extends EventEmitter {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSING = 2
+  static readonly CLOSED = 3
+
+  readyState: number = MockWebSocket.CONNECTING
+  readonly sent: Array<Buffer | string> = []
+  pings = 0
+  terminated = false
+
+  constructor(
+    public readonly url?: string,
+    public readonly opts?: Record<string, unknown>,
+  ) {
+    super()
+    sockets.push(this)
+  }
+
+  send(data: Buffer | string, callback?: (err?: Error | null) => void): void {
+    this.sent.push(data)
+    callback?.()
+  }
+
+  ping(): void {
+    this.pings++
+  }
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED
+  }
+
+  terminate(): void {
+    if (this.terminated) {
+      return
+    }
+    this.terminated = true
+    this.readyState = MockWebSocket.CLOSED
+    this.emit('close')
+  }
+
+  /** Drive the open transition the way the real socket would. */
+  simulateOpen(): void {
+    this.readyState = MockWebSocket.OPEN
+    this.emit('open')
+  }
+}
+
+vi.mock('ws', () => ({
+  WebSocket: MockWebSocket,
+  default: { WebSocket: MockWebSocket },
+}))
+
+// setup.ts eagerly imports the SDK (and the real 'ws') before this file's mock
+// takes hold, so drop the cached graph and re-import against the mock.
+// Mirrors logger-runtime.test.ts.
+vi.resetModules()
+const { registerWorker } = await import('../src/index')
+
+function makeWorker(address: string, headers?: Record<string, string>) {
+  return registerWorker(address, {
+    otel: { enabled: false },
+    headers,
+    reconnectionConfig: { initialDelayMs: 10, jitterFactor: 0 },
+  })
+}
+
+beforeEach(() => {
+  sockets.length = 0
+})
+
+// Restore real timers before the global afterAll in setup.ts runs, so the SDK
+// shutdown logic (which relies on real setTimeout) is not blocked.
+afterAll(() => {
+  vi.useRealTimers()
+})
+
+describe('Sdk – WebSocket handshake timeout and keepalive heartbeat', () => {
+  it('passes handshakeTimeout (and headers) to the WebSocket constructor', async () => {
+    const sdk = makeWorker('ws://heartbeat-opts.test', { a: 'b' })
+    try {
+      expect(sockets[0].opts).toMatchObject({ handshakeTimeout: 10000 })
+      expect(sockets[0].opts?.headers).toEqual({ a: 'b' })
+    } finally {
+      await sdk.shutdown()
+    }
+  })
+
+  it('pings every 20s and stays connected while pongs keep arriving', async () => {
+    vi.useFakeTimers()
+    const sdk = makeWorker('ws://heartbeat-ping.test')
+    try {
+      const sock = sockets[0]
+      sock.simulateOpen()
+
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(sock.pings).toBe(1)
+      sock.emit('pong')
+
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(sock.pings).toBe(2)
+      sock.emit('pong')
+
+      // 60s of wall time has passed, but the deadline was kept fresh.
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(sock.pings).toBe(3)
+      expect(sock.terminated).toBe(false)
+    } finally {
+      vi.useRealTimers()
+      await sdk.shutdown()
+    }
+  })
+
+  it('terminates after 60s without inbound frames and reconnects', async () => {
+    vi.useFakeTimers()
+    const sdk = makeWorker('ws://heartbeat-idle.test')
+    try {
+      const sock = sockets[0]
+      sock.simulateOpen()
+
+      // Ticks at 20s/40s ping; the 60s tick crosses the idle deadline.
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(sock.pings).toBe(2)
+      expect(sock.terminated).toBe(true)
+
+      // terminate() emitted 'close' -> backoff (10ms, jitter 0) -> fresh socket.
+      await vi.advanceTimersByTimeAsync(20)
+      expect(sockets.length).toBe(2)
+      expect(sockets[1]).not.toBe(sock)
+    } finally {
+      vi.useRealTimers()
+      await sdk.shutdown()
+    }
+  })
+
+  it('any inbound message resets the idle deadline', async () => {
+    vi.useFakeTimers()
+    const sdk = makeWorker('ws://heartbeat-touch.test')
+    try {
+      const sock = sockets[0]
+      sock.simulateOpen()
+
+      await vi.advanceTimersByTimeAsync(40_000)
+      sock.emit('message', Buffer.from('{"type":"noop"}'))
+
+      // t=60s: only 20s since the last inbound frame — still alive.
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(sock.terminated).toBe(false)
+
+      // t=100s: 60s since the last inbound frame — terminated.
+      await vi.advanceTimersByTimeAsync(40_000)
+      expect(sock.terminated).toBe(true)
+    } finally {
+      vi.useRealTimers()
+      await sdk.shutdown()
+    }
+  })
+})

--- a/sdk/packages/node/iii/tests/connection-heartbeat.test.ts
+++ b/sdk/packages/node/iii/tests/connection-heartbeat.test.ts
@@ -145,22 +145,24 @@ describe('Sdk – WebSocket handshake timeout and keepalive heartbeat', () => {
     }
   })
 
-  it('any inbound message resets the idle deadline', async () => {
+  it('an inbound frame between ping ticks resets the idle deadline exactly', async () => {
     vi.useFakeTimers()
     const sdk = makeWorker('ws://heartbeat-touch.test')
     try {
       const sock = sockets[0]
       sock.simulateOpen()
 
-      await vi.advanceTimersByTimeAsync(40_000)
+      // Frame lands mid-tick at t=30s -> deadline moves to exactly t=90s.
+      await vi.advanceTimersByTimeAsync(30_000)
       sock.emit('message', Buffer.from('{"type":"noop"}'))
 
-      // t=60s: only 20s since the last inbound frame — still alive.
-      await vi.advanceTimersByTimeAsync(20_000)
+      // t=89.999s: 59.999s since the last inbound frame — still alive.
+      await vi.advanceTimersByTimeAsync(59_999)
       expect(sock.terminated).toBe(false)
 
-      // t=100s: 60s since the last inbound frame — terminated.
-      await vi.advanceTimersByTimeAsync(40_000)
+      // t=90s: exactly 60s after the last inbound frame — terminated, not
+      // deferred to the next ping tick at t=100s.
+      await vi.advanceTimersByTimeAsync(1)
       expect(sock.terminated).toBe(true)
     } finally {
       vi.useRealTimers()


### PR DESCRIPTION
## Summary

Node SDK parity with the Rust hardening from MOT-3857 (Python already gets this from `websockets` defaults):

- **`handshakeTimeout: 10s`** on every `ws` client the SDK creates — the bridge socket (`iii.ts`), both channel sockets (`channels.ts`), and the OTel telemetry socket (`helpers/.../telemetry-system/connection.ts`). A stalled TCP/upgrade now fails the attempt and re-enters the existing reconnect backoff instead of wedging a worker forever.
- **Client-side keepalive on the bridge socket**: ping every 20s; a dedicated 60s idle deadline (`Timeout.refresh()`ed on every inbound message/ping/pong frame) terminates the socket exactly 60s after the last inbound frame, forcing a reconnect. The engine never initiates pings and only auto-pongs, so client-side keepalive is the only half-open detection possible.

Constants `WS_HANDSHAKE_TIMEOUT_MS = 10s` / `WS_PING_INTERVAL_MS = 20s` / `WS_IDLE_TIMEOUT_MS = 60s` mirror Rust's `ConnTimings`. No new public options (Rust keeps these private; Python relies on library defaults).

The heartbeat starts in `onSocketOpen`, stops in `onSocketClose`, and is explicitly stopped in `shutdown()` — shutdown removes listeners before closing, so it never reaches the close handler and would otherwise leak the timers and keep the process alive.

## Verification

- New `tests/connection-heartbeat.test.ts` (mocked `ws` + fake timers): options reach the constructor; 20s ping cadence with pongs keeping the link alive; idle terminate → reconnect; a mid-tick inbound frame moves the deadline to exactly +60s (not the next ping tick).
- Wire checks driving the **built package** with real sockets:
  - Stalled TCP listener (accepts, never upgrades): `Opening handshake has timed out` at t≈10.1s, retry connected at t=10.6s.
  - Silent WS server (`autoPong: false`) sending one frame at t=30.1s: pings observed at 20/40/60/80s, idle terminate at **t=90.1s** (exactly last-frame + 60s), reconnect at t=90.6s.
  - Both drivers end with `sdk.shutdown()` and no `process.exit()` — clean natural exit, no leaked timer handles.
- `pnpm build` (iii) and `tsc --noEmit` + build (helpers) green; all hermetic ws tests pass. `tests/trigger-type-lifecycle.test.ts` fails 3/3 on a clean tree too (pre-existing, unrelated).

## Out of scope

- `iii-browser` — native `WebSocket`, no client options argument.
- Heartbeat/idle detection for the channel and OTel sockets — they got `handshakeTimeout` only; follow-up if wanted.

Linear: MOT-3968

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebSocket keepalive (periodic pings) and connection idle monitoring.
  * Automatically terminates and reconnects when no inbound activity is detected.
  * Inbound frames and heartbeat responses refresh the idle timer.

* **Bug Fixes**
  * WebSocket handshakes now use a consistent capped 10-second timeout for improved reliability.

* **Tests**
  * Added automated coverage for handshake timeouts, ping/idle behavior, termination at the expected deadline, and reconnect timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->