### PR TITLE
fix(worker): validate dependency graphs without depth cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,12 +401,10 @@ jobs:
           # install it directly (full `apt-get update` only as a fallback).
           sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
             || { sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross; }
-          # The arm64 runtime lib needs the freshly-added arm64 source indexed.
-          # Scope the update to just that list so we don't refresh every index.
-          sudo apt-get update \
-            -o Dir::Etc::sourcelist="sources.list.d/arm64.list" \
-            -o Dir::Etc::sourceparts="-" \
-            -o APT::Get::List-Cleanup="0"
+          # Multi-arch libc packages must have matching versions. Refresh the
+          # amd64 index too, so apt can upgrade its installed libc6 alongside
+          # the arm64 dependency selected from the newly-added sources.
+          sudo apt-get update
           sudo apt-get install -y libcap-ng-dev:arm64
 
       - name: Add target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,9 @@ jobs:
           MIRROR=http://azure.ports.ubuntu.com/ubuntu-ports/
           echo "deb [arch=arm64] $MIRROR $(lsb_release -cs) main restricted universe" | sudo tee /etc/apt/sources.list.d/arm64.list
           echo "deb [arch=arm64] $MIRROR $(lsb_release -cs)-updates main restricted universe" | sudo tee -a /etc/apt/sources.list.d/arm64.list
+          # libc6 is multi-arch and must match the security-patched version
+          # already installed for amd64 on the runner.
+          echo "deb [arch=arm64] $MIRROR $(lsb_release -cs)-security main restricted universe" | sudo tee -a /etc/apt/sources.list.d/arm64.list
           # The amd64 cross toolchain is already indexed on the runner image, so
           # install it directly (full `apt-get update` only as a fallback).
           sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross \

--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -37,6 +37,12 @@ pub struct AddArgs {
     /// local engine) instead of creating an orphan config file here.
     #[arg(long, value_name = "HOST[:PORT]")]
     pub host: Option<String>,
+
+    /// Proceed without prompting when the resolved dependency graph contains
+    /// more than 32 workers. Required for large-graph installs in CI or other
+    /// non-interactive environments.
+    #[arg(long, short = 'y')]
+    pub yes: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/crates/iii-worker/src/cli/host_shim.rs
+++ b/crates/iii-worker/src/cli/host_shim.rs
@@ -246,6 +246,10 @@ pub fn classify_handler_error(rc: i32, captured: &str, op: &str, name_hint: &str
         return WorkerOpError::ConsentRequired { op: op.to_string() };
     }
 
+    if lower == "operation cancelled" {
+        return WorkerOpError::Cancelled;
+    }
+
     if let Some(reason) = detail.strip_prefix("dependency graph is invalid: ") {
         return WorkerOpError::DependencyGraphInvalid {
             reason: reason.to_string(),
@@ -1146,6 +1150,12 @@ mod tests {
             "large-worker",
         );
         assert_eq!(err.kind(), WorkerOpErrorKind::ConsentRequired);
+    }
+
+    #[test]
+    fn classify_handler_error_maps_declined_prompt_to_w170() {
+        let err = classify_handler_error(1, "error: operation cancelled\n", "add", "large-worker");
+        assert_eq!(err.kind(), WorkerOpErrorKind::Cancelled);
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/host_shim.rs
+++ b/crates/iii-worker/src/cli/host_shim.rs
@@ -239,6 +239,19 @@ pub fn classify_handler_error(rc: i32, captured: &str, op: &str, name_hint: &str
         return WorkerOpError::not_found(name);
     }
 
+    if lower.contains("requires confirmation")
+        || lower.contains("pass yes:true")
+        || lower.contains("pass --yes")
+    {
+        return WorkerOpError::ConsentRequired { op: op.to_string() };
+    }
+
+    if let Some(reason) = detail.strip_prefix("dependency graph is invalid: ") {
+        return WorkerOpError::DependencyGraphInvalid {
+            reason: reason.to_string(),
+        };
+    }
+
     // Everything else stays as W900 but without the "(rc N)" leak.
     let msg = if detail.is_empty() {
         format!("iii worker {op} exited with rc {rc}")
@@ -443,6 +456,11 @@ impl WorkerHostShim for CliHostShim {
         let force = opts.force;
         let reset_config = opts.reset_config;
         let wait = opts.wait;
+        let assume_yes = opts.yes;
+        let can_prompt = {
+            use std::io::IsTerminal as _;
+            std::io::stdin().is_terminal() && std::io::stderr().is_terminal()
+        };
         // Snapshot config workers BEFORE the install so we can diff and
         // recover the canonical worker name on success. For OCI installs
         // `source_label_name` returns a raw reference, which lockfile
@@ -462,15 +480,19 @@ impl WorkerHostShim for CliHostShim {
                     reset_config,
                     brief,
                     wait,
+                    assume_yes,
+                    can_prompt,
                 )
                 .await
             } else {
-                crate::cli::managed::handle_managed_add(
+                crate::cli::managed::handle_managed_add_with_consent(
                     &image_or_name_clone,
                     brief,
                     force,
                     reset_config,
                     wait,
+                    assume_yes,
+                    can_prompt,
                 )
                 .await
             }
@@ -1113,6 +1135,28 @@ mod tests {
         assert_eq!(err.kind(), WorkerOpErrorKind::InvalidName);
         // Must not say "internal:" anymore.
         assert!(!err.to_string().contains("internal:"));
+    }
+
+    #[test]
+    fn classify_handler_error_maps_large_graph_consent_to_w104() {
+        let err = classify_handler_error(
+            1,
+            "error: \"install large dependency graph\" requires confirmation: pass yes:true\n",
+            "add",
+            "large-worker",
+        );
+        assert_eq!(err.kind(), WorkerOpErrorKind::ConsentRequired);
+    }
+
+    #[test]
+    fn classify_handler_error_maps_invalid_graph_to_w184() {
+        let err = classify_handler_error(
+            1,
+            "error: dependency graph is invalid: dependency cycle detected involving: a, b\n",
+            "add",
+            "cycle-worker",
+        );
+        assert_eq!(err.kind(), WorkerOpErrorKind::DependencyGraphInvalid);
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -616,21 +616,64 @@ pub async fn handle_local_add(
         return 1;
     }
 
-    // 5. Check if already exists in config.yaml
-    if super::config_file::worker_exists(&worker_name) {
-        if !force {
-            eprintln!(
-                "{} Worker '{}' is already in config.yaml.\n  \
-                 Fix options:\n    \
-                   - Keep it: `iii worker status {}` to see how it's doing.\n    \
-                   - Replace it: rerun with --force (stops VM, clears artifacts).\n    \
-                   - Wipe the config entry too: --force --reset-config.",
-                "error:".red(),
-                worker_name,
-                worker_name
-            );
-            return 1;
-        }
+    // 5. Reject a duplicate before doing registry work unless this is an
+    // explicit replacement.
+    let worker_exists = super::config_file::worker_exists(&worker_name);
+    if worker_exists && !force {
+        eprintln!(
+            "{} Worker '{}' is already in config.yaml.\n  \
+             Fix options:\n    \
+               - Keep it: `iii worker status {}` to see how it's doing.\n    \
+               - Replace it: rerun with --force (stops VM, clears artifacts).\n    \
+               - Wipe the config entry too: --force --reset-config.",
+            "error:".red(),
+            worker_name,
+            worker_name
+        );
+        return 1;
+    }
+
+    // 5a. Parse, resolve, validate, and confirm every declared dependency
+    // before --force is allowed to stop the existing worker or delete its
+    // artifacts. Installation remains after cleanup, but it consumes this
+    // already-approved graph instead of resolving or prompting again.
+    let declared_deps = match manifest_doc.as_ref() {
+        Some(doc) => match super::project::manifest_dependencies_from_doc(doc) {
+            Ok(deps) => deps,
+            Err(e) => {
+                eprintln!(
+                    "{} {} in {}\n  \
+                     Fix: correct the `dependencies:` block and rerun \
+                     `iii worker add {}`.",
+                    "error:".red(),
+                    e,
+                    manifest_path.display(),
+                    path,
+                );
+                return 1;
+            }
+        },
+        None => std::collections::BTreeMap::new(),
+    };
+    let prepared_dependencies =
+        match super::managed::prepare_manifest_dependencies(&declared_deps, assume_yes, can_prompt)
+            .await
+        {
+            Ok(prepared) => prepared,
+            Err(e) => {
+                eprintln!(
+                    "{} {}\n  \
+                     No worker state was changed. Rerun `iii worker add {}` \
+                     after fixing the failure.",
+                    "error:".red(),
+                    e,
+                    path,
+                );
+                return 1;
+            }
+        };
+
+    if worker_exists {
         // --force: stop if running, clear artifacts
         if super::managed::is_worker_running(&worker_name) {
             eprintln!("  Stopping running worker {}...", worker_name.bold());
@@ -678,38 +721,12 @@ pub async fn handle_local_add(
         }
     }
 
-    // 5b. Resolve + install declared manifest dependencies BEFORE we touch
-    //     config.yaml. A failure here leaves the local worker NOT in
-    //     config.yaml and iii.lock unchanged — retry is just retry, no
-    //     `--force` dance required. This is load-bearing: reversing this
-    //     order recreates the "already in config.yaml" rerun trap.
-    //     Parsed from the single manifest doc read in step 3a.
-    let declared_deps = match manifest_doc.as_ref() {
-        Some(doc) => match super::project::manifest_dependencies_from_doc(doc) {
-            Ok(deps) => deps,
-            Err(e) => {
-                eprintln!(
-                    "{} {} in {}\n  \
-                     Fix: correct the `dependencies:` block and rerun \
-                     `iii worker add {}`.",
-                    "error:".red(),
-                    e,
-                    manifest_path.display(),
-                    path,
-                );
-                return 1;
-            }
-        },
-        None => std::collections::BTreeMap::new(),
-    };
-    if !declared_deps.is_empty()
-        && let Err(e) = super::managed::install_manifest_dependencies(
-            &declared_deps,
-            brief,
-            assume_yes,
-            can_prompt,
-        )
-        .await
+    // 5b. Install the graph approved above before appending the local worker
+    // to config.yaml. New adds retain the all-or-nothing behavior; force adds
+    // may now mutate only after resolution, validation, and consent succeed.
+    if let Some(prepared) = prepared_dependencies
+        && let Err(e) =
+            super::managed::install_prepared_manifest_dependencies(prepared, brief).await
     {
         eprintln!(
             "{} {}\n  \

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -469,6 +469,8 @@ pub async fn handle_local_add(
     reset_config: bool,
     brief: bool,
     wait: bool,
+    assume_yes: bool,
+    can_prompt: bool,
 ) -> i32 {
     // 1. Resolve path to absolute
     let project_path = match std::fs::canonicalize(path) {
@@ -701,7 +703,13 @@ pub async fn handle_local_add(
         None => std::collections::BTreeMap::new(),
     };
     if !declared_deps.is_empty()
-        && let Err(e) = super::managed::install_manifest_dependencies(&declared_deps, brief).await
+        && let Err(e) = super::managed::install_manifest_dependencies(
+            &declared_deps,
+            brief,
+            assume_yes,
+            can_prompt,
+        )
+        .await
     {
         eprintln!(
             "{} {}\n  \
@@ -1855,6 +1863,8 @@ resources:
             /*reset_config=*/ false,
             /*brief=*/ false,
             /*wait=*/ false,
+            /*assume_yes=*/ false,
+            /*can_prompt=*/ false,
         )
         .await;
 

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -32,8 +32,9 @@ use super::builtin_defaults::{
 use super::config_file::ResolvedWorkerType;
 use super::lifecycle::build_container_spec;
 use super::registry::{
-    BinaryWorkerResponse, BundleWorkerResponse, MANIFEST_PATH, ResolvedWorkerGraph,
-    WorkerInfoResponse, fetch_resolved_worker_graph, fetch_worker_info, parse_worker_input,
+    BinaryWorkerResponse, BundleWorkerResponse, DependencyGraphStats, MANIFEST_PATH,
+    ResolvedWorkerGraph, WorkerInfoResponse, fetch_resolved_worker_graph, fetch_worker_info,
+    parse_worker_input,
 };
 use super::worker_manager::state::WorkerDef;
 use std::collections::BTreeMap;
@@ -1121,7 +1122,10 @@ pub async fn handle_worker_update(worker_name: Option<&str>) -> i32 {
             }
         };
 
-        let rc = handle_resolved_graph_add(&graph, false).await;
+        // `worker update` is an explicit request to apply the new graph for
+        // an already-pinned root. Do not introduce an unrelated interactive
+        // prompt into that maintenance path.
+        let rc = handle_resolved_graph_add(&graph, false, true, false).await;
         if rc != 0 {
             fail_count += 1;
         }
@@ -1420,13 +1424,69 @@ fn populate_manifest_hash_fields(lockfile: &mut super::lockfile::WorkerLockfile)
     lockfile.declared_dependencies = Some(deps);
 }
 
-async fn handle_resolved_graph_add(graph: &ResolvedWorkerGraph, brief: bool) -> i32 {
-    // Enforce client-side dependency-graph bounds BEFORE touching any
-    // filesystem state. A compromised or malformed registry response
-    // must not be able to drive thousands of installs from a single
-    // `iii worker add`. See registry::enforce_dep_graph_bounds
-    // (MAX_DEPENDENCY_DEPTH, MAX_TRANSITIVE_DEPS).
-    if let Err(e) = super::registry::enforce_dep_graph_bounds(graph) {
+fn confirm_large_dependency_graph(
+    stats: DependencyGraphStats,
+    assume_yes: bool,
+    can_prompt: bool,
+) -> Result<(), crate::core::error::WorkerOpError> {
+    use crate::core::error::WorkerOpError;
+
+    if !stats.requires_confirmation() {
+        return Ok(());
+    }
+
+    let dependency_count = stats.node_count.saturating_sub(1);
+    eprintln!(
+        "  {} this worker resolves to {} dependencies ({} workers total, {} dependency edges).",
+        "warning:".yellow(),
+        dependency_count,
+        stats.node_count,
+        stats.edge_count,
+    );
+    if assume_yes {
+        return Ok(());
+    }
+    if !can_prompt {
+        return Err(WorkerOpError::ConsentRequired {
+            op: format!(
+                "install large dependency graph ({} workers); pass yes:true or --yes",
+                stats.node_count
+            ),
+        });
+    }
+
+    use std::io::{BufRead as _, Write as _};
+    eprint!(
+        "Continue installing all {} workers? [y/N] ",
+        stats.node_count
+    );
+    let _ = std::io::stderr().flush();
+    let mut response = String::new();
+    let _ = std::io::stdin().lock().read_line(&mut response);
+    if matches!(response.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+        Ok(())
+    } else {
+        Err(WorkerOpError::Cancelled)
+    }
+}
+
+async fn handle_resolved_graph_add(
+    graph: &ResolvedWorkerGraph,
+    brief: bool,
+    assume_yes: bool,
+    can_prompt: bool,
+) -> i32 {
+    // Validate the complete graph BEFORE touching filesystem state. Long
+    // acyclic chains are legitimate; cycles, dangling edges, duplicate nodes,
+    // and resolver-injected disconnected nodes are not.
+    let stats = match super::registry::validate_dependency_graph(graph) {
+        Ok(stats) => stats,
+        Err(e) => {
+            eprintln!("{} {}", "error:".red(), e);
+            return 1;
+        }
+    };
+    if let Err(e) = confirm_large_dependency_graph(stats, assume_yes, can_prompt) {
         eprintln!("{} {}", "error:".red(), e);
         return 1;
     }
@@ -1656,6 +1716,8 @@ pub(crate) fn merge_resolved_graphs(
 pub(crate) async fn install_manifest_dependencies(
     deps: &std::collections::BTreeMap<String, String>,
     brief: bool,
+    assume_yes: bool,
+    can_prompt: bool,
 ) -> Result<(), String> {
     if deps.is_empty() {
         return Ok(());
@@ -1688,7 +1750,7 @@ pub(crate) async fn install_manifest_dependencies(
 
     let merged = merge_resolved_graphs(graphs)?;
 
-    let rc = handle_resolved_graph_add(&merged, brief).await;
+    let rc = handle_resolved_graph_add(&merged, brief, assume_yes, can_prompt).await;
     if rc != 0 {
         return Err(format!(
             "failed to install merged dependency graph (exit {rc}); no partial \
@@ -1705,6 +1767,29 @@ pub async fn handle_managed_add(
     reset_config: bool,
     wait: bool,
 ) -> i32 {
+    use std::io::IsTerminal as _;
+
+    handle_managed_add_with_consent(
+        image_or_name,
+        brief,
+        force,
+        reset_config,
+        wait,
+        false,
+        std::io::stdin().is_terminal() && std::io::stderr().is_terminal(),
+    )
+    .await
+}
+
+pub async fn handle_managed_add_with_consent(
+    image_or_name: &str,
+    brief: bool,
+    force: bool,
+    reset_config: bool,
+    wait: bool,
+    assume_yes: bool,
+    can_prompt: bool,
+) -> i32 {
     // Local path workers: starts with '.', '/', or '~'
     if super::local_worker::is_local_path(image_or_name) {
         return super::local_worker::handle_local_add(
@@ -1713,6 +1798,8 @@ pub async fn handle_managed_add(
             reset_config,
             brief,
             wait,
+            assume_yes,
+            can_prompt,
         )
         .await;
     }
@@ -1876,7 +1963,7 @@ pub async fn handle_managed_add(
 
     match fetch_resolved_worker_graph(&name, version.as_deref(), None).await {
         Ok(graph) => {
-            let rc = handle_resolved_graph_add(&graph, brief).await;
+            let rc = handle_resolved_graph_add(&graph, brief, assume_yes, can_prompt).await;
             return finish_add(&name, rc, wait, brief).await;
         }
         Err(e) if should_fallback_to_legacy_registry_error(&name, &e) => {
@@ -4016,6 +4103,40 @@ mod tests {
 
     static CWD_LOCK: Mutex<()> = Mutex::new(());
 
+    #[test]
+    fn large_graph_requires_consent_when_non_interactive() {
+        let stats = DependencyGraphStats {
+            node_count: super::super::registry::LARGE_DEPENDENCY_GRAPH_THRESHOLD + 1,
+            edge_count: 40,
+        };
+        let err = confirm_large_dependency_graph(stats, false, false)
+            .expect_err("non-interactive large graph needs explicit consent");
+        assert!(matches!(
+            err,
+            crate::core::error::WorkerOpError::ConsentRequired { .. }
+        ));
+    }
+
+    #[test]
+    fn large_graph_yes_bypasses_prompt() {
+        let stats = DependencyGraphStats {
+            node_count: super::super::registry::LARGE_DEPENDENCY_GRAPH_THRESHOLD + 1,
+            edge_count: 40,
+        };
+        confirm_large_dependency_graph(stats, true, false)
+            .expect("--yes must allow a structurally valid large graph");
+    }
+
+    #[test]
+    fn graph_at_warning_threshold_needs_no_consent() {
+        let stats = DependencyGraphStats {
+            node_count: super::super::registry::LARGE_DEPENDENCY_GRAPH_THRESHOLD,
+            edge_count: 40,
+        };
+        confirm_large_dependency_graph(stats, false, false)
+            .expect("threshold is a soft boundary, not a hard failure");
+    }
+
     /// Run an async closure with CWD set to a temp dir, then restore.
     /// Uses a drop guard so CWD is restored even if the closure panics.
     async fn in_temp_dir_async<F, Fut>(f: F)
@@ -4728,7 +4849,7 @@ workers:
                 edges: Vec::new(),
             };
 
-            let rc = handle_resolved_graph_add(&graph, true).await;
+            let rc = handle_resolved_graph_add(&graph, true, true, false).await;
 
             assert_eq!(rc, 1);
             assert!(!std::path::Path::new("config.yaml").exists());
@@ -4786,7 +4907,7 @@ workers:
                 edges: Vec::new(),
             };
 
-            let rc = handle_resolved_graph_add(&graph, true).await;
+            let rc = handle_resolved_graph_add(&graph, true, true, false).await;
 
             assert_eq!(rc, 1);
             assert_eq!(
@@ -4868,7 +4989,7 @@ workers:
                 }],
             };
 
-            let rc = handle_resolved_graph_add(&graph, true).await;
+            let rc = handle_resolved_graph_add(&graph, true, true, false).await;
 
             assert_eq!(rc, 1);
             assert_eq!(
@@ -4976,7 +5097,7 @@ workers:
                 ],
             };
 
-            let rc = handle_resolved_graph_add(&graph, true).await;
+            let rc = handle_resolved_graph_add(&graph, true, true, false).await;
 
             assert_eq!(rc, 0);
             let config = std::fs::read_to_string("config.yaml").unwrap();
@@ -5314,7 +5435,7 @@ workers:
             );
             let graph = graph_with(resolved_binary_worker(worker_name, "1.0.0", binaries));
 
-            let rc = handle_resolved_graph_add(&graph, true).await;
+            let rc = handle_resolved_graph_add(&graph, true, true, false).await;
 
             assert_eq!(rc, 0, "binary resolve add should succeed");
             assert!(
@@ -5343,7 +5464,7 @@ workers:
         in_temp_dir_async(|_| async move {
             let graph = graph_with(resolved_engine_worker("iii-exec", "2.0.0"));
 
-            let rc = handle_resolved_graph_add(&graph, true).await;
+            let rc = handle_resolved_graph_add(&graph, true, true, false).await;
 
             assert_eq!(rc, 0);
             assert!(
@@ -7065,7 +7186,7 @@ dependencies:
     #[tokio::test]
     async fn install_manifest_dependencies_empty_is_noop() {
         let deps: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
-        let result = super::install_manifest_dependencies(&deps, true).await;
+        let result = super::install_manifest_dependencies(&deps, true, false, false).await;
         assert!(result.is_ok(), "empty deps must succeed as noop");
     }
 
@@ -7075,7 +7196,7 @@ dependencies:
         unsafe { std::env::set_var("III_API_URL", "http://127.0.0.1:1") };
         let mut deps = std::collections::BTreeMap::new();
         deps.insert("math-worker".to_string(), "^0.1.0".to_string());
-        let result = super::install_manifest_dependencies(&deps, true).await;
+        let result = super::install_manifest_dependencies(&deps, true, false, false).await;
         match prev {
             Some(v) => unsafe { std::env::set_var("III_API_URL", v) },
             None => unsafe { std::env::remove_var("III_API_URL") },
@@ -7097,7 +7218,7 @@ dependencies:
         unsafe { std::env::set_var("III_API_URL", "http://127.0.0.1:1") };
         let mut deps = std::collections::BTreeMap::new();
         deps.insert("math-worker".to_string(), "1.0.0-beta.1".to_string());
-        let result = super::install_manifest_dependencies(&deps, true).await;
+        let result = super::install_manifest_dependencies(&deps, true, false, false).await;
         match prev {
             Some(v) => unsafe { std::env::set_var("III_API_URL", v) },
             None => unsafe { std::env::remove_var("III_API_URL") },

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -1476,43 +1476,56 @@ async fn handle_resolved_graph_add(
     assume_yes: bool,
     can_prompt: bool,
 ) -> i32 {
-    // Validate the complete graph BEFORE touching filesystem state. Long
-    // acyclic chains are legitimate; cycles, dangling edges, duplicate nodes,
-    // and resolver-injected disconnected nodes are not.
-    let stats = match super::registry::validate_dependency_graph(graph) {
-        Ok(stats) => stats,
+    let roots = std::slice::from_ref(&graph.root.name);
+    let prepared = match preflight_resolved_graph(graph, roots, assume_yes, can_prompt) {
+        Ok(prepared) => prepared,
         Err(e) => {
             eprintln!("{} {}", "error:".red(), e);
             return 1;
         }
     };
-    if let Err(e) = confirm_large_dependency_graph(stats, assume_yes, can_prompt) {
-        eprintln!("{} {}", "error:".red(), e);
-        return 1;
-    }
+    handle_preflighted_resolved_graph_add(graph, prepared, brief).await
+}
+
+struct PreparedResolvedGraph {
+    graph_lockfile: super::lockfile::WorkerLockfile,
+}
+
+/// Complete every fallible, non-mutating graph check before an install may
+/// replace existing worker state. The returned value proves that validation
+/// and any required operator consent already succeeded, so callers can carry
+/// it across the `--force` cleanup boundary without resolving or prompting
+/// twice.
+fn preflight_resolved_graph(
+    graph: &ResolvedWorkerGraph,
+    roots: &[String],
+    assume_yes: bool,
+    can_prompt: bool,
+) -> Result<PreparedResolvedGraph, String> {
+    let stats = super::registry::validate_dependency_graph_roots(graph, roots)
+        .map_err(|e| e.to_string())?;
+    confirm_large_dependency_graph(stats, assume_yes, can_prompt).map_err(|e| e.to_string())?;
 
     for node in &graph.graph {
         if let Err(e) = super::registry::validate_worker_name(&node.name) {
-            eprintln!(
-                "{} invalid resolved worker '{}': {}",
-                "error:".red(),
-                node.name,
-                e
-            );
-            return 1;
+            return Err(format!("invalid resolved worker '{}': {}", node.name, e));
         }
     }
 
-    let graph_lockfile = match lockfile_from_graph(graph).and_then(|lockfile| {
+    let graph_lockfile = lockfile_from_graph(graph).and_then(|lockfile| {
         lockfile.to_yaml()?;
         Ok(lockfile)
-    }) {
-        Ok(lockfile) => lockfile,
-        Err(e) => {
-            eprintln!("{} {}", "error:".red(), e);
-            return 1;
-        }
-    };
+    })?;
+
+    Ok(PreparedResolvedGraph { graph_lockfile })
+}
+
+async fn handle_preflighted_resolved_graph_add(
+    graph: &ResolvedWorkerGraph,
+    prepared: PreparedResolvedGraph,
+    brief: bool,
+) -> i32 {
+    let PreparedResolvedGraph { graph_lockfile } = prepared;
 
     let lock_path = super::lockfile::lockfile_path();
     let mut lockfile = match read_lockfile_or_default(lock_path) {
@@ -1662,9 +1675,15 @@ async fn handle_resolved_graph_add(
 /// If the same name appears at different versions across graphs, returns an
 /// error naming the conflicting dep and both versions — this is the cross-dep
 /// version-conflict gate.
+#[derive(Debug)]
+pub(crate) struct ResolvedWorkerForest {
+    graph: ResolvedWorkerGraph,
+    roots: Vec<String>,
+}
+
 pub(crate) fn merge_resolved_graphs(
     graphs: Vec<(String, ResolvedWorkerGraph)>,
-) -> Result<ResolvedWorkerGraph, String> {
+) -> Result<ResolvedWorkerForest, String> {
     if graphs.is_empty() {
         return Err("merge_resolved_graphs: no graphs provided".to_string());
     }
@@ -1673,8 +1692,12 @@ pub(crate) fn merge_resolved_graphs(
         std::collections::BTreeMap::new();
     let mut edges: Vec<super::registry::ResolvedEdge> = Vec::new();
     let first_root = graphs[0].1.root.clone();
+    let mut roots = Vec::with_capacity(graphs.len());
 
     for (origin, graph) in graphs {
+        super::registry::validate_dependency_graph(&graph)
+            .map_err(|e| format!("invalid resolved graph for `{origin}`: {e}"))?;
+        roots.push(graph.root.name.clone());
         for node in graph.graph {
             if let Some(existing) = nodes_by_name.get(&node.name) {
                 if existing.version != node.version {
@@ -1695,12 +1718,22 @@ pub(crate) fn merge_resolved_graphs(
         edges.extend(graph.edges);
     }
 
-    Ok(ResolvedWorkerGraph {
-        root: first_root,
-        target: None,
-        graph: nodes_by_name.into_values().collect(),
-        edges,
+    roots.sort();
+    roots.dedup();
+    Ok(ResolvedWorkerForest {
+        graph: ResolvedWorkerGraph {
+            root: first_root,
+            target: None,
+            graph: nodes_by_name.into_values().collect(),
+            edges,
+        },
+        roots,
     })
+}
+
+pub(crate) struct PreparedManifestDependencies {
+    forest: ResolvedWorkerForest,
+    prepared: PreparedResolvedGraph,
 }
 
 /// Resolve every declared manifest dependency against the registry and install
@@ -1709,18 +1742,17 @@ pub(crate) fn merge_resolved_graphs(
 ///
 /// Pass-1: resolve each dep via `fetch_resolved_worker_graph` (serial — fine
 /// for ≤3 deps; parallel fan-out is a future optimization).
-/// Pass-2: merge all graphs into one synthetic graph (dedupes shared
+/// Pass-2: merge all graphs into one dependency forest (dedupes shared
 /// transitive deps, errors on cross-graph version conflicts).
-/// Pass-3: single call to `handle_resolved_graph_add`. Its snapshot/rollback
-/// boundary covers the whole chain — no partial-install state is possible.
-pub(crate) async fn install_manifest_dependencies(
+/// Pass-3: preflight the complete forest once; installation then uses one
+/// snapshot/rollback boundary, so no partial-install state is possible.
+pub(crate) async fn prepare_manifest_dependencies(
     deps: &std::collections::BTreeMap<String, String>,
-    brief: bool,
     assume_yes: bool,
     can_prompt: bool,
-) -> Result<(), String> {
+) -> Result<Option<PreparedManifestDependencies>, String> {
     if deps.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
 
     let mut graphs = Vec::with_capacity(deps.len());
@@ -1748,9 +1780,22 @@ pub(crate) async fn install_manifest_dependencies(
         graphs.push((name.clone(), graph));
     }
 
-    let merged = merge_resolved_graphs(graphs)?;
+    let forest = merge_resolved_graphs(graphs)?;
+    let prepared = preflight_resolved_graph(&forest.graph, &forest.roots, assume_yes, can_prompt)?;
 
-    let rc = handle_resolved_graph_add(&merged, brief, assume_yes, can_prompt).await;
+    Ok(Some(PreparedManifestDependencies { forest, prepared }))
+}
+
+pub(crate) async fn install_prepared_manifest_dependencies(
+    dependencies: PreparedManifestDependencies,
+    brief: bool,
+) -> Result<(), String> {
+    let rc = handle_preflighted_resolved_graph_add(
+        &dependencies.forest.graph,
+        dependencies.prepared,
+        brief,
+    )
+    .await;
     if rc != 0 {
         return Err(format!(
             "failed to install merged dependency graph (exit {rc}); no partial \
@@ -1758,6 +1803,19 @@ pub(crate) async fn install_manifest_dependencies(
         ));
     }
     Ok(())
+}
+
+#[cfg(test)]
+pub(crate) async fn install_manifest_dependencies(
+    deps: &std::collections::BTreeMap<String, String>,
+    brief: bool,
+    assume_yes: bool,
+    can_prompt: bool,
+) -> Result<(), String> {
+    let Some(prepared) = prepare_manifest_dependencies(deps, assume_yes, can_prompt).await? else {
+        return Ok(());
+    };
+    install_prepared_manifest_dependencies(prepared, brief).await
 }
 
 pub async fn handle_managed_add(
@@ -1779,6 +1837,64 @@ pub async fn handle_managed_add(
         std::io::stdin().is_terminal() && std::io::stderr().is_terminal(),
     )
     .await
+}
+
+/// Apply the destructive half of `--force`.
+///
+/// Registry and manifest callers must invoke this only after their source has
+/// been resolved and preflighted, including any required operator consent.
+async fn apply_force_replacement(worker_name: &str, force: bool, reset_config: bool) -> i32 {
+    if !force {
+        return 0;
+    }
+
+    if let Err(e) = super::registry::validate_worker_name(worker_name) {
+        eprintln!("{} {}", "error:".red(), e);
+        return 1;
+    }
+
+    if is_worker_running(worker_name) {
+        eprintln!(
+            "  {} {} is running, stopping first...",
+            "⟳".cyan(),
+            worker_name.bold()
+        );
+        let stop_rc = handle_managed_stop(worker_name).await;
+        if stop_rc != 0 {
+            // Don't abort — artifacts will be wiped below anyway, and the
+            // most common "failure" is "already stopped between
+            // is_worker_running and the signal" which is benign.
+            eprintln!(
+                "  {} stop exited {} — continuing with force add anyway",
+                "warning:".yellow(),
+                stop_rc
+            );
+        }
+    }
+
+    if is_any_builtin(worker_name) {
+        eprintln!(
+            "  {} '{}' is a builtin worker, no artifacts to re-download.",
+            "info:".cyan(),
+            worker_name,
+        );
+    } else {
+        let freed = delete_worker_artifacts(worker_name);
+        if freed > 0 {
+            eprintln!(
+                "  {} Cleared {:.1} MB of artifacts for {}",
+                "✓".green(),
+                freed as f64 / 1_048_576.0,
+                worker_name.bold(),
+            );
+        }
+    }
+
+    if reset_config && let Err(e) = super::config_file::remove_worker(worker_name) {
+        tracing::debug!("remove_worker during force: {}", e);
+    }
+
+    0
 }
 
 pub async fn handle_managed_add_with_consent(
@@ -1804,73 +1920,12 @@ pub async fn handle_managed_add_with_consent(
         .await;
     }
 
-    // --force: stop if running, delete artifacts, then proceed with a fresh
-    // add. Before the fix this path errored out with "Stop it first" when a
-    // running worker was detected — which defeats the point of --force. The
-    // whole sequence (stop → clear → add) is what a user means by "force."
-    if force {
-        let (plain_name, _) = parse_worker_input(image_or_name);
-
-        let is_oci_ref = plain_name.contains('/') || plain_name.contains(':');
-        if !is_oci_ref && let Err(e) = super::registry::validate_worker_name(&plain_name) {
-            eprintln!("{} {}", "error:".red(), e);
-            return 1;
-        }
-
-        if is_worker_running(&plain_name) {
-            eprintln!(
-                "  {} {} is running, stopping first...",
-                "⟳".cyan(),
-                plain_name.bold()
-            );
-            let stop_rc = handle_managed_stop(&plain_name).await;
-            if stop_rc != 0 {
-                // Don't abort — artifacts will be wiped below anyway, and the
-                // most common "failure" is "already stopped between is_worker_running
-                // and the signal" which is benign. Surface it so a stuck worker
-                // doesn't silently confuse the user.
-                eprintln!(
-                    "  {} stop exited {} — continuing with force add anyway",
-                    "warning:".yellow(),
-                    stop_rc
-                );
-            }
-        }
-
-        if is_any_builtin(&plain_name) {
-            eprintln!(
-                "  {} '{}' is a builtin worker, no artifacts to re-download.",
-                "info:".cyan(),
-                plain_name,
-            );
-        } else {
-            let freed = delete_worker_artifacts(&plain_name);
-            if freed > 0 {
-                eprintln!(
-                    "  {} Cleared {:.1} MB of artifacts for {}",
-                    "✓".green(),
-                    freed as f64 / 1_048_576.0,
-                    plain_name.bold(),
-                );
-            }
-        }
-
-        if reset_config {
-            match super::config_file::remove_worker(&plain_name) {
-                Ok(()) => {}
-                Err(e) => {
-                    tracing::debug!("remove_worker during force: {}", e);
-                }
-            }
-        }
-    }
-
     // Direct OCI reference (contains '/' or ':') — passthrough, skip API
     if image_or_name.contains('/') || image_or_name.contains(':') {
         if !brief {
             eprintln!("  Resolving {}...", image_or_name.bold());
         }
-        let name = image_or_name
+        let name = super::oci_ref::canonical_cache_key(image_or_name)
             .rsplit('/')
             .next()
             .unwrap_or(image_or_name)
@@ -1879,6 +1934,9 @@ pub async fn handle_managed_add_with_consent(
             .unwrap_or(image_or_name);
         if !brief {
             eprintln!("  {} Resolved to {}", "✓".green(), image_or_name.dimmed());
+        }
+        if apply_force_replacement(name, force, reset_config).await != 0 {
+            return 1;
         }
         let rc = handle_oci_pull_and_add(name, image_or_name, brief).await;
         return finish_add(name, rc, wait, brief).await;
@@ -1890,6 +1948,9 @@ pub async fn handle_managed_add_with_consent(
     // Mandatory builtins are always injected by the engine with Rust defaults;
     // they must not be written into config.yaml via `iii worker add`.
     if MANDATORY_BUILTIN_NAMES.contains(&name.as_str()) {
+        if apply_force_replacement(&name, force, reset_config).await != 0 {
+            return 1;
+        }
         if !brief {
             eprintln!(
                 "  {} '{}' is a mandatory engine worker (always on; configure via the configuration worker, not config.yaml).",
@@ -1903,6 +1964,9 @@ pub async fn handle_managed_add_with_consent(
     // Check for engine-builtin workers first (no network needed).
     if let Some(default_yaml) = get_builtin_default(&name) {
         let builtin_version = resolve_builtin_version(version.as_deref());
+        if apply_force_replacement(&name, force, reset_config).await != 0 {
+            return 1;
+        }
         let already_exists = super::config_file::worker_exists(&name);
         // Bare `- name:` entry: builtins boot with their Rust defaults and
         // own their configuration through the configuration worker, so the
@@ -1963,7 +2027,18 @@ pub async fn handle_managed_add_with_consent(
 
     match fetch_resolved_worker_graph(&name, version.as_deref(), None).await {
         Ok(graph) => {
-            let rc = handle_resolved_graph_add(&graph, brief, assume_yes, can_prompt).await;
+            let roots = std::slice::from_ref(&graph.root.name);
+            let prepared = match preflight_resolved_graph(&graph, roots, assume_yes, can_prompt) {
+                Ok(prepared) => prepared,
+                Err(e) => {
+                    eprintln!("{} {}", "error:".red(), e);
+                    return 1;
+                }
+            };
+            if apply_force_replacement(&name, force, reset_config).await != 0 {
+                return 1;
+            }
+            let rc = handle_preflighted_resolved_graph_add(&graph, prepared, brief).await;
             return finish_add(&name, rc, wait, brief).await;
         }
         Err(e) if should_fallback_to_legacy_registry_error(&name, &e) => {
@@ -1982,6 +2057,10 @@ pub async fn handle_managed_add_with_consent(
             return 1;
         }
     };
+
+    if apply_force_replacement(&name, force, reset_config).await != 0 {
+        return 1;
+    }
 
     let rc = match response {
         WorkerInfoResponse::Binary(r) => handle_binary_add(&name, &r, brief).await,
@@ -4135,6 +4214,148 @@ mod tests {
         };
         confirm_large_dependency_graph(stats, false, false)
             .expect("threshold is a soft boundary, not a hard failure");
+    }
+
+    fn write_large_engine_graph_fixture(dir: &std::path::Path, root: &str) -> std::path::PathBuf {
+        let node_count = super::super::registry::LARGE_DEPENDENCY_GRAPH_THRESHOLD as usize + 1;
+        let names = std::iter::once(root.to_string())
+            .chain((1..node_count).map(|index| format!("dep-{index}")))
+            .collect::<Vec<_>>();
+        let graph = names
+            .iter()
+            .map(|name| {
+                serde_json::json!({
+                    "name": name,
+                    "type": "engine",
+                    "version": "1.0.0",
+                    "repo": "",
+                    "config": {},
+                    "dependencies": {}
+                })
+            })
+            .collect::<Vec<_>>();
+        let edges = names
+            .windows(2)
+            .map(|pair| {
+                serde_json::json!({
+                    "from": pair[0],
+                    "to": pair[1],
+                    "range": "^1.0.0"
+                })
+            })
+            .collect::<Vec<_>>();
+        let fixture = dir.join("large-graph.json");
+        std::fs::write(
+            &fixture,
+            serde_json::to_vec(&serde_json::json!({
+                "root": {"name": root, "version": "1.0.0"},
+                "graph": graph,
+                "edges": edges
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fixture
+    }
+
+    #[tokio::test]
+    async fn managed_force_waits_for_graph_consent_before_deleting_artifacts() {
+        in_temp_dir_async(|dir| async move {
+            let _env_guard = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let home = dir.join("home");
+            std::fs::create_dir_all(&home).unwrap();
+            let _home_guard = set_env_var_for_test("HOME", &home);
+            let fixture = write_large_engine_graph_fixture(&dir, "root-worker");
+            let _api_guard =
+                set_env_var_for_test("III_API_URL", format!("file://{}", fixture.display()));
+
+            std::fs::write("config.yaml", "workers:\n  - name: root-worker\n").unwrap();
+            let artifact = home.join(".iii/workers/root-worker/sentinel");
+            std::fs::create_dir_all(artifact.parent().unwrap()).unwrap();
+            std::fs::write(&artifact, "preserve until consent").unwrap();
+
+            let rc = handle_managed_add_with_consent(
+                "root-worker",
+                true,
+                true,
+                false,
+                false,
+                false,
+                false,
+            )
+            .await;
+
+            assert_eq!(rc, 1, "missing consent must reject a large graph");
+            assert!(
+                artifact.exists(),
+                "--force must not delete artifacts before consent"
+            );
+            assert!(
+                std::fs::read_to_string("config.yaml")
+                    .unwrap()
+                    .contains("root-worker"),
+                "the existing config entry must remain intact"
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn local_force_waits_for_dependency_consent_before_cleanup() {
+        in_temp_dir_async(|dir| async move {
+            let _env_guard = crate::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let home = dir.join("home");
+            std::fs::create_dir_all(&home).unwrap();
+            let _home_guard = set_env_var_for_test("HOME", &home);
+            let fixture = write_large_engine_graph_fixture(&dir, "registry-dep");
+            let _api_guard =
+                set_env_var_for_test("III_API_URL", format!("file://{}", fixture.display()));
+
+            let project = dir.join("local-worker");
+            std::fs::create_dir_all(&project).unwrap();
+            std::fs::write(
+                project.join("iii.worker.yaml"),
+                "name: local-worker\nscripts:\n  start: \"bun src/index.ts\"\n\
+                 dependencies:\n  registry-dep: \"^1.0.0\"\n",
+            )
+            .unwrap();
+            std::fs::write(
+                "config.yaml",
+                "workers:\n  - name: local-worker\n    worker_path: /old/path\n",
+            )
+            .unwrap();
+            let marker = home.join(".iii/managed/local-worker/var/.iii-prepared");
+            std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+            std::fs::write(&marker, "preserve until consent").unwrap();
+
+            let rc = super::super::local_worker::handle_local_add(
+                project.to_str().unwrap(),
+                true,
+                true,
+                true,
+                false,
+                false,
+                false,
+            )
+            .await;
+
+            assert_eq!(rc, 1, "missing consent must reject a large graph");
+            assert!(
+                marker.exists(),
+                "local --force must not clear managed state before consent"
+            );
+            assert!(
+                std::fs::read_to_string("config.yaml")
+                    .unwrap()
+                    .contains("/old/path"),
+                "reset-config must not run before consent"
+            );
+        })
+        .await;
     }
 
     /// Run an async closure with CWD set to a temp dir, then restore.
@@ -7232,7 +7453,7 @@ dependencies:
 
     #[test]
     fn merge_graphs_unifies_shared_nodes_at_same_version() {
-        let a = graph_with_nodes(
+        let mut a = graph_with_nodes(
             "a",
             "1.0.0",
             vec![
@@ -7240,7 +7461,12 @@ dependencies:
                 resolved_binary_worker("shared", "1.2.3", StdHashMap::new()),
             ],
         );
-        let b = graph_with_nodes(
+        a.edges.push(cli_registry::ResolvedEdge {
+            from: "a".to_string(),
+            to: "shared".to_string(),
+            range: "^1.0.0".to_string(),
+        });
+        let mut b = graph_with_nodes(
             "b",
             "1.0.0",
             vec![
@@ -7248,19 +7474,50 @@ dependencies:
                 resolved_binary_worker("shared", "1.2.3", StdHashMap::new()),
             ],
         );
+        b.edges.push(cli_registry::ResolvedEdge {
+            from: "b".to_string(),
+            to: "shared".to_string(),
+            range: "^1.0.0".to_string(),
+        });
         let merged =
             super::merge_resolved_graphs(vec![("a".to_string(), a), ("b".to_string(), b)]).unwrap();
         let names: std::collections::BTreeSet<_> =
-            merged.graph.iter().map(|n| n.name.clone()).collect();
+            merged.graph.graph.iter().map(|n| n.name.clone()).collect();
         assert_eq!(
             names,
             ["a", "b", "shared"].iter().map(|s| s.to_string()).collect()
         );
+        let stats = cli_registry::validate_dependency_graph_roots(&merged.graph, &merged.roots)
+            .expect("both declared roots must make the merged forest reachable");
+        assert_eq!(stats.node_count, 3);
+    }
+
+    #[test]
+    fn merge_graphs_accepts_independent_declared_roots() {
+        let a = graph_with_nodes(
+            "alpha",
+            "1.0.0",
+            vec![resolved_binary_worker("alpha", "1.0.0", StdHashMap::new())],
+        );
+        let b = graph_with_nodes(
+            "beta",
+            "2.0.0",
+            vec![resolved_binary_worker("beta", "2.0.0", StdHashMap::new())],
+        );
+
+        let merged =
+            super::merge_resolved_graphs(vec![("alpha".to_string(), a), ("beta".to_string(), b)])
+                .expect("independent manifest dependencies should merge");
+        let stats = cli_registry::validate_dependency_graph_roots(&merged.graph, &merged.roots)
+            .expect("each declared dependency is a legitimate forest root");
+
+        assert_eq!(merged.roots, vec!["alpha", "beta"]);
+        assert_eq!(stats.node_count, 2);
     }
 
     #[test]
     fn merge_graphs_errors_on_cross_graph_version_mismatch() {
-        let a = graph_with_nodes(
+        let mut a = graph_with_nodes(
             "a",
             "1.0.0",
             vec![
@@ -7268,7 +7525,12 @@ dependencies:
                 resolved_binary_worker("shared", "1.2.3", StdHashMap::new()),
             ],
         );
-        let b = graph_with_nodes(
+        a.edges.push(cli_registry::ResolvedEdge {
+            from: "a".to_string(),
+            to: "shared".to_string(),
+            range: "^1.0.0".to_string(),
+        });
+        let mut b = graph_with_nodes(
             "b",
             "1.0.0",
             vec![
@@ -7276,6 +7538,11 @@ dependencies:
                 resolved_binary_worker("shared", "2.0.0", StdHashMap::new()),
             ],
         );
+        b.edges.push(cli_registry::ResolvedEdge {
+            from: "b".to_string(),
+            to: "shared".to_string(),
+            range: "^1.0.0".to_string(),
+        });
         let err = super::merge_resolved_graphs(vec![("a".to_string(), a), ("b".to_string(), b)])
             .unwrap_err();
         assert!(

--- a/crates/iii-worker/src/cli/registry.rs
+++ b/crates/iii-worker/src/cli/registry.rs
@@ -7,12 +7,19 @@
 //! OCI registry resolution for worker images.
 
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::sync::LazyLock;
 
 pub const MANIFEST_PATH: &str = "/iii/worker.yaml";
 
 const DEFAULT_API_URL: &str = "https://api.workers.iii.dev";
+/// Maximum registry JSON response accepted by the client.
+///
+/// Dependency safety is primarily enforced structurally (cycle detection)
+/// and at artifact boundaries (download/extraction byte caps). Bounding the
+/// resolver response itself prevents an untrusted or buggy registry from
+/// allocating unbounded memory before those checks can run.
+pub const MAX_REGISTRY_RESPONSE_BYTES: u64 = 1024 * 1024;
 
 /// Shared HTTP client for registry and download operations.
 /// Reuses connections and TLS sessions across requests.
@@ -198,8 +205,7 @@ pub async fn fetch_worker_info(
         #[cfg(debug_assertions)]
         {
             let path = base_or_file.strip_prefix("file://").unwrap();
-            std::fs::read_to_string(path)
-                .map_err(|e| format!("Failed to read local API fixture at {}: {}", path, e))?
+            read_local_registry_fixture(path)?
         }
     } else {
         let url = format!("{}/download/{}", base_or_file, name);
@@ -230,9 +236,7 @@ pub async fn fetch_worker_info(
             return Err(format!("Failed to resolve worker: HTTP {}", resp.status()));
         }
 
-        resp.text()
-            .await
-            .map_err(|e| format!("Failed to read API response: {}", e))?
+        read_registry_response(resp).await?
     };
 
     serde_json::from_str(&body).map_err(|e| format!("Failed to parse worker info: {}", e))
@@ -257,8 +261,7 @@ pub async fn fetch_resolved_worker_graph(
         #[cfg(debug_assertions)]
         {
             let path = base_or_file.strip_prefix("file://").unwrap();
-            std::fs::read_to_string(path)
-                .map_err(|e| format!("Failed to read local API fixture at {}: {}", path, e))?
+            read_local_registry_fixture(path)?
         }
     } else {
         let url = format!("{}/resolve", base_or_file);
@@ -289,116 +292,189 @@ pub async fn fetch_resolved_worker_graph(
             ));
         }
 
-        resp.text()
-            .await
-            .map_err(|e| format!("Failed to read API response: {}", e))?
+        read_registry_response(resp).await?
     };
 
     serde_json::from_str(&body).map_err(|e| format!("Failed to parse worker graph: {}", e))
 }
 
-/// Maximum number of `dependencies:` levels a single `iii worker add`
-/// install graph may traverse. A registry-resolved graph deeper than
-/// this is rejected before any install loop runs. The cap is a
-/// defense-in-depth measure: server-side resolution should already
-/// stop fork-bomb-shaped graphs, but a compromised or malformed
-/// resolver response should never let a client install thousands of
-/// workers from a single `iii worker add`.
-pub const MAX_DEPENDENCY_DEPTH: u32 = 5;
-
-/// Maximum total node count in a resolved install graph (root +
-/// transitives). Pairs with `MAX_DEPENDENCY_DEPTH`: a wide-but-shallow
-/// fan-out should also be refused before the install loop walks it.
-pub const MAX_TRANSITIVE_DEPS: u32 = 32;
-
-/// Validate a `ResolvedWorkerGraph` against client-side install bounds.
+/// A graph larger than this is valid, but requires explicit operator consent.
 ///
-/// This runs AFTER the registry returned the graph and BEFORE the
-/// install loop touches the filesystem. Rejecting at this seam means
-/// neither the lockfile nor `~/.iii/workers-bundle/` ever see the
-/// partial state of an oversized install attempt.
+/// This replaces the old hard `MAX_TRANSITIVE_DEPS = 32` rejection. A node
+/// count is useful for UX ("this command installs a lot"), but it is not a
+/// meaningful resource boundary by itself. Actual bytes are bounded by the
+/// binary and bundle download/extraction caps.
+pub const LARGE_DEPENDENCY_GRAPH_THRESHOLD: u32 = 32;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DependencyGraphStats {
+    pub node_count: u32,
+    pub edge_count: u32,
+}
+
+impl DependencyGraphStats {
+    pub fn requires_confirmation(self) -> bool {
+        self.node_count > LARGE_DEPENDENCY_GRAPH_THRESHOLD
+    }
+}
+
+/// Validate a registry-resolved graph without imposing an arbitrary depth cap.
 ///
-/// Returns `Ok(())` when the graph is within bounds, or
-/// `WorkerOpError::BundleDepGraphExceeded` naming the dimension that
-/// failed. Only used by bundle workers today, but the bounds are
-/// independent of worker kind — every install flow that consumes a
-/// resolved graph is welcome to call this.
-pub fn enforce_dep_graph_bounds(
+/// The old depth-5 and node-count-32 hard failures rejected legitimate
+/// compositions such as `eval@0.1.0`. This validator instead enforces the
+/// structural properties the installer actually relies on:
+///
+/// - worker names are unique,
+/// - every edge references a declared node,
+/// - every declared node is reachable from the requested root,
+/// - the graph is acyclic.
+///
+/// Traversal is iterative and O(nodes + unique edges), so a long dependency
+/// chain does not consume call stack. Oversized registry responses and
+/// artifacts are bounded separately by byte limits.
+pub fn validate_dependency_graph(
     graph: &ResolvedWorkerGraph,
-) -> Result<(), crate::core::error::WorkerOpError> {
-    let node_count = graph.graph.len() as u32;
-    if node_count > MAX_TRANSITIVE_DEPS {
-        return Err(crate::core::error::WorkerOpError::BundleDepGraphExceeded {
-            dimension: "transitive_count".into(),
-            limit: MAX_TRANSITIVE_DEPS,
-            actual: node_count,
+) -> Result<DependencyGraphStats, crate::core::error::WorkerOpError> {
+    use crate::core::error::WorkerOpError;
+
+    let root = graph.root.name.as_str();
+    let mut graph_names = HashSet::with_capacity(graph.graph.len());
+    for worker in &graph.graph {
+        if !graph_names.insert(worker.name.as_str()) {
+            return Err(WorkerOpError::DependencyGraphInvalid {
+                reason: format!("duplicate worker node {:?}", worker.name),
+            });
+        }
+    }
+
+    let mut nodes = graph_names;
+    nodes.insert(root);
+
+    let mut adjacency: HashMap<&str, HashSet<&str>> = HashMap::new();
+    let mut indegree: HashMap<&str, u32> = nodes.iter().map(|&name| (name, 0)).collect();
+    let mut unique_edge_count = 0u32;
+
+    for edge in &graph.edges {
+        let from = edge.from.as_str();
+        let to = edge.to.as_str();
+        if !nodes.contains(from) || !nodes.contains(to) {
+            return Err(WorkerOpError::DependencyGraphInvalid {
+                reason: format!(
+                    "edge {:?} -> {:?} references an undeclared worker",
+                    edge.from, edge.to
+                ),
+            });
+        }
+
+        if adjacency.entry(from).or_default().insert(to) {
+            unique_edge_count = unique_edge_count.saturating_add(1);
+            *indegree.get_mut(to).expect("validated dependency node") += 1;
+        }
+    }
+
+    // Reject disconnected payload nodes. They are not dependencies of the
+    // requested root and must not be installed merely because the resolver
+    // included them in its response.
+    let mut reachable = HashSet::new();
+    let mut frontier = vec![root];
+    while let Some(node) = frontier.pop() {
+        if !reachable.insert(node) {
+            continue;
+        }
+        if let Some(children) = adjacency.get(node) {
+            frontier.extend(children.iter().copied());
+        }
+    }
+    if reachable.len() != nodes.len() {
+        let unreachable = nodes
+            .difference(&reachable)
+            .copied()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(WorkerOpError::DependencyGraphInvalid {
+            reason: format!("worker node(s) are unreachable from {root:?}: {unreachable}"),
         });
     }
 
-    // Find the longest path from `root.name`. The graph is a DAG by
-    // construction (registry rejects cycles during resolve). Edges are
-    // deduped into a set-backed adjacency so a malformed response with
-    // repeated edges cannot inflate the traversal, and each node is
-    // re-expanded only when it is reached via a strictly deeper path.
-    // That memoization is what keeps a wide diamond DAG — many distinct
-    // paths, few distinct nodes — from being counted path-by-path: the
-    // old walk lacked it and rejected legitimate graphs (e.g. a bundle
-    // whose transitives shared a dependency) with a spurious
-    // `edge_traversal` error.
-    let mut adjacency: std::collections::HashMap<&str, std::collections::HashSet<&str>> =
-        std::collections::HashMap::new();
-    for edge in &graph.edges {
-        adjacency.entry(&edge.from).or_default().insert(&edge.to);
-    }
-
-    // Deepest path on which each node has already been expanded. A DAG
-    // within bounds expands each node at most MAX_DEPENDENCY_DEPTH + 1
-    // times (once per strictly deeper path), so the number of expansions
-    // — the only work that pushes new frontier entries — is bounded by
-    // node_count * (depth + 1).
-    let mut best_depth: std::collections::HashMap<&str, u32> = std::collections::HashMap::new();
-    let mut frontier: Vec<(&str, u32)> = vec![(graph.root.name.as_str(), 0)];
-    // Backstop against a graph that is malformed in a way the DAG
-    // invariant should have prevented (self-reference, hidden cycle).
-    // It counts *expansions*, not frontier pops: a dense DAG pushes each
-    // node once per parent, so pops grow with node_count squared while
-    // expansions stay linear. Bounding pops here would reject a valid
-    // dense graph; bounding expansions does not. Memo-skipped pops are
-    // O(1) and cannot outnumber the pushes the expansions produced.
-    let mut expanded = 0u32;
-    let expansion_budget = node_count
-        .saturating_add(1)
-        .saturating_mul(MAX_DEPENDENCY_DEPTH + 1);
-    while let Some((node, depth)) = frontier.pop() {
-        if depth >= MAX_DEPENDENCY_DEPTH {
-            return Err(crate::core::error::WorkerOpError::BundleDepGraphExceeded {
-                dimension: "depth".into(),
-                limit: MAX_DEPENDENCY_DEPTH,
-                actual: depth + 1,
-            });
-        }
-        // Skip nodes already reached via an equal-or-deeper path: the
-        // longest path through them is already accounted for.
-        if best_depth.get(node).is_some_and(|&seen| depth <= seen) {
-            continue;
-        }
-        best_depth.insert(node, depth);
-        expanded += 1;
-        if expanded > expansion_budget {
-            return Err(crate::core::error::WorkerOpError::BundleDepGraphExceeded {
-                dimension: "edge_traversal".into(),
-                limit: expansion_budget,
-                actual: expanded,
-            });
-        }
+    // Kahn's algorithm provides explicit cycle detection without recursion.
+    let mut queue: VecDeque<&str> = indegree
+        .iter()
+        .filter_map(|(&name, &degree)| (degree == 0).then_some(name))
+        .collect();
+    let mut visited = 0usize;
+    while let Some(node) = queue.pop_front() {
+        visited += 1;
         if let Some(children) = adjacency.get(node) {
             for &child in children {
-                frontier.push((child, depth + 1));
+                let degree = indegree.get_mut(child).expect("validated dependency node");
+                *degree -= 1;
+                if *degree == 0 {
+                    queue.push_back(child);
+                }
             }
         }
     }
+    if visited != nodes.len() {
+        let cyclic = indegree
+            .iter()
+            .filter_map(|(&name, &degree)| (degree > 0).then_some(name))
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(WorkerOpError::DependencyGraphInvalid {
+            reason: format!("dependency cycle detected involving: {cyclic}"),
+        });
+    }
 
-    Ok(())
+    Ok(DependencyGraphStats {
+        node_count: nodes.len().try_into().unwrap_or(u32::MAX),
+        edge_count: unique_edge_count,
+    })
+}
+
+#[cfg(debug_assertions)]
+fn read_local_registry_fixture(path: &str) -> Result<String, String> {
+    let metadata = std::fs::metadata(path)
+        .map_err(|e| format!("Failed to read local API fixture at {path}: {e}"))?;
+    if metadata.len() > MAX_REGISTRY_RESPONSE_BYTES {
+        return Err(format!(
+            "Registry response too large: {} bytes, limit {}",
+            metadata.len(),
+            MAX_REGISTRY_RESPONSE_BYTES
+        ));
+    }
+    std::fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read local API fixture at {path}: {e}"))
+}
+
+async fn read_registry_response(response: reqwest::Response) -> Result<String, String> {
+    use futures::StreamExt as _;
+
+    if let Some(length) = response.content_length()
+        && length > MAX_REGISTRY_RESPONSE_BYTES
+    {
+        return Err(format!(
+            "Registry response too large: {length} bytes, limit {MAX_REGISTRY_RESPONSE_BYTES}"
+        ));
+    }
+
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("Failed to read API response: {e}"))?;
+        let next_len = body.len().saturating_add(chunk.len());
+        if next_len as u64 > MAX_REGISTRY_RESPONSE_BYTES {
+            return Err(format!(
+                "Registry response too large: more than {MAX_REGISTRY_RESPONSE_BYTES} bytes"
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    String::from_utf8(body).map_err(|e| format!("Registry response is not valid UTF-8: {e}"))
 }
 
 #[cfg(test)]
@@ -652,6 +728,26 @@ mod tests {
         assert_eq!(graph.root.name, "hello-worker");
         assert_eq!(graph.graph.len(), 2);
         assert_eq!(graph.edges[0].to, "helper");
+    }
+
+    #[test]
+    fn registry_fixture_larger_than_response_budget_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let response_path = dir.path().join("oversized.json");
+        std::fs::write(
+            &response_path,
+            vec![b' '; MAX_REGISTRY_RESPONSE_BYTES as usize + 1],
+        )
+        .unwrap();
+
+        let result = read_local_registry_fixture(
+            response_path
+                .to_str()
+                .expect("temporary fixture path is valid UTF-8"),
+        );
+
+        let err = result.expect_err("oversized registry response must be rejected");
+        assert!(err.contains("Registry response too large"), "{err}");
     }
 
     #[tokio::test]

--- a/crates/iii-worker/src/cli/registry.rs
+++ b/crates/iii-worker/src/cli/registry.rs
@@ -335,9 +335,27 @@ impl DependencyGraphStats {
 pub fn validate_dependency_graph(
     graph: &ResolvedWorkerGraph,
 ) -> Result<DependencyGraphStats, crate::core::error::WorkerOpError> {
+    validate_dependency_graph_roots(graph, std::slice::from_ref(&graph.root.name))
+}
+
+/// Validate a merged dependency forest from every explicitly requested root.
+///
+/// Manifest dependencies are resolved independently, so their merged graph
+/// can have multiple legitimate roots. Keeping the roots separate avoids
+/// inventing dependency edges while preserving the same reachability and
+/// cycle guarantees as [`validate_dependency_graph`].
+pub(crate) fn validate_dependency_graph_roots(
+    graph: &ResolvedWorkerGraph,
+    roots: &[String],
+) -> Result<DependencyGraphStats, crate::core::error::WorkerOpError> {
     use crate::core::error::WorkerOpError;
 
-    let root = graph.root.name.as_str();
+    if roots.is_empty() {
+        return Err(WorkerOpError::DependencyGraphInvalid {
+            reason: "dependency graph has no requested roots".to_string(),
+        });
+    }
+
     let mut graph_names = HashSet::with_capacity(graph.graph.len());
     for worker in &graph.graph {
         if !graph_names.insert(worker.name.as_str()) {
@@ -348,7 +366,8 @@ pub fn validate_dependency_graph(
     }
 
     let mut nodes = graph_names;
-    nodes.insert(root);
+    let roots = roots.iter().map(String::as_str).collect::<BTreeSet<_>>();
+    nodes.extend(roots.iter().copied());
 
     let mut adjacency: HashMap<&str, HashSet<&str>> = HashMap::new();
     let mut indegree: HashMap<&str, u32> = nodes.iter().map(|&name| (name, 0)).collect();
@@ -372,11 +391,11 @@ pub fn validate_dependency_graph(
         }
     }
 
-    // Reject disconnected payload nodes. They are not dependencies of the
-    // requested root and must not be installed merely because the resolver
+    // Reject disconnected payload nodes. They are not dependencies of any
+    // requested root and must not be installed merely because a resolver
     // included them in its response.
     let mut reachable = HashSet::new();
-    let mut frontier = vec![root];
+    let mut frontier = roots.iter().copied().collect::<Vec<_>>();
     while let Some(node) = frontier.pop() {
         if !reachable.insert(node) {
             continue;
@@ -393,8 +412,18 @@ pub fn validate_dependency_graph(
             .into_iter()
             .collect::<Vec<_>>()
             .join(", ");
+        let root_description = if roots.len() == 1 {
+            format!("{:?}", roots.first().expect("non-empty roots"))
+        } else {
+            format!(
+                "declared roots [{}]",
+                roots.iter().copied().collect::<Vec<_>>().join(", ")
+            )
+        };
         return Err(WorkerOpError::DependencyGraphInvalid {
-            reason: format!("worker node(s) are unreachable from {root:?}: {unreachable}"),
+            reason: format!(
+                "worker node(s) are unreachable from {root_description}: {unreachable}"
+            ),
         });
     }
 

--- a/crates/iii-worker/src/core/add.rs
+++ b/crates/iii-worker/src/core/add.rs
@@ -168,6 +168,7 @@ mod tests {
             },
             force: false,
             reset_config: false,
+            yes: false,
             wait: true,
         };
         let outcome = run(opts, &ctx, &sink, &StubShim).await.unwrap();
@@ -186,6 +187,7 @@ mod tests {
             },
             force: false,
             reset_config: false,
+            yes: false,
             wait: true,
         };
         let outcome = run(opts, &ctx, &sink, &StubShim).await.unwrap();
@@ -204,6 +206,7 @@ mod tests {
             },
             force: false,
             reset_config: false,
+            yes: false,
             wait: true,
         };
         let _ = run(opts, &ctx, &sink, &StubShim).await.unwrap();
@@ -308,6 +311,7 @@ mod tests {
             },
             force: false,
             reset_config: false,
+            yes: false,
             wait: true,
         };
         let res = run(opts, &ctx, &sink, &FailingShim).await;

--- a/crates/iii-worker/src/core/error.rs
+++ b/crates/iii-worker/src/core/error.rs
@@ -37,6 +37,7 @@ pub enum WorkerOpErrorKind {
     BundleArchiveUnsafe,           // W181
     BundleResourceClamped,         // W182  (carried by warn events, not Err returns)
     BundleDepGraphExceeded,        // W183
+    DependencyGraphInvalid,        // W184
     Internal,                      // W900
 }
 
@@ -70,6 +71,7 @@ impl WorkerOpErrorKind {
             Self::BundleArchiveUnsafe => "W181",
             Self::BundleResourceClamped => "W182",
             Self::BundleDepGraphExceeded => "W183",
+            Self::DependencyGraphInvalid => "W184",
             Self::Internal => "W900",
         }
     }
@@ -197,6 +199,9 @@ pub enum WorkerOpError {
         actual: u32,
     },
 
+    #[error("dependency graph is invalid: {reason}")]
+    DependencyGraphInvalid { reason: String },
+
     #[error("internal: {message}")]
     Internal { message: String },
 }
@@ -255,6 +260,7 @@ impl WorkerOpError {
             Self::BundleManifestRejected { .. } => K::BundleManifestRejected,
             Self::BundleArchiveUnsafe { .. } => K::BundleArchiveUnsafe,
             Self::BundleDepGraphExceeded { .. } => K::BundleDepGraphExceeded,
+            Self::DependencyGraphInvalid { .. } => K::DependencyGraphInvalid,
             Self::Internal { .. } => K::Internal,
         }
     }
@@ -337,6 +343,7 @@ impl WorkerOpError {
             } => {
                 json!({ "dimension": dimension, "limit": limit, "actual": actual })
             }
+            Self::DependencyGraphInvalid { reason } => json!({ "reason": reason }),
             Self::Internal { message } => json!({ "message": message }),
         };
         json!({
@@ -467,6 +474,19 @@ mod tests {
             "ConsentRequired must not reuse InvalidSource's 'invalid worker source' stem"
         );
         assert!(payload["message"].as_str().unwrap().contains("yes:true"));
+    }
+
+    #[test]
+    fn dependency_graph_invalid_is_w184() {
+        let err = WorkerOpError::DependencyGraphInvalid {
+            reason: "dependency cycle detected involving: a, b".into(),
+        };
+        let payload = err.to_payload();
+        assert_eq!(payload["code"], "W184");
+        assert_eq!(
+            payload["details"]["reason"],
+            "dependency cycle detected involving: a, b"
+        );
     }
 
     #[test]

--- a/crates/iii-worker/src/core/host.rs
+++ b/crates/iii-worker/src/core/host.rs
@@ -156,6 +156,7 @@ mod tests {
             },
             force: false,
             reset_config: false,
+            yes: false,
             wait: false,
         };
         let outcome = shim.add(opts, &ctx, &NullSink).await.unwrap();

--- a/crates/iii-worker/src/core/types.rs
+++ b/crates/iii-worker/src/core/types.rs
@@ -48,6 +48,11 @@ pub struct AddOptions {
         description = "Reset the worker's config.yaml block before re-adding. Combine with force=true for a clean reinstall."
     )]
     pub reset_config: bool,
+    #[serde(default)]
+    #[schemars(
+        description = "Proceed without confirmation when a registry dependency graph contains more than 32 workers. Required for large-graph installs over the trigger or in non-interactive environments."
+    )]
+    pub yes: bool,
     #[serde(default = "default_wait")]
     #[schemars(
         description = "Block until the worker reports ready. Default true. Over the trigger surface installs routinely exceed bus invocation timeouts (npm install etc.) — prefer wait:false and poll worker::status. If a wait:true call times out, the install KEEPS RUNNING server-side: do not re-issue blindly (the project lock will be busy, W120); poll worker::status instead."
@@ -60,6 +65,7 @@ fn add_options_example() -> serde_json::Value {
         "source": {"kind": "registry", "name": "pdfkit", "version": "1.0.0"},
         "force": false,
         "reset_config": false,
+        "yes": false,
         "wait": true
     })
 }
@@ -436,6 +442,7 @@ mod tests {
             },
             force: false,
             reset_config: false,
+            yes: false,
             wait: true,
         };
         let v = serde_json::to_value(&opts).unwrap();

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -140,6 +140,7 @@ async fn async_main() -> anyhow::Result<()> {
                                 source: remote_source_for_cli(name, host),
                                 force,
                                 reset_config: args.reset_config,
+                                yes: args.yes,
                                 wait: !no_wait,
                             },
                         )
@@ -179,6 +180,7 @@ async fn async_main() -> anyhow::Result<()> {
                     source,
                     force,
                     reset_config: args.reset_config,
+                    yes: args.yes,
                     wait: !no_wait,
                 };
 
@@ -278,6 +280,7 @@ async fn async_main() -> anyhow::Result<()> {
                                 source: remote_source_for_cli(name, host),
                                 force: true,
                                 reset_config: args.reset_config,
+                                yes: args.yes,
                                 wait: false,
                             },
                         )
@@ -295,6 +298,7 @@ async fn async_main() -> anyhow::Result<()> {
                     source: parse_source_for_cli(name),
                     force: true,
                     reset_config: args.reset_config,
+                    yes: args.yes,
                     wait: false,
                 };
 

--- a/crates/iii-worker/tests/bundle_worker_integration.rs
+++ b/crates/iii-worker/tests/bundle_worker_integration.rs
@@ -50,8 +50,8 @@ use iii_worker::cli::config_file::{
 };
 use iii_worker::cli::managed::handle_bundle_add;
 use iii_worker::cli::registry::{
-    BundleWorkerResponse, MAX_DEPENDENCY_DEPTH, MAX_TRANSITIVE_DEPS, ResolvedEdge, ResolvedRoot,
-    ResolvedWorker, ResolvedWorkerGraph, enforce_dep_graph_bounds,
+    BundleWorkerResponse, LARGE_DEPENDENCY_GRAPH_THRESHOLD, ResolvedEdge, ResolvedRoot,
+    ResolvedWorker, ResolvedWorkerGraph, validate_dependency_graph,
 };
 use iii_worker::core::error::WorkerOpError;
 
@@ -556,7 +556,10 @@ fn dep_graph_accepts_within_bounds() {
             },
         ],
     };
-    enforce_dep_graph_bounds(&graph).expect("within bounds");
+    let stats = validate_dependency_graph(&graph).expect("valid graph");
+    assert_eq!(stats.node_count, 4);
+    assert_eq!(stats.edge_count, 4);
+    assert!(!stats.requires_confirmation());
 }
 
 #[test]
@@ -612,19 +615,15 @@ fn dep_graph_accepts_wide_shared_dependencies() {
         graph: nodes,
         edges,
     };
-    enforce_dep_graph_bounds(&graph).expect("wide shared-dependency graph is within bounds");
+    validate_dependency_graph(&graph).expect("wide shared-dependency graph is valid");
 }
 
 #[test]
 fn dep_graph_accepts_dense_layered_graph() {
-    // Regression for the backstop itself. `walked` counts frontier pops,
-    // and a dense DAG pushes each node once per parent, so pops grow
-    // roughly with node_count squared while distinct nodes stay small.
-    // A budget that is only linear in node_count therefore rejects a
-    // valid dense graph. This is the maximal shape within bounds: four
-    // fully-connected layers of width 8 — 32 nodes (the transitive_count
-    // cap), longest path 4 (under the depth cap) — which produces ~200
-    // pops and tripped the first linear budget.
+    // Regression for dense but valid DAGs. Four fully-connected layers of
+    // width 8 produce many more edges than nodes. Validation must remain
+    // linear in the payload size and classify the 33-node graph (including
+    // the root) for confirmation instead of rejecting it.
     const WIDTH: usize = 8;
     let layers: Vec<Vec<String>> = (0..4)
         .map(|l| (0..WIDTH).map(|w| format!("l{l}_{w}")).collect())
@@ -660,7 +659,8 @@ fn dep_graph_accepts_dense_layered_graph() {
         graph: nodes,
         edges,
     };
-    enforce_dep_graph_bounds(&graph).expect("dense in-bounds layered graph is accepted");
+    let stats = validate_dependency_graph(&graph).expect("dense layered graph is valid");
+    assert!(stats.requires_confirmation());
 }
 
 #[test]
@@ -681,16 +681,19 @@ fn dep_graph_tolerates_repeated_edges() {
             })
             .collect(),
     };
-    enforce_dep_graph_bounds(&graph).expect("repeated identical edges collapse to one");
+    let stats = validate_dependency_graph(&graph).expect("repeated identical edges collapse");
+    assert_eq!(stats.edge_count, 1);
 }
 
 #[test]
-fn dep_graph_rejects_excessive_depth() {
-    // Linear chain root → n0 → n1 → ... → n_{depth}.
-    let mut nodes = vec![make_resolved_worker("root")];
+fn dep_graph_accepts_long_acyclic_chain() {
+    // Regression for eval@0.1.0, whose legitimate six-node chain was rejected
+    // by the old hard depth-5 guard. Exercise a substantially longer chain to
+    // prove validation is iterative rather than recursion/depth based.
+    let mut nodes = vec![];
     let mut edges = vec![];
     let mut prev = "root".to_string();
-    for i in 0..(MAX_DEPENDENCY_DEPTH + 2) {
+    for i in 0..64 {
         let n = format!("n{i}");
         nodes.push(make_resolved_worker(&n));
         edges.push(ResolvedEdge {
@@ -706,28 +709,14 @@ fn dep_graph_rejects_excessive_depth() {
         graph: nodes,
         edges,
     };
-    let err = enforce_dep_graph_bounds(&graph).expect_err("depth cap fires");
-    let WorkerOpError::BundleDepGraphExceeded {
-        dimension, limit, ..
-    } = err
-    else {
-        panic!("expected BundleDepGraphExceeded");
-    };
-    // Either the depth-cap fires, or the edge-traversal guard fires
-    // first on a malformed/over-long graph. Both are acceptable as
-    // long as the rejection carries a sensible dimension.
-    assert!(
-        dimension == "depth" || dimension == "edge_traversal" || dimension == "transitive_count",
-        "dimension was: {dimension}"
-    );
-    assert!(limit > 0);
+    let stats = validate_dependency_graph(&graph).expect("long acyclic graph is valid");
+    assert_eq!(stats.node_count, 65);
+    assert!(stats.requires_confirmation());
 }
 
 #[test]
-fn dep_graph_rejects_excessive_breadth() {
-    // root with MAX_TRANSITIVE_DEPS+1 direct dependencies (depth 1 but
-    // node count over cap).
-    let extra = (MAX_TRANSITIVE_DEPS as usize) + 5;
+fn dep_graph_large_breadth_requires_confirmation_instead_of_failing() {
+    let extra = (LARGE_DEPENDENCY_GRAPH_THRESHOLD as usize) + 5;
     let nodes: Vec<_> = (0..extra)
         .map(|i| make_resolved_worker(&format!("dep{i}")))
         .collect();
@@ -744,11 +733,73 @@ fn dep_graph_rejects_excessive_breadth() {
         graph: nodes,
         edges,
     };
-    let err = enforce_dep_graph_bounds(&graph).expect_err("breadth cap fires");
+    let stats = validate_dependency_graph(&graph).expect("wide graph remains structurally valid");
+    assert!(stats.requires_confirmation());
+}
+
+#[test]
+fn dep_graph_rejects_cycle() {
+    let graph = ResolvedWorkerGraph {
+        root: make_root_worker("root"),
+        target: None,
+        graph: vec![make_resolved_worker("a"), make_resolved_worker("b")],
+        edges: vec![
+            ResolvedEdge {
+                from: "root".into(),
+                to: "a".into(),
+                range: "*".into(),
+            },
+            ResolvedEdge {
+                from: "a".into(),
+                to: "b".into(),
+                range: "*".into(),
+            },
+            ResolvedEdge {
+                from: "b".into(),
+                to: "a".into(),
+                range: "*".into(),
+            },
+        ],
+    };
+    let err = validate_dependency_graph(&graph).expect_err("cycle must be rejected");
     assert!(
-        matches!(err, WorkerOpError::BundleDepGraphExceeded { .. }),
-        "expected BundleDepGraphExceeded, got {err:?}"
+        matches!(err, WorkerOpError::DependencyGraphInvalid { ref reason } if reason.contains("cycle")),
+        "expected cycle error, got {err:?}"
     );
+}
+
+#[test]
+fn dep_graph_accepts_eval_0_1_0_shape() {
+    let names = [
+        "harness",
+        "context-manager",
+        "llm-router",
+        "state",
+        "configuration",
+    ];
+    let graph = ResolvedWorkerGraph {
+        root: ResolvedRoot {
+            name: "eval".into(),
+            version: "0.1.0".into(),
+        },
+        target: None,
+        graph: std::iter::once(make_resolved_worker("eval"))
+            .chain(names.iter().map(|name| make_resolved_worker(name)))
+            .collect(),
+        edges: std::iter::once("eval")
+            .chain(names.iter().copied())
+            .collect::<Vec<_>>()
+            .windows(2)
+            .map(|pair| ResolvedEdge {
+                from: pair[0].into(),
+                to: pair[1].into(),
+                range: "*".into(),
+            })
+            .collect(),
+    };
+    let stats = validate_dependency_graph(&graph).expect("eval@0.1.0 graph must be accepted");
+    assert_eq!(stats.node_count, 6);
+    assert!(!stats.requires_confirmation());
 }
 
 // =============================================================================

--- a/crates/iii-worker/tests/local_worker_integration.rs
+++ b/crates/iii-worker/tests/local_worker_integration.rs
@@ -384,8 +384,16 @@ async fn handle_local_add_valid_path() {
         std::fs::create_dir_all(&project_dir).unwrap();
         std::fs::write(project_dir.join("package.json"), "{}").unwrap();
 
-        let result =
-            handle_local_add(project_dir.to_str().unwrap(), false, false, true, false).await;
+        let result = handle_local_add(
+            project_dir.to_str().unwrap(),
+            false,
+            false,
+            true,
+            false,
+            false,
+            false,
+        )
+        .await;
         assert_eq!(result, 0, "handle_local_add should return 0 for valid path");
 
         // Without manifest, resolve_worker_name falls back to directory name
@@ -431,7 +439,16 @@ async fn handle_local_add_rejects_duplicate_without_force() {
             .build(&cwd);
 
         let result =
-            handle_local_add(project_dir.to_str().unwrap(), false, false, true, false).await;
+            handle_local_add(
+                project_dir.to_str().unwrap(),
+                false,
+                false,
+                true,
+                false,
+                false,
+                false,
+            )
+            .await;
         assert_eq!(
             result, 1,
             "should return 1 when worker exists and force=false"
@@ -462,7 +479,16 @@ async fn handle_local_add_force_replaces_existing() {
             .build(&cwd);
 
         let result =
-            handle_local_add(project_dir.to_str().unwrap(), true, true, true, false).await;
+            handle_local_add(
+                project_dir.to_str().unwrap(),
+                true,
+                true,
+                true,
+                false,
+                false,
+                false,
+            )
+            .await;
         assert_eq!(result, 0, "should return 0 with force=true");
 
         let stored_path = get_worker_path("my-worker");
@@ -533,7 +559,16 @@ async fn handle_local_add_force_removes_prepared_marker() {
         std::fs::create_dir_all(managed_dir.join("var/iii/deps/node_modules")).unwrap();
 
         let result =
-            handle_local_add(project_dir.to_str().unwrap(), true, false, true, false).await;
+            handle_local_add(
+                project_dir.to_str().unwrap(),
+                true,
+                false,
+                true,
+                false,
+                false,
+                false,
+            )
+            .await;
         assert_eq!(result, 0, "force add should succeed");
 
         // Config entry replaced with the new canonical path.
@@ -641,7 +676,16 @@ async fn handle_local_add_force_removes_marker_when_dir_wipe_fails() {
         let _restore = RestorePerms(&managed_dir);
 
         let result =
-            handle_local_add(project_dir.to_str().unwrap(), true, false, true, false).await;
+            handle_local_add(
+                project_dir.to_str().unwrap(),
+                true,
+                false,
+                true,
+                false,
+                false,
+                false,
+            )
+            .await;
 
         assert_eq!(result, 0, "force add should still succeed when the dir wipe fails");
         assert!(
@@ -722,7 +766,16 @@ async fn handle_local_add_force_fails_when_marker_removal_errors() {
         let _restore = RestorePerms(&var_dir);
 
         let result =
-            handle_local_add(project_dir.to_str().unwrap(), true, false, true, false).await;
+            handle_local_add(
+                project_dir.to_str().unwrap(),
+                true,
+                false,
+                true,
+                false,
+                false,
+                false,
+            )
+            .await;
 
         assert_eq!(
             result, 1,
@@ -747,7 +800,8 @@ async fn handle_local_add_canonicalizes_relative_path() {
         std::fs::create_dir_all(&project_dir).unwrap();
         std::fs::write(project_dir.join("package.json"), "{}").unwrap();
 
-        let result = handle_local_add("./rel-worker", false, false, true, false).await;
+        let result =
+            handle_local_add("./rel-worker", false, false, true, false, false, false).await;
         assert_eq!(result, 0, "should succeed with relative path");
 
         // Without manifest, name falls back to directory name "rel-worker"
@@ -767,8 +821,16 @@ async fn handle_local_add_canonicalizes_relative_path() {
 #[tokio::test]
 async fn handle_local_add_invalid_path_returns_error() {
     in_temp_dir_async(|| async {
-        let result =
-            handle_local_add("/nonexistent/path/to/worker", false, false, true, false).await;
+        let result = handle_local_add(
+            "/nonexistent/path/to/worker",
+            false,
+            false,
+            true,
+            false,
+            false,
+            false,
+        )
+        .await;
         assert_eq!(result, 1, "should return 1 for nonexistent path");
     })
     .await;

--- a/crates/iii-worker/tests/worker_integration.rs
+++ b/crates/iii-worker/tests/worker_integration.rs
@@ -192,7 +192,17 @@ fn add_subcommand_fields() {
                 vec!["ghcr.io/iii-hq/node:latest".to_string()]
             );
             assert!(!force);
+            assert!(!args.yes);
         }
+        _ => panic!("expected Add"),
+    }
+}
+
+#[test]
+fn add_subcommand_accepts_yes_for_large_dependency_graphs() {
+    let cli = Cli::parse_from(["iii-worker", "add", "large-worker", "--yes"]);
+    match cli.command {
+        Commands::Add { args, .. } => assert!(args.yes),
         _ => panic!("expected Add"),
     }
 }

--- a/crates/iii-worker/tests/worker_trigger_integration.rs
+++ b/crates/iii-worker/tests/worker_trigger_integration.rs
@@ -339,6 +339,14 @@ fn classify_not_found_lifts_to_w110() {
 }
 
 #[test]
+fn classify_declined_prompt_lifts_to_w170() {
+    let stderr = "error: operation cancelled\n";
+    let err = classify_handler_error(1, stderr, "add", "large-worker");
+    assert_eq!(err.kind(), WorkerOpErrorKind::Cancelled);
+    assert_eq!(parse_envelope(&err_payload(&err)).0, "W170");
+}
+
+#[test]
 fn classify_unknown_failure_is_w900_without_rc_leak() {
     let stderr = "error: HTTP 503 service unavailable\n";
     let err = classify_handler_error(2, stderr, "add", "anything");

--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -165,6 +165,7 @@ iii worker add [OPTIONS] <WORKER[@VERSION]|PATH>...
 | ------ | ----------- |
 | `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block), instead of keeping the existing entry. With `add`, takes effect only together with `--force`; `reinstall` applies force automatically |
 | `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host. When omitted and the current directory has no config file, falls back to `--host localhost` (the running local engine) instead of creating an orphan config file here |
+| `-y, --yes` | Proceed without prompting when the resolved dependency graph contains more than 32 workers. Required for large-graph installs in CI or other non-interactive environments |
 | `-f, --force` | Force re-download: delete existing artifacts before adding |
 | `--no-wait` | Don't block waiting for the engine to finish booting the worker |
 
@@ -265,6 +266,7 @@ iii worker reinstall [OPTIONS] <WORKER[@VERSION]|PATH>...
 | ------ | ----------- |
 | `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block), instead of keeping the existing entry. With `add`, takes effect only together with `--force`; `reinstall` applies force automatically |
 | `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host. When omitted and the current directory has no config file, falls back to `--host localhost` (the running local engine) instead of creating an orphan config file here |
+| `-y, --yes` | Proceed without prompting when the resolved dependency graph contains more than 32 workers. Required for large-graph installs in CI or other non-interactive environments |
 
 ### `iii worker remove`
 

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -297,7 +297,7 @@ iii worker restart [OPTIONS] <WORKER>
 | Option | Description |
 | ------ | ----------- |
 | `--no-wait` | Return immediately. Don't block waiting for the worker to report ready |
-| `--port <PORT>` | Engine WebSocket port the spawned worker connects back to. Same semantics as `start --port` [default: 49134] |
+| `--port <PORT>` | Engine WebSocket port the spawned worker connects back to. Same semantics as `start --port` |
 | `--config <PATH>` | Same as `start --config` |
 
 ### `iii worker sandbox`
@@ -463,7 +463,7 @@ iii worker start [OPTIONS] <WORKER>
 | Option | Description |
 | ------ | ----------- |
 | `--no-wait` | Return immediately. Don't block waiting for the worker to report ready |
-| `--port <PORT>` | Engine WebSocket port the spawned worker connects back to. Defaults to DEFAULT_PORT; the engine passes its configured iii-worker-manager port when auto-spawning external workers so non-default manager ports don't silently break connectivity [default: 49134] |
+| `--port <PORT>` | Engine WebSocket port the spawned worker connects back to. Defaults to the iii-worker-manager port in config.yaml (else 49134); the engine passes its configured port explicitly when auto-spawning external workers so non-default manager ports don't silently break connectivity |
 | `--config <PATH>` | YAML config forwarded to the spawned worker binary as `--config <path>`. Binary workers only; OCI workers warn and ignore |
 
 ### `iii worker status`

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -163,6 +163,7 @@ iii worker add [OPTIONS] <WORKER[@VERSION]|PATH>...
 | ------ | ----------- |
 | `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block), instead of keeping the existing entry. With `add`, takes effect only together with `--force`; `reinstall` applies force automatically |
 | `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host. When omitted and the current directory has no config file, falls back to `--host localhost` (the running local engine) instead of creating an orphan config file here |
+| `-y, --yes` | Proceed without prompting when the resolved dependency graph contains more than 32 workers. Required for large-graph installs in CI or other non-interactive environments |
 | `-f, --force` | Force re-download: delete existing artifacts before adding |
 | `--no-wait` | Don't block waiting for the engine to finish booting the worker |
 
@@ -263,6 +264,7 @@ iii worker reinstall [OPTIONS] <WORKER[@VERSION]|PATH>...
 | ------ | ----------- |
 | `--reset-config` | Discard the worker's config.yaml entry and recreate it fresh (dropping any hand-written config block), instead of keeping the existing entry. With `add`, takes effect only together with `--force`; `reinstall` applies force automatically |
 | `--host <HOST[:PORT]>` | Install through a RUNNING iii engine instead of editing the config file in the current directory: connects to HOST[:PORT] (ex. `localhost:49134`; port defaults to 49134; ws:// and wss:// URLs are also accepted and used as-is) and invokes its worker::add. The engine applies the add in ITS project directory, so this works from any folder and with engines on non-default ports. Local worker PATHs resolve on the engine host. When omitted and the current directory has no config file, falls back to `--host localhost` (the running local engine) instead of creating an orphan config file here |
+| `-y, --yes` | Proceed without prompting when the resolved dependency graph contains more than 32 workers. Required for large-graph installs in CI or other non-interactive environments |
 
 ### `iii worker remove`
 


### PR DESCRIPTION
## Summary

- replace the hard dependency depth and node-count rejections with iterative structural validation for cycles, dangling edges, duplicate nodes, and disconnected nodes
- treat graphs above 32 workers as valid but require explicit confirmation, with `--yes` and `yes: true` support for non-interactive and trigger-based installs
- cap registry JSON responses at 1 MiB, add the structured `W184` invalid-graph error, and update CLI documentation
- add regression coverage for long chains, dense and shared-dependency DAGs, duplicate edges, cycles, large graphs, and the `eval@0.1.0` graph

## Terminal demo

### 1. Deep dependency graph: `eval@0.1.0`

![Live registry installation of eval@0.1.0](https://vhs.charm.sh/vhs-6Frc24gvd6jKj8fwWZ48Kb.gif)

### 2. Original multi-worker command

![iii worker add harness console eval](https://vhs.charm.sh/vhs-2Ro0FCgJe5buVFjXJMayQI.gif)

### 3. Interactive confirmation for 33 workers

![Interactive confirmation for a valid 33-worker graph](https://vhs.charm.sh/vhs-2Y415EZQZtVh7n6tJ5FsOu.gif)

### 4. Non-interactive approval with `--yes`

![Large graph installation using --yes](https://vhs.charm.sh/vhs-1And4mRlQ2DNhWYtIBWQHu.gif)

The graph-size and multi-worker control paths use a deterministic local resolver fixture; the `eval@0.1.0` case resolves against the live registry.

## Root cause

The client rejected any resolved dependency chain deeper than five levels even when the registry returned a legitimate acyclic graph. `eval@0.1.0` resolves through a six-level chain, so installation failed before touching the filesystem with `bundle dependency graph depth exceeded: limit 5, found 6`.

A fixed node cap also conflated operator intent with resource safety. The graph size is now surfaced for confirmation, while actual safety is enforced through structural validation and byte limits.

## Impact

Valid deeply composed workers such as `eval@0.1.0` can now be installed. Malformed or hostile resolver payloads remain blocked through explicit cycle and graph-integrity checks, bounded registry responses, and the existing artifact download and extraction limits.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p iii-worker`
- `cargo clippy -p iii-worker --all-targets --all-features` (completed with existing project warnings)
- `cargo test -p iii-worker --lib -- --test-threads=1` — 963 passed, 1 ignored
- relevant integration suites — 112 passed
- `cargo build --release -p iii-worker`
- release binary installed `eval@0.1.0` successfully, resolving 16 workers and writing `config.yaml` and `iii.lock`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `-y/--yes` to worker add and reinstall to bypass confirmation for large dependency graphs.
  * Added interactive consent prompts, cancellation handling, and safeguards for non-interactive installations.
  * Improved dependency-graph validation, including cycle and structural checks.
* **Bug Fixes**
  * Added limits for oversized registry responses.
  * Improved error reporting for cancelled operations, required consent, and invalid dependency graphs.
* **Documentation**
  * Updated CLI references for the new option and clarified `--port` defaults and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->