### PR TITLE
Show package install commands in alpha releases

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -287,8 +287,44 @@ jobs:
           body: |
             ## Install
 
+            ### Engine
+
             ```sh
             curl -fsSL https://install.iii.dev/iii/main/install.sh | III_RELEASE_TAG=${{ needs.prepare.outputs.tag }} sh
+            ```
+
+            ### Node.js
+
+            ```sh
+            pnpm add \
+              iii-sdk@${{ needs.prepare.outputs.version }} \
+              iii-browser-sdk@${{ needs.prepare.outputs.version }} \
+              @iii-dev/helpers@${{ needs.prepare.outputs.version }} \
+              @iii-dev/observability@${{ needs.prepare.outputs.version }}
+            ```
+
+            ### Python
+
+            ```sh
+            pip install \
+              iii-sdk==${{ needs.prepare.outputs.python_version }} \
+              iii-helpers==${{ needs.prepare.outputs.python_version }} \
+              iii-observability==${{ needs.prepare.outputs.python_version }}
+            ```
+
+            ### Rust
+
+            ```sh
+            cargo add \
+              iii-sdk@${{ needs.prepare.outputs.version }} \
+              iii-helpers@${{ needs.prepare.outputs.version }} \
+              iii-observability@${{ needs.prepare.outputs.version }}
+            ```
+
+            ### Go
+
+            ```sh
+            go get github.com/iii-hq/iii/sdk/packages/go/iii@v${{ needs.prepare.outputs.version }}
             ```
 
   init-build:


### PR DESCRIPTION
## Summary

- group alpha release install commands by ecosystem
- list every npm, PyPI, crates.io, and Go package published by the alpha workflow
- use the PEP 440 version output for Python and the semantic version output for Node.js, Rust, and Go

## Why

Alpha release pages only showed how to install the engine. Consumers had to infer package names and prerelease versions for the SDKs and supporting libraries.

## Impact

Each alpha release page now provides copyable commands for the engine and all 10 published SDK packages across Node.js, Python, Rust, and Go. Stable release behavior is unchanged.

## Validation

- parsed `.github/workflows/alpha-release.yml` successfully with PyYAML
- verified every published package appears in the correct ecosystem section
- rendered and checked an example using `0.21.6-alpha.3` and Python version `0.21.6a3`
- checked local CLI syntax for `pnpm add`, `cargo add`, and `go get`
- ran `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded alpha release notes with installation instructions for Engine, Node.js, Python, Rust, and Go.
  * Added version-specific commands for installing or adding the generated alpha release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->