### PR TITLE
fix(engine): repair protocol_serde_bench compilation

### DIFF
--- a/engine/benches/protocol_serde_bench.rs
+++ b/engine/benches/protocol_serde_bench.rs
@@ -78,6 +78,7 @@ fn build_messages() -> Vec<(&'static str, Message)> {
             "WorkerRegistered",
             Message::WorkerRegistered {
                 worker_id: Uuid::new_v4().to_string(),
+                reattach_token: Some(Uuid::new_v4().to_string()),
             },
         ),
     ]


### PR DESCRIPTION
## Problem

`cargo bench -p iii --bench '*'` (the command run by the Benchmark Release workflow) fails to compile:

\`\`\`
error[E0063]: missing field \`reattach_token\` in initializer of \`Message\`
  --> engine/benches/protocol_serde_bench.rs:79:13
error: could not compile \`iii\` (bench "protocol_serde_bench") due to 1 previous error
\`\`\`

The worker-reconnect work added a `reattach_token` field to `Message::WorkerRegistered`, but `protocol_serde_bench.rs` still constructed the variant without it. Every benchmark run since has been broken.

## Fix

Add `reattach_token: Some(...)` to the `WorkerRegistered` initializer in the bench. Using a populated token (rather than `None`) keeps the field exercised in the serialize/deserialize/roundtrip cases.

## Verification

\`\`\`
cargo bench -p iii --bench protocol_serde_bench -- --quick
\`\`\`

Compiles and runs clean; all protocol cases including `protocol_roundtrip/WorkerRegistered` execute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated protocol serialization benchmarks to include reattachment tokens in worker registration messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->