### PR TITLE
fix(iii-queue): isolate RabbitMQ DLQ inspection channels

### DIFF
--- a/engine/src/workers/queue/adapters/rabbitmq/adapter.rs
+++ b/engine/src/workers/queue/adapters/rabbitmq/adapter.rs
@@ -38,6 +38,7 @@ use super::{
 };
 
 pub struct RabbitMQAdapter {
+    connection: Arc<Connection>,
     publisher: Arc<Publisher>,
     retry_handler: Arc<RetryHandler>,
     topology: Arc<TopologyManager>,
@@ -67,6 +68,33 @@ impl RabbitMQAdapter {
         }
     }
 
+    /// Returns a channel reserved for probes and DLQ administration. RabbitMQ
+    /// closes a channel after a failed passive declaration, so these operations
+    /// must never share the long-lived channel used by consumers and publishers.
+    async fn inspection_channel(&self) -> anyhow::Result<Channel> {
+        self.connection
+            .create_channel()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to create RabbitMQ inspection channel: {}", e))
+    }
+
+    async fn passive_queue_message_count(&self, queue_name: &str) -> anyhow::Result<u64> {
+        let channel = self.inspection_channel().await?;
+        let queue = channel
+            .queue_declare(
+                queue_name,
+                lapin::options::QueueDeclareOptions {
+                    passive: true,
+                    ..Default::default()
+                },
+                lapin::types::FieldTable::default(),
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to get queue info: {}", e))?;
+
+        Ok(queue.message_count() as u64)
+    }
+
     /// Scan a DLQ for a specific message by ID, applying `on_found` when the target is located.
     /// Non-target messages are nacked back to the queue.
     ///
@@ -85,9 +113,9 @@ impl RabbitMQAdapter {
         Fut: std::future::Future<Output = anyhow::Result<()>>,
     {
         let (dlq_name, is_fn_queue) = Self::resolve_dlq_name(topic);
+        let channel = self.inspection_channel().await?;
 
-        let queue_info = self
-            .channel
+        let queue_info = channel
             .queue_declare(
                 &dlq_name,
                 lapin::options::QueueDeclareOptions {
@@ -102,8 +130,7 @@ impl RabbitMQAdapter {
         let count = queue_info.message_count();
 
         for _ in 0..count {
-            let get_result = self
-                .channel
+            let get_result = channel
                 .basic_get(&dlq_name, BasicGetOptions { no_ack: false })
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to get message from DLQ: {}", e))?;
@@ -153,15 +180,17 @@ impl RabbitMQAdapter {
     }
 
     pub async fn new(config: RabbitMQConfig, engine: Arc<Engine>) -> anyhow::Result<Self> {
-        let connection = Connection::connect(&config.amqp_url, ConnectionProperties::default())
-            .await
-            .map_err(|e| {
-                anyhow::anyhow!(
-                    "Failed to connect to RabbitMQ at {}: {}",
-                    config.amqp_url,
-                    e
-                )
-            })?;
+        let connection = Arc::new(
+            Connection::connect(&config.amqp_url, ConnectionProperties::default())
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Failed to connect to RabbitMQ at {}: {}",
+                        config.amqp_url,
+                        e
+                    )
+                })?,
+        );
 
         let channel = connection
             .create_channel()
@@ -184,6 +213,7 @@ impl RabbitMQAdapter {
         let retry_handler = Arc::new(RetryHandler::new(Arc::clone(&publisher)));
 
         Ok(Self {
+            connection,
             publisher,
             retry_handler,
             topology,
@@ -218,6 +248,7 @@ fn delivery_stable_id(delivery: &Delivery) -> String {
 impl Clone for RabbitMQAdapter {
     fn clone(&self) -> Self {
         Self {
+            connection: Arc::clone(&self.connection),
             publisher: Arc::clone(&self.publisher),
             retry_handler: Arc::clone(&self.retry_handler),
             topology: Arc::clone(&self.topology),
@@ -439,11 +470,11 @@ impl QueueAdapter for RabbitMQAdapter {
         use serde_json::Value;
 
         let (dlq_name, is_fn_queue) = Self::resolve_dlq_name(topic);
+        let channel = self.inspection_channel().await?;
         let mut count: u64 = 0;
 
         loop {
-            let get_result = self
-                .channel
+            let get_result = channel
                 .basic_get(&dlq_name, BasicGetOptions { no_ack: false })
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to get message from DLQ: {}", e))?;
@@ -475,7 +506,7 @@ impl QueueAdapter for RabbitMQAdapter {
                                 properties
                             };
 
-                        self.channel
+                        channel
                             .basic_publish(
                                 &names.exchange(),
                                 queue_name,
@@ -627,28 +658,15 @@ impl QueueAdapter for RabbitMQAdapter {
         // while topic-based queues use RabbitNames (e.g., user.created -> .dlq).
         let (dlq_name, _is_fn_queue) = Self::resolve_dlq_name(topic);
 
-        let queue = self
-            .channel
-            .queue_declare(
-                &dlq_name,
-                lapin::options::QueueDeclareOptions {
-                    passive: true,
-                    ..Default::default()
-                },
-                lapin::types::FieldTable::default(),
-            )
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get DLQ info: {}", e))?;
-
-        Ok(queue.message_count() as u64)
+        self.passive_queue_message_count(&dlq_name).await
     }
 
     async fn dlq_messages(&self, topic: &str, count: usize) -> anyhow::Result<Vec<Value>> {
         let (dlq_name, _is_fn_queue) = Self::resolve_dlq_name(topic);
+        let channel = self.inspection_channel().await?;
 
         // Cap iteration at actual queue depth to avoid unnecessary basic_get calls
-        let queue_depth = match self
-            .channel
+        let queue_depth = match channel
             .queue_declare(
                 &dlq_name,
                 lapin::options::QueueDeclareOptions {
@@ -668,8 +686,7 @@ impl QueueAdapter for RabbitMQAdapter {
         let mut deliveries = Vec::new();
 
         for _ in 0..fetch_count {
-            let get_result = self
-                .channel
+            let get_result = channel
                 .basic_get(&dlq_name, BasicGetOptions { no_ack: false })
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to get message from DLQ: {}", e))?;
@@ -704,10 +721,10 @@ impl QueueAdapter for RabbitMQAdapter {
         limit: u64,
     ) -> anyhow::Result<Vec<crate::workers::queue::DlqMessage>> {
         let (dlq_name, is_fn_queue) = Self::resolve_dlq_name(topic);
+        let channel = self.inspection_channel().await?;
 
         // Cap at actual queue depth
-        let queue_depth = match self
-            .channel
+        let queue_depth = match channel
             .queue_declare(
                 &dlq_name,
                 lapin::options::QueueDeclareOptions {
@@ -727,8 +744,7 @@ impl QueueAdapter for RabbitMQAdapter {
         let mut deliveries_to_nack = Vec::new();
 
         for i in 0..fetch_count {
-            let get_result = self
-                .channel
+            let get_result = channel
                 .basic_get(&dlq_name, BasicGetOptions { no_ack: false })
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to get message from DLQ: {}", e))?;
@@ -1170,36 +1186,14 @@ impl QueueAdapter for RabbitMQAdapter {
         };
 
         // Get main queue depth (passive declare to inspect without creating)
-        let depth = match self
-            .channel
-            .queue_declare(
-                &queue_name,
-                lapin::options::QueueDeclareOptions {
-                    passive: true,
-                    ..Default::default()
-                },
-                lapin::types::FieldTable::default(),
-            )
-            .await
-        {
-            Ok(info) => info.message_count() as u64,
+        let depth = match self.passive_queue_message_count(&queue_name).await {
+            Ok(count) => count,
             Err(_) => 0,
         };
 
         // Get DLQ depth
-        let dlq_depth = match self
-            .channel
-            .queue_declare(
-                &dlq_name,
-                lapin::options::QueueDeclareOptions {
-                    passive: true,
-                    ..Default::default()
-                },
-                lapin::types::FieldTable::default(),
-            )
-            .await
-        {
-            Ok(info) => info.message_count() as u64,
+        let dlq_depth = match self.passive_queue_message_count(&dlq_name).await {
+            Ok(count) => count,
             Err(_) => 0,
         };
 

--- a/engine/tests/rabbitmq_queue_integration.rs
+++ b/engine/tests/rabbitmq_queue_integration.rs
@@ -20,7 +20,10 @@ use uuid::Uuid;
 use iii::{
     engine::Engine,
     function::{Function, FunctionResult},
-    workers::{queue::QueueWorker, traits::Worker},
+    workers::{
+        queue::{FunctionQueueConfig, QueueWorker},
+        traits::Worker,
+    },
 };
 
 use common::queue_helpers::{
@@ -37,6 +40,71 @@ use common::rabbitmq_helpers::{
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn missing_dlq_inspection_does_not_close_function_queue_channel() {
+    let ctx = get_rabbitmq().await;
+    let prefix = test_prefix();
+    let missing_queue = format!("{prefix}-missing");
+    let function_queue = format!("{prefix}-function");
+    let engine = Arc::new(Engine::new());
+
+    // Deliberately start without function queues: the passive DLQ inspection
+    // below must observe a nonexistent broker queue before setup begins.
+    let module = QueueWorker::for_test(
+        engine,
+        Some(json!({
+            "adapter": {
+                "name": "rabbitmq",
+                "config": { "amqp_url": ctx.amqp_url }
+            }
+        })),
+    )
+    .await
+    .expect("RabbitMQ adapter should connect");
+
+    assert!(
+        module
+            .function_queue_dlq_count(&missing_queue)
+            .await
+            .is_err(),
+        "a nonexistent DLQ must report an inspection error"
+    );
+
+    let adapter = module.adapter_snapshot();
+    let config = FunctionQueueConfig::default();
+    adapter
+        .setup_function_queue(&function_queue, &config)
+        .await
+        .expect("a failed DLQ inspection must not close the function queue channel");
+    let mut receiver = adapter
+        .consume_function_queue(&function_queue, 1)
+        .await
+        .expect("a failed DLQ inspection must not prevent function queue consumption");
+
+    adapter
+        .publish_to_function_queue(
+            &function_queue,
+            "test::rmq_dlq_channel",
+            json!({"source": "dlq-channel-regression"}),
+            "dlq-channel-regression-message",
+            config.max_retries,
+            config.backoff_ms,
+            None,
+            None,
+            None,
+        )
+        .await;
+
+    let message = tokio::time::timeout(Duration::from_secs(5), receiver.recv())
+        .await
+        .expect("function queue should receive a published message")
+        .expect("function queue receiver should remain open");
+    adapter
+        .ack_function_queue(&function_queue, message.delivery_id)
+        .await
+        .expect("function queue acknowledgement should succeed");
+}
 
 #[tokio::test]
 async fn full_roundtrip_enqueue_consume_invoke() {


### PR DESCRIPTION
## Summary

- create disposable RabbitMQ channels for passive queue probes and DLQ operations
- keep the long-lived publisher/consumer channel isolated from broker-side passive-declare failures
- add a real RabbitMQ regression covering missing-DLQ inspection followed by function queue setup, delivery, and acknowledgement

## Root cause

RabbitMQ closes an AMQP channel after a passive declaration for a nonexistent queue. The builtin `iii-queue` adapter used its single shared channel for that inspection and for function-queue topology and consumers. A failed DLQ inspection therefore made subsequent function-queue setup fail with a closed-channel error.

## Impact

A nonexistent DLQ still reports an inspection error, but it no longer prevents unrelated function queues from being configured, consumed, published to, or acknowledged.

Related to #2017.

## Validation

- `cargo test -p iii --test rabbitmq_queue_integration -- --nocapture` (21 passed with real Docker RabbitMQ)
- `cargo fmt --all -- --check`
- `git diff --check`

`cargo clippy -p iii --all-targets --all-features -- -D warnings` was attempted but is currently blocked by three unrelated existing lints in `crates/scaffolder-core`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved RabbitMQ queue reliability by isolating diagnostic and dead-letter queue checks from active message-processing channels.
  - Queue processing now continues normally after an inspection of a missing dead-letter queue fails.
  - Enhanced dead-letter queue monitoring, message retrieval, redriving, and queue statistics reliability.
  - Improved consistency when inspecting queue depths and managing messages across primary and dead-letter queues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->