### PR TITLE
fix(ci): build alpha release binaries from tagged commit

### DIFF
--- a/.github/scripts/test_rust_binary_workflow.py
+++ b/.github/scripts/test_rust_binary_workflow.py
@@ -18,6 +18,7 @@ def test_build_checks_out_release_tag():
     checkout = job.split("- uses: actions/checkout@v4", 1)[1].split("\n\n", 1)[0]
 
     assert "ref: refs/tags/${{ inputs.tag_name }}" in checkout
+    assert "persist-credentials: false" in checkout
 
 
 def test_build_validates_manifest_version_before_upload():

--- a/.github/scripts/test_rust_binary_workflow.py
+++ b/.github/scripts/test_rust_binary_workflow.py
@@ -1,0 +1,39 @@
+"""Regression tests for the reusable Rust binary release workflow."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/_rust-binary.yml"
+WORKFLOW_DOCS = ROOT / ".github/workflows/WORKFLOWS.md"
+
+
+def build_job() -> str:
+    workflow = WORKFLOW.read_text()
+    return workflow.split("\n  build:\n", 1)[1].split("\n  notify-result:\n", 1)[0]
+
+
+def test_build_checks_out_release_tag():
+    job = build_job()
+    checkout = job.split("- uses: actions/checkout@v4", 1)[1].split("\n\n", 1)[0]
+
+    assert "ref: refs/tags/${{ inputs.tag_name }}" in checkout
+
+
+def test_build_validates_manifest_version_before_upload():
+    job = build_job()
+    validation = job.index("- name: Validate release version")
+    upload = job.index("- name: Build and upload binary")
+
+    assert validation < upload
+    assert ".github/scripts/validate_rust_release_version.sh" in job
+
+
+def test_alpha_install_example_passes_tag_to_shell():
+    docs = WORKFLOW_DOCS.read_text()
+
+    assert (
+        "curl -fsSL https://iii.dev/install.sh | "
+        "III_RELEASE_TAG=iii-alpha/v0.19.2-alpha.1 sh"
+    ) in docs
+    assert "III_RELEASE_TAG=iii-alpha/v0.19.2-alpha.1 curl" not in docs

--- a/.github/scripts/test_validate_rust_release_version.bats
+++ b/.github/scripts/test_validate_rust_release_version.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+setup() {
+  ROOT=$(cd "$BATS_TEST_DIRNAME/../.." && pwd)
+  VALIDATE="$ROOT/.github/scripts/validate_rust_release_version.sh"
+  VERSION=$(awk -F '"' '/^version = "/ { print $2; exit }' "$ROOT/engine/Cargo.toml")
+}
+
+@test "accepts a package with a direct version" {
+  run bash "$VALIDATE" "$ROOT/engine/Cargo.toml" "iii/v$VERSION" iii
+
+  [ "$status" -eq 0 ]
+}
+
+@test "accepts a package with a workspace-inherited version" {
+  run bash "$VALIDATE" "$ROOT/crates/iii-worker/Cargo.toml" "iii/v$VERSION" iii-worker
+
+  [ "$status" -eq 0 ]
+}
+
+@test "rejects a manifest version that differs from the release tag" {
+  run bash "$VALIDATE" "$ROOT/engine/Cargo.toml" "iii/v999.0.0" iii
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not match release tag '999.0.0'"* ]]
+}

--- a/.github/scripts/validate_rust_release_version.sh
+++ b/.github/scripts/validate_rust_release_version.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+manifest_path="$1"
+tag_name="$2"
+package_name="$3"
+
+expected="${tag_name##*/v}"
+actual=$(cargo metadata --format-version 1 --no-deps --manifest-path "$manifest_path" \
+  | jq -r --arg package "$package_name" \
+    'first(.packages[] | select(.name == $package) | .version) // empty')
+
+if [[ -z "$actual" ]]; then
+  echo "error: package '$package_name' not found for manifest '$manifest_path'" >&2
+  exit 1
+fi
+
+if [[ "$actual" != "$expected" ]]; then
+  echo "error: manifest version '$actual' does not match release tag '$expected'" >&2
+  exit 1
+fi
+
+echo "validated $package_name v$actual against $tag_name"

--- a/.github/workflows/WORKFLOWS.md
+++ b/.github/workflows/WORKFLOWS.md
@@ -132,7 +132,7 @@ Publishes an alpha prerelease of every SDK (npm, pypi, crates, go), the engine b
 
 **Isolation:** the `iii-alpha/v*` namespace does not match `release-iii.yml`'s `iii/v*` trigger, so the official pipeline never fires. Engine binaries land on a separate prerelease (own tag namespace); workers use the dedicated `alpha` registry tag — neither collides with the official `iii/v*` releases or the `next`/`latest` channels. **Console, docker and homebrew are intentionally excluded.**
 
-**Engine install:** because the binaries live under `iii-alpha/v*`, install them with the `III_RELEASE_TAG` override on `install.sh`, e.g. `III_RELEASE_TAG=iii-alpha/v0.19.2-alpha.1 curl -fsSL https://iii.dev/install.sh | sh`. The worker-publish job uses the same override to pin the engine CLI.
+**Engine install:** because the binaries live under `iii-alpha/v*`, install them with the `III_RELEASE_TAG` override on `install.sh`, e.g. `curl -fsSL https://iii.dev/install.sh | III_RELEASE_TAG=iii-alpha/v0.19.2-alpha.1 sh`. The worker-publish job uses the same override to pin the engine CLI.
 
 **Tag format:** `iii-alpha/v{version}` (e.g., `iii-alpha/v0.19.2-alpha.1`)
 

--- a/.github/workflows/_rust-binary.yml
+++ b/.github/workflows/_rust-binary.yml
@@ -206,6 +206,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ steps.generate_token.outputs.token }}
+          ref: refs/tags/${{ inputs.tag_name }}
 
       - name: Download pre-built artifact
         if: inputs.artifact_name != ''
@@ -277,6 +278,14 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: ${{ inputs.bin_name }}-${{ matrix.target }}
+
+      - name: Validate release version
+        shell: bash
+        env:
+          BIN_NAME: ${{ inputs.bin_name }}
+          MANIFEST_PATH: ${{ inputs.manifest_path }}
+          TAG_NAME: ${{ inputs.tag_name }}
+        run: bash .github/scripts/validate_rust_release_version.sh "$MANIFEST_PATH" "$TAG_NAME" "$BIN_NAME"
 
       - name: Build and upload binary
         uses: taiki-e/upload-rust-binary-action@v1

--- a/.github/workflows/_rust-binary.yml
+++ b/.github/workflows/_rust-binary.yml
@@ -207,6 +207,7 @@ jobs:
         with:
           token: ${{ steps.generate_token.outputs.token }}
           ref: refs/tags/${{ inputs.tag_name }}
+          persist-credentials: false
 
       - name: Download pre-built artifact
         if: inputs.artifact_name != ''

--- a/engine/install.sh
+++ b/engine/install.sh
@@ -268,8 +268,8 @@ Requires: curl, jq, tar (unzip if installing a .zip asset)
 Examples:
   curl -fsSL https://iii.dev/install.sh | sh
   curl -fsSL https://iii.dev/install.sh | sh -s -- --next
-  VERSION=0.11.0 curl -fsSL https://iii.dev/install.sh | sh
-  BIN_DIR=/usr/local/bin curl -fsSL https://iii.dev/install.sh | sh
+  curl -fsSL https://iii.dev/install.sh | VERSION=0.11.0 sh
+  curl -fsSL https://iii.dev/install.sh | BIN_DIR=/usr/local/bin sh
 USAGE
       exit 0
       ;;
@@ -486,8 +486,8 @@ if [ -z "$asset_url" ]; then
     echo ""
     echo "Try:"
     echo "  - Install a stable release:  curl -fsSL https://iii.dev/install.sh | sh"
-    echo "  - Pin a different version:   VERSION=<x.y.z> curl -fsSL https://iii.dev/install.sh | sh"
-    echo "  - Override target triple:    TARGET=<triple> curl -fsSL https://iii.dev/install.sh | sh"
+    echo "  - Pin a different version:   curl -fsSL https://iii.dev/install.sh | VERSION=<x.y.z> sh"
+    echo "  - Override target triple:    curl -fsSL https://iii.dev/install.sh | TARGET=<triple> sh"
     echo "  - Browse all releases:       https://github.com/$REPO/releases"
   } >&2
   err "download" "no release asset found for target: $target"

--- a/engine/tests/install_sh_unit.bats
+++ b/engine/tests/install_sh_unit.bats
@@ -146,6 +146,15 @@ EOF
   [[ "$output" == *"x86_64-apple-darwin"* ]]
 }
 
+@test "install.sh --help passes environment overrides to sh" {
+  run sh "$INSTALL_SH" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"curl -fsSL https://iii.dev/install.sh | VERSION=0.11.0 sh"* ]]
+  [[ "$output" == *"curl -fsSL https://iii.dev/install.sh | BIN_DIR=/usr/local/bin sh"* ]]
+  [[ "$output" != *"VERSION=0.11.0 curl"* ]]
+  [[ "$output" != *"BIN_DIR=/usr/local/bin curl"* ]]
+}
+
 # ─────────────────────────────────────────────────────────────
 # Argument parsing: unknown flags
 # ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- check out the requested release tag before building Rust release binaries
- reject builds whose Cargo package version does not match the release tag
- support packages that inherit their version from the Cargo workspace
- pass installer environment overrides to `sh` instead of `curl` in examples

## Root cause

The reusable Rust binary workflow checked out the caller branch because its `actions/checkout` step did not specify a ref. The later `ref` passed to the upload action selected the destination GitHub release, but did not change the source being compiled. This allowed a `0.21.8-next.1` binary to be attached to the `iii-alpha/v0.21.6-alpha.1` release.

The alpha installation example also scoped `III_RELEASE_TAG` to `curl`, so the installer process did not receive it and selected the latest stable release instead.

## Impact

Alpha and stable binary jobs now build from the tagged commit and fail before compilation/upload if the manifest version and tag differ. Installer examples now pin versions and destinations as documented.

## Validation

- `python -m pytest .github/scripts/test_rust_binary_workflow.py .github/scripts/test_calculate_release_version.py .github/scripts/test_bump_manifests.py -q` (147 passed)
- `bats .github/scripts/test_validate_rust_release_version.bats` (3 passed)
- filtered installer regression test (passed)
- `shellcheck` for the changed shell scripts (passed)
- `actionlint .github/workflows/_rust-binary.yml` (passed)

## Known unrelated failure

The complete `engine/tests/install_sh_unit.bats` run still has its existing macOS permission-mode failure in `install_bin copies file and sets mode 755`; the new installer regression test passes independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated release-version validation before Rust binaries are built and uploaded.
  * Release builds now check out the specified Git tag.
* **Bug Fixes**
  * Corrected alpha installation instructions so the release tag is passed to the installer properly.
* **Tests**
  * Added coverage for release workflow behavior, version validation logic, and installer command output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->