### PR TITLE
fix(queue): preserve invocation metadata across queued delivery

### DIFF
--- a/docs/next/reference/engine-protocol.mdx
+++ b/docs/next/reference/engine-protocol.mdx
@@ -139,7 +139,9 @@ distinct argument alongside the payload. It is useful for providing contextual i
 the trigger or execution context to the receiving function. A target function shared by many
 triggers can use it to recover which registration fired and with what context.
 
-`metadata` can be provided both via `registerTrigger` and direct `trigger()` invocations.
+`metadata` can be provided both via `registerTrigger` and direct `trigger()` invocations. When
+`action` is `enqueue`, the queue treats metadata as an opaque sidecar: it must be redelivered to
+the target function separately from `data`, including after retries and dead-letter redrive.
 
 `traceparent` and `baggage` contain W3C trace
 context. `action` is the routing flag (see [Trigger actions](#trigger-actions) below);
@@ -198,7 +200,8 @@ For synchronous calls the engine assigns an `invocation_id`, forwards the `Invok
 owning worker, and waits for the matching `InvocationResult`. For `Void` actions the engine forwards
 without an `invocation_id` and never expects a reply. For `Enqueue` the engine hands the invocation
 to the queue worker, which persists it and re-invokes the target function on a subscriber according
-to the queue's retry policy.
+to the queue's retry policy. Enqueued delivery preserves the original `data` payload and carries
+`metadata` as invocation metadata for the eventual handler call.
 
 ## Engine discovery functions
 

--- a/docs/next/reference/engine-protocol.mdx.skill.md
+++ b/docs/next/reference/engine-protocol.mdx.skill.md
@@ -137,7 +137,9 @@ distinct argument alongside the payload. It is useful for providing contextual i
 the trigger or execution context to the receiving function. A target function shared by many
 triggers can use it to recover which registration fired and with what context.
 
-`metadata` can be provided both via `registerTrigger` and direct `trigger()` invocations.
+`metadata` can be provided both via `registerTrigger` and direct `trigger()` invocations. When
+`action` is `enqueue`, the queue treats metadata as an opaque sidecar: it must be redelivered to
+the target function separately from `data`, including after retries and dead-letter redrive.
 
 `traceparent` and `baggage` contain W3C trace
 context. `action` is the routing flag (see [Trigger actions](#trigger-actions) below);
@@ -196,7 +198,8 @@ For synchronous calls the engine assigns an `invocation_id`, forwards the `Invok
 owning worker, and waits for the matching `InvocationResult`. For `Void` actions the engine forwards
 without an `invocation_id` and never expects a reply. For `Enqueue` the engine hands the invocation
 to the queue worker, which persists it and re-invokes the target function on a subscriber according
-to the queue's retry policy.
+to the queue's retry policy. Enqueued delivery preserves the original `data` payload and carries
+`metadata` as invocation metadata for the eventual handler call.
 
 ## Engine discovery functions
 

--- a/docs/reference/engine-protocol.mdx
+++ b/docs/reference/engine-protocol.mdx
@@ -139,7 +139,9 @@ distinct argument alongside the payload. It is useful for providing contextual i
 the trigger or execution context to the receiving function. A target function shared by many
 triggers can use it to recover which registration fired and with what context.
 
-`metadata` can be provided both via `registerTrigger` and direct `trigger()` invocations.
+`metadata` can be provided both via `registerTrigger` and direct `trigger()` invocations. When
+`action` is `enqueue`, the queue treats metadata as an opaque sidecar: it must be redelivered to
+the target function separately from `data`, including after retries and dead-letter redrive.
 
 `traceparent` and `baggage` contain W3C trace
 context. `action` is the routing flag (see [Trigger actions](#trigger-actions) below);
@@ -198,7 +200,8 @@ For synchronous calls the engine assigns an `invocation_id`, forwards the `Invok
 owning worker, and waits for the matching `InvocationResult`. For `Void` actions the engine forwards
 without an `invocation_id` and never expects a reply. For `Enqueue` the engine hands the invocation
 to the queue worker, which persists it and re-invokes the target function on a subscriber according
-to the queue's retry policy.
+to the queue's retry policy. Enqueued delivery preserves the original `data` payload and carries
+`metadata` as invocation metadata for the eventual handler call.
 
 ## Engine discovery functions
 

--- a/docs/reference/engine-protocol.mdx.skill.md
+++ b/docs/reference/engine-protocol.mdx.skill.md
@@ -137,7 +137,9 @@ distinct argument alongside the payload. It is useful for providing contextual i
 the trigger or execution context to the receiving function. A target function shared by many
 triggers can use it to recover which registration fired and with what context.
 
-`metadata` can be provided both via `registerTrigger` and direct `trigger()` invocations.
+`metadata` can be provided both via `registerTrigger` and direct `trigger()` invocations. When
+`action` is `enqueue`, the queue treats metadata as an opaque sidecar: it must be redelivered to
+the target function separately from `data`, including after retries and dead-letter redrive.
 
 `traceparent` and `baggage` contain W3C trace
 context. `action` is the routing flag (see [Trigger actions](#trigger-actions) below);
@@ -196,7 +198,8 @@ For synchronous calls the engine assigns an `invocation_id`, forwards the `Invok
 owning worker, and waits for the matching `InvocationResult`. For `Void` actions the engine forwards
 without an `invocation_id` and never expects a reply. For `Enqueue` the engine hands the invocation
 to the queue worker, which persists it and re-invokes the target function on a subscriber according
-to the queue's retry policy.
+to the queue's retry policy. Enqueued delivery preserves the original `data` payload and carries
+`metadata` as invocation metadata for the eventual handler call.
 
 ## Engine discovery functions
 

--- a/engine/src/builtins/queue.rs
+++ b/engine/src/builtins/queue.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use tokio::{
     sync::{RwLock, Semaphore},
     task::JoinHandle,
-    time::{Duration, interval},
+    time::{interval, Duration},
 };
 use uuid::Uuid;
 
@@ -42,6 +42,8 @@ pub struct Job {
     #[serde(default)]
     pub baggage: Option<String>,
     #[serde(default)]
+    pub metadata: Option<Value>,
+    #[serde(default)]
     pub function_id: Option<String>,
     #[serde(default)]
     pub message_id: Option<String>,
@@ -55,6 +57,7 @@ impl Job {
         backoff_delay_ms: u64,
         traceparent: Option<String>,
         baggage: Option<String>,
+        metadata: Option<Value>,
     ) -> Self {
         Self::new_with_group(
             queue,
@@ -64,6 +67,7 @@ impl Job {
             None,
             traceparent,
             baggage,
+            metadata,
         )
     }
 
@@ -75,6 +79,7 @@ impl Job {
         group_id: Option<String>,
         traceparent: Option<String>,
         baggage: Option<String>,
+        metadata: Option<Value>,
     ) -> Self {
         Self {
             id: Uuid::new_v4().to_string(),
@@ -91,6 +96,7 @@ impl Job {
             group_id,
             traceparent,
             baggage,
+            metadata,
             function_id: None,
             message_id: None,
         }
@@ -360,6 +366,7 @@ impl BuiltinQueue {
             self.config.backoff_ms,
             traceparent,
             baggage,
+            None,
         );
         let job_id = job.id.clone();
 
@@ -400,6 +407,7 @@ impl BuiltinQueue {
             Some(group_id.to_string()),
             traceparent,
             baggage,
+            None,
         );
         let job_id = job.id.clone();
 
@@ -440,6 +448,7 @@ impl BuiltinQueue {
             self.config.backoff_ms,
             traceparent,
             baggage,
+            None,
         );
         let job_id = job.id.clone();
 
@@ -1372,7 +1381,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_exponential_backoff_calculation() {
-        let mut job = Job::new("test", serde_json::json!({}), 5, 1000, None, None);
+        let mut job = Job::new("test", serde_json::json!({}), 5, 1000, None, None, None);
 
         assert_eq!(job.calculate_backoff(), 1000);
 
@@ -1389,7 +1398,15 @@ mod tests {
     #[tokio::test]
     async fn calculate_backoff_normal_cases() {
         // attempts_made=1 => backoff_delay_ms * 2^0 = 1000
-        let mut job = Job::new("test_queue", serde_json::json!({}), 100, 1000, None, None);
+        let mut job = Job::new(
+            "test_queue",
+            serde_json::json!({}),
+            100,
+            1000,
+            None,
+            None,
+            None,
+        );
         job.attempts_made = 1;
         assert_eq!(job.calculate_backoff(), 1000);
 
@@ -1404,7 +1421,15 @@ mod tests {
 
     #[tokio::test]
     async fn calculate_backoff_saturates_at_high_attempts() {
-        let mut job = Job::new("test_queue", serde_json::json!({}), 100, 1000, None, None);
+        let mut job = Job::new(
+            "test_queue",
+            serde_json::json!({}),
+            100,
+            1000,
+            None,
+            None,
+            None,
+        );
 
         // attempts_made=56 => 2^55 overflows when multiplied by 1000, saturates to u64::MAX
         job.attempts_made = 56;
@@ -1422,7 +1447,15 @@ mod tests {
     #[tokio::test]
     async fn calculate_backoff_zero_attempts() {
         // attempts_made=0 => saturating_sub(1) = 0, so result = backoff_delay_ms * 2^0 = backoff_delay_ms
-        let mut job = Job::new("test_queue", serde_json::json!({}), 100, 1000, None, None);
+        let mut job = Job::new(
+            "test_queue",
+            serde_json::json!({}),
+            100,
+            1000,
+            None,
+            None,
+            None,
+        );
         job.attempts_made = 0;
         assert_eq!(job.calculate_backoff(), 1000);
     }
@@ -1694,14 +1727,61 @@ mod tests {
             Some("user-123".to_string()),
             None,
             None,
+            None,
         );
         assert_eq!(job.group_id, Some("user-123".to_string()));
     }
 
     #[tokio::test]
     async fn test_job_without_group_id() {
-        let job = Job::new("test_queue", serde_json::json!({}), 3, 1000, None, None);
+        let job = Job::new(
+            "test_queue",
+            serde_json::json!({}),
+            3,
+            1000,
+            None,
+            None,
+            None,
+        );
         assert_eq!(job.group_id, None);
+    }
+
+    #[tokio::test]
+    async fn job_metadata_round_trips_and_legacy_jobs_default_to_none() {
+        let metadata = serde_json::json!({
+            "object": { "nested": true },
+            "array": [1, "two", null],
+            "string": "value",
+            "number": 3,
+            "bool": false,
+            "null": null
+        });
+        let job = Job::new(
+            "test_queue",
+            serde_json::json!({"payload": true}),
+            3,
+            1000,
+            None,
+            None,
+            Some(metadata.clone()),
+        );
+
+        let encoded = serde_json::to_value(&job).expect("job should serialize");
+        let decoded: Job = serde_json::from_value(encoded).expect("job should deserialize");
+        assert_eq!(decoded.metadata, Some(metadata));
+
+        let legacy = serde_json::json!({
+            "id": "legacy",
+            "queue": "test_queue",
+            "data": { "payload": true },
+            "attempts_made": 0,
+            "max_attempts": 3,
+            "backoff_delay_ms": 1000,
+            "created_at": 1
+        });
+        let decoded_legacy: Job =
+            serde_json::from_value(legacy).expect("legacy job should deserialize");
+        assert_eq!(decoded_legacy.metadata, None);
     }
 
     #[tokio::test]
@@ -2007,7 +2087,7 @@ mod tests {
             queue
                 .push_fifo(
                     "race_queue",
-                    serde_json::json!({"order": i}),
+                    serde_json::json!({ "order": i }),
                     "same-group",
                     None,
                     None,
@@ -2372,7 +2452,7 @@ mod tests {
         let queue = BuiltinQueue::new(kv_store, pubsub, config);
 
         for i in 0..3 {
-            let data = serde_json::json!({"index": i});
+            let data = serde_json::json!({ "index": i });
             queue.push("test_queue", data, None, None).await;
             let job = queue.pop("test_queue").await.unwrap();
             queue
@@ -2503,7 +2583,7 @@ mod tests {
 
         let mut job_ids = Vec::new();
         for i in 0..3 {
-            let data = serde_json::json!({"index": i});
+            let data = serde_json::json!({ "index": i });
             let id = queue.push("test_queue", data, None, None).await;
             let job = queue.pop("test_queue").await.unwrap();
             queue
@@ -2598,7 +2678,7 @@ mod tests {
 
         let mut job_ids = Vec::new();
         for i in 0..3 {
-            let data = serde_json::json!({"index": i});
+            let data = serde_json::json!({ "index": i });
             let id = queue.push("test_queue", data, None, None).await;
             let job = queue.pop("test_queue").await.unwrap();
             queue
@@ -2622,7 +2702,7 @@ mod tests {
     async fn push_n_jobs_to_dlq(queue: &BuiltinQueue, queue_name: &str, n: usize) -> Vec<String> {
         let mut ids = Vec::with_capacity(n);
         for i in 0..n {
-            let data = serde_json::json!({"index": i});
+            let data = serde_json::json!({ "index": i });
             let id = queue.push(queue_name, data, None, None).await;
             let job = queue.pop(queue_name).await.unwrap();
             queue

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 
 use crate::{
     function::{Function, FunctionHandler, FunctionResult, FunctionsRegistry},
-    invocation::{InvocationHandler, http_function::HttpFunctionConfig},
+    invocation::{http_function::HttpFunctionConfig, InvocationHandler},
     protocol::{ErrorBody, Message},
     services::{Service, ServicesRegistry},
     telemetry::{
@@ -35,7 +35,7 @@ use crate::{
     workers::{
         engine_fn::TRIGGER_WORKERS_AVAILABLE,
         http_functions::HttpFunctionsWorker,
-        worker::{WorkerManagerConfig, channels::ChannelManager, rbac_session},
+        worker::{channels::ChannelManager, rbac_session, WorkerManagerConfig},
     },
 };
 
@@ -1027,6 +1027,7 @@ impl Engine {
                         let queue = queue.to_string();
                         let message_receipt_id = Uuid::new_v4().to_string();
                         let data = data.clone();
+                        let metadata = metadata.clone();
                         let traceparent = traceparent.clone();
                         let baggage = baggage.clone();
                         let queued_baggage = crate::telemetry::baggage_with_function_id(
@@ -1069,6 +1070,7 @@ impl Engine {
                                             "queue": queue.clone(),
                                             "function_id": function_id.clone(),
                                             "data": data,
+                                            "metadata": metadata,
                                             "messageReceiptId": message_receipt_id.clone(),
                                             "traceparent": traceparent.clone(),
                                             "baggage": queued_baggage,
@@ -2132,8 +2134,8 @@ mod tests {
     use std::{
         collections::HashMap,
         sync::{
-            Arc, Mutex,
             atomic::{AtomicUsize, Ordering},
+            Arc, Mutex,
         },
         time::Duration,
     };
@@ -2149,7 +2151,7 @@ mod tests {
         worker_connections::WorkerConnection,
         workers::{
             engine_fn::TRIGGER_WORKERS_AVAILABLE,
-            http_functions::{HttpFunctionsWorker, config::HttpFunctionsConfig},
+            http_functions::{config::HttpFunctionsConfig, HttpFunctionsWorker},
             observability::metrics::ensure_default_meter,
             traits::Worker,
         },
@@ -2254,21 +2256,17 @@ mod tests {
             .get_service::<HttpFunctionsWorker>("http_functions")
             .expect("http_functions service registered");
 
-        assert!(
-            http_module
-                .http_functions()
-                .contains_key("external.my_lambda")
-        );
+        assert!(http_module
+            .http_functions()
+            .contains_key("external.my_lambda"));
 
         engine.cleanup_worker(&worker).await;
 
         assert!(engine.functions.get("external.my_lambda").is_none());
 
-        assert!(
-            !http_module
-                .http_functions()
-                .contains_key("external.my_lambda")
-        );
+        assert!(!http_module
+            .http_functions()
+            .contains_key("external.my_lambda"));
     }
 
     // ---------------------------------------------------------------
@@ -2358,7 +2356,7 @@ mod tests {
     /// the rest of the fields at sensible defaults for register/unregister
     /// tests. Used by the prefix regression tests for iii-hq/iii#1508.
     fn session_with_prefix(prefix: &str) -> crate::workers::worker::rbac_session::Session {
-        use crate::workers::worker::{WorkerManagerConfig, rbac_session::Session};
+        use crate::workers::worker::{rbac_session::Session, WorkerManagerConfig};
         use uuid::Uuid;
         Session {
             engine: Arc::new(Engine::new()),
@@ -2641,12 +2639,10 @@ mod tests {
             .await
             .expect("register trigger should succeed");
 
-        assert!(
-            engine
-                .trigger_registry
-                .triggers
-                .contains_key("unreg_trigger")
-        );
+        assert!(engine
+            .trigger_registry
+            .triggers
+            .contains_key("unreg_trigger"));
 
         // Drain channel messages from register
         while rx.try_recv().is_ok() {}
@@ -2831,7 +2827,12 @@ mod tests {
                     action: Some(crate::protocol::TriggerAction::Enqueue {
                         queue: "harness-turn".to_string(),
                     }),
-                    metadata: None,
+                    metadata: Some(json!({
+                        "iii.ccp": {
+                            "version": "1",
+                            "id": "ccp-provider-test"
+                        }
+                    })),
                 },
             )
             .await
@@ -2863,6 +2864,15 @@ mod tests {
         assert_eq!(input["queue"], "harness-turn");
         assert_eq!(input["function_id"], "harness::turn");
         assert_eq!(input["data"], json!({"session_id": "s1"}));
+        assert_eq!(
+            input["metadata"],
+            json!({
+                "iii.ccp": {
+                    "version": "1",
+                    "id": "ccp-provider-test"
+                }
+            })
+        );
         assert_eq!(input["messageReceiptId"], receipt);
         assert_eq!(
             input["traceparent"],
@@ -3447,18 +3457,14 @@ mod tests {
             .await
             .expect("register trigger should succeed");
 
-        assert!(
-            engine
-                .trigger_registry
-                .triggers
-                .contains_key("cleanup_trigger")
-        );
-        assert!(
-            engine
-                .trigger_registry
-                .trigger_types
-                .contains_key("cleanup_trigger_type")
-        );
+        assert!(engine
+            .trigger_registry
+            .triggers
+            .contains_key("cleanup_trigger"));
+        assert!(engine
+            .trigger_registry
+            .trigger_types
+            .contains_key("cleanup_trigger_type"));
 
         // Drain channel messages
         while rx.try_recv().is_ok() {}
@@ -4062,12 +4068,10 @@ mod tests {
             .router_msg(&worker, &msg)
             .await
             .expect("RegisterTrigger should succeed at protocol level");
-        assert!(
-            engine
-                .trigger_registry
-                .pending_triggers
-                .contains_key("trig-early")
-        );
+        assert!(engine
+            .trigger_registry
+            .pending_triggers
+            .contains_key("trig-early"));
 
         // The provider shows up and registers the type: the parked intent
         // is activated and forwarded to the provider.
@@ -4117,12 +4121,10 @@ mod tests {
             .router_msg(&worker, &msg)
             .await
             .expect("RegisterTrigger should succeed at protocol level");
-        assert!(
-            engine
-                .trigger_registry
-                .pending_triggers
-                .contains_key("trig-orphan")
-        );
+        assert!(engine
+            .trigger_registry
+            .pending_triggers
+            .contains_key("trig-orphan"));
 
         // The worker disconnects while its registration is still parked: the
         // intent must be reaped with the connection, exactly like a live
@@ -4330,12 +4332,10 @@ mod tests {
             .await
             .expect("RegisterService without description should succeed");
 
-        assert!(
-            engine
-                .service_registry
-                .services
-                .contains_key("minimal-service")
-        );
+        assert!(engine
+            .service_registry
+            .services
+            .contains_key("minimal-service"));
     }
 
     // =========================================================================
@@ -5358,23 +5358,19 @@ mod tests {
         // Drain channel
         while rx.try_recv().is_ok() {}
 
-        assert!(
-            engine
-                .trigger_registry
-                .triggers
-                .contains_key("cleanup_trigger")
-        );
+        assert!(engine
+            .trigger_registry
+            .triggers
+            .contains_key("cleanup_trigger"));
 
         // Cleanup
         engine.cleanup_worker(&worker).await;
 
         // Trigger should be removed (unregister_worker removes all triggers for the worker)
-        assert!(
-            !engine
-                .trigger_registry
-                .triggers
-                .contains_key("cleanup_trigger")
-        );
+        assert!(!engine
+            .trigger_registry
+            .triggers
+            .contains_key("cleanup_trigger"));
     }
 
     #[tokio::test]
@@ -5431,12 +5427,10 @@ mod tests {
 
         assert!(engine.functions.get("nonexistent").is_none());
         assert!(!engine.trigger_registry.triggers.contains_key("anything"));
-        assert!(
-            !engine
-                .worker_registry
-                .workers
-                .contains_key(&uuid::Uuid::new_v4())
-        );
+        assert!(!engine
+            .worker_registry
+            .workers
+            .contains_key(&uuid::Uuid::new_v4()));
     }
 
     // =========================================================================
@@ -5517,12 +5511,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(
-            engine
-                .trigger_registry
-                .triggers
-                .contains_key("trigger_meta_1")
-        );
+        assert!(engine
+            .trigger_registry
+            .triggers
+            .contains_key("trigger_meta_1"));
         let trigger = engine
             .trigger_registry
             .triggers

--- a/engine/src/workers/queue/adapters/bridge.rs
+++ b/engine/src/workers/queue/adapters/bridge.rs
@@ -9,7 +9,7 @@ use std::{collections::HashMap, sync::Arc};
 use async_trait::async_trait;
 use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
 use iii_sdk::trigger::Trigger;
-use iii_sdk::{Error, IIIClient, InitOptions, TriggerAction, register_worker};
+use iii_sdk::{register_worker, Error, IIIClient, InitOptions, TriggerAction};
 use serde_json::Value;
 use tokio::sync::RwLock;
 use uuid::Uuid;
@@ -21,8 +21,8 @@ use crate::{
     engine::{Engine, EngineTrait},
     telemetry::SpanExt,
     workers::queue::{
-        QueueAdapter, SubscriberQueueConfig,
         registry::{QueueAdapterFuture, QueueAdapterRegistration},
+        QueueAdapter, SubscriberQueueConfig,
     },
 };
 
@@ -329,6 +329,7 @@ impl QueueAdapter for BridgeAdapter {
         queue_name: &str,
         function_id: &str,
         data: Value,
+        metadata: Option<Value>,
         _message_id: &str,
         _max_retries: u32,
         _backoff_ms: u64,
@@ -338,18 +339,21 @@ impl QueueAdapter for BridgeAdapter {
         // bridge forwards the enqueue unchanged.
         _priority: Option<u8>,
     ) {
-        if let Err(e) = self
-            .bridge
-            .trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload: data,
-                action: Some(TriggerAction::Enqueue {
-                    queue: queue_name.to_string(),
-                }),
-                timeout_ms: None,
-            })
-            .await
-        {
+        let request = TriggerRequest {
+            function_id: function_id.to_string(),
+            payload: data,
+            action: Some(TriggerAction::Enqueue {
+                queue: queue_name.to_string(),
+            }),
+            timeout_ms: None,
+        };
+        let result = if let Some(metadata) = metadata {
+            self.bridge.trigger(request.metadata(metadata)).await
+        } else {
+            self.bridge.trigger(request).await
+        };
+
+        if let Err(e) = result {
             tracing::error!(error = %e, queue = %queue_name, function_id = %function_id, "Failed to enqueue via bridge");
         }
     }

--- a/engine/src/workers/queue/adapters/builtin/adapter.rs
+++ b/engine/src/workers/queue/adapters/builtin/adapter.rs
@@ -7,14 +7,14 @@
 use std::{
     collections::{HashMap, HashSet},
     sync::{
-        Arc,
         atomic::{AtomicU64, Ordering},
+        Arc,
     },
 };
 
 use async_trait::async_trait;
 use serde_json::Value;
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::{mpsc, RwLock};
 
 use tracing::Instrument;
 
@@ -32,8 +32,8 @@ use crate::{
     engine::{Engine, EngineTrait},
     telemetry::SpanExt,
     workers::queue::{
-        QueueAdapter, SubscriberQueueConfig,
         registry::{QueueAdapterFuture, QueueAdapterRegistration},
+        QueueAdapter, SubscriberQueueConfig,
     },
 };
 
@@ -87,6 +87,7 @@ impl JobHandler for FunctionHandler {
         let function_id = self.function_id.clone();
         let condition_function_id = self.condition_function_id.clone();
         let data = job.data.clone();
+        let metadata = job.metadata.clone();
 
         async move {
             if let Some(ref condition_id) = condition_function_id {
@@ -116,7 +117,9 @@ impl JobHandler for FunctionHandler {
                 }
             }
 
-            let result = engine.call(&function_id, data).await;
+            let result = engine
+                .call_with_metadata(&function_id, data, metadata)
+                .await;
             match &result {
                 Ok(_) => {
                     tracing::Span::current().record("otel.status_code", "OK");
@@ -408,6 +411,7 @@ impl QueueAdapter for BuiltinQueueAdapter {
         queue_name: &str,
         function_id: &str,
         data: Value,
+        metadata: Option<Value>,
         message_id: &str,
         max_retries: u32,
         backoff_ms: u64,
@@ -428,6 +432,7 @@ impl QueueAdapter for BuiltinQueueAdapter {
                 backoff_ms,
                 traceparent,
                 baggage,
+                metadata,
             )
         };
         self.queue.push_job(job).await;
@@ -492,6 +497,7 @@ impl QueueAdapter for BuiltinQueueAdapter {
                         delivery_id,
                         function_id: job.function_id.unwrap_or_default(),
                         data: job.data,
+                        metadata: job.metadata,
                         attempt: job.attempts_made,
                         message_id: job.message_id,
                         traceparent: job.traceparent,
@@ -660,8 +666,8 @@ mod tests {
     use std::collections::HashSet;
     use std::time::Duration;
 
-    use crate::workers::queue::SubscriberQueueConfig;
     use crate::workers::queue::config::FunctionQueueConfig;
+    use crate::workers::queue::SubscriberQueueConfig;
     use crate::{
         builtins::queue::{Job, QueueMode},
         function::{Function, FunctionResult},
@@ -797,6 +803,7 @@ mod tests {
             100,
             Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string()),
             Some("queue=jobs".to_string()),
+            None,
         );
 
         let success = FunctionHandler {
@@ -912,6 +919,7 @@ mod tests {
                 "test-q",
                 "fn::handler",
                 json!({"key": "value"}),
+                None,
                 "test-msg-id",
                 3,
                 1000,
@@ -960,6 +968,7 @@ mod tests {
                 "test-q",
                 "fn::handler",
                 json!({"k": "v"}),
+                None,
                 "msg-1",
                 1,
                 1000,
@@ -1035,6 +1044,7 @@ mod tests {
                     "test-q",
                     "fn::handler",
                     json!({ "i": i }),
+                    None,
                     &format!("msg-{i}"),
                     1,
                     1000,
@@ -1112,6 +1122,7 @@ mod tests {
                 "test-q",
                 "fn::handler",
                 json!({"ack": true}),
+                None,
                 "test-msg-id",
                 3,
                 1000,
@@ -1156,6 +1167,7 @@ mod tests {
                 "test-q",
                 "fn::handler",
                 json!({"nack": true}),
+                None,
                 "test-msg-id",
                 3,
                 1000,
@@ -1202,7 +1214,8 @@ mod tests {
                 .publish_to_function_queue(
                     "test-q",
                     "fn::handler",
-                    json!({"order": i}),
+                    json!({ "order": i }),
+                    None,
                     "test-msg-id",
                     3,
                     1000,
@@ -1222,7 +1235,7 @@ mod tests {
 
             assert_eq!(
                 msg.data,
-                json!({"order": i}),
+                json!({ "order": i }),
                 "messages should arrive in order"
             );
             delivery_ids.push(msg.delivery_id);
@@ -1258,7 +1271,8 @@ mod tests {
                 .publish_to_function_queue(
                     "test-q",
                     "fn::handler",
-                    json!({"idx": i}),
+                    json!({ "idx": i }),
+                    None,
                     "test-msg-id",
                     3,
                     1000,
@@ -1302,6 +1316,7 @@ mod tests {
                 "test-q",
                 "fn::handler",
                 json!({"traced": true}),
+                None,
                 "test-msg-id",
                 3,
                 1000,
@@ -1679,7 +1694,7 @@ mod tests {
 
         let mut ids = Vec::new();
         for i in 0..5 {
-            let id = push_to_dlq(&adapter, "peek-topic", json!({"idx": i})).await;
+            let id = push_to_dlq(&adapter, "peek-topic", json!({ "idx": i })).await;
             ids.push(id);
         }
 

--- a/engine/src/workers/queue/adapters/rabbitmq/adapter.rs
+++ b/engine/src/workers/queue/adapters/rabbitmq/adapter.rs
@@ -10,13 +10,13 @@ use std::{
     collections::HashMap,
     str::FromStr,
     sync::{
-        Arc,
         atomic::{AtomicU64, Ordering},
+        Arc,
     },
 };
 
 use async_trait::async_trait;
-use lapin::{Channel, Connection, ConnectionProperties, message::Delivery, options::*};
+use lapin::{message::Delivery, options::*, Channel, Connection, ConnectionProperties};
 use serde_json::Value;
 use tokio::{sync::RwLock, task::JoinHandle};
 use uuid::Uuid;
@@ -24,8 +24,8 @@ use uuid::Uuid;
 use crate::{
     engine::Engine,
     workers::queue::{
-        FunctionQueueConfig, QueueAdapter, SubscriberQueueConfig,
         registry::{QueueAdapterFuture, QueueAdapterRegistration},
+        FunctionQueueConfig, QueueAdapter, SubscriberQueueConfig,
     },
 };
 
@@ -284,8 +284,15 @@ impl QueueAdapter for RabbitMQAdapter {
         // `maxPriority`, and clamps it to its own `x-max-priority`.
         let priority =
             super::types::priority_from_data(&data, self.config.priority_field.as_deref());
-        let job = Job::new(topic, data, self.config.max_attempts, traceparent, baggage)
-            .with_priority(priority);
+        let job = Job::new(
+            topic,
+            data,
+            self.config.max_attempts,
+            traceparent,
+            baggage,
+            None,
+        )
+        .with_priority(priority);
 
         if let Err(e) = self.topology.setup_topic(topic).await {
             tracing::error!(
@@ -861,6 +868,7 @@ impl QueueAdapter for RabbitMQAdapter {
         queue_name: &str,
         function_id: &str,
         data: Value,
+        metadata: Option<Value>,
         message_id: &str,
         _max_retries: u32,
         _backoff_ms: u64,
@@ -896,6 +904,20 @@ impl QueueAdapter for RabbitMQAdapter {
                 "baggage".into(),
                 lapin::types::AMQPValue::LongString(bg.as_str().into()),
             );
+        }
+        if let Some(metadata) = metadata {
+            match serde_json::to_string(&metadata) {
+                Ok(serialized) => {
+                    headers.insert(
+                        "metadata".into(),
+                        lapin::types::AMQPValue::LongString(serialized.into()),
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, queue = %queue_name, "Failed to serialize function queue metadata");
+                    return;
+                }
+            }
         }
 
         let mut properties = lapin::BasicProperties::default()
@@ -1017,6 +1039,17 @@ impl QueueAdapter for RabbitMQAdapter {
                                     _ => None,
                                 });
 
+                        let metadata =
+                            headers
+                                .and_then(|h| h.inner().get("metadata"))
+                                .and_then(|v| match v {
+                                    lapin::types::AMQPValue::LongString(s) => {
+                                        serde_json::from_str::<serde_json::Value>(&s.to_string())
+                                            .ok()
+                                    }
+                                    _ => None,
+                                });
+
                         let attempt = headers
                             .and_then(|h| h.inner().get("x-attempt"))
                             .and_then(|v| match v {
@@ -1037,6 +1070,7 @@ impl QueueAdapter for RabbitMQAdapter {
                             delivery_id,
                             function_id,
                             data,
+                            metadata,
                             attempt,
                             message_id,
                             traceparent,

--- a/engine/src/workers/queue/adapters/rabbitmq/types.rs
+++ b/engine/src/workers/queue/adapters/rabbitmq/types.rs
@@ -24,6 +24,8 @@ pub struct Job {
     pub traceparent: Option<String>,
     #[serde(default)]
     pub baggage: Option<String>,
+    #[serde(default)]
+    pub metadata: Option<Value>,
     /// AMQP message priority (0..=queue `x-max-priority`). Carried on the job so
     /// it survives requeue and DLQ-redrive republishes; stamped onto
     /// `BasicProperties` at publish time. `None` means default priority.
@@ -38,6 +40,7 @@ impl Job {
         max_attempts: u32,
         traceparent: Option<String>,
         baggage: Option<String>,
+        metadata: Option<Value>,
     ) -> Self {
         Self {
             id: Uuid::new_v4().to_string(),
@@ -51,6 +54,7 @@ impl Job {
                 .as_millis() as u64,
             traceparent,
             baggage,
+            metadata,
             priority: None,
         }
     }
@@ -163,6 +167,7 @@ mod tests {
             3,
             None,
             None,
+            None,
         );
         assert_eq!(job.topic, "test.topic");
         assert_eq!(job.attempts_made, 0);
@@ -173,8 +178,44 @@ mod tests {
 
     #[test]
     fn test_job_with_priority() {
-        let job = Job::new("t", serde_json::json!({}), 1, None, None).with_priority(Some(7));
+        let job = Job::new("t", serde_json::json!({}), 1, None, None, None).with_priority(Some(7));
         assert_eq!(job.priority, Some(7));
+    }
+
+    #[test]
+    fn test_job_metadata_round_trips_and_legacy_jobs_default_to_none() {
+        let metadata = serde_json::json!({
+            "object": { "nested": true },
+            "array": [1, "two", null],
+            "string": "value",
+            "number": 3,
+            "bool": false,
+            "null": null
+        });
+        let job = Job::new(
+            "test.topic",
+            serde_json::json!({"key": "value"}),
+            3,
+            None,
+            None,
+            Some(metadata.clone()),
+        );
+
+        let encoded = serde_json::to_value(&job).expect("job should serialize");
+        let decoded: Job = serde_json::from_value(encoded).expect("job should deserialize");
+        assert_eq!(decoded.metadata, Some(metadata));
+
+        let legacy = serde_json::json!({
+            "id": "legacy",
+            "topic": "test.topic",
+            "data": { "key": "value" },
+            "attempts_made": 0,
+            "max_attempts": 3,
+            "created_at": 1
+        });
+        let decoded_legacy: Job =
+            serde_json::from_value(legacy).expect("legacy job should deserialize");
+        assert_eq!(decoded_legacy.metadata, None);
     }
 
     #[test]

--- a/engine/src/workers/queue/adapters/rabbitmq/worker.rs
+++ b/engine/src/workers/queue/adapters/rabbitmq/worker.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 
 use futures::StreamExt;
-use lapin::{Channel, message::Delivery, options::*};
+use lapin::{message::Delivery, options::*, Channel};
 use tokio::sync::Semaphore;
 use tracing::Instrument;
 
@@ -224,6 +224,7 @@ impl Worker {
         async {
             let engine = Arc::clone(&self.engine);
             let data = job.data.clone();
+            let metadata = job.metadata.clone();
 
             if let Some(condition_path) = condition_function_id {
                 tracing::debug!(
@@ -252,7 +253,7 @@ impl Worker {
                 }
             }
 
-            match engine.call(function_id, data).await {
+            match engine.call_with_metadata(function_id, data, metadata).await {
                 Ok(_) => {
                     tracing::debug!(job_id = %job.id, "Job processed successfully");
                     tracing::Span::current().record("otel.status_code", "OK");

--- a/engine/src/workers/queue/adapters/redis_adapter.rs
+++ b/engine/src/workers/queue/adapters/redis_adapter.rs
@@ -8,7 +8,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use futures::StreamExt;
-use redis::{AsyncCommands, Client, aio::ConnectionManager};
+use redis::{aio::ConnectionManager, AsyncCommands, Client};
 use serde_json::Value;
 use tokio::{
     sync::{Mutex, RwLock},
@@ -23,8 +23,8 @@ use crate::{
     telemetry::SpanExt,
     workers::{
         queue::{
-            QueueAdapter, SubscriberQueueConfig,
             registry::{QueueAdapterFuture, QueueAdapterRegistration},
+            QueueAdapter, SubscriberQueueConfig,
         },
         redis::DEFAULT_REDIS_CONNECTION_TIMEOUT,
     },
@@ -363,6 +363,7 @@ impl QueueAdapter for RedisAdapter {
         queue_name: &str,
         function_id: &str,
         data: Value,
+        metadata: Option<Value>,
         message_id: &str,
         _max_retries: u32,
         _backoff_ms: u64,
@@ -381,6 +382,7 @@ impl QueueAdapter for RedisAdapter {
             },
             "function_id": function_id,
             "message_id": message_id,
+            "metadata": metadata,
             "data": data,
         });
 

--- a/engine/src/workers/queue/message.rs
+++ b/engine/src/workers/queue/message.rs
@@ -15,6 +15,8 @@ pub struct QueueMessage {
     pub function_id: String,
     /// The payload to pass to the function
     pub data: Value,
+    /// Opaque invocation metadata to pass alongside the payload
+    pub metadata: Option<Value>,
     /// Current attempt number (derived from transport-native retry count)
     pub attempt: u32,
     /// Publisher-assigned message ID for tracking and cancellation
@@ -36,6 +38,7 @@ mod tests {
             delivery_id: 42,
             function_id: "functions.process_order".to_string(),
             data: json!({"order_id": "o-1"}),
+            metadata: Some(json!({"source": "test"})),
             attempt: 0,
             message_id: Some("msg-123".to_string()),
             traceparent: Some("00-abc-def-01".to_string()),
@@ -45,6 +48,7 @@ mod tests {
         assert_eq!(msg.delivery_id, 42);
         assert_eq!(msg.function_id, "functions.process_order");
         assert_eq!(msg.data["order_id"], "o-1");
+        assert_eq!(msg.metadata, Some(json!({"source": "test"})));
         assert_eq!(msg.attempt, 0);
         assert!(msg.traceparent.is_some());
         assert!(msg.baggage.is_some());
@@ -56,6 +60,7 @@ mod tests {
             delivery_id: 1,
             function_id: "fn".to_string(),
             data: json!(null),
+            metadata: None,
             attempt: 3,
             message_id: None,
             traceparent: None,

--- a/engine/src/workers/queue/mod.rs
+++ b/engine/src/workers/queue/mod.rs
@@ -82,6 +82,7 @@ pub trait QueueAdapter: Send + Sync + 'static {
         _queue_name: &str,
         _function_id: &str,
         _data: Value,
+        _metadata: Option<Value>,
         _message_id: &str,
         _max_retries: u32,
         _backoff_ms: u64,

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -8,8 +8,8 @@ use std::{
     collections::HashMap,
     pin::Pin,
     sync::{
-        Arc, Mutex as StdMutex, RwLock,
         atomic::{AtomicBool, Ordering},
+        Arc, Mutex as StdMutex, RwLock,
     },
 };
 
@@ -20,13 +20,13 @@ use futures::{Future, FutureExt};
 use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::panic::AssertUnwindSafe;
 use tokio::task::AbortHandle;
 
 use super::{
-    QueueAdapter, SubscriberQueueConfig, TopicInfo,
     config::{FunctionQueueConfig, QueueModuleConfig},
+    QueueAdapter, SubscriberQueueConfig, TopicInfo,
 };
 use tracing::Instrument;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -35,7 +35,7 @@ use crate::{
     engine::{Engine, EngineTrait, Handler, RegisterFunctionRequest},
     function::FunctionResult,
     protocol::ErrorBody,
-    telemetry::{SpanExt, inject_baggage_from_context, inject_traceparent_from_context},
+    telemetry::{inject_baggage_from_context, inject_traceparent_from_context, SpanExt},
     trigger::{Trigger, TriggerRegistrator, TriggerType},
     workers::traits::{AdapterFactory, ConfigurableWorker, Worker},
 };
@@ -161,6 +161,7 @@ impl QueueWorker {
         queue_name: &str,
         function_id: &str,
         data: Value,
+        metadata: Option<Value>,
         message_id: &str,
         traceparent: Option<String>,
         baggage: Option<String>,
@@ -224,6 +225,7 @@ impl QueueWorker {
                 queue_name,
                 function_id,
                 data,
+                metadata,
                 message_id,
                 queue_config.max_retries,
                 queue_config.backoff_ms,
@@ -860,11 +862,14 @@ impl QueueWorker {
                         baggage.as_deref(),
                     );
 
-                    let result =
-                        AssertUnwindSafe(async { engine.call(&function_id, msg.data).await })
-                            .catch_unwind()
-                            .instrument(span)
-                            .await;
+                    let result = AssertUnwindSafe(async {
+                        engine
+                            .call_with_metadata(&function_id, msg.data, msg.metadata)
+                            .await
+                    })
+                    .catch_unwind()
+                    .instrument(span)
+                    .await;
 
                     match result {
                         Ok(Ok(_)) => {
@@ -1537,6 +1542,7 @@ mod tests {
         unsubscribe_count: AtomicU64,
         last_topic: Mutex<String>,
         last_data: Mutex<Option<Value>>,
+        last_function_queue_metadata: Mutex<Option<Value>>,
         last_traceparent: Mutex<Option<String>>,
         last_baggage: Mutex<Option<String>>,
         redrive_dlq_result: AtomicU64,
@@ -1565,6 +1571,7 @@ mod tests {
                 unsubscribe_count: AtomicU64::new(0),
                 last_topic: Mutex::new(String::new()),
                 last_data: Mutex::new(None),
+                last_function_queue_metadata: Mutex::new(None),
                 last_traceparent: Mutex::new(None),
                 last_baggage: Mutex::new(None),
                 redrive_dlq_result: AtomicU64::new(0),
@@ -1610,6 +1617,7 @@ mod tests {
             _queue_name: &str,
             _function_id: &str,
             _data: Value,
+            metadata: Option<Value>,
             _message_id: &str,
             _max_retries: u32,
             _backoff_ms: u64,
@@ -1618,6 +1626,7 @@ mod tests {
             _priority: Option<u8>,
         ) {
             self.enqueue_to_queue_count.fetch_add(1, Ordering::SeqCst);
+            *self.last_function_queue_metadata.lock().await = metadata;
         }
 
         async fn subscribe(
@@ -2201,12 +2210,10 @@ mod tests {
         let (engine, module, _adapter) = setup_queue_module();
         let result = module.initialize().await;
         assert!(result.is_ok());
-        assert!(
-            engine
-                .trigger_registry
-                .trigger_types
-                .contains_key("durable:subscriber")
-        );
+        assert!(engine
+            .trigger_registry
+            .trigger_types
+            .contains_key("durable:subscriber"));
     }
 
     // =========================================================================
@@ -2225,7 +2232,7 @@ mod tests {
 
     #[test]
     fn build_provisions_builtin_default_queue() {
-        use super::super::config::{DEFAULT_QUEUE_NAME, QueueModuleConfig};
+        use super::super::config::{QueueModuleConfig, DEFAULT_QUEUE_NAME};
 
         crate::workers::observability::metrics::ensure_default_meter();
         let engine = Arc::new(Engine::new());
@@ -2243,7 +2250,7 @@ mod tests {
 
     #[tokio::test]
     async fn enqueue_to_default_queue_succeeds_without_config() {
-        use super::super::config::{DEFAULT_QUEUE_NAME, QueueModuleConfig};
+        use super::super::config::{QueueModuleConfig, DEFAULT_QUEUE_NAME};
 
         crate::workers::observability::metrics::ensure_default_meter();
         let engine = Arc::new(Engine::new());
@@ -2257,6 +2264,7 @@ mod tests {
                 DEFAULT_QUEUE_NAME,
                 "fn-1",
                 json!({"key": "value"}),
+                None,
                 "test-msg-id",
                 None,
                 None,
@@ -2328,6 +2336,7 @@ mod tests {
                 "nonexistent",
                 "fn-1",
                 json!({"key": "value"}),
+                None,
                 "test-msg-id",
                 None,
                 None,
@@ -2350,6 +2359,7 @@ mod tests {
                 "payment",
                 "fn-1",
                 json!({"amount": 100}), // missing "transaction_id"
+                None,
                 "test-msg-id",
                 None,
                 None,
@@ -2372,6 +2382,7 @@ mod tests {
                 "payment",
                 "fn-1",
                 json!({"transaction_id": null, "amount": 100}),
+                None,
                 "test-msg-id",
                 None,
                 None,
@@ -2394,6 +2405,7 @@ mod tests {
                 "payment",
                 "fn-1",
                 json!({"transaction_id": "txn-123", "amount": 100}),
+                None,
                 "test-msg-id",
                 None,
                 None,
@@ -2411,6 +2423,7 @@ mod tests {
                 "default",
                 "fn-1",
                 json!({"key": "value"}),
+                None,
                 "test-msg-id",
                 None,
                 None,
@@ -2418,6 +2431,38 @@ mod tests {
             .await;
         assert!(result.is_ok());
         assert_eq!(adapter.enqueue_to_queue_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn enqueue_to_function_queue_forwards_metadata_to_adapter() {
+        let (_engine, module, adapter) = setup_queue_module_with_configs();
+        let metadata = json!({
+            "object": { "nested": true },
+            "array": [1, "two", null],
+            "string": "value",
+            "number": 3,
+            "bool": false,
+            "null": null
+        });
+
+        let result = module
+            .enqueue_to_function_queue(
+                "default",
+                "fn-1",
+                json!({"key": "value"}),
+                Some(metadata.clone()),
+                "test-msg-id",
+                None,
+                None,
+            )
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(adapter.enqueue_to_queue_count.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            *adapter.last_function_queue_metadata.lock().await,
+            Some(metadata)
+        );
     }
 
     // =========================================================================
@@ -2513,6 +2558,7 @@ mod tests {
                 "default",
                 "integration::ack_fn",
                 json!({"task": "do_work"}),
+                None,
                 "test-msg-id",
                 3,
                 1000,
@@ -2541,6 +2587,69 @@ mod tests {
             1,
             "Function should have been called exactly once"
         );
+    }
+
+    #[tokio::test]
+    async fn integration_enqueue_consume_preserves_metadata_without_changing_data() {
+        let (engine, module, adapter) = setup_integration_module().await;
+
+        let captured_data = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let captured_metadata = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let data_store = captured_data.clone();
+        let metadata_store = captured_metadata.clone();
+
+        let function = crate::function::Function {
+            handler: Arc::new(move |_invocation_id, input, _session, metadata| {
+                let data_store = data_store.clone();
+                let metadata_store = metadata_store.clone();
+                Box::pin(async move {
+                    data_store.lock().await.push(input);
+                    metadata_store.lock().await.push(metadata);
+                    FunctionResult::Success(Some(json!({ "ok": true })))
+                })
+            }),
+            _function_id: "integration::metadata_fn".to_string(),
+            _description: Some("test".to_string()),
+            request_format: None,
+            response_format: None,
+            metadata: None,
+        };
+        engine
+            .functions
+            .register_function("integration::metadata_fn".to_string(), function);
+
+        let data = json!({"task": "do_work"});
+        let metadata = json!({"iii.ccp": {"version": "1"}, "array": [1, true, null]});
+
+        adapter
+            .publish_to_function_queue(
+                "default",
+                "integration::metadata_fn",
+                data.clone(),
+                Some(metadata.clone()),
+                "test-msg-id",
+                3,
+                1000,
+                None,
+                None,
+                None,
+            )
+            .await;
+
+        module
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+        let (_shutdown_tx_keep, shutdown_rx) = tokio::sync::watch::channel(false);
+        module
+            .start_background_tasks(shutdown_rx, _shutdown_tx_keep.clone())
+            .await
+            .expect("start_background_tasks should succeed");
+
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        assert_eq!(*captured_data.lock().await, vec![data]);
+        assert_eq!(*captured_metadata.lock().await, vec![Some(metadata)]);
     }
 
     #[tokio::test]
@@ -2577,6 +2686,7 @@ mod tests {
                 "default",
                 "integration::fail_fn",
                 json!({"task": "will_fail"}),
+                None,
                 "test-msg-id",
                 3,
                 100,
@@ -2644,6 +2754,7 @@ mod tests {
                     "payment",
                     "integration::fifo_fn",
                     json!({"transaction_id": txn_id, "amount": 100}),
+                    None,
                     "test-msg-id",
                     3,
                     1000,
@@ -2720,7 +2831,8 @@ mod tests {
                 .publish_to_function_queue(
                     "default",
                     "integration::concurrent_fn",
-                    json!({"task_id": format!("task-{}", i)}),
+                    json!({ "task_id": format!("task-{}", i) }),
+                    None,
                     "test-msg-id",
                     3,
                     1000,

--- a/engine/tests/common/queue_helpers.rs
+++ b/engine/tests/common/queue_helpers.rs
@@ -1,8 +1,8 @@
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use tokio::sync::Mutex;
 
 use iii::{
@@ -47,7 +47,7 @@ pub async fn enqueue(
 ) -> anyhow::Result<()> {
     let message_id = uuid::Uuid::new_v4().to_string();
     worker
-        .enqueue_to_function_queue(queue_name, function_id, data, &message_id, None, None)
+        .enqueue_to_function_queue(queue_name, function_id, data, None, &message_id, None, None)
         .await
 }
 

--- a/engine/tests/dlq_redrive_e2e.rs
+++ b/engine/tests/dlq_redrive_e2e.rs
@@ -12,12 +12,13 @@
 //! They also cover the `iii trigger` CLI subcommand (argument parsing + connection handling).
 
 use std::sync::{
+    atomic::{AtomicBool, AtomicU64, Ordering},
     Arc,
-    atomic::{AtomicU64, Ordering},
 };
 use std::time::Duration;
 
-use serde_json::{Value, json};
+use serde_json::{json, Value};
+use tokio::sync::Mutex;
 
 use iii::{
     engine::Engine,
@@ -84,7 +85,28 @@ async fn enqueue(
 ) -> anyhow::Result<()> {
     let message_id = uuid::Uuid::new_v4().to_string();
     worker
-        .enqueue_to_function_queue(queue_name, function_id, data, &message_id, None, None)
+        .enqueue_to_function_queue(queue_name, function_id, data, None, &message_id, None, None)
+        .await
+}
+
+async fn enqueue_with_metadata(
+    worker: &QueueWorker,
+    queue_name: &str,
+    function_id: &str,
+    data: Value,
+    metadata: Value,
+) -> anyhow::Result<()> {
+    let message_id = uuid::Uuid::new_v4().to_string();
+    worker
+        .enqueue_to_function_queue(
+            queue_name,
+            function_id,
+            data,
+            Some(metadata),
+            &message_id,
+            None,
+            None,
+        )
         .await
 }
 
@@ -485,6 +507,101 @@ async fn e2e_flaky_function_recovers_after_redrive() {
         total_success >= 1,
         "Flaky function should eventually succeed after redrives, \
          fails={total_fails}, successes={total_success}"
+    );
+}
+
+#[tokio::test]
+async fn e2e_queue_metadata_survives_dlq_and_redrive() {
+    iii::workers::observability::metrics::ensure_default_meter();
+    let engine = Arc::new(Engine::new());
+
+    let allow_success = Arc::new(AtomicBool::new(false));
+    let call_count = Arc::new(AtomicU64::new(0));
+    let captured_metadata = Arc::new(Mutex::new(Vec::new()));
+
+    let allow = allow_success.clone();
+    let count = call_count.clone();
+    let metadata_store = captured_metadata.clone();
+    let function = Function {
+        handler: Arc::new(move |_invocation_id, _input, _session, metadata| {
+            let allow = allow.clone();
+            let count = count.clone();
+            let metadata_store = metadata_store.clone();
+            Box::pin(async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                if allow.load(Ordering::SeqCst) {
+                    metadata_store.lock().await.push(metadata);
+                    FunctionResult::Success(Some(json!({ "ok": true })))
+                } else {
+                    FunctionResult::Failure(ErrorBody {
+                        code: "PROCESSING_ERROR".to_string(),
+                        message: "simulated processing failure".to_string(),
+                        stacktrace: None,
+                    })
+                }
+            })
+        }),
+        _function_id: "e2e::metadata_redrive".to_string(),
+        _description: Some("captures metadata after redrive".to_string()),
+        request_format: None,
+        response_format: None,
+        metadata: None,
+    };
+    engine
+        .functions
+        .register_function("e2e::metadata_redrive".to_string(), function);
+
+    let module = QueueWorker::for_test(engine.clone(), Some(queue_config_with_fast_retries()))
+        .await
+        .expect("create should succeed");
+    module.register_functions(engine.clone());
+    module
+        .initialize()
+        .await
+        .expect("initialize should succeed");
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    module
+        .start_background_tasks(shutdown_rx, shutdown_tx)
+        .await
+        .expect("start_background_tasks should succeed");
+
+    let metadata = json!({
+        "iii.ccp": {
+            "version": "1",
+            "id": "ccp-redrive-test",
+            "validation": { "status": "valid" }
+        },
+        "array": [1, true, null],
+        "scalar": "kept"
+    });
+
+    enqueue_with_metadata(
+        &module,
+        "orders",
+        "e2e::metadata_redrive",
+        json!({ "order_id": "ORD-META" }),
+        metadata.clone(),
+    )
+    .await
+    .expect("enqueue should succeed");
+
+    tokio::time::sleep(Duration::from_millis(2000)).await;
+    assert_eq!(dlq_count(&module, "orders").await, 1);
+    let dlq_messages = module
+        .function_queue_dlq_messages("orders", 1)
+        .await
+        .expect("dlq messages should be inspectable");
+    assert_eq!(dlq_messages[0]["job"]["metadata"], metadata);
+
+    allow_success.store(true, Ordering::SeqCst);
+    let result = invoke_redrive(&engine, "orders").await;
+    assert!(matches!(result, FunctionResult::Success(_)));
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert_eq!(*captured_metadata.lock().await, vec![Some(metadata)]);
+    assert!(
+        call_count.load(Ordering::SeqCst) >= 2,
+        "function should have failed before redrive and succeeded after redrive"
     );
 }
 

--- a/engine/tests/rabbitmq_queue_integration.rs
+++ b/engine/tests/rabbitmq_queue_integration.rs
@@ -8,12 +8,12 @@
 
 mod common;
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
-use lapin::{Connection, ConnectionProperties, options::*};
-use serde_json::{Value, json};
+use lapin::{options::*, Connection, ConnectionProperties};
+use serde_json::{json, Value};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
@@ -87,6 +87,7 @@ async fn missing_dlq_inspection_does_not_close_function_queue_channel() {
             &function_queue,
             "test::rmq_dlq_channel",
             json!({"source": "dlq-channel-regression"}),
+            None,
             "dlq-channel-regression-message",
             config.max_retries,
             config.backoff_ms,
@@ -373,7 +374,7 @@ async fn concurrent_processing() {
             &module,
             &format!("{prefix}-default"),
             "test::rmq_slow",
-            json!({"idx": i}),
+            json!({ "idx": i }),
         )
         .await
         .expect("Enqueue should succeed");
@@ -436,7 +437,7 @@ async fn multiple_queues_operate_independently() {
             &module,
             &format!("{prefix}-default"),
             "test::rmq_default",
-            json!({"idx": i}),
+            json!({ "idx": i }),
         )
         .await
         .expect("Enqueue to default should succeed");


### PR DESCRIPTION
## SummaryPreserve opaque invocation `metadata` across queued function delivery so metadata that already exists at enqueue time reaches the final handler as metadata, not as part of `data`.Refs iii-hq/iii#2039.## What Changed- Include `metadata` in the internal enqueue-provider payload for `TriggerAction::Enqueue`.- Thread `metadata: Option<Value>` through `QueueWorker::enqueue_to_function_queue`, `QueueAdapter::publish_to_function_queue`, and `QueueMessage`.- Preserve metadata in builtin queue jobs, including serde round trips and legacy jobs without a metadata field.- Preserve metadata through Redis function queue envelopes.- Preserve metadata through RabbitMQ function queues using an AMQP header, while keeping the message body as the original business `data`.- Preserve metadata through bridge adapter enqueue calls via the SDK trigger metadata builder.- Deliver queued function messages with `engine.call_with_metadata(function_id, data, metadata)`.- Add coverage for arbitrary JSON metadata, queue delivery, enqueue provider routing, and DLQ/redrive continuity.## What Did Not Change- No new CCP worker was added.- No new memory backend was added.- No public CCP API or schema was introduced.- No code interprets `metadata["iii.ccp"]`; it remains opaque transport metadata.- Queue `data` is not wrapped or mutated to carry metadata.- Topic/pubsub metadata behavior is left out of scope for this first PR.## Compatibility- Builtin queue jobs and RabbitMQ jobs use `#[serde(default)]` for `metadata`, so older serialized jobs without metadata still deserialize as `None`.- RabbitMQ function queue message bodies remain the original serialized `data`; metadata rides in headers to avoid changing handler payloads or DLQ inspection semantics.- Calls without metadata pass `None` and preserve the existing behavior.## ValidationLocal Windows MSVC cargo builds are blocked in this environment because `link.exe` is missing. I validated with the official Rust Docker image and persistent Cargo cache/target volumes.Passed:```textrustfmt --edition 2024 --config skip_children=true --check <changed Rust files>git diff --checkcargo check -p iii --lib --no-default-features --message-format shortFinished `dev` profile in 10m 24scargo check -p iii --lib --all-features --message-format shortFinished `dev` profile in 7m 59scargo test -p iii job_metadata_round_trips_and_legacy_jobs_default_to_none --lib --no-default-features -- --nocapture2 passed; 0 failedcargo test -p iii integration_enqueue_consume_preserves_metadata_without_changing_data --lib --no-default-features -- --nocapture1 passed; 0 failedcargo test -p iii enqueue_action_routes_through_registered_queue_provider --lib --no-default-features -- --nocapture1 passed; 0 failedcargo test -p iii e2e_queue_metadata_survives_dlq_and_redrive --test dlq_redrive_e2e --no-default-features -- --nocapture1 passed; 0 failed```Observed existing warning during Rust checks/tests:```textwarning: unused imports: `Context` and `Result` --> crates/iii-worker/src/cli/worker_manager/platform.rs:9:14```Not run locally:```textcargo test -p iii --test rabbitmq_queue_integration -- --nocapture```RabbitMQ integration should run in CI where the existing broker/test workflow is available.## Automated Review / Follow-UpQodo is expected to run automatically after this PR opens. I will address any actionable bot review comments in follow-up commits on this branch.<!-- This is an auto-generated comment: release notes by coderabbit.ai -->## Summary by CodeRabbit## New Features- Added support for optional JSON metadata on queued function invocations.- Metadata is preserved separately from the payload across queue delivery, retries, and dead-letter redrive.- Metadata is available to the eventual handler without changing the invocation data.## Bug Fixes- Improved compatibility for existing queued jobs without metadata; they continue to work with metadata set to no value.## Documentation- Updated engine protocol documentation to describe metadata handling throughout the invocation lifecycle.## Tests- Added coverage for metadata propagation, serialization, deserialization, and end-to-end delivery.<!-- end of auto-generated comment: release notes by coderabbit.ai -->## License Agreement- [x] I license my contributions to this repository under Apache 2.0, and I have all necessary rights over the code I am contributing.

## Automated Review / Follow-Up

- CodeRabbit completed review and raised one docs/SDK impact nitpick.
- Verified SDK surfaces already expose invocation metadata on trigger requests/handlers.
- Addressed the docs portion in follow-up commit `bc5c0208` by clarifying that enqueue preserves `metadata` as an opaque sidecar through retries and DLQ redrive.
- Qodo is expected to run automatically if enabled for this repository; no local Qodo CLI was available in this environment.