### PR TITLE
fix(node-sdk,browser-sdk): default trigger generics so untyped calls pass tsc (MOT-4076)

### DIFF
--- a/docs/next/creating-workers/workers.mdx
+++ b/docs/next/creating-workers/workers.mdx
@@ -154,25 +154,25 @@ get the current state of the registry. Each returns a list:
     <Tab title="Node / TypeScript">
       ```typescript
       // engine::workers::list, pass { worker_id: "<uuid>" } to look up one worker
-      const { workers } = await worker.trigger<any, any>({
+      const { workers } = await worker.trigger({
         function_id: "engine::workers::list",
         payload: {},
       });
 
       // engine::functions::list
-      const { functions } = await worker.trigger<any, any>({
+      const { functions } = await worker.trigger({
         function_id: "engine::functions::list",
         payload: { include_internal: false },
       });
 
       // engine::triggers::list
-      const { triggers } = await worker.trigger<any, any>({
+      const { triggers } = await worker.trigger({
         function_id: "engine::triggers::list",
         payload: { include_internal: false },
       });
 
       // engine::registered-triggers::list
-      const { registered_triggers } = await worker.trigger<any, any>({
+      const { registered_triggers } = await worker.trigger({
         function_id: "engine::registered-triggers::list",
         payload: { include_internal: false },
       });

--- a/docs/next/creating-workers/workers.mdx.skill.md
+++ b/docs/next/creating-workers/workers.mdx.skill.md
@@ -150,25 +150,25 @@ get the current state of the registry. Each returns a list:
     <Tab title="Node / TypeScript">
       ```typescript
       // engine::workers::list, pass { worker_id: "<uuid>" } to look up one worker
-      const { workers } = await worker.trigger<any, any>({
+      const { workers } = await worker.trigger({
         function_id: "engine::workers::list",
         payload: {},
       });
 
       // engine::functions::list
-      const { functions } = await worker.trigger<any, any>({
+      const { functions } = await worker.trigger({
         function_id: "engine::functions::list",
         payload: { include_internal: false },
       });
 
       // engine::triggers::list
-      const { triggers } = await worker.trigger<any, any>({
+      const { triggers } = await worker.trigger({
         function_id: "engine::triggers::list",
         payload: { include_internal: false },
       });
 
       // engine::registered-triggers::list
-      const { registered_triggers } = await worker.trigger<any, any>({
+      const { registered_triggers } = await worker.trigger({
         function_id: "engine::registered-triggers::list",
         payload: { include_internal: false },
       });

--- a/sdk/packages/node/iii-browser/src/iii.ts
+++ b/sdk/packages/node/iii-browser/src/iii.ts
@@ -320,7 +320,10 @@ class Sdk implements ISdk {
    * })
    * ```
    */
-  trigger = async <TInput, TOutput>(request: TriggerRequest<TInput>): Promise<TOutput> => {
+  // biome-ignore lint/suspicious/noExplicitAny: TOutput defaults to any so untyped calls type-check (the engine cannot express the return type statically)
+  trigger = async <TInput = unknown, TOutput = any>(
+    request: TriggerRequest<TInput>,
+  ): Promise<TOutput> => {
     const { function_id, payload, action, timeoutMs } = request
     const effectiveTimeout = timeoutMs ?? this.invocationTimeoutMs
 

--- a/sdk/packages/node/iii-browser/src/types.ts
+++ b/sdk/packages/node/iii-browser/src/types.ts
@@ -138,7 +138,8 @@ export interface ISdk {
    * })
    * ```
    */
-  trigger<TInput, TOutput>(request: TriggerRequest<TInput>): Promise<TOutput>
+  // biome-ignore lint/suspicious/noExplicitAny: TOutput defaults to any so untyped calls type-check (the engine cannot express the return type statically)
+  trigger<TInput = unknown, TOutput = any>(request: TriggerRequest<TInput>): Promise<TOutput>
 
   /**
    * Registers a new trigger type. A trigger type is a way to invoke a function when a certain event occurs.

--- a/sdk/packages/node/iii-browser/tests/trigger-typing.type-check.ts
+++ b/sdk/packages/node/iii-browser/tests/trigger-typing.type-check.ts
@@ -1,0 +1,40 @@
+/**
+ * Type-level regression test for MOT-4076: `worker.trigger` must type-check
+ * without explicit type arguments. Not executed at runtime — vitest only picks
+ * up `*.test.ts` — but `tsc --noEmit` (run in CI) compiles it.
+ */
+import { registerWorker } from '../src/index'
+
+// biome-ignore lint/correctness/noUnusedVariables: compile-only assertions
+async function triggerTypingAssertions() {
+  const worker = registerWorker('ws://localhost:49134')
+
+  // No type args: TOutput defaults to any, so property access compiles.
+  const { workers } = await worker.trigger({
+    function_id: 'engine::workers::list',
+    payload: {},
+  })
+  void workers
+
+  // Explicit <any, any> keeps compiling.
+  // biome-ignore lint/suspicious/noExplicitAny: exercising the explicit-any call style
+  const { functions } = await worker.trigger<any, any>({
+    function_id: 'engine::functions::list',
+    payload: { include_internal: false },
+  })
+  void functions
+
+  // Fully typed style keeps compiling.
+  const typed = await worker.trigger<{ name: string }, { message: string }>({
+    function_id: 'greet',
+    payload: { name: 'World' },
+  })
+  void typed.message
+
+  // Input type alone now also works (output defaults to any).
+  const { triggers } = await worker.trigger<{ include_internal: boolean }>({
+    function_id: 'engine::triggers::list',
+    payload: { include_internal: false },
+  })
+  void triggers
+}

--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -483,7 +483,10 @@ class Sdk implements IIIClient {
    * })
    * ```
    */
-  trigger = async <TInput, TOutput>(request: TriggerRequest<TInput>): Promise<TOutput> => {
+  // biome-ignore lint/suspicious/noExplicitAny: TOutput defaults to any so untyped calls type-check (the engine cannot express the return type statically)
+  trigger = async <TInput = unknown, TOutput = any>(
+    request: TriggerRequest<TInput>,
+  ): Promise<TOutput> => {
     const { function_id, payload, action, timeoutMs, metadata } = request
     const effectiveTimeout = timeoutMs ?? this.invocationTimeoutMs
 

--- a/sdk/packages/node/iii/src/types.ts
+++ b/sdk/packages/node/iii/src/types.ts
@@ -174,7 +174,8 @@ export interface IIIClient {
    * })
    * ```
    */
-  trigger<TInput, TOutput>(request: TriggerRequest<TInput>): Promise<TOutput>
+  // biome-ignore lint/suspicious/noExplicitAny: TOutput defaults to any so untyped calls type-check (the engine cannot express the return type statically)
+  trigger<TInput = unknown, TOutput = any>(request: TriggerRequest<TInput>): Promise<TOutput>
 
   /**
    * Registers a new trigger type. A trigger type is a way to invoke a function when a certain event occurs.

--- a/sdk/packages/node/iii/tests/trigger-typing.type-check.ts
+++ b/sdk/packages/node/iii/tests/trigger-typing.type-check.ts
@@ -1,0 +1,40 @@
+/**
+ * Type-level regression test for MOT-4076: `worker.trigger` must type-check
+ * without explicit type arguments. Not executed at runtime — vitest only picks
+ * up `*.test.ts` — but `tsc --noEmit` (run in CI) compiles it.
+ */
+import { registerWorker } from '../src/index'
+
+// biome-ignore lint/correctness/noUnusedVariables: compile-only assertions
+async function triggerTypingAssertions() {
+  const worker = registerWorker('ws://localhost:49134')
+
+  // No type args: TOutput defaults to any, so property access compiles.
+  const { workers } = await worker.trigger({
+    function_id: 'engine::workers::list',
+    payload: {},
+  })
+  void workers
+
+  // Explicit <any, any> keeps compiling.
+  // biome-ignore lint/suspicious/noExplicitAny: exercising the explicit-any call style
+  const { functions } = await worker.trigger<any, any>({
+    function_id: 'engine::functions::list',
+    payload: { include_internal: false },
+  })
+  void functions
+
+  // Fully typed style keeps compiling.
+  const typed = await worker.trigger<{ name: string }, { message: string }>({
+    function_id: 'greet',
+    payload: { name: 'World' },
+  })
+  void typed.message
+
+  // Input type alone now also works (output defaults to any).
+  const { triggers } = await worker.trigger<{ include_internal: boolean }>({
+    function_id: 'engine::triggers::list',
+    payload: { include_internal: false },
+  })
+  void triggers
+}


### PR DESCRIPTION
## What

Default `worker.trigger`'s generics to `<TInput = unknown, TOutput = any>` (interface + implementation, in both `iii-sdk` and `iii-browser-sdk`) so calling `trigger` without explicit type arguments passes `tsc --noEmit`.

Fixes [MOT-4076](https://linear.app/motia/issue/MOT-4076/fix-workertrigger-typescript-typing-when-types-are-missing)

## Why

`trigger<TInput, TOutput>` had no generic defaults. `TInput` is inferred from `payload`, but `TOutput` has no inference site, so a bare call inferred it as `unknown` — and any property access on the result failed type checking:

```
src/index.ts:7:11 - error TS2339: Property 'workers' does not exist on type 'unknown'.

7   const { workers } = await worker.trigger({
```

And since TypeScript doesn't allow partial type arguments without defaults, users were forced to write `trigger<any, any>`.

With the defaults, all call styles compile:

```typescript
await worker.trigger({ ... })                                   // NEW: works, returns Promise<any>
await worker.trigger<{ include_internal: boolean }>({ ... })    // NEW: input-only, output defaults to any
await worker.trigger<any, any>({ ... })                         // unchanged
await worker.trigger<{ name: string }, { message: string }>({ ... }) // unchanged
```

This is the "default to `any`" option from the ticket. It's strictly non-breaking and forward-compatible with the longer-term option of generating real per-function types (codegen roadmap).

## Evidence

Same consumer code, same `tsc`, against the SDK typings built before and after this change:

![before/after tsc evidence](https://vhs.charm.sh/vhs-2Zg1i31NCXYs35AulotnG0.gif)

**Before** (signature `trigger<TInput, TOutput>`):

```
$ npx tsc -p tsconfig.before.json
src/index.ts(7,11): error TS2339: Property 'workers' does not exist on type 'unknown'.
tsc exit code: 2
```

**After** (signature `trigger<TInput = unknown, TOutput = any>`):

```
$ npx tsc -p tsconfig.after.json
tsc exit code: 0
```

## Notes

- Added `tests/trigger-typing.type-check.ts` to both packages: compile-only regression tests asserting all four call styles. They are exercised by the existing CI `tsc --noEmit` steps (vitest ignores them — not `*.test.ts`).
- Updated the `docs/next/creating-workers/workers.mdx` example to drop the now-unneeded `<any, any>`. Left the released `docs/` copy alone since the published SDK still requires it; `.skill.md` files are generated on render.
- Verified locally: `tsc --noEmit` clean on both packages; built `d.mts`/`d.cts` carry the defaults; a standalone consumer importing `iii-sdk` with `strict` compiles the Slack-thread snippet; browser suite 54/54; node SDK integration suite 240/242 against CI-style local engines — the 2 failures (`trigger-fault-tolerance`, `trigger-registration-error`) fail identically at `main`, i.e. pre-existing flakes unrelated to this change.
- Deliberately out of scope: typed overloads so `TriggerAction.Void()` returns `Promise<undefined>` and `Enqueue` returns `Promise<EnqueueResult>` (as the docblock table already claims). `Void()`/`Enqueue()` return narrowed literal types, so this is feasible as a small follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved TypeScript SDK ergonomics: `trigger(...)` can now be called without explicitly specifying generic type parameters (defaults provided for input/output).

* **Documentation**
  * Updated “Inspecting the live registry” examples to use the new streamlined `worker.trigger(...)` call style while keeping the same registry calls and destructured results.

* **Tests**
  * Added compile-only type-regression coverage ensuring `trigger(...)` type-checks with omitted, partial, and fully specified generic types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->