### PR TITLE
chore(worker): warn about deprecated builtin names

### DIFF
--- a/crates/iii-worker/src/cli/builtin_defaults.rs
+++ b/crates/iii-worker/src/cli/builtin_defaults.rs
@@ -15,6 +15,21 @@ pub const BUILTIN_NAMES: [&str; 7] = [
     "iii-sandbox",
 ];
 
+const DEPRECATED_BUILTIN_REPLACEMENTS: [(&str, &str); 5] = [
+    ("iii-http", "http"),
+    ("iii-cron", "cron"),
+    ("iii-queue", "queue"),
+    ("iii-state", "state"),
+    ("iii-pubsub", "pubsub"),
+];
+
+/// Return the unprefixed replacement for a deprecated builtin worker name.
+pub fn deprecated_builtin_replacement(name: &str) -> Option<&'static str> {
+    DEPRECATED_BUILTIN_REPLACEMENTS
+        .iter()
+        .find_map(|(deprecated, replacement)| (*deprecated == name).then_some(*replacement))
+}
+
 /// Optional builtin workers: baked into the engine but disabled by default.
 /// They have no auto-generated YAML config and must be configured manually.
 pub const OPTIONAL_BUILTIN_NAMES: [&str; 2] = ["iii-exec", "iii-bridge"];
@@ -115,6 +130,41 @@ pub fn get_builtin_default(name: &str) -> Option<String> {
 mod tests {
     use super::*;
     use serde_yaml::Value;
+
+    #[test]
+    fn deprecated_builtin_replacement_returns_unprefixed_name() {
+        let replacements = [
+            ("iii-http", "http"),
+            ("iii-cron", "cron"),
+            ("iii-queue", "queue"),
+            ("iii-state", "state"),
+            ("iii-pubsub", "pubsub"),
+        ];
+
+        for (deprecated, replacement) in replacements {
+            assert_eq!(
+                deprecated_builtin_replacement(deprecated),
+                Some(replacement)
+            );
+        }
+    }
+
+    #[test]
+    fn deprecated_builtin_replacement_returns_none_for_other_names() {
+        for name in [
+            "http",
+            "cron",
+            "queue",
+            "state",
+            "pubsub",
+            "iii-stream",
+            "iii-sandbox",
+            "iii-http-functions",
+            "pdfkit",
+        ] {
+            assert_eq!(deprecated_builtin_replacement(name), None);
+        }
+    }
 
     #[test]
     fn all_builtins_return_some() {

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -114,22 +114,38 @@ async fn async_main() -> anyhow::Result<()> {
             force,
             no_wait,
         } => {
+            use colored::Colorize;
+            use iii_worker::cli::builtin_defaults::deprecated_builtin_replacement;
             use iii_worker::cli::host_shim::CliHostShim;
             use iii_worker::cli::stderr_sink::StderrSink;
-            use iii_worker::core::{AddOptions, ProjectCtx, add as core_add};
+            use iii_worker::core::{AddOptions, ProjectCtx, WorkerSource, add as core_add};
 
             let total = args.worker_names.len();
             let brief = total > 1;
             let mut fail_count = 0usize;
 
             for (i, name) in args.worker_names.iter().enumerate() {
+                let source = parse_source_for_cli(name);
+                if let WorkerSource::Registry {
+                    name: registry_name,
+                    ..
+                } = &source
+                    && let Some(replacement) = deprecated_builtin_replacement(registry_name)
+                {
+                    eprintln!(
+                        "{} Worker name '{}' is deprecated and will be removed in a future version. Use `iii worker add {}` instead.",
+                        "warning:".yellow(),
+                        registry_name,
+                        replacement
+                    );
+                }
+
                 if brief {
-                    use colored::Colorize;
                     eprintln!("  [{}/{}] Adding {}...", i + 1, total, name.bold());
                 }
 
                 let opts = AddOptions {
-                    source: parse_source_for_cli(name),
+                    source,
                     force,
                     reset_config: args.reset_config,
                     wait: !no_wait,

--- a/crates/iii-worker/tests/worker_integration.rs
+++ b/crates/iii-worker/tests/worker_integration.rs
@@ -209,6 +209,34 @@ fn add_subcommand_multiple_workers() {
 }
 
 #[test]
+fn add_prefixed_builtin_prints_deprecation_warning_and_replacement() {
+    let temp = tempfile::tempdir().expect("failed to create isolated temp directory");
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_iii-worker"))
+        .args(["add", "iii-http", "--no-wait"])
+        .current_dir(temp.path())
+        .env("HOME", temp.path())
+        .env("NO_COLOR", "1")
+        .env("III_API_URL", "http://127.0.0.1:0")
+        .output()
+        .expect("failed to execute iii-worker binary");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "iii-worker add failed with status {}\nstderr:\n{}",
+        output.status,
+        stderr
+    );
+    assert!(stderr.contains("iii-http"), "stderr was:\n{stderr}");
+    assert!(stderr.contains("deprecated"), "stderr was:\n{stderr}");
+    assert!(stderr.contains("future version"), "stderr was:\n{stderr}");
+    assert!(
+        stderr.contains("iii worker add http"),
+        "stderr was:\n{stderr}"
+    );
+}
+
+#[test]
 fn sync_subcommand_accepts_frozen_flag() {
     let cli = Cli::parse_from(["iii-worker", "sync", "--frozen"]);
     match cli.command {

--- a/engine/src/trigger.rs
+++ b/engine/src/trigger.rs
@@ -27,14 +27,29 @@ pub const KNOWN_TRIGGER_TYPE_PROVIDERS: &[(&str, &str)] = &[
     ("configuration", "configuration"),
 ];
 
+const DEPRECATED_PROVIDER_REPLACEMENTS: &[(&str, &str)] = &[
+    ("iii-http", "http"),
+    ("iii-cron", "cron"),
+    ("iii-state", "state"),
+    ("iii-pubsub", "pubsub"),
+];
+
 /// Maps a known trigger type to the worker package that provides it. Connected
-/// workers are attributed by UUID first; this table supplies install guidance
-/// when the provider is absent and discovery fallback for in-process workers.
+/// workers are attributed by UUID first; this table supplies discovery fallback
+/// for in-process workers and identifies the provider when install guidance is
+/// needed.
 pub fn known_trigger_type_provider(trigger_type_id: &str) -> Option<&'static str> {
     KNOWN_TRIGGER_TYPE_PROVIDERS
         .iter()
         .find(|(id, _)| *id == trigger_type_id)
         .map(|(_, worker)| *worker)
+}
+
+fn preferred_install_name(provider: &'static str) -> &'static str {
+    DEPRECATED_PROVIDER_REPLACEMENTS
+        .iter()
+        .find_map(|(deprecated, replacement)| (*deprecated == provider).then_some(*replacement))
+        .unwrap_or(provider)
 }
 
 /// Outcome of [`TriggerRegistry::register_trigger`].
@@ -418,12 +433,15 @@ impl TriggerRegistry {
             trigger.trigger_type.purple().bold(),
         );
         match known_trigger_type_provider(&trigger.trigger_type) {
-            Some(worker_name) => format!(
-                "{} If this persists, the {} worker is missing — run: {}",
-                base,
-                worker_name.cyan().bold(),
-                format!("iii worker add {}", worker_name).green().bold()
-            ),
+            Some(worker_name) => {
+                let install_name = preferred_install_name(worker_name);
+                format!(
+                    "{} If this persists, the {} worker is missing — run: {}",
+                    base,
+                    install_name.cyan().bold(),
+                    format!("iii worker add {}", install_name).green().bold()
+                )
+            }
             None => format!(
                 "{} If this persists, search for a worker that provides this trigger type at {}",
                 base,
@@ -846,22 +864,25 @@ mod tests {
     }
 
     #[test]
-    fn pending_warning_names_missing_builtin_worker() {
-        let msg = TriggerRegistry::pending_trigger_warning(&make_trigger("t1", "http"));
-        assert!(
-            msg.contains("iii worker add iii-http"),
-            "Expected hint with 'iii worker add iii-http', got: {msg}"
-        );
-    }
+    fn pending_warning_uses_new_install_names_without_changing_legacy_owners() {
+        let cases = [
+            ("http", "iii-http", "http"),
+            ("cron", "iii-cron", "cron"),
+            ("subscribe", "iii-pubsub", "pubsub"),
+            ("state", "iii-state", "state"),
+            ("durable:subscriber", "queue", "queue"),
+        ];
 
-    #[test]
-    fn pending_warning_for_durable_subscriber_points_to_standalone_queue_worker() {
-        let msg =
-            TriggerRegistry::pending_trigger_warning(&make_trigger("t1", "durable:subscriber"));
-        assert!(
-            msg.contains("iii worker add queue"),
-            "expected standalone queue installation hint, got: {msg}"
-        );
+        for (trigger_type, owner, install_name) in cases {
+            assert_eq!(known_trigger_type_provider(trigger_type), Some(owner));
+
+            let msg = TriggerRegistry::pending_trigger_warning(&make_trigger("t1", trigger_type));
+            let expected_hint = format!("iii worker add {install_name}");
+            assert!(
+                msg.contains(&expected_hint),
+                "Expected hint with '{expected_hint}', got: {msg}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- warn when `iii worker add` receives the deprecated prefixed builtin names
- suggest the unprefixed replacements for http, cron, queue, state, and pubsub
- preserve the existing install behavior and add unit and CLI integration coverage

## Demo

![Deprecated builtin worker warnings](https://vhs.charm.sh/vhs-1JZG9UvR9Nn064XxOtUjRF.gif)

## Why

These builtin workers are now available under unprefixed names. The legacy `iii-*` names remain compatible for now, but users need a clear migration path before those aliases are removed in a future version.

## Impact

Existing commands such as `iii worker add iii-http` continue to run normally and now print a warning to stderr recommending `iii worker add http`. Local workers, OCI references, unrelated registry workers, and non-`add` flows are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p iii-worker --no-fail-fast`
- `git diff --check`

Clippy remains blocked by pre-existing lints outside the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deprecation warnings for legacy built-in worker names (e.g., `iii-http`), including the recommended `iii worker add <replacement>` command.
  * Pending-trigger installation hints now suggest the preferred/deprecated replacement install names for provider/trigger types.

* **Bug Fixes**
  * Improved `worker add` to consistently detect deprecated built-ins and display the correct guidance.

* **Tests**
  * Added unit coverage for deprecated-name replacement resolution.
  * Added an integration test asserting `iii-http` deprecation messaging (including guidance to use the replacement command).
  * Updated trigger-warning hint tests to validate the new preferred mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->