### PR TITLE
fix(iii-worker): count nodes not paths in dep graph bounds check

### DIFF
--- a/crates/iii-worker/src/cli/registry.rs
+++ b/crates/iii-worker/src/cli/registry.rs
@@ -335,32 +335,43 @@ pub fn enforce_dep_graph_bounds(
         });
     }
 
-    // BFS over edges to find the longest path from `root.name`. The
-    // graph is a DAG by construction (registry rejects cycles during
-    // resolve), so we can use simple visited-set + depth tracking.
-    let mut adjacency: std::collections::HashMap<&str, Vec<&str>> =
+    // Find the longest path from `root.name`. The graph is a DAG by
+    // construction (registry rejects cycles during resolve). Edges are
+    // deduped into a set-backed adjacency so a malformed response with
+    // repeated edges cannot inflate the traversal, and each node is
+    // re-expanded only when it is reached via a strictly deeper path.
+    // That memoization is what keeps a wide diamond DAG — many distinct
+    // paths, few distinct nodes — from being counted path-by-path: the
+    // old walk lacked it and rejected legitimate graphs (e.g. a bundle
+    // whose transitives shared a dependency) with a spurious
+    // `edge_traversal` error.
+    let mut adjacency: std::collections::HashMap<&str, std::collections::HashSet<&str>> =
         std::collections::HashMap::new();
     for edge in &graph.edges {
-        adjacency.entry(&edge.from).or_default().push(&edge.to);
+        adjacency.entry(&edge.from).or_default().insert(&edge.to);
     }
 
+    // Deepest path on which each node has already been expanded. A DAG
+    // within bounds expands each node at most MAX_DEPENDENCY_DEPTH + 1
+    // times, so total work is bounded by node_count * (depth + 1).
+    let mut best_depth: std::collections::HashMap<&str, u32> = std::collections::HashMap::new();
     let mut frontier: Vec<(&str, u32)> = vec![(graph.root.name.as_str(), 0)];
-    let mut max_depth: u32 = 0;
-    // Bound the walk at MAX_TRANSITIVE_DEPS to keep this cheap even on
-    // a maliciously crafted very-wide graph.
+    // Backstop against a graph that is malformed in a way the DAG
+    // invariant should have prevented (self-reference, hidden cycle).
+    // With deduped adjacency and memoization a well-formed in-bounds
+    // graph never approaches this ceiling.
     let mut walked = 0u32;
+    let walk_budget = node_count
+        .saturating_add(1)
+        .saturating_mul(MAX_DEPENDENCY_DEPTH + 1);
     while let Some((node, depth)) = frontier.pop() {
         walked += 1;
-        if walked > MAX_TRANSITIVE_DEPS.saturating_mul(2) {
-            // Defense against malformed graphs with repeated edges.
+        if walked > walk_budget {
             return Err(crate::core::error::WorkerOpError::BundleDepGraphExceeded {
                 dimension: "edge_traversal".into(),
-                limit: MAX_TRANSITIVE_DEPS.saturating_mul(2),
+                limit: walk_budget,
                 actual: walked,
             });
-        }
-        if depth > max_depth {
-            max_depth = depth;
         }
         if depth >= MAX_DEPENDENCY_DEPTH {
             return Err(crate::core::error::WorkerOpError::BundleDepGraphExceeded {
@@ -369,14 +380,19 @@ pub fn enforce_dep_graph_bounds(
                 actual: depth + 1,
             });
         }
+        // Skip nodes already reached via an equal-or-deeper path: the
+        // longest path through them is already accounted for.
+        if best_depth.get(node).is_some_and(|&seen| depth <= seen) {
+            continue;
+        }
+        best_depth.insert(node, depth);
         if let Some(children) = adjacency.get(node) {
-            for child in children {
+            for &child in children {
                 frontier.push((child, depth + 1));
             }
         }
     }
 
-    let _ = max_depth; // retained for future structured logging
     Ok(())
 }
 

--- a/crates/iii-worker/src/cli/registry.rs
+++ b/crates/iii-worker/src/cli/registry.rs
@@ -353,26 +353,23 @@ pub fn enforce_dep_graph_bounds(
 
     // Deepest path on which each node has already been expanded. A DAG
     // within bounds expands each node at most MAX_DEPENDENCY_DEPTH + 1
-    // times, so total work is bounded by node_count * (depth + 1).
+    // times (once per strictly deeper path), so the number of expansions
+    // — the only work that pushes new frontier entries — is bounded by
+    // node_count * (depth + 1).
     let mut best_depth: std::collections::HashMap<&str, u32> = std::collections::HashMap::new();
     let mut frontier: Vec<(&str, u32)> = vec![(graph.root.name.as_str(), 0)];
     // Backstop against a graph that is malformed in a way the DAG
     // invariant should have prevented (self-reference, hidden cycle).
-    // With deduped adjacency and memoization a well-formed in-bounds
-    // graph never approaches this ceiling.
-    let mut walked = 0u32;
-    let walk_budget = node_count
+    // It counts *expansions*, not frontier pops: a dense DAG pushes each
+    // node once per parent, so pops grow with node_count squared while
+    // expansions stay linear. Bounding pops here would reject a valid
+    // dense graph; bounding expansions does not. Memo-skipped pops are
+    // O(1) and cannot outnumber the pushes the expansions produced.
+    let mut expanded = 0u32;
+    let expansion_budget = node_count
         .saturating_add(1)
         .saturating_mul(MAX_DEPENDENCY_DEPTH + 1);
     while let Some((node, depth)) = frontier.pop() {
-        walked += 1;
-        if walked > walk_budget {
-            return Err(crate::core::error::WorkerOpError::BundleDepGraphExceeded {
-                dimension: "edge_traversal".into(),
-                limit: walk_budget,
-                actual: walked,
-            });
-        }
         if depth >= MAX_DEPENDENCY_DEPTH {
             return Err(crate::core::error::WorkerOpError::BundleDepGraphExceeded {
                 dimension: "depth".into(),
@@ -386,6 +383,14 @@ pub fn enforce_dep_graph_bounds(
             continue;
         }
         best_depth.insert(node, depth);
+        expanded += 1;
+        if expanded > expansion_budget {
+            return Err(crate::core::error::WorkerOpError::BundleDepGraphExceeded {
+                dimension: "edge_traversal".into(),
+                limit: expansion_budget,
+                actual: expanded,
+            });
+        }
         if let Some(children) = adjacency.get(node) {
             for &child in children {
                 frontier.push((child, depth + 1));

--- a/crates/iii-worker/tests/bundle_worker_integration.rs
+++ b/crates/iii-worker/tests/bundle_worker_integration.rs
@@ -560,6 +560,83 @@ fn dep_graph_accepts_within_bounds() {
 }
 
 #[test]
+fn dep_graph_accepts_wide_shared_dependencies() {
+    // Regression: a shallow but wide DAG whose nodes share dependencies
+    // has far more distinct root→leaf paths than distinct nodes. The old
+    // walk counted paths, so a legitimate in-bounds graph (few nodes,
+    // depth well under the cap) was rejected with a spurious
+    // `edge_traversal` error. This is the shape a real bundle produced:
+    // `iii worker add <bundle>` failed with
+    // "edge_traversal exceeded: limit 64, found 65".
+    //
+    // Fully-connected layers of width 3: root → L1(3) → L2(3) → L3(3) → leaf.
+    // 11 distinct nodes, longest path 4 — both within bounds — but 3*3*3
+    // = 27 paths reach the leaf, which alone overflows the old limit of 64.
+    let layers = [
+        vec!["a0", "a1", "a2"],
+        vec!["b0", "b1", "b2"],
+        vec!["c0", "c1", "c2"],
+        vec!["leaf"],
+    ];
+
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
+    for name in layers.iter().flatten() {
+        nodes.push(make_resolved_worker(name));
+    }
+    // root fully connects to the first layer.
+    for name in &layers[0] {
+        edges.push(ResolvedEdge {
+            from: "root".into(),
+            to: (*name).into(),
+            range: "*".into(),
+        });
+    }
+    // each layer fully connects to the next (bipartite), so nodes share
+    // downstream dependencies.
+    for pair in layers.windows(2) {
+        for from in &pair[0] {
+            for to in &pair[1] {
+                edges.push(ResolvedEdge {
+                    from: (*from).into(),
+                    to: (*to).into(),
+                    range: "*".into(),
+                });
+            }
+        }
+    }
+
+    let graph = ResolvedWorkerGraph {
+        root: make_root_worker("root"),
+        target: None,
+        graph: nodes,
+        edges,
+    };
+    enforce_dep_graph_bounds(&graph).expect("wide shared-dependency graph is within bounds");
+}
+
+#[test]
+fn dep_graph_tolerates_repeated_edges() {
+    // A malformed resolver response repeating the same edge must not be
+    // able to inflate the traversal: deduped adjacency collapses the
+    // duplicates, so a two-node graph stays within bounds no matter how
+    // many identical edges it carries.
+    let graph = ResolvedWorkerGraph {
+        root: make_root_worker("root"),
+        target: None,
+        graph: vec![make_resolved_worker("a")],
+        edges: (0..1000)
+            .map(|_| ResolvedEdge {
+                from: "root".into(),
+                to: "a".into(),
+                range: "*".into(),
+            })
+            .collect(),
+    };
+    enforce_dep_graph_bounds(&graph).expect("repeated identical edges collapse to one");
+}
+
+#[test]
 fn dep_graph_rejects_excessive_depth() {
     // Linear chain root → n0 → n1 → ... → n_{depth}.
     let mut nodes = vec![make_resolved_worker("root")];

--- a/crates/iii-worker/tests/bundle_worker_integration.rs
+++ b/crates/iii-worker/tests/bundle_worker_integration.rs
@@ -616,6 +616,54 @@ fn dep_graph_accepts_wide_shared_dependencies() {
 }
 
 #[test]
+fn dep_graph_accepts_dense_layered_graph() {
+    // Regression for the backstop itself. `walked` counts frontier pops,
+    // and a dense DAG pushes each node once per parent, so pops grow
+    // roughly with node_count squared while distinct nodes stay small.
+    // A budget that is only linear in node_count therefore rejects a
+    // valid dense graph. This is the maximal shape within bounds: four
+    // fully-connected layers of width 8 — 32 nodes (the transitive_count
+    // cap), longest path 4 (under the depth cap) — which produces ~200
+    // pops and tripped the first linear budget.
+    const WIDTH: usize = 8;
+    let layers: Vec<Vec<String>> = (0..4)
+        .map(|l| (0..WIDTH).map(|w| format!("l{l}_{w}")).collect())
+        .collect();
+
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
+    for name in layers.iter().flatten() {
+        nodes.push(make_resolved_worker(name));
+    }
+    for name in &layers[0] {
+        edges.push(ResolvedEdge {
+            from: "root".into(),
+            to: name.clone(),
+            range: "*".into(),
+        });
+    }
+    for pair in layers.windows(2) {
+        for from in &pair[0] {
+            for to in &pair[1] {
+                edges.push(ResolvedEdge {
+                    from: from.clone(),
+                    to: to.clone(),
+                    range: "*".into(),
+                });
+            }
+        }
+    }
+
+    let graph = ResolvedWorkerGraph {
+        root: make_root_worker("root"),
+        target: None,
+        graph: nodes,
+        edges,
+    };
+    enforce_dep_graph_bounds(&graph).expect("dense in-bounds layered graph is accepted");
+}
+
+#[test]
 fn dep_graph_tolerates_repeated_edges() {
     // A malformed resolver response repeating the same edge must not be
     // able to inflate the traversal: deduped adjacency collapses the


### PR DESCRIPTION
## Problem

`iii worker add <bundle>` fails on a legitimate bundle with:

```
error: bundle dependency graph edge_traversal exceeded: limit 64, found 65
```

`enforce_dep_graph_bounds` (in `crates/iii-worker/src/cli/registry.rs`) walks the resolved worker graph to enforce depth and node-count caps. The walk had **no visited-set** — despite a comment claiming one — so a shallow-but-wide DAG whose transitives **share a dependency** was counted path-by-path. Distinct root→leaf paths grow multiplicatively with shared nodes, so a graph with only a handful of unique nodes (well within `transitive_count` and `depth`) overflowed the `edge_traversal` backstop (`MAX_TRANSITIVE_DEPS * 2 = 64`).

## Fix

Replace the naive walk with a **memoized longest-path DFS**:

- Adjacency is deduped into a `HashSet`, so a malformed response repeating edges can't inflate the traversal.
- Each node is re-expanded only when reached via a strictly deeper path (`best_depth` map), so total work is bounded by `node_count * (depth + 1)`.
- The `edge_traversal` guard becomes a real defense against graphs that violate the DAG invariant, instead of a trap for valid ones.

Depth and node-count semantics are unchanged.

## Tests

- `dep_graph_accepts_wide_shared_dependencies` — width-3 layered diamond (11 nodes, 27 leaf paths). Verified it reproduces the exact failure on the old code: `edge_traversal exceeded: limit 64, found 65`, and passes with the fix.
- `dep_graph_tolerates_repeated_edges` — 1000 identical edges collapse to one via dedup.
- Existing depth/breadth/within-bounds tests still pass.

```
test dep_graph_accepts_within_bounds ... ok
test dep_graph_accepts_wide_shared_dependencies ... ok
test dep_graph_tolerates_repeated_edges ... ok
test dep_graph_rejects_excessive_depth ... ok
test dep_graph_rejects_excessive_breadth ... ok
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency-graph validation to better handle shared downstream dependencies and repeated edges.
  * Prevented valid wide and dense dependency graphs from being incorrectly rejected due to overly strict traversal limits.
* **Tests**
  * Added integration coverage for wide shared dependency graphs, dense layered graphs, and repeated-edge scenarios in worker dependency-graph validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->