### PR TITLE
fix(engine,iii-worker): propagate manager port to registry binary workers (MOT-4149)

### DIFF
--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -131,11 +131,12 @@ pub enum Commands {
         no_wait: bool,
 
         /// Engine WebSocket port the spawned worker connects back to. Defaults
-        /// to DEFAULT_PORT; the engine passes its configured
-        /// iii-worker-manager port when auto-spawning external workers so
-        /// non-default manager ports don't silently break connectivity.
-        #[arg(long, default_value_t = DEFAULT_PORT)]
-        port: u16,
+        /// to the iii-worker-manager port in config.yaml (else 49134); the
+        /// engine passes its configured port explicitly when auto-spawning
+        /// external workers so non-default manager ports don't silently
+        /// break connectivity.
+        #[arg(long)]
+        port: Option<u16>,
 
         /// YAML config forwarded to the spawned worker binary as `--config <path>`.
         /// Binary workers only; OCI workers warn and ignore.
@@ -170,8 +171,8 @@ pub enum Commands {
 
         /// Engine WebSocket port the spawned worker connects back to. Same
         /// semantics as `start --port`.
-        #[arg(long, default_value_t = DEFAULT_PORT)]
-        port: u16,
+        #[arg(long)]
+        port: Option<u16>,
 
         /// Same as `start --config`.
         #[arg(long, value_name = "PATH")]

--- a/crates/iii-worker/src/cli/host_shim.rs
+++ b/crates/iii-worker/src/cli/host_shim.rs
@@ -569,8 +569,13 @@ impl WorkerHostShim for CliHostShim {
         _events: &dyn EventSink,
     ) -> Result<StartOutcome, WorkerOpError> {
         // handle_managed_start expects port: u16 + config: Option<&Path>.
-        use crate::cli::app::DEFAULT_PORT;
-        let port = opts.port.unwrap_or(DEFAULT_PORT);
+        // No explicit port in the request: resolve the engine's actual
+        // manager port from config.yaml (honors III_CONFIG_PATH) instead of
+        // assuming the compiled-in default — a daemon serving a non-default
+        // engine must not point spawned workers at 49134 (workers#526).
+        let port = opts
+            .port
+            .unwrap_or_else(crate::cli::config_file::manager_port);
         let name_for_call = opts.name.clone();
         let config_for_call = opts.config.clone();
         let wait = opts.wait;
@@ -586,7 +591,7 @@ impl WorkerHostShim for CliHostShim {
             Ok(StartOutcome {
                 name: opts.name,
                 pid,
-                port: opts.port,
+                port: Some(port),
             })
         } else {
             Err(classify_handler_error(rc, &captured, "start", &opts.name))

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -3411,7 +3411,7 @@ pub async fn handle_managed_start(
             );
             return 1;
         }
-        if !is_engine_running() {
+        if !is_engine_running_on(port) {
             eprintln!(
                 "{} '{}' is a builtin served by the iii engine, but the engine isn't running.\n  \
                  Start the engine:  iii",
@@ -3469,7 +3469,7 @@ pub async fn handle_managed_start(
             )
         }
         ResolvedWorkerType::Binary { binary_path } => {
-            StartOutcome::Exit(start_binary_worker(worker_name, &binary_path, config).await)
+            StartOutcome::Exit(start_binary_worker(worker_name, &binary_path, config, port).await)
         }
         ResolvedWorkerType::Config => StartOutcome::FallThrough,
     };
@@ -3511,7 +3511,7 @@ pub async fn handle_managed_start(
             match binary_download::download_and_install_binary(worker_name, binary_info).await {
                 Ok(installed_path) => {
                     eprintln!("  {} Installed successfully", "✓".green());
-                    let rc = start_binary_worker(worker_name, &installed_path, config).await;
+                    let rc = start_binary_worker(worker_name, &installed_path, config, port).await;
                     return finish_start(worker_name, rc, wait, port).await;
                 }
                 Err(e) => {
@@ -3559,7 +3559,7 @@ pub async fn handle_managed_start(
                 );
                 return 1;
             }
-            if !is_engine_running() {
+            if !is_engine_running_on(port) {
                 eprintln!(
                     "{} '{}' is an engine builtin, but the engine isn't running.\n  \
                      Start the engine:  iii",
@@ -3624,9 +3624,12 @@ async fn finish_start(worker_name: &str, rc: i32, wait: bool, port: u16) -> i32 
 pub async fn handle_managed_restart(
     worker_name: &str,
     wait: bool,
-    port: u16,
+    port: Option<u16>,
     config: Option<&std::path::Path>,
 ) -> i32 {
+    // No explicit --port: target the engine config.yaml actually points at
+    // (honors engine-exported III_CONFIG_PATH), not the compiled-in default.
+    let port = port.unwrap_or_else(super::config_file::manager_port);
     if let Err(e) = super::registry::validate_worker_name(worker_name) {
         eprintln!("{} {}", "error:".red(), e);
         return 1;
@@ -3692,6 +3695,7 @@ async fn start_binary_worker(
     worker_name: &str,
     binary_path: &std::path::Path,
     config: Option<&std::path::Path>,
+    port: u16,
 ) -> i32 {
     // Kill any stale process from a previous engine run
     kill_stale_worker(worker_name).await;
@@ -3737,6 +3741,13 @@ async fn start_binary_worker(
     // engine truth (`iii worker status`/`list`) matches connections by this
     // name.
     cmd.env("III_WORKER_NAME", worker_name);
+    // Engine WS URL — the documented worker contract (III_URL/III_ENGINE_URL
+    // are engine-set). Without these a registry binary on a non-default
+    // manager port dials its compiled-in ws://127.0.0.1:49134 default and
+    // strands retrying (iii-hq/workers#526).
+    let engine_url = format!("ws://127.0.0.1:{}", port);
+    cmd.env("III_ENGINE_URL", &engine_url);
+    cmd.env("III_URL", &engine_url);
     cmd.stdout(stdout_file).stderr(stderr_file);
 
     #[cfg(unix)]
@@ -6724,6 +6735,70 @@ dependencies:
         let _h = super::super::test_support::lock_home();
         // Should not panic when no PID files exist
         kill_stale_worker("__iii_test_nonexistent_99999__").await;
+    }
+
+    /// The env half of the binary spawn contract (iii-hq/workers#526):
+    /// registry binaries receive the engine URL ONLY via these exports —
+    /// no --url flag exists on the spawn — so dropping them silently
+    /// re-strands every binary worker on non-default manager ports. The
+    /// probe "binary" dumps its env to stdout, which start_binary_worker
+    /// wires to ~/.iii/logs/<name>/stdout.log.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn start_binary_worker_exports_engine_url_env() {
+        let _h = super::super::test_support::lock_home();
+        let tmp = tempfile::tempdir().unwrap();
+        let original_home = std::env::var_os("HOME");
+        // SAFETY: test-only, serialized via test_support::lock_home.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+
+        let probe = tmp.path().join("env-probe.sh");
+        std::fs::write(&probe, "#!/bin/sh\nenv\n").unwrap();
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&probe, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        // Distinctive port: proves the child sees THIS spawn's port, not
+        // a hardcoded default.
+        let rc = start_binary_worker("__iii_test_env_probe__", &probe, None, 50123).await;
+
+        // Child is detached; poll the log briefly for the env dump.
+        let log = tmp
+            .path()
+            .join(".iii/logs/__iii_test_env_probe__/stdout.log");
+        let mut content = String::new();
+        for _ in 0..50 {
+            content = std::fs::read_to_string(&log).unwrap_or_default();
+            if content.contains("III_URL=") {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+
+        // Restore HOME before asserting so a failing assert can't leak
+        // the temp HOME into later env-reading tests.
+        // SAFETY: test-only, serialized via test_support::lock_home.
+        unsafe {
+            match &original_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        assert_eq!(rc, 0, "probe spawn must succeed");
+        assert!(
+            content.contains("III_ENGINE_URL=ws://127.0.0.1:50123"),
+            "child must see III_ENGINE_URL for this spawn's port; got: {content:?}"
+        );
+        assert!(
+            content.contains("III_URL=ws://127.0.0.1:50123"),
+            "child must see III_URL for this spawn's port; got: {content:?}"
+        );
+        assert!(
+            content.contains("III_WORKER_NAME=__iii_test_env_probe__"),
+            "child must see its managed identity; got: {content:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -410,7 +410,7 @@ async fn async_main() -> anyhow::Result<()> {
             // Adapt CLI Start arg shape to StartOptions.
             let opts = StartOptions {
                 name: worker_name,
-                port: Some(port),
+                port,
                 config: config.map(|p| p.display().to_string()),
                 wait: !no_wait,
             };

--- a/crates/iii-worker/tests/config_managed_integration.rs
+++ b/crates/iii-worker/tests/config_managed_integration.rs
@@ -454,7 +454,7 @@ async fn handle_managed_restart_invalid_name_fails_fast() {
         let rc = iii_worker::cli::managed::handle_managed_restart(
             "bad name with spaces",
             false,
-            iii_worker::DEFAULT_PORT,
+            Some(iii_worker::DEFAULT_PORT),
             None,
         )
         .await;
@@ -487,7 +487,7 @@ async fn handle_managed_restart_on_not_running_surfaces_start_rc() {
         let restart_rc = iii_worker::cli::managed::handle_managed_restart(
             "iii-http",
             false,
-            iii_worker::DEFAULT_PORT,
+            Some(iii_worker::DEFAULT_PORT),
             None,
         )
         .await;

--- a/crates/iii-worker/tests/worker_integration.rs
+++ b/crates/iii-worker/tests/worker_integration.rs
@@ -75,8 +75,11 @@ fn cli_parses_all_subcommands() {
 #[test]
 fn start_subcommand_matches_engine_spawn_args() {
     // Bare-name form used when a human runs `iii-worker start <name>` from
-    // the terminal. Must still parse cleanly and default port to DEFAULT_PORT.
-    // Humans DO expect the wait-for-ready status panel here; only the engine
+    // the terminal. Must still parse cleanly with NO parsed port — the
+    // handler then resolves config.yaml's iii-worker-manager port (else
+    // DEFAULT_PORT), so a bare start on a non-default-port host targets the
+    // engine actually configured there (iii-hq/workers#526). Humans DO
+    // expect the wait-for-ready status panel here; only the engine
     // auto-spawn path opts out via --no-wait.
     let cli = Cli::try_parse_from(["iii-worker", "start", "image-resize"])
         .expect("bare start form must parse");
@@ -90,9 +93,8 @@ fn start_subcommand_matches_engine_spawn_args() {
             assert_eq!(worker_name, "image-resize");
             assert!(!no_wait, "bare human invocation keeps default wait=true");
             assert_eq!(
-                port,
-                iii_worker::DEFAULT_PORT,
-                "bare form must default to DEFAULT_PORT"
+                port, None,
+                "bare form parses no port; the handler resolves config.yaml"
             );
             assert!(config.is_none(), "bare human form has no --config");
         }
@@ -128,7 +130,7 @@ fn start_subcommand_accepts_port_flag_from_engine_spawn() {
         } => {
             assert_eq!(worker_name, "pdfkit");
             assert!(no_wait, "engine auto-spawn must pass --no-wait");
-            assert_eq!(port, 49199, "--port must surface the custom port");
+            assert_eq!(port, Some(49199), "--port must surface the custom port");
             assert!(config.is_none(), "no --config in this spawn form");
         }
         _ => panic!("expected Start"),
@@ -173,7 +175,7 @@ fn restart_subcommand_accepts_port_flag() {
             worker_name, port, ..
         } => {
             assert_eq!(worker_name, "pdfkit");
-            assert_eq!(port, 49199);
+            assert_eq!(port, Some(49199));
         }
         _ => panic!("expected Restart"),
     }

--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -297,7 +297,7 @@ iii worker restart [OPTIONS] <WORKER>
 | Option | Description |
 | ------ | ----------- |
 | `--no-wait` | Return immediately. Don't block waiting for the worker to report ready |
-| `--port <PORT>` | Engine WebSocket port the spawned worker connects back to. Same semantics as `start --port` [default: 49134] |
+| `--port <PORT>` | Engine WebSocket port the spawned worker connects back to. Same semantics as `start --port` |
 | `--config <PATH>` | Same as `start --config` |
 
 ### `iii worker sandbox`
@@ -463,7 +463,7 @@ iii worker start [OPTIONS] <WORKER>
 | Option | Description |
 | ------ | ----------- |
 | `--no-wait` | Return immediately. Don't block waiting for the worker to report ready |
-| `--port <PORT>` | Engine WebSocket port the spawned worker connects back to. Defaults to DEFAULT_PORT; the engine passes its configured iii-worker-manager port when auto-spawning external workers so non-default manager ports don't silently break connectivity [default: 49134] |
+| `--port <PORT>` | Engine WebSocket port the spawned worker connects back to. Defaults to the iii-worker-manager port in config.yaml (else 49134); the engine passes its configured port explicitly when auto-spawning external workers so non-default manager ports don't silently break connectivity |
 | `--config <PATH>` | YAML config forwarded to the spawned worker binary as `--config <path>`. Binary workers only; OCI workers warn and ignore |
 
 ### `iii worker status`

--- a/docs/next/upgrading/from-0-21-x.mdx
+++ b/docs/next/upgrading/from-0-21-x.mdx
@@ -87,6 +87,14 @@ This step applies only to Rust workers that called the removed constructor. Node
 and Go workers need no change here. This handler was only in the Rust SDK a short time so it's
 unlikely that code was using it.
 
+## Behavior change: worker start port resolution
+
+`iii worker start` and `restart` (and the worker-manager daemon's `worker::start`) without an
+explicit `--port` now resolve the engine's `iii-worker-manager` port from `config.yaml` instead of
+always assuming `49134`. Auto-spawned registry binaries also receive `III_URL`/`III_ENGINE_URL`
+pointing at the engine's actual port, so worker builds that honor those variables connect correctly
+on non-default ports. Pass `--port` explicitly to target a specific port.
+
 ## Migration checklist
 
 - [ ] Rename the always-running workers to their unprefixed names in `config.yaml`,

--- a/engine/src/workers/registry_worker.rs
+++ b/engine/src/workers/registry_worker.rs
@@ -132,6 +132,17 @@ fn spawn_args(worker_name: &str, port: u16, config_path: Option<&std::path::Path
     args
 }
 
+/// Env exported to the spawned `iii-worker start` tree so binary workers
+/// (which inherit their parent's environment) receive THIS engine's actual
+/// WS address instead of falling back to their compiled-in
+/// ws://127.0.0.1:49134 default (iii-hq/workers#526). Mirrors the
+/// MOT-3970 exports in external.rs for builtin daemons. Kept pure so the
+/// env contract regression-tests without spawning, like `spawn_args`.
+fn spawn_url_env(port: u16) -> [(&'static str, String); 2] {
+    let url = format!("ws://127.0.0.1:{}", port);
+    [("III_ENGINE_URL", url.clone()), ("III_URL", url)]
+}
+
 // =============================================================================
 // iii-worker binary resolution
 // =============================================================================
@@ -320,6 +331,12 @@ impl ExternalWorkerProcess {
         // iii` left every managed worker running: this path — not
         // external.rs — is how production workers are spawned.
         cmd.env("III_ENGINE_PID", std::process::id().to_string());
+        // Engine WS URL for the whole detached tree (workers#526): binary
+        // workers inherit env from `iii-worker start`, so exporting here
+        // reaches them even through a version-skewed iii-worker binary.
+        for (key, value) in spawn_url_env(port) {
+            cmd.env(key, value);
+        }
         // Same-file contract: the spawned `iii-worker start` (and everything
         // it detaches — VM boot, source watcher restarts) must read the
         // engine's actual config file, not assume ./config.yaml in its cwd.
@@ -1027,6 +1044,21 @@ mod tests {
                 "--port".to_string(),
                 "49199".to_string(),
                 "--no-wait".to_string(),
+            ],
+        );
+    }
+
+    /// The env half of the spawn contract (iii-hq/workers#526): binary
+    /// workers receive the engine URL only via inherited env, so the
+    /// exported pair must carry the actual manager port. Drift here
+    /// re-strands every registry binary on non-default ports.
+    #[test]
+    fn spawn_url_env_carries_manager_port() {
+        assert_eq!(
+            spawn_url_env(3034),
+            [
+                ("III_ENGINE_URL", "ws://127.0.0.1:3034".to_string()),
+                ("III_URL", "ws://127.0.0.1:3034".to_string()),
             ],
         );
     }


### PR DESCRIPTION
Fixes links 2 of iii-hq/workers#526 (link 1 landed as MOT-3970 / #1974; link 3 is the sibling workers-repo PR).

## Problem
On a non-default `iii-worker-manager` port, registry **binary** workers never learn the engine's address:
- `start_binary_worker` dropped the `--port` it was invoked with — the child env carried only `III_WORKER_NAME`
- the engine's registry auto-spawn (`ExternalWorkerProcess::spawn`) exported no URL env for the tree
- daemon `worker::start` and bare `iii-worker start`/`restart` assumed `DEFAULT_PORT` (49134)

## Changes
- `start_binary_worker(.., port)` exports `III_ENGINE_URL`/`III_URL` = `ws://127.0.0.1:{port}` — same contract `external.rs` exports for builtin daemons (MOT-3970)
- `ExternalWorkerProcess::spawn` exports the pair (pure `spawn_url_env` helper, unit-tested) so the whole detached tree inherits it — covers version-skewed `iii-worker` binaries and source-watcher respawns
- `--port` on `start`/`restart` is now `Option<u16>`; absent → resolve config.yaml's manager port via `config_file::manager_port()` (honors `III_CONFIG_PATH`); daemon `worker::start` same
- builtin liveness gates use `is_engine_running_on(port)` instead of ignoring an explicit `--port`
- regenerated CLI reference; upgrade note in `docs/next/upgrading/from-0-21-x.mdx`

## Tests
- new `start_binary_worker_exports_engine_url_env` (spawns an env-dumping probe on port 50123, asserts the child sees the URLs)
- new `spawn_url_env_carries_manager_port` unit test
- updated CLI contract tests (`worker_integration.rs`: bare form now parses `port: None`)
- full `cargo test -p iii-worker` + `-p iii --lib workers::registry_worker` green

MOT-4149

https://claude.ai/code/session_01UM4FHiZB9tL4ZvhDqmzWq9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker start and restart now use the configured engine manager port when `--port` is omitted.
  * Explicit ports remain supported for targeting a specific manager endpoint.
  * Automatically started workers now connect to non-default manager ports correctly.

* **Bug Fixes**
  * Fixed worker processes sometimes connecting to the default port instead of the configured port.

* **Documentation**
  * Updated CLI reference and upgrade guidance to describe the new port resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->