### PR TITLE
fix(engine): park undeliverable trigger binds instead of dropping them (MOT-4081)

### DIFF
--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -626,7 +626,20 @@ impl Engine {
                     return Ok(());
                 }
 
-                self.trigger_registry.triggers.remove(id);
+                // Re-park instead of dropping; park only when this call
+                // removed it — a concurrent disconnect GC may have already
+                // reaped it, and parking then would resurrect a dead binding.
+                if let Some((_, failed)) = self.trigger_registry.triggers.remove(id) {
+                    tracing::warn!(
+                        trigger_id = %id,
+                        trigger_type = %stored_trigger_type,
+                        function_id = %stored_function_id,
+                        "Trigger registration rejected by provider; parked as pending until the trigger type re-registers"
+                    );
+                    self.trigger_registry
+                        .pending_triggers
+                        .insert(failed.id.clone(), failed);
+                }
 
                 let Some(originator_id) = originator_id else {
                     tracing::debug!(
@@ -3503,7 +3516,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_trigger_registration_result_forwards_error_to_originator() {
+    async fn test_trigger_registration_result_error_forwards_parks_and_replays() {
         ensure_default_meter();
         let engine = Engine::new();
 
@@ -3564,8 +3577,39 @@ mod tests {
 
         assert!(
             engine.trigger_registry.triggers.get("trig-1").is_none(),
-            "failed trigger should be removed from registry"
+            "failed trigger leaves the live registry"
         );
+        assert!(
+            engine
+                .trigger_registry
+                .pending_triggers
+                .contains_key("trig-1"),
+            "failed trigger is parked for replay, not dropped"
+        );
+
+        // Provider reconnects with a fresh registrator: the parked intent replays.
+        let (reg2_tx, mut reg2_rx) = mpsc::channel::<Outbound>(8);
+        let reg2 = WorkerConnection::new(reg2_tx);
+        engine
+            .trigger_registry
+            .register_trigger_type(crate::trigger::TriggerType::new(
+                "http",
+                "test trigger type",
+                Box::new(reg2.clone()),
+                Some(reg2.id),
+            ))
+            .await
+            .expect("re-registering the trigger type should succeed");
+
+        assert!(engine.trigger_registry.pending_triggers.is_empty());
+        assert!(engine.trigger_registry.triggers.contains_key("trig-1"));
+        let replayed = reg2_rx
+            .try_recv()
+            .expect("replacement registrator receives the replayed RegisterTrigger");
+        assert!(matches!(
+            replayed,
+            Outbound::Protocol(Message::RegisterTrigger { .. })
+        ));
     }
 
     #[tokio::test]

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -629,16 +629,25 @@ impl Engine {
                 // Re-park instead of dropping; park only when this call
                 // removed it — a concurrent disconnect GC may have already
                 // reaped it, and parking then would resurrect a dead binding.
-                if let Some((_, failed)) = self.trigger_registry.triggers.remove(id) {
-                    tracing::warn!(
-                        trigger_id = %id,
-                        trigger_type = %stored_trigger_type,
-                        function_id = %stored_function_id,
-                        "Trigger registration rejected by provider; parked as pending until the trigger type re-registers"
-                    );
-                    self.trigger_registry
-                        .pending_triggers
-                        .insert(failed.id.clone(), failed);
+                // The transition lock makes the remove+park atomic with an
+                // explicit unregister's two-map clear.
+                {
+                    let _park = self
+                        .trigger_registry
+                        .park_transition
+                        .lock()
+                        .expect("park_transition lock poisoned");
+                    if let Some((_, failed)) = self.trigger_registry.triggers.remove(id) {
+                        tracing::warn!(
+                            trigger_id = %id,
+                            trigger_type = %stored_trigger_type,
+                            function_id = %stored_function_id,
+                            "Trigger registration rejected by provider; parked as pending until the trigger type re-registers"
+                        );
+                        self.trigger_registry
+                            .pending_triggers
+                            .insert(failed.id.clone(), failed);
+                    }
                 }
 
                 let Some(originator_id) = originator_id else {
@@ -3610,6 +3619,72 @@ mod tests {
             replayed,
             Outbound::Protocol(Message::RegisterTrigger { .. })
         ));
+    }
+
+    /// A late async rejection racing an explicit unregister. Whatever the
+    /// interleave, the binding must never resurrect: once both complete it is
+    /// in neither the live registry nor the pending bucket.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn unregister_racing_late_rejection_never_resurrects_the_binding() {
+        ensure_default_meter();
+        for _ in 0..100 {
+            let engine = Arc::new(Engine::new());
+
+            let (user_tx, _user_rx) = mpsc::channel::<Outbound>(8);
+            let user = WorkerConnection::new(user_tx);
+            engine.worker_registry.register_worker(user.clone());
+
+            let (registrator_tx, _registrator_rx) = mpsc::channel::<Outbound>(8);
+            let registrator = WorkerConnection::new(registrator_tx);
+            insert_trigger_type_for(&engine, "http", &registrator);
+
+            engine.trigger_registry.triggers.insert(
+                "trig-race".to_string(),
+                crate::trigger::Trigger {
+                    id: "trig-race".to_string(),
+                    trigger_type: "http".to_string(),
+                    function_id: "fn-1".to_string(),
+                    config: serde_json::json!({}),
+                    worker_id: Some(user.id),
+                    metadata: None,
+                },
+            );
+
+            let msg = Message::TriggerRegistrationResult {
+                id: "trig-race".to_string(),
+                trigger_type: "http".to_string(),
+                function_id: "fn-1".to_string(),
+                error: Some(crate::protocol::ErrorBody::new("provider_error", "boom")),
+            };
+
+            let reject = {
+                let engine = Arc::clone(&engine);
+                let registrator = registrator.clone();
+                tokio::spawn(async move { engine.router_msg(&registrator, &msg).await })
+            };
+            let unregister = {
+                let engine = Arc::clone(&engine);
+                tokio::spawn(async move {
+                    engine
+                        .trigger_registry
+                        .unregister_trigger("trig-race".to_string(), None)
+                        .await
+                })
+            };
+
+            reject.await.unwrap().unwrap();
+            let removed = unregister.await.unwrap().unwrap();
+
+            assert!(removed, "the binding existed in one of the buckets");
+            assert!(!engine.trigger_registry.triggers.contains_key("trig-race"));
+            assert!(
+                !engine
+                    .trigger_registry
+                    .pending_triggers
+                    .contains_key("trig-race"),
+                "explicitly unregistered binding resurrected as a pending intent"
+            );
+        }
     }
 
     #[tokio::test]

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -626,29 +626,14 @@ impl Engine {
                     return Ok(());
                 }
 
-                // Re-park instead of dropping; park only when this call
-                // removed it — a concurrent disconnect GC may have already
-                // reaped it, and parking then would resurrect a dead binding.
-                // The transition lock makes the remove+park atomic with an
-                // explicit unregister's two-map clear.
-                {
-                    let _park = self
-                        .trigger_registry
-                        .park_transition
-                        .lock()
-                        .expect("park_transition lock poisoned");
-                    if let Some((_, failed)) = self.trigger_registry.triggers.remove(id) {
-                        tracing::warn!(
-                            trigger_id = %id,
-                            trigger_type = %stored_trigger_type,
-                            function_id = %stored_function_id,
-                            "Trigger registration rejected by provider; parked as pending until the trigger type re-registers"
-                        );
-                        self.trigger_registry
-                            .pending_triggers
-                            .insert(failed.id.clone(), failed);
-                    }
-                }
+                // Re-park instead of dropping (no-op if a concurrent
+                // disconnect GC or unregister already reaped it). If the
+                // reporting provider was replaced while the rejection was in
+                // flight, the registry re-activates the intent through the
+                // replacement instead of stranding it.
+                self.trigger_registry
+                    .park_rejected_trigger(id, worker.id)
+                    .await;
 
                 let Some(originator_id) = originator_id else {
                     tracing::debug!(
@@ -3683,6 +3668,83 @@ mod tests {
                     .pending_triggers
                     .contains_key("trig-race"),
                 "explicitly unregistered binding resurrected as a pending intent"
+            );
+        }
+    }
+
+    /// A provider replacement racing a late rejection from the replaced
+    /// generation. Whatever the interleave, the binding must end live under
+    /// the replacement — never stranded in the pending bucket.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn provider_replacement_racing_late_rejection_never_strands_the_binding() {
+        ensure_default_meter();
+        for _ in 0..100 {
+            let engine = Arc::new(Engine::new());
+
+            let (user_tx, _user_rx) = mpsc::channel::<Outbound>(8);
+            let user = WorkerConnection::new(user_tx);
+            engine.worker_registry.register_worker(user.clone());
+
+            let (old_tx, _old_rx) = mpsc::channel::<Outbound>(8);
+            let old_provider = WorkerConnection::new(old_tx);
+            insert_trigger_type_for(&engine, "http", &old_provider);
+
+            engine.trigger_registry.triggers.insert(
+                "trig-race".to_string(),
+                crate::trigger::Trigger {
+                    id: "trig-race".to_string(),
+                    trigger_type: "http".to_string(),
+                    function_id: "fn-1".to_string(),
+                    config: serde_json::json!({}),
+                    worker_id: Some(user.id),
+                    metadata: None,
+                },
+            );
+
+            let msg = Message::TriggerRegistrationResult {
+                id: "trig-race".to_string(),
+                trigger_type: "http".to_string(),
+                function_id: "fn-1".to_string(),
+                error: Some(crate::protocol::ErrorBody::new("provider_error", "boom")),
+            };
+
+            let (new_tx, _new_rx) = mpsc::channel::<Outbound>(8);
+            let new_provider = WorkerConnection::new(new_tx);
+
+            let reject = {
+                let engine = Arc::clone(&engine);
+                let old_provider = old_provider.clone();
+                tokio::spawn(async move { engine.router_msg(&old_provider, &msg).await })
+            };
+            let replace = {
+                let engine = Arc::clone(&engine);
+                let new_provider = new_provider.clone();
+                tokio::spawn(async move {
+                    engine
+                        .trigger_registry
+                        .register_trigger_type(crate::trigger::TriggerType::new(
+                            "http",
+                            "replacement",
+                            Box::new(new_provider.clone()),
+                            Some(new_provider.id),
+                        ))
+                        .await
+                })
+            };
+
+            reject.await.unwrap().unwrap();
+            replace.await.unwrap().unwrap();
+
+            assert!(
+                engine.trigger_registry.triggers.contains_key("trig-race"),
+                "binding must end live under the replacement provider"
+            );
+            assert!(
+                !engine
+                    .trigger_registry
+                    .pending_triggers
+                    .contains_key("trig-race"),
+                "binding stranded in pending despite a live replacement provider"
             );
         }
     }

--- a/engine/src/trigger.rs
+++ b/engine/src/trigger.rs
@@ -241,6 +241,13 @@ pub struct TriggerRegistry {
     /// (re)registers, at which point they are activated and moved into
     /// `triggers`. Keyed by trigger id, like `triggers`.
     pub pending_triggers: Arc<DashMap<String, Trigger>>,
+    /// Serializes two-map transitions between `triggers` and
+    /// `pending_triggers` (a late-rejection re-park vs an explicit
+    /// unregister). DashMap only makes each map operation atomic; without
+    /// this, a re-park's remove+insert can interleave with an unregister's
+    /// removes and resurrect an explicitly-unregistered binding. Held only
+    /// around the map operations, never across an await.
+    pub park_transition: std::sync::Mutex<()>,
 }
 
 impl TriggerRegistry {
@@ -249,6 +256,7 @@ impl TriggerRegistry {
             trigger_types: Arc::new(DashMap::new()),
             triggers: Arc::new(DashMap::new()),
             pending_triggers: Arc::new(DashMap::new()),
+            park_transition: std::sync::Mutex::new(()),
         }
     }
 
@@ -554,23 +562,33 @@ impl TriggerRegistry {
             trigger_type.as_deref().unwrap_or("<missing>").purple()
         );
 
-        let Some(trigger_entry) = self.triggers.get(&id) else {
-            // A parked intent has no live registration to tear down —
-            // dropping it from the pending bucket is the whole unregister.
-            return Ok(self.pending_triggers.remove(&id).is_some());
+        let trigger = {
+            let _park = self
+                .park_transition
+                .lock()
+                .expect("park_transition lock poisoned");
+            let Some(trigger_entry) = self.triggers.get(&id) else {
+                // A parked intent has no live registration to tear down —
+                // dropping it from the pending bucket is the whole unregister.
+                return Ok(self.pending_triggers.remove(&id).is_some());
+            };
+            trigger_entry.value().clone()
         };
-        let trigger = trigger_entry.value().clone();
-        drop(trigger_entry);
 
         if let Some(tt) = self.trigger_types.get(&trigger.trigger_type) {
             tt.registrator.unregister_trigger(trigger.clone()).await?;
         }
 
-        self.triggers.remove(&id);
-        // A late async rejection may have re-parked this binding while the
-        // registrator call above was in flight; an explicit unregister must
+        // A late async rejection may re-park this binding while the
+        // registrator call above is in flight; an explicit unregister must
         // win over that park or the intent resurrects on the next type
-        // registration.
+        // registration. The transition lock makes this two-map clear atomic
+        // with the re-park's own live-to-pending move.
+        let _park = self
+            .park_transition
+            .lock()
+            .expect("park_transition lock poisoned");
+        self.triggers.remove(&id);
         self.pending_triggers.remove(&id);
 
         Ok(true)

--- a/engine/src/trigger.rs
+++ b/engine/src/trigger.rs
@@ -593,6 +593,48 @@ impl TriggerRegistry {
 
         Ok(true)
     }
+
+    /// Move a live binding to `pending_triggers` after its provider reported
+    /// an async registration error (the caller has already verified the
+    /// reporter owned the trigger type). No-op when the binding is already
+    /// gone — a concurrent disconnect GC or explicit unregister reaped it,
+    /// and parking then would resurrect a dead binding.
+    pub async fn park_rejected_trigger(&self, id: &str, reporter_worker_id: Uuid) {
+        let parked_type = {
+            let _park = self
+                .park_transition
+                .lock()
+                .expect("park_transition lock poisoned");
+            let Some((_, failed)) = self.triggers.remove(id) else {
+                return;
+            };
+            tracing::warn!(
+                trigger_id = %id,
+                trigger_type = %failed.trigger_type,
+                function_id = %failed.function_id,
+                "Trigger registration rejected by provider; parked as pending until the trigger type re-registers"
+            );
+            let trigger_type_id = failed.trigger_type.clone();
+            self.pending_triggers.insert(failed.id.clone(), failed);
+            trigger_type_id
+        };
+
+        // Close the park/replacement race (mirror of the unknown-type park in
+        // `register_trigger`): the reporter's ownership was checked before the
+        // park, but a replacement provider may have registered — and drained
+        // pending intents — in between, which would strand this park until
+        // yet another re-registration. If the type's current owner is no
+        // longer the reporter, claim the intent back (via `remove`, so we
+        // never double-activate with a drain) and activate it through the
+        // current provider. While the reporter still owns the type the park
+        // is intended: replaying would just be rejected again.
+        if let Some(trigger_type) = self.trigger_types.get(&parked_type)
+            && trigger_type.worker_id != Some(reporter_worker_id)
+            && let Some((_, parked)) = self.pending_triggers.remove(id)
+        {
+            self.activate_pending_trigger(&trigger_type, parked).await;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1533,6 +1575,63 @@ mod tests {
         assert!(
             !registry.pending_triggers.contains_key("t1"),
             "explicit unregister must clear a raced re-park, or the intent replays on the next type registration"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_rejection_after_provider_replacement_reactivates_through_current_provider() {
+        let registry = TriggerRegistry::new();
+        let old_provider = Uuid::new_v4();
+        let replacement = Arc::new(ControlledRegistrator::new(false, false));
+        registry
+            .register_trigger_type(TriggerType::new(
+                "webhook",
+                "gen B",
+                Box::new(Arc::clone(&replacement)),
+                Some(Uuid::new_v4()),
+            ))
+            .await
+            .unwrap();
+        registry
+            .triggers
+            .insert("t1".to_string(), make_trigger("t1", "webhook"));
+
+        // The rejection reporter is the replaced generation's worker, not the
+        // current owner: the park must immediately re-activate through the
+        // replacement instead of stranding the binding.
+        registry.park_rejected_trigger("t1", old_provider).await;
+
+        assert!(registry.triggers.contains_key("t1"));
+        assert!(!registry.pending_triggers.contains_key("t1"));
+        assert_eq!(replacement.register_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn rejection_from_current_owner_parks_without_replay_pingpong() {
+        let registry = TriggerRegistry::new();
+        let owner_worker = Uuid::new_v4();
+        let owner = Arc::new(ControlledRegistrator::new(false, false));
+        registry
+            .register_trigger_type(TriggerType::new(
+                "webhook",
+                "Webhook",
+                Box::new(Arc::clone(&owner)),
+                Some(owner_worker),
+            ))
+            .await
+            .unwrap();
+        registry
+            .triggers
+            .insert("t1".to_string(), make_trigger("t1", "webhook"));
+
+        registry.park_rejected_trigger("t1", owner_worker).await;
+
+        assert!(!registry.triggers.contains_key("t1"));
+        assert!(registry.pending_triggers.contains_key("t1"));
+        assert_eq!(
+            owner.register_count.load(Ordering::SeqCst),
+            0,
+            "no replay back to the provider that just rejected the bind"
         );
     }
 

--- a/engine/src/trigger.rs
+++ b/engine/src/trigger.rs
@@ -57,9 +57,10 @@ fn preferred_install_name(provider: &'static str) -> &'static str {
 pub enum RegisterTriggerOutcome {
     /// The trigger type was available and the binding is live.
     Registered,
-    /// The trigger type is not (yet) available. The registration intent is
-    /// parked in [`TriggerRegistry::pending_triggers`] and will be activated
-    /// automatically when the trigger type registers.
+    /// The trigger type is not (yet) available, or the bind could not be
+    /// delivered to its provider (connection closing). The registration
+    /// intent is parked in [`TriggerRegistry::pending_triggers`] and will be
+    /// activated automatically when the trigger type (re)registers.
     Deferred,
 }
 
@@ -165,6 +166,22 @@ impl TriggerType {
     }
 }
 
+/// Marker error for registrator failures where the bind never reached the
+/// provider (its connection channel is closed — the worker is dying or
+/// disconnecting). The registry parks such binds for replay on the next type
+/// (re)registration. Any other registrator error is a provider rejection
+/// (e.g. invalid config): a definitive answer that fails the registration.
+#[derive(Debug)]
+pub struct RegistratorUnavailable;
+
+impl std::fmt::Display for RegistratorUnavailable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("trigger provider connection unavailable")
+    }
+}
+
+impl std::error::Error for RegistratorUnavailable {}
+
 pub trait TriggerRegistrator: Send + Sync {
     fn register_trigger(
         &self,
@@ -216,8 +233,10 @@ impl std::hash::Hash for Trigger {
 pub struct TriggerRegistry {
     pub trigger_types: Arc<DashMap<String, TriggerType>>,
     pub triggers: Arc<DashMap<String, Trigger>>,
-    /// Registration intents whose trigger type is not currently available:
-    /// either it never registered, or its provider worker disconnected. These
+    /// Registration intents whose trigger type is not currently available or
+    /// whose activation did not complete: the type never registered, its
+    /// provider worker disconnected, the bind could not be delivered, or the
+    /// provider asynchronously rejected the activation. These
     /// bindings are disabled (they never fire) until the trigger type
     /// (re)registers, at which point they are activated and moved into
     /// `triggers`. Keyed by trigger id, like `triggers`.
@@ -482,8 +501,28 @@ impl TriggerRegistry {
             .register_trigger(trigger.clone())
             .await
         {
-            tracing::error!(error = %err, "Error registering trigger");
-            return Err(err);
+            if err.downcast_ref::<RegistratorUnavailable>().is_none() {
+                // The provider processed and rejected the bind (e.g. invalid
+                // config): a definitive answer, not a delivery failure. Fail
+                // the registration so callers surface the error, and leave any
+                // previous live registration of this id tracked — the provider
+                // still runs it and it must stay reachable for teardown.
+                tracing::error!(error = %err, "Error registering trigger");
+                return Err(err);
+            }
+            tracing::error!(
+                error = %err,
+                trigger_id = %trigger.id,
+                trigger_type = %trigger.trigger_type,
+                "Trigger provider unreachable; bind parked as pending until the trigger type re-registers"
+            );
+            // Park instead of failing; an undeliverable re-registration
+            // supersedes a previous live binding with the same id (the dying
+            // provider's jobs die with it) — the binding must end in exactly
+            // one bucket.
+            self.triggers.remove(&trigger.id);
+            self.pending_triggers.insert(trigger.id.clone(), trigger);
+            return Ok(RegisterTriggerOutcome::Deferred);
         }
 
         drop(trigger_type);
@@ -528,6 +567,11 @@ impl TriggerRegistry {
         }
 
         self.triggers.remove(&id);
+        // A late async rejection may have re-parked this binding while the
+        // registrator call above was in flight; an explicit unregister must
+        // win over that park or the intent resurrects on the next type
+        // registration.
+        self.pending_triggers.remove(&id);
 
         Ok(true)
     }
@@ -1329,11 +1373,149 @@ mod tests {
         let err = registry
             .register_trigger(make_trigger("t-error", "durable:subscriber"))
             .await
-            .expect_err("register should fail when registrator errors");
+            .expect_err("provider rejection should fail the registration");
 
         assert_eq!(err.to_string(), "register failed");
         assert_eq!(registrator.register_count.load(Ordering::SeqCst), 1);
         assert!(!registry.triggers.contains_key("t-error"));
+        assert!(
+            !registry.pending_triggers.contains_key("t-error"),
+            "a rejected bind must not be parked"
+        );
+    }
+
+    fn closed_channel_connection() -> crate::worker_connections::WorkerConnection {
+        let (tx, rx) = tokio::sync::mpsc::channel::<crate::engine::Outbound>(1);
+        drop(rx);
+        crate::worker_connections::WorkerConnection::new(tx)
+    }
+
+    #[tokio::test]
+    async fn register_trigger_transport_failure_parks_and_next_type_registration_activates() {
+        let registry = TriggerRegistry::new();
+        // Real provider connection whose channel is already closed: the send
+        // fails, which must classify as RegistratorUnavailable and park.
+        let trigger_type = TriggerType::new(
+            "durable:subscriber",
+            "Queue",
+            Box::new(closed_channel_connection()),
+            None,
+        );
+        registry.register_trigger_type(trigger_type).await.unwrap();
+
+        let outcome = registry
+            .register_trigger(make_trigger("t-park", "durable:subscriber"))
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, RegisterTriggerOutcome::Deferred);
+        assert!(!registry.triggers.contains_key("t-park"));
+        assert!(
+            registry.pending_triggers.contains_key("t-park"),
+            "undeliverable bind is parked, not dropped"
+        );
+
+        // Provider heals and re-registers the type: the parked intent activates.
+        let healthy = Arc::new(ControlledRegistrator::new(false, false));
+        let trigger_type = TriggerType::new(
+            "durable:subscriber",
+            "Queue",
+            Box::new(Arc::clone(&healthy)),
+            None,
+        );
+        registry.register_trigger_type(trigger_type).await.unwrap();
+
+        assert_eq!(healthy.register_count.load(Ordering::SeqCst), 1);
+        assert!(registry.pending_triggers.is_empty());
+        assert!(registry.triggers.contains_key("t-park"));
+    }
+
+    #[tokio::test]
+    async fn rejected_reregistration_keeps_existing_live_binding_tracked() {
+        let registry = TriggerRegistry::new();
+        let failing = Arc::new(ControlledRegistrator::new(true, false));
+        registry.trigger_types.insert(
+            "webhook".to_string(),
+            TriggerType::new("webhook", "Webhook", Box::new(Arc::clone(&failing)), None),
+        );
+        registry
+            .triggers
+            .insert("t1".to_string(), make_trigger("t1", "webhook"));
+
+        let result = registry
+            .register_trigger(make_trigger("t1", "webhook"))
+            .await;
+
+        assert!(result.is_err());
+        assert!(
+            registry.triggers.contains_key("t1"),
+            "the previous live registration must stay tracked for teardown"
+        );
+        assert!(!registry.pending_triggers.contains_key("t1"));
+    }
+
+    #[tokio::test]
+    async fn undeliverable_reregistration_of_live_binding_ends_parked_not_split() {
+        let registry = TriggerRegistry::new();
+        registry.trigger_types.insert(
+            "webhook".to_string(),
+            TriggerType::new(
+                "webhook",
+                "Webhook",
+                Box::new(closed_channel_connection()),
+                None,
+            ),
+        );
+        registry
+            .triggers
+            .insert("t1".to_string(), make_trigger("t1", "webhook"));
+
+        let result = registry
+            .register_trigger(make_trigger("t1", "webhook"))
+            .await;
+
+        assert!(matches!(result, Ok(RegisterTriggerOutcome::Deferred)));
+        assert!(
+            !registry.triggers.contains_key("t1"),
+            "stale live entry must not survive; the dying provider's jobs die with it"
+        );
+        assert!(registry.pending_triggers.contains_key("t1"));
+    }
+
+    #[tokio::test]
+    async fn unregister_live_trigger_clears_stale_pending_intent() {
+        // Mid-unregister race state: a late async rejection re-parked the
+        // binding while the registrator unregister call was in flight.
+        let registry = TriggerRegistry::new();
+        let registrator = Arc::new(ControlledRegistrator::new(false, false));
+        registry.trigger_types.insert(
+            "webhook".to_string(),
+            TriggerType::new(
+                "webhook",
+                "Webhook",
+                Box::new(Arc::clone(&registrator)),
+                None,
+            ),
+        );
+        registry
+            .triggers
+            .insert("t1".to_string(), make_trigger("t1", "webhook"));
+        registry
+            .pending_triggers
+            .insert("t1".to_string(), make_trigger("t1", "webhook"));
+
+        let removed = registry
+            .unregister_trigger("t1".to_string(), None)
+            .await
+            .unwrap();
+
+        assert!(removed);
+        assert_eq!(registrator.unregister_count.load(Ordering::SeqCst), 1);
+        assert!(!registry.triggers.contains_key("t1"));
+        assert!(
+            !registry.pending_triggers.contains_key("t1"),
+            "explicit unregister must clear a raced re-park, or the intent replays on the next type registration"
+        );
     }
 
     #[tokio::test]

--- a/engine/src/worker_connections/traits.rs
+++ b/engine/src/worker_connections/traits.rs
@@ -18,7 +18,7 @@ use crate::{
     function::{FunctionHandler, FunctionResult},
     protocol::{ErrorBody, Message},
     telemetry::{inject_baggage_from_context, inject_traceparent_from_context},
-    trigger::{Trigger, TriggerRegistrator},
+    trigger::{RegistratorUnavailable, Trigger, TriggerRegistrator},
     worker_connections::WorkerConnection,
 };
 
@@ -65,10 +65,9 @@ impl TriggerRegistrator for WorkerConnection {
                 .await;
             if let Err(err) = sent {
                 acks.remove(&trigger_id);
-                return Err(anyhow::anyhow!(
-                    "failed to send register trigger message through worker channel: {}",
-                    err
-                ));
+                return Err(anyhow::Error::new(RegistratorUnavailable).context(format!(
+                    "failed to send register trigger message through worker channel: {err}"
+                )));
             }
 
             let Some(rx) = rx else { return Ok(()) };
@@ -96,7 +95,7 @@ impl TriggerRegistrator for WorkerConnection {
     /// triggers would stall the connection until the timeout — the ack can
     /// only be read once the loop is free again. Failures are still handled:
     /// the worker's `TriggerRegistrationResult` takes the late-unwind path in
-    /// `router_msg`, which removes the trigger from the registry.
+    /// `router_msg`, which re-parks the trigger as a pending intent.
     fn replay_trigger(
         &self,
         trigger: Trigger,


### PR DESCRIPTION
## Context

Recoverable triggers (#1962) park a `register_trigger` whose trigger type is not yet registered and activate it when the type appears. MOT-4073 removed all worker-side pending-bind retry machinery on that strength — but a bind that reaches the engine while the type **is** registered and whose activation then fails was **dropped, not parked**, staying silently unbound until the binding worker restarted (e.g. guidance hooks missing from prompts, workflow wake/stamp hooks lost).

## Fix

Reuses the existing park/drain machinery (`pending_triggers` + type-registration drain); no new machinery.

- **Found-type path** (`TriggerRegistry::register_trigger`): a bind whose delivery to the provider fails is parked and returns `Deferred`; the drain re-activates it when the type (re)registers. Delivery failure is classified by a new `RegistratorUnavailable` marker, attached where `WorkerConnection`'s register send fails (provider channel closed — worker dying/disconnecting). Provider **rejections** (e.g. invalid config from the in-process cron/http/queue/… registrators) still fail synchronously: failure acks and `trigger_registration_failed` are unchanged, and a rejected re-registration keeps the previous live registration of the same id tracked for teardown.
- **Async registrator error** (`router_msg` handling `TriggerRegistrationResult`): the bind is re-parked instead of removed (fire-and-forget binds have no other recovery channel); the error is still forwarded to the originator.
- **Unregister vs late rejection race**: `unregister_trigger`'s live path now also clears `pending_triggers`, so an explicit unregister wins over a concurrent late-rejection re-park in every interleaving.

## Behavior changes

- A bind whose provider connection is closing now defers silently (matching unknown-type behavior) instead of erroring, and recovers when the provider re-registers the type.
- An async provider rejection parks the bind for replay on the next type registration; the error is still forwarded to the originator.

## Tests

- `register_trigger_transport_failure_parks_and_next_type_registration_activates` — park + heal through a real closed-channel `WorkerConnection`, exercising the marker classification end to end
- `undeliverable_reregistration_of_live_binding_ends_parked_not_split` — live-XOR-parked invariant on an undeliverable re-registration
- `rejected_reregistration_keeps_existing_live_binding_tracked` — a rejection never untracks the previous live activation
- `test_register_trigger_propagates_registrator_error` — rejections still fail and are never parked
- `unregister_live_trigger_clears_stale_pending_intent` — explicit unregister clears a raced re-park
- `test_trigger_registration_result_error_forwards_parks_and_replays` — async rejection forwards the error, parks, and replays to the reconnected provider over real connection channels

`cargo test -p iii --lib`: 1964 passed. Changed-line coverage verified with `cargo llvm-cov` (all functional lines hit; the only unhit line is the empty fall-through of the concurrent-reap guard, a cross-thread race window with no await points).

Fixes MOT-4081

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failed trigger registrations are now safely parked and replayed after the trigger type/provider is available again.
  * Undeliverable provider-connection issues are treated as deferred/parkable instead of being lost permanently.
  * Definitive provider rejections still surface as errors and are not retried.
  * Trigger unregistrations are now race-safe, preventing late failures from resurrecting bindings.
* **Tests**
  * Updated and expanded coverage for park-and-replay behavior and concurrent unregister/replacement vs. late rejections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->