### PR TITLE
feat(website): make the hero headline "an agentic development environment"

### DIFF
--- a/website/src/components/landing/scripts/02-page-behaviors.html
+++ b/website/src/components/landing/scripts/02-page-behaviors.html
@@ -71,23 +71,36 @@
     });
   });
 
-  // ============= Hero rotating descriptor =============
-  const rotatingDescriptors = [
-    'simple','scalable','durable','extensible','fast',
-    'composable','observable','reliable','interoperable'
-  ];
-  const heroDesc = document.getElementById('hero-desc');
-  if (heroDesc){
-    let rotIdx = 0;
-    setInterval(() => {
-      heroDesc.classList.add('is-anim');
+  // ============= Hero rotating descriptors =============
+  // The headline reads "an agentic development environment" on arrival and
+  // holds it long enough to be read as a claim before anything starts moving.
+  const HERO_HOLD_MS = 10000;
+  function rotateWords(el, words, period){
+    if (!el) return;
+    let i = 0;
+    const tick = () => {
+      el.classList.add('is-anim');
       setTimeout(() => {
-        rotIdx = (rotIdx + 1) % rotatingDescriptors.length;
-        heroDesc.textContent = rotatingDescriptors[rotIdx];
-        heroDesc.classList.remove('is-anim');
+        i = (i + 1) % words.length;
+        el.textContent = words[i];
+        el.classList.remove('is-anim');
       }, 400);
-    }, 3000);
+    };
+    setTimeout(() => { tick(); setInterval(tick, period); }, HERO_HOLD_MS);
   }
+  // Two carousels on one headline. The subject turns slowly, and its period is
+  // not a multiple of the noun's, so the two keep landing on fresh pairings.
+  rotateWords(document.getElementById('hero-desc'), [
+    'development','production','testing','staging','debugging',
+    'orchestration','integration','deployment'
+  ], 3000);
+  // Held back with its markup in 03-hero.html — three rotating lines at once
+  // is too much motion. rotateWords no-ops on the missing element either way.
+  // rotateWords(document.getElementById('hero-for'), [
+  //   'building','architecting','experimenting','vibing','shipping',
+  //   'prototyping','refactoring','exploring'
+  // ], 5000);
+  rotateWords(document.getElementById('hero-subj'), ['an agentic','a human'], 8000);
 
   // ============= Email signup helpers =============
   function getMailmodoFormUrl(){

--- a/website/src/components/landing/scripts/02-page-behaviors.html
+++ b/website/src/components/landing/scripts/02-page-behaviors.html
@@ -74,7 +74,7 @@
   // ============= Hero rotating descriptors =============
   // The headline reads "an agentic development environment" on arrival and
   // holds it long enough to be read as a claim before anything starts moving.
-  const HERO_HOLD_MS = 10000;
+  const HERO_HOLD_MS = 8000;
   function rotateWords(el, words, period){
     if (!el) return;
     let i = 0;

--- a/website/src/components/landing/sections/03-hero.html
+++ b/website/src/components/landing/sections/03-hero.html
@@ -3,8 +3,13 @@
   <div class="hero-inner">
     <div class="hero-left">
       <h1 class="hero-headline" id="hero-headline" aria-live="polite">
-        <span class="line">build unreasonably <span class="desc" id="hero-desc">simple</span></span>
-        <span class="line mute">software</span>
+        <!-- One carousel per line. Keeping hero-desc alone on its line stops a
+             long word like "orchestration" from rewrapping the subject above it. -->
+        <span class="line"><span class="desc plain" id="hero-subj">an agentic</span></span>
+        <span class="line"><span class="desc" id="hero-desc">development</span></span>
+        <span class="line mute">environment</span>
+        <!-- Third carousel, held back: three rotating lines at once is too much motion. -->
+        <!-- <span class="line mute">for <span class="desc" id="hero-for">building</span></span> -->
       </h1>
 
       <p class="hero-sub">Modern software stacks are an exercise in integrating services.</p>

--- a/website/src/styles/landing.css
+++ b/website/src/styles/landing.css
@@ -142,6 +142,9 @@
     transition: opacity .4s ease, transform .4s ease;
     will-change: opacity, transform;
   }
+  /* Second carousel on the same line — keeps the single-accent look by
+     rotating in ink rather than a second orange word. */
+  .hero-headline .desc.plain{ color:var(--ink); }
   .hero-headline .desc.is-anim{
     opacity:0;
     transform: translateY(14px);


### PR DESCRIPTION
Replaces `build unreasonably <simple> software` with a claim about what iii actually is, carried by two carousels instead of one.

```
an agentic     hero-subj, 8s, ink
development    hero-desc, 3s, accent
environment    static, mute
```

`hero-subj` rotates between **an agentic** and **a human**. `hero-desc` rotates through development, production, testing, staging, debugging, orchestration, integration, and deployment.

## Behavior

- The page holds the full phrase **an agentic development environment** for eight seconds on arrival, so it reads as a statement before anything moves. Both carousels then start together at that mark.
- The subject turns slowly, on a period that is not a multiple of the noun's, so the two keep landing on fresh pairings rather than marching in lockstep.
- Each carousel sits alone on its own `.line`, so a long word like `orchestration` cannot rewrap the line above it. Only the changing word moves.

## Implementation

The old inline rotation loop became a `rotateWords(el, words, period)` helper that both carousels call. The fade-and-lift transition on `.desc` is unchanged. The only new CSS is `.desc.plain`, which keeps the second rotating word in ink so the line retains a single accent.

A third carousel (`for building / architecting / experimenting / vibing …`) is included commented out in both files. Three rotating lines at once was too much motion, but the copy is worth keeping to hand, and `rotateWords` no-ops on a missing element so uncommenting the markup alone would also work.

Branched off `main` rather than stacked onto #2030; the two changes are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the hero headline to highlight an agentic development environment.
  * Added rotating hero text featuring environment-related terms and alternating agentic/human messaging.
  * Improved headline styling for clearer, more consistent text presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->