### PR TITLE
fix(engine,sdk): worker reconnect ownership kill loop (MOT-4025, iii#1975)

### DIFF
--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -46,6 +46,11 @@ const MTRC_WS_PREFIX: &[u8] = b"MTRC";
 /// Magic prefix for logs binary frames (used by SDKs for OTEL logs)
 const LOGS_WS_PREFIX: &[u8] = b"LOGS";
 
+/// How long a `Reattach` waits for the evicted previous connection's read
+/// loop to exit and finish its own cleanup before tearing the connection
+/// down directly (wedged reader guard).
+const REATTACH_EVICT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// Function provided by the standalone `queue` worker for named enqueue
 /// actions. The engine owns receipt generation and uses this function only as
 /// the durable transport boundary.
@@ -1412,6 +1417,74 @@ impl Engine {
 
                 Ok(())
             }
+            Message::Reattach {
+                previous_worker_id,
+                reattach_token,
+            } => {
+                // First message of a reconnect replay: the worker presents
+                // the identity of its previous connection so the engine can
+                // retire it before processing the replayed registrations
+                // that follow on this sequential read loop — they must land
+                // on a clean slate instead of racing the old connection's
+                // cleanup (the reconnect ownership kill loop).
+                let Ok(prev) = Uuid::parse_str(previous_worker_id) else {
+                    tracing::warn!(
+                        worker_id = %worker.id,
+                        previous_worker_id = %previous_worker_id,
+                        "Reattach with malformed previous worker id; ignoring"
+                    );
+                    return Ok(());
+                };
+                if prev == worker.id {
+                    return Ok(());
+                }
+                let Some(old) = self.worker_registry.get_worker(&prev) else {
+                    return Ok(());
+                };
+                // Worker ids are public (engine::workers::list, the
+                // workers-available trigger), so the id alone must never be
+                // able to evict a live worker. The token was only ever sent
+                // over the previous connection's own socket — presenting it
+                // proves this is the same worker reconnecting.
+                if reattach_token.as_deref() != Some(old.reattach_token.to_string().as_str()) {
+                    tracing::warn!(
+                        worker_id = %worker.id,
+                        previous_worker = %prev,
+                        "Reattach with wrong or missing token; ignoring"
+                    );
+                    return Ok(());
+                }
+                tracing::info!(
+                    new_worker = %worker.id,
+                    previous_worker = %prev,
+                    "Reattach: retiring previous connection of reconnected worker"
+                );
+                // Evict FIRST: the old read loop exits at its next poll
+                // (biased select checks eviction before draining more
+                // frames), discarding any still-buffered stale
+                // registrations, and its exit path runs the connection's
+                // cleanup. Await that cleanup's COMPLETION — running it here
+                // concurrently with a still-draining reader could snapshot
+                // before an in-flight registration commits and orphan it.
+                old.evict.notify_one();
+                let cleaned = if old.has_reader.load(std::sync::atomic::Ordering::SeqCst) {
+                    let mut done = old.cleanup_done.subscribe();
+                    matches!(
+                        tokio::time::timeout(REATTACH_EVICT_TIMEOUT, done.wait_for(|d| *d)).await,
+                        Ok(Ok(_))
+                    )
+                } else {
+                    false
+                };
+                if !cleaned {
+                    // No reader on this connection (or it is wedged
+                    // mid-message): tear down directly. The ownership guards
+                    // in the release paths keep any late stale write from
+                    // clobbering the replay that follows.
+                    self.cleanup_worker(&old).await;
+                }
+                Ok(())
+            }
             Message::Ping => {
                 self.send_msg(worker, Message::Pong).await;
                 Ok(())
@@ -1507,15 +1580,23 @@ impl Engine {
         });
 
         let worker = WorkerConnection::with_session(tx.clone(), session);
+        // Mark before registering: from the moment this connection is
+        // discoverable, a Reattach targeting it can rely on this read loop
+        // to exit on eviction and run the cleanup.
+        worker
+            .has_reader
+            .store(true, std::sync::atomic::Ordering::SeqCst);
 
         tracing::debug!(worker_id = %worker.id, peer = %peer, "Assigned worker ID");
         self.worker_registry.register_worker(worker.clone());
 
-        // Send worker ID back to the worker
+        // Send worker ID back to the worker, along with the secret it must
+        // present to reattach (retire this connection) after a reconnect.
         self.send_msg(
             &worker,
             Message::WorkerRegistered {
                 worker_id: worker.id.to_string(),
+                reattach_token: Some(worker.reattach_token.to_string()),
             },
         )
         .await;
@@ -1529,6 +1610,20 @@ impl Engine {
 
         loop {
             tokio::select! {
+                // `biased` + eviction first: once a reattaching successor
+                // evicts this connection, the loop must exit at the very next
+                // iteration instead of draining more buffered frames — a
+                // stale registration replayed from this socket after eviction
+                // would re-claim ids for a retired identity.
+                biased;
+                _ = worker.evict.notified() => {
+                    tracing::info!(worker_id = %worker.id, peer = %peer, "Worker evicted by reattaching successor");
+                    break;
+                }
+                _ = shutdown_rx.changed() => {
+                    tracing::info!(peer = %peer, "Shutdown signal received, closing worker connection");
+                    break;
+                }
                 frame = ws_rx.next() => {
                     match frame {
                         Some(Ok(WsMessage::Text(text))) => {
@@ -1564,10 +1659,6 @@ impl Engine {
                             break;
                         }
                     }
-                }
-                _ = shutdown_rx.changed() => {
-                    tracing::info!(peer = %peer, "Shutdown signal received, closing worker connection");
-                    break;
                 }
             }
         }
@@ -1653,6 +1744,24 @@ impl Engine {
     }
 
     async fn cleanup_worker(&self, worker: &WorkerConnection) {
+        // Run this connection's teardown exactly once, with COMPLETION
+        // visible to every caller: the loser of the claim waits for the
+        // winner to finish instead of returning early. "cleanup_worker
+        // returned" must always mean "the slate is clean" — a reattach that
+        // returned while a concurrent exit-path teardown was still mid-flight
+        // would let the successor's replay race the remaining removals, which
+        // is exactly the bug this path exists to close. No double
+        // worker_disconnected trigger, no double death metrics.
+        if worker
+            .cleanup_claimed
+            .swap(true, std::sync::atomic::Ordering::SeqCst)
+        {
+            tracing::debug!(worker_id = %worker.id, "Cleanup already running or done; awaiting completion");
+            let mut done = worker.cleanup_done.subscribe();
+            let _ = done.wait_for(|done| *done).await;
+            return;
+        }
+
         let regular_functions = worker.get_regular_function_ids().await;
         let external_functions = worker.get_external_function_ids().await;
 
@@ -1744,6 +1853,7 @@ impl Engine {
         self.fire_triggers(TRIGGER_WORKERS_AVAILABLE, workers_data)
             .await;
 
+        worker.cleanup_done.send_replace(true);
         tracing::debug!(worker_id = %worker.id, "Worker triggers unregistered");
     }
 
@@ -1787,19 +1897,21 @@ impl Engine {
 
     /// Atomically removes `function_id` from the engine ONLY if `worker_id`
     /// is still the recorded owner. Returns true if the removal occurred.
-    /// `DashMap::remove_if` gives compare-and-swap semantics: no other thread
-    /// can race the predicate against the actual remove, which closes the
-    /// TOCTOU window a check-then-remove pair would leave between reading
-    /// ownership and `remove_function_from_engine`.
+    /// Holds the `function_owners` entry (shard write lock) across the
+    /// engine-global removal: `claim_function`'s `insert` serializes behind
+    /// the same lock, so a racing claim can never land between the ownership
+    /// check and `remove_function_from_engine` — the window that let a stale
+    /// connection's cleanup delete its reconnected successor's fresh
+    /// registration. NOTE: `remove_function_from_engine` must never touch
+    /// `function_owners`, or this deadlocks.
     fn release_function_if_owner(&self, worker_id: &Uuid, function_id: &str) -> bool {
-        let removed = self
-            .function_owners
-            .remove_if(function_id, |_, owner| owner == worker_id);
-        if removed.is_some() {
-            self.remove_function_from_engine(function_id);
-            true
-        } else {
-            false
+        match self.function_owners.entry(function_id.to_string()) {
+            dashmap::mapref::entry::Entry::Occupied(entry) if entry.get() == worker_id => {
+                self.remove_function_from_engine(function_id);
+                entry.remove();
+                true
+            }
+            _ => false,
         }
     }
 
@@ -3476,6 +3588,7 @@ mod tests {
 
         let msg = Message::WorkerRegistered {
             worker_id: "some-worker-id".to_string(),
+            reattach_token: None,
         };
 
         engine
@@ -4466,6 +4579,355 @@ mod tests {
                 *owner, new_worker.id,
                 "the new worker should be the recorded owner after the race"
             );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_reattach_evicts_old_worker_and_cleanup_is_idempotent() {
+        // Reconnect kill loop fix (iii-hq/iii#1975): a reconnecting worker
+        // presents its previous connection's id + reattach token via
+        // `Message::Reattach`. With no reader attached, the engine must
+        // retire the old connection directly (so the replay lands on a clean
+        // slate) and signal eviction; a later exit-path `cleanup_worker`
+        // must then be a completed no-op.
+        ensure_default_meter();
+        let engine = Engine::new();
+
+        // OLD connection registers fn1.
+        let (tx_old, _rx_old) = mpsc::channel::<Outbound>(8);
+        let old_worker = WorkerConnection::new(tx_old);
+        engine.worker_registry.register_worker(old_worker.clone());
+        engine
+            .router_msg(
+                &old_worker,
+                &Message::RegisterFunction {
+                    id: "fn1".to_string(),
+                    description: None,
+                    request_format: None,
+                    response_format: None,
+                    metadata: None,
+                    invocation: None,
+                },
+            )
+            .await
+            .expect("old register");
+        assert!(engine.functions.get("fn1").is_some());
+
+        // NEW connection reattaches, presenting the old worker's id + token.
+        let (tx_new, _rx_new) = mpsc::channel::<Outbound>(8);
+        let new_worker = WorkerConnection::new(tx_new);
+        engine.worker_registry.register_worker(new_worker.clone());
+        engine
+            .router_msg(
+                &new_worker,
+                &Message::Reattach {
+                    previous_worker_id: old_worker.id.to_string(),
+                    reattach_token: Some(old_worker.reattach_token.to_string()),
+                },
+            )
+            .await
+            .expect("reattach");
+
+        // Old connection retired: gone from the registry, its fn released,
+        // and its read loop woken to exit.
+        assert!(!engine.worker_registry.workers.contains_key(&old_worker.id));
+        assert!(
+            engine.functions.get("fn1").is_none(),
+            "old connection's function released on reattach"
+        );
+        tokio::time::timeout(
+            std::time::Duration::from_millis(200),
+            old_worker.evict.notified(),
+        )
+        .await
+        .expect("evicted old worker's read loop must be signalled to exit");
+
+        // NEW connection replays fn1 (owned by new now).
+        engine
+            .router_msg(
+                &new_worker,
+                &Message::RegisterFunction {
+                    id: "fn1".to_string(),
+                    description: None,
+                    request_format: None,
+                    response_format: None,
+                    metadata: None,
+                    invocation: None,
+                },
+            )
+            .await
+            .expect("new register");
+        assert!(engine.functions.get("fn1").is_some());
+        assert_eq!(*engine.function_owners.get("fn1").unwrap(), new_worker.id);
+
+        // The evicted old socket task now runs its own exit-path cleanup. It
+        // must NOT tear down fn1 (now owned by the new connection).
+        engine.cleanup_worker(&old_worker).await;
+        assert!(
+            engine.functions.get("fn1").is_some(),
+            "idempotent cleanup of the evicted old connection must not touch the live function"
+        );
+        assert_eq!(*engine.function_owners.get("fn1").unwrap(), new_worker.id);
+        assert!(engine.worker_registry.workers.contains_key(&new_worker.id));
+    }
+
+    #[tokio::test]
+    async fn test_reattach_with_reader_awaits_the_readers_own_cleanup() {
+        // When the old connection has a live read loop (the production
+        // path), Reattach must evict it and WAIT for the reader's own
+        // exit-path cleanup to complete before returning — never run
+        // teardown concurrently with a still-draining reader.
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+
+        let (tx_old, _rx_old) = mpsc::channel::<Outbound>(8);
+        let old_worker = WorkerConnection::new(tx_old);
+        old_worker
+            .has_reader
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        engine.worker_registry.register_worker(old_worker.clone());
+        engine
+            .router_msg(
+                &old_worker,
+                &Message::RegisterFunction {
+                    id: "reader_fn".to_string(),
+                    description: None,
+                    request_format: None,
+                    response_format: None,
+                    metadata: None,
+                    invocation: None,
+                },
+            )
+            .await
+            .expect("old register");
+
+        // Simulated read loop: wait for eviction, then run the exit-path
+        // cleanup — exactly what handle_worker does.
+        let reader = {
+            let engine = engine.clone();
+            let old = old_worker.clone();
+            tokio::spawn(async move {
+                old.evict.notified().await;
+                engine.cleanup_worker(&old).await;
+            })
+        };
+
+        let (tx_new, _rx_new) = mpsc::channel::<Outbound>(8);
+        let new_worker = WorkerConnection::new(tx_new);
+        engine.worker_registry.register_worker(new_worker.clone());
+        engine
+            .router_msg(
+                &new_worker,
+                &Message::Reattach {
+                    previous_worker_id: old_worker.id.to_string(),
+                    reattach_token: Some(old_worker.reattach_token.to_string()),
+                },
+            )
+            .await
+            .expect("reattach");
+
+        // Reattach returned => the reader-driven cleanup COMPLETED: old
+        // connection gone, its registration released.
+        assert!(!engine.worker_registry.workers.contains_key(&old_worker.id));
+        assert!(engine.functions.get("reader_fn").is_none());
+        assert!(*old_worker.cleanup_done.borrow());
+        tokio::time::timeout(std::time::Duration::from_secs(1), reader)
+            .await
+            .expect("reader task must have exited")
+            .expect("reader task must not panic");
+    }
+
+    #[tokio::test]
+    async fn test_reattach_requires_matching_token() {
+        // Worker ids are publicly discoverable (engine::workers::list, the
+        // workers-available trigger), so an id without the per-connection
+        // secret must never evict a live worker.
+        ensure_default_meter();
+        let engine = Engine::new();
+
+        let (tx_old, _rx_old) = mpsc::channel::<Outbound>(8);
+        let old_worker = WorkerConnection::new(tx_old);
+        engine.worker_registry.register_worker(old_worker.clone());
+
+        let (tx_new, _rx_new) = mpsc::channel::<Outbound>(8);
+        let new_worker = WorkerConnection::new(tx_new);
+        engine.worker_registry.register_worker(new_worker.clone());
+
+        // Missing token.
+        engine
+            .router_msg(
+                &new_worker,
+                &Message::Reattach {
+                    previous_worker_id: old_worker.id.to_string(),
+                    reattach_token: None,
+                },
+            )
+            .await
+            .expect("reattach without token ok");
+        assert!(engine.worker_registry.workers.contains_key(&old_worker.id));
+
+        // Wrong token.
+        engine
+            .router_msg(
+                &new_worker,
+                &Message::Reattach {
+                    previous_worker_id: old_worker.id.to_string(),
+                    reattach_token: Some(uuid::Uuid::new_v4().to_string()),
+                },
+            )
+            .await
+            .expect("reattach with wrong token ok");
+        assert!(engine.worker_registry.workers.contains_key(&old_worker.id));
+        assert!(!*old_worker.cleanup_done.borrow());
+    }
+
+    #[tokio::test]
+    async fn test_reattach_self_garbage_and_unknown_are_noops() {
+        ensure_default_meter();
+        let engine = Engine::new();
+
+        let (tx, _rx) = mpsc::channel::<Outbound>(8);
+        let worker = WorkerConnection::new(tx);
+        engine.worker_registry.register_worker(worker.clone());
+
+        // Reattaching to itself is a no-op (it must not evict its own loop).
+        engine
+            .router_msg(
+                &worker,
+                &Message::Reattach {
+                    previous_worker_id: worker.id.to_string(),
+                    reattach_token: Some(worker.reattach_token.to_string()),
+                },
+            )
+            .await
+            .expect("self reattach ok");
+        assert!(engine.worker_registry.workers.contains_key(&worker.id));
+
+        // Malformed id: ignored, no error, worker untouched.
+        engine
+            .router_msg(
+                &worker,
+                &Message::Reattach {
+                    previous_worker_id: "not-a-uuid".to_string(),
+                    reattach_token: None,
+                },
+            )
+            .await
+            .expect("garbage reattach ok");
+        assert!(engine.worker_registry.workers.contains_key(&worker.id));
+
+        // Unknown (never-registered) id: ignored, no error.
+        engine
+            .router_msg(
+                &worker,
+                &Message::Reattach {
+                    previous_worker_id: uuid::Uuid::new_v4().to_string(),
+                    reattach_token: None,
+                },
+            )
+            .await
+            .expect("unknown reattach ok");
+        assert!(engine.worker_registry.workers.contains_key(&worker.id));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_concurrent_replay_and_cleanup_preserves_reregistered_state() {
+        // The reconnect race at its real interleaving, exercising the function
+        // guard (F2) and the trigger-binding guard (F1) together: an old
+        // connection's `cleanup_worker` runs concurrently with the new
+        // connection's replayed RegisterFunction + RegisterTrigger. Both the
+        // function and the binding must end up owned by the new connection.
+        ensure_default_meter();
+
+        for _ in 0..50 {
+            let engine = Arc::new(Engine::new());
+
+            // Provider owns the trigger type for the whole test.
+            let (tx_p, _rx_p) = mpsc::channel::<Outbound>(8);
+            let provider = WorkerConnection::new(tx_p);
+            engine.worker_registry.register_worker(provider.clone());
+            engine
+                .router_msg(
+                    &provider,
+                    &Message::RegisterTriggerType {
+                        id: "evt".to_string(),
+                        description: "provider".to_string(),
+                        trigger_request_format: None,
+                        call_request_format: None,
+                    },
+                )
+                .await
+                .expect("register trigger type");
+
+            let (tx_old, _rx_old) = mpsc::channel::<Outbound>(8);
+            let old_worker = WorkerConnection::new(tx_old);
+            engine.worker_registry.register_worker(old_worker.clone());
+            let reg_fn = Message::RegisterFunction {
+                id: "raced_fn".to_string(),
+                description: None,
+                request_format: None,
+                response_format: None,
+                metadata: None,
+                invocation: None,
+            };
+            let reg_trigger = Message::RegisterTrigger {
+                id: "t1".to_string(),
+                trigger_type: "evt".to_string(),
+                function_id: "raced_fn".to_string(),
+                config: serde_json::json!({}),
+                metadata: None,
+            };
+            engine
+                .router_msg(&old_worker, &reg_fn)
+                .await
+                .expect("old fn");
+            engine
+                .router_msg(&old_worker, &reg_trigger)
+                .await
+                .expect("old trigger");
+
+            let (tx_new, _rx_new) = mpsc::channel::<Outbound>(8);
+            let new_worker = WorkerConnection::new(tx_new);
+            engine.worker_registry.register_worker(new_worker.clone());
+
+            let replay = {
+                let engine = engine.clone();
+                let new_worker = new_worker.clone();
+                let reg_fn = reg_fn.clone();
+                let reg_trigger = reg_trigger.clone();
+                tokio::spawn(async move {
+                    engine
+                        .router_msg(&new_worker, &reg_fn)
+                        .await
+                        .expect("new fn");
+                    engine
+                        .router_msg(&new_worker, &reg_trigger)
+                        .await
+                        .expect("new trigger");
+                })
+            };
+            let cleanup = {
+                let engine = engine.clone();
+                let old_worker = old_worker.clone();
+                tokio::spawn(async move { engine.cleanup_worker(&old_worker).await })
+            };
+            replay.await.expect("replay task");
+            cleanup.await.expect("cleanup task");
+
+            assert!(
+                engine.functions.get("raced_fn").is_some(),
+                "function must survive concurrent cleanup"
+            );
+            assert_eq!(
+                *engine.function_owners.get("raced_fn").unwrap(),
+                new_worker.id
+            );
+            let t1 = engine
+                .trigger_registry
+                .triggers
+                .get("t1")
+                .expect("binding must survive concurrent cleanup");
+            assert_eq!(t1.worker_id, Some(new_worker.id));
         }
     }
 

--- a/engine/src/protocol.rs
+++ b/engine/src/protocol.rs
@@ -126,8 +126,28 @@ pub enum Message {
     },
     Ping,
     Pong,
+    /// Worker→engine, sent as the first message of a reconnect, before the
+    /// registration replay: `previous_worker_id` and `reattach_token` are
+    /// the values the engine handed this worker via `WorkerRegistered` on
+    /// its previous connection. The engine retires that previous connection
+    /// (same teardown as a disconnect) so the replay lands on a clean slate
+    /// instead of racing the old connection's cleanup. The token is
+    /// required: worker ids are publicly discoverable, the token was only
+    /// ever sent over the previous connection's own socket. Old engines
+    /// warn-log and ignore unknown message types, so this is version-skew
+    /// safe.
+    Reattach {
+        previous_worker_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reattach_token: Option<String>,
+    },
     WorkerRegistered {
         worker_id: String,
+        /// Secret the worker must present in `Reattach` to retire this
+        /// connection after a reconnect. Optional on the wire so older
+        /// SDKs/engines interop cleanly.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reattach_token: Option<String>,
     },
 }
 
@@ -236,6 +256,50 @@ mod tests {
             }
             _ => panic!("unexpected message variant"),
         }
+    }
+
+    #[test]
+    fn reattach_round_trips() {
+        // Token present.
+        let raw = r#"{"type":"reattach","previous_worker_id":"abc-123","reattach_token":"tok-1"}"#;
+        let message: Message = serde_json::from_str(raw).expect("reattach should deserialize");
+        match &message {
+            Message::Reattach {
+                previous_worker_id,
+                reattach_token,
+            } => {
+                assert_eq!(previous_worker_id, "abc-123");
+                assert_eq!(reattach_token.as_deref(), Some("tok-1"));
+            }
+            _ => panic!("unexpected message variant"),
+        }
+        let serialized = serde_json::to_string(&message).expect("serialize");
+        assert_eq!(serialized, raw);
+
+        // Token absent (older SDK): still deserializes, token None.
+        let raw = r#"{"type":"reattach","previous_worker_id":"abc-123"}"#;
+        let message: Message = serde_json::from_str(raw).expect("tokenless reattach deserializes");
+        assert!(matches!(
+            message,
+            Message::Reattach {
+                reattach_token: None,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn worker_registered_token_is_optional_on_the_wire() {
+        // Older engines omit the token; SDKs must still parse the frame.
+        let raw = r#"{"type":"workerregistered","worker_id":"w-1"}"#;
+        let message: Message = serde_json::from_str(raw).expect("should deserialize");
+        assert!(matches!(
+            message,
+            Message::WorkerRegistered {
+                reattach_token: None,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/engine/src/trigger.rs
+++ b/engine/src/trigger.rs
@@ -250,7 +250,23 @@ impl TriggerRegistry {
 
         for trigger in worker_triggers {
             tracing::debug!(trigger_id = trigger.id, "Removing trigger");
-            self.triggers.remove(&trigger.id);
+            // The entry may have been replaced between the snapshot above and
+            // now (worker reconnect: the new connection replays the same
+            // trigger id before the old connection's cleanup runs). Only
+            // remove it — and only unregister it with the registrator — if it
+            // still belongs to the disconnecting worker; a replaced binding
+            // keeps firing. Same guard as trigger types below.
+            if self
+                .triggers
+                .remove_if(&trigger.id, |_, t| t.worker_id == Some(*worker_id))
+                .is_none()
+            {
+                tracing::debug!(
+                    trigger_id = trigger.id,
+                    "Trigger already replaced by another worker; leaving it"
+                );
+                continue;
+            }
 
             if let Some(trigger_type) = self.trigger_types.get(&trigger.trigger_type) {
                 tracing::debug!(trigger_type_id = trigger_type.id, "Unregistering trigger");
@@ -833,6 +849,82 @@ mod tests {
                 a.register_count.load(Ordering::SeqCst),
                 1,
                 "stale generation receives nothing after replacement"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn replayed_binding_survives_stale_worker_cleanup() {
+        // Regression guard for the reconnect kill loop (iii-hq/iii#1975),
+        // binding half. When a worker's socket drops and its SDK reconnects,
+        // the new connection replays its RegisterTrigger batch while the old
+        // connection's `unregister_worker` cleanup runs concurrently. The
+        // cleanup used to `triggers.remove(id)` unconditionally from a
+        // snapshot, deleting (and provider-unregistering) the binding the new
+        // connection had just re-registered — the console watcher would die
+        // and never come back. Post-fix, removal is guarded by an ownership
+        // CAS, mirroring the trigger-type guard in the same function.
+        for _ in 0..100 {
+            let registry = Arc::new(TriggerRegistry::new());
+
+            // Trigger type owned by a separate provider worker so the stale
+            // worker's cleanup never removes the type (which would orphan the
+            // binding into `pending_triggers` and mask the guard we test).
+            let provider = Arc::new(ControlledRegistrator::new(false, false));
+            let provider_worker = Uuid::new_v4();
+            registry
+                .register_trigger_type(TriggerType::new(
+                    "evt",
+                    "provider",
+                    Box::new(provider.clone()),
+                    Some(provider_worker),
+                ))
+                .await
+                .unwrap();
+
+            let old_worker = Uuid::new_v4();
+            let new_worker = Uuid::new_v4();
+
+            // Filler bindings owned by the old worker widen the snapshot→remove
+            // window: each removal awaits the provider's unregister, giving the
+            // racing re-registration room to land before `t1`'s turn.
+            for fid in ["f1", "f2", "f3"] {
+                let mut b = make_trigger(fid, "evt");
+                b.worker_id = Some(old_worker);
+                registry.register_trigger(b).await.unwrap();
+            }
+            let mut binding = make_trigger("t1", "evt");
+            binding.worker_id = Some(old_worker);
+            registry.register_trigger(binding).await.unwrap();
+
+            let cleanup = {
+                let registry = registry.clone();
+                tokio::spawn(async move { registry.unregister_worker(&old_worker).await })
+            };
+            let reregister = {
+                let registry = registry.clone();
+                tokio::spawn(async move {
+                    let mut replay = make_trigger("t1", "evt");
+                    replay.worker_id = Some(new_worker);
+                    registry.register_trigger(replay).await.unwrap();
+                })
+            };
+            let (r1, r2) = tokio::join!(cleanup, reregister);
+            r1.unwrap();
+            r2.unwrap();
+
+            let t1 = registry
+                .triggers
+                .get("t1")
+                .expect("re-registered binding must survive the stale worker's cleanup");
+            assert_eq!(
+                t1.worker_id,
+                Some(new_worker),
+                "surviving binding must be owned by the reconnected worker"
+            );
+            assert!(
+                !registry.pending_triggers.contains_key("t1"),
+                "binding must be live, not parked"
             );
         }
     }

--- a/engine/src/worker_connections/mod.rs
+++ b/engine/src/worker_connections/mod.rs
@@ -6,12 +6,16 @@
 
 pub mod traits;
 
-use std::{collections::HashSet, str::FromStr, sync::Arc};
+use std::{
+    collections::HashSet,
+    str::FromStr,
+    sync::{Arc, atomic::AtomicBool},
+};
 
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use opentelemetry::KeyValue;
-use tokio::sync::{RwLock, mpsc, oneshot};
+use tokio::sync::{Notify, RwLock, mpsc, oneshot, watch};
 use uuid::Uuid;
 
 use schemars::JsonSchema;
@@ -246,6 +250,30 @@ pub struct WorkerConnection {
     /// (function-path) registrations wait on an entry here — see the
     /// `TriggerRegistrator` impl in `traits.rs`.
     pub pending_trigger_acks: Arc<DashMap<String, oneshot::Sender<Option<ErrorBody>>>>,
+    /// Signaled when a reconnecting successor of this worker reattaches
+    /// (`Message::Reattach`): the connection's read loop must exit (its exit
+    /// path runs the connection's cleanup). Shared across clones so the
+    /// registry's copy can wake the socket task.
+    pub evict: Arc<Notify>,
+    /// True once a `handle_worker` read loop services this connection — i.e.
+    /// `evict` has a listener whose exit path will run the cleanup. Reattach
+    /// uses this to choose between "evict and await the reader's own
+    /// cleanup" and "no reader: clean up directly".
+    pub has_reader: Arc<AtomicBool>,
+    /// Claimed (swap to true) by the single caller that runs this
+    /// connection's teardown; later callers await `cleanup_done` instead of
+    /// returning early, so `cleanup_worker` returning always means the
+    /// teardown has COMPLETED.
+    pub cleanup_claimed: Arc<AtomicBool>,
+    /// Flips to true when the connection's teardown has completed.
+    /// `subscribe()` + `wait_for(|d| *d)` to await it.
+    pub cleanup_done: Arc<watch::Sender<bool>>,
+    /// Per-connection secret, sent to the worker only over its own socket
+    /// (in `WorkerRegistered`). A reconnecting successor must present it in
+    /// `Message::Reattach` to retire this connection: worker ids alone are
+    /// public (`engine::workers::list`, the workers-available trigger) and
+    /// must not suffice to evict a live worker.
+    pub reattach_token: Uuid,
 }
 
 impl WorkerConnection {
@@ -269,6 +297,11 @@ impl WorkerConnection {
             isolation: None,
             session: None,
             pending_trigger_acks: Arc::new(DashMap::new()),
+            evict: Arc::new(Notify::new()),
+            has_reader: Arc::new(AtomicBool::new(false)),
+            cleanup_claimed: Arc::new(AtomicBool::new(false)),
+            cleanup_done: Arc::new(watch::channel(false).0),
+            reattach_token: Uuid::new_v4(),
         }
     }
 
@@ -292,6 +325,11 @@ impl WorkerConnection {
             isolation: None,
             session: Some(Arc::new(session)),
             pending_trigger_acks: Arc::new(DashMap::new()),
+            evict: Arc::new(Notify::new()),
+            has_reader: Arc::new(AtomicBool::new(false)),
+            cleanup_claimed: Arc::new(AtomicBool::new(false)),
+            cleanup_done: Arc::new(watch::channel(false).0),
+            reattach_token: Uuid::new_v4(),
         }
     }
 

--- a/sdk/packages/go/iii/client.go
+++ b/sdk/packages/go/iii/client.go
@@ -55,6 +55,14 @@ type Client struct {
 	conn     *websocket.Conn
 	writerWG sync.WaitGroup
 
+	// workerID/reattachToken are the engine-assigned identity from the last
+	// WorkerRegistered frame, presented back via a Reattach frame on reconnect so
+	// the engine retires the previous connection before the registration replay.
+	// The token authorizes the eviction (ids alone are publicly listable).
+	// Guarded by mu.
+	workerID      string
+	reattachToken string
+
 	// In-memory registries, replayed on every (re)connect. Keyed by id.
 	functions    map[string]registeredFunction
 	triggers     map[string]*RegisterTriggerMessage
@@ -516,6 +524,33 @@ func (c *Client) runConnection() error {
 	// The engine can send large registration payloads; lift the default read limit.
 	conn.SetReadLimit(-1)
 
+	// Reconnect: present the previous engine-assigned identity as the very
+	// first frame — written directly here, before the writer goroutine,
+	// StateConnected, or onConnect expose this socket to any other traffic —
+	// so the engine retires the old connection before anything can hit its
+	// stale registrations. The token proves we ARE that worker (ids alone
+	// are publicly listable).
+	c.mu.Lock()
+	prevWorkerID, prevToken := c.workerID, c.reattachToken
+	c.mu.Unlock()
+	if prevWorkerID != "" {
+		frame, merr := MarshalMessage(&ReattachMessage{
+			PreviousWorkerID: prevWorkerID,
+			ReattachToken:    prevToken,
+		})
+		if merr == nil {
+			if werr := conn.Write(connCtx, websocket.MessageText, frame); werr != nil {
+				_ = conn.CloseNow()
+				select {
+				case <-c.shutdown:
+					return nil
+				default:
+					return werr
+				}
+			}
+		}
+	}
+
 	// A reply channel owned by THIS connection. Connection-scoped replies go here so they
 	// can never be drained by a later connection's writer (iii-hq/iii#1749).
 	reply := make(chan []byte, 64)
@@ -717,7 +752,16 @@ func (c *Client) dispatch(ctx context.Context, dec *DecodedMessage) {
 		if frame, err := MarshalMessage(&PongMessage{}); err == nil {
 			c.enqueueOutboundDirect(frame)
 		}
-	case MsgWorkerRegistered, MsgTriggerRegistrationResult:
+	case MsgWorkerRegistered:
+		// Remember the engine-assigned identity so the next reconnect can present
+		// it via Reattach.
+		if dec.WorkerRegistered != nil {
+			c.mu.Lock()
+			c.workerID = dec.WorkerRegistered.WorkerID
+			c.reattachToken = dec.WorkerRegistered.ReattachToken
+			c.mu.Unlock()
+		}
+	case MsgTriggerRegistrationResult:
 		// Informational; nothing to do. (A trigger-registration error is the engine's
 		// to surface; the reference SDKs only log it.)
 	default:

--- a/sdk/packages/go/iii/protocol.go
+++ b/sdk/packages/go/iii/protocol.go
@@ -45,6 +45,7 @@ const (
 	MsgPing                      MessageType = "ping"
 	MsgPong                      MessageType = "pong"
 	MsgWorkerRegistered          MessageType = "workerregistered"
+	MsgReattach                  MessageType = "reattach"
 )
 
 // ErrorBody is the wire representation of a remote error
@@ -225,6 +226,21 @@ type RegisterServiceMessage struct {
 // (engine/src/protocol.rs:123-125). The worker treats it as informational.
 type WorkerRegisteredMessage struct {
 	WorkerID string `json:"worker_id"`
+	// ReattachToken is the secret to present in a ReattachMessage on reconnect;
+	// empty on older engines.
+	ReattachToken string `json:"reattach_token,omitempty"`
+}
+
+// Reattach is sent worker->engine as the first message of a reconnect, before the
+// registration replay: PreviousWorkerID is the id the engine assigned via
+// WorkerRegistered on the previous connection. The engine retires that connection so
+// the replay lands on a clean slate instead of racing its cleanup.
+type ReattachMessage struct {
+	PreviousWorkerID string `json:"previous_worker_id"`
+	// ReattachToken authorizes retiring the previous connection: worker ids are
+	// publicly listable, the token was only ever sent over that connection's own
+	// socket.
+	ReattachToken string `json:"reattach_token,omitempty"`
 }
 
 // PingMessage is the payloadless keepalive the engine sends; it serializes to
@@ -283,6 +299,8 @@ func MarshalMessage(msg any) ([]byte, error) {
 		return marshalEnvelope(MsgRegisterService, m)
 	case *WorkerRegisteredMessage:
 		return marshalEnvelope(MsgWorkerRegistered, m)
+	case *ReattachMessage:
+		return marshalEnvelope(MsgReattach, m)
 	case *PingMessage:
 		return marshalEnvelope(MsgPing, struct{}{})
 	case *PongMessage:
@@ -310,6 +328,8 @@ func MarshalMessage(msg any) ([]byte, error) {
 		return marshalEnvelope(MsgRegisterService, &m)
 	case WorkerRegisteredMessage:
 		return marshalEnvelope(MsgWorkerRegistered, &m)
+	case ReattachMessage:
+		return marshalEnvelope(MsgReattach, &m)
 	case PingMessage:
 		return marshalEnvelope(MsgPing, struct{}{})
 	case PongMessage:

--- a/sdk/packages/go/iii/reattach_test.go
+++ b/sdk/packages/go/iii/reattach_test.go
@@ -1,0 +1,72 @@
+package iii
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestReconnectSendsReattach is the Go half of iii-hq/iii#1975: on reconnect the
+// client must present the previous engine-assigned worker id via a reattach frame
+// BEFORE replaying its registrations, and must send no reattach on the first connect.
+func TestReconnectSendsReattach(t *testing.T) {
+	m := newMockEngine(t)
+	c := New(m.url, WithReconnectConfig(ReconnectConfig{
+		InitialDelay:      10 * time.Millisecond,
+		MaxDelay:          50 * time.Millisecond,
+		BackoffMultiplier: 2,
+		JitterFactor:      0,
+		MaxRetries:        -1,
+	}))
+	_ = c.RegisterFunction("reattach::fn", func(ctx context.Context, _ json.RawMessage) (any, error) {
+		return nil, nil
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := c.Connect(ctx); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	// First connect: the function registers, and no reattach is sent yet.
+	first := m.waitFor(func(msgs []map[string]json.RawMessage) bool {
+		return countRegister(msgs, string(MsgRegisterFunction), "reattach::fn") >= 1
+	}, 2*time.Second)
+	if countType(first, string(MsgReattach)) != 0 {
+		t.Fatalf("no reattach must be sent on the first connect, got %d", countType(first, string(MsgReattach)))
+	}
+
+	// The engine assigns this connection an identity.
+	m.mu.Lock()
+	conn := m.active
+	m.mu.Unlock()
+	if err := m.send(ctx, conn, &WorkerRegisteredMessage{WorkerID: "w-old", ReattachToken: "tok-old"}); err != nil {
+		t.Fatalf("send workerregistered: %v", err)
+	}
+	// Give the dispatch loop time to store the id before the socket drops.
+	time.Sleep(200 * time.Millisecond)
+
+	m.clear()
+	m.closeActiveConnection()
+
+	// After reconnect, a reattach carrying the old id must precede the replay.
+	got := m.waitFor(func(msgs []map[string]json.RawMessage) bool {
+		return countRegister(msgs, string(MsgRegisterFunction), "reattach::fn") >= 1
+	}, 3*time.Second)
+
+	reattachIdx := indexOfType(got, string(MsgReattach))
+	registerIdx := indexOfType(got, string(MsgRegisterFunction))
+	if reattachIdx < 0 {
+		t.Fatalf("reattach frame must be sent on reconnect; frames: %v", got)
+	}
+	if reattachIdx >= registerIdx {
+		t.Errorf("reattach (idx %d) must precede the registration replay (idx %d)", reattachIdx, registerIdx)
+	}
+	if pid := stringField(got[reattachIdx], "previous_worker_id"); pid != "w-old" {
+		t.Errorf("reattach previous_worker_id = %q, want %q", pid, "w-old")
+	}
+	if tok := stringField(got[reattachIdx], "reattach_token"); tok != "tok-old" {
+		t.Errorf("reattach reattach_token = %q, want %q", tok, "tok-old")
+	}
+}

--- a/sdk/packages/node/iii-browser/src/iii-types.ts
+++ b/sdk/packages/node/iii-browser/src/iii-types.ts
@@ -9,6 +9,7 @@ export enum MessageType {
   UnregisterTriggerType = 'unregistertriggertype',
   TriggerRegistrationResult = 'triggerregistrationresult',
   WorkerRegistered = 'workerregistered',
+  Reattach = 'reattach',
 }
 
 export type RegisterTriggerTypeMessage = {

--- a/sdk/packages/node/iii-browser/src/iii.ts
+++ b/sdk/packages/node/iii-browser/src/iii.ts
@@ -78,6 +78,8 @@ class Sdk implements ISdk {
   private connectionState: IIIConnectionState = 'disconnected'
   private connectionListeners = new Set<(state: IIIConnectionState) => void>()
   private isShuttingDown = false
+  private workerId?: string
+  private reattachToken?: string
 
   constructor(
     private readonly address: string,
@@ -520,6 +522,20 @@ class Sdk implements ISdk {
       this.ws.onmessage = this.onMessage.bind(this)
     }
 
+    // Reconnect: present the previous engine-assigned identity BEFORE the
+    // registration replay so the engine retires the old connection and the
+    // replay lands on a clean slate instead of racing its cleanup. The
+    // token proves we ARE that worker (ids alone are publicly listable).
+    if (this.workerId) {
+      this.sendMessageRaw(
+        JSON.stringify({
+          type: MessageType.Reattach,
+          previous_worker_id: this.workerId,
+          reattach_token: this.reattachToken,
+        }),
+      )
+    }
+
     this.triggerTypes.forEach(({ message }) => {
       this.sendMessage(MessageType.RegisterTriggerType, message, true)
     })
@@ -754,6 +770,10 @@ class Sdk implements ISdk {
       this.onUnregisterTrigger(
         message as { trigger_type?: string; id: string; function_id?: string; config?: unknown },
       )
+    } else if (msgType === MessageType.WorkerRegistered) {
+      const { worker_id, reattach_token } = message as { worker_id: string; reattach_token?: string }
+      this.workerId = worker_id
+      this.reattachToken = reattach_token
     }
   }
 }

--- a/sdk/packages/node/iii/src/iii-types.ts
+++ b/sdk/packages/node/iii/src/iii-types.ts
@@ -24,6 +24,7 @@ export enum MessageType {
   UnregisterTriggerType = 'unregistertriggertype',
   TriggerRegistrationResult = 'triggerregistrationresult',
   WorkerRegistered = 'workerregistered',
+  Reattach = 'reattach',
 }
 
 export type RegisterTriggerTypeMessage = {
@@ -232,6 +233,8 @@ export type InvocationResultMessage = {
 export type WorkerRegisteredMessage = {
   message_type: MessageType.WorkerRegistered
   worker_id: string
+  /** Secret to present in a reattach frame on reconnect; absent on older engines. */
+  reattach_token?: string
 }
 
 export type UnregisterFunctionMessage = {

--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -145,6 +145,7 @@ class Sdk implements IIIClient {
   private workerName: string
   private workerDescription?: string
   private workerId?: string
+  private reattachToken?: string
   private reconnectTimeout?: NodeJS.Timeout
   private heartbeatInterval?: NodeJS.Timeout
   private idleTimeout?: NodeJS.Timeout
@@ -782,6 +783,20 @@ class Sdk implements IIIClient {
     this.ws?.on('pong', touch)
     this.startHeartbeat()
 
+    // Reconnect: present the previous engine-assigned identity BEFORE the
+    // registration replay so the engine retires the old connection and the
+    // replay lands on a clean slate instead of racing its cleanup. The
+    // token proves we ARE that worker (ids alone are publicly listable).
+    if (this.workerId) {
+      this.sendMessageRaw(
+        JSON.stringify({
+          type: MessageType.Reattach,
+          previous_worker_id: this.workerId,
+          reattach_token: this.reattachToken,
+        }),
+      )
+    }
+
     this.triggerTypes.forEach(({ message }) => {
       this.sendMessage(MessageType.RegisterTriggerType, message, true)
     })
@@ -1100,8 +1115,9 @@ class Sdk implements IIIClient {
         message as { id: string; trigger_type?: string; type?: string; function_id: string; error?: { code: string; message: string; stacktrace?: string } },
       )
     } else if (msgType === MessageType.WorkerRegistered) {
-      const { worker_id } = message as WorkerRegisteredMessage
+      const { worker_id, reattach_token } = message as WorkerRegisteredMessage
       this.workerId = worker_id
+      this.reattachToken = reattach_token
       console.debug('[iii] Worker registered with ID:', worker_id)
       this.startMetricsReporting()
     }

--- a/sdk/packages/node/iii/tests/connection-reattach.test.ts
+++ b/sdk/packages/node/iii/tests/connection-reattach.test.ts
@@ -1,0 +1,118 @@
+import { EventEmitter } from 'node:events'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Inline mock for the 'ws' module (same shape as connection-heartbeat.test.ts):
+// records sent frames and mirrors terminate() -> 'close' so the reconnect path
+// can be driven with fake timers.
+const sockets: MockWebSocket[] = []
+
+class MockWebSocket extends EventEmitter {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSING = 2
+  static readonly CLOSED = 3
+
+  readyState: number = MockWebSocket.CONNECTING
+  readonly sent: Array<Buffer | string> = []
+  terminated = false
+
+  constructor(
+    public readonly url?: string,
+    public readonly opts?: Record<string, unknown>,
+  ) {
+    super()
+    sockets.push(this)
+  }
+
+  send(data: Buffer | string, callback?: (err?: Error | null) => void): void {
+    this.sent.push(data)
+    callback?.()
+  }
+
+  ping(): void {}
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED
+  }
+
+  terminate(): void {
+    if (this.terminated) return
+    this.terminated = true
+    this.readyState = MockWebSocket.CLOSED
+    this.emit('close')
+  }
+
+  simulateOpen(): void {
+    this.readyState = MockWebSocket.OPEN
+    this.emit('open')
+  }
+
+  sentMessages(): Array<Record<string, unknown>> {
+    return this.sent.map((s) => JSON.parse(s.toString()) as Record<string, unknown>)
+  }
+}
+
+vi.mock('ws', () => ({
+  WebSocket: MockWebSocket,
+  default: { WebSocket: MockWebSocket },
+}))
+
+vi.resetModules()
+const { registerWorker } = await import('../src/index')
+
+function makeWorker(address: string) {
+  return registerWorker(address, {
+    otel: { enabled: false },
+    reconnectionConfig: { initialDelayMs: 10, jitterFactor: 0 },
+  })
+}
+
+beforeEach(() => {
+  sockets.length = 0
+})
+
+afterAll(() => {
+  vi.useRealTimers()
+})
+
+describe('Sdk – reconnect reattach handshake', () => {
+  it('sends reattach with the prior worker id before replaying registrations on reconnect', async () => {
+    vi.useFakeTimers()
+    const sdk = makeWorker('ws://reattach.test')
+    try {
+      sdk.registerFunction('reattach::fn', async () => ({ ok: true }))
+
+      // First connect: registrations replay, but NO reattach (no prior id yet).
+      const sock0 = sockets[0]
+      sock0.simulateOpen()
+      expect(sock0.sentMessages().some((m) => m.type === 'reattach')).toBe(false)
+
+      // Engine assigns this connection an identity + reattach secret.
+      sock0.emit(
+        'message',
+        JSON.stringify({ type: 'workerregistered', worker_id: 'w-1', reattach_token: 'tok-1' }),
+      )
+
+      // Drop the socket; the SDK reconnects.
+      sock0.terminate()
+      await vi.advanceTimersByTimeAsync(50)
+
+      const sock1 = sockets[1]
+      expect(sock1).toBeDefined()
+      sock1.simulateOpen()
+
+      const sent1 = sock1.sentMessages()
+      const reattachIdx = sent1.findIndex((m) => m.type === 'reattach')
+      const registerIdx = sent1.findIndex((m) => typeof m.type === 'string' && m.type.startsWith('register'))
+
+      expect(reattachIdx).toBeGreaterThanOrEqual(0)
+      expect(sent1[reattachIdx].previous_worker_id).toBe('w-1')
+      expect(sent1[reattachIdx].reattach_token).toBe('tok-1')
+      expect(registerIdx).toBeGreaterThanOrEqual(0)
+      expect(reattachIdx).toBeLessThan(registerIdx)
+    } finally {
+      vi.useRealTimers()
+      await sdk.shutdown()
+    }
+  })
+})

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -207,6 +207,7 @@ class III:
         # _set_connection_state as soon as connect_async starts.
         self._connection_listeners: list[ConnectionStateCallback] = []
         self._worker_id: str | None = None
+        self._reattach_token: str | None = None
 
         # Background event loop thread
         self._loop = asyncio.new_event_loop()
@@ -397,6 +398,18 @@ class III:
     async def _on_connected(self) -> None:
         self._reconnect_attempt = 0
         self._set_connection_state("connected")
+        # Reconnect: present the previous engine-assigned identity BEFORE the
+        # registration replay so the engine retires the old connection and the
+        # replay lands on a clean slate instead of racing its cleanup. The
+        # token proves we ARE that worker (ids alone are publicly listable).
+        if self._worker_id:
+            reattach: dict[str, Any] = {
+                "type": MessageType.REATTACH.value,
+                "previous_worker_id": self._worker_id,
+            }
+            if self._reattach_token:
+                reattach["reattach_token"] = self._reattach_token
+            await self._send(reattach)
         # Re-register all (snapshot to avoid mutation from caller thread)
         for trigger_type_data in list(self._trigger_types.values()):
             await self._send(trigger_type_data.message)
@@ -505,6 +518,7 @@ class III:
         elif msg_type == MessageType.WORKER_REGISTERED.value:
             worker_id = data.get("worker_id", "")
             self._worker_id = worker_id
+            self._reattach_token = data.get("reattach_token")
             log.debug(f"Worker registered with ID: {worker_id}")
 
     def _handle_result(self, invocation_id: str, result: Any, error: Any) -> None:

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -457,7 +457,12 @@ class III:
     async def _send(self, msg: Any) -> None:
         data = self._to_dict(msg)
         if self._ws and self._ws.state.name == "OPEN":
-            log.debug(f"Send: {json.dumps(data)[:200]}")
+            # Redact the reattach secret from debug logs; it authorizes
+            # evicting this worker's previous connection.
+            log_safe = {
+                k: ("***" if k == "reattach_token" else v) for k, v in data.items()
+            }
+            log.debug(f"Send: {json.dumps(log_safe)[:200]}")
             await self._ws.send(json.dumps(data))
         else:
             if len(self._queue) >= MAX_QUEUE_SIZE:

--- a/sdk/packages/python/iii/src/iii/iii_types.py
+++ b/sdk/packages/python/iii/src/iii/iii_types.py
@@ -21,6 +21,7 @@ class MessageType(str, Enum):
     UNREGISTER_TRIGGER_TYPE = "unregistertriggertype"
     TRIGGER_REGISTRATION_RESULT = "triggerregistrationresult"
     WORKER_REGISTERED = "workerregistered"
+    REATTACH = "reattach"
 
 
 class RegisterTriggerTypeMessage(BaseModel):

--- a/sdk/packages/python/iii/tests/test_reconnect_sends_reattach.py
+++ b/sdk/packages/python/iii/tests/test_reconnect_sends_reattach.py
@@ -1,0 +1,77 @@
+"""iii-hq/iii#1975 regression: on reconnect the SDK must present the previous
+engine-assigned worker id via a ``reattach`` frame BEFORE replaying its
+registration batch, so the engine retires the old connection and the replay
+lands on a clean slate instead of racing its cleanup. On the first connect,
+with no prior id, no reattach is sent.
+
+Driven directly against ``_on_connected`` (no socket needed): the reattach is
+the first thing sent, gated on a stored ``_worker_id``.
+"""
+
+import asyncio
+
+from iii.iii import III
+from iii.iii_constants import InitOptions
+from iii.iii_types import MessageType
+
+
+def test_reconnect_sends_reattach_first(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "iii_helpers.observability.telemetry.init_otel", lambda **kwargs: None
+    )
+    monkeypatch.setattr(
+        "iii_helpers.observability.telemetry.attach_event_loop", lambda loop: None
+    )
+
+    # The constructor auto-connects on a background thread; it never reaches a
+    # real engine here (unused.test fails to resolve), so it never calls
+    # _on_connected on its own — we drive that directly below. shutdown() in
+    # the finally stops the (non-daemon) loop thread.
+    client = III("ws://unused.test", InitOptions())
+
+    sent: list = []
+
+    async def fake_send(msg) -> None:
+        sent.append(msg)
+
+    monkeypatch.setattr(client, "_send", fake_send)
+    monkeypatch.setattr(client, "_register_worker_metadata", lambda: None)
+    client._ws = None  # _receive_loop returns immediately
+
+    # One binding to replay, so ordering (reattach before replay) is observable.
+    client._triggers["t1"] = {"type": "registertrigger", "id": "t1"}
+
+    async def drive() -> None:
+        # First connect: no stored id yet -> no reattach.
+        await client._on_connected()
+        assert not any(
+            isinstance(m, dict) and m.get("type") == MessageType.REATTACH.value
+            for m in sent
+        ), f"no reattach must be sent on first connect: {sent}"
+
+        # Engine assigns an identity + secret; the socket then drops and
+        # reconnects.
+        client._worker_id = "w-old"
+        client._reattach_token = "tok-old"
+        sent.clear()
+        await client._on_connected()
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(drive())
+    finally:
+        loop.close()
+        client.shutdown()
+
+    assert sent, "reconnect must send frames"
+    first = sent[0]
+    assert isinstance(first, dict) and first.get("type") == MessageType.REATTACH.value, (
+        f"reattach must be the first frame on reconnect, got: {sent}"
+    )
+    assert first.get("previous_worker_id") == "w-old"
+    assert first.get("reattach_token") == "tok-old"
+    # And it must precede the replayed registration.
+    assert any(
+        (m.get("type") if isinstance(m, dict) else getattr(m, "type", None)) == "registertrigger"
+        for m in sent[1:]
+    ), f"registration replay must follow the reattach: {sent}"

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -780,6 +780,14 @@ struct IIIInner {
     headers: Mutex<Option<HashMap<String, String>>>,
     otel_config: Mutex<Option<OtelConfig>>,
     timings: Mutex<ConnTimings>,
+    /// Engine-assigned worker id from `WorkerRegistered`; presented back via
+    /// `Message::Reattach` on reconnect so the engine retires the previous
+    /// connection before the registration replay.
+    worker_id: Mutex<Option<String>>,
+    /// Secret paired with `worker_id` (from the same `WorkerRegistered`
+    /// frame); required by the engine to authorize the reattach — ids alone
+    /// are publicly discoverable.
+    reattach_token: Mutex<Option<String>>,
 }
 
 /// WebSocket client for communication with the III Engine.
@@ -815,6 +823,8 @@ impl IIIClient {
             headers: Mutex::new(None),
             otel_config: Mutex::new(None),
             timings: Mutex::new(ConnTimings::default()),
+            worker_id: Mutex::new(None),
+            reattach_token: Mutex::new(None),
         };
         Self {
             inner: Arc::new(inner),
@@ -1412,6 +1422,32 @@ impl IIIClient {
                     self.set_connection_state(IIIConnectionState::Connected);
                     let (mut ws_tx, mut ws_rx) = stream.split();
 
+                    // Reconnect: present the previous engine-assigned identity
+                    // BEFORE the registration replay so the engine retires the
+                    // old connection and the replay lands on a clean slate
+                    // instead of racing its cleanup. The token proves we ARE
+                    // that worker (ids alone are publicly listable). Sent
+                    // directly (not via `queue`) so it never accumulates
+                    // across retries.
+                    let previous_worker_id = self.inner.worker_id.lock_or_recover().clone();
+                    if let Some(previous_worker_id) = previous_worker_id {
+                        let reattach_token = self.inner.reattach_token.lock_or_recover().clone();
+                        if let Err(err) = self
+                            .send_ws(
+                                &mut ws_tx,
+                                &Message::Reattach {
+                                    previous_worker_id,
+                                    reattach_token,
+                                },
+                            )
+                            .await
+                        {
+                            tracing::warn!(error = %err, "failed to send reattach; reconnecting");
+                            sleep(t.retry_delay).await;
+                            continue;
+                        }
+                    }
+
                     queue.extend(self.collect_registrations());
                     Self::dedupe_registrations(&mut queue);
 
@@ -1722,8 +1758,13 @@ impl IIIClient {
             Message::Ping => {
                 let _ = self.send_message(Message::Pong);
             }
-            Message::WorkerRegistered { worker_id } => {
+            Message::WorkerRegistered {
+                worker_id,
+                reattach_token,
+            } => {
                 tracing::debug!(worker_id = %worker_id, "Worker registered");
+                *self.inner.worker_id.lock_or_recover() = Some(worker_id);
+                *self.inner.reattach_token.lock_or_recover() = reattach_token;
             }
             Message::TriggerRegistrationResult {
                 id,

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -2884,7 +2884,8 @@ mod tests {
         assert_eq!(IIIClient::registration_key(&Message::Pong), None);
         assert_eq!(
             IIIClient::registration_key(&Message::WorkerRegistered {
-                worker_id: "w".to_string()
+                worker_id: "w".to_string(),
+                reattach_token: None
             }),
             None
         );

--- a/sdk/packages/rust/iii/src/protocol.rs
+++ b/sdk/packages/rust/iii/src/protocol.rs
@@ -170,8 +170,23 @@ pub enum Message {
     },
     Ping,
     Pong,
+    /// Sent to the engine as the first message of a reconnect, before the
+    /// registration replay: `previous_worker_id` and `reattach_token` are
+    /// the values the engine assigned via `WorkerRegistered` on the previous
+    /// connection. The engine retires that connection so the replay lands on
+    /// a clean slate; the token is required because worker ids alone are
+    /// publicly discoverable.
+    Reattach {
+        previous_worker_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reattach_token: Option<String>,
+    },
     WorkerRegistered {
         worker_id: String,
+        /// Secret to present in `Reattach` on reconnect; absent on older
+        /// engines.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reattach_token: Option<String>,
     },
 }
 

--- a/sdk/packages/rust/iii/tests/reattach.rs
+++ b/sdk/packages/rust/iii/tests/reattach.rs
@@ -1,0 +1,100 @@
+//! Wire-level test for the reconnect reattach handshake (iii-hq/iii#1975).
+//!
+//! On reconnect the SDK must present the engine-assigned worker id from the
+//! previous connection (via a `reattach` frame) BEFORE replaying its
+//! registration batch, so the engine can retire the old connection and the
+//! replay lands on a clean slate instead of racing its cleanup. On the first
+//! connect there is no prior id, so no reattach is sent.
+
+mod common;
+
+use std::time::Duration;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::json;
+
+use iii_sdk::{Error, InitOptions, RegisterFunction, register_worker};
+
+use common::mock_engine::{MockEngine, count_register, count_type, message_id, message_type};
+
+#[derive(Deserialize, JsonSchema)]
+struct GreetInput {
+    name: String,
+}
+
+fn greet(input: GreetInput) -> Result<String, Error> {
+    Ok(format!("Hello, {}", input.name))
+}
+
+#[tokio::test]
+async fn reattach_sent_on_reconnect_and_precedes_registration_replay() {
+    let mock = MockEngine::start().await;
+    let iii = register_worker(mock.url(), InitOptions::default());
+    iii.register_function("reattach::fn", RegisterFunction::new(greet));
+
+    // First connect: the function is registered and NO reattach is sent
+    // (the SDK has no prior worker id yet).
+    let msgs = mock
+        .wait_for(
+            |m| count_register(m, "registerfunction", "reattach::fn") >= 1,
+            Duration::from_secs(5),
+        )
+        .await;
+    assert_eq!(
+        count_type(&msgs, "reattach"),
+        0,
+        "no reattach must be sent on the first connect: {msgs:#?}"
+    );
+
+    // The engine assigns this connection an identity + reattach secret.
+    mock.send_to_client(
+        json!({"type":"workerregistered","worker_id":"w-old","reattach_token":"tok-old"}),
+    );
+    // Give the receive loop time to store the id before we drop the socket.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // Drop the socket; the SDK reconnects and replays. It must now lead with
+    // a reattach carrying the previous id.
+    mock.clear();
+    mock.close_active_connection();
+
+    let msgs = mock
+        .wait_for(
+            |m| count_register(m, "registerfunction", "reattach::fn") >= 1,
+            Duration::from_secs(5),
+        )
+        .await;
+
+    let reattach_idx = msgs
+        .iter()
+        .position(|m| message_type(m) == Some("reattach"))
+        .expect("a reattach frame must be sent on reconnect");
+    let regfn_idx = msgs
+        .iter()
+        .position(|m| {
+            message_type(m) == Some("registerfunction") && message_id(m) == Some("reattach::fn")
+        })
+        .expect("the function must be replayed on reconnect");
+
+    assert!(
+        reattach_idx < regfn_idx,
+        "reattach must precede the registration replay: {msgs:#?}"
+    );
+    assert_eq!(
+        msgs[reattach_idx]
+            .get("previous_worker_id")
+            .and_then(|v| v.as_str()),
+        Some("w-old"),
+        "reattach must carry the previous connection's worker id"
+    );
+    assert_eq!(
+        msgs[reattach_idx]
+            .get("reattach_token")
+            .and_then(|v| v.as_str()),
+        Some("tok-old"),
+        "reattach must carry the previous connection's token"
+    );
+
+    iii.shutdown_async().await;
+}


### PR DESCRIPTION
## What

Fixes the permanent kill loop a worker could enter after its WebSocket dropped and its SDK reconnected. Closes iii-hq/iii#1975 (MOT-4025 defects #1 and #2).

Three engine changes plus a reconnect handshake wired through all five SDKs:

- **Trigger-binding guard** (`trigger.rs`): `TriggerRegistry::unregister_worker` now removes a binding only via an ownership CAS, and only provider-unregisters when the remove actually happened — mirroring the trigger-*type* guard already in that function. This was the watcher-death path.
- **Atomic function release** (`engine/mod.rs`): `release_function_if_owner` holds the `function_owners` shard entry lock across `remove_function_from_engine`, so a racing claim can no longer have its fresh handler deleted. Fixes both `cleanup_worker` and the `UnregisterFunction` arm.
- **Reattach handshake** (`protocol.rs`, `worker_connections/mod.rs`, `engine/mod.rs`): on reconnect a worker presents its previous worker id + a per-connection `reattach_token`. The engine authenticates the token, evicts the old read loop (biased `select!`, so it drains no further stale frames), and **awaits that connection's cleanup to completion** before the replay batch is processed. `cleanup_worker` is idempotent and completion-visible (claim flag + `watch` channel), with a wedged-reader timeout fallback.
- **SDKs (node, browser, python, rust, go)**: store `worker_id` + `reattach_token` from `WorkerRegistered`, and send a `Reattach` frame **first** on every reconnect, before the registration replay. In Go the frame is written synchronously right after dial, before the writer goroutine / `StateConnected` / `onConnect` expose the socket.

## Why

The engine mints a fresh worker `Uuid` per connection and no SDK presented its prior identity back, so a reconnecting worker always looked like a *second live claimant* for its own function/trigger ids. A fresh process doesn't race (its old socket dies before the new one connects); an SDK reconnect dials immediately, so the old connection's `cleanup_worker` ran concurrently with the new connection's registration replay and the engine ping-ponged ownership — logging `Function ownership transferred between two live workers` on repeat, killing re-registered functions/triggers, and taking down session-manager watchers, the queue provider handoff, and iii-worker-ops on the reporting rig.

Worker ids are publicly discoverable (`engine::workers::list`, the workers-available trigger), so the reattach is authenticated by a secret token that only ever travels over the worker's own socket — an id alone must not be able to evict a live worker.

## Notes

- **Wire-compatible / skew-safe.** `Reattach`, and the new `reattach_token` field on `Reattach`/`WorkerRegistered`, are all optional on the wire. Old engines warn-log and ignore the unknown frame; old SDKs never send it. Behaviour degrades to the prior (racy but not worse) path, never to an error.
- **Known residual (not fixed here):** if a connection dies *before* its `WorkerRegistered` arrives, the SDK can't know its id, so that one reconnect can still produce a single ghost-with-WARN hop that the ownership guards keep correct and the next reconnect heals. Closing it fully would require an await-the-engine gate with timeout fallbacks in all five SDK replay paths — more risk than the symptom warrants.
- **Out of scope (pre-existing, separate tickets):** no engine-side liveness reaper for half-open sockets; `UnregisterTrigger`/`unregister_trigger` still lack owner gates.
- **Verification.** Engine lib suite green (1968 passing) incl. new tests: reattach eviction + reader-await-completion + token-required + concurrent replay/cleanup, the trigger-binding race, and protocol round-trips. One wire-level reattach test per SDK: rust / node / browser / python all run green locally; the **Go** test + code changes are written and reviewed but **unverified locally (no Go toolchain on the author's machine)** — please confirm CI runs them. `cargo fmt --all` and workspace `cargo check --all-features` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable reconnect “reattach” support across Go, Node.js, Python, and Rust SDKs.
  * Reconnecting clients now send a `reattach` frame (when available) before replaying registrations/messages.
  * Added optional per-connection reattach tokens while staying compatible with older engines.

* **Bug Fixes**
  * Improved worker connection eviction and teardown coordination to prevent race-related stale cleanup.
  * Hardened cleanup to be fully completion-once and safe under concurrent callers.
  * Prevented stale worker disconnect logic from clobbering newer trigger bindings.

* **Tests**
  * Expanded reconnect/serialization and ordering tests, including token presence/absence and trigger re-registration race coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->