### PR TITLE
fix(engine): isolate test configuration persistence in tempdirs

### DIFF
--- a/engine/src/workers/config.rs
+++ b/engine/src/workers/config.rs
@@ -1047,6 +1047,24 @@ impl Default for EngineBuilder {
 mod tests {
     use super::*;
 
+    /// Configuration-worker entry whose fs adapter persists into a throwaway
+    /// tempdir. Every `build()` boots the mandatory configuration worker, and
+    /// its default adapter writes `./config/<id>.yaml` relative to the test
+    /// cwd — polluting the repo tree and leaking one run's persisted entries
+    /// into the next: the persisted value is the runtime source of truth, so
+    /// e.g. a stream port persisted by run A overrides run B's inline worker
+    /// config. Keep the returned `TempDir` alive for the test's duration.
+    fn isolated_config_entry() -> (Value, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("create config tempdir");
+        let entry = serde_json::json!({
+            "adapter": {
+                "name": crate::workers::configuration::adapters::fs::ADAPTER_NAME,
+                "config": { "directory": dir.path().to_string_lossy() }
+            }
+        });
+        (entry, dir)
+    }
+
     fn restore_env_var(name: &str, value: Option<std::ffi::OsString>) {
         unsafe {
             match value {
@@ -2011,7 +2029,9 @@ modules:
         REGISTERED.store(0, Ordering::SeqCst);
         DESTROYED.store(0, Ordering::SeqCst);
 
+        let (config_entry, _config_dir) = isolated_config_entry();
         let builder = EngineBuilder::new()
+            .add_worker("configuration", Some(config_entry))
             .register_worker::<LifecycleModule>("test::Lifecycle")
             .add_worker(
                 "test::Lifecycle",
@@ -2068,7 +2088,9 @@ modules:
             }
         }
 
+        let (config_entry, _config_dir) = isolated_config_entry();
         let builder = EngineBuilder::new()
+            .add_worker("configuration", Some(config_entry))
             .register_worker::<ListedWorker>("test::Listed")
             .add_worker("test::Listed", None)
             .build()
@@ -2161,7 +2183,9 @@ modules:
             }
         }
 
+        let (config_entry, _config_dir) = isolated_config_entry();
         let builder = EngineBuilder::new()
+            .add_worker("configuration", Some(config_entry))
             .register_worker::<BackgroundStartFailsWorker>("test::BackgroundStartFails")
             .add_worker("test::BackgroundStartFails", None)
             .build()
@@ -2260,7 +2284,9 @@ modules:
         FAILING_DESTROYS.store(0, Ordering::SeqCst);
         SUCCESSFUL_DESTROYS.store(0, Ordering::SeqCst);
 
+        let (config_entry, _config_dir) = isolated_config_entry();
         let builder = EngineBuilder::new()
+            .add_worker("configuration", Some(config_entry))
             .register_worker::<DestroyFailsWorker>("test::DestroyFails")
             .register_worker::<DestroySucceedsWorker>("test::DestroySucceeds")
             .add_worker("test::DestroyFails", None)
@@ -2294,7 +2320,9 @@ modules:
 
         // Bind happens in `start_background_tasks` (not `build`/`initialize`),
         // so we have to step through the worker lifecycle manually.
+        let (config_entry, _config_dir) = isolated_config_entry();
         let builder = EngineBuilder::new()
+            .add_worker("configuration", Some(config_entry))
             .add_worker(
                 "iii-stream",
                 Some(serde_json::json!({
@@ -2496,7 +2524,9 @@ workers:
         // `sdk/fixtures/config-test.yaml` -- if that fixture's port ever
         // needs rewording, this test keeps the plumbing honest.
         let custom_port: u16 = 49199;
+        let (config_entry, _config_dir) = isolated_config_entry();
         let builder = EngineBuilder::new()
+            .add_worker("configuration", Some(config_entry))
             .add_worker(
                 "iii-worker-manager",
                 Some(serde_json::json!({
@@ -2524,11 +2554,13 @@ workers:
         // has no custom config, so the port resolution must land on
         // DEFAULT_PORT. Losing this fallback would regress every existing
         // deployment that doesn't explicitly pin a port.
+        let (config_entry, _config_dir) = isolated_config_entry();
         let builder = EngineBuilder::new()
             .with_config(EngineConfig {
                 modules: Vec::new(),
                 workers: Vec::new(),
             })
+            .add_worker("configuration", Some(config_entry))
             .build()
             .await
             .expect("build with no explicit workers");
@@ -2564,11 +2596,13 @@ workers:
         // Spawned workers receive III_CONFIG_PATH from `Engine::config_path`;
         // a relative path (the CLI default is the bare "config.yaml") would
         // resolve against the CHILD's cwd and defeat the whole handshake.
+        let (config_entry, _config_dir) = isolated_config_entry();
         let builder = EngineBuilder::new()
             .with_config(EngineConfig {
                 modules: Vec::new(),
                 workers: Vec::new(),
             })
+            .add_worker("configuration", Some(config_entry))
             .with_config_path("config.yaml")
             .build()
             .await
@@ -2627,8 +2661,10 @@ workers:
         // content shape; this pins the engine side of that contract).
         let cfg: EngineConfig = serde_yaml::from_str(&EngineConfig::starter_config_yaml())
             .expect("starter config must parse");
+        let (config_entry, _config_dir) = isolated_config_entry();
         let builder = EngineBuilder::new()
             .with_config(cfg)
+            .add_worker("configuration", Some(config_entry))
             .build()
             .await
             .expect("an empty starter config must boot (mandatory workers injected)");

--- a/engine/tests/builtin_functions_e2e.rs
+++ b/engine/tests/builtin_functions_e2e.rs
@@ -4,8 +4,22 @@ use serde_json::json;
 
 use iii::{EngineBuilder, engine::EngineTrait, workers::telemetry::is_iii_builtin_function_id};
 
-async fn boot_bare_engine() -> iii::EngineBuilder {
-    EngineBuilder::new()
+/// The mandatory `configuration` worker persists entries on boot; point its
+/// store at a tempdir so the tests write nothing into the repo-relative
+/// `engine/config/` and leak nothing between runs. The returned `TempDir`
+/// must stay alive for the test's duration.
+async fn boot_bare_engine() -> (iii::EngineBuilder, tempfile::TempDir) {
+    let config_dir = tempfile::tempdir().expect("create config tempdir");
+    let builder = EngineBuilder::new()
+        .add_worker(
+            "configuration",
+            Some(json!({
+                "adapter": {
+                    "name": "fs",
+                    "config": { "directory": config_dir.path().to_string_lossy() }
+                }
+            })),
+        )
         .add_worker("iii-engine-functions", None)
         .add_worker("iii-state", None)
         .add_worker("iii-stream", Some(json!({ "port": 0 })))
@@ -16,7 +30,8 @@ async fn boot_bare_engine() -> iii::EngineBuilder {
         .add_worker("iii-worker-manager", Some(json!({ "port": 0 })))
         .build()
         .await
-        .expect("engine build should succeed")
+        .expect("engine build should succeed");
+    (builder, config_dir)
 }
 
 /// Boots the engine with all default modules (ephemeral ports to avoid
@@ -24,7 +39,7 @@ async fn boot_bare_engine() -> iii::EngineBuilder {
 /// and asserts every returned function_id is classified as an iii builtin.
 #[tokio::test]
 async fn all_functions_on_bare_engine_are_iii_builtins() {
-    let builder = boot_bare_engine().await;
+    let (builder, _config_dir) = boot_bare_engine().await;
     let engine = builder.engine();
 
     tokio::time::sleep(Duration::from_secs(2)).await;
@@ -90,7 +105,7 @@ async fn all_functions_on_bare_engine_are_iii_builtins() {
 /// `request_schema` / `response_schema` keys.
 #[tokio::test]
 async fn functions_info_returns_schemas_for_engine_builtin() {
-    let builder = boot_bare_engine().await;
+    let (builder, _config_dir) = boot_bare_engine().await;
     let engine = builder.engine();
 
     tokio::time::sleep(Duration::from_secs(2)).await;
@@ -135,7 +150,7 @@ async fn functions_info_returns_schemas_for_engine_builtin() {
 /// request order, without failing the batch.
 #[tokio::test]
 async fn functions_info_batch_returns_details_and_markers() {
-    let builder = boot_bare_engine().await;
+    let (builder, _config_dir) = boot_bare_engine().await;
     let engine = builder.engine();
 
     tokio::time::sleep(Duration::from_secs(2)).await;
@@ -188,7 +203,7 @@ async fn functions_info_batch_returns_details_and_markers() {
 /// instances. Every row must carry an `id`, `worker_name`, and `description`.
 #[tokio::test]
 async fn triggers_list_returns_trigger_types() {
-    let builder = boot_bare_engine().await;
+    let (builder, _config_dir) = boot_bare_engine().await;
     let engine = builder.engine();
 
     tokio::time::sleep(Duration::from_secs(2)).await;
@@ -236,7 +251,7 @@ async fn triggers_list_returns_trigger_types() {
 /// canonical `{ registered_triggers: [] }` envelope.
 #[tokio::test]
 async fn registered_triggers_list_returns_canonical_envelope() {
-    let builder = boot_bare_engine().await;
+    let (builder, _config_dir) = boot_bare_engine().await;
     let engine = builder.engine();
 
     tokio::time::sleep(Duration::from_secs(2)).await;
@@ -277,7 +292,7 @@ async fn registered_triggers_list_returns_canonical_envelope() {
 /// Looking up a known in-process runtime worker by `name` must succeed.
 #[tokio::test]
 async fn workers_info_returns_full_surface_for_runtime_worker() {
-    let builder = boot_bare_engine().await;
+    let (builder, _config_dir) = boot_bare_engine().await;
     let engine = builder.engine();
 
     tokio::time::sleep(Duration::from_secs(2)).await;
@@ -317,7 +332,7 @@ async fn workers_info_returns_full_surface_for_runtime_worker() {
 /// registry for iii-http, iii-cron, iii-state, etc.
 #[tokio::test]
 async fn workers_info_attributes_trigger_types_to_in_process_worker() {
-    let builder = boot_bare_engine().await;
+    let (builder, _config_dir) = boot_bare_engine().await;
     let engine = builder.engine();
 
     tokio::time::sleep(Duration::from_secs(2)).await;

--- a/engine/tests/config_reload_e2e.rs
+++ b/engine/tests/config_reload_e2e.rs
@@ -46,11 +46,21 @@ fn disable_builtin_daemons() {
     });
 }
 
-/// A minimal YAML config with no user-defined workers or modules. Mandatory
-/// workers (telemetry, observability, engine-functions) are auto-injected by
-/// `EngineBuilder::build()` and do not bind fixed ports.
-fn minimal_config_yaml() -> &'static str {
-    "workers: []\nmodules: []\n"
+/// A minimal YAML config whose `configuration` worker persists into
+/// `store_dir`, with `extra_workers` (yaml list items, or "") appended to the
+/// workers list. Mandatory workers (telemetry, observability,
+/// engine-functions) are auto-injected by `EngineBuilder::build()` and do not
+/// bind fixed ports.
+///
+/// Every yaml revision a reload test writes must keep the `configuration`
+/// entry: reload re-reads the file, and a config without it re-injects the
+/// mandatory configuration worker with its default cwd-relative `./config`
+/// store — littering the repo tree and leaking persisted entries into later
+/// runs.
+fn minimal_config_yaml(store_dir: &str, extra_workers: &str) -> String {
+    format!(
+        "workers:\n  - name: configuration\n    config:\n      adapter:\n        name: fs\n        config:\n          directory: {store_dir}\n{extra_workers}modules: []\n"
+    )
 }
 
 /// Write `contents` to `path` synchronously.
@@ -137,9 +147,11 @@ impl Worker for TestEphemeralWorker {
 #[serial]
 async fn config_change_reloads_without_crashing() {
     disable_builtin_daemons();
+    let store = tempfile::tempdir().expect("store dir");
+    let store_dir = store.path().to_str().unwrap().to_string();
     let tmp = tempfile::NamedTempFile::new().expect("create tempfile");
     let path = tmp.path().to_path_buf();
-    write_config(&path, minimal_config_yaml());
+    write_config(&path, &minimal_config_yaml(&store_dir, ""));
 
     let cfg = EngineConfig::config_file(path.to_str().unwrap()).expect("load initial config");
 
@@ -157,7 +169,10 @@ async fn config_change_reloads_without_crashing() {
 
     // Rewrite the config with a trivially-different-but-equivalent body.
     // The file watcher detects the change, debounces 500ms, then reloads.
-    write_config(&path, "workers: []\nmodules: []\n# reload trigger\n");
+    write_config(
+        &path,
+        &format!("{}# reload trigger\n", minimal_config_yaml(&store_dir, "")),
+    );
 
     // Wait for watcher debounce (500ms) + reload pipeline.
     tokio::time::sleep(Duration::from_millis(1500)).await;
@@ -181,9 +196,11 @@ async fn config_change_reloads_without_crashing() {
 #[serial]
 async fn broken_yaml_config_exits_engine() {
     disable_builtin_daemons();
+    let store = tempfile::tempdir().expect("store dir");
+    let store_dir = store.path().to_str().unwrap().to_string();
     let tmp = tempfile::NamedTempFile::new().expect("create tempfile");
     let path = tmp.path().to_path_buf();
-    write_config(&path, minimal_config_yaml());
+    write_config(&path, &minimal_config_yaml(&store_dir, ""));
 
     let cfg = EngineConfig::config_file(path.to_str().unwrap()).expect("load initial config");
 
@@ -237,9 +254,11 @@ async fn config_reload_removes_worker_function_registrations() {
 
     // Start with the ephemeral worker declared in the config so build() will
     // instantiate it and record its function registration in the engine.
-    let initial_yaml = format!(
-        "workers:\n  - name: {}\nmodules: []\n",
-        TEST_EPHEMERAL_WORKER_NAME
+    let store = tempfile::tempdir().expect("store dir");
+    let store_dir = store.path().to_str().unwrap().to_string();
+    let initial_yaml = minimal_config_yaml(
+        &store_dir,
+        &format!("  - name: {}\n", TEST_EPHEMERAL_WORKER_NAME),
     );
     write_config(&path, &initial_yaml);
 
@@ -269,7 +288,7 @@ async fn config_reload_removes_worker_function_registrations() {
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Rewrite the config with the worker removed.
-    write_config(&path, minimal_config_yaml());
+    write_config(&path, &minimal_config_yaml(&store_dir, ""));
 
     // Wait for watcher debounce (500ms) + reload pipeline.
     tokio::time::sleep(Duration::from_millis(1500)).await;

--- a/engine/tests/iii_queue_optin_registration.rs
+++ b/engine/tests/iii_queue_optin_registration.rs
@@ -7,7 +7,19 @@ use iii::{EngineBuilder, engine::EngineTrait};
 /// the caller-facing queue/DLQ functions.
 #[tokio::test]
 async fn explicit_iii_queue_entry_registers_queue_functions() {
+    // The mandatory configuration worker persists entries on boot; point its
+    // store at a tempdir so the test writes nothing into the repo tree.
+    let config_dir = tempfile::tempdir().expect("create config tempdir");
     let builder = EngineBuilder::new()
+        .add_worker(
+            "configuration",
+            Some(json!({
+                "adapter": {
+                    "name": "fs",
+                    "config": { "directory": config_dir.path().to_string_lossy() }
+                }
+            })),
+        )
         .add_worker("iii-engine-functions", None)
         .add_worker("iii-observability", None)
         .add_worker("iii-queue", None)

--- a/engine/tests/reload_manager_unit.rs
+++ b/engine/tests/reload_manager_unit.rs
@@ -84,14 +84,30 @@ async fn duplicate_worker_names_get_instance_ids() {
     assert_eq!(foo_entries[1].worker_type(), "foo");
 }
 
-fn minimal_config() -> EngineConfig {
-    serde_yaml::from_str("workers: []\nmodules: []\n").unwrap()
+/// Minimal config whose `configuration` worker persists into a throwaway
+/// tempdir, so the engine boot writes nothing into the repo-relative
+/// `engine/config/`. Keep the TempDir alive for the test's duration.
+fn minimal_config() -> (EngineConfig, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("create config tempdir");
+    let mut config: EngineConfig = serde_yaml::from_str("workers: []\nmodules: []\n").unwrap();
+    config.workers.push(iii::workers::config::WorkerEntry {
+        name: "configuration".to_string(),
+        image: None,
+        config: Some(serde_json::json!({
+            "adapter": {
+                "name": "fs",
+                "config": { "directory": dir.path().to_string_lossy() }
+            }
+        })),
+    });
+    (config, dir)
 }
 
 #[tokio::test]
 async fn commit_noop_when_diff_is_empty() {
+    let (config, _config_dir) = minimal_config();
     let mut builder = EngineBuilder::new()
-        .with_config(minimal_config())
+        .with_config(config)
         .build()
         .await
         .unwrap();

--- a/engine/tests/reload_scope_unit.rs
+++ b/engine/tests/reload_scope_unit.rs
@@ -115,8 +115,27 @@ async fn builder_produces_running_workers_with_matching_entries() {
         "default config must define at least one worker entry"
     );
 
+    // Point the default config's configuration worker at a tempdir store so
+    // the boot writes nothing into the repo-relative ./config.
+    let (config_entry, _config_dir) = isolated_config_entry();
+    let mut boot_config = EngineConfig::default_config();
+    let mut found = false;
+    for entry in boot_config
+        .modules
+        .iter_mut()
+        .chain(boot_config.workers.iter_mut())
+    {
+        if entry.name == config_entry.name {
+            entry.config = config_entry.config.clone();
+            found = true;
+        }
+    }
+    if !found {
+        boot_config.workers.push(config_entry);
+    }
+
     let builder = EngineBuilder::new()
-        .with_config(EngineConfig::default_config())
+        .with_config(boot_config)
         .build()
         .await
         .expect("build should succeed for default config");
@@ -148,32 +167,58 @@ async fn builder_produces_running_workers_with_matching_entries() {
     }
 }
 
-// Helper: minimal config whose only explicit worker is iii-worker-manager
-// bound to an ephemeral port. Mandatory workers (telemetry, observability,
-// engine-functions) will be injected by build() but don't bind fixed ports.
-// This lets builder-plumbing tests coexist with the other integration tests
-// in this binary that also exercise build(), without fighting over the real
-// default_config()'s fixed ports (iii-http, iii-stream, iii-worker-manager).
-fn minimal_config_for_builder_tests() -> iii::workers::config::EngineConfig {
-    iii::workers::config::EngineConfig {
+// Helper: a `configuration` worker entry persisting into a throwaway
+// tempdir, so engine boots in this binary neither write the repo-relative
+// `engine/config/` nor leak persisted entries between runs. Keep the
+// returned TempDir alive for the test's duration.
+fn isolated_config_entry() -> (iii::workers::config::WorkerEntry, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("create config tempdir");
+    let entry = iii::workers::config::WorkerEntry {
+        name: "configuration".to_string(),
+        image: None,
+        config: Some(serde_json::json!({
+            "adapter": {
+                "name": "fs",
+                "config": { "directory": dir.path().to_string_lossy() }
+            }
+        })),
+    };
+    (entry, dir)
+}
+
+// Helper: minimal config whose only explicit workers are iii-worker-manager
+// bound to an ephemeral port and a tempdir-isolated configuration worker.
+// Mandatory workers (telemetry, observability, engine-functions) will be
+// injected by build() but don't bind fixed ports. This lets builder-plumbing
+// tests coexist with the other integration tests in this binary that also
+// exercise build(), without fighting over the real default_config()'s fixed
+// ports (iii-http, iii-stream, iii-worker-manager).
+fn minimal_config_for_builder_tests() -> (iii::workers::config::EngineConfig, tempfile::TempDir) {
+    let (config_entry, config_dir) = isolated_config_entry();
+    let config = iii::workers::config::EngineConfig {
         modules: Vec::new(),
-        workers: vec![iii::workers::config::WorkerEntry {
-            name: "iii-worker-manager".to_string(),
-            image: None,
-            config: Some(serde_json::json!({
-                "host": "127.0.0.1",
-                "port": 0,
-            })),
-        }],
-    }
+        workers: vec![
+            iii::workers::config::WorkerEntry {
+                name: "iii-worker-manager".to_string(),
+                image: None,
+                config: Some(serde_json::json!({
+                    "host": "127.0.0.1",
+                    "port": 0,
+                })),
+            },
+            config_entry,
+        ],
+    };
+    (config, config_dir)
 }
 
 #[tokio::test]
 async fn config_path_is_stored_when_set() {
     use iii::EngineBuilder;
 
+    let (config, _config_dir) = minimal_config_for_builder_tests();
     let builder = EngineBuilder::new()
-        .with_config(minimal_config_for_builder_tests())
+        .with_config(config)
         .with_config_path("/tmp/fake-config.yaml")
         .build()
         .await
@@ -186,8 +231,9 @@ async fn config_path_is_stored_when_set() {
 async fn config_path_is_none_when_not_set() {
     use iii::EngineBuilder;
 
+    let (config, _config_dir) = minimal_config_for_builder_tests();
     let builder = EngineBuilder::new()
-        .with_config(minimal_config_for_builder_tests())
+        .with_config(config)
         .build()
         .await
         .unwrap();
@@ -225,16 +271,20 @@ async fn serve_returns_on_sigterm() {
     // here because its enabled-by-default workers (iii-stream, iii-http,
     // etc.) bind fixed ports and would conflict with other integration tests
     // running in parallel.
+    let (config_entry, _config_dir) = isolated_config_entry();
     let config = EngineConfig {
         modules: Vec::new(),
-        workers: vec![iii::workers::config::WorkerEntry {
-            name: "iii-worker-manager".to_string(),
-            image: None,
-            config: Some(serde_json::json!({
-                "host": "127.0.0.1",
-                "port": 0,
-            })),
-        }],
+        workers: vec![
+            iii::workers::config::WorkerEntry {
+                name: "iii-worker-manager".to_string(),
+                image: None,
+                config: Some(serde_json::json!({
+                    "host": "127.0.0.1",
+                    "port": 0,
+                })),
+            },
+            config_entry,
+        ],
     };
 
     let builder = EngineBuilder::new()


### PR DESCRIPTION
## Problem

`engine_builder_reports_worker_name_on_stream_bind_failure` (config.rs) is self-polluting: it passes on a clean tree and fails on every consecutive run with `start_background_tasks should fail when the stream port is occupied`. More broadly, every test that boots an engine — lib builder tests and several integration test binaries — writes an untracked `engine/config/` directory into the repo on each `cargo test` run.

First flagged in the reviewer note on #2045; reproduced identically with that branch's changes stashed, so this is independent and pre-existing.

## Root cause

Every `EngineBuilder::build()` boots the mandatory `configuration` worker, whose default fs adapter persists entries into the cwd-relative `./config` (`DEFAULT_DIRECTORY`, adapters/fs.rs), which is `engine/config/` under `cargo test`. Each run of the bind-failure test persists `iii-stream.yaml` carrying that run's dynamically reserved port. Persisted entries are the runtime source of truth (they override inline worker config), so the next run's stream worker adopts the stale port from the previous run, which is free again, binds it successfully, and the expected bind failure never happens.

Deterministic repro on `main`:

```
rm -rf engine/config
cargo test -p iii --lib engine_builder_reports_worker_name_on_stream_bind_failure  # ok
cargo test -p iii --lib engine_builder_reports_worker_name_on_stream_bind_failure  # FAILED
```

## Fix

Test-only, two commits.

**Commit 1 — lib builder tests (`config.rs`).** A tests-module helper `isolated_config_entry()` returns a `configuration` worker entry whose fs adapter points at a throwaway `tempfile::TempDir` (the adapter already supports an explicit `directory:` override; the helper references `fs::ADAPTER_NAME` rather than a string literal). All nine `build()`-calling builder tests pre-add that entry; mandatory injection skips workers already declared, so nothing is double-booted. `with_config()` replaces the builder config, so the three sites using it add the entry after it. Builder tests that never call `build()` are untouched, as is the production default directory.

**Commit 2 — integration test binaries.** Same isolation for every `tests/*.rs` binary that boots engines:

- `builtin_functions_e2e`: `boot_bare_engine()` declares a tempdir-backed `configuration` worker and returns the `TempDir` alongside the builder (7 call sites).
- `iii_queue_optin_registration`: same entry added inline.
- `reload_scope_unit`: an `isolated_config_entry()` helper feeds the minimal-config helper, the `default_config()` boot (mutate-or-push of the existing `configuration` entry), and the SIGTERM test's inline config.
- `reload_manager_unit`: `minimal_config()` carries the entry and returns the `TempDir`.
- `config_reload_e2e`: `minimal_config_yaml()` is parameterized with a per-test store dir and the `configuration` worker block, and **every yaml revision the reload tests write keeps that entry** — reload re-reads the file, so a revision without it would re-inject the mandatory configuration worker with its default `./config` store mid-test.

Needs no change: `worker_trigger_e2e` already chdirs into a tempdir for its whole run, and the per-worker `*_configuration_e2e` suites already build `FsAdapter` against tempdirs via `ConfigurationWorker::for_test`.

## Verification

- The previously flaky test passes on two consecutive runs (was: pass, then fail).
- `workers::config` module: 147 passed, twice consecutively.
- Full engine lib suite: 1988 passed, 0 failed, twice consecutively.
- All five modified integration binaries plus `worker_trigger_e2e`: green on two consecutive runs (`config_reload_e2e` 6, `builtin_functions_e2e` 7, `iii_queue_optin_registration` 1, `reload_scope_unit` 8, `reload_manager_unit` 11).
- `ls engine/config` after lib and integration runs: no such directory — the residue is gone.
- `cargo fmt` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by giving configuration-related tests temporary, independent storage.
  * Prevented test runs from sharing persisted configuration or affecting repository files.
  * Expanded isolation across engine startup, reload, failure-handling, queue registration, and shutdown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->