### PR TITLE
fix(observability): treat empty baggage header as absent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2831,6 +2831,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -1456,7 +1456,12 @@ where
     P: TextMapPropagator,
 {
     let mut carrier: HashMap<String, String> = HashMap::new();
-    carrier.insert(header.to_string(), value.to_string());
+    // An empty header value is treated as absent. A present-but-empty `baggage`
+    // header makes `BaggagePropagator::extract` log a per-call
+    // `InvalidKeyValueFormat` warning (empty split yields an unparsable entry).
+    if !value.is_empty() {
+        carrier.insert(header.to_string(), value.to_string());
+    }
     propagator.extract(&carrier)
 }
 
@@ -1479,13 +1484,16 @@ pub fn extract_context_with_state(
     baggage: Option<&str>,
 ) -> Context {
     let mut carrier: HashMap<String, String> = HashMap::new();
-    if let Some(tp) = traceparent {
+    // Empty values are treated as absent: a present-but-empty `baggage` header
+    // makes `BaggagePropagator::extract` emit a per-call `InvalidKeyValueFormat`
+    // warning, so callers passing `Some("")` must not seed the carrier.
+    if let Some(tp) = traceparent.filter(|s| !s.is_empty()) {
         carrier.insert("traceparent".to_string(), tp.to_string());
     }
-    if let Some(ts) = tracestate {
+    if let Some(ts) = tracestate.filter(|s| !s.is_empty()) {
         carrier.insert("tracestate".to_string(), ts.to_string());
     }
-    if let Some(bg) = baggage {
+    if let Some(bg) = baggage.filter(|s| !s.is_empty()) {
         carrier.insert("baggage".to_string(), bg.to_string());
     }
 
@@ -7687,6 +7695,47 @@ mod tests {
         drop(span_ref);
         assert!(inject_traceparent_from_context(&cx).is_none());
         assert!(inject_baggage_from_context(&cx).is_none());
+    }
+
+    #[test]
+    fn empty_baggage_header_does_not_emit_propagator_warning() {
+        use std::sync::{Arc, Mutex};
+        use tracing::subscriber::with_default;
+        use tracing_subscriber::Layer;
+        use tracing_subscriber::layer::{Context as LayerContext, SubscriberExt};
+
+        // Captures the metadata name of every event emitted on this thread.
+        // The OTel `BaggagePropagator` logs `warn!(name: "BaggagePropagator
+        // .Extract.InvalidKeyValueFormat", ...)` when it parses an empty
+        // `baggage` header, which is exactly what a present-but-empty carrier
+        // entry produced before the fix.
+        #[derive(Clone, Default)]
+        struct WarnCapture(Arc<Mutex<Vec<String>>>);
+        impl<S: tracing::Subscriber> Layer<S> for WarnCapture {
+            fn on_event(&self, event: &tracing::Event<'_>, _cx: LayerContext<'_, S>) {
+                self.0
+                    .lock()
+                    .unwrap()
+                    .push(event.metadata().name().to_string());
+            }
+        }
+
+        let capture = WarnCapture::default();
+        let names = capture.0.clone();
+        let subscriber = tracing_subscriber::registry().with(capture);
+        with_default(subscriber, || {
+            // Absent and empty baggage must be indistinguishable: neither seeds
+            // the carrier, so the propagator never sees an unparsable header.
+            let _ = extract_context(None, Some(""));
+            let _ = extract_baggage("");
+            let _ = baggage_with_function_id(None, "fn-1");
+        });
+
+        let warned = names.lock().unwrap();
+        assert!(
+            !warned.iter().any(|n| n.contains("BaggagePropagator")),
+            "empty baggage must not trigger BaggagePropagator warnings, got: {warned:?}"
+        );
     }
 
     #[test]

--- a/sdk/packages/rust/helpers/Cargo.toml
+++ b/sdk/packages/rust/helpers/Cargo.toml
@@ -34,3 +34,4 @@ opentelemetry-http = { version = "0.31", features = ["reqwest"] }
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio", "trace", "testing"] }
 serial_test = "3"
 tokio = { version = "1", features = ["test-util"] }
+tracing-subscriber = { version = "0.3", features = ["registry"] }

--- a/sdk/packages/rust/helpers/src/observability/telemetry/context.rs
+++ b/sdk/packages/rust/helpers/src/observability/telemetry/context.rs
@@ -100,7 +100,12 @@ pub fn inject_baggage() -> Option<String> {
 /// Extract baggage from a W3C baggage header string
 pub fn extract_baggage(baggage: &str) -> OtelContext {
     let mut carrier = HeaderMap(HashMap::new());
-    carrier.0.insert("baggage".to_string(), baggage.to_string());
+    // An empty header is treated as absent. A present-but-empty `baggage`
+    // header makes `BaggagePropagator::extract` log a per-call
+    // `InvalidKeyValueFormat` warning (empty split yields an unparsable entry).
+    if !baggage.is_empty() {
+        carrier.0.insert("baggage".to_string(), baggage.to_string());
+    }
 
     baggage_propagator().extract(&carrier)
 }
@@ -109,11 +114,14 @@ pub fn extract_baggage(baggage: &str) -> OtelContext {
 pub fn extract_context(traceparent: Option<&str>, baggage: Option<&str>) -> OtelContext {
     let mut carrier = HeaderMap(HashMap::new());
 
-    if let Some(tp) = traceparent {
+    // Empty values are treated as absent: a present-but-empty `baggage` header
+    // makes `BaggagePropagator::extract` emit a per-call `InvalidKeyValueFormat`
+    // warning, so callers passing `Some("")` must not seed the carrier.
+    if let Some(tp) = traceparent.filter(|s| !s.is_empty()) {
         carrier.0.insert("traceparent".to_string(), tp.to_string());
     }
 
-    if let Some(bg) = baggage {
+    if let Some(bg) = baggage.filter(|s| !s.is_empty()) {
         carrier.0.insert("baggage".to_string(), bg.to_string());
     }
 
@@ -286,6 +294,44 @@ mod tests {
         let _guard = cx.attach();
 
         assert_eq!(get_baggage_entry("user_id"), None);
+    }
+
+    #[test]
+    fn empty_baggage_header_does_not_emit_propagator_warning() {
+        use std::sync::{Arc, Mutex};
+        use tracing::subscriber::with_default;
+        use tracing_subscriber::Layer;
+        use tracing_subscriber::layer::{Context as LayerContext, SubscriberExt};
+
+        // Captures the metadata name of every event on this thread. The OTel
+        // `BaggagePropagator` logs `warn!(name: "BaggagePropagator.Extract
+        // .InvalidKeyValueFormat", ...)` when it parses an empty `baggage`
+        // header — exactly what a present-but-empty carrier entry produced
+        // before the fix.
+        #[derive(Clone, Default)]
+        struct WarnCapture(Arc<Mutex<Vec<String>>>);
+        impl<S: tracing::Subscriber> Layer<S> for WarnCapture {
+            fn on_event(&self, event: &tracing::Event<'_>, _cx: LayerContext<'_, S>) {
+                self.0
+                    .lock()
+                    .unwrap()
+                    .push(event.metadata().name().to_string());
+            }
+        }
+
+        let capture = WarnCapture::default();
+        let names = capture.0.clone();
+        let subscriber = tracing_subscriber::registry().with(capture);
+        with_default(subscriber, || {
+            let _ = extract_context(None, Some(""));
+            let _ = extract_baggage("");
+        });
+
+        let warned = names.lock().unwrap();
+        assert!(
+            !warned.iter().any(|n| n.contains("BaggagePropagator")),
+            "empty baggage must not trigger BaggagePropagator warnings, got: {warned:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Fixes #2008.

Running the observability worker against an OTEL collector floods logs with, many times a second:

```
name="BaggagePropagator.Extract.InvalidKeyValueFormat"
baggage_header=""
level="warn"
```

## Root cause

The context-extraction helpers seed the carrier with a `baggage` header **even when the incoming value is empty or absent**. OTel 0.31's `BaggagePropagator::extract` then splits `""`, gets one unparsable entry, and logs `InvalidKeyValueFormat` on **every** extraction. Any request/queue message/cron tick without incoming baggage hits this path, so it fires continuously under load.

Key distinction (an *absent* header is silent; a *present-but-empty* one warns):

| carrier | result |
|---|---|
| `baggage` header absent | silent |
| `baggage` header present but `""` | **warn** ← what iii did |

## Fix

Treat an empty header value as absent — do not insert it into the carrier. Mirrored across both copies of the helper:

- `engine/src/workers/observability/otel.rs` — `extract_header` + `extract_context_with_state`
- `sdk/packages/rust/helpers/src/observability/telemetry/context.rs` — `extract_baggage` + `extract_context`

## Tests

Warn-capture regression test in each crate: extracts empty/absent baggage under a capturing `tracing` subscriber and asserts no `BaggagePropagator` warning is emitted. Both fail before the fix, pass after.

## Notes

- No public API or protocol change; behavior for valid baggage is unchanged.
- Reproduced against `opentelemetry_sdk 0.31.0` (same version as the report).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty tracing and baggage headers are now treated as absent.
  * Prevented unnecessary observability warnings caused by empty baggage values.
  * Improved context and baggage extraction behavior across supported integrations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->