### PR TITLE
fix(queue): rebuild the transport named by the stored configuration at boot

### DIFF
--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -1169,7 +1169,36 @@ impl Worker for QueueWorker {
             // restart. On failure keep the seed (already validated in
             // `initialize`), matching the runtime apply gate.
             Ok(config) => match config.validate() {
-                Ok(()) => self.set_config(config),
+                // The stored entry is the runtime source of truth and the
+                // config.yaml block is seed-only (it is stripped after the
+                // first boot), so on a later boot `create` may have resolved
+                // the default adapter while the stored value names another
+                // one. The stored selection must drive the transport too:
+                // rebuild it here, before consumers spawn below. Adopting only
+                // the config value would also erase the old-vs-new adapter
+                // diff that `apply_config` relies on, silently pinning the
+                // queue to the wrong transport for the process lifetime.
+                Ok(()) => {
+                    if Self::effective_adapter(&self.config_snapshot())
+                        != Self::effective_adapter(&config)
+                    {
+                        match Self::resolve_adapter(&self.engine, &config).await {
+                            // No consumers exist yet, so unlike the hot-swap in
+                            // `apply_config` there is nothing to rebind.
+                            Ok(adapter) => self.set_live(config, adapter),
+                            // Keep the seed config alongside the seed adapter
+                            // (all-or-nothing, matching the `apply_config`
+                            // gate) so the two can never disagree.
+                            Err(err) => tracing::warn!(
+                                error = %err,
+                                "iii-queue: failed to build the adapter named by the stored \
+                                 configuration; continuing with static config"
+                            ),
+                        }
+                    } else {
+                        self.set_config(config);
+                    }
+                }
                 Err(err) => tracing::warn!(
                     error = %err,
                     "iii-queue: stored configuration is invalid; continuing with static config"

--- a/engine/tests/queue_configuration_e2e.rs
+++ b/engine/tests/queue_configuration_e2e.rs
@@ -5,10 +5,10 @@
 // See LICENSE and PATENTS files for details.
 
 //! End-to-end test for the `iii-queue` ↔ `configuration` worker integration:
-//! seed-on-first-boot, no-clobber across worker restarts, hot-add of a queue
-//! (live consumer), hot-change of per-queue settings, full adapter/transport
-//! hot-swap, all-or-nothing gate on an invalid value, and `${VAR:default}`
-//! expansion.
+//! seed-on-first-boot, no-clobber across worker restarts, adoption of the
+//! stored transport on restart, hot-add of a queue (live consumer), hot-change
+//! of per-queue settings, full adapter/transport hot-swap, all-or-nothing gate
+//! on an invalid value, and `${VAR:default}` expansion.
 //!
 //! Modeled on `engine/tests/http_configuration_e2e.rs` — composes the two
 //! workers against a real `FsAdapter` on a `tempfile::tempdir()`. The queue
@@ -195,6 +195,116 @@ async fn runtime_edit_survives_worker_restart() {
     assert_eq!(
         restarted.config_snapshot().queue_configs["default"].concurrency,
         5
+    );
+}
+
+#[tokio::test]
+async fn restart_without_yaml_adapter_block_rebuilds_stored_transport() {
+    let _serial = SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    let counter = Arc::new(AtomicU64::new(0));
+    register_counting_function(&harness.engine, "e2e::restart", counter.clone());
+
+    // First boot: the config.yaml block selects a non-default transport and
+    // seeds the configuration entry (adapter included). `memory` stands in for
+    // any non-builtin backend without needing an external broker.
+    let worker = start_queue_worker(
+        &harness,
+        json!({
+            "adapter": { "name": "memory" },
+            "queue_configs": { "jobs": { "concurrency": 1 } }
+        }),
+    )
+    .await;
+    worker.destroy().await.expect("destroy");
+
+    // Restarted process: after the first boot the engine strips the seeded
+    // `config:` block from config.yaml, so `create` runs with no block and
+    // resolves the default (builtin) transport.
+    let restarted = QueueWorker::for_test(harness.engine.clone(), Some(json!({})))
+        .await
+        .expect("queue worker");
+    restarted.initialize().await.expect("queue initialize");
+    Worker::register_functions(&restarted, harness.engine.clone());
+    let boot_adapter = restarted.adapter_snapshot();
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    restarted
+        .start_background_tasks(shutdown_rx, shutdown_tx)
+        .await
+        .expect("queue start_background_tasks");
+
+    // The stored entry is the runtime source of truth: adopting its value must
+    // also rebuild the transport it names — not adopt the config while leaving
+    // consumers on the default transport resolved at create time.
+    assert_eq!(
+        restarted
+            .config_snapshot()
+            .adapter
+            .as_ref()
+            .map(|a| a.name.as_str()),
+        Some("memory"),
+        "the stored adapter selection must be adopted on restart"
+    );
+    assert!(
+        !Arc::ptr_eq(&boot_adapter, &restarted.adapter_snapshot()),
+        "the transport must be rebuilt to the stored adapter, not left on the \
+         default resolved at create time"
+    );
+
+    // Consumers were spawned on the rebuilt transport: a job enqueued after
+    // the restart is delivered.
+    enqueue(&restarted, "jobs", "e2e::restart", json!({}))
+        .await
+        .expect("enqueue after restart");
+    wait_for(
+        || counter.load(Ordering::SeqCst) >= 1,
+        "handler invoked on the stored transport after restart",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn restart_with_matching_adapter_keeps_boot_transport() {
+    let _serial = SERIAL.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let harness = build_harness(dir.path()).await;
+
+    // First boot with no adapter block: the stored entry carries no adapter
+    // selection either.
+    let worker = start_queue_worker(
+        &harness,
+        json!({ "queue_configs": { "jobs": { "concurrency": 1 } } }),
+    )
+    .await;
+    worker.destroy().await.expect("destroy");
+
+    // Restart, also with no adapter block. `None` vs the filled-in default
+    // must not read as an adapter change: the transport resolved at create
+    // time is kept, only the config value is adopted.
+    let restarted = QueueWorker::for_test(harness.engine.clone(), Some(json!({})))
+        .await
+        .expect("queue worker");
+    restarted.initialize().await.expect("queue initialize");
+    Worker::register_functions(&restarted, harness.engine.clone());
+    let boot_adapter = restarted.adapter_snapshot();
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    restarted
+        .start_background_tasks(shutdown_rx, shutdown_tx)
+        .await
+        .expect("queue start_background_tasks");
+
+    assert!(
+        Arc::ptr_eq(&boot_adapter, &restarted.adapter_snapshot()),
+        "a matching adapter selection must not rebuild the transport on restart"
+    );
+    // The stored per-queue settings are still adopted.
+    assert_eq!(
+        restarted.config_snapshot().queue_configs["jobs"].concurrency,
+        1
     );
 }
 


### PR DESCRIPTION
## Summary

When a process restarts in an environment where the engine has already persisted the queue worker's configuration (the seeded `config:` block is stripped from `config.yaml` after first boot, and the stored configuration entry becomes the runtime source of truth), the queue silently comes up on the builtin in-memory adapter even though the stored configuration names an external one (e.g. `rabbitmq`). The mechanism: `QueueWorker::create` resolves the adapter from the (now empty) static config — defaulting to `builtin` — and `start_background_tasks` adopted the validated stored configuration via `set_config` only, so the config *value* was updated but the live transport was never rebuilt; overwriting the snapshot also destroyed the old-vs-new adapter diff that `apply_config` relies on to trigger a transport hot-swap, so every consumer spawned on the builtin adapter and the process stayed pinned there for its whole lifetime while durable messages accumulated unconsumed in the external broker.

## Fix

In `start_background_tasks` (`engine/src/workers/queue/queue.rs`), when the validated stored configuration selects a different effective adapter than the one resolved at create time, resolve/build that adapter and swap config + transport atomically with `set_live` **before** consumers spawn. If the adapter build fails, degrade all-or-nothing to the statically-resolved adapter and seed config — the same gate `apply_config` applies for runtime updates. When the stored selection matches the create-time adapter (including `None` vs the explicit default), the existing `set_config` path is kept unchanged, so there is no spurious transport rebuild on the common path.

This is the minimal change: it reuses the existing `resolve_adapter` / `set_live` machinery already used by `apply_config` for runtime hot-swaps, only extending the boot-time adoption path to apply the same transport semantics it already applies to the config value. ~30 lines, no behavior change for first boots or for boots where the static and stored adapters agree.

## Testing

- `cargo test -p iii --all-features --test queue_configuration_e2e`
  - **without the fix** (patch stashed): 13/14 — the new test `restart_without_yaml_adapter_block_rebuilds_stored_transport` fails precisely on the assertion that the stored adapter's transport was rebuilt (red confirmed)
  - **with the fix**: 14/14 passed (green confirmed)
- New regression tests in `engine/tests/queue_configuration_e2e.rs`:
  - `restart_without_yaml_adapter_block_rebuilds_stored_transport` — simulates a restart where the yaml no longer carries the adapter block but the stored configuration names a non-default adapter; asserts the transport is rebuilt before consumers start
  - `restart_with_matching_adapter_keeps_boot_transport` — asserts no spurious swap when the stored selection matches the boot-time adapter (`None` vs explicit default)
- `cargo test -p iii --all-features --lib workers::queue` → 163 passed
- `cargo test -p iii --all-features --test queue_e2e_happy_path --test queue_e2e_failure_retry --test queue_e2e_fanout --test queue_e2e_concurrency_resilience --test queue_integration --test iii_queue_optin_registration` → all passed (1+3+3+7+2+12), 0 failed
- `RABBITMQ_URL=amqp://localhost:5672 cargo test -p iii --test rabbitmq_queue_integration` against a disposable `rabbitmq:3-management-alpine` broker → 20 passed
- `cargo build -p iii --all-features` → OK; `cargo fmt --all -- --check` → clean
- `cargo clippy -p iii --all-features --all-targets -- -D warnings` fails on pre-existing lints on `main` (engine clippy is currently commented out in CI); with those pre-existing lint classes allowed, no diagnostics touch the files modified here

## Licensing :
- [X] I license my contributions to this repository under Apache 2.0, and I have all necessary rights over the code I am contributing.

Fixes #1986


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue worker restarts to correctly restore the configured adapter and transport selection.
  * Ensured queued work reaches consumers after a restart when stored transport settings differ from defaults.
  * Preserved the existing transport when stored and active adapter selections already match.
  * Continued applying stored per-queue settings during restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->