### PR TITLE
fix(engine,iii-worker): pass engine's actual WS address to spawned builtin daemons (MOT-3970)

### DIFF
--- a/crates/iii-worker/Cargo.toml
+++ b/crates/iii-worker/Cargo.toml
@@ -34,7 +34,7 @@ msb_krun = { version = "0.1.16", features = ["net", "blk"] }
 oci-client = "0.16"
 oci-spec = "0.9"
 tokio = { version = "1", features = ["process", "macros", "rt-multi-thread", "fs", "signal", "time", "io-std"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 # MDX CLI reference generation for the hidden `gen-cli-docs` subcommand.
 iii-clap-docs = { path = "../iii-clap-docs" }
 colored = "3.0.0"

--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -626,7 +626,10 @@ mod daemon_engine_arg_tests {
 
         assert_eq!(sandbox_env, "ws://127.0.0.1:55555");
         assert_eq!(manager_env, "ws://127.0.0.1:55555");
-        assert_eq!(sandbox_flag, "ws://flag:1", "explicit --engine must beat env");
+        assert_eq!(
+            sandbox_flag, "ws://flag:1",
+            "explicit --engine must beat env"
+        );
         assert_eq!(default, "ws://127.0.0.1:49134", "no env, no flag: default");
     }
 }

--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -327,7 +327,7 @@ pub struct WatchSourceArgs {
 #[derive(Args, Debug)]
 pub struct WorkerManagerDaemonArgs {
     /// Engine WebSocket URL to connect back to.
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_ENGINE_URL", default_value = "ws://127.0.0.1:49134")]
     pub engine: String,
 
     /// Project root the daemon mutates. Defaults to CWD at start.
@@ -344,7 +344,7 @@ pub struct SandboxDaemonArgs {
     pub config: String,
 
     /// Engine WebSocket URL to connect back to.
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_ENGINE_URL", default_value = "ws://127.0.0.1:49134")]
     pub engine: String,
 }
 
@@ -578,5 +578,55 @@ mod init_parse_tests {
             Commands::Init(args) => assert_eq!(args.template_dir.as_deref(), Some("/tmp/fix")),
             _ => panic!("expected Init variant"),
         }
+    }
+}
+
+#[cfg(test)]
+mod daemon_engine_arg_tests {
+    use super::*;
+    use clap::Parser;
+
+    fn sandbox_engine(argv: &[&str]) -> String {
+        match Cli::try_parse_from(argv).expect("should parse").command {
+            Commands::SandboxDaemon(args) => args.engine,
+            _ => panic!("expected SandboxDaemon variant"),
+        }
+    }
+
+    fn worker_manager_engine(argv: &[&str]) -> String {
+        match Cli::try_parse_from(argv).expect("should parse").command {
+            Commands::WorkerManagerDaemon(args) => args.engine,
+            _ => panic!("expected WorkerManagerDaemon variant"),
+        }
+    }
+
+    /// The engine exports III_ENGINE_URL when spawning builtin daemons
+    /// (engine/src/workers/external.rs); both daemons must honor it so
+    /// they connect back to the spawning engine's actual worker-listener
+    /// port, not the hardcoded default (MOT-3970). Explicit --engine
+    /// still wins (clap precedence: flag > env > default).
+    #[test]
+    #[serial_test::serial]
+    fn daemon_engine_args_honor_env_and_flag_precedence() {
+        // SAFETY: edition 2024 requires unsafe wrap; test is #[serial].
+        unsafe {
+            std::env::set_var("III_ENGINE_URL", "ws://127.0.0.1:55555");
+        }
+        // Capture first, assert after cleanup: a failing assert must not
+        // leak the var into later env-reading tests in this process.
+        let sandbox_env = sandbox_engine(&["iii-worker", "sandbox-daemon"]);
+        let manager_env = worker_manager_engine(&["iii-worker", "worker-manager-daemon"]);
+        let sandbox_flag =
+            sandbox_engine(&["iii-worker", "sandbox-daemon", "--engine", "ws://flag:1"]);
+        // SAFETY: edition 2024 requires unsafe wrap; test is #[serial].
+        unsafe {
+            std::env::remove_var("III_ENGINE_URL");
+        }
+        let default = sandbox_engine(&["iii-worker", "sandbox-daemon"]);
+
+        assert_eq!(sandbox_env, "ws://127.0.0.1:55555");
+        assert_eq!(manager_env, "ws://127.0.0.1:55555");
+        assert_eq!(sandbox_flag, "ws://flag:1", "explicit --engine must beat env");
+        assert_eq!(default, "ws://127.0.0.1:49134", "no env, no flag: default");
     }
 }

--- a/engine/src/workers/config.rs
+++ b/engine/src/workers/config.rs
@@ -347,7 +347,8 @@ impl WorkerRegistry {
                 info.name,
                 info.binary_path.display()
             );
-            let module = super::external::ExternalWorker::new(info, config);
+            let module =
+                super::external::ExternalWorker::new(info, config, engine.worker_manager_port());
             return Ok(Box::new(ExternalProcessWorker::new(Box::new(module))));
         }
 

--- a/engine/src/workers/external.rs
+++ b/engine/src/workers/external.rs
@@ -180,6 +180,11 @@ pub struct ExternalWorker {
     name: String,
     binary_path: PathBuf,
     extra_args: Vec<String>,
+    /// Effective `iii-worker-manager` port, from `engine.worker_manager_port()`.
+    /// Exported to the child as III_ENGINE_URL/III_URL so builtin daemons
+    /// (sandbox-daemon, worker-manager-daemon) connect back to THIS engine
+    /// instead of their hardcoded ws://127.0.0.1:49134 default (MOT-3970).
+    worker_manager_port: u16,
     config: Option<Value>,
     child: Arc<Mutex<Option<Child>>>,
     config_file: Arc<Mutex<Option<PathBuf>>>,
@@ -193,7 +198,7 @@ pub struct ExternalWorker {
 }
 
 impl ExternalWorker {
-    pub fn new(info: ExternalWorkerInfo, config: Option<Value>) -> Self {
+    pub fn new(info: ExternalWorkerInfo, config: Option<Value>, worker_manager_port: u16) -> Self {
         let name = info.name.clone();
         let display_name = Box::leak(format!("ExternalWorker({})", &name).into_boxed_str());
         Self {
@@ -201,6 +206,7 @@ impl ExternalWorker {
             name,
             binary_path: info.binary_path,
             extra_args: info.extra_args,
+            worker_manager_port,
             config,
             child: Arc::new(Mutex::new(None)),
             config_file: Arc::new(Mutex::new(None)),
@@ -331,6 +337,16 @@ impl Worker for ExternalWorker {
         // engine — wrappers and debugger reparenting break it — so iii-worker's
         // daemon_exit module prefers this handshake when present.
         cmd.env("III_ENGINE_PID", std::process::id().to_string());
+
+        // Engine WS URL for the child. Builtin daemons' --engine args fall
+        // back to this env (clap `env =`), so they connect to THIS engine's
+        // actual worker-listener port rather than their hardcoded default —
+        // two engines on one host each get their own daemon (MOT-3970).
+        // Also the documented contract for conventional externals: the
+        // manifest promises III_URL/III_ENGINE_URL are engine-set.
+        let engine_url = format!("ws://127.0.0.1:{}", self.worker_manager_port);
+        cmd.env("III_ENGINE_URL", &engine_url);
+        cmd.env("III_URL", &engine_url);
 
         // Lifeline pipe: we hold the write end (never written) for the
         // child's lifetime; the kernel closes it the instant this engine
@@ -729,7 +745,7 @@ mod tests {
             binary_path: PathBuf::from("/tmp/test-worker"),
             extra_args: vec![],
         };
-        let module = ExternalWorker::new(info, None);
+        let module = ExternalWorker::new(info, None, crate::workers::worker::DEFAULT_PORT);
         assert_eq!(module.name, "test-worker");
         assert_eq!(module.binary_path, PathBuf::from("/tmp/test-worker"));
         assert!(module.config.is_none());
@@ -743,7 +759,8 @@ mod tests {
             binary_path: PathBuf::from("/tmp/configured-worker"),
             extra_args: vec![],
         };
-        let module = ExternalWorker::new(info, Some(config.clone()));
+        let module =
+            ExternalWorker::new(info, Some(config.clone()), crate::workers::worker::DEFAULT_PORT);
         assert_eq!(module.config, Some(config));
     }
 
@@ -754,7 +771,7 @@ mod tests {
             binary_path: PathBuf::from("/tmp/my-worker"),
             extra_args: vec![],
         };
-        let module = ExternalWorker::new(info, None);
+        let module = ExternalWorker::new(info, None, crate::workers::worker::DEFAULT_PORT);
         assert_eq!(module.name(), "ExternalWorker(my-worker)");
     }
 
@@ -765,7 +782,7 @@ mod tests {
             binary_path: PathBuf::from("/tmp/test-worker"),
             extra_args: vec![],
         };
-        let module = ExternalWorker::new(info, None);
+        let module = ExternalWorker::new(info, None, crate::workers::worker::DEFAULT_PORT);
         let name1 = module.name();
         let name2 = module.name();
         assert_eq!(
@@ -781,7 +798,7 @@ mod tests {
             binary_path: PathBuf::from("/tmp/clone-test"),
             extra_args: vec![],
         };
-        let module = ExternalWorker::new(info, None);
+        let module = ExternalWorker::new(info, None, crate::workers::worker::DEFAULT_PORT);
         let cloned = module.clone();
 
         // Arc pointers should be the same (shared state)
@@ -797,7 +814,7 @@ mod tests {
             binary_path: PathBuf::from("/tmp/init-test"),
             extra_args: vec![],
         };
-        let module = ExternalWorker::new(info, None);
+        let module = ExternalWorker::new(info, None, crate::workers::worker::DEFAULT_PORT);
         assert!(module.initialize().await.is_ok());
     }
 
@@ -808,7 +825,7 @@ mod tests {
             binary_path: PathBuf::from("/tmp/destroy-test"),
             extra_args: vec![],
         };
-        let module = ExternalWorker::new(info, None);
+        let module = ExternalWorker::new(info, None, crate::workers::worker::DEFAULT_PORT);
         // destroy on a fresh module (no spawned child) should succeed
         assert!(module.destroy().await.is_ok());
     }
@@ -820,7 +837,7 @@ mod tests {
             binary_path: PathBuf::from("/tmp/cleanup-test"),
             extra_args: vec![],
         };
-        let module = ExternalWorker::new(info, None);
+        let module = ExternalWorker::new(info, None, crate::workers::worker::DEFAULT_PORT);
 
         // Simulate a config file being written
         let temp_config = std::env::temp_dir().join("iii-cleanup-test-config.yaml");
@@ -1000,7 +1017,9 @@ mod tests {
             extra_args: vec!["first-arg".into(), "second-arg".into()],
         };
 
-        let worker = ExternalWorker::new(info, Some(serde_json::json!({"key": "val"})));
+        // Distinctive port: the assertion below proves the child received
+        // THIS worker's port, not a hardcoded default.
+        let worker = ExternalWorker::new(info, Some(serde_json::json!({"key": "val"})), 50123);
 
         // The probe reads ARGV_LOG from env. Set it on the parent so
         // the spawned child inherits.
@@ -1049,6 +1068,10 @@ mod tests {
             assert!(
                 env_line.contains("lifeline_open=yes"),
                 "child's lifeline fd must be open after exec; got: {env_line:?}"
+            );
+            assert!(
+                env_line.contains("engine_url=ws://127.0.0.1:50123"),
+                "child must see this engine's actual WS URL, not a default; got: {env_line:?}"
             );
         }
     }

--- a/engine/src/workers/external.rs
+++ b/engine/src/workers/external.rs
@@ -759,8 +759,11 @@ mod tests {
             binary_path: PathBuf::from("/tmp/configured-worker"),
             extra_args: vec![],
         };
-        let module =
-            ExternalWorker::new(info, Some(config.clone()), crate::workers::worker::DEFAULT_PORT);
+        let module = ExternalWorker::new(
+            info,
+            Some(config.clone()),
+            crate::workers::worker::DEFAULT_PORT,
+        );
         assert_eq!(module.config, Some(config));
     }
 

--- a/engine/tests/fixtures/argv_probe.sh
+++ b/engine/tests/fixtures/argv_probe.sh
@@ -6,7 +6,8 @@
 {
   printf '%s\n' "$*"
   if [ -e "/dev/fd/${III_LIFELINE_FD:-999}" ]; then lifeline_open=yes; else lifeline_open=no; fi
-  printf 'engine_pid=%s lifeline_fd=%s lifeline_open=%s\n' \
-    "${III_ENGINE_PID:-unset}" "${III_LIFELINE_FD:-unset}" "$lifeline_open"
+  printf 'engine_pid=%s lifeline_fd=%s lifeline_open=%s engine_url=%s\n' \
+    "${III_ENGINE_PID:-unset}" "${III_LIFELINE_FD:-unset}" "$lifeline_open" \
+    "${III_ENGINE_URL:-unset}"
 } > "$ARGV_LOG"
 sleep 30


### PR DESCRIPTION
Fixes [MOT-3970](https://linear.app/motia/issue/MOT-3970/) (found smoke-testing MOT-3857).

## Problem

The engine spawns builtin daemons via the `KNOWN_EXTERNAL` table (`iii-sandbox` → `iii-worker sandbox-daemon`, `iii-worker-ops` → `iii-worker worker-manager-daemon`) with argv = subcommand + optional `--config` only — no engine URL. Both daemons' `--engine` args hardcode `ws://127.0.0.1:49134` with no env fallback.

An engine running its worker WS listener on any non-default port therefore spawned daemons that connected to **whatever sat on 49134** — a different engine instance (cross-engine registration clobbering) or nothing. Two engines on one host could not each get their own daemon.

## Fix

Env var rather than argv, because the same `external.rs` spawn path also runs legacy `iii.toml` externals (arbitrary binaries that accept no `--engine` flag), and `III_ENGINE_URL` is already the documented engine-set contract (`worker_manifest.rs`, `build_local_env`, libkrun path):

- **engine**: `ExternalWorker` now carries the effective `iii-worker-manager` port (`engine.worker_manager_port()`, same source as the already-fixed `registry_worker` sibling path) and exports `III_ENGINE_URL`/`III_URL` = `ws://127.0.0.1:<port>` to every spawned external worker, next to `III_ENGINE_PID`.
- **iii-worker**: `WorkerManagerDaemonArgs.engine` and `SandboxDaemonArgs.engine` gain `env = "III_ENGINE_URL"` (clap `env` feature added). Precedence: explicit `--engine` > env > default, so existing integration tests and manual invocations are untouched.

## Tests

- `argv_probe.sh` spawn-contract fixture now reports `engine_url=`; the engine spawn test constructs the worker with a distinctive port (50123) and asserts the child received `ws://127.0.0.1:50123` (fails with `engine_url=unset` without the fix).
- New serial parse test in `app.rs`: both daemons pick up `III_ENGINE_URL`, explicit flag beats env, default without either.

## Verification

- `cargo test -p iii external` (52), `--test external_known_sandbox` (2), `worker_manager_port` (3), `cargo test -p iii-worker cli::app` (4) — all green; `cargo fmt --all --check` clean; no new clippy warnings in touched files.
- Live smoke: engine with `iii-worker-manager: {port: 50123}` + `iii-worker-ops` → daemon spawned with bare argv held ESTABLISHED connections to `127.0.0.1:50123`, zero connections to 49134, and registered its `worker::*` functions on the spawning engine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker daemon commands can now read the engine URL from the `III_ENGINE_URL` environment variable.
  * Explicit command-line engine settings continue to take precedence over environment variables.
  * External workers now connect using the configured worker manager port, including non-default ports.

* **Bug Fixes**
  * Fixed external worker processes receiving an outdated or hardcoded engine connection URL.

* **Tests**
  * Added coverage for environment-variable parsing, precedence, default values, and custom worker manager ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->