### PR TITLE
(MOT-4412) fix(engine): quarantine stale managed workers

### DIFF
--- a/crates/iii-worker/src/cli/engine_identity.rs
+++ b/crates/iii-worker/src/cli/engine_identity.rs
@@ -1,0 +1,60 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+use std::collections::HashMap;
+
+pub const ENGINE_RUN_ID_ENV: &str = "III_ENGINE_RUN_ID";
+
+pub fn engine_run_id() -> Option<String> {
+    std::env::var(ENGINE_RUN_ID_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+pub fn managed_engine_url(engine_url: impl Into<String>) -> String {
+    let run_id = engine_run_id();
+    managed_engine_url_with_run_id(engine_url.into(), run_id.as_deref())
+}
+
+fn managed_engine_url_with_run_id(mut engine_url: String, run_id: Option<&str>) -> String {
+    let Some(run_id) = run_id else {
+        return engine_url;
+    };
+
+    let separator = if engine_url.contains('?') { '&' } else { '?' };
+    engine_url.push(separator);
+    engine_url.push_str("engine_run_id=");
+    engine_url.push_str(&run_id);
+    engine_url
+}
+
+pub fn insert_engine_run_id(env: &mut HashMap<String, String>) {
+    if let Some(run_id) = engine_run_id() {
+        env.insert(ENGINE_RUN_ID_ENV.to_string(), run_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn appends_run_identity_and_preserves_existing_query() {
+        assert_eq!(
+            managed_engine_url_with_run_id("ws://host:49134".into(), Some("run-1")),
+            "ws://host:49134?engine_run_id=run-1"
+        );
+        assert_eq!(
+            managed_engine_url_with_run_id("ws://host:49134?token=x".into(), Some("run-1")),
+            "ws://host:49134?token=x&engine_run_id=run-1"
+        );
+        assert_eq!(
+            managed_engine_url_with_run_id("ws://host:49134".into(), None),
+            "ws://host:49134"
+        );
+    }
+}

--- a/crates/iii-worker/src/cli/lifecycle.rs
+++ b/crates/iii-worker/src/cli/lifecycle.rs
@@ -9,7 +9,7 @@
 use super::worker_manager::adapter::ContainerSpec;
 use super::worker_manager::state::WorkerDef;
 
-pub fn build_container_spec(name: &str, def: &WorkerDef, _engine_url: &str) -> ContainerSpec {
+pub fn build_container_spec(name: &str, def: &WorkerDef, engine_url: &str) -> ContainerSpec {
     match def {
         WorkerDef::Managed {
             image,
@@ -25,6 +25,9 @@ pub fn build_container_spec(name: &str, def: &WorkerDef, _engine_url: &str) -> C
                 // connections by this name. Not overridable via worker env —
                 // identity comes from the config entry.
                 env.insert("III_WORKER_NAME".to_string(), name.to_string());
+                env.insert("III_ENGINE_URL".to_string(), engine_url.to_string());
+                env.insert("III_URL".to_string(), engine_url.to_string());
+                super::engine_identity::insert_engine_run_id(&mut env);
                 env
             },
             memory_limit: resources.as_ref().and_then(|r| r.memory.clone()),

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -371,7 +371,11 @@ echo "iii: workspace ready; deps mounted VM-local from $DEPS_ROOT" >&2"#
 pub fn build_env_exports(env: &HashMap<String, String>) -> String {
     let mut parts: Vec<String> = Vec::new();
     for (k, v) in env {
-        if k == "III_ENGINE_URL" || k == "III_URL" || k == "III_WORKER_NAME" {
+        if k == "III_ENGINE_URL"
+            || k == "III_URL"
+            || k == "III_WORKER_NAME"
+            || k == super::engine_identity::ENGINE_RUN_ID_ENV
+        {
             continue;
         }
         if !k.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') || k.is_empty() {
@@ -404,10 +408,15 @@ pub fn build_local_env(
     // `hostname:pid` fallback instead reads as "not registered" forever.
     env.insert("III_WORKER_NAME".to_string(), worker_name.to_string());
     for (key, value) in project_env {
-        if key != "III_ENGINE_URL" && key != "III_URL" && key != "III_WORKER_NAME" {
+        if key != "III_ENGINE_URL"
+            && key != "III_URL"
+            && key != "III_WORKER_NAME"
+            && key != super::engine_identity::ENGINE_RUN_ID_ENV
+        {
             env.insert(key.clone(), value.clone());
         }
     }
+    super::engine_identity::insert_engine_run_id(&mut env);
     env
 }
 
@@ -1163,7 +1172,9 @@ async fn start_worker_impl(
     let is_prepared = prepared_marker.exists();
 
     // 6. Build env with engine URL + OCI env + config.yaml env
-    let engine_url = engine_url_for_runtime("libkrun", "0.0.0.0", port, &None);
+    let engine_url = super::engine_identity::managed_engine_url(engine_url_for_runtime(
+        "libkrun", "0.0.0.0", port, &None,
+    ));
     let config_env = super::config_file::get_worker_config_as_env(worker_name);
 
     let mut combined_project_env = project.env.clone();

--- a/crates/iii-worker/src/cli/managed.rs
+++ b/crates/iii-worker/src/cli/managed.rs
@@ -3831,7 +3831,7 @@ async fn start_oci_worker(worker_name: &str, worker_def: &WorkerDef, port: u16) 
     let adapter = super::worker_manager::create_adapter("libkrun");
     eprintln!("  Starting {} (OCI)...", worker_name.bold());
 
-    let engine_url = format!("ws://localhost:{}", port);
+    let engine_url = super::engine_identity::managed_engine_url(format!("ws://localhost:{}", port));
     let spec = build_container_spec(worker_name, worker_def, &engine_url);
 
     let pid_file = dirs::home_dir()
@@ -3911,9 +3911,12 @@ async fn start_binary_worker(
     // are engine-set). Without these a registry binary on a non-default
     // manager port dials its compiled-in ws://127.0.0.1:49134 default and
     // strands retrying (iii-hq/workers#526).
-    let engine_url = format!("ws://127.0.0.1:{}", port);
+    let engine_url = super::engine_identity::managed_engine_url(format!("ws://127.0.0.1:{}", port));
     cmd.env("III_ENGINE_URL", &engine_url);
     cmd.env("III_URL", &engine_url);
+    if let Some(run_id) = super::engine_identity::engine_run_id() {
+        cmd.env(super::engine_identity::ENGINE_RUN_ID_ENV, run_id);
+    }
     cmd.stdout(stdout_file).stderr(stderr_file);
 
     #[cfg(unix)]

--- a/crates/iii-worker/src/cli/mod.rs
+++ b/crates/iii-worker/src/cli/mod.rs
@@ -10,6 +10,7 @@ pub mod builtin_defaults;
 pub mod bundle_download;
 pub mod config_file;
 pub mod download;
+pub mod engine_identity;
 pub mod erofs;
 pub mod firmware;
 pub mod gen_docs;

--- a/crates/iii-worker/src/cli/project.rs
+++ b/crates/iii-worker/src/cli/project.rs
@@ -421,7 +421,10 @@ pub fn load_from_manifest(manifest_path: &std::path::Path) -> Option<ProjectInfo
     let mut env = HashMap::new();
     if let Some(env_map) = &manifest.env {
         for (key, val) in env_map {
-            if key != "III_URL" && key != "III_ENGINE_URL" {
+            if key != "III_URL"
+                && key != "III_ENGINE_URL"
+                && key != super::engine_identity::ENGINE_RUN_ID_ENV
+            {
                 env.insert(key.clone(), val.clone());
             }
         }

--- a/crates/iii-worker/src/cli/worker_manifest.rs
+++ b/crates/iii-worker/src/cli/worker_manifest.rs
@@ -80,7 +80,7 @@ pub struct WorkerManifest {
     pub scripts: Option<ScriptsSection>,
 
     #[schemars(
-        description = "Optional string->string env vars injected into the worker process. III_URL / III_ENGINE_URL are set by the engine and ignored here."
+        description = "Optional string->string env vars injected into the worker process. III_URL, III_ENGINE_URL, and III_ENGINE_RUN_ID are set by the engine and ignored here."
     )]
     pub env: Option<BTreeMap<String, String>>,
 

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -30,7 +30,10 @@ use crate::{
         inject_traceparent_from_context,
     },
     trigger::{Trigger, TriggerRegistry, TriggerType},
-    worker_connections::{RuntimeWorkerInfo, WorkerConnection, WorkerConnectionRegistry},
+    worker_connections::{
+        RuntimeWorkerInfo, WorkerAuthority, WorkerConnection, WorkerConnectionRegistry,
+        WorkerIdentityConflict,
+    },
     workers::worker::rbac_session::Session,
     workers::{
         engine_fn::TRIGGER_WORKERS_AVAILABLE,
@@ -55,6 +58,21 @@ const REATTACH_EVICT_TIMEOUT: std::time::Duration = std::time::Duration::from_se
 /// actions. The engine owns receipt generation and uses this function only as
 /// the durable transport boundary.
 const ENQUEUE_PROVIDER_FUNCTION_ID: &str = "engine::queue::enqueue";
+
+fn worker_authority_from_uri(uri: &Uri, current_run_id: Uuid) -> WorkerAuthority {
+    let managed_run_id = uri.query().and_then(|query| {
+        query.split('&').find_map(|pair| {
+            pair.strip_prefix("engine_run_id=")
+                .and_then(|value| Uuid::parse_str(value).ok())
+        })
+    });
+
+    if managed_run_id == Some(current_run_id) {
+        WorkerAuthority::CurrentManaged
+    } else {
+        WorkerAuthority::Unscoped
+    }
+}
 
 /// Handles binary frames with OTEL telemetry prefixes.
 /// Returns true if the frame was handled (matched a known prefix), false otherwise.
@@ -216,6 +234,10 @@ pub trait EngineTrait: Send + Sync {
 
 #[derive(Clone)]
 pub struct Engine {
+    /// Ephemeral identity for this engine process. Managed workers receive it
+    /// through a reserved environment variable and echo it in their WS URL,
+    /// allowing a restarted engine to distinguish its children from orphans.
+    run_id: Uuid,
     pub worker_registry: Arc<WorkerConnectionRegistry>,
     pub runtime_workers: Arc<DashMap<String, RuntimeWorkerInfo>>,
     pub functions: Arc<FunctionsRegistry>,
@@ -248,6 +270,15 @@ pub struct Engine {
     config_path: Arc<std::sync::OnceLock<std::path::PathBuf>>,
 }
 
+enum OwnershipClaim {
+    Accepted {
+        previous_to_quarantine: Option<WorkerConnection>,
+    },
+    Rejected {
+        current: WorkerConnection,
+    },
+}
+
 fn resolve_registration_id(worker: &WorkerConnection, id: &str) -> String {
     if let Some(prefix) = worker
         .session
@@ -270,6 +301,7 @@ impl Engine {
     pub fn new() -> Self {
         let active_scope = Arc::new(std::sync::Mutex::new(None));
         Self {
+            run_id: Uuid::new_v4(),
             worker_registry: Arc::new(WorkerConnectionRegistry::new()),
             runtime_workers: Arc::new(DashMap::new()),
             functions: Arc::new(FunctionsRegistry::with_scope(active_scope.clone())),
@@ -283,6 +315,10 @@ impl Engine {
             worker_manager_port: Arc::new(std::sync::OnceLock::new()),
             config_path: Arc::new(std::sync::OnceLock::new()),
         }
+    }
+
+    pub fn run_id(&self) -> Uuid {
+        self.run_id
     }
 
     /// Returns the effective `iii-worker-manager` port. Resolved from config
@@ -594,6 +630,87 @@ impl Engine {
 
     #[doc(hidden)]
     pub async fn router_msg(&self, worker: &WorkerConnection, msg: &Message) -> anyhow::Result<()> {
+        if worker.authority() == WorkerAuthority::Quarantined {
+            let conflict = worker.identity_conflict();
+            let message = conflict.as_ref().map_or_else(
+                || "This worker connection is quarantined after an identity conflict.".to_string(),
+                |conflict| {
+                    let current = conflict
+                        .current_worker_name
+                        .as_deref()
+                        .unwrap_or(&conflict.current_worker_id);
+                    format!(
+                        "This worker is quarantined because function '{}' is owned by the current managed worker '{}'. Stop the duplicate process, then restart iii if the conflict remains.",
+                        conflict.function_id, current
+                    )
+                },
+            );
+            let error = ErrorBody::new("engine/worker_identity_conflict", message);
+
+            match msg {
+                // Metadata remains available so Console can show the worker's
+                // name, pid, runtime, and recovery guidance.
+                Message::InvokeFunction { function_id, .. }
+                    if function_id == "engine::workers::register" => {}
+                Message::InvokeFunction {
+                    invocation_id,
+                    function_id,
+                    traceparent,
+                    baggage,
+                    ..
+                } => {
+                    self.send_msg(
+                        worker,
+                        Message::InvocationResult {
+                            invocation_id: (*invocation_id).unwrap_or_else(Uuid::new_v4),
+                            function_id: function_id.clone(),
+                            result: None,
+                            error: Some(error),
+                            traceparent: traceparent.clone(),
+                            baggage: baggage.clone(),
+                        },
+                    )
+                    .await;
+                    return Ok(());
+                }
+                Message::RegisterTrigger {
+                    id,
+                    trigger_type,
+                    function_id,
+                    ..
+                } => {
+                    self.send_msg(
+                        worker,
+                        Message::TriggerRegistrationResult {
+                            id: id.clone(),
+                            trigger_type: trigger_type.clone(),
+                            function_id: function_id.clone(),
+                            error: Some(error),
+                        },
+                    )
+                    .await;
+                    return Ok(());
+                }
+                Message::RegisterFunction { .. }
+                | Message::UnregisterFunction { .. }
+                | Message::RegisterTriggerType { .. }
+                | Message::UnregisterTrigger { .. }
+                | Message::RegisterService { .. }
+                | Message::Reattach { .. } => {
+                    tracing::warn!(
+                        worker_id = %worker.id,
+                        "Ignoring business registration from quarantined worker"
+                    );
+                    return Ok(());
+                }
+                Message::TriggerRegistrationResult { .. }
+                | Message::InvocationResult { .. }
+                | Message::Ping
+                | Message::Pong
+                | Message::WorkerRegistered { .. } => {}
+            }
+        }
+
         match msg {
             Message::TriggerRegistrationResult {
                 id,
@@ -1347,10 +1464,13 @@ impl Engine {
                 // id, and tear down the registration we're about to write.
                 // Claiming first makes the CAS release in cleanup see the new
                 // owner and bail out for every subsequent step.
-                if invocation.is_some() {
-                    self.claim_external_function(worker.id, &reg_id);
+                let claimed = if invocation.is_some() {
+                    self.claim_external_function(worker, &reg_id).await
                 } else {
-                    self.claim_function(worker.id, &reg_id);
+                    self.claim_function(worker, &reg_id).await
+                };
+                if !claimed {
+                    return Ok(());
                 }
 
                 self.service_registry
@@ -1566,6 +1686,7 @@ impl Engine {
     ) -> anyhow::Result<()> {
         tracing::debug!(peer = %peer, "Worker connected via WebSocket");
         let (mut ws_tx, mut ws_rx) = socket.split();
+        let authority = worker_authority_from_uri(&uri, self.run_id);
 
         let session =
             match rbac_session::handle_session(peer, Arc::new(self.clone()), config, uri, headers)
@@ -1606,7 +1727,7 @@ impl Engine {
             }
         });
 
-        let worker = WorkerConnection::with_session(tx.clone(), session);
+        let worker = WorkerConnection::with_session_and_authority(tx.clone(), session, authority);
         // Mark before registering: from the moment this connection is
         // discoverable, a Reattach targeting it can rely on this read loop
         // to exit on eviction and run the cleanup.
@@ -1614,7 +1735,7 @@ impl Engine {
             .has_reader
             .store(true, std::sync::atomic::Ordering::SeqCst);
 
-        tracing::debug!(worker_id = %worker.id, peer = %peer, "Assigned worker ID");
+        tracing::debug!(worker_id = %worker.id, peer = %peer, authority = worker.authority().as_str(), "Assigned worker ID");
         self.worker_registry.register_worker(worker.clone());
 
         // Send worker ID back to the worker, along with the secret it must
@@ -1770,6 +1891,128 @@ impl Engine {
         Ok(())
     }
 
+    async fn remove_worker_business_state(
+        &self,
+        worker: &WorkerConnection,
+        clear_local_state: bool,
+    ) {
+        let mut regular_functions: std::collections::HashSet<String> = worker
+            .get_regular_function_ids()
+            .await
+            .into_iter()
+            .collect();
+        regular_functions.extend(
+            self.function_owners
+                .iter()
+                .filter(|entry| *entry.value() == worker.id)
+                .map(|entry| entry.key().clone()),
+        );
+
+        let mut external_functions: std::collections::HashSet<String> = worker
+            .get_external_function_ids()
+            .await
+            .into_iter()
+            .collect();
+        external_functions.extend(
+            self.external_function_owners
+                .iter()
+                .filter(|entry| *entry.value() == worker.id)
+                .map(|entry| entry.key().clone()),
+        );
+
+        if clear_local_state {
+            worker.function_ids.write().await.clear();
+            worker.external_function_ids.write().await.clear();
+        }
+
+        tracing::debug!(worker_id = %worker.id, functions = ?regular_functions, "Removing worker business registrations");
+        for function_id in &regular_functions {
+            if !self.release_function_if_owner(&worker.id, function_id) {
+                tracing::debug!(
+                    worker_id = %worker.id,
+                    function_id = %function_id,
+                    "Skipping function removal — owner changed"
+                );
+            }
+        }
+
+        if !external_functions.is_empty() {
+            let http_module = self
+                .service_registry
+                .get_service::<HttpFunctionsWorker>("http_functions");
+            for function_id in &external_functions {
+                if self
+                    .external_function_owners
+                    .get(function_id)
+                    .is_none_or(|owner| *owner != worker.id)
+                {
+                    continue;
+                }
+
+                match &http_module {
+                    Some(module) => {
+                        if let Err(err) = module.unregister_http_function(function_id).await {
+                            tracing::error!(
+                                worker_id = %worker.id,
+                                function_id = %function_id,
+                                error = ?err,
+                                "Failed to unregister external function"
+                            );
+                            self.remove_function(function_id);
+                        }
+                        if self
+                            .external_function_owners
+                            .get(function_id)
+                            .is_some_and(|owner| *owner == worker.id)
+                        {
+                            self.service_registry
+                                .remove_function_from_services(function_id);
+                        }
+                    }
+                    None => self.remove_function_from_engine(function_id),
+                }
+                self.external_function_owners
+                    .remove_if(function_id, |_, owner| *owner == worker.id);
+            }
+        }
+
+        let worker_invocations: Vec<Uuid> =
+            worker.invocations.read().await.iter().copied().collect();
+        if clear_local_state {
+            worker.invocations.write().await.clear();
+        }
+        for invocation_id in worker_invocations {
+            tracing::debug!(invocation_id = %invocation_id, "Halting invocation");
+            self.invocations.halt_invocation(&invocation_id);
+        }
+
+        self.trigger_registry.unregister_worker(&worker.id).await;
+        self.channel_manager.remove_channels_by_worker(&worker.id);
+    }
+
+    async fn quarantine_worker(&self, worker: &WorkerConnection, conflict: WorkerIdentityConflict) {
+        if !worker.quarantine(conflict.clone()) {
+            return;
+        }
+
+        tracing::warn!(
+            worker_id = %worker.id,
+            worker_name = ?worker.name,
+            function_id = %conflict.function_id,
+            current_worker_id = %conflict.current_worker_id,
+            "Worker quarantined after managed identity conflict"
+        );
+        self.remove_worker_business_state(worker, true).await;
+
+        let workers_data = serde_json::json!({
+            "event": "worker_identity_conflict",
+            "worker_id": worker.id.to_string(),
+            "conflict": conflict,
+        });
+        self.fire_triggers(TRIGGER_WORKERS_AVAILABLE, workers_data)
+            .await;
+    }
+
     async fn cleanup_worker(&self, worker: &WorkerConnection) {
         // Run this connection's teardown exactly once, with COMPLETION
         // visible to every caller: the loser of the claim waits for the
@@ -1789,88 +2032,7 @@ impl Engine {
             return;
         }
 
-        let regular_functions = worker.get_regular_function_ids().await;
-        let external_functions = worker.get_external_function_ids().await;
-
-        tracing::debug!(worker_id = %worker.id, functions = ?regular_functions, "Worker registered functions");
-        for function_id in regular_functions.iter() {
-            if !self.release_function_if_owner(&worker.id, function_id) {
-                tracing::debug!(
-                    worker_id = %worker.id,
-                    function_id = %function_id,
-                    "Skipping function removal — owner changed (another worker registered after)"
-                );
-            }
-        }
-
-        if !external_functions.is_empty() {
-            let http_module = self
-                .service_registry
-                .get_service::<HttpFunctionsWorker>("http_functions");
-            for function_id in external_functions.iter() {
-                // Snapshot ownership without releasing — releasing first would
-                // open a window where a racing `RegisterFunction` can claim
-                // ownership mid-teardown, and the remaining teardown steps
-                // (service_registry + http_module) would then wipe the new
-                // owner's fresh state. Keep ownership through teardown and
-                // CAS-release at the end so a racing claim reliably aborts
-                // us at the next ownership check.
-                if self
-                    .external_function_owners
-                    .get(function_id)
-                    .is_none_or(|r| *r != worker.id)
-                {
-                    tracing::debug!(
-                        worker_id = %worker.id,
-                        function_id = %function_id,
-                        "Skipping external function removal — owner changed"
-                    );
-                    continue;
-                }
-                match &http_module {
-                    Some(module) => {
-                        if let Err(err) = module.unregister_http_function(function_id).await {
-                            tracing::error!(
-                                worker_id = %worker.id,
-                                function_id = %function_id,
-                                error = ?err,
-                                "Failed to unregister external function during worker cleanup"
-                            );
-                            self.remove_function(function_id);
-                        }
-                        // Re-check before wiping service_registry: the
-                        // `.await` above is a yield point a racing claim can
-                        // slip through, and service_registry is shared with
-                        // the claimant's setup path (router_msg populates it
-                        // before claim completes).
-                        if self
-                            .external_function_owners
-                            .get(function_id)
-                            .is_some_and(|r| *r == worker.id)
-                        {
-                            self.service_registry
-                                .remove_function_from_services(function_id);
-                        }
-                    }
-                    None => self.remove_function_from_engine(function_id),
-                }
-                // CAS-release ownership. A racing claim will have overwritten
-                // the entry with a new owner id; that predicate fails and we
-                // leave their ownership intact.
-                self.external_function_owners
-                    .remove_if(function_id, |_, owner| *owner == worker.id);
-            }
-        }
-
-        let worker_invocations = worker.invocations.read().await;
-        tracing::debug!(worker_id = %worker.id, invocations = ?worker_invocations, "Worker invocations");
-        for invocation_id in worker_invocations.iter() {
-            tracing::debug!(invocation_id = %invocation_id, "Halting invocation");
-            self.invocations.halt_invocation(invocation_id);
-        }
-
-        self.trigger_registry.unregister_worker(&worker.id).await;
-        self.channel_manager.remove_channels_by_worker(&worker.id);
+        self.remove_worker_business_state(worker, false).await;
         self.worker_registry.unregister_worker(&worker.id);
 
         let workers_data = serde_json::json!({
@@ -1884,42 +2046,133 @@ impl Engine {
         tracing::debug!(worker_id = %worker.id, "Worker triggers unregistered");
     }
 
-    /// Records `worker_id` as the current owner of `function_id`. Logs a warning
-    /// when the previous owner was a different worker still in the registry —
-    /// that is the cross-worker overwrite shape that, post-defensive-cleanup,
-    /// can leave a hijacked entry behind. Operators can grep for this WARN
-    /// to detect potential function-id squatting.
-    fn claim_function(&self, worker_id: Uuid, function_id: &str) {
-        if let Some(previous) = self
-            .function_owners
-            .insert(function_id.to_string(), worker_id)
-            && previous != worker_id
-            && self.worker_registry.workers.contains_key(&previous)
-        {
-            tracing::warn!(
-                new_owner = %worker_id,
-                previous_owner = %previous,
-                function_id = %function_id,
-                "Function ownership transferred between two live workers — possible cross-worker overwrite"
-            );
+    fn identity_conflict(function_id: &str, current: &WorkerConnection) -> WorkerIdentityConflict {
+        WorkerIdentityConflict {
+            function_id: function_id.to_string(),
+            current_worker_id: current.id.to_string(),
+            current_worker_name: current.name.clone(),
+            current_worker_pid: current.pid,
         }
     }
 
-    /// HTTP-invocation variant of `claim_function`.
-    fn claim_external_function(&self, worker_id: Uuid, function_id: &str) {
-        if let Some(previous) = self
-            .external_function_owners
-            .insert(function_id.to_string(), worker_id)
-            && previous != worker_id
-            && self.worker_registry.workers.contains_key(&previous)
-        {
-            tracing::warn!(
-                new_owner = %worker_id,
-                previous_owner = %previous,
-                function_id = %function_id,
-                "External function ownership transferred between two live workers — possible cross-worker overwrite"
-            );
+    fn claim_owner(
+        &self,
+        owners: &DashMap<String, Uuid>,
+        worker: &WorkerConnection,
+        function_id: &str,
+    ) -> OwnershipClaim {
+        use dashmap::mapref::entry::Entry;
+
+        if worker.authority() == WorkerAuthority::Quarantined {
+            return OwnershipClaim::Rejected {
+                current: worker.clone(),
+            };
         }
+
+        match owners.entry(function_id.to_string()) {
+            Entry::Vacant(entry) => {
+                // Re-check after taking the shard lock: another function's
+                // collision can quarantine this connection concurrently.
+                if worker.authority() == WorkerAuthority::Quarantined {
+                    return OwnershipClaim::Rejected {
+                        current: worker.clone(),
+                    };
+                }
+                entry.insert(worker.id);
+                OwnershipClaim::Accepted {
+                    previous_to_quarantine: None,
+                }
+            }
+            Entry::Occupied(entry) if *entry.get() == worker.id => OwnershipClaim::Accepted {
+                previous_to_quarantine: None,
+            },
+            Entry::Occupied(mut entry) => {
+                let previous_id = *entry.get();
+                let previous = self.worker_registry.get_worker(&previous_id);
+
+                if worker.authority() == WorkerAuthority::Quarantined {
+                    return OwnershipClaim::Rejected {
+                        current: previous.unwrap_or_else(|| worker.clone()),
+                    };
+                }
+
+                if worker.authority() == WorkerAuthority::Unscoped
+                    && previous
+                        .as_ref()
+                        .is_some_and(|owner| owner.authority() == WorkerAuthority::CurrentManaged)
+                {
+                    return OwnershipClaim::Rejected {
+                        current: previous.expect("checked as present"),
+                    };
+                }
+
+                entry.insert(worker.id);
+                let previous_to_quarantine =
+                    if worker.authority() == WorkerAuthority::CurrentManaged {
+                        previous
+                    } else {
+                        None
+                    };
+
+                if previous_to_quarantine.is_none()
+                    && self.worker_registry.workers.contains_key(&previous_id)
+                {
+                    tracing::warn!(
+                        new_owner = %worker.id,
+                        previous_owner = %previous_id,
+                        function_id = %function_id,
+                        "Function ownership transferred between two unscoped live workers"
+                    );
+                }
+
+                OwnershipClaim::Accepted {
+                    previous_to_quarantine,
+                }
+            }
+        }
+    }
+
+    async fn finish_owner_claim(
+        &self,
+        owners: &DashMap<String, Uuid>,
+        worker: &WorkerConnection,
+        function_id: &str,
+        claim: OwnershipClaim,
+    ) -> bool {
+        match claim {
+            OwnershipClaim::Accepted {
+                previous_to_quarantine,
+            } => {
+                if let Some(previous) = previous_to_quarantine {
+                    let conflict = Self::identity_conflict(function_id, worker);
+                    self.quarantine_worker(&previous, conflict).await;
+                }
+                // Quarantining the previous owner yields. A third connection
+                // may win the same id during that await, so only the worker
+                // that still owns the map entry may publish global state.
+                worker.authority() != WorkerAuthority::Quarantined
+                    && owners
+                        .get(function_id)
+                        .is_some_and(|owner| *owner == worker.id)
+            }
+            OwnershipClaim::Rejected { current } => {
+                let conflict = Self::identity_conflict(function_id, &current);
+                self.quarantine_worker(worker, conflict).await;
+                false
+            }
+        }
+    }
+
+    async fn claim_function(&self, worker: &WorkerConnection, function_id: &str) -> bool {
+        let claim = self.claim_owner(&self.function_owners, worker, function_id);
+        self.finish_owner_claim(&self.function_owners, worker, function_id, claim)
+            .await
+    }
+
+    async fn claim_external_function(&self, worker: &WorkerConnection, function_id: &str) -> bool {
+        let claim = self.claim_owner(&self.external_function_owners, worker, function_id);
+        self.finish_owner_claim(&self.external_function_owners, worker, function_id, claim)
+            .await
     }
 
     /// Atomically removes `function_id` from the engine ONLY if `worker_id`
@@ -2141,12 +2394,13 @@ mod tests {
     use serde::Serialize;
     use serde_json::json;
     use tokio::sync::mpsc;
+    use uuid::Uuid;
 
     use crate::{
         config::SecurityConfig,
         function::FunctionResult,
         protocol::{HttpInvocationRef, Message},
-        worker_connections::WorkerConnection,
+        worker_connections::{WorkerAuthority, WorkerConnection},
         workers::{
             engine_fn::TRIGGER_WORKERS_AVAILABLE,
             http_functions::{HttpFunctionsWorker, config::HttpFunctionsConfig},
@@ -2176,6 +2430,28 @@ mod tests {
         {
             Err(serde::ser::Error::custom("serialization exploded"))
         }
+    }
+
+    #[test]
+    fn websocket_run_identity_selects_managed_authority() {
+        let current = Uuid::new_v4();
+        let stale = Uuid::new_v4();
+        let current_uri = format!("/ws?engine_run_id={current}").parse().unwrap();
+        let stale_uri = format!("/ws?engine_run_id={stale}").parse().unwrap();
+        let missing_uri = "/ws".parse().unwrap();
+
+        assert_eq!(
+            super::worker_authority_from_uri(&current_uri, current),
+            WorkerAuthority::CurrentManaged
+        );
+        assert_eq!(
+            super::worker_authority_from_uri(&stale_uri, current),
+            WorkerAuthority::Unscoped
+        );
+        assert_eq!(
+            super::worker_authority_from_uri(&missing_uri, current),
+            WorkerAuthority::Unscoped
+        );
     }
 
     #[test]
@@ -3274,7 +3550,11 @@ mod tests {
         // Ownership gate on UnregisterFunction requires the worker to be the
         // recorded owner. This test sidesteps `router_msg` to seed state, so
         // populate the owner map directly to match the production invariant.
-        engine.claim_external_function(worker.id, "external.cleanup");
+        assert!(
+            engine
+                .claim_external_function(&worker, "external.cleanup")
+                .await
+        );
 
         engine
             .router_msg(
@@ -4696,6 +4976,113 @@ mod tests {
             engine.external_function_owners.contains_key("ext_fn"),
             "external ownership entry for the WS worker must be intact"
         );
+    }
+
+    #[tokio::test]
+    async fn current_managed_worker_replaces_and_quarantines_stale_owner() {
+        ensure_default_meter();
+        let engine = Engine::new();
+        let register = |id: &str| Message::RegisterFunction {
+            id: id.to_string(),
+            description: None,
+            request_format: None,
+            response_format: None,
+            metadata: None,
+            invocation: None,
+        };
+
+        let (stale_tx, _stale_rx) = mpsc::channel::<Outbound>(8);
+        let stale = WorkerConnection::new_with_authority(stale_tx, WorkerAuthority::Unscoped);
+        engine.worker_registry.register_worker(stale.clone());
+        engine
+            .router_msg(&stale, &register("provider::kimi::stream"))
+            .await
+            .unwrap();
+        engine
+            .router_msg(&stale, &register("provider::kimi::old_only"))
+            .await
+            .unwrap();
+
+        let (current_tx, _current_rx) = mpsc::channel::<Outbound>(8);
+        let current =
+            WorkerConnection::new_with_authority(current_tx, WorkerAuthority::CurrentManaged);
+        engine.worker_registry.register_worker(current.clone());
+        engine
+            .router_msg(&current, &register("provider::kimi::stream"))
+            .await
+            .unwrap();
+
+        assert_eq!(stale.authority(), WorkerAuthority::Quarantined);
+        assert!(stale.identity_conflict().is_some());
+        assert_eq!(
+            *engine
+                .function_owners
+                .get("provider::kimi::stream")
+                .unwrap(),
+            current.id
+        );
+        assert!(engine.functions.get("provider::kimi::old_only").is_none());
+        assert!(engine.worker_registry.get_worker(&stale.id).is_some());
+        assert_eq!(stale.function_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn unscoped_worker_cannot_replace_current_managed_owner() {
+        ensure_default_meter();
+        let engine = Engine::new();
+        let register = Message::RegisterFunction {
+            id: "provider::kimi::stream".to_string(),
+            description: None,
+            request_format: None,
+            response_format: None,
+            metadata: None,
+            invocation: None,
+        };
+
+        let (current_tx, _current_rx) = mpsc::channel::<Outbound>(8);
+        let current =
+            WorkerConnection::new_with_authority(current_tx, WorkerAuthority::CurrentManaged);
+        engine.worker_registry.register_worker(current.clone());
+        engine.router_msg(&current, &register).await.unwrap();
+
+        let (stale_tx, mut stale_rx) = mpsc::channel::<Outbound>(8);
+        let stale = WorkerConnection::new_with_authority(stale_tx, WorkerAuthority::Unscoped);
+        engine.worker_registry.register_worker(stale.clone());
+        engine.router_msg(&stale, &register).await.unwrap();
+
+        assert_eq!(stale.authority(), WorkerAuthority::Quarantined);
+        assert_eq!(
+            *engine
+                .function_owners
+                .get("provider::kimi::stream")
+                .unwrap(),
+            current.id
+        );
+
+        engine
+            .router_msg(
+                &stale,
+                &Message::InvokeFunction {
+                    invocation_id: Some(Uuid::new_v4()),
+                    function_id: "router::provider::register".to_string(),
+                    data: json!({}),
+                    traceparent: None,
+                    baggage: None,
+                    action: None,
+                    metadata: None,
+                },
+            )
+            .await
+            .unwrap();
+        match stale_rx.recv().await {
+            Some(Outbound::Protocol(Message::InvocationResult { error, .. })) => {
+                assert_eq!(
+                    error.expect("identity error").code,
+                    "engine/worker_identity_conflict"
+                );
+            }
+            other => panic!("expected identity conflict response, got {other:?}"),
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/engine/src/worker_connections/mod.rs
+++ b/engine/src/worker_connections/mod.rs
@@ -9,7 +9,10 @@ pub mod traits;
 use std::{
     collections::HashSet,
     str::FromStr,
-    sync::{Arc, atomic::AtomicBool},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU8, Ordering},
+    },
 };
 
 use chrono::{DateTime, Utc};
@@ -32,6 +35,50 @@ pub struct WorkerConnectionTelemetryMeta {
     pub language: Option<String>,
     pub project_name: Option<String>,
     pub framework: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkerAuthority {
+    CurrentManaged,
+    Unscoped,
+    Quarantined,
+}
+
+impl WorkerAuthority {
+    const fn as_u8(self) -> u8 {
+        match self {
+            Self::CurrentManaged => 0,
+            Self::Unscoped => 1,
+            Self::Quarantined => 2,
+        }
+    }
+
+    fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::CurrentManaged,
+            2 => Self::Quarantined,
+            _ => Self::Unscoped,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CurrentManaged => "current_managed",
+            Self::Unscoped => "unscoped",
+            Self::Quarantined => "quarantined",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+pub struct WorkerIdentityConflict {
+    pub function_id: String,
+    pub current_worker_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_worker_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_worker_pid: Option<u32>,
 }
 
 #[derive(Clone, Debug)]
@@ -245,6 +292,8 @@ pub struct WorkerConnection {
     pub pid: Option<u32>,
     pub isolation: Option<String>,
     pub session: Option<Arc<Session>>,
+    authority: Arc<AtomicU8>,
+    identity_conflict: Arc<std::sync::RwLock<Option<WorkerIdentityConflict>>>,
     /// In-flight `Message::RegisterTrigger` deliveries awaiting this worker's
     /// `TriggerRegistrationResult` ack, keyed by trigger id. Only ownerless
     /// (function-path) registrations wait on an entry here — see the
@@ -278,6 +327,10 @@ pub struct WorkerConnection {
 
 impl WorkerConnection {
     pub fn new(channel: mpsc::Sender<Outbound>) -> Self {
+        Self::new_with_authority(channel, WorkerAuthority::Unscoped)
+    }
+
+    pub fn new_with_authority(channel: mpsc::Sender<Outbound>, authority: WorkerAuthority) -> Self {
         let id = Uuid::new_v4();
         Self {
             id,
@@ -296,6 +349,8 @@ impl WorkerConnection {
             pid: None,
             isolation: None,
             session: None,
+            authority: Arc::new(AtomicU8::new(authority.as_u8())),
+            identity_conflict: Arc::new(std::sync::RwLock::new(None)),
             pending_trigger_acks: Arc::new(DashMap::new()),
             evict: Arc::new(Notify::new()),
             has_reader: Arc::new(AtomicBool::new(false)),
@@ -306,6 +361,14 @@ impl WorkerConnection {
     }
 
     pub fn with_session(channel: mpsc::Sender<Outbound>, session: Session) -> Self {
+        Self::with_session_and_authority(channel, session, WorkerAuthority::Unscoped)
+    }
+
+    pub fn with_session_and_authority(
+        channel: mpsc::Sender<Outbound>,
+        session: Session,
+        authority: WorkerAuthority,
+    ) -> Self {
         let id = Uuid::new_v4();
         Self {
             id,
@@ -324,6 +387,8 @@ impl WorkerConnection {
             pid: None,
             isolation: None,
             session: Some(Arc::new(session)),
+            authority: Arc::new(AtomicU8::new(authority.as_u8())),
+            identity_conflict: Arc::new(std::sync::RwLock::new(None)),
             pending_trigger_acks: Arc::new(DashMap::new()),
             evict: Arc::new(Notify::new()),
             has_reader: Arc::new(AtomicBool::new(false)),
@@ -331,6 +396,34 @@ impl WorkerConnection {
             cleanup_done: Arc::new(watch::channel(false).0),
             reattach_token: Uuid::new_v4(),
         }
+    }
+
+    pub fn authority(&self) -> WorkerAuthority {
+        WorkerAuthority::from_u8(self.authority.load(Ordering::SeqCst))
+    }
+
+    pub fn identity_conflict(&self) -> Option<WorkerIdentityConflict> {
+        self.identity_conflict
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    /// Marks the connection quarantined exactly once. Returns true for the
+    /// caller that performed the transition and must remove business state.
+    pub fn quarantine(&self, conflict: WorkerIdentityConflict) -> bool {
+        if self
+            .authority
+            .swap(WorkerAuthority::Quarantined.as_u8(), Ordering::SeqCst)
+            == WorkerAuthority::Quarantined.as_u8()
+        {
+            return false;
+        }
+        *self
+            .identity_conflict
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(conflict);
+        true
     }
 
     pub async fn function_count(&self) -> usize {

--- a/engine/src/workers/config.rs
+++ b/engine/src/workers/config.rs
@@ -409,8 +409,12 @@ impl WorkerRegistry {
                 info.env
                     .push(("III_CONFIG_PATH".to_string(), path.display().to_string()));
             }
-            let module =
-                super::external::ExternalWorker::new(info, config, engine.worker_manager_port());
+            let module = super::external::ExternalWorker::new_managed(
+                info,
+                config,
+                engine.worker_manager_port(),
+                engine.run_id(),
+            );
             return Ok(Box::new(ExternalProcessWorker::new(Box::new(module))));
         }
 
@@ -427,6 +431,7 @@ impl WorkerRegistry {
             port,
             config.as_ref(),
             engine.config_path(),
+            engine.run_id(),
         )
         .await
         .map_err(|e| anyhow::anyhow!("Failed to start worker '{}': {}", name, e))?;

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -18,7 +18,10 @@ use crate::{
     function::FunctionResult,
     protocol::{ErrorBody, StreamChannelRef, WorkerMetrics},
     trigger::{Trigger, TriggerRegistrator, TriggerType, known_trigger_type_provider},
-    worker_connections::{RuntimeWorkerInfo, WorkerConnection, WorkerConnectionTelemetryMeta},
+    worker_connections::{
+        RuntimeWorkerInfo, WorkerAuthority, WorkerConnection, WorkerConnectionTelemetryMeta,
+        WorkerIdentityConflict,
+    },
     workers::traits::Worker,
     workers::worker::rbac_session::Session,
 };
@@ -327,6 +330,12 @@ pub struct WorkerSummary {
     pub active_invocations: usize,
     pub isolation: Option<String>,
     pub ip_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+    pub authority: WorkerAuthority,
+    pub quarantined: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub identity_conflict: Option<WorkerIdentityConflict>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -347,6 +356,10 @@ pub struct WorkerDetailEnvelope {
     /// (not present on the registry surface).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pid: Option<u32>,
+    pub authority: WorkerAuthority,
+    pub quarantined: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub identity_conflict: Option<WorkerIdentityConflict>,
     /// Whether this worker is an in-process engine module. Engine-local
     /// extra.
     pub internal: bool,
@@ -693,7 +706,13 @@ impl EngineFunctionsWorker {
                 continue;
             }
 
-            if filter_worker_id.is_none() && w.pid.is_none() {
+            // Historical SDK connections without metadata stay hidden from
+            // the default list, but quarantined connections must remain
+            // visible so operators can identify and stop the duplicate.
+            if filter_worker_id.is_none()
+                && w.pid.is_none()
+                && w.authority() != WorkerAuthority::Quarantined
+            {
                 continue;
             }
 
@@ -714,6 +733,10 @@ impl EngineFunctionsWorker {
                 active_invocations,
                 isolation: w.isolation.clone(),
                 ip_address,
+                pid: w.pid,
+                authority: w.authority(),
+                quarantined: w.authority() == WorkerAuthority::Quarantined,
+                identity_conflict: w.identity_conflict(),
             });
         }
 
@@ -738,6 +761,10 @@ impl EngineFunctionsWorker {
                 active_invocations: 0,
                 isolation: Some("in-process".to_string()),
                 ip_address: None,
+                pid: None,
+                authority: WorkerAuthority::CurrentManaged,
+                quarantined: false,
+                identity_conflict: None,
             });
         }
 
@@ -857,6 +884,9 @@ impl EngineFunctionsWorker {
             isolation: w.isolation.clone(),
             ip_address,
             pid: w.pid,
+            authority: w.authority(),
+            quarantined: w.authority() == WorkerAuthority::Quarantined,
+            identity_conflict: w.identity_conflict(),
             internal: false,
             latest_metrics,
         }
@@ -878,6 +908,9 @@ impl EngineFunctionsWorker {
             isolation: Some("in-process".to_string()),
             ip_address: None,
             pid: None,
+            authority: WorkerAuthority::CurrentManaged,
+            quarantined: false,
+            identity_conflict: None,
             internal: w.internal,
             latest_metrics: None,
         }
@@ -1957,6 +1990,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_worker_summaries_keeps_pidless_quarantined_workers_visible() {
+        let (engine, module) = setup_engine_and_module();
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let worker = crate::worker_connections::WorkerConnection::new(tx);
+        worker.quarantine(WorkerIdentityConflict {
+            function_id: "provider::kimi::stream".to_string(),
+            current_worker_id: uuid::Uuid::new_v4().to_string(),
+            current_worker_name: Some("provider-kimi".to_string()),
+            current_worker_pid: Some(42),
+        });
+        engine.worker_registry.register_worker(worker);
+
+        let workers = module.list_worker_summaries(None).await;
+        assert_eq!(workers.len(), 1);
+        assert!(workers[0].quarantined);
+        assert_eq!(workers[0].authority, WorkerAuthority::Quarantined);
+    }
+
+    #[tokio::test]
     async fn list_worker_summaries_includes_runtime_worker_snapshots() {
         let (engine, module) = setup_engine_and_module();
 
@@ -2281,12 +2333,18 @@ mod tests {
             active_invocations: 0,
             isolation: None,
             ip_address: None,
+            pid: Some(42),
+            authority: WorkerAuthority::CurrentManaged,
+            quarantined: false,
+            identity_conflict: None,
         };
         let json = serde_json::to_value(&summary).expect("serialize");
         assert!(json.get("description").is_some());
         assert!(json["description"].is_null());
         assert_eq!(json["name"], "agent-memory");
         assert_eq!(json["function_count"], 9);
+        assert_eq!(json["authority"], "current_managed");
+        assert_eq!(json["pid"], 42);
     }
 
     // ── Lifecycle tests ─────────────────────────────────────────────────

--- a/engine/src/workers/external.rs
+++ b/engine/src/workers/external.rs
@@ -28,6 +28,7 @@ use tokio::{
     sync::Mutex,
     time::{Duration, timeout},
 };
+use uuid::Uuid;
 
 use crate::{engine::Engine, workers::traits::Worker};
 
@@ -185,6 +186,7 @@ pub struct ExternalWorker {
     /// (sandbox-daemon, worker-manager-daemon) connect back to THIS engine
     /// instead of their hardcoded ws://127.0.0.1:49134 default (MOT-3970).
     worker_manager_port: u16,
+    engine_run_id: Option<Uuid>,
     env: Vec<(String, String)>,
     config: Option<Value>,
     child: Arc<Mutex<Option<Child>>>,
@@ -213,6 +215,24 @@ const BACKOFF_RESET_UPTIME: Duration = Duration::from_secs(60);
 
 impl ExternalWorker {
     pub fn new(info: ExternalWorkerInfo, config: Option<Value>, worker_manager_port: u16) -> Self {
+        Self::new_with_run_id(info, config, worker_manager_port, None)
+    }
+
+    pub fn new_managed(
+        info: ExternalWorkerInfo,
+        config: Option<Value>,
+        worker_manager_port: u16,
+        engine_run_id: Uuid,
+    ) -> Self {
+        Self::new_with_run_id(info, config, worker_manager_port, Some(engine_run_id))
+    }
+
+    fn new_with_run_id(
+        info: ExternalWorkerInfo,
+        config: Option<Value>,
+        worker_manager_port: u16,
+        engine_run_id: Option<Uuid>,
+    ) -> Self {
         let name = info.name.clone();
         let display_name = Box::leak(format!("ExternalWorker({})", &name).into_boxed_str());
         Self {
@@ -221,6 +241,7 @@ impl ExternalWorker {
             binary_path: info.binary_path,
             extra_args: info.extra_args,
             worker_manager_port,
+            engine_run_id,
             env: info.env,
             config,
             child: Arc::new(Mutex::new(None)),
@@ -282,7 +303,11 @@ impl ExternalWorker {
         // two engines on one host each get their own daemon (MOT-3970).
         // Re-exported on every respawn (MOT-3857 supervisor) so a respawned
         // daemon keeps the same contract.
-        let engine_url = format!("ws://127.0.0.1:{}", self.worker_manager_port);
+        let mut engine_url = format!("ws://127.0.0.1:{}", self.worker_manager_port);
+        if let Some(run_id) = self.engine_run_id {
+            engine_url.push_str(&format!("?engine_run_id={run_id}"));
+            cmd.env("III_ENGINE_RUN_ID", run_id.to_string());
+        }
         cmd.env("III_ENGINE_URL", &engine_url);
         cmd.env("III_URL", &engine_url);
 

--- a/engine/src/workers/registry_worker.rs
+++ b/engine/src/workers/registry_worker.rs
@@ -138,9 +138,13 @@ fn spawn_args(worker_name: &str, port: u16, config_path: Option<&std::path::Path
 /// ws://127.0.0.1:49134 default (iii-hq/workers#526). Mirrors the
 /// MOT-3970 exports in external.rs for builtin daemons. Kept pure so the
 /// env contract regression-tests without spawning, like `spawn_args`.
-fn spawn_url_env(port: u16) -> [(&'static str, String); 2] {
+fn spawn_url_env(port: u16, run_id: uuid::Uuid) -> [(&'static str, String); 3] {
     let url = format!("ws://127.0.0.1:{}", port);
-    [("III_ENGINE_URL", url.clone()), ("III_URL", url)]
+    [
+        ("III_ENGINE_URL", url.clone()),
+        ("III_URL", url),
+        ("III_ENGINE_RUN_ID", run_id.to_string()),
+    ]
 }
 
 // =============================================================================
@@ -252,6 +256,7 @@ impl ExternalWorkerProcess {
         port: u16,
         config: Option<&Value>,
         engine_config_path: Option<&std::path::Path>,
+        engine_run_id: uuid::Uuid,
     ) -> Result<Self, String> {
         let worker_binary = resolve_iii_worker_binary()
             .ok_or_else(|| {
@@ -319,7 +324,7 @@ impl ExternalWorkerProcess {
         // Engine WS URL for the whole detached tree (workers#526): binary
         // workers inherit env from `iii-worker start`, so exporting here
         // reaches them even through a version-skewed iii-worker binary.
-        for (key, value) in spawn_url_env(port) {
+        for (key, value) in spawn_url_env(port, engine_run_id) {
             cmd.env(key, value);
         }
         // Same-file contract: the spawned `iii-worker start` (and everything
@@ -1039,11 +1044,13 @@ mod tests {
     /// re-strands every registry binary on non-default ports.
     #[test]
     fn spawn_url_env_carries_manager_port() {
+        let run_id = uuid::Uuid::nil();
         assert_eq!(
-            spawn_url_env(3034),
+            spawn_url_env(3034, run_id),
             [
                 ("III_ENGINE_URL", "ws://127.0.0.1:3034".to_string()),
                 ("III_URL", "ws://127.0.0.1:3034".to_string()),
+                ("III_ENGINE_RUN_ID", run_id.to_string()),
             ],
         );
     }


### PR DESCRIPTION
## Summary

- stamp engine-managed worker trees with an ephemeral engine-run identity
- preserve the current engine child as function owner and quarantine stale or duplicate connections
- remove quarantined business registrations while keeping worker metadata and actionable conflict details visible
- expose authority, PID, and identity-conflict data through the engine worker APIs

## Testing

- cargo check --manifest-path engine/Cargo.toml -p iii -p iii-worker
- cargo test --manifest-path engine/Cargo.toml -p iii --lib cleanup_worker
- targeted engine tests for run identity, ownership replacement, rejection, concurrency, replay, and pidless quarantine visibility
- standalone rustc unit test for the pure iii-worker engine identity helper

The complete iii-worker test binary could not link locally because libcap-ng is not installed; cargo check passed for iii-worker and the pure helper test passed independently.

Provider and Console support: https://github.com/iii-hq/workers/pull/784

Refs MOT-4412