### PR TITLE
fix(engine): reject duplicate migrated builtin workers

### DIFF
--- a/engine/src/workers/config.rs
+++ b/engine/src/workers/config.rs
@@ -21,6 +21,14 @@ use notify::Watcher;
 use super::{registry::WorkerRegistration, traits::Worker};
 use crate::engine::Engine;
 
+const MIGRATED_BUILTIN_WORKERS: &[(&str, &str)] = &[
+    ("iii-http", "http"),
+    ("iii-cron", "cron"),
+    ("iii-queue", "queue"),
+    ("iii-state", "state"),
+    ("iii-pubsub", "pubsub"),
+];
+
 // =============================================================================
 // EngineConfig (YAML structure)
 // =============================================================================
@@ -99,8 +107,31 @@ impl EngineConfig {
         let yaml_content = Self::expand_env_vars(&yaml_content);
         let mut cfg: Self = serde_yaml::from_str(&yaml_content)
             .map_err(|e| anyhow::anyhow!("Failed to parse config file '{}': {}", path, e))?;
+        cfg.validate_migrated_worker_duplicates()?;
         cfg.ensure_builtin_daemons();
         Ok(cfg)
+    }
+
+    fn validate_migrated_worker_duplicates(&self) -> anyhow::Result<()> {
+        let worker_names: HashSet<&str> = self
+            .workers
+            .iter()
+            .chain(self.modules.iter())
+            .map(|entry| entry.name.as_str())
+            .collect();
+
+        for (deprecated, replacement) in MIGRATED_BUILTIN_WORKERS {
+            if worker_names.contains(deprecated) && worker_names.contains(replacement) {
+                anyhow::bail!(
+                    "Duplicate worker configuration: '{}' is the deprecated name for '{}', but both are present. Remove '{}'.",
+                    deprecated,
+                    replacement,
+                    deprecated
+                );
+            }
+        }
+
+        Ok(())
     }
 
     /// Returns a config with default port and default modules (from inventory).
@@ -1217,6 +1248,27 @@ mod tests {
 
         let config = EngineConfig::config_file(path.to_str().unwrap()).unwrap();
         assert!(config.modules.is_empty());
+    }
+
+    #[test]
+    fn test_config_file_rejects_duplicate_migrated_workers() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+
+        for (deprecated, replacement) in MIGRATED_BUILTIN_WORKERS {
+            std::fs::write(
+                &path,
+                format!("workers:\n  - name: {deprecated}\nmodules:\n  - name: {replacement}\n"),
+            )
+            .unwrap();
+
+            let error = EngineConfig::config_file(path.to_str().unwrap()).unwrap_err();
+            let message = error.to_string();
+
+            assert!(message.contains("Duplicate worker"), "{message}");
+            assert!(message.contains(deprecated), "{message}");
+            assert!(message.contains(replacement), "{message}");
+        }
     }
 
     #[test]

--- a/engine/src/workers/config.rs
+++ b/engine/src/workers/config.rs
@@ -120,15 +120,21 @@ impl EngineConfig {
             .map(|entry| entry.name.as_str())
             .collect();
 
-        for (deprecated, replacement) in MIGRATED_BUILTIN_WORKERS {
-            if worker_names.contains(deprecated) && worker_names.contains(replacement) {
-                anyhow::bail!(
-                    "Duplicate worker configuration: '{}' is the deprecated name for '{}', but both are present. Remove '{}'.",
-                    deprecated,
-                    replacement,
-                    deprecated
-                );
-            }
+        let conflicts: Vec<String> = MIGRATED_BUILTIN_WORKERS
+            .iter()
+            .filter(|(deprecated, replacement)| {
+                worker_names.contains(deprecated) && worker_names.contains(replacement)
+            })
+            .map(|(deprecated, replacement)| {
+                format!(
+                    "- '{}' is the deprecated name for '{}', but both are present. Remove '{}' from your configuration.",
+                    deprecated, replacement, deprecated
+                )
+            })
+            .collect();
+
+        if !conflicts.is_empty() {
+            anyhow::bail!("Duplicate worker configurations:\n{}", conflicts.join("\n"));
         }
 
         Ok(())
@@ -1269,6 +1275,33 @@ mod tests {
             assert!(message.contains(deprecated), "{message}");
             assert!(message.contains(replacement), "{message}");
         }
+    }
+
+    #[test]
+    fn test_config_file_reports_all_duplicate_migrated_workers() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(
+            &path,
+            "workers:\n  - name: iii-cron\n  - name: cron\n  - name: iii-queue\n  - name: queue\n",
+        )
+        .unwrap();
+
+        let error = EngineConfig::config_file(path.to_str().unwrap()).unwrap_err();
+        let message = error.to_string();
+
+        assert!(
+            message.contains("Duplicate worker configurations:"),
+            "{message}"
+        );
+        assert!(
+            message.contains("Remove 'iii-cron' from your configuration."),
+            "{message}"
+        );
+        assert!(
+            message.contains("Remove 'iii-queue' from your configuration."),
+            "{message}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reject config files that declare both a deprecated builtin worker name and its unprefixed replacement
- report every migrated-worker collision in a single actionable error
- validate collisions across both `workers` and legacy `modules` entries
- cover HTTP, cron, queue, state, and pubsub migrations with regression tests

## Demo

![All duplicate migrated builtin worker errors](https://vhs.charm.sh/vhs-8Ip331v6zFKSzzmaheO7E.gif)

## Why

A configuration containing entries such as `iii-queue` and `queue` allowed the engine to start both implementations. The workers then competed to register overlapping functions and triggers, which could leave consumers such as the harness unable to use `queue::define`.

## Root cause

Worker names were only assigned instance IDs for literal duplicates. Deprecated and replacement names are different strings, so the configuration loader did not recognize that they represent the same migrated builtin worker.

## Impact

The engine now fails before initializing workers and reports every conflicting pair at once. Each conflict identifies the deprecated entry to remove from the configuration. Configurations containing only the deprecated name or only the replacement remain compatible.

## Validation

- `cargo test -p iii --lib duplicate_migrated_workers -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- manual startup with simultaneous `iii-cron`/`cron` and `iii-queue`/`queue` conflicts, which reported both before worker initialization


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added configuration validation to detect conflicts between deprecated worker names and their replacements.
  * Configuration loading now reports all conflicting pairs with clear guidance on which entries to remove.
  * Prevented configurations containing duplicate deprecated and replacement workers from loading successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->