### PR TITLE
fix(iii-worker): hostless worker add from a non-project dir targets the running engine (MOT-4091)

### DIFF
--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -32,7 +32,9 @@ pub struct AddArgs {
     /// also accepted and used as-is) and invokes its worker::add. The
     /// engine applies the add in ITS project directory, so this works from
     /// any folder and with engines on non-default ports. Local worker PATHs
-    /// resolve on the engine host.
+    /// resolve on the engine host. When omitted and the current directory
+    /// has no config file, falls back to `--host localhost` — the running
+    /// local engine — instead of creating an orphan config file here.
     #[arg(long, value_name = "HOST[:PORT]")]
     pub host: Option<String>,
 }

--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -33,8 +33,8 @@ pub struct AddArgs {
     /// engine applies the add in ITS project directory, so this works from
     /// any folder and with engines on non-default ports. Local worker PATHs
     /// resolve on the engine host. When omitted and the current directory
-    /// has no config file, falls back to `--host localhost` — the running
-    /// local engine — instead of creating an orphan config file here.
+    /// has no config file, falls back to `--host localhost` (the running
+    /// local engine) instead of creating an orphan config file here.
     #[arg(long, value_name = "HOST[:PORT]")]
     pub host: Option<String>,
 }

--- a/crates/iii-worker/src/cli/remote_ops.rs
+++ b/crates/iii-worker/src/cli/remote_ops.rs
@@ -12,11 +12,36 @@
 //! artifacts, locks — so the CLI can run from any directory (or machine)
 //! that can reach the engine. Without `--host`, `iii worker add` edits the
 //! config file in the current directory and only a same-directory engine
-//! picks the change up.
+//! picks the change up — unless the current directory has no config file
+//! at all, in which case [`implicit_host_fallback`] routes the op to the
+//! default local engine instead.
 
 use colored::Colorize;
 
 use crate::core::{AddOptions, AddOutcome};
+
+/// Implicit `--host localhost` for hostless ops in a NON-project cwd
+/// (MOT-4091): with no config file here (and no engine-exported
+/// `III_CONFIG_PATH`), a local edit would create an orphan config file no
+/// engine watches, then hang waiting for a worker that never boots. Prints
+/// a note so the redirect is never silent. `None` means "edit local files
+/// as before" — the cwd is a project, or is unresolvable (the local path
+/// reports that error itself).
+pub fn implicit_host_fallback() -> Option<String> {
+    let cwd = std::env::current_dir().ok()?;
+    if crate::core::project::local_config_present(&cwd) {
+        return None;
+    }
+    eprintln!(
+        "{} no config file in {} — installing through the engine at localhost:{} instead.\n  \
+         Run from your project directory to edit a local config, or pass --host to target \
+         another engine.",
+        "note:".cyan(),
+        cwd.display(),
+        super::app::DEFAULT_PORT,
+    );
+    Some("localhost".to_string())
+}
 
 /// Turn a `--host` value into an engine WebSocket URL.
 ///
@@ -159,8 +184,10 @@ fn remote_error_message(e: &iii_sdk::Error) -> String {
 
 /// Install workers through the engine at `host`. `adds` pairs the
 /// user-facing label (the argv token) with the fully-built options shipped
-/// to `worker::add`. Returns a process exit code.
-pub async fn handle_remote_add(host: &str, adds: Vec<(String, AddOptions)>) -> i32 {
+/// to `worker::add`. `implicit` marks the [`implicit_host_fallback`] path —
+/// the user never typed `--host`, so unreachable-engine guidance must not
+/// tell them to fix it. Returns a process exit code.
+pub async fn handle_remote_add(host: &str, adds: Vec<(String, AddOptions)>, implicit: bool) -> i32 {
     let url = match host_to_ws_url(host) {
         Ok(url) => url,
         Err(e) => {
@@ -170,11 +197,14 @@ pub async fn handle_remote_add(host: &str, adds: Vec<(String, AddOptions)>) -> i
     };
 
     if let Err(e) = check_engine_reachable(&url).await {
-        eprintln!(
-            "{} {}\n  Start the engine there first (`iii`), or fix --host.",
-            "error:".red(),
-            e
-        );
+        let hint = if implicit {
+            "No config file here and no engine on this machine: run this from your project \
+             directory (or start the engine there with `iii`), or pass --host to target a \
+             remote engine."
+        } else {
+            "Start the engine there first (`iii`), or fix --host."
+        };
+        eprintln!("{} {}\n  {}", "error:".red(), e, hint);
         return 1;
     }
 

--- a/crates/iii-worker/src/core/project.rs
+++ b/crates/iii-worker/src/core/project.rs
@@ -120,6 +120,23 @@ impl ProjectCtx {
     }
 }
 
+/// True when worker ops have a local config target: the engine exported
+/// `III_CONFIG_PATH` (its value wins over cwd probing — see
+/// [`ProjectCtx::config_path`]) or `root` already holds a config candidate.
+/// When false, a hostless `iii worker add` has nothing here to edit —
+/// writing anyway would create an orphan config file no engine watches,
+/// then hang waiting for a worker that never boots (MOT-4091).
+pub fn local_config_present(root: &Path) -> bool {
+    if let Some(p) = std::env::var_os("III_CONFIG_PATH")
+        && !p.is_empty()
+    {
+        return true;
+    }
+    CONFIG_CANDIDATES
+        .iter()
+        .any(|name| root.join(name).exists())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -194,6 +211,38 @@ mod tests {
         std::fs::write(dir.path().join("config.yaml"), "workers: []\n").unwrap();
         let ctx = ProjectCtx::open_unlocked(dir.path().to_path_buf());
         assert_eq!(ctx.config_path(), dir.path().join("iii.config.yaml"));
+    }
+
+    #[test]
+    fn local_config_present_false_for_empty_dir() {
+        let dir = TempDir::new().unwrap();
+        assert!(!local_config_present(dir.path()));
+    }
+
+    #[test]
+    fn local_config_present_true_for_either_candidate() {
+        let canonical = TempDir::new().unwrap();
+        std::fs::write(canonical.path().join("iii.config.yaml"), "workers: []\n").unwrap();
+        assert!(local_config_present(canonical.path()));
+
+        let legacy = TempDir::new().unwrap();
+        std::fs::write(legacy.path().join("config.yaml"), "workers: []\n").unwrap();
+        assert!(local_config_present(legacy.path()));
+    }
+
+    #[test]
+    fn local_config_present_true_when_env_points_elsewhere() {
+        // The engine exports III_CONFIG_PATH to every process it spawns;
+        // ops then target that file, so an empty cwd is still "local".
+        let dir = TempDir::new().unwrap();
+        let prior = std::env::var_os("III_CONFIG_PATH");
+        unsafe { std::env::set_var("III_CONFIG_PATH", "/srv/proj/config.yml") };
+        let present = local_config_present(dir.path());
+        match prior {
+            Some(v) => unsafe { std::env::set_var("III_CONFIG_PATH", v) },
+            None => unsafe { std::env::remove_var("III_CONFIG_PATH") },
+        }
+        assert!(present);
     }
 
     #[test]

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -123,7 +123,13 @@ async fn async_main() -> anyhow::Result<()> {
             // --host: route the add through the target engine's worker::add
             // trigger. The engine host edits ITS config file and installs
             // artifacts there — nothing in the CLI's cwd is touched.
-            if let Some(host) = args.host.as_deref() {
+            // Hostless from a non-project directory falls back to the
+            // default local engine (MOT-4091).
+            let host_flag = args
+                .host
+                .clone()
+                .or_else(iii_worker::cli::remote_ops::implicit_host_fallback);
+            if let Some(host) = host_flag.as_deref() {
                 let adds = args
                     .worker_names
                     .iter()
@@ -139,7 +145,9 @@ async fn async_main() -> anyhow::Result<()> {
                         )
                     })
                     .collect();
-                let rc = iii_worker::cli::remote_ops::handle_remote_add(host, adds).await;
+                let rc =
+                    iii_worker::cli::remote_ops::handle_remote_add(host, adds, args.host.is_none())
+                        .await;
                 std::process::exit(rc);
             }
 
@@ -253,8 +261,13 @@ async fn async_main() -> anyhow::Result<()> {
             use iii_worker::cli::stderr_sink::StderrSink;
             use iii_worker::core::{AddOptions, ProjectCtx, add as core_add};
 
-            // Reinstall is `add --force`; same --host routing as Add.
-            if let Some(host) = args.host.as_deref() {
+            // Reinstall is `add --force`; same --host routing (and
+            // non-project-cwd fallback, MOT-4091) as Add.
+            let host_flag = args
+                .host
+                .clone()
+                .or_else(iii_worker::cli::remote_ops::implicit_host_fallback);
+            if let Some(host) = host_flag.as_deref() {
                 let adds = args
                     .worker_names
                     .iter()
@@ -270,7 +283,9 @@ async fn async_main() -> anyhow::Result<()> {
                         )
                     })
                     .collect();
-                let rc = iii_worker::cli::remote_ops::handle_remote_add(host, adds).await;
+                let rc =
+                    iii_worker::cli::remote_ops::handle_remote_add(host, adds, args.host.is_none())
+                        .await;
                 std::process::exit(rc);
             }
 

--- a/crates/iii-worker/tests/worker_integration.rs
+++ b/crates/iii-worker/tests/worker_integration.rs
@@ -211,6 +211,10 @@ fn add_subcommand_multiple_workers() {
 #[test]
 fn add_prefixed_builtin_prints_deprecation_warning_and_replacement() {
     let temp = tempfile::tempdir().expect("failed to create isolated temp directory");
+    // A config file keeps the add on the local path — without one, hostless
+    // add falls back to the running engine (MOT-4091) and this test would
+    // depend on whatever listens on the default port.
+    std::fs::write(temp.path().join("config.yaml"), "workers: []\n").unwrap();
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_iii-worker"))
         .args(["add", "iii-http", "--no-wait"])
         .current_dir(temp.path())
@@ -233,6 +237,35 @@ fn add_prefixed_builtin_prints_deprecation_warning_and_replacement() {
     assert!(
         stderr.contains("iii worker add http"),
         "stderr was:\n{stderr}"
+    );
+}
+
+/// MOT-4091: hostless `add` from a directory with no config file must not
+/// create one there — it redirects to the default local engine instead.
+/// The bogus worker name makes the op fail identically whether or not an
+/// engine happens to listen on the default port (connection refused vs.
+/// engine-side not-found), so the assertions are environment-independent.
+#[test]
+fn add_from_non_project_dir_redirects_and_leaves_cwd_untouched() {
+    let temp = tempfile::tempdir().expect("failed to create isolated temp directory");
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_iii-worker"))
+        .args(["add", "definitely-not-a-worker-mot4091", "--no-wait"])
+        .current_dir(temp.path())
+        .env("HOME", temp.path())
+        .env("NO_COLOR", "1")
+        .env_remove("III_CONFIG_PATH")
+        .output()
+        .expect("failed to execute iii-worker binary");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "stderr was:\n{stderr}");
+    assert!(
+        stderr.contains("no config file in"),
+        "expected the fallback note, stderr was:\n{stderr}"
+    );
+    assert!(
+        !temp.path().join("iii.config.yaml").exists() && !temp.path().join("config.yaml").exists(),
+        "hostless add from a non-project dir must not create a config file"
     );
 }
 

--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -164,7 +164,7 @@ iii worker add [OPTIONS] <WORKER[@VERSION]|PATH>...
 | Option | Description |
 | ------ | ----------- |
 | `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block), instead of keeping the existing entry. With `add`, takes effect only together with `--force`; `reinstall` applies force automatically |
-| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host. When omitted and the current directory has no config file, falls back to `--host localhost` — the running local engine — instead of creating an orphan config file here |
+| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host. When omitted and the current directory has no config file, falls back to `--host localhost` (the running local engine) instead of creating an orphan config file here |
 | `-f, --force` | Force re-download: delete existing artifacts before adding |
 | `--no-wait` | Don't block waiting for the engine to finish booting the worker |
 
@@ -264,7 +264,7 @@ iii worker reinstall [OPTIONS] <WORKER[@VERSION]|PATH>...
 | Option | Description |
 | ------ | ----------- |
 | `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block), instead of keeping the existing entry. With `add`, takes effect only together with `--force`; `reinstall` applies force automatically |
-| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host. When omitted and the current directory has no config file, falls back to `--host localhost` — the running local engine — instead of creating an orphan config file here |
+| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host. When omitted and the current directory has no config file, falls back to `--host localhost` (the running local engine) instead of creating an orphan config file here |
 
 ### `iii worker remove`
 

--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -164,7 +164,7 @@ iii worker add [OPTIONS] <WORKER[@VERSION]|PATH>...
 | Option | Description |
 | ------ | ----------- |
 | `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block), instead of keeping the existing entry. With `add`, takes effect only together with `--force`; `reinstall` applies force automatically |
-| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host |
+| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host. When omitted and the current directory has no config file, falls back to `--host localhost` — the running local engine — instead of creating an orphan config file here |
 | `-f, --force` | Force re-download: delete existing artifacts before adding |
 | `--no-wait` | Don't block waiting for the engine to finish booting the worker |
 
@@ -264,7 +264,7 @@ iii worker reinstall [OPTIONS] <WORKER[@VERSION]|PATH>...
 | Option | Description |
 | ------ | ----------- |
 | `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block), instead of keeping the existing entry. With `add`, takes effect only together with `--force`; `reinstall` applies force automatically |
-| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host |
+| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host. When omitted and the current directory has no config file, falls back to `--host localhost` — the running local engine — instead of creating an orphan config file here |
 
 ### `iii worker remove`
 

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -162,7 +162,7 @@ iii worker add [OPTIONS] <WORKER[@VERSION]|PATH>...
 | Option | Description |
 | ------ | ----------- |
 | `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block), instead of keeping the existing entry. With `add`, takes effect only together with `--force`; `reinstall` applies force automatically |
-| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host |
+| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host. When omitted and the current directory has no config file, falls back to `--host localhost` — the running local engine — instead of creating an orphan config file here |
 | `-f, --force` | Force re-download: delete existing artifacts before adding |
 | `--no-wait` | Don't block waiting for the engine to finish booting the worker |
 
@@ -262,7 +262,7 @@ iii worker reinstall [OPTIONS] <WORKER[@VERSION]|PATH>...
 | Option | Description |
 | ------ | ----------- |
 | `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block), instead of keeping the existing entry. With `add`, takes effect only together with `--force`; `reinstall` applies force automatically |
-| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host |
+| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host. When omitted and the current directory has no config file, falls back to `--host localhost` — the running local engine — instead of creating an orphan config file here |
 
 ### `iii worker remove`
 

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -162,7 +162,7 @@ iii worker add [OPTIONS] <WORKER[@VERSION]|PATH>...
 | Option | Description |
 | ------ | ----------- |
 | `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block), instead of keeping the existing entry. With `add`, takes effect only together with `--force`; `reinstall` applies force automatically |
-| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host. When omitted and the current directory has no config file, falls back to `--host localhost` — the running local engine — instead of creating an orphan config file here |
+| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host. When omitted and the current directory has no config file, falls back to `--host localhost` (the running local engine) instead of creating an orphan config file here |
 | `-f, --force` | Force re-download: delete existing artifacts before adding |
 | `--no-wait` | Don't block waiting for the engine to finish booting the worker |
 
@@ -262,7 +262,7 @@ iii worker reinstall [OPTIONS] <WORKER[@VERSION]|PATH>...
 | Option | Description |
 | ------ | ----------- |
 | `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block), instead of keeping the existing entry. With `add`, takes effect only together with `--force`; `reinstall` applies force automatically |
-| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host. When omitted and the current directory has no config file, falls back to `--host localhost` — the running local engine — instead of creating an orphan config file here |
+| `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host. When omitted and the current directory has no config file, falls back to `--host localhost` (the running local engine) instead of creating an orphan config file here |
 
 ### `iii worker remove`
 

--- a/docs/next/using-iii/workers.mdx
+++ b/docs/next/using-iii/workers.mdx
@@ -105,6 +105,11 @@ iii worker add pdfkit --host localhost:49134
 With `--host` the CLI calls the engine's `worker::add` trigger and the engine applies the install
 in its own project directory; nothing in your current folder is touched.
 
+Running `iii worker add` from a directory with **no** config file does not create one there:
+the command falls back to `--host localhost` and installs through the engine running on your
+machine, printing a note that it did so. Only a directory that already holds a config file (or
+an explicit `--host`) decides where the install lands.
+
 <Note>
   `iii worker add` downloads worker images from remote repositories (the iii registry or an OCI
   registry) or from a local folder, then runs them in a microVM. A bare reference such as

--- a/docs/next/using-iii/workers.mdx.skill.md
+++ b/docs/next/using-iii/workers.mdx.skill.md
@@ -90,6 +90,11 @@ iii worker add pdfkit --host localhost:49134
 With `--host` the CLI calls the engine's `worker::add` trigger and the engine applies the install
 in its own project directory; nothing in your current folder is touched.
 
+Running `iii worker add` from a directory with **no** config file does not create one there:
+the command falls back to `--host localhost` and installs through the engine running on your
+machine, printing a note that it did so. Only a directory that already holds a config file (or
+an explicit `--host`) decides where the install lands.
+
 <Note>
   `iii worker add` downloads worker images from remote repositories (the iii registry or an OCI
   registry) or from a local folder, then runs them in a microVM. A bare reference such as


### PR DESCRIPTION
## Problem

Follow-up to #1970 (MOT-4091). `iii worker add` without `--host`, run from a directory holding no config file, still edited the CLI's cwd: it created a fresh `iii.config.yaml` no engine was watching, then hung up to 120s waiting for a worker that would never boot.

## Solution

- Hostless `add` (and `reinstall`, which shares the path) from a **non-project** directory now falls back to `--host localhost` — installing through the running local engine's `worker::add` trigger — and prints a note saying so:

  ```
  note: no config file in /some/dir — installing through the engine at localhost:49134 instead.
    Run from your project directory to edit a local config, or pass --host to target another engine.
  ```

- "Non-project" means: no `iii.config.yaml` / `config.yaml` in the cwd **and** no engine-exported `III_CONFIG_PATH`. A directory with a config file, an exported `III_CONFIG_PATH`, or an explicit `--host` all behave exactly as before.
- When the fallback engine is unreachable, the error tells the user to run from their project directory or pass `--host`, instead of the explicit-path hint "fix --host" for a flag they never typed.
- New `core::project::local_config_present()` makes the decision; `cli::remote_ops::implicit_host_fallback()` applies it.

## Verification

- Unit tests for `local_config_present` (empty dir, either config candidate, `III_CONFIG_PATH` set); all 954 `iii-worker` lib tests pass.
- Live with the built binary:
  - empty dir → note printed, routed to `ws://localhost:49134`, **nothing created in the cwd**, exit 1 on failure;
  - dir with `config.yaml` → local path, no note;
  - empty dir with `III_CONFIG_PATH` set → local path, no note;
  - explicit `--host` to a dead port → unchanged fail-fast hint.
- `docs/next/cli-reference` regenerated via `scripts/generate-cli-docs.sh`; `workers.mdx` prose updated and both `.skill.md` artifacts re-rendered with `iii-skill-render`.

> Testing from source: `iii worker …` dispatches to the separately installed `iii-worker` binary — run `make install-iii-worker` so the fallback is actually in the binary on PATH.

## Demo

Live terminal session against a running engine (custom config path, started from another directory): hostless `iii worker add pubsub` from an empty `/tmp` dir prints the fallback note, installs through `ws://localhost:49134`, the engine's own config hot-reloads — and the cwd stays untouched.

![MOT-4091 live demo](https://raw.githubusercontent.com/iii-hq/iii/653eb2d793598a38aa71aed65c8693a41498db17/mot-4091-evidence.gif)

<sub>GIF hosted on the non-merging `assets/mot-4091-demo` branch; asciinema source in the comments below.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `iii worker add` and `iii worker reinstall` now fall back to the local engine (`--host localhost`) when `--host` is omitted and no local config exists.
  - Prevents creating orphan `iii.config.yaml` / `config.yaml` when run outside a project directory.

- **Bug Fixes**
  - Refined error/hint messaging for hostless (implicit) operations, including clearer “run in project dir or use `--host`” guidance.

- **Documentation**
  - Updated `--host` option docs and worker guidance to match the new fallback behavior.

- **Tests**
  - Added/adjusted integration tests for non-project runs and verified the working directory remains untouched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
