### PR TITLE
Show install command in alpha release notes

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -284,6 +284,12 @@ jobs:
           draft: false
           prerelease: true
           generate_release_notes: false
+          body: |
+            ## Install
+
+            ```sh
+            curl -fsSL https://install.iii.dev/iii/main/install.sh | III_RELEASE_TAG=${{ needs.prepare.outputs.tag }} sh
+            ```
 
   init-build:
     name: Build iii-init (${{ matrix.target }})


### PR DESCRIPTION
## Summary

- add an Install section to alpha GitHub prereleases
- interpolate the exact alpha release tag into `III_RELEASE_TAG`

## Why

Alpha release pages currently do not show how to install the corresponding prerelease. This makes the exact install command available directly on each release page.

## Impact

Users can copy the command from an alpha release and install that exact engine version. Stable release behavior is unchanged.

## Validation

- parsed `.github/workflows/alpha-release.yml` successfully with PyYAML
- verified the generated release body contains the expected install command
- ran `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Alpha releases now include an **Install** section with a ready-to-run command for installing the corresponding prerelease version.
  * The installation command automatically targets the specific alpha release tag, helping ensure the intended version is installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->