### PR TITLE
feat(iii-worker): accept registry tags in manifests

### DIFF
--- a/crates/iii-worker/src/cli/project.rs
+++ b/crates/iii-worker/src/cli/project.rs
@@ -253,7 +253,7 @@ pub fn validate_manifest_keys(
         "unknown key(s) in {}: [{}]. Supported fields are: name, description, \
          runtime.base_image, scripts.(setup|install|start), env, dependencies, \
          resources.(cpus|memory), plus the registry publish metadata keys \
-         (iii, deploy, manifest) which the engine accepts and ignores.",
+         (iii, deploy, manifest, tags) which the engine accepts and ignores.",
         manifest_path.display(),
         unknown.join(", "),
     ))
@@ -1015,6 +1015,9 @@ env:
   FOO: bar
 dependencies:
   iii-http: "^0.19"
+tags:
+  - http
+  - api
 resources:
   cpus: 2
   memory: 2048
@@ -1042,15 +1045,15 @@ resources:
 
     #[test]
     fn validate_keys_accepts_publish_metadata_keys() {
-        // iii/deploy/manifest are release-CI metadata carried by every worker
+        // iii/deploy/manifest/tags are release-CI metadata carried by workers
         // in the workers repo; `worker add` must accept them (neither unknown
         // nor deprecated) so one manifest satisfies both validators.
-        let d = doc("iii: v1\nname: w\ndeploy: binary\nmanifest: Cargo.toml\n");
+        let d = doc("iii: v1\nname: w\ndeploy: binary\nmanifest: Cargo.toml\ntags:\n  - api\n");
         assert!(validate_manifest_keys(&d, &dummy_manifest_path()).is_ok());
         let m = super::super::worker_manifest::WorkerManifest::from_value(&d).unwrap();
         let (unknown, deprecated) = m.classify_keys();
         assert!(unknown.is_empty(), "got: {unknown:?}");
-        for key in ["iii", "deploy", "manifest"] {
+        for key in ["iii", "deploy", "manifest", "tags"] {
             assert!(
                 !deprecated.iter().any(|x| x == key),
                 "`{key}` must not be deprecated: {deprecated:?}"

--- a/crates/iii-worker/src/cli/worker_manifest.rs
+++ b/crates/iii-worker/src/cli/worker_manifest.rs
@@ -96,8 +96,9 @@ pub struct WorkerManifest {
 
     // Registry publish metadata. The workers-repo release CI requires these
     // keys (deploy/manifest pick the release artifact type and version
-    // source); the engine accepts them so one iii.worker.yaml can satisfy
-    // both validators, but never reads them at add/start time.
+    // source; tags provide discovery aliases); the engine accepts them so one
+    // iii.worker.yaml can satisfy both validators, but never reads them at
+    // add/start time.
     #[schemars(
         description = "Registry publish metadata: manifest format marker, e.g. `v1`. Accepted and ignored by the engine."
     )]
@@ -112,6 +113,11 @@ pub struct WorkerManifest {
         description = "Registry publish metadata: file the release version is read from (e.g. `Cargo.toml`, `package.json`, `pyproject.toml`), consumed by the workers-repo release CI. Accepted and ignored by the engine."
     )]
     pub manifest: Option<String>,
+
+    #[schemars(
+        description = "Registry publish metadata: search aliases for agent and user discovery (e.g. `sql`, `postgres`). Accepted and ignored by the engine."
+    )]
+    pub tags: Option<Vec<String>>,
 
     #[schemars(
         with = "Option<JsonValue>",
@@ -277,6 +283,24 @@ fn shape_problems(doc: &YamlValue) -> Vec<String> {
             problems.push(format!(
                 "`{section}` must be a mapping of indented `key: value` fields, got {}",
                 yaml_value_desc(v)
+            ));
+        }
+    }
+
+    if let Some(tags) = present(doc.get("tags")) {
+        if let Some(entries) = tags.as_sequence() {
+            for (index, value) in entries.iter().enumerate() {
+                if value.as_str().is_none() {
+                    problems.push(format!(
+                        "`tags[{index}]` must be a string, got {}",
+                        yaml_value_desc(value)
+                    ));
+                }
+            }
+        } else {
+            problems.push(format!(
+                "`tags` must be a list of strings, got {}",
+                yaml_value_desc(tags)
             ));
         }
     }
@@ -709,6 +733,32 @@ mod tests {
     }
 
     #[test]
+    fn report_accepts_registry_tags() {
+        let r = report("name: database\ntags:\n  - sql\n  - postgres\nscripts:\n  start: run\n");
+
+        assert!(r.valid, "registry tags must not invalidate: {r:?}");
+        assert!(r.unknown_keys.is_empty(), "got: {:?}", r.unknown_keys);
+
+        let r = report("name: database\ntags: sql\nscripts:\n  start: run\n");
+        assert!(!r.valid, "tags must be a list: {r:?}");
+        assert!(
+            r.errors
+                .iter()
+                .any(|e| e.contains("`tags` must be a list of strings")),
+            "got: {r:?}"
+        );
+
+        let r = report("name: database\ntags:\n  - sql\n  - 7\nscripts:\n  start: run\n");
+        assert!(!r.valid, "tag entries must be strings: {r:?}");
+        assert!(
+            r.errors
+                .iter()
+                .any(|e| e.contains("`tags[1]` must be a string, got the number 7")),
+            "got: {r:?}"
+        );
+    }
+
+    #[test]
     fn report_minimal_manifest_is_valid() {
         let r = report("name: w\nscripts:\n  start: \"node i.js\"\n");
         assert!(r.valid, "got: {r:?}");
@@ -930,13 +980,21 @@ mod tests {
         assert!(runtime_kind_desc.contains("DEPRECATED"));
         // Publish metadata is in the schema (so authored manifests validate)
         // and described as engine-ignored (so LLMs don't cargo-cult it).
-        for field in ["iii", "deploy", "manifest"] {
+        for field in ["iii", "deploy", "manifest", "tags"] {
             let desc = s["properties"][field]["description"].as_str().unwrap_or("");
             assert!(
                 desc.contains("ignored by the engine"),
                 "`{field}` must be described as engine-ignored: {desc:?}"
             );
         }
+        assert_eq!(
+            s["properties"]["tags"]["type"],
+            serde_json::json!(["array", "null"])
+        );
+        assert_eq!(
+            s["properties"]["tags"]["items"]["type"],
+            serde_json::json!("string")
+        );
     }
 
     #[test]

--- a/docs/next/creating-workers/worker-manifest.mdx
+++ b/docs/next/creating-workers/worker-manifest.mdx
@@ -186,14 +186,22 @@ Optional integer. Number of vCPUs. Defaults to `2`, capped at `4`.
 
 Optional integer. Memory in MiB. Defaults to `2048`, capped at `4096`.
 
-## Publish metadata: `iii`, `deploy`, `manifest`
+## Publish metadata: `iii`, `deploy`, `manifest`, `tags`
 
-Optional strings used by the workers-repository release pipeline, not by the engine. The engine
+Optional metadata used by the workers-repository release pipeline, not by the engine. The engine
 accepts these keys (so a manifest published from the workers repo also works with local
-`iii worker add`) but never reads them.
+`iii worker add`) but never reads them at runtime.
 
 ```yaml
 iii: v1 # manifest format marker
 deploy: image # release artifact type: binary | image | bundle
 manifest: pyproject.toml # file the release version is read from
+tags: # search aliases sent to the workers registry
+  - http
+  - rest
+  - api
 ```
+
+`iii`, `deploy`, and `manifest` are strings. `tags` is a list of strings used for agent and user
+discovery in the workers registry. Keep tags short, lowercase, and focused on terms someone would
+search for rather than repeating the worker description.

--- a/docs/next/creating-workers/worker-manifest.mdx.skill.md
+++ b/docs/next/creating-workers/worker-manifest.mdx.skill.md
@@ -182,14 +182,22 @@ Optional integer. Number of vCPUs. Defaults to `2`, capped at `4`.
 
 Optional integer. Memory in MiB. Defaults to `2048`, capped at `4096`.
 
-## Publish metadata: `iii`, `deploy`, `manifest`
+## Publish metadata: `iii`, `deploy`, `manifest`, `tags`
 
-Optional strings used by the workers-repository release pipeline, not by the engine. The engine
+Optional metadata used by the workers-repository release pipeline, not by the engine. The engine
 accepts these keys (so a manifest published from the workers repo also works with local
-`iii worker add`) but never reads them.
+`iii worker add`) but never reads them at runtime.
 
 ```yaml
 iii: v1 # manifest format marker
 deploy: image # release artifact type: binary | image | bundle
 manifest: pyproject.toml # file the release version is read from
+tags: # search aliases sent to the workers registry
+  - http
+  - rest
+  - api
 ```
+
+`iii`, `deploy`, and `manifest` are strings. `tags` is a list of strings used for agent and user
+discovery in the workers registry. Keep tags short, lowercase, and focused on terms someone would
+search for rather than repeating the worker description.


### PR DESCRIPTION
## Summary
- accept optional `tags` metadata in `iii.worker.yaml` without changing worker runtime behavior
- validate tag list and element shapes with clear errors and expose the field in the generated schema
- document the registry metadata in the next-version worker manifest reference

## Test plan
- [x] `cargo fmt --all`
- [x] focused worker manifest tests (36 passed)
- [x] focused project manifest tests (52 passed)
- [x] `cargo check -p iii-worker --lib`

Refs MOT-4059


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `tags` in worker manifest publish metadata.
  * Tags are accepted as a list of strings and can be used for registry discovery.
  * Invalid tag formats now produce clear validation errors.

* **Documentation**
  * Updated worker manifest reference documentation with `tags` syntax, usage details, and recommended tag conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->