### PR TITLE
fix(website): wire blog markdown export into the build and target the website dist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,9 +169,9 @@ The `skills/` directory contains 26 agent skills (iii-prefixed) auto-discovered 
 Published at https://iii.dev/blog/ — architecture posts and worked examples for coding agents. Each post is available as markdown:
 
 - Index: https://iii.dev/blog/index.md
-- Posts: https://iii.dev/blog/<slug>.md (e.g. https://iii.dev/blog/add-a-worker.md)
+- Posts: https://iii.dev/blog/<slug>.md (every slug listed in the index)
 
-Source lives in `blog/src/content/blog/`. Also indexed in https://iii.dev/llms.txt and https://iii.dev/AGENTS.md.
+Source lives in `website/src/content/blog/`. Also indexed in https://iii.dev/llms.txt and https://iii.dev/AGENTS.md.
 
 ## Licensing
 

--- a/website/package.json
+++ b/website/package.json
@@ -7,10 +7,10 @@
   "engines": {
     "node": ">=22.12.0"
   },
-  "description": "iii.dev — one Astro static site: landing, blog, and the /roadmap tech-spec decks",
+  "description": "iii.dev \u2014 one Astro static site: landing, blog, and the /roadmap tech-spec decks",
   "scripts": {
     "dev": "astro dev",
-    "build": "tsx scripts/validate-roadmap.ts && astro build && tsx scripts/generate-llms-agents.ts && tsx scripts/generate-sitemap.ts",
+    "build": "tsx scripts/validate-roadmap.ts && astro build && tsx scripts/generate-blog-md.ts && tsx scripts/generate-llms-agents.ts && tsx scripts/generate-sitemap.ts",
     "preview": "astro preview",
     "type-check": "tsc -p roadmap --noEmit",
     "test": "tsx --test scripts/*.test.ts ../infra/terraform/website/cloudfront_functions/*.test.js",

--- a/website/scripts/blog-posts.ts
+++ b/website/scripts/blog-posts.ts
@@ -12,7 +12,7 @@ export interface BlogPost {
   draft: boolean
 }
 
-const BLOG_CONTENT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/content/blog')
+export const BLOG_CONTENT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/content/blog')
 
 // Minimal frontmatter reader sized to our schema (title, pubDate, updatedDate,
 // draft). We pull the YAML block between leading `---` fences and parse only

--- a/website/scripts/generate-blog-md.test.ts
+++ b/website/scripts/generate-blog-md.test.ts
@@ -4,20 +4,32 @@ import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
 import { exportBlogMarkdown, formatBlogPostLinkLine, rewriteBlogImagePaths } from './generate-blog-md'
+import { SITE_ORIGIN } from './routes'
 
 async function setupTempBlogDirs(): Promise<{ contentDir: string; distDir: string }> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'iii-blog-md-'))
   const contentDir = path.join(root, 'content')
-  const distDir = path.join(root, 'dist')
+  const distDir = path.join(root, 'dist-blog')
   await fs.mkdir(contentDir, { recursive: true })
-  await fs.mkdir(path.join(distDir, '_astro'), { recursive: true })
+  await fs.mkdir(distDir, { recursive: true })
   return { contentDir, distDir }
 }
 
-test('rewriteBlogImagePaths maps source assets to built _astro URLs', () => {
+async function writeBuiltPostHtml(distDir: string, slug: string, assetPaths: string[]): Promise<void> {
+  await fs.mkdir(path.join(distDir, slug), { recursive: true })
+  const imgs = assetPaths.map((p) => `<img src="${p}">`).join('')
+  await fs.writeFile(path.join(distDir, slug, 'index.html'), `<html><body>${imgs}</body></html>`, 'utf8')
+}
+
+test('rewriteBlogImagePaths maps source assets to built asset URLs', () => {
   const body = '![banner](../../assets/blog/demo/banner.png)'
-  const out = rewriteBlogImagePaths(body, ['banner.DU5X-Ggo_1kFy9f.webp'])
-  assert.match(out, /https:\/\/iii\.dev\/blog\/_astro\/banner\.DU5X-Ggo_1kFy9f\.webp/)
+  const out = rewriteBlogImagePaths(body, ['/_astro/banner.DU5X-Ggo_1kFy9f.webp'])
+  assert.equal(out, `![banner](${SITE_ORIGIN}/_astro/banner.DU5X-Ggo_1kFy9f.webp)`)
+})
+
+test('rewriteBlogImagePaths leaves unknown images untouched', () => {
+  const body = '![banner](../../assets/blog/demo/banner.png)'
+  assert.equal(rewriteBlogImagePaths(body, []), body)
 })
 
 test('formatBlogPostLinkLine escapes brackets in title', () => {
@@ -29,13 +41,10 @@ test('formatBlogPostLinkLine escapes brackets in title', () => {
     pubDate: new Date('2026-06-01'),
     draft: false,
   })
-  assert.equal(
-    line,
-    '- [Loop \\[engineering\\]](https://iii.dev/blog/demo.md) — desc',
-  )
+  assert.equal(line, `- [Loop \\[engineering\\]](${SITE_ORIGIN}/blog/demo.md) — desc`)
 })
 
-test('exportBlogMarkdown writes slug.md and index.md', async () => {
+test('exportBlogMarkdown writes slug.md and index.md with asset URLs from the built page', async () => {
   const { contentDir, distDir } = await setupTempBlogDirs()
   await fs.writeFile(
     path.join(contentDir, 'demo.md'),
@@ -49,20 +58,20 @@ pubDate: 2026-06-01
 `,
     'utf8',
   )
-  await fs.writeFile(path.join(distDir, '_astro', 'banner.abc123.webp'), '', 'utf8')
+  await writeBuiltPostHtml(distDir, 'demo', ['/_astro/banner.abc123.webp'])
 
   const count = await exportBlogMarkdown(contentDir, distDir)
   assert.equal(count, 1)
 
   const exported = await fs.readFile(path.join(distDir, 'demo.md'), 'utf8')
   assert.match(exported, /title: 'Demo'/)
-  assert.match(exported, /https:\/\/iii\.dev\/blog\/_astro\/banner\.abc123\.webp/)
+  assert.ok(exported.includes(`${SITE_ORIGIN}/_astro/banner.abc123.webp`))
 
   const index = await fs.readFile(path.join(distDir, 'index.md'), 'utf8')
-  assert.match(index, /https:\/\/iii\.dev\/blog\/demo\.md/)
+  assert.ok(index.includes(`${SITE_ORIGIN}/blog/demo.md`))
 })
 
-test('exportBlogMarkdown resolves same-basename images from the post built HTML', async () => {
+test('exportBlogMarkdown resolves same-basename images per post from each built page', async () => {
   const { contentDir, distDir } = await setupTempBlogDirs()
   const posts = [
     { slug: 'post-a', hash: 'aaa111' },
@@ -81,13 +90,7 @@ pubDate: 2026-06-01
 `,
       'utf8',
     )
-    await fs.writeFile(path.join(distDir, '_astro', `banner.${hash}.webp`), '', 'utf8')
-    await fs.mkdir(path.join(distDir, slug), { recursive: true })
-    await fs.writeFile(
-      path.join(distDir, slug, 'index.html'),
-      `<html><body><img src="/blog/_astro/banner.${hash}.webp"></body></html>`,
-      'utf8',
-    )
+    await writeBuiltPostHtml(distDir, slug, [`/_astro/banner.${hash}.webp`])
   }
 
   await exportBlogMarkdown(contentDir, distDir)
@@ -104,6 +107,22 @@ test('exportBlogMarkdown throws when no publishable posts exist', async () => {
   await assert.rejects(() => exportBlogMarkdown(contentDir, distDir), /no publishable blog posts/)
 })
 
+test('exportBlogMarkdown throws when a post has no built page yet', async () => {
+  const { contentDir, distDir } = await setupTempBlogDirs()
+  await fs.writeFile(
+    path.join(contentDir, 'unbuilt.md'),
+    `---
+title: 'Unbuilt'
+description: 'd'
+pubDate: 2026-06-01
+---
+`,
+    'utf8',
+  )
+
+  await assert.rejects(() => exportBlogMarkdown(contentDir, distDir), /run `astro build` first/)
+})
+
 test('exportBlogMarkdown reads .mdx sources and writes slug.md output', async () => {
   const { contentDir, distDir } = await setupTempBlogDirs()
   await fs.writeFile(
@@ -118,6 +137,7 @@ MDX body
 `,
     'utf8',
   )
+  await writeBuiltPostHtml(distDir, 'mdx-post', [])
 
   const count = await exportBlogMarkdown(contentDir, distDir)
   assert.equal(count, 1)
@@ -127,5 +147,5 @@ MDX body
   assert.match(exported, /MDX body/)
 
   const index = await fs.readFile(path.join(distDir, 'index.md'), 'utf8')
-  assert.match(index, /https:\/\/iii\.dev\/blog\/mdx-post\.md/)
+  assert.ok(index.includes(`${SITE_ORIGIN}/blog/mdx-post.md`))
 })

--- a/website/scripts/generate-blog-md.ts
+++ b/website/scripts/generate-blog-md.ts
@@ -1,12 +1,14 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import { type BlogPost, readBlogPosts } from './blog-posts'
+import { BLOG_CONTENT_DIR, type BlogPost, readBlogPosts } from './blog-posts'
 import { SITE_ORIGIN } from './routes'
 
 const WEBSITE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
-const BLOG_DIST = path.resolve(WEBSITE_ROOT, '../blog/dist')
-const BLOG_CONTENT = path.resolve(WEBSITE_ROOT, '../blog/src/content/blog')
+// The export runs after `astro build` (see the package build script), so the
+// built site is the source of truth for asset URLs and the output lands next
+// to the built /blog pages.
+const BLOG_DIST = path.join(WEBSITE_ROOT, 'dist', 'blog')
 
 const IMAGE_RE = /!\[([^\]]*)\]\(\.\.\/\.\.\/assets\/blog\/[^/]+\/([^)]+)\)/g
 
@@ -21,50 +23,42 @@ export function formatBlogPostLinkLine(post: BlogPost): string {
   return `- [${title}](${url}) — ${description}`
 }
 
-async function listAstroAssets(distDir: string): Promise<string[]> {
-  try {
-    return await fs.readdir(path.join(distDir, '_astro'))
-  } catch {
-    return []
-  }
-}
+// Absolute asset paths as they appear in the built HTML (e.g.
+// /_astro/banner.CKx2.png). Captured from each post's own page so the export
+// never guesses where the bundler put an image or what it hashed it to.
+const BUILT_ASSET_PATH_RE = /["'(](\/[^"'()\s]*_astro\/[^"'()\s]+)["')]/g
 
-const POST_ASSET_RE = /\/blog\/_astro\/([^"'\s)]+)/g
-
-async function listPostAstroAssets(distDir: string, slug: string): Promise<string[] | null> {
-  let html: string
-  try {
-    html = await fs.readFile(path.join(distDir, slug, 'index.html'), 'utf8')
-  } catch {
-    return null
-  }
+export async function listPostAssetPaths(distDir: string, slug: string): Promise<string[]> {
+  const htmlPath = path.join(distDir, slug, 'index.html')
+  const html = await fs.readFile(htmlPath, 'utf8').catch(() => {
+    throw new Error(`generate-blog-md: ${htmlPath} missing — run \`astro build\` first`)
+  })
   const assets = new Set<string>()
-  for (const match of html.matchAll(POST_ASSET_RE)) assets.add(match[1])
-  return assets.size > 0 ? [...assets] : null
+  for (const match of html.matchAll(BUILT_ASSET_PATH_RE)) assets.add(match[1])
+  return [...assets]
 }
 
-function resolveAssetUrl(filename: string, astroAssets: string[]): string | null {
+function resolveAssetUrl(filename: string, assetPaths: string[]): string | null {
   const stem = path.basename(filename, path.extname(filename))
-  const match = astroAssets.find((file) => file.startsWith(`${stem}.`))
-  return match ? `${SITE_ORIGIN}/blog/_astro/${match}` : null
+  const match = assetPaths.find((assetPath) => path.basename(assetPath).startsWith(`${stem}.`))
+  return match ? `${SITE_ORIGIN}${match}` : null
 }
 
-export function rewriteBlogImagePaths(body: string, astroAssets: string[]): string {
+export function rewriteBlogImagePaths(body: string, assetPaths: string[]): string {
   return body.replace(IMAGE_RE, (full, alt: string, filename: string) => {
-    const url = resolveAssetUrl(filename, astroAssets)
+    const url = resolveAssetUrl(filename, assetPaths)
     return url ? `![${alt}](${url})` : full
   })
 }
 
 export async function exportBlogMarkdown(
-  contentDir = BLOG_CONTENT,
+  contentDir = BLOG_CONTENT_DIR,
   distDir = BLOG_DIST,
 ): Promise<number> {
   const posts = (await readBlogPosts(contentDir)).filter((post) => !post.draft)
   if (posts.length === 0) {
     throw new Error(`no publishable blog posts found in ${contentDir} — refusing to export an empty blog`)
   }
-  const astroAssets = await listAstroAssets(distDir)
 
   await Promise.all(
     posts.map(async (post) => {
@@ -73,8 +67,8 @@ export async function exportBlogMarkdown(
       }
       const sourcePath = path.join(contentDir, post.sourceFile)
       const raw = await fs.readFile(sourcePath, 'utf8')
-      const postAssets = (await listPostAstroAssets(distDir, post.slug)) ?? astroAssets
-      const exported = rewriteBlogImagePaths(raw, postAssets)
+      const assetPaths = await listPostAssetPaths(distDir, post.slug)
+      const exported = rewriteBlogImagePaths(raw, assetPaths)
       await fs.writeFile(path.join(distDir, `${post.slug}.md`), exported, 'utf8')
     }),
   )


### PR DESCRIPTION
Follow-up to #1934. That PR merged with half of its conflict-resolution missing: the deploy built and synced the blog HTML but never produced the markdown exports, so llms.txt and AGENTS.md now link to https://iii.dev/blog/index.md and per-post .md URLs that 404 (S3 NoSuchKey; the deploy log shows no .md uploads under blog/).

Two gaps, both closed here:

1. The export was never wired into the build. The deploy workflow intentionally runs one `pnpm --filter iii-website build`, but the package build script did not call `generate-blog-md.ts`, so nothing emitted `dist/blog/*.md`. The script now runs between `astro build` and `generate-llms-agents.ts`.
2. `generate-blog-md.ts` still targeted the pre-#1955 layout (`../blog/dist`, `../blog/src/content/blog`, `/blog/_astro/` asset prefix), all removed when the blog moved into the website build. It now reads the content dir from `blog-posts.ts` (single source, newly exported), writes into `website/dist/blog/`, and resolves image URLs by capturing the hashed asset paths from each post's built page instead of assuming a prefix. A post without a built page is a loud build failure rather than a silent fallback.

Also updates the export tests to the built-page contract (including a new missing-built-page failure case, asserting against `SITE_ORIGIN` rather than a literal host) and fixes the stale `blog/src/content/blog/` pointer in AGENTS.md.

Verified with a clean `pnpm build` on Node 22: 7 posts plus index.md exported to `dist/blog/` with hashed `/_astro/` image URLs, blog section present in `dist/llms.txt`, `.md` URLs in the sitemap. `pnpm test` 100/100, `pnpm test:dist` 19/19.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blog posts now generate Markdown versions with links and image references based on the published site URL.
  * Blog Markdown generation is included in the website build process.

* **Bug Fixes**
  * Improved handling of post-specific image assets, including duplicate filenames across posts.
  * Builds now clearly report when published blog pages are missing before Markdown export.

* **Documentation**
  * Updated blog content location and publication guidance in the project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->