### PR TITLE
fix: preserve legacy queue compatibility for default namespace

### DIFF
--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -1648,18 +1648,28 @@ impl Engine {
 
                         tokio::spawn(
                             async move {
+                                let mut enqueue_input = serde_json::json!({
+                                    "queue": queue.clone(),
+                                    "function_id": function_id.clone(),
+                                    "data": data,
+                                    "messageReceiptId": message_receipt_id.clone(),
+                                    "traceparent": traceparent.clone(),
+                                    "baggage": queued_baggage,
+                                });
+                                // The standalone queue predates namespaces and
+                                // strictly rejects unknown request fields. Keep
+                                // the default namespace wire-compatible with
+                                // those releases; only a non-default target
+                                // needs the additive field understood by a
+                                // namespace-aware queue provider.
+                                if target_namespace != DEFAULT_NAMESPACE {
+                                    enqueue_input["namespace"] =
+                                        Value::String(target_namespace.clone());
+                                }
                                 let result = engine
                                     .call_with_metadata(
                                         ENQUEUE_PROVIDER_FUNCTION_ID,
-                                        serde_json::json!({
-                                            "queue": queue.clone(),
-                                            "function_id": function_id.clone(),
-                                            "data": data,
-                                            "namespace": target_namespace.clone(),
-                                            "messageReceiptId": message_receipt_id.clone(),
-                                            "traceparent": traceparent.clone(),
-                                            "baggage": queued_baggage,
-                                        }),
+                                        enqueue_input,
                                         None,
                                     )
                                     .await;
@@ -4302,6 +4312,10 @@ mod tests {
         assert_eq!(input["queue"], "harness-turn");
         assert_eq!(input["function_id"], "harness::turn");
         assert_eq!(input["data"], json!({"session_id": "s1"}));
+        assert!(
+            input.get("namespace").is_none(),
+            "default namespace must be omitted for legacy queue providers: {input}"
+        );
         assert_eq!(input["messageReceiptId"], receipt);
         assert_eq!(
             input["traceparent"],


### PR DESCRIPTION
## Summary

- omit the `namespace` field from `engine::queue::enqueue` payloads when routing to the default namespace
- preserve the field for non-default namespaces so namespace-aware queue providers can route correctly
- add a regression assertion for the legacy default-namespace payload shape

## Root cause

PR #1984 added namespace propagation to enqueue actions, but the engine sent the new field unconditionally. Existing standalone queue workers use a strict request schema and reject unknown fields, causing default-namespace harness turns to fail before they could be enqueued.

## Impact

This restores compatibility with existing queue workers, including the queue version used by the harness, while retaining namespace propagation for non-default targets.

## Validation

- `cargo test -p iii --lib enqueue_action_routes_through_registered_queue_provider -- --nocapture`
- `cargo test -p iii --test queue_integration builtin_enqueue_runs_target_in_captured_namespace -- --nocapture`
- full library test suite: 2,045 passed, 6 ignored
- namespace smoke suite: 216 checks passed with no failures or skips

This PR is stacked on #1984 and targets its `feat/namespare` branch.
