### PR TITLE
feat(website): use each blog post banner as its own og:image

### DIFF
--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -3,15 +3,20 @@ import { defineCollection, z } from 'astro:content'
 
 const blog = defineCollection({
   loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/blog' }),
-  schema: z.object({
-    title: z.string(),
-    description: z.string(),
-    pubDate: z.coerce.date(),
-    updatedDate: z.coerce.date().optional(),
-    draft: z.boolean().optional().default(false),
-    tags: z.array(z.string()).optional().default([]),
-    author: z.string().optional(),
-  }),
+  schema: ({ image }) =>
+    z.object({
+      title: z.string(),
+      description: z.string(),
+      pubDate: z.coerce.date(),
+      updatedDate: z.coerce.date().optional(),
+      draft: z.boolean().optional().default(false),
+      tags: z.array(z.string()).optional().default([]),
+      author: z.string().optional(),
+      // The post's banner image, reused as its og:image / twitter:image link
+      // preview instead of the site-wide default. Same relative path as the
+      // banner already embedded as the post's first inline image.
+      ogImage: image().optional(),
+    }),
 })
 
 export const collections = { blog }

--- a/website/src/content/blog/add-a-worker.md
+++ b/website/src/content/blog/add-a-worker.md
@@ -4,6 +4,7 @@ description: 'The cloud is a bazaar, and that was okay until agents arrived and 
 pubDate: 2026-05-07
 author: 'Mike Piccolo, Founder & CEO of iii'
 tags: ['agents', 'architecture', 'workers', 'cloudflare']
+ogImage: ../../assets/blog/add-a-worker/banner.png
 ---
 
 ![Add a worker — every category collapses into the same primitive](../../assets/blog/add-a-worker/banner.png)

--- a/website/src/content/blog/building-agents-for-real-world.md
+++ b/website/src/content/blog/building-agents-for-real-world.md
@@ -4,6 +4,7 @@ description: 'Reliable agent systems converge when validation, isolation, and ob
 pubDate: 2026-05-14
 author: 'Mike Piccolo, Founder & CEO of iii'
 tags: ['agents', 'architecture', 'runtime', 'workers']
+ogImage: ../../assets/blog/building-agents-for-real-world/banner.png
 ---
 
 ![Agents break at month six — the fix is the runtime](../../assets/blog/building-agents-for-real-world/banner.png)

--- a/website/src/content/blog/how-to-build-your-own-agent-harness.md
+++ b/website/src/content/blog/how-to-build-your-own-agent-harness.md
@@ -4,6 +4,7 @@ description: 'Most agent teams adopt a harness as one decision. iii decomposes i
 pubDate: 2026-05-28
 author: 'Mike Piccolo, Founder & CEO of iii'
 tags: ['agents', 'harness', 'architecture', 'workers', 'orchestration']
+ogImage: ../../assets/blog/how-to-build-your-own-agent-harness/cover.png
 ---
 
 ![How to Build Your Own Agent Harness — loops, tools, memory, sandbox, and observability](../../assets/blog/how-to-build-your-own-agent-harness/cover.png)

--- a/website/src/content/blog/loop-engineering-is-just-software-engineering.md
+++ b/website/src/content/blog/loop-engineering-is-just-software-engineering.md
@@ -4,6 +4,7 @@ description: 'Loop engineering describes an event-driven, observable, stateful d
 pubDate: 2026-06-25
 author: 'Mike Piccolo, Founder & CEO of iii'
 tags: ['agents', 'architecture', 'harness', 'loops', 'workers']
+ogImage: ../../assets/blog/loop-engineering-is-just-software-engineering/banner.png
 ---
 
 ![Loop Engineering Is Just Software Engineering. We Have a Name for That.](../../assets/blog/loop-engineering-is-just-software-engineering/banner.png)

--- a/website/src/content/blog/loops-graphs-and-the-layer-that-matters.md
+++ b/website/src/content/blog/loops-graphs-and-the-layer-that-matters.md
@@ -4,6 +4,7 @@ description: 'Prompt engineering, context engineering, loop engineering, graph e
 pubDate: 2026-07-21
 author: 'Mike Piccolo, Founder & CEO of iii'
 tags: ['agents', 'architecture', 'harness', 'loops', 'graphs', 'workers']
+ogImage: ../../assets/blog/loops-graphs-and-the-layer-that-matters/banner.png
 ---
 
 ![Loops, graphs, and the layer that matters -- patterns come down, substrates hold.](../../assets/blog/loops-graphs-and-the-layer-that-matters/banner.png)

--- a/website/src/content/blog/the-harness-is-the-backend.md
+++ b/website/src/content/blog/the-harness-is-the-backend.md
@@ -5,6 +5,7 @@ description: 'The agent harness debate takes for granted that the harness is its
 pubDate: 2026-04-28  
 author: 'Mike Piccolo, Founder & CEO of iii'  
 tags: ['agents', 'architecture', 'harness', 'backend']
+ogImage: ../../assets/blog/the-harness-is-the-backend/point-to-point-vs-shared-runtime.png
 ---
 
 The most important architectural question in AI infrastructure right now isn't

--- a/website/src/content/blog/the-substrate-is-installable.md
+++ b/website/src/content/blog/the-substrate-is-installable.md
@@ -4,6 +4,7 @@ description: 'Every long-running agent ends up rebuilding the same surrounding l
 pubDate: 2026-05-21
 author: 'Mike Piccolo, Founder & CEO of iii'
 tags: ['agents', 'architecture', 'substrate', 'registry']
+ogImage: ../../assets/blog/the-substrate-is-installable/banner.png
 ---
 
 ![The substrate is installable — every category collapses into iii worker add](../../assets/blog/the-substrate-is-installable/banner.png)

--- a/website/src/content/blog/why-agent-sandboxes-are-converging-on-libkrun-not-firecracker.md
+++ b/website/src/content/blog/why-agent-sandboxes-are-converging-on-libkrun-not-firecracker.md
@@ -4,6 +4,7 @@ description: 'Local-first coding agents need hardware isolation on macOS and Lin
 pubDate: 2026-05-15
 author: 'Rohit Ghumare'
 tags: ['agents', 'sandbox', 'libkrun', 'firecracker']
+ogImage: ../../assets/blog/why-agent-sandboxes-are-converging-on-libkrun-not-firecracker/banner.png
 ---
 
 ![Why agent sandboxes are converging on libkrun, not Firecracker](../../assets/blog/why-agent-sandboxes-are-converging-on-libkrun-not-firecracker/banner.png)

--- a/website/src/layouts/BlogLayout.astro
+++ b/website/src/layouts/BlogLayout.astro
@@ -18,9 +18,23 @@ interface Props {
   ogType?: 'website' | 'article'
   publishedTime?: Date
   modifiedTime?: Date
+  /** Absolute URL to the post's own banner image; falls back to the site-wide default. */
+  ogImage?: string
+  ogImageWidth?: number
+  ogImageHeight?: number
 }
 
-const { title, description, canonicalPath, ogType = 'website', publishedTime, modifiedTime } = Astro.props
+const {
+  title,
+  description,
+  canonicalPath,
+  ogType = 'website',
+  publishedTime,
+  modifiedTime,
+  ogImage = 'https://iii.dev/og-image.png',
+  ogImageWidth,
+  ogImageHeight,
+} = Astro.props
 const canonical = new URL(canonicalPath, Astro.site).toString()
 ---
 
@@ -42,11 +56,13 @@ const canonical = new URL(canonicalPath, Astro.site).toString()
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:url" content={canonical} />
-    <meta property="og:image" content="https://iii.dev/og-image.png" />
+    <meta property="og:image" content={ogImage} />
+    {ogImageWidth && <meta property="og:image:width" content={ogImageWidth.toString()} />}
+    {ogImageHeight && <meta property="og:image:height" content={ogImageHeight.toString()} />}
     {publishedTime && <meta property="article:published_time" content={publishedTime.toISOString()} />}
     {modifiedTime && <meta property="article:modified_time" content={modifiedTime.toISOString()} />}
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:image" content="https://iii.dev/og-image.png" />
+    <meta name="twitter:image" content={ogImage} />
     <slot name="head" />
   </head>
   <body>

--- a/website/src/layouts/BlogPost.astro
+++ b/website/src/layouts/BlogPost.astro
@@ -1,13 +1,22 @@
 ---
+import { getImage } from 'astro:assets'
 import type { CollectionEntry } from 'astro:content'
 import FormattedDate from '../components/blog/FormattedDate.astro'
 import BlogLayout from './BlogLayout.astro'
 
 type Props = CollectionEntry<'blog'>['data'] & { slug: string }
 
-const { title, description, pubDate, updatedDate, author, slug } = Astro.props
+const { title, description, pubDate, updatedDate, author, slug, ogImage } = Astro.props
 const canonicalPath = `/blog/${slug}/`
 const canonical = new URL(canonicalPath, Astro.site).toString()
+
+// Reuse the post's own banner as its link-preview image instead of the
+// site-wide default, so sharing a post in Slack/Twitter/etc. shows the post
+// itself rather than the generic iii.dev card.
+const resolvedOgImage = ogImage ? await getImage({ src: ogImage, format: 'png' }) : undefined
+const ogImageUrl = resolvedOgImage
+  ? new URL(resolvedOgImage.src, Astro.site).toString()
+  : 'https://iii.dev/og-image.png'
 
 const jsonLd = {
   '@context': 'https://schema.org',
@@ -23,7 +32,7 @@ const jsonLd = {
     url: 'https://iii.dev/',
     logo: { '@type': 'ImageObject', url: 'https://iii.dev/favicon.svg' },
   },
-  image: 'https://iii.dev/og-image.png',
+  image: ogImageUrl,
   url: canonical,
   mainEntityOfPage: canonical,
 }
@@ -36,6 +45,9 @@ const jsonLd = {
   ogType="article"
   publishedTime={pubDate}
   modifiedTime={updatedDate}
+  ogImage={ogImageUrl}
+  ogImageWidth={resolvedOgImage?.attributes.width}
+  ogImageHeight={resolvedOgImage?.attributes.height}
 >
   <script is:inline type="application/ld+json" slot="head" set:html={JSON.stringify(jsonLd)} />
   <article>


### PR DESCRIPTION
## Summary
- Every blog post's link preview (Slack, Twitter, etc.) fell back to the site wide `https://iii.dev/og-image.png` default instead of the post's own banner.
- Adds an optional `ogImage` frontmatter field (via the content collection's `image()` schema helper) to all 8 blog posts, pointing at the same banner already used as each post's first inline image.
- `BlogPost.astro` resolves `ogImage` through `astro:assets`' `getImage()` to a real, hashed static asset URL and passes it (plus its width/height) down to `BlogLayout.astro`, which now uses it for `og:image`, `og:image:width/height`, and `twitter:image` instead of the hardcoded default. Falls back to the old default when a post has no `ogImage`.
- Also updates the post's JSON-LD `image` field to match.

## Test plan
- [x] `astro build` and confirmed `dist/blog/<slug>/index.html` now has `og:image`/`twitter:image` pointing at each post's own hashed `/_astro/<banner>.<hash>.png`, e.g. `loops-graphs-and-the-layer-that-matters` -> `banner.DxD6lx-X_xiFYp.png`, `the-harness-is-the-backend` -> `point-to-point-vs-shared-runtime.DOGZ7jMg_7RhXr.png`
- [x] Spot-checked all 8 posts resolve to their own image, including the two with non-`banner.png` filenames (`cover.png`, `point-to-point-vs-shared-runtime.png`)
- [x] `pnpm dev:website` still serves the blog correctly in dev


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Blog posts now support custom Open Graph images for richer link previews.
  - Social sharing metadata and structured data use each post’s configured image when available.
  - Open Graph image dimensions are included when available.
  - Posts without a custom image continue using the site-wide default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->