### PR TITLE
fix(infra): repair iii.dev /api/search 502 and retire stale smoke expectations

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -71,11 +71,14 @@ jobs:
           assert_header_contains "/" "strict-transport-security" "max-age"
           assert_header_contains "/" "x-content-type-options" "nosniff"
 
-          # /docs redirects preserve the /docs prefix (Mintlify serves only under /docs/*)
-          assert_redirect_to "/docs" "https://docs.iii.dev/docs"
-          assert_redirect_to "/docs/quickstart" "https://docs.iii.dev/docs/quickstart"
+          # /docs* is proxied to the docs origin on the same domain (no redirect)
+          assert_status "/docs" 200
+          assert_header_contains "/docs" "content-type" "text/html"
+          assert_status "/docs/quickstart" 200
 
-          assert_status "/llms.txt" 404
+          # llms.txt / AGENTS.md are generated into every deploy on purpose
+          assert_status "/llms.txt" 200
+          assert_status "/AGENTS.md" 200
 
           # /api/search must return JSON, not HTML — catches SPA fallback leaking into /api/*
           content_type=$(curl -sSI "$BASE_URL/api/search?q=test" | awk 'BEGIN{IGNORECASE=1} /^content-type:/ {for(i=2;i<=NF;i++) printf "%s ", $i; print ""}' | tr -d '\r' | head -1)
@@ -87,7 +90,10 @@ jobs:
 
           assert_status "/this-file-does-not-exist.jpg" 404
 
-          assert_status "/some/client/route" 200
+          # Unknown extensionless paths are a real 404 by design (see
+          # cloudfront_functions/redirects.js — the old SPA fallback served
+          # homepage HTML as 200 and Google indexed it as soft duplicates)
+          assert_status "/some/client/route" 404
           assert_header_contains "/some/client/route" "content-type" "text/html"
 
           echo

--- a/infra/terraform/website/cloudfront.tf
+++ b/infra/terraform/website/cloudfront.tf
@@ -94,6 +94,10 @@ locals {
   cache_policy_disabled_id     = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # CachingDisabled
   origin_request_cors_s3_id    = "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf" # CORS-S3Origin
   origin_request_all_viewer_id = "216adef6-5c7f-47e4-b989-5492eafa07d3" # AllViewer
+  # Vercel routes requests by Host header, so a proxied *.vercel.app origin
+  # must receive its own hostname; forwarding the viewer's `Host: iii.dev`
+  # there makes CloudFront 502.
+  origin_request_all_viewer_except_host_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # AllViewerExceptHostHeader
 }
 
 resource "aws_cloudfront_distribution" "site" {
@@ -173,7 +177,7 @@ resource "aws_cloudfront_distribution" "site" {
     compress               = true
 
     cache_policy_id            = local.cache_policy_disabled_id
-    origin_request_policy_id   = local.origin_request_all_viewer_id
+    origin_request_policy_id   = local.origin_request_all_viewer_except_host_id
     response_headers_policy_id = aws_cloudfront_response_headers_policy.site.id
 
     # No function_association: SPA fallback must not rewrite /api/search responses.


### PR DESCRIPTION
## What's broken

The post-deploy **Website Smoke Tests** workflow has failed on every run since at least July 14.

**`/api/search` on iii.dev returns a CloudFront 502.** The `/api/search*` behavior proxies to `iii-docs.vercel.app` with the managed **AllViewer** origin-request policy, which forwards the viewer's `Host: iii.dev` to Vercel. Vercel routes by Host and can't serve that hostname from the search project, so CloudFront reports a bad gateway. Verified from outside: the origin answers `200 application/json` when it receives its own hostname, `404`/`502` when it receives `iii.dev`.

The smoke expectations also describe the pre-migration architecture: `/docs` 301-to-docs.iii.dev (now proxied on the same domain, serves 200), `/llms.txt` 404 (the build generates it on purpose, plus `AGENTS.md`), and SPA fallback on unknown routes (`redirects.js` deliberately 404s those since the soft-404 SEO fix).

## Fix

- `/api/search*` behavior → managed **AllViewerExceptHostHeader** (`b689b0a8-53d0-40ab-baf2-68738e2966ac`) so the Vercel origin sees `Host: iii-docs.vercel.app`. `/docs*` behaviors untouched — that origin accepts the forwarded host.
- Smoke assertions updated to the live architecture.

## After merge

Needs `terraform apply` in `infra/terraform/website`. Sibling PR for the demo-iframe frame headers: see fix/website-frame-headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation pages now load directly with HTML responses.
  * Added publicly available `/llms.txt` and `/AGENTS.md` resources.

* **Bug Fixes**
  * Improved search API routing to prevent gateway errors.
  * Unknown extensionless paths now correctly return a 404 instead of an application page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->