### PR TITLE
ci: publish release candidates to rc

### DIFF
--- a/.github/scripts/build_skills_payload.py
+++ b/.github/scripts/build_skills_payload.py
@@ -105,7 +105,7 @@ def main() -> int:
     parser.add_argument(
         "--version",
         required=True,
-        help="Worker version tag or semver to attach this snapshot to (e.g. latest, next, 1.2.3).",
+        help="Worker version tag or semver to attach this snapshot to (e.g. latest, rc, 1.2.3).",
     )
     parser.add_argument("--out", default="skills-payload.json")
     parser.add_argument(

--- a/.github/workflows/WORKFLOWS.md
+++ b/.github/workflows/WORKFLOWS.md
@@ -82,7 +82,7 @@ Entry point for all releases. Provides a form with:
 |-------|---------|
 | `target` | `iii` |
 | `bump` | `patch`, `minor`, `major` |
-| `prerelease` | `none`, `alpha`, `beta`, `rc`, `next` |
+| `prerelease` | `none`, `rc` |
 | `dry_run` | boolean |
 
 **What it does:**
@@ -96,7 +96,7 @@ Entry point for all releases. Provides a form with:
 7. Updates docs from `docs/next/` on stable releases (`pin_docs.py rotate`, which dispatches on the version):
    - **minor/major** — rotates: archives the old Latest into `docs/OLD-MINOR-0/` (its `Latest` block becomes archived), promotes `docs/next/` into the root as a new `Latest` block labeled with the **tag version** (the official version comes from the tag and can be anything), relabels the `Next` block to `MINOR + 1` (reusing the `docs/next/` folder), and reorders the dropdown (Next, Latest, archived newest-first — Mintlify's own ordering does not work).
    - **patch** — syncs in place: replaces the root content with `docs/next/`. No archive, no `Next` bump, no version-block changes — it just refreshes the current Latest's docs.
-   - **all prereleases** (`alpha`/`beta`/`rc`/`next`) leave docs untouched.
+   - **release candidates** (`rc`) leave docs untouched.
    - In-content links are version-relative, so files move verbatim; only `docs.json` nav paths carry the version prefix.
 8. Commits the version bump (including any docs changes), creates an annotated tag, and pushes both
 9. Posts a Slack notification
@@ -174,7 +174,7 @@ setup (parse tag metadata, Slack notification)
   └─► notify-complete (aggregated Slack status)
 ```
 
-**Downstream validations:** once every publish job succeeds (non-dry-run), `trigger-validations` dispatches `init-smoke.yml` in `iii-hq/templates` and `quickstart-validate.yml` in `iii-hq/quickstart-validator`, passing `channel=next` for a prerelease or `channel=main` for a stable release. Both repos report results to their own Slack threads. Requires the `III_CI_APP` GitHub App installed on both repos with `actions: write`.
+**Downstream validations:** once every publish job succeeds (non-dry-run), `trigger-validations` dispatches `init-smoke.yml` in `iii-hq/templates` and `quickstart-validate.yml` in `iii-hq/quickstart-validator`, passing `channel=rc` for a release candidate or `channel=main` for a stable release. Both repos report results to their own Slack threads. Requires the `III_CI_APP` GitHub App installed on both repos with `actions: write`.
 
 **Setup job** parses the tag to determine:
 - `version` — stripped prefix (e.g., `iii/v1.2.3` becomes `1.2.3`)

--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -27,7 +27,7 @@ on:
         type: string
         default: ''
       registry_tag:
-        description: 'Registry tag (latest, next, ...)'
+        description: 'Registry tag (latest, rc, ...)'
         required: false
         type: string
         default: latest

--- a/.github/workflows/_publish-engine-workers.yml
+++ b/.github/workflows/_publish-engine-workers.yml
@@ -86,9 +86,10 @@ jobs:
               expected="${GITHUB_REF_NAME#iii/v}"
             fi
             install_args=()
-            if [[ "$expected" == *-* ]]; then
-              install_args+=("--next")
-            fi
+            case "$expected" in
+              *-rc.*) install_args+=("--rc") ;;
+              *-*)    install_args+=("--next") ;;
+            esac
             VERSION="$expected" sh /tmp/install-iii.sh "${install_args[@]}"
           fi
           {

--- a/.github/workflows/_publish-worker-skills.yml
+++ b/.github/workflows/_publish-worker-skills.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       registry_tag:
-        description: 'Registry version tag (latest, next, ...)'
+        description: 'Registry version tag (latest, rc, ...)'
         required: false
         type: string
         default: latest

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -10,7 +10,7 @@ name: Alpha Release
 #   * Engine binaries — iii / iii-worker / iii-init, attached to a GitHub
 #     prerelease on the iii-alpha/v* tag.
 #   * Builtin workers + skills — to the workers registry under a dedicated
-#     `alpha` tag (never next/latest).
+#     `alpha` tag (never rc/latest).
 #   Console, docker and homebrew are intentionally excluded.
 #
 # Isolation guarantees:
@@ -20,7 +20,7 @@ name: Alpha Release
 #     lives only in an ephemeral commit that the alpha tag points at.
 #   * Engine binaries land on their own prerelease and workers use the
 #     dedicated `alpha` registry tag, so nothing collides with the official
-#     iii/v* releases or the next/latest channels.
+#     iii/v* releases or the rc/latest channels.
 #
 # Run from: Actions -> Alpha Release -> "Use workflow from: <feature-branch>".
 # Note: dry_run still creates the iii-alpha tag (publishers need it to check
@@ -262,7 +262,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────
   # Engine pipeline (isolated): binaries -> GitHub prerelease on the
   # iii-alpha/v* tag, builtin workers -> dedicated `alpha` registry tag.
-  # Nothing here touches the official iii/v* releases or the next/latest
+  # Nothing here touches the official iii/v* releases or the rc/latest
   # worker channels. Console, docker and homebrew are intentionally out.
   # ──────────────────────────────────────────────────────────────
 

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -25,10 +25,7 @@ on:
         type: choice
         options:
           - none
-          - alpha
-          - beta
           - rc
-          - next
         default: none
       dry_run:
         description: 'Dry run (creates -dry-run.N tag, builds without publishing)'
@@ -76,7 +73,7 @@ jobs:
           # requires a pre-release label. Use patch/minor/major to START a
           # train (they pick the base); none cannot infer one.
           if [[ "$BUMP" == "none" && "$PRERELEASE" == "none" ]]; then
-            echo "::error::bump 'none' requires a pre-release label (alpha/beta/rc/next). Use patch/minor/major for a stable release."
+            echo "::error::bump 'none' requires the rc pre-release label. Use patch/minor/major for a stable release."
             exit 1
           fi
 

--- a/.github/workflows/release-iii.yml
+++ b/.github/workflows/release-iii.yml
@@ -685,7 +685,7 @@ jobs:
     with:
       worker: ${{ matrix.worker }}
       worker_dir: ${{ matrix.worker_dir }}
-      registry_tag: ${{ needs.setup.outputs.is_prerelease == 'true' && 'next' || 'latest' }}
+      registry_tag: ${{ needs.setup.outputs.npm_tag }}
     secrets: inherit
 
   publish-worker-skills:
@@ -694,7 +694,7 @@ jobs:
     if: needs.setup.outputs.dry_run != 'true'
     uses: ./.github/workflows/_publish-worker-skills.yml
     with:
-      registry_tag: ${{ needs.setup.outputs.is_prerelease == 'true' && 'next' || 'latest' }}
+      registry_tag: ${{ needs.setup.outputs.npm_tag }}
     secrets: inherit
 
   # ──────────────────────────────────────────────────────────────
@@ -702,8 +702,8 @@ jobs:
   #
   # Once every publish job has succeeded (the validators install the
   # freshly-published artifacts), dispatch the smoke/quickstart workflows
-  # in the templates and quickstart-validator repos. A prerelease publishes
-  # the `next` channel; a stable release publishes `main`. Skipped on
+  # in the templates and quickstart-validator repos. A release candidate uses
+  # the `rc` channel; a stable release uses `main`. Skipped on
   # dry-run and whenever any publish job failed (`!failure()`).
   # ──────────────────────────────────────────────────────────────
 
@@ -727,7 +727,7 @@ jobs:
     if: ${{ !cancelled() && !failure() && needs.setup.outputs.dry_run != 'true' }}
     runs-on: ubuntu-latest
     env:
-      CHANNEL: ${{ needs.setup.outputs.is_prerelease == 'true' && 'next' || 'main' }}
+      CHANNEL: ${{ needs.setup.outputs.is_prerelease == 'true' && 'rc' || 'main' }}
     steps:
       - name: Generate token
         id: generate_token

--- a/engine/install.sh
+++ b/engine/install.sh
@@ -219,6 +219,7 @@ fi
 
 engine_version="${VERSION:-}"
 use_next=false
+use_rc=false
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -240,6 +241,10 @@ while [ $# -gt 0 ]; do
       use_next=true
       shift
       ;;
+    --rc)
+      use_rc=true
+      shift
+      ;;
     -h|--help)
       cat <<'USAGE'
 Usage: install.sh [OPTIONS] [VERSION]
@@ -249,6 +254,7 @@ Install the iii engine (includes CLI commands).
 Options:
   -h, --help            Show this help message
   --next                Install the latest "next" pre-release
+  --rc                  Install the latest release candidate
 
 Environment variables:
   VERSION               Engine version to install (e.g., 0.11.0)
@@ -268,6 +274,7 @@ Requires: curl, jq, tar (unzip if installing a .zip asset)
 Examples:
   curl -fsSL https://iii.dev/install.sh | sh
   curl -fsSL https://iii.dev/install.sh | sh -s -- --next
+  curl -fsSL https://iii.dev/install.sh | sh -s -- --rc
   curl -fsSL https://iii.dev/install.sh | VERSION=0.11.0 sh
   curl -fsSL https://iii.dev/install.sh | BIN_DIR=/usr/local/bin sh
 USAGE
@@ -286,6 +293,10 @@ USAGE
 done
 
 VERSION="$engine_version"
+
+if [ "$use_next" = "true" ] && [ "$use_rc" = "true" ]; then
+  err "args" "--next and --rc cannot be used together"
+fi
 
 # ---------------------------------------------------------------------------
 # Dependency checks
@@ -394,10 +405,21 @@ elif [ -n "$VERSION" ]; then
     fi
   fi
 
-  # Reject prereleases unless --next was passed
+  # Reject prereleases unless an explicit prerelease channel was requested.
   _is_prerelease=$(printf '%s' "$json" | jq -r '.prerelease // false')
-  if [ "$_is_prerelease" = "true" ] && [ "$use_next" != "true" ]; then
-    err "download" "version $VERSION is a prerelease — use a stable release or pass --next"
+  if [ "$_is_prerelease" = "true" ] && [ "$use_next" != "true" ] && [ "$use_rc" != "true" ]; then
+    err "download" "version $VERSION is a prerelease — use a stable release or pass --next/--rc"
+  fi
+elif [ "$use_rc" = "true" ]; then
+  info "installing latest release candidate"
+  api_url="https://api.github.com/repos/$REPO/releases?per_page=20"
+  if ! json_list=$(github_api "$api_url" 2>/dev/null); then
+    check_rate_limit_or_continue "$api_url"
+    err "download" "failed to list releases"
+  fi
+  json=$(printf '%s' "$json_list" | jq -c 'first(.[] | select(.tag_name | test("^iii/v[0-9]+\\.[0-9]+\\.[0-9]+-rc\\.[0-9]+$")))')
+  if [ "$json" = "null" ] || [ -z "$json" ]; then
+    err "download" "no release candidate found"
   fi
 elif [ "$use_next" = "true" ]; then
   info "installing latest next release"
@@ -443,7 +465,7 @@ if [ -z "$release_version" ]; then
   release_version=$(printf '%s' "$json" | jq -r '.tag_name' | sed -E 's#^(iii/)?v##')
 fi
 
-if [ "$use_next" = "true" ] && [ -n "$release_version" ]; then
+if { [ "$use_next" = "true" ] || [ "$use_rc" = "true" ]; } && [ -n "$release_version" ]; then
   info "installing $BIN_NAME v$release_version"
 fi
 

--- a/engine/tests/install_sh_integration.sh
+++ b/engine/tests/install_sh_integration.sh
@@ -60,6 +60,11 @@ case "$help_output" in
   *) fail "--help missing --next documentation" ;;
 esac
 
+case "$help_output" in
+  *"--rc"*) pass "--help documents --rc" ;;
+  *) fail "--help missing --rc documentation" ;;
+esac
+
 # ─────────────────────────────────────────────────────────────
 # Test 2: unknown flag rejected
 # ─────────────────────────────────────────────────────────────
@@ -67,6 +72,13 @@ if sh "$INSTALL_SH" --nonsense-flag >/dev/null 2>&1; then
   fail "unknown flag was accepted; expected exit non-zero"
 fi
 pass "unknown flag rejected"
+
+# --next and --rc select mutually exclusive prerelease channels, so reject a
+# conflicting request before making any network call.
+if sh "$INSTALL_SH" --next --rc >/dev/null 2>&1; then
+  fail "--next and --rc were accepted together; expected exit non-zero"
+fi
+pass "conflicting prerelease channels rejected"
 
 # ─────────────────────────────────────────────────────────────
 # Test 3: deprecated --no-cli emits warning but doesn't fail arg parsing


### PR DESCRIPTION
## What changed

- Restricts official prereleases created from `main` to the `rc` label.
- Publishes workers and skills using the release dist-tag: `rc` for release candidates and `latest` for stable releases.
- Dispatches downstream validators with `channel=rc`.
- Adds `--rc` to the public installer, which resolves the latest official `iii/vX.Y.Z-rc.N` release.
- Uses `--rc` when worker publishing installs an exact RC version.
- Updates workflow documentation and descriptions for the new channel.

## Why

Builds published from `main` are candidates for the next stable version. The `rc` channel makes that meaning explicit across installation, registries, and validations.

## Rollout order

Merge this PR first so `install.sh --rc` is available. Then merge:

- iii-hq/templates#47
- iii-hq/quickstart-validator#10

Do not create an RC until all three PRs have merged.

## Validation

- `sh -n engine/install.sh`
- `sh -n engine/tests/install_sh_integration.sh`
- Verified that `--help` documents `--rc`
- Verified that `--next --rc` is rejected before a network call
- RC tag selection tested against a synthetic release list
- RC version scenarios executed directly with `.github/scripts/calculate_release_version.py`
- `git diff --check`
- Searched `.github/` for remaining operational `next` references

The containerized `actionlint` check could not run because pulling its image timed out during the TLS handshake with the registry.