### PR TITLE
fix(iii-network,sdk-python): first-boot worker zombies — VM transport wake starvation + SDK reconnect death (MOT-3966)

### DIFF
--- a/crates/iii-network/Cargo.toml
+++ b/crates/iii-network/Cargo.toml
@@ -23,3 +23,4 @@ hickory-proto = "0.25"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+libc = "0.2"

--- a/crates/iii-network/src/backend.rs
+++ b/crates/iii-network/src/backend.rs
@@ -57,7 +57,21 @@ impl NetBackend for SmoltcpBackend {
     /// Deliver a frame from smoltcp to the guest. Prepends a zeroed
     /// virtio-net header.
     fn read_frame(&mut self, buf: &mut [u8]) -> Result<usize, ReadError> {
-        let frame = self.shared.rx_ring.pop().ok_or(ReadError::NothingRead)?;
+        let frame = match self.shared.rx_ring.pop() {
+            Some(frame) => frame,
+            None => {
+                // The NetWorker epolls rx_wake's read end EDGE_TRIGGERED and
+                // never reads it, so the accumulated wake bytes must be
+                // consumed here — a full pipe silently swallows every future
+                // wake() and no edge is ever raised again (MOT-3966 stall).
+                // Re-pop once after draining: a push whose wake byte the drain
+                // consumed is visible to the second pop (queue Release/Acquire
+                // + the pipe syscalls order it); any later push writes into
+                // the now-empty pipe and raises a fresh edge.
+                self.shared.rx_wake.drain();
+                self.shared.rx_ring.pop().ok_or(ReadError::NothingRead)?
+            }
+        };
 
         let total_len = VIRTIO_NET_HDR_LEN + frame.len();
         if total_len > buf.len() {
@@ -193,5 +207,37 @@ mod tests {
         let backend = make_backend(16);
         let fd = backend.raw_socket_fd();
         assert!(fd >= 0);
+    }
+
+    /// MOT-3966: the NetWorker never reads the rx_wake pipe, so read_frame's
+    /// empty path must drain it — otherwise wake bytes accumulate until the
+    /// pipe is full and the edge-triggered consumer never wakes again.
+    #[test]
+    fn read_frame_empty_path_drains_wake_pipe() {
+        let shared = Arc::new(SharedState::new(16));
+        let mut backend = SmoltcpBackend::new(shared.clone());
+
+        // Accumulate wake bytes like a long-lived VM would.
+        for _ in 0..4096 {
+            shared.rx_wake.wake();
+        }
+
+        shared.rx_ring.push(vec![0xAB; 4]).unwrap();
+        shared.rx_wake.wake();
+
+        let mut buf = vec![0u8; 64];
+        assert!(backend.read_frame(&mut buf).is_ok());
+        // Empty pop: must return NothingRead AND consume the pipe backlog.
+        assert!(backend.read_frame(&mut buf).is_err());
+
+        // Pipe empty ⇒ every future push-then-wake lands a byte and raises a
+        // fresh edge. Pre-fix this held 4097 stale bytes.
+        let mut b = [0u8; 8192];
+        // SAFETY: valid nonblocking pipe read end, local buffer.
+        let n = unsafe { libc::read(shared.rx_wake.as_raw_fd(), b.as_mut_ptr().cast(), b.len()) };
+        assert!(
+            n < 0,
+            "pipe must be empty after the empty-pop drain, got {n} bytes"
+        );
     }
 }

--- a/crates/iii-network/src/conn.rs
+++ b/crates/iii-network/src/conn.rs
@@ -39,10 +39,14 @@ pub struct ConnectionTracker {
 struct Connection {
     src: SocketAddr,
     dst: SocketAddr,
-    to_proxy: mpsc::Sender<Bytes>,
+    /// `None` once the guest's FIN has been drained — dropping the sender is
+    /// how EOF propagates to the proxy task (its `recv()` yields `None`).
+    to_proxy: Option<mpsc::Sender<Bytes>>,
     from_proxy: mpsc::Receiver<Bytes>,
     proxy_channels: Option<ProxyChannels>,
     proxy_spawned: bool,
+    /// Set when `from_proxy` disconnects — the proxy task has exited.
+    proxy_gone: bool,
     write_buf: Option<(Bytes, usize)>,
     close_attempts: u16,
 }
@@ -118,13 +122,14 @@ impl ConnectionTracker {
             Connection {
                 src,
                 dst,
-                to_proxy: to_proxy_tx,
+                to_proxy: Some(to_proxy_tx),
                 from_proxy: from_proxy_rx,
                 proxy_channels: Some(ProxyChannels {
                     from_smoltcp: to_proxy_rx,
                     to_smoltcp: from_proxy_tx,
                 }),
                 proxy_spawned: false,
+                proxy_gone: false,
                 write_buf: None,
                 close_attempts: 0,
             },
@@ -148,7 +153,14 @@ impl ConnectionTracker {
 
             let socket = sockets.get_mut::<tcp::Socket>(handle);
 
-            if conn.to_proxy.is_closed() {
+            // Proxy task gone: it died (host connect/IO failure) or finished
+            // after a propagated guest FIN. Flush remaining proxy→guest bytes,
+            // then close; abort if the guest never drains us.
+            let proxy_dead = conn
+                .to_proxy
+                .as_ref()
+                .map_or(conn.proxy_gone, |tx| tx.is_closed());
+            if proxy_dead {
                 write_proxy_data(socket, conn);
                 if conn.write_buf.is_none() {
                     socket.close();
@@ -161,15 +173,28 @@ impl ConnectionTracker {
                 continue;
             }
 
-            while socket.can_recv() {
-                match socket.recv_slice(&mut relay_buf) {
-                    Ok(n) if n > 0 => {
-                        let data = Bytes::copy_from_slice(&relay_buf[..n]);
-                        if conn.to_proxy.try_send(data).is_err() {
-                            break;
-                        }
+            if let Some(to_proxy) = &conn.to_proxy {
+                while socket.can_recv() {
+                    // Reserve channel capacity BEFORE consuming: recv_slice
+                    // dequeues bytes already ACKed to the guest, so dropping
+                    // them on a full channel puts a permanent hole in the
+                    // stream. On Full, leave them buffered — the shrinking
+                    // TCP window backpressures the guest instead.
+                    let Ok(permit) = to_proxy.try_reserve() else {
+                        break;
+                    };
+                    match socket.recv_slice(&mut relay_buf) {
+                        Ok(n) if n > 0 => permit.send(Bytes::copy_from_slice(&relay_buf[..n])),
+                        _ => break,
                     }
-                    _ => break,
+                }
+
+                // Guest FIN fully drained (`may_recv` stays true while data
+                // remains buffered): propagate EOF by dropping the sender —
+                // the proxy's `recv()` yields `None` after the queued data
+                // and it half-closes the host side.
+                if !socket.may_recv() {
+                    conn.to_proxy = None;
                 }
             }
 
@@ -187,7 +212,14 @@ impl ConnectionTracker {
             }
 
             let socket = sockets.get::<tcp::Socket>(handle);
-            if socket.state() == tcp::State::Established {
+            // CloseWait too: a guest that sends ACK+data+FIN within one poll
+            // batch is first observed here already past Established. Its
+            // request bytes are still retrievable (`can_recv` is buffer-only)
+            // and `may_send` holds in CloseWait, so the response path works.
+            if matches!(
+                socket.state(),
+                tcp::State::Established | tcp::State::CloseWait
+            ) {
                 conn.proxy_spawned = true;
 
                 if let Some(channels) = conn.proxy_channels.take() {
@@ -371,7 +403,11 @@ fn write_proxy_data(socket: &mut tcp::Socket<'_>, conn: &mut Connection) {
                     conn.write_buf = Some((data, 0));
                 }
             }
-            Err(_) => break,
+            Err(mpsc::error::TryRecvError::Disconnected) => {
+                conn.proxy_gone = true;
+                break;
+            }
+            Err(mpsc::error::TryRecvError::Empty) => break,
         }
     }
 }

--- a/crates/iii-network/src/conn.rs
+++ b/crates/iii-network/src/conn.rs
@@ -163,6 +163,12 @@ impl ConnectionTracker {
             if proxy_dead {
                 write_proxy_data(socket, conn);
                 if conn.write_buf.is_none() {
+                    if !matches!(
+                        socket.state(),
+                        tcp::State::Closed | tcp::State::TimeWait | tcp::State::FinWait2
+                    ) {
+                        tracing::debug!(src = %conn.src, dst = %conn.dst, state = ?socket.state(), "proxy gone; closing socket");
+                    }
                     socket.close();
                 } else {
                     conn.close_attempts += 1;
@@ -220,6 +226,7 @@ impl ConnectionTracker {
                 socket.state(),
                 tcp::State::Established | tcp::State::CloseWait
             ) {
+                tracing::debug!(src = %conn.src, dst = %conn.dst, state = ?socket.state(), "connection ready; spawning proxy");
                 conn.proxy_spawned = true;
 
                 if let Some(channels) = conn.proxy_channels.take() {
@@ -235,6 +242,26 @@ impl ConnectionTracker {
         new
     }
 
+    /// Log one line per tracked connection (state, relay eligibility,
+    /// buffered bytes). Debug-level; the poll loop calls this on its
+    /// cleanup cadence (~1s) so a wedged connection narrates itself.
+    pub fn debug_snapshot(&self, sockets: &mut SocketSet<'_>) {
+        for (&handle, conn) in &self.connections {
+            let socket = sockets.get::<tcp::Socket>(handle);
+            tracing::debug!(
+                src = %conn.src,
+                dst = %conn.dst,
+                state = ?socket.state(),
+                spawned = conn.proxy_spawned,
+                gone = conn.proxy_gone,
+                eof_sent = conn.to_proxy.is_none(),
+                rx_buffered = socket.recv_queue(),
+                tx_buffered = socket.send_queue(),
+                "conn snapshot"
+            );
+        }
+    }
+
     /// Remove closed connections and their sockets.
     ///
     /// Only removes sockets in the `Closed` state. Sockets in `TimeWait`
@@ -244,6 +271,7 @@ impl ConnectionTracker {
         self.connections.retain(|&handle, conn| {
             let socket = sockets.get::<tcp::Socket>(handle);
             if matches!(socket.state(), tcp::State::Closed) {
+                tracing::debug!(src = %conn.src, dst = %conn.dst, "connection reaped");
                 keys.remove(&(conn.src, conn.dst));
                 sockets.remove(handle);
                 false

--- a/crates/iii-network/src/proxy.rs
+++ b/crates/iii-network/src/proxy.rs
@@ -65,6 +65,7 @@ async fn tcp_proxy_task(
 ) -> io::Result<()> {
     let host_dst = resolve_host_dst(dst, gateway_ipv4);
     let stream = TcpStream::connect(host_dst).await?;
+    tracing::debug!(%dst, %host_dst, "proxy connected");
     let (mut server_rx, mut server_tx) = stream.into_split();
 
     let mut server_buf = vec![0u8; SERVER_READ_BUF_SIZE];

--- a/crates/iii-network/src/proxy.rs
+++ b/crates/iii-network/src/proxy.rs
@@ -68,10 +68,11 @@ async fn tcp_proxy_task(
     let (mut server_rx, mut server_tx) = stream.into_split();
 
     let mut server_buf = vec![0u8; SERVER_READ_BUF_SIZE];
+    let mut guest_open = true;
 
     loop {
         tokio::select! {
-            data = from_smoltcp.recv() => {
+            data = from_smoltcp.recv(), if guest_open => {
                 match data {
                     Some(bytes) => {
                         if let Err(e) = server_tx.write_all(&bytes).await {
@@ -79,7 +80,12 @@ async fn tcp_proxy_task(
                             break;
                         }
                     }
-                    None => break,
+                    None => {
+                        // Guest sent FIN: half-close toward the server but
+                        // keep relaying its remaining response bytes back.
+                        guest_open = false;
+                        let _ = server_tx.shutdown().await;
+                    }
                 }
             }
 

--- a/crates/iii-network/src/stack.rs
+++ b/crates/iii-network/src/stack.rs
@@ -268,11 +268,17 @@ pub fn smoltcp_poll_loop(
         poll_iteration(&mut state, &shared, &config, &tokio_handle);
 
         let now = smoltcp_now();
+        // Clamp: `max(1)` — smoltcp reports `PollAt::Now` while the device is
+        // full (rx_ring backed up), which would busy-spin this thread at 100%
+        // CPU; `min(100)` — the relay tick must fire even when a distant timer
+        // (e.g. a TimeWait socket, 10s) is the only pending event, because
+        // nothing wakes this loop when a proxy task frees channel capacity.
         let timeout_ms = state
             .iface
             .poll_delay(now, &state.sockets)
             .map(|d| d.total_millis().min(i32::MAX as u64) as i32)
-            .unwrap_or(100);
+            .unwrap_or(100)
+            .clamp(1, 100);
 
         // SAFETY: poll_fds is a valid array of pollfd structs with valid fds.
         unsafe {

--- a/crates/iii-network/src/stack.rs
+++ b/crates/iii-network/src/stack.rs
@@ -141,10 +141,18 @@ pub fn poll_iteration(
     while let Some(frame) = state.device.stage_next_frame() {
         match classify_frame(frame) {
             FrameAction::TcpSyn { src, dst } => {
-                if !state.conn_tracker.has_socket_for(&src, &dst) {
-                    state
-                        .conn_tracker
-                        .create_tcp_socket(src, dst, &mut state.sockets);
+                if state.conn_tracker.has_socket_for(&src, &dst) {
+                    // The SYN falls through to the existing socket for this
+                    // tuple. smoltcp silently drops a pure SYN against any
+                    // post-Listen socket, so this is only harmless while
+                    // that socket is still making progress (MOT-3966).
+                    tracing::debug!(%src, %dst, "SYN for tracked tuple; passthrough to existing socket");
+                } else {
+                    let created =
+                        state
+                            .conn_tracker
+                            .create_tcp_socket(src, dst, &mut state.sockets);
+                    tracing::debug!(%src, %dst, created, "SYN: new connection");
                 }
                 state
                     .iface
@@ -190,6 +198,7 @@ pub fn poll_iteration(
 
     if state.last_cleanup.elapsed() >= std::time::Duration::from_secs(1) {
         state.conn_tracker.cleanup_closed(&mut state.sockets);
+        state.conn_tracker.debug_snapshot(&mut state.sockets);
         state.udp_relay.cleanup_expired();
         state.last_cleanup = std::time::Instant::now();
     }

--- a/crates/iii-network/src/wake_pipe.rs
+++ b/crates/iii-network/src/wake_pipe.rs
@@ -55,33 +55,39 @@ impl WakePipe {
 
     /// Signal the reader. Safe to call from any thread, multiple times.
     ///
-    /// Writes a single byte. A full pipe is NOT safe to ignore: msb_krun's
+    /// Writes a single byte. A dropped write is NOT safe to ignore: msb_krun's
     /// NetWorker registers the read end EDGE_TRIGGERED (kqueue `EV_CLEAR`) and
-    /// never reads it, so a dropped write means no event is ever delivered
-    /// again — the MOT-3966 permanent host→guest stall. On a failed write we
-    /// self-heal: drain our own read end (both ends live in this process;
-    /// concurrent drainers are harmless — only edges matter, not bytes) and
-    /// retry once so the write lands and raises a fresh edge.
+    /// never reads it, so a lost write means no event is ever delivered
+    /// again — the MOT-3966 permanent host→guest stall. On failure we
+    /// self-heal and retry, bounded so a persistent error can't spin:
+    /// - full pipe (EAGAIN): drain our own read end (both ends live in this
+    ///   process; concurrent drainers are harmless — only edges matter, not
+    ///   bytes) so the next write lands and raises a fresh edge;
+    /// - interrupted (EINTR): just write again.
     pub fn wake(&self) {
-        // SAFETY: write_fd is a valid, non-blocking file descriptor.
-        // Writing 1 byte to a pipe is atomic on all POSIX systems.
-        let n = unsafe { libc::write(self.write_fd.as_raw_fd(), [1u8].as_ptr().cast(), 1) };
-        if n == 1 {
-            return;
-        }
+        for attempt in 0..3 {
+            // SAFETY: write_fd is a valid, non-blocking file descriptor.
+            // Writing 1 byte to a pipe is atomic on all POSIX systems.
+            let n = unsafe { libc::write(self.write_fd.as_raw_fd(), [1u8].as_ptr().cast(), 1) };
+            if n == 1 {
+                return;
+            }
 
-        let failed = FAILED_WAKES.fetch_add(1, Ordering::Relaxed) + 1;
-        if failed == 1 || failed.is_multiple_of(1000) {
-            tracing::warn!(
-                failed,
-                "wake pipe full; draining and retrying (consumer not draining its pipe?)"
-            );
-        }
+            if attempt == 0 {
+                let failed = FAILED_WAKES.fetch_add(1, Ordering::Relaxed) + 1;
+                if failed == 1 || failed.is_multiple_of(1000) {
+                    tracing::warn!(
+                        failed,
+                        "wake pipe write failed; self-healing (consumer not draining its pipe?)"
+                    );
+                }
+            }
 
-        self.drain();
-        // SAFETY: as above.
-        unsafe {
-            libc::write(self.write_fd.as_raw_fd(), [1u8].as_ptr().cast(), 1);
+            let interrupted =
+                n < 0 && std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted;
+            if !interrupted {
+                self.drain();
+            }
         }
     }
 

--- a/crates/iii-network/src/wake_pipe.rs
+++ b/crates/iii-network/src/wake_pipe.rs
@@ -4,6 +4,17 @@
 //! The write end signals, the read end is pollable via `epoll`/`kqueue`/`poll`.
 
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Process-wide count of `wake()` calls whose first write found the pipe
+/// full. A rising value means some consumer is not draining its pipe —
+/// the MOT-3966 stall signature.
+static FAILED_WAKES: AtomicU64 = AtomicU64::new(0);
+
+/// Number of `wake()` first-writes that failed because the pipe was full.
+pub fn failed_wakes() -> u64 {
+    FAILED_WAKES.load(Ordering::Relaxed)
+}
 
 /// Cross-platform wake notification built on `pipe()`.
 ///
@@ -44,11 +55,31 @@ impl WakePipe {
 
     /// Signal the reader. Safe to call from any thread, multiple times.
     ///
-    /// Writes a single byte. If the pipe buffer is full the write is silently
-    /// dropped — the reader will still wake because there are unread bytes.
+    /// Writes a single byte. A full pipe is NOT safe to ignore: msb_krun's
+    /// NetWorker registers the read end EDGE_TRIGGERED (kqueue `EV_CLEAR`) and
+    /// never reads it, so a dropped write means no event is ever delivered
+    /// again — the MOT-3966 permanent host→guest stall. On a failed write we
+    /// self-heal: drain our own read end (both ends live in this process;
+    /// concurrent drainers are harmless — only edges matter, not bytes) and
+    /// retry once so the write lands and raises a fresh edge.
     pub fn wake(&self) {
         // SAFETY: write_fd is a valid, non-blocking file descriptor.
         // Writing 1 byte to a pipe is atomic on all POSIX systems.
+        let n = unsafe { libc::write(self.write_fd.as_raw_fd(), [1u8].as_ptr().cast(), 1) };
+        if n == 1 {
+            return;
+        }
+
+        let failed = FAILED_WAKES.fetch_add(1, Ordering::Relaxed) + 1;
+        if failed == 1 || failed.is_multiple_of(1000) {
+            tracing::warn!(
+                failed,
+                "wake pipe full; draining and retrying (consumer not draining its pipe?)"
+            );
+        }
+
+        self.drain();
+        // SAFETY: as above.
         unsafe {
             libc::write(self.write_fd.as_raw_fd(), [1u8].as_ptr().cast(), 1);
         }
@@ -62,9 +93,15 @@ impl WakePipe {
             // SAFETY: read_fd is a valid, non-blocking file descriptor.
             let n =
                 unsafe { libc::read(self.read_fd.as_raw_fd(), buf.as_mut_ptr().cast(), buf.len()) };
-            if n <= 0 {
-                break;
+            if n > 0 {
+                continue;
             }
+            // EINTR must retry: treating it as drained can strand bytes and,
+            // for an edge-triggered peer, a permanently-readable stale state.
+            if n < 0 && std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            break;
         }
     }
 
@@ -145,5 +182,49 @@ mod tests {
     fn nonblocking_read() {
         let pipe = WakePipe::new();
         pipe.drain();
+    }
+
+    /// MOT-3966: a full pipe must not swallow wakes — the consumer is
+    /// edge-triggered, so a dropped write means no event is ever raised
+    /// again. wake() must self-heal by draining and retrying.
+    #[test]
+    fn wake_self_heals_on_full_pipe() {
+        let pipe = WakePipe::new();
+        // Fill the pipe raw (bypassing wake's self-heal) until EAGAIN.
+        let one = [1u8];
+        loop {
+            // SAFETY: valid nonblocking fd, 1-byte write.
+            let n = unsafe { libc::write(pipe.write_fd.as_raw_fd(), one.as_ptr().cast(), 1) };
+            if n != 1 {
+                break;
+            }
+        }
+
+        let before = failed_wakes();
+        pipe.wake();
+        assert!(
+            failed_wakes() > before,
+            "first write should have failed on a full pipe"
+        );
+
+        // Exactly the retried wake byte remains — the pipe was drained and
+        // the wake landed, so a fresh edge was raised.
+        let mut buf = [0u8; 4096];
+        let mut total = 0isize;
+        loop {
+            // SAFETY: valid nonblocking fd reading into a local buffer.
+            let n =
+                unsafe { libc::read(pipe.read_fd.as_raw_fd(), buf.as_mut_ptr().cast(), buf.len()) };
+            if n <= 0 {
+                break;
+            }
+            total += n;
+        }
+        assert_eq!(total, 1, "only the retried wake byte should remain");
+
+        // And the pipe has room again.
+        // SAFETY: as above.
+        let n = unsafe { libc::write(pipe.write_fd.as_raw_fd(), one.as_ptr().cast(), 1) };
+        assert_eq!(n, 1);
     }
 }

--- a/crates/iii-network/tests/network_integration.rs
+++ b/crates/iii-network/tests/network_integration.rs
@@ -9,13 +9,18 @@ use std::net::Ipv4Addr;
 use std::sync::Arc;
 
 use iii_network::{
-    ConnectionTracker, DnsInterceptor, PollLoopConfig, PollLoopState, SharedState, SmoltcpBackend,
-    SmoltcpDevice, UdpRelay, create_interface, poll_iteration,
+    ConnectionTracker, DnsInterceptor, FrameAction, NewConnection, PollLoopConfig, PollLoopState,
+    SharedState, SmoltcpBackend, SmoltcpDevice, UdpRelay, classify_frame, create_interface,
+    poll_iteration,
 };
 use msb_krun::backends::net::NetBackend;
-use smoltcp::iface::SocketSet;
-use smoltcp::phy::Device;
+use smoltcp::iface::{PollResult, SocketSet};
+use smoltcp::phy::{ChecksumCapabilities, Device};
 use smoltcp::time::Instant;
+use smoltcp::wire::{
+    ArpOperation, ArpPacket, ArpRepr, EthernetAddress, EthernetFrame, EthernetProtocol,
+    EthernetRepr, IpProtocol, Ipv4Packet, Ipv4Repr, TcpControl, TcpPacket, TcpRepr, TcpSeqNumber,
+};
 
 /// Test 3: Network connectivity — frame flow from backend through shared state to device.
 ///
@@ -295,6 +300,39 @@ async fn poll_iteration_multiple_syns() {
     }
 }
 
+// ---------------------------------------------------------------------------
+// MOT-3966: wake-pipe reliability soak
+// ---------------------------------------------------------------------------
+
+/// The rx_wake pipe must never accumulate bytes across a long-lived VM's
+/// traffic: the msb_krun NetWorker epolls it EDGE_TRIGGERED and never reads
+/// it, so an ever-filling pipe eventually swallows every wake (16 KiB budget
+/// on macOS) and host→guest delivery dies permanently.
+#[test]
+fn soak_wake_pipe_survives_100k_frames() {
+    let shared = Arc::new(SharedState::new(64));
+    let mut backend = SmoltcpBackend::new(shared.clone());
+    let mut buf = vec![0u8; 256];
+    let mut delivered = 0u32;
+
+    for i in 0..100_000u32 {
+        shared.rx_ring.push(i.to_be_bytes().to_vec()).unwrap();
+        shared.rx_wake.wake();
+        // Mimic msb_krun's process_rx: loop read_frame until NothingRead.
+        while backend.read_frame(&mut buf).is_ok() {
+            delivered += 1;
+        }
+    }
+
+    assert_eq!(delivered, 100_000);
+
+    // The pipe must end drained, not accumulating toward saturation.
+    let mut b = [0u8; 512];
+    // SAFETY: valid nonblocking pipe read end, local buffer.
+    let n = unsafe { libc::read(shared.rx_wake.as_raw_fd(), b.as_mut_ptr().cast(), b.len()) };
+    assert!(n < 0, "wake pipe accumulated {n} bytes over the soak");
+}
+
 /// Cleanup runs when last_cleanup is old enough.
 #[tokio::test]
 async fn poll_iteration_cleanup_runs_after_interval() {
@@ -312,4 +350,586 @@ async fn poll_iteration_cleanup_runs_after_interval() {
         state.last_cleanup > old_cleanup,
         "last_cleanup should be updated after >= 1s elapsed"
     );
+}
+
+// ---------------------------------------------------------------------------
+// MOT-3966: data-pump correctness tests with a seq-aware in-test TCP guest
+// ---------------------------------------------------------------------------
+
+/// Minimal TCP client living "inside the guest": builds checksummed
+/// Ethernet/IPv4/TCP frames, answers ARP, tracks seq/ack/window, and
+/// collects payload bytes the gateway sends back.
+struct TestGuest {
+    guest_mac: EthernetAddress,
+    gateway_mac: EthernetAddress,
+    guest_ip: Ipv4Addr,
+    gateway_ip: Ipv4Addr,
+    dst_ip: Ipv4Addr,
+    src_port: u16,
+    dst_port: u16,
+    /// Next sequence number we send.
+    seq: u32,
+    /// Next byte we expect from the peer (valid once established).
+    ack: u32,
+    /// Peer's advertised receive window.
+    peer_window: u16,
+    /// Highest ack number the peer has sent (bytes of ours it has).
+    peer_acked: u32,
+    established: bool,
+    peer_fin: bool,
+    received: Vec<u8>,
+}
+
+impl TestGuest {
+    fn new(config: &PollLoopConfig, dst_ip: Ipv4Addr, src_port: u16, dst_port: u16) -> Self {
+        Self {
+            guest_mac: EthernetAddress(config.guest_mac),
+            gateway_mac: EthernetAddress(config.gateway_mac),
+            guest_ip: config.guest_ipv4,
+            gateway_ip: config.gateway_ipv4,
+            dst_ip,
+            src_port,
+            dst_port,
+            seq: 1000,
+            ack: 0,
+            peer_window: 0,
+            peer_acked: 1000,
+            established: false,
+            peer_fin: false,
+            received: Vec::new(),
+        }
+    }
+
+    /// Bytes in flight (sent but not yet acked by the peer).
+    fn in_flight(&self) -> u32 {
+        self.seq.wrapping_sub(self.peer_acked)
+    }
+
+    /// Gratuitous ARP request so smoltcp learns our MAC before replying —
+    /// avoids the SYN-ACK being parked on neighbor resolution.
+    fn arp_announce(&self) -> Vec<u8> {
+        let arp = ArpRepr::EthernetIpv4 {
+            operation: ArpOperation::Request,
+            source_hardware_addr: self.guest_mac,
+            source_protocol_addr: self.guest_ip,
+            target_hardware_addr: EthernetAddress::BROADCAST,
+            target_protocol_addr: self.gateway_ip,
+        };
+        let eth = EthernetRepr {
+            src_addr: self.guest_mac,
+            dst_addr: EthernetAddress::BROADCAST,
+            ethertype: EthernetProtocol::Arp,
+        };
+        let mut buf = vec![0u8; 14 + arp.buffer_len()];
+        eth.emit(&mut EthernetFrame::new_unchecked(&mut buf));
+        arp.emit(&mut ArpPacket::new_unchecked(&mut buf[14..]));
+        buf
+    }
+
+    fn tcp_frame(&mut self, control: TcpControl, payload: &[u8]) -> Vec<u8> {
+        let tcp = TcpRepr {
+            src_port: self.src_port,
+            dst_port: self.dst_port,
+            control,
+            seq_number: TcpSeqNumber(self.seq as i32),
+            ack_number: self.established.then_some(TcpSeqNumber(self.ack as i32)),
+            window_len: 65535,
+            window_scale: None,
+            max_seg_size: (control == TcpControl::Syn).then_some(1460),
+            sack_permitted: false,
+            sack_ranges: [None, None, None],
+            timestamp: None,
+            payload,
+        };
+        let ip = Ipv4Repr {
+            src_addr: self.guest_ip,
+            dst_addr: self.dst_ip,
+            next_header: IpProtocol::Tcp,
+            payload_len: tcp.buffer_len(),
+            hop_limit: 64,
+        };
+        let eth = EthernetRepr {
+            src_addr: self.guest_mac,
+            dst_addr: self.gateway_mac,
+            ethertype: EthernetProtocol::Ipv4,
+        };
+
+        let mut buf = vec![0u8; 14 + ip.buffer_len() + tcp.buffer_len()];
+        let caps = ChecksumCapabilities::default();
+        eth.emit(&mut EthernetFrame::new_unchecked(&mut buf));
+        ip.emit(&mut Ipv4Packet::new_unchecked(&mut buf[14..]), &caps);
+        tcp.emit(
+            &mut TcpPacket::new_unchecked(&mut buf[14 + ip.buffer_len()..]),
+            &self.guest_ip.into(),
+            &self.dst_ip.into(),
+            &caps,
+        );
+
+        self.seq = self
+            .seq
+            .wrapping_add(payload.len() as u32)
+            .wrapping_add(matches!(control, TcpControl::Syn | TcpControl::Fin) as u32);
+        buf
+    }
+
+    fn syn(&mut self) -> Vec<u8> {
+        self.tcp_frame(TcpControl::Syn, &[])
+    }
+
+    fn data(&mut self, payload: &[u8]) -> Vec<u8> {
+        self.tcp_frame(TcpControl::Psh, payload)
+    }
+
+    fn fin(&mut self) -> Vec<u8> {
+        self.tcp_frame(TcpControl::Fin, &[])
+    }
+
+    fn pure_ack(&mut self) -> Vec<u8> {
+        self.tcp_frame(TcpControl::None, &[])
+    }
+
+    /// Consume every frame the gateway emitted; update seq/ack/window state,
+    /// collect payloads, and queue ARP replies / pure ACKs back into tx_ring.
+    fn drain_egress(&mut self, shared: &SharedState) {
+        let mut ack_due = false;
+
+        while let Some(frame) = shared.rx_ring.pop() {
+            let Ok(eth) = EthernetFrame::new_checked(&frame[..]) else {
+                continue;
+            };
+            match eth.ethertype() {
+                EthernetProtocol::Arp => {
+                    let Ok(arp) = ArpPacket::new_checked(eth.payload()) else {
+                        continue;
+                    };
+                    if arp.operation() == ArpOperation::Request {
+                        let reply = ArpRepr::EthernetIpv4 {
+                            operation: ArpOperation::Reply,
+                            source_hardware_addr: self.guest_mac,
+                            source_protocol_addr: self.guest_ip,
+                            target_hardware_addr: self.gateway_mac,
+                            target_protocol_addr: self.gateway_ip,
+                        };
+                        let eth_out = EthernetRepr {
+                            src_addr: self.guest_mac,
+                            dst_addr: self.gateway_mac,
+                            ethertype: EthernetProtocol::Arp,
+                        };
+                        let mut buf = vec![0u8; 14 + reply.buffer_len()];
+                        eth_out.emit(&mut EthernetFrame::new_unchecked(&mut buf));
+                        reply.emit(&mut ArpPacket::new_unchecked(&mut buf[14..]));
+                        shared.tx_ring.push(buf).unwrap();
+                    }
+                }
+                EthernetProtocol::Ipv4 => {
+                    let Ok(ip) = Ipv4Packet::new_checked(eth.payload()) else {
+                        continue;
+                    };
+                    if ip.next_header() != IpProtocol::Tcp {
+                        continue;
+                    }
+                    let (src_addr, dst_addr) = (ip.src_addr(), ip.dst_addr());
+                    let Ok(tcp_pkt) = TcpPacket::new_checked(ip.payload()) else {
+                        continue;
+                    };
+                    let Ok(tcp) = TcpRepr::parse(
+                        &tcp_pkt,
+                        &src_addr.into(),
+                        &dst_addr.into(),
+                        &ChecksumCapabilities::default(),
+                    ) else {
+                        continue;
+                    };
+                    if tcp.dst_port != self.src_port {
+                        continue;
+                    }
+
+                    assert!(
+                        tcp.control != TcpControl::Rst,
+                        "gateway sent an unexpected RST"
+                    );
+
+                    if let Some(ack) = tcp.ack_number {
+                        self.peer_acked = ack.0 as u32;
+                    }
+                    self.peer_window = tcp.window_len;
+
+                    if tcp.control == TcpControl::Syn {
+                        // SYN-ACK: complete the handshake.
+                        self.ack = (tcp.seq_number.0 as u32).wrapping_add(1);
+                        self.established = true;
+                        ack_due = true;
+                    } else {
+                        if !tcp.payload.is_empty() {
+                            self.received.extend_from_slice(tcp.payload);
+                            self.ack = self.ack.wrapping_add(tcp.payload.len() as u32);
+                            ack_due = true;
+                        }
+                        if tcp.control == TcpControl::Fin {
+                            self.peer_fin = true;
+                            self.ack = self.ack.wrapping_add(1);
+                            ack_due = true;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if ack_due {
+            let ack = self.pure_ack();
+            shared.tx_ring.push(ack).unwrap();
+        }
+    }
+}
+
+/// Monotonic smoltcp clock for the proxy-less poll helper.
+fn test_now() -> Instant {
+    static EPOCH: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
+    Instant::from_millis(
+        EPOCH
+            .get_or_init(std::time::Instant::now)
+            .elapsed()
+            .as_millis() as i64,
+    )
+}
+
+/// One poll-loop pass that does everything `poll_iteration` does for TCP
+/// EXCEPT spawning real proxy tasks — new connections are returned to the
+/// caller, which acts as the proxy (deterministic backpressure control).
+fn poll_no_proxy(state: &mut PollLoopState) -> Vec<NewConnection> {
+    let now = test_now();
+
+    while let Some(frame) = state.device.stage_next_frame() {
+        if let FrameAction::TcpSyn { src, dst } = classify_frame(frame) {
+            if !state.conn_tracker.has_socket_for(&src, &dst) {
+                state
+                    .conn_tracker
+                    .create_tcp_socket(src, dst, &mut state.sockets);
+            }
+        }
+        state
+            .iface
+            .poll_ingress_single(now, &mut state.device, &mut state.sockets);
+    }
+
+    while !matches!(
+        state
+            .iface
+            .poll_egress(now, &mut state.device, &mut state.sockets),
+        PollResult::None
+    ) {}
+
+    state.conn_tracker.relay_data(&mut state.sockets);
+    let new = state.conn_tracker.take_new_connections(&mut state.sockets);
+
+    while !matches!(
+        state
+            .iface
+            .poll_egress(now, &mut state.device, &mut state.sockets),
+        PollResult::None
+    ) {}
+
+    new
+}
+
+/// S1 (MOT-3966): a full `to_proxy` channel must NOT lose bytes. Pre-fix,
+/// `relay_data` dequeued from the socket (already ACKed to the guest) and
+/// dropped the chunk when `try_send` failed — a permanent hole in the
+/// stream. Post-fix the bytes stay in the socket buffer and the window
+/// closes; everything is delivered once the channel drains.
+#[tokio::test]
+async fn relay_backpressure_loses_no_bytes() {
+    let shared = Arc::new(SharedState::new(2048));
+    let config = test_config();
+    let handle = tokio::runtime::Handle::current();
+    let mut state = build_state(&shared, &config, &handle);
+
+    let dst_ip = Ipv4Addr::new(93, 184, 216, 34);
+    let mut guest = TestGuest::new(&config, dst_ip, 41000, 9999);
+
+    // ARP + handshake.
+    shared.tx_ring.push(guest.arp_announce()).unwrap();
+    poll_no_proxy(&mut state);
+    let syn = guest.syn();
+    shared.tx_ring.push(syn).unwrap();
+    let mut conn = None;
+    for _ in 0..20 {
+        let mut new = poll_no_proxy(&mut state);
+        guest.drain_egress(&shared);
+        if let Some(c) = new.pop() {
+            conn = Some(c);
+        }
+        if guest.established && conn.is_some() {
+            break;
+        }
+    }
+    let NewConnection {
+        mut from_smoltcp,
+        to_smoltcp: _to_smoltcp,
+        ..
+    } = conn.expect("connection should be established and handed to the proxy");
+
+    // Phase 1: pump data WITHOUT consuming the channel until the advertised
+    // window stays closed (socket buffer full ⇒ channel full: 32 slots).
+    let total: usize = 900 * 1024;
+    let pattern = |i: usize| (i % 251) as u8;
+    let mut sent = 0usize;
+    let mut zero_window_polls = 0u32;
+    let mut safety = 0u32;
+
+    while sent < total && zero_window_polls < 5 {
+        safety += 1;
+        assert!(safety < 20_000, "phase 1 did not converge");
+
+        let window = guest.peer_window as usize;
+        let in_flight = guest.in_flight() as usize;
+        let budget = window.saturating_sub(in_flight);
+        if budget == 0 {
+            poll_no_proxy(&mut state);
+            guest.drain_egress(&shared);
+            if guest.peer_window == 0 && guest.in_flight() == 0 {
+                zero_window_polls += 1;
+            }
+            continue;
+        }
+        zero_window_polls = 0;
+
+        let len = budget.min(1460).min(total - sent);
+        let payload: Vec<u8> = (sent..sent + len).map(pattern).collect();
+        let frame = guest.data(&payload);
+        shared.tx_ring.push(frame).unwrap();
+        sent += len;
+
+        poll_no_proxy(&mut state);
+        guest.drain_egress(&shared);
+    }
+
+    assert!(
+        zero_window_polls >= 5 || sent == total,
+        "expected either sustained zero-window backpressure or full send"
+    );
+
+    // Phase 2: act as the proxy — drain the channel while pumping the rest.
+    let mut delivered: Vec<u8> = Vec::with_capacity(total);
+    let mut idle = 0u32;
+    while delivered.len() < sent || sent < total {
+        while let Ok(chunk) = from_smoltcp.try_recv() {
+            delivered.extend_from_slice(&chunk);
+        }
+
+        if sent < total {
+            let window = guest.peer_window as usize;
+            let in_flight = guest.in_flight() as usize;
+            let budget = window.saturating_sub(in_flight);
+            if budget > 0 {
+                let len = budget.min(1460).min(total - sent);
+                let payload: Vec<u8> = (sent..sent + len).map(pattern).collect();
+                let frame = guest.data(&payload);
+                shared.tx_ring.push(frame).unwrap();
+                sent += len;
+                idle = 0;
+            }
+        }
+
+        poll_no_proxy(&mut state);
+        guest.drain_egress(&shared);
+
+        idle += 1;
+        assert!(
+            idle < 50_000,
+            "phase 2 stalled: {}/{} bytes",
+            delivered.len(),
+            sent
+        );
+    }
+
+    assert_eq!(sent, total);
+    assert_eq!(
+        delivered.len(),
+        total,
+        "bytes were lost in the relay under backpressure"
+    );
+    for (i, &b) in delivered.iter().enumerate() {
+        assert_eq!(b, pattern(i), "stream corrupted at offset {i}");
+    }
+}
+
+/// Poll + let proxy tasks run, until `done` or the deadline expires.
+async fn pump_until(
+    state: &mut PollLoopState,
+    shared: &Arc<SharedState>,
+    config: &PollLoopConfig,
+    handle: &tokio::runtime::Handle,
+    guest: &mut TestGuest,
+    mut done: impl FnMut(&TestGuest, &PollLoopState) -> bool,
+    what: &str,
+) {
+    for _ in 0..2000 {
+        poll_iteration(state, shared, config, handle);
+        guest.drain_egress(shared);
+        if done(guest, state) {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+    }
+    panic!("timed out waiting for: {what}");
+}
+
+/// S2+S3 (MOT-3966): a guest that sends ACK+request+FIN inside ONE poll
+/// batch is first observed past Established (CloseWait). The proxy must
+/// still spawn, deliver the request, propagate the FIN to the server (EOF),
+/// relay the response back, and the tracker entry must be reaped.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fast_closing_connection_still_proxied_and_reaped() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = std::thread::spawn(move || {
+        use std::io::{Read, Write};
+        let (mut sock, _) = listener.accept().unwrap();
+        let mut req = Vec::new();
+        // Returns only on EOF — requires the guest FIN to be propagated.
+        sock.read_to_end(&mut req).unwrap();
+        sock.write_all(b"pong").unwrap();
+        req
+    });
+
+    let shared = Arc::new(SharedState::new(2048));
+    let config = test_config();
+    let handle = tokio::runtime::Handle::current();
+    let mut state = build_state(&shared, &config, &handle);
+
+    // dst = gateway ⇒ the proxy rewrites to 127.0.0.1:port.
+    let mut guest = TestGuest::new(&config, config.gateway_ipv4, 42000, port);
+
+    shared.tx_ring.push(guest.arp_announce()).unwrap();
+    poll_iteration(&mut state, &shared, &config, &handle);
+
+    // SYN → SYN-ACK.
+    let syn = guest.syn();
+    shared.tx_ring.push(syn).unwrap();
+    pump_until(
+        &mut state,
+        &shared,
+        &config,
+        &handle,
+        &mut guest,
+        |g, _| g.established,
+        "handshake",
+    )
+    .await;
+
+    // Drop the handshake ACK, request, and FIN into ONE batch: the tracker
+    // first sees this socket in CloseWait.
+    let ack = guest.pure_ack();
+    let data = guest.data(b"ping");
+    let fin = guest.fin();
+    shared.tx_ring.push(ack).unwrap();
+    shared.tx_ring.push(data).unwrap();
+    shared.tx_ring.push(fin).unwrap();
+
+    pump_until(
+        &mut state,
+        &shared,
+        &config,
+        &handle,
+        &mut guest,
+        |g, _| g.received == b"pong" && g.peer_fin,
+        "response + FIN from the gateway",
+    )
+    .await;
+
+    let req = server.join().unwrap();
+    assert_eq!(req, b"ping", "server must receive the request bytes");
+
+    // The connection must be fully reaped (socket Closed, key released).
+    let src: std::net::SocketAddr = format!("{}:42000", config.guest_ipv4).parse().unwrap();
+    let dst: std::net::SocketAddr = format!("{}:{}", config.gateway_ipv4, port).parse().unwrap();
+    state.last_cleanup = std::time::Instant::now() - std::time::Duration::from_secs(2);
+    pump_until(
+        &mut state,
+        &shared,
+        &config,
+        &handle,
+        &mut guest,
+        |_, s| !s.conn_tracker.has_socket_for(&src, &dst),
+        "connection reaped after close",
+    )
+    .await;
+}
+
+/// S3 (MOT-3966): guest half-close on a long-lived connection reaches the
+/// server as EOF while the response path stays open.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn guest_fin_propagates_as_server_eof() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (eof_tx, eof_rx) = std::sync::mpsc::channel::<()>();
+    let server = std::thread::spawn(move || {
+        use std::io::{Read, Write};
+        let (mut sock, _) = listener.accept().unwrap();
+        let mut buf = [0u8; 4];
+        sock.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"ping");
+        // Next read must observe EOF once the guest FINs.
+        let n = sock.read(&mut [0u8; 16]).unwrap();
+        assert_eq!(n, 0, "expected EOF from the propagated guest FIN");
+        eof_tx.send(()).unwrap();
+        sock.write_all(b"pong").unwrap();
+    });
+
+    let shared = Arc::new(SharedState::new(2048));
+    let config = test_config();
+    let handle = tokio::runtime::Handle::current();
+    let mut state = build_state(&shared, &config, &handle);
+    let mut guest = TestGuest::new(&config, config.gateway_ipv4, 43000, port);
+
+    shared.tx_ring.push(guest.arp_announce()).unwrap();
+    poll_iteration(&mut state, &shared, &config, &handle);
+
+    let syn = guest.syn();
+    shared.tx_ring.push(syn).unwrap();
+    pump_until(
+        &mut state,
+        &shared,
+        &config,
+        &handle,
+        &mut guest,
+        |g, _| g.established,
+        "handshake",
+    )
+    .await;
+
+    let data = guest.data(b"ping");
+    shared.tx_ring.push(data).unwrap();
+
+    // Let the request flow, then half-close from the guest.
+    pump_until(
+        &mut state,
+        &shared,
+        &config,
+        &handle,
+        &mut guest,
+        |g, _| g.in_flight() == 0,
+        "request acked",
+    )
+    .await;
+    let fin = guest.fin();
+    shared.tx_ring.push(fin).unwrap();
+
+    pump_until(
+        &mut state,
+        &shared,
+        &config,
+        &handle,
+        &mut guest,
+        |g, _| g.received == b"pong",
+        "response after half-close",
+    )
+    .await;
+
+    eof_rx
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .expect("server never observed EOF — guest FIN was not propagated");
+    server.join().unwrap();
 }

--- a/crates/iii-network/tests/network_integration.rs
+++ b/crates/iii-network/tests/network_integration.rs
@@ -476,6 +476,16 @@ impl TestGuest {
         self.tcp_frame(TcpControl::Syn, &[])
     }
 
+    /// Retransmit the initial SYN with the same ISN, like a kernel SYN
+    /// retry. Only valid before any data has been sent.
+    fn retransmit_syn(&mut self) -> Vec<u8> {
+        let after = self.seq;
+        self.seq = after.wrapping_sub(1);
+        let frame = self.tcp_frame(TcpControl::Syn, &[]);
+        debug_assert_eq!(self.seq, after);
+        frame
+    }
+
     fn data(&mut self, payload: &[u8]) -> Vec<u8> {
         self.tcp_frame(TcpControl::Psh, payload)
     }
@@ -932,4 +942,142 @@ async fn guest_fin_propagates_as_server_eof() {
         .recv_timeout(std::time::Duration::from_secs(1))
         .expect("server never observed EOF — guest FIN was not propagated");
     server.join().unwrap();
+}
+
+/// MOT-3966 first-boot wedge repro: the engine's listener isn't up yet when
+/// the guest first dials, so the proxy dial is REFUSED and the stack closes
+/// the guest connection. The guest then reconnects from the SAME source port
+/// (Linux reuses the ephemeral port for the same destination once the prior
+/// socket is closed). The stale tracker entry pins the (src,dst) key, the
+/// retry SYN is swallowed by the lingering smoltcp socket, and — the field
+/// wedge — once the connection finally establishes, its bytes must still
+/// reach the (now-listening) server.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn refused_dial_then_same_port_reconnect_delivers_data() {
+    // Reserve a port with no listener: bind, capture, drop. The first dial
+    // gets ECONNREFUSED, exactly like the engine's listener racing VM spawn.
+    let placeholder = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = placeholder.local_addr().unwrap().port();
+    drop(placeholder);
+
+    let shared = Arc::new(SharedState::new(2048));
+    let config = test_config();
+    let handle = tokio::runtime::Handle::current();
+    let mut state = build_state(&shared, &config, &handle);
+
+    const SRC_PORT: u16 = 44100;
+
+    // --- Attempt A: establishes guest-side, proxy dial refused, stack
+    // closes toward the guest, guest completes the close handshake. ---
+    let mut guest_a = TestGuest::new(&config, config.gateway_ipv4, SRC_PORT, port);
+    shared.tx_ring.push(guest_a.arp_announce()).unwrap();
+    poll_iteration(&mut state, &shared, &config, &handle);
+
+    let syn = guest_a.syn();
+    shared.tx_ring.push(syn).unwrap();
+    pump_until(
+        &mut state,
+        &shared,
+        &config,
+        &handle,
+        &mut guest_a,
+        |g, _| g.established,
+        "attempt A handshake",
+    )
+    .await;
+
+    // Guest ships its request immediately (the WS upgrade in the field).
+    let ack = guest_a.pure_ack();
+    let data = guest_a.data(b"attempt-a upgrade");
+    shared.tx_ring.push(ack).unwrap();
+    shared.tx_ring.push(data).unwrap();
+
+    // Refused dial → proxy dies → relay closes → guest sees FIN.
+    pump_until(
+        &mut state,
+        &shared,
+        &config,
+        &handle,
+        &mut guest_a,
+        |g, _| g.peer_fin,
+        "FIN from refused dial",
+    )
+    .await;
+    // Guest closes too (its FIN), mirroring the app closing on EOF.
+    let fin = guest_a.fin();
+    shared.tx_ring.push(fin).unwrap();
+    poll_iteration(&mut state, &shared, &config, &handle);
+    guest_a.drain_egress(&shared);
+
+    // --- Engine "comes up": bind the real listener now. ---
+    let listener = std::net::TcpListener::bind(("127.0.0.1", port)).unwrap();
+    let server = std::thread::spawn(move || {
+        use std::io::Read;
+        let (mut sock, _) = listener.accept().unwrap();
+        let mut req = Vec::new();
+        sock.read_to_end(&mut req).unwrap();
+        req
+    });
+
+    // --- Attempt B: same (src,dst) tuple, like Linux port reuse. ---
+    let mut guest_b = TestGuest::new(&config, config.gateway_ipv4, SRC_PORT, port);
+    // Fresh kernel connection: a new (random) ISN, unrelated to attempt A's.
+    guest_b.seq = 900_000;
+    guest_b.peer_acked = 900_000;
+    let syn = guest_b.syn();
+    shared.tx_ring.push(syn).unwrap();
+
+    // Drive with SYN retransmits like a real kernel: the stale entry pins
+    // the tuple while the old socket lingers (TIME-WAIT is 10s in smoltcp),
+    // so keep retrying for up to ~15s of wall time.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    let mut next_retransmit = std::time::Instant::now() + std::time::Duration::from_secs(1);
+    while !guest_b.established {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "attempt B never established: retry SYN swallowed forever"
+        );
+        // Force cleanup cadence like the real loop.
+        state.last_cleanup = std::time::Instant::now() - std::time::Duration::from_secs(2);
+        poll_iteration(&mut state, &shared, &config, &handle);
+        guest_b.drain_egress(&shared);
+        if std::time::Instant::now() >= next_retransmit && !guest_b.established {
+            let rt = guest_b.retransmit_syn();
+            shared.tx_ring.push(rt).unwrap();
+            next_retransmit = std::time::Instant::now() + std::time::Duration::from_secs(1);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    // The wedge: these bytes must reach the server.
+    let ack = guest_b.pure_ack();
+    let data = guest_b.data(b"attempt-b upgrade");
+    shared.tx_ring.push(ack).unwrap();
+    shared.tx_ring.push(data).unwrap();
+    let fin_deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let mut sent_fin = false;
+    loop {
+        assert!(
+            std::time::Instant::now() < fin_deadline,
+            "attempt B data was never delivered/acked (the MOT-3966 wedge)"
+        );
+        poll_iteration(&mut state, &shared, &config, &handle);
+        guest_b.drain_egress(&shared);
+        if guest_b.in_flight() == 0 && !sent_fin {
+            // Data acked — close so the server's read_to_end returns.
+            let fin = guest_b.fin();
+            shared.tx_ring.push(fin).unwrap();
+            sent_fin = true;
+        }
+        if sent_fin && guest_b.peer_fin {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    let req = server.join().unwrap();
+    assert_eq!(
+        req, b"attempt-b upgrade",
+        "server must receive attempt B's bytes"
+    );
 }

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -7,7 +7,7 @@
 use clap::{CommandFactory, FromArgMatches};
 use iii_worker::{Cli, Commands};
 
-/// A `stdout` tracing writer that never reports I/O errors back to the fmt
+/// A `stderr` tracing writer that never reports I/O errors back to the fmt
 /// layer. The fmt layer's sole error path is an `eprintln!`, which PANICS
 /// when stderr is *also* a broken pipe — precisely the engine-death case for
 /// the spawned daemons (`worker-manager-daemon`, `sandbox-daemon`): the engine
@@ -18,23 +18,23 @@ use iii_worker::{Cli, Commands};
 /// (`daemon_exit::redirect_stdio_to_exit_log`) and these same writes land there
 /// as forensics. For one-shot CLI use it just turns a `… | head` EPIPE into a
 /// silent drop instead of a panic — strictly better either way.
-struct ResilientStdout;
+struct ResilientStderr;
 
-impl std::io::Write for ResilientStdout {
+impl std::io::Write for ResilientStderr {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        let _ = std::io::Write::write_all(&mut std::io::stdout(), buf);
+        let _ = std::io::Write::write_all(&mut std::io::stderr(), buf);
         Ok(buf.len())
     }
     fn flush(&mut self) -> std::io::Result<()> {
-        let _ = std::io::Write::flush(&mut std::io::stdout());
+        let _ = std::io::Write::flush(&mut std::io::stderr());
         Ok(())
     }
 }
 
-impl tracing_subscriber::fmt::MakeWriter<'_> for ResilientStdout {
-    type Writer = ResilientStdout;
+impl tracing_subscriber::fmt::MakeWriter<'_> for ResilientStderr {
+    type Writer = ResilientStderr;
     fn make_writer(&self) -> Self::Writer {
-        ResilientStdout
+        ResilientStderr
     }
 }
 
@@ -68,7 +68,7 @@ fn main() -> anyhow::Result<()> {
 
 async fn async_main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
-        .with_writer(ResilientStdout)
+        .with_writer(ResilientStderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),

--- a/crates/iii-worker/tests/engine_death_cascade_integration.rs
+++ b/crates/iii-worker/tests/engine_death_cascade_integration.rs
@@ -563,12 +563,13 @@ fn daemon_survives_its_stdio_dying_with_the_engine() {
     let lifeline = iii_worker::daemon_exit::attach_lifeline_std(&mut cmd).expect("attach lifeline");
     let mut daemon = KillOnDrop(cmd.spawn().expect("spawn daemon"));
 
-    // Readiness gate: scan the piped stdout for the armed line, then hand
-    // the handle back so this test can break the pipe at "engine death".
-    let stdout = daemon.0.stdout.take().expect("piped stdout");
+    // Readiness gate: scan the piped stderr (tracing's sink) for the armed
+    // line, then hand the handle back so this test can break the pipe at
+    // "engine death".
+    let stderr = daemon.0.stderr.take().expect("piped stderr");
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
-        let mut reader = std::io::BufReader::new(stdout);
+        let mut reader = std::io::BufReader::new(stderr);
         let mut line = String::new();
         let mut armed = false;
         while reader.read_line(&mut line).is_ok_and(|n| n > 0) {
@@ -580,9 +581,9 @@ fn daemon_survives_its_stdio_dying_with_the_engine() {
         }
         let _ = tx.send((armed, reader.into_inner()));
     });
-    let (armed, stdout) = rx
+    let (armed, stderr) = rx
         .recv_timeout(Duration::from_secs(10))
-        .expect("daemon produced no armed line on its piped stdout");
+        .expect("daemon produced no armed line on its piped stderr");
     assert!(armed, "daemon never armed the lifeline watch");
 
     // Engine death, production-shaped: the process dies AND every pipe it
@@ -590,8 +591,8 @@ fn daemon_survives_its_stdio_dying_with_the_engine() {
     let _ = fake_engine.0.kill();
     let _ = fake_engine.0.wait();
     drop(lifeline);
-    drop(stdout);
-    drop(daemon.0.stderr.take());
+    drop(stderr);
+    drop(daemon.0.stdout.take());
 
     let crumb_file = breadcrumb_path(tmp.path(), "worker-manager-daemon");
     let deadline = Instant::now() + EXIT_DEADLINE;

--- a/sdk/packages/node/iii/tests/trigger-registration-error.test.ts
+++ b/sdk/packages/node/iii/tests/trigger-registration-error.test.ts
@@ -29,12 +29,24 @@ describe('trigger registration error surfacing', () => {
     await new Promise<void>((resolve) => wss.close(() => resolve()))
   })
 
+  // Deterministic wait: a blind post-connect sleep flakes under CI load
+  // (serverSocket still undefined at send time).
+  const waitFor = async <T,>(get: () => T | undefined, ms = 5000): Promise<T> => {
+    const deadline = Date.now() + ms
+    for (;;) {
+      const v = get()
+      if (v !== undefined) return v
+      if (Date.now() > deadline) throw new Error('timed out waiting for condition')
+      await new Promise((r) => setTimeout(r, 10))
+    }
+  }
+
   it('logs to console.error on TriggerRegistrationResult with error', async () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
     sdk = registerWorker(url)
-    await new Promise((r) => setTimeout(r, 50))
+    const sock = await waitFor(() => serverSocket)
 
-    serverSocket!.send(
+    sock.send(
       JSON.stringify({
         type: 'triggerregistrationresult',
         id: 'trig-1',
@@ -48,7 +60,7 @@ describe('trigger registration error surfacing', () => {
       }),
     )
 
-    await new Promise((r) => setTimeout(r, 20))
+    await waitFor(() => (spy.mock.calls.length > 0 ? true : undefined))
     expect(spy).toHaveBeenCalled()
     const formatted = spy.mock.calls.map((args) => args.join(' ')).join('\n')
     expect(formatted).toContain('trig-1')
@@ -60,9 +72,9 @@ describe('trigger registration error surfacing', () => {
   it('does not log on TriggerRegistrationResult success (no error field)', async () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
     sdk = registerWorker(url)
-    await new Promise((r) => setTimeout(r, 50))
+    const sock = await waitFor(() => serverSocket)
 
-    serverSocket!.send(
+    sock.send(
       JSON.stringify({
         type: 'triggerregistrationresult',
         id: 'trig-2',
@@ -71,7 +83,8 @@ describe('trigger registration error surfacing', () => {
       }),
     )
 
-    await new Promise((r) => setTimeout(r, 20))
+    // Negative assertion is inherently time-bounded: give handling a beat.
+    await new Promise((r) => setTimeout(r, 100))
     const registrationLogs = spy.mock.calls
       .map((args) => args.join(' '))
       .filter((msg) => msg.includes('Trigger registration'))

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -346,17 +346,18 @@ class III:
             )
             log.info(f"Connected to {self._address}")
             await self._on_connected()
-        except (
-            ConnectionError,
-            OSError,
-            TimeoutError,
-            asyncio.TimeoutError,
-            # Not an OSError: raised when the peer accepts TCP but the WS
-            # upgrade fails/stalls (the MOT-3931 zombie-VM mode). Without it
-            # the connect/reconnect task dies and retrying stops silently.
-            websockets.InvalidHandshake,
-        ) as e:
-            log.warning(f"Connection failed: {e}")
+        except Exception as e:
+            # Catch everything: a connect-time failure must never kill the
+            # reconnect loop. Enumerating exception types here has failed
+            # twice — ConnectionError/OSError missed websockets'
+            # InvalidHandshake (MOT-3931), and that in turn missed
+            # InvalidMessage, raised when the engine-boot listener race
+            # surfaces through iii-network's accept-then-dial as an EOF
+            # between TCP connect and the WS 101 (MOT-3966): the exception
+            # escaped, the connect task died silently, and the worker stayed
+            # a zombie with zero retries. CancelledError is BaseException,
+            # so shutdown cancellation still propagates.
+            log.warning(f"Connection failed: {type(e).__name__}: {e}")
             if self._running:
                 self._schedule_reconnect()
 

--- a/sdk/packages/python/iii/tests/test_reconnect_survives_handshake_eof.py
+++ b/sdk/packages/python/iii/tests/test_reconnect_survives_handshake_eof.py
@@ -1,0 +1,106 @@
+"""MOT-3966 regression: the reconnect loop must survive handshake-level failures.
+
+First-boot conditions: the engine autostarts bundle workers before its worker
+listener is accepting, and the VM's userspace network stack (iii-network)
+accepts the guest's TCP connection before dialing the host — so "nothing
+listening yet" surfaces to the client as an EOF between TCP connect and the
+WS 101. The websockets library raises that as ``InvalidMessage`` (an
+``InvalidHandshake``, NOT a ``ConnectionError``/``OSError``). The SDK's old
+narrow ``except`` let it escape ``_do_connect``, silently killing the connect
+task with zero retries: the worker stayed a zombie for the VM's lifetime.
+"""
+
+import base64
+import hashlib
+import socket
+import threading
+
+from iii.iii import III
+from iii.iii_constants import InitOptions
+from iii_helpers.observability import ReconnectionConfig
+
+WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+
+def _minimal_ws_server(listener: socket.socket, eof_first_n: int) -> None:
+    """Accept loop: the first ``eof_first_n`` connections are closed without
+    sending a byte (EOF during the client's handshake — the engine-boot race
+    as seen through iii-network's accept-then-dial). Later connections get a
+    real RFC 6455 101 reply and are held open."""
+    held = []
+    accepted = 0
+    while True:
+        try:
+            conn, _ = listener.accept()
+        except OSError:
+            return  # listener closed: test over
+        accepted += 1
+        if accepted <= eof_first_n:
+            conn.close()
+            continue
+
+        data = b""
+        try:
+            while b"\r\n\r\n" not in data:
+                chunk = conn.recv(4096)
+                if not chunk:
+                    break
+                data += chunk
+            key = ""
+            for line in data.decode("latin1").split("\r\n"):
+                if line.lower().startswith("sec-websocket-key:"):
+                    key = line.split(":", 1)[1].strip()
+            accept = base64.b64encode(
+                hashlib.sha1((key + WS_GUID).encode()).digest()
+            ).decode()
+            conn.sendall(
+                b"HTTP/1.1 101 Switching Protocols\r\n"
+                b"Upgrade: websocket\r\n"
+                b"Connection: Upgrade\r\n"
+                b"Sec-WebSocket-Accept: " + accept.encode() + b"\r\n\r\n"
+            )
+        except OSError:
+            conn.close()
+            continue
+        held.append(conn)  # keep open; the client streams registrations
+
+
+def test_reconnect_survives_handshake_eof(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "iii_helpers.observability.telemetry.init_otel", lambda **kwargs: None
+    )
+    monkeypatch.setattr(
+        "iii_helpers.observability.telemetry.attach_event_loop", lambda loop: None
+    )
+
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(8)
+    port = listener.getsockname()[1]
+    server = threading.Thread(
+        target=_minimal_ws_server, args=(listener, 1), daemon=True
+    )
+    server.start()
+
+    client = III(
+        f"ws://127.0.0.1:{port}",
+        InitOptions(
+            reconnection_config=ReconnectionConfig(
+                initial_delay_ms=100,
+                max_delay_ms=200,
+                jitter_factor=0.0,
+            ),
+        ),
+    )
+    try:
+        # Pre-fix: the first connection's EOF raised InvalidMessage out of
+        # _do_connect, the connect task died silently, no retry ever ran,
+        # and this wait timed out with the client stuck "connecting".
+        client._connected_event.wait(timeout=10)
+        assert client._connection_state == "connected", (
+            f"client never recovered from the handshake EOF "
+            f"(state={client._connection_state!r}; reconnect loop died)"
+        )
+    finally:
+        client.shutdown()
+        listener.close()


### PR DESCRIPTION
Closes MOT-3966. Two root causes, both live-verified on the harness rig (Apple Silicon, libkrun VMs).

## Root cause 1 — VM transport (crates/iii-network)

msb_krun's NetWorker registers our backend fd EDGE_TRIGGERED and assumes it is a real data socket whose readability drains as frames are read. `SmoltcpBackend` hands it the `rx_wake` pipe read end instead — and nothing ever read that pipe. Once it filled (~16Ki wakes on macOS), `wake()` silently no-opped, no edge ever fired again, and every host→guest frame rotted in `rx_ring` forever while guest→host kept flowing. Once `rx_ring` filled, `poll_delay` returned `Some(0)` and the poll thread also hot-spun at 100% CPU.

Fixes:
- `read_frame`'s empty path drains the pipe then re-pops (race analysis in the commit).
- `wake()` self-heals on a full pipe (drain own read end + retry once) — covers msb_krun code paths that never reach `read_frame` (deferred-frame exit, rx-queue notification inversion) — plus a failed-wake counter and rate-limited warn.
- Poll-loop sleep clamped to 1..=100 ms (kills the hot-spin; guarantees the relay tick past distant TCP timers).
- Data-pump correctness: `relay_data` reserves channel capacity before consuming (was silently dropping already-ACKed bytes under backpressure), proxies also spawn for connections first observed in CloseWait (ACK+data+FIN in one poll batch), and guest FIN propagates as a server-side half-close — fixing a CloseWait/fd/connection-key leak that marched VMs toward the 256-connection RST wall.
- Observability: tracing now goes to stderr (the guest serial console and host tracing shared stdout.log and tore each other's lines), debug logs at every tracker gate, and a 1 Hz per-connection snapshot under `RUST_LOG=iii_network=debug`.

## Root cause 2 — Python SDK reconnect loop

On engine boot, workers autostart before the worker listener accepts (filed separately as MOT-4057). iii-network accepts-then-dials, so the guest sees TCP connect succeed followed by EOF before the WS 101 — which the websockets library raises as `InvalidMessage`. `_do_connect`'s enumerated `except` didn't cover it: the exception escaped, the connect task died silently, no reconnect was ever scheduled, and the worker zombied for the VM's lifetime (3/3 on engine restarts; proven by reproducing the exact exception inside a wedged guest). Enumerating exception types here has now failed twice (ConnectionError-only → +InvalidHandshake), so `_do_connect` catches `Exception` (CancelledError is BaseException and still propagates).

## Tests

- `crates/iii-network`: wake-pipe saturation/self-heal units, a 100k-frame soak, and a seq-aware in-test TCP guest driving the real stack: backpressure loses no bytes, fast-closing connections still get proxied and reaped, guest FIN reaches the server as EOF, and the first-boot sequence (refused dial → same-source-port reconnect) delivers once the listener is up. All verified to fail on the pre-fix code with the predicted mechanisms.
- `sdk/packages/python`: a server that EOFs the first handshake must not kill the reconnect loop; the client must connect on a later attempt (fails on the old except clause with the exact field signature — stuck `connecting`, zero retries).

## Live verification

Instrumented first-boot runs on the rig show refused dials being caught and logged by the SDK, reconnects completing the WS handshake through the race, and the transport narrating clean close/reap cycles. Full evidence trail on MOT-3966 in Linear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wake-pipe reliability under saturation/full-pipe conditions, with recovery after edge-trigger wake stalls.
  * Prevented data loss/stream holes under relay backpressure and tightened EOF/connection teardown behavior.
  * Preserved server responses when the guest closes, including correct half-close handling and improved proxy readiness/close behavior.
  * Fixed SDK reconnect continuation after interrupted WebSocket handshake EOF.
* **Diagnostics**
  * Added wake-pipe health reporting and richer connection state/debug snapshots.
* **Testing**
  * Added wake-pipe soak and multiple proxy/data-relay regression tests; made Node/engine readiness checks deterministic and added Python reconnect regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->