### PR TITLE
fix(infra): let the landing page frame its own console demo

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -63,6 +63,19 @@ jobs:
             fi
           }
 
+          # Exact single-token headers: a substring check would pass a merged
+          # duplicate like "DENY, SAMEORIGIN".
+          assert_header_equals() {
+            local path="$1" header="$2" expected="$3"
+            local value
+            value=$(curl -sSI "$BASE_URL$path" | awk -v h="$header" 'BEGIN{IGNORECASE=1} tolower($1)==tolower(h)":" {for(i=2;i<=NF;i++) printf "%s ", $i; print ""}' | tr -d '\r' | head -1 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+            if [ "$(printf '%s' "$value" | tr '[:lower:]' '[:upper:]')" = "$(printf '%s' "$expected" | tr '[:lower:]' '[:upper:]')" ]; then
+              pass "$path header '$header' = '$value'"
+            else
+              fail "$path header '$header' expected exactly '$expected', got '$value'"
+            fi
+          }
+
           echo "Smoke testing $BASE_URL"
           echo
 
@@ -80,7 +93,7 @@ jobs:
           # The landing page iframes its own console demo — X-Frame-Options
           # DENY would make the browser refuse to render it
           assert_status "/console-demo/index.html" 200
-          assert_header_contains "/console-demo/index.html" "x-frame-options" "SAMEORIGIN"
+          assert_header_equals "/console-demo/index.html" "x-frame-options" "SAMEORIGIN"
 
           # /api/search must return JSON, not HTML — catches SPA fallback leaking into /api/*
           content_type=$(curl -sSI "$BASE_URL/api/search?q=test" | awk 'BEGIN{IGNORECASE=1} /^content-type:/ {for(i=2;i<=NF;i++) printf "%s ", $i; print ""}' | tr -d '\r' | head -1)

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -77,6 +77,11 @@ jobs:
 
           assert_status "/llms.txt" 404
 
+          # The landing page iframes its own console demo — X-Frame-Options
+          # DENY would make the browser refuse to render it
+          assert_status "/console-demo/index.html" 200
+          assert_header_contains "/console-demo/index.html" "x-frame-options" "SAMEORIGIN"
+
           # /api/search must return JSON, not HTML — catches SPA fallback leaking into /api/*
           content_type=$(curl -sSI "$BASE_URL/api/search?q=test" | awk 'BEGIN{IGNORECASE=1} /^content-type:/ {for(i=2;i<=NF;i++) printf "%s ", $i; print ""}' | tr -d '\r' | head -1)
           if echo "$content_type" | grep -qi 'json'; then

--- a/infra/terraform/website/cloudfront.tf
+++ b/infra/terraform/website/cloudfront.tf
@@ -8,11 +8,13 @@ locals {
     "img-src 'self' data: https:",
     "font-src 'self' data:",
     "connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://www.googletagmanager.com https://api.cr-relay.com https://api.mailmodo.com https://${var.search_api_origin}",
-    "frame-src https://www.googletagmanager.com",
+    # 'self': the landing page embeds its own /console-demo/index.html.
+    "frame-src 'self' https://www.googletagmanager.com",
     "form-action 'self' https://api.mailmodo.com",
     "object-src 'none'",
     "base-uri 'self'",
-    "frame-ancestors 'none'",
+    # 'self', not 'none': /console-demo/* is framed by the landing page.
+    "frame-ancestors 'self'",
     "upgrade-insecure-requests",
   ])
 }
@@ -54,8 +56,12 @@ resource "aws_cloudfront_response_headers_policy" "site" {
       override = true
     }
 
+    # SAMEORIGIN, not DENY: the landing page embeds /console-demo/index.html
+    # in an iframe, and this policy rides every S3-origin response. DENY made
+    # the browser refuse to render the site's own demo. Third-party embedding
+    # stays blocked.
     frame_options {
-      frame_option = "DENY"
+      frame_option = "SAMEORIGIN"
       override     = true
     }
 


### PR DESCRIPTION
## What's broken

The landing page embeds `/console-demo/index.html` in an iframe, but the CloudFront response-headers policy stamps **`X-Frame-Options: DENY`** on every S3-origin response, so browsers refuse to render the site's own demo:

```
Refused to display 'https://iii.dev/...' in a frame because it set 'X-Frame-Options' to 'deny'
```

The report-only CSP flags the same thing (`frame-src` allows only googletagmanager; `frame-ancestors 'none'`) — harmless today, but it would break the demo the day the CSP flips to enforced.

## Fix

- `frame_options`: `DENY` → `SAMEORIGIN` (the site can frame itself; third-party embedding stays blocked)
- CSP: `frame-src 'self' https://www.googletagmanager.com`, `frame-ancestors 'self'`
- Smoke assertion that `/console-demo/index.html` serves `X-Frame-Options: SAMEORIGIN`, so this can't silently regress

## After merge

Needs `terraform apply` in `infra/terraform/website`. Sibling PR for the `/api/search` 502 + stale smoke expectations: #2022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled the embedded console demo to render within the same website.

* **Bug Fixes**
  * Updated browser framing protections to support same-origin embedding while continuing to block third-party embedding.

* **Tests**
  * Improved smoke test coverage by adding stricter header assertions and verifying the console demo returns the expected framing security headers (HTTP 200 and same-origin framing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->