### PR TITLE
let ccbot crawl us for training data

### DIFF
--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -66,9 +66,10 @@ Allow: /
 Disallow: /preview
 Disallow: /roadmap
 
-# Training-only crawlers (no citation capability) — opt out
 User-agent: CCBot
-Disallow: /
+Allow: /
+Disallow: /preview
+Disallow: /roadmap
 
 Sitemap: https://iii.dev/sitemap.xml
 Sitemap: https://iii.dev/docs/sitemap.xml


### PR DESCRIPTION
## What

Allow CCBot

## Why

So we can get into its training data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated search engine crawling rules to allow CCBot to access the site homepage.
  * Continued blocking CCBot from accessing preview and roadmap pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->