### PR TITLE
feat(cli): address a namespace from `iii trigger`

### DIFF
--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -97,6 +97,7 @@ iii trigger [OPTIONS] [FUNCTION_PATH] [KV]...
 | `--address <ADDRESS>` | Engine host address [default: localhost] |
 | `--port <PORT>` | Engine WebSocket port [default: 49134] |
 | `--timeout-ms <TIMEOUT_MS>` | Max time to wait for the invocation result (milliseconds) [default: 30000] |
+| `--namespace <NS>` | Namespace to resolve FUNCTION_PATH in. Omit to resolve in the engine's `default` namespace; routing is strict, so a function registered in another namespace is only reachable with this flag |
 
 <Note>
   `iii trigger <function> --help` additionally queries a running engine for the function's description and request schema. That output depends on which workers are registered and is not part of this page; see [Creating Workers / Functions](../creating-workers/functions#attach-request-and-response-schemas).

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -95,6 +95,7 @@ iii trigger [OPTIONS] [FUNCTION_PATH] [KV]...
 | `--address <ADDRESS>` | Engine host address [default: localhost] |
 | `--port <PORT>` | Engine WebSocket port [default: 49134] |
 | `--timeout-ms <TIMEOUT_MS>` | Max time to wait for the invocation result (milliseconds) [default: 30000] |
+| `--namespace <NS>` | Namespace to resolve FUNCTION_PATH in. Omit to resolve in the engine's `default` namespace; routing is strict, so a function registered in another namespace is only reachable with this flag |
 
 <Note>
   `iii trigger <function> --help` additionally queries a running engine for the function's description and request schema. That output depends on which workers are registered and is not part of this page; see [Creating Workers / Functions](../creating-workers/functions#attach-request-and-response-schemas).

--- a/engine/src/cli_trigger/exec.rs
+++ b/engine/src/cli_trigger/exec.rs
@@ -16,18 +16,24 @@ pub async fn invoke(
     address: &str,
     port: u16,
     timeout_ms: u64,
+    namespace: Option<&str>,
 ) -> Result<(), TriggerCliError> {
     let url = format!("ws://{}:{}", address, port);
     let iii = register_worker(&url, InitOptions::default());
 
-    let result = iii
-        .trigger(TriggerRequest {
-            function_id: function_path.to_string(),
-            payload,
-            action: None,
-            timeout_ms: Some(timeout_ms),
-        })
-        .await;
+    let request = TriggerRequest {
+        function_id: function_path.to_string(),
+        payload,
+        action: None,
+        timeout_ms: Some(timeout_ms),
+    };
+
+    // Omitted when absent so the engine keeps resolving in `default`: the
+    // caller's own namespace never influences routing.
+    let result = match namespace {
+        Some(namespace) => iii.trigger(request.namespace(namespace)).await,
+        None => iii.trigger(request).await,
+    };
 
     iii.shutdown_async().await;
 

--- a/engine/src/cli_trigger/help.rs
+++ b/engine/src/cli_trigger/help.rs
@@ -15,13 +15,14 @@ pub async fn print(
     address: &str,
     port: u16,
     timeout_ms: u64,
+    namespace: Option<&str>,
 ) -> Result<()> {
     match function_path {
         None => {
             print_static_help();
             Ok(())
         }
-        Some(fn_path) => match fetch_fn_meta(fn_path, address, port, timeout_ms).await {
+        Some(fn_path) => match fetch_fn_meta(fn_path, address, port, timeout_ms, namespace).await {
             Ok(Some(meta)) => {
                 render_fn_help(fn_path, &meta);
                 Ok(())
@@ -59,6 +60,7 @@ async fn fetch_fn_meta(
     address: &str,
     port: u16,
     timeout_ms: u64,
+    namespace: Option<&str>,
 ) -> Result<Option<Value>> {
     let url = format!("ws://{}:{}", address, port);
     let iii = register_worker(&url, InitOptions::default());
@@ -67,10 +69,17 @@ async fn fetch_fn_meta(
     // request/response schemas — `engine::functions::list` returns slim
     // summaries (id + description) and would leave the Parameters table
     // permanently empty.
+    // `engine::functions::info` itself lives in `default`, but it takes the
+    // target namespace in its payload: the same id can exist in several.
+    let mut payload = json!({ "function_id": fn_path });
+    if let Some(namespace) = namespace {
+        payload["namespace"] = json!(namespace);
+    }
+
     let result = iii
         .trigger(TriggerRequest {
             function_id: "engine::functions::info".to_string(),
-            payload: json!({ "function_id": fn_path }),
+            payload,
             action: None,
             timeout_ms: Some(timeout_ms),
         })

--- a/engine/src/cli_trigger/mod.rs
+++ b/engine/src/cli_trigger/mod.rs
@@ -53,6 +53,12 @@ pub struct TriggerArgs {
     #[arg(long, default_value_t = 30_000)]
     pub timeout_ms: u64,
 
+    /// Namespace to resolve FUNCTION_PATH in. Omit to resolve in the engine's
+    /// `default` namespace; routing is strict, so a function registered in
+    /// another namespace is only reachable with this flag.
+    #[arg(long, value_name = "NS")]
+    pub namespace: Option<String>,
+
     /// Print help. With a FUNCTION_PATH, queries a running engine for that
     /// function's description and request schema.
     #[arg(short = 'h', long = "help", action = clap::ArgAction::SetTrue)]
@@ -66,6 +72,7 @@ pub async fn run_trigger(args: &TriggerArgs) -> Result<(), TriggerCliError> {
             &args.address,
             args.port,
             args.timeout_ms,
+            args.namespace.as_deref(),
         )
         .await?;
         return Ok(());
@@ -80,6 +87,7 @@ pub async fn run_trigger(args: &TriggerArgs) -> Result<(), TriggerCliError> {
         &args.address,
         args.port,
         args.timeout_ms,
+        args.namespace.as_deref(),
     )
     .await
 }
@@ -98,6 +106,7 @@ mod tests {
             port: DEFAULT_PORT,
             timeout_ms: 800,
             help: false,
+            namespace: None,
         };
         let err = run_trigger(&args).await.unwrap_err().to_string();
         assert!(
@@ -117,6 +126,7 @@ mod tests {
             port: 19999,
             timeout_ms: 800,
             help: false,
+            namespace: None,
         };
         let err = run_trigger(&args).await.unwrap_err().to_string();
         // The OS may immediately return ECONNREFUSED on closed ports, in which
@@ -143,6 +153,7 @@ mod tests {
             port: DEFAULT_PORT,
             timeout_ms: 30_000,
             help: false,
+            namespace: None,
         };
         let err = run_trigger(&args).await.unwrap_err().to_string();
         assert!(

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -980,4 +980,36 @@ mod tests {
         assert!(cli.config.is_none());
         assert!(worker_dispatch_envs(&cli).is_empty());
     }
+    #[test]
+    fn trigger_parses_namespace_flag_alongside_kv_pairs() {
+        let cli = Cli::try_parse_from([
+            "iii",
+            "trigger",
+            "compose::up",
+            "--namespace",
+            "host-a",
+            "container=api",
+        ])
+        .expect("should parse trigger --namespace");
+
+        match cli.command {
+            Some(Commands::Trigger(args)) => {
+                assert_eq!(args.namespace.as_deref(), Some("host-a"));
+                assert_eq!(args.function_path.as_deref(), Some("compose::up"));
+                assert_eq!(args.kv, vec!["container=api".to_string()]);
+            }
+            _ => panic!("expected Trigger subcommand"),
+        }
+    }
+
+    #[test]
+    fn trigger_without_the_flag_carries_no_namespace() {
+        let cli = Cli::try_parse_from(["iii", "trigger", "state::get", "key=a"])
+            .expect("should parse a plain trigger");
+        match cli.command {
+            Some(Commands::Trigger(args)) => assert!(args.namespace.is_none()),
+            _ => panic!("expected Trigger subcommand"),
+        }
+    }
+
 }


### PR DESCRIPTION
Targets `feat/namespare` (#1984), not `main`: it depends on the namespace routing that PR introduces.

## The problem

Routing is strict — a function registered in a namespace is not reachable without naming it, and the caller's own namespace never influences where an invocation resolves. That is the property the feature exists for, and it left the CLI able to reach only `default`: everything except the projects namespaces are for.

## The change

`--namespace <NS>` on `iii trigger`, threaded through both paths a trigger can take.

**Invocation.** The request carries the namespace when the flag is present and omits it when it is not, so an unqualified call resolves in `default` exactly as before. Omitting rather than defaulting is deliberate: the two are the same today, and only one of them stays correct if the engine ever grows a per-connection default.

**Help.** `fetch_fn_meta` takes it too. `iii trigger api::ping --namespace orders --help` has to look the function up where it lives; without this it queries `default`, finds nothing, and reports a registered function as missing — the failure mode most likely to be read as "my worker did not start".

```bash
iii trigger api::ping --namespace orders
iii trigger api::ping --namespace orders --help
```

## Verification

Two parsing tests: the flag alongside `key=value` pairs, and its absence carrying no namespace. `cargo test -p iii --bin iii` is green (139 tests), and clippy reports nothing new on the touched files.

The CLI reference is regenerated, so the `cli-docs-built` job stays green.

## Where this came from

Extracted from the compose daemon branch, which needs it to address a project's namespace from scripts. Nothing here depends on compose — it is the CLI half of namespace routing, and it belongs with the rest of it.
