### PR TITLE
docs(install): provider-picking quickstart panel

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -34,16 +34,13 @@ body {
   background: var(--iii-bg) !important;
   color: var(--iii-ink) !important;
   font-family:
-    "Chivo Mono",
-    ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
-    "Liberation Mono",
-    "Courier New",
-    monospace !important;
-  font-feature-settings: "liga" 0, "clig" 0, "calt" 0, "dlig" 0;
+    "Chivo Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace !important;
+  font-feature-settings:
+    "liga" 0,
+    "clig" 0,
+    "calt" 0,
+    "dlig" 0;
   scrollbar-gutter: stable;
 }
 
@@ -81,15 +78,8 @@ select,
 code,
 pre {
   font-family:
-    "Chivo Mono",
-    ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
-    "Liberation Mono",
-    "Courier New",
-    monospace !important;
+    "Chivo Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace !important;
 }
 
 a {
@@ -119,15 +109,8 @@ h5,
 h6 {
   color: var(--iii-ink) !important;
   font-family:
-    "Chivo Mono",
-    ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
-    "Liberation Mono",
-    "Courier New",
-    monospace !important;
+    "Chivo Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace !important;
   letter-spacing: -0.02em;
 }
 
@@ -217,7 +200,9 @@ pre code,
 }
 
 .code-block .line.line-highlight::after,
-.code-block [data-component-part="code-block-root"]:not(.has-line-numbers) .line.line-highlight::before {
+.code-block
+  [data-component-part="code-block-root"]:not(.has-line-numbers)
+  .line.line-highlight::before {
   background: #c5e4c0 !important;
   border-left-color: #6da46d !important;
 }
@@ -228,9 +213,15 @@ html.dark .code-block .line.line-highlight,
 }
 
 html.dark .code-block .line.line-highlight::after,
-html.dark .code-block [data-component-part="code-block-root"]:not(.has-line-numbers) .line.line-highlight::before,
+html.dark
+  .code-block
+  [data-component-part="code-block-root"]:not(.has-line-numbers)
+  .line.line-highlight::before,
 [data-theme="dark"] .code-block .line.line-highlight::after,
-[data-theme="dark"] .code-block [data-component-part="code-block-root"]:not(.has-line-numbers) .line.line-highlight::before {
+[data-theme="dark"]
+  .code-block
+  [data-component-part="code-block-root"]:not(.has-line-numbers)
+  .line.line-highlight::before {
   background: #3d5e3d !important;
   border-left-color: #8fbf8f !important;
 }
@@ -316,8 +307,7 @@ td:first-child {
   line-height: 1.4 !important;
   padding-block: 0.28rem !important;
   text-decoration: none !important;
-  transition:
-    color 150ms ease;
+  transition: color 150ms ease;
   white-space: normal !important;
 }
 
@@ -440,7 +430,9 @@ html.iii-navbar-hidden #sidebar {
 }
 
 #content-side-layout {
-  transition: top 200ms ease, height 200ms ease;
+  transition:
+    top 200ms ease,
+    height 200ms ease;
 }
 
 html.iii-navbar-hidden #content-side-layout {
@@ -495,4 +487,179 @@ body,
 .tab-container > [role="tablist"] + div > [role="tabpanel"].hidden {
   display: block !important;
   visibility: hidden;
+}
+
+/* ---------------------------------------------------------------------------
+   Install-page quickstart panel (`.iii-qs`).
+
+   A terminal-style recipe whose llm-provider pills swap two slots in place:
+   the provider setup lines at the top and the `iii worker add` line near the
+   bottom. Every variant ships in the markup; a hidden radio group plus
+   `:has(:checked)` decides which one is displayed, so the picker needs no
+   javascript and keeps working with keyboard and screen readers (the pills
+   are real `<label>`s for real radios).
+   --------------------------------------------------------------------------- */
+
+.iii-qs {
+  border: 1px solid var(--iii-rule);
+  background: var(--iii-bg);
+  margin: 1.5rem 0;
+}
+
+/* Clipped rather than `display: none`: the radios stay focusable, so the
+   picker is reachable by keyboard and announced as a radio group. */
+.iii-qs-radio {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.iii-qs-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem 1rem;
+  border-bottom: 1px solid var(--iii-rule);
+  background: var(--iii-panel);
+  padding: 0.5rem 1rem;
+}
+
+.iii-qs-title {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+  color: var(--iii-ink-faint);
+}
+
+.iii-qs-picker {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.iii-qs-picker-label {
+  font-size: 11px;
+  color: var(--iii-ink-faint);
+  margin-right: 0.25rem;
+}
+
+.iii-qs-pill {
+  border: 1px solid var(--iii-rule);
+  background: var(--iii-bg);
+  color: var(--iii-ink-faint);
+  cursor: pointer;
+  font-size: 11px;
+  line-height: 1;
+  padding: 0.3125rem 0.5rem;
+  user-select: none;
+}
+
+.iii-qs-pill:hover {
+  color: var(--iii-ink);
+  border-color: var(--iii-ink-ghost);
+}
+
+/* Keyboard focus lands on the clipped radio, so ring its pill instead. */
+.iii-qs:has(#qs-none:focus-visible) .iii-qs-pill[for="qs-none"],
+.iii-qs:has(#qs-openai:focus-visible) .iii-qs-pill[for="qs-openai"],
+.iii-qs:has(#qs-anthropic:focus-visible) .iii-qs-pill[for="qs-anthropic"],
+.iii-qs:has(#qs-deepseek:focus-visible) .iii-qs-pill[for="qs-deepseek"],
+.iii-qs:has(#qs-kimi:focus-visible) .iii-qs-pill[for="qs-kimi"],
+.iii-qs:has(#qs-openrouter:focus-visible) .iii-qs-pill[for="qs-openrouter"],
+.iii-qs:has(#qs-xai:focus-visible) .iii-qs-pill[for="qs-xai"],
+.iii-qs:has(#qs-zai:focus-visible) .iii-qs-pill[for="qs-zai"],
+.iii-qs:has(#qs-github-copilot:focus-visible) .iii-qs-pill[for="qs-github-copilot"],
+.iii-qs:has(#qs-openai-codex:focus-visible) .iii-qs-pill[for="qs-openai-codex"],
+.iii-qs:has(#qs-llamacpp:focus-visible) .iii-qs-pill[for="qs-llamacpp"] {
+  outline: 2px solid var(--iii-accent);
+  outline-offset: 2px;
+}
+
+.iii-qs:has(#qs-none:checked) .iii-qs-pill[for="qs-none"],
+.iii-qs:has(#qs-openai:checked) .iii-qs-pill[for="qs-openai"],
+.iii-qs:has(#qs-anthropic:checked) .iii-qs-pill[for="qs-anthropic"],
+.iii-qs:has(#qs-deepseek:checked) .iii-qs-pill[for="qs-deepseek"],
+.iii-qs:has(#qs-kimi:checked) .iii-qs-pill[for="qs-kimi"],
+.iii-qs:has(#qs-openrouter:checked) .iii-qs-pill[for="qs-openrouter"],
+.iii-qs:has(#qs-xai:checked) .iii-qs-pill[for="qs-xai"],
+.iii-qs:has(#qs-zai:checked) .iii-qs-pill[for="qs-zai"],
+.iii-qs:has(#qs-github-copilot:checked) .iii-qs-pill[for="qs-github-copilot"],
+.iii-qs:has(#qs-openai-codex:checked) .iii-qs-pill[for="qs-openai-codex"],
+.iii-qs:has(#qs-llamacpp:checked) .iii-qs-pill[for="qs-llamacpp"] {
+  background: var(--iii-ink);
+  border-color: var(--iii-ink);
+  color: var(--iii-bg);
+}
+
+.iii-qs-body {
+  padding: 0.75rem 1rem;
+  font-size: 12.5px;
+  line-height: 1.7;
+  overflow-x: auto;
+}
+
+.iii-qs-comment {
+  color: var(--iii-ink-ghost);
+  font-style: italic;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  /* Keeps comments and the `$` prompt out of a click-and-drag selection, so
+     copying the recipe yields runnable lines only. */
+  user-select: none;
+}
+
+.iii-qs-cmd {
+  display: flex;
+  gap: 0.5rem;
+  color: var(--iii-ink);
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
+/* Mintlify auto-links bare urls. In a command line that reads as an invitation
+   to click something meant to be copied, so keep those inert; urls inside a
+   comment line stay clickable. */
+.iii-qs-cmd a {
+  color: inherit !important;
+  font-weight: inherit !important;
+  text-decoration: none !important;
+  border-bottom: 0 !important;
+  pointer-events: none;
+}
+
+.iii-qs-prompt {
+  color: var(--iii-accent);
+  user-select: none;
+}
+
+.iii-qs-gap {
+  height: 0.75rem;
+}
+
+/* Only the selected provider's slots are shown. */
+.iii-qs-slot {
+  display: none;
+}
+
+.iii-qs:has(#qs-none:checked) .iii-qs-slot[data-qs="none"],
+.iii-qs:has(#qs-openai:checked) .iii-qs-slot[data-qs="openai"],
+.iii-qs:has(#qs-anthropic:checked) .iii-qs-slot[data-qs="anthropic"],
+.iii-qs:has(#qs-deepseek:checked) .iii-qs-slot[data-qs="deepseek"],
+.iii-qs:has(#qs-kimi:checked) .iii-qs-slot[data-qs="kimi"],
+.iii-qs:has(#qs-openrouter:checked) .iii-qs-slot[data-qs="openrouter"],
+.iii-qs:has(#qs-xai:checked) .iii-qs-slot[data-qs="xai"],
+.iii-qs:has(#qs-zai:checked) .iii-qs-slot[data-qs="zai"],
+.iii-qs:has(#qs-github-copilot:checked) .iii-qs-slot[data-qs="github-copilot"],
+.iii-qs:has(#qs-openai-codex:checked) .iii-qs-slot[data-qs="openai-codex"],
+.iii-qs:has(#qs-llamacpp:checked) .iii-qs-slot[data-qs="llamacpp"] {
+  display: block;
 }

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -515,7 +515,6 @@ body,
   margin: -1px;
   padding: 0;
   overflow: hidden;
-  clip: rect(0 0 0 0);
   clip-path: inset(50%);
   white-space: nowrap;
 }

--- a/docs/next/creating-workers/workers.mdx
+++ b/docs/next/creating-workers/workers.mdx
@@ -60,6 +60,12 @@ scaffold into any other non-empty directory.
   add`. See [Using iii / Workers](../using-iii/workers#finding-workers) for the registry surface.
 </Note>
 
+<Info title="Engine and SDK versions">
+  The engine and SDK packages can have different patch versions within the same minor line. Keep the
+  engine and SDKs on the same minor version, for example `0.11.x`, unless a release note says
+  otherwise.
+</Info>
+
 ## Connecting to the engine
 
 A worker connects to the engine over WebSocket. The convention is to set the engine URL via the

--- a/docs/next/creating-workers/workers.mdx.skill.md
+++ b/docs/next/creating-workers/workers.mdx.skill.md
@@ -56,6 +56,12 @@ scaffold into any other non-empty directory.
   add`. See [Using iii / Workers](../using-iii/workers#finding-workers) for the registry surface.
 </Note>
 
+<Info title="Engine and SDK versions">
+  The engine and SDK packages can have different patch versions within the same minor line. Keep the
+  engine and SDKs on the same minor version, for example `0.11.x`, unless a release note says
+  otherwise.
+</Info>
+
 ## Connecting to the engine
 
 A worker connects to the engine over WebSocket. The convention is to set the engine URL via the

--- a/docs/next/install.mdx
+++ b/docs/next/install.mdx
@@ -73,7 +73,7 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-slot" data-qs="openai">
       <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span> export OPENAI_API_KEY=yourkey</span>
@@ -90,7 +90,7 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-slot" data-qs="anthropic">
       <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span> export ANTHROPIC_API_KEY=yourkey</span>
@@ -98,7 +98,7 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-slot" data-qs="deepseek">
       <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span> export DEEPSEEK_API_KEY=yourkey</span>
@@ -106,7 +106,7 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-slot" data-qs="kimi">
       <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span> export MOONSHOT_API_KEY=yourkey</span>
@@ -114,7 +114,7 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-slot" data-qs="openrouter">
       <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span> export OPENROUTER_API_KEY=yourkey</span>
@@ -122,7 +122,7 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-slot" data-qs="xai">
       <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span> export XAI_API_KEY=yourkey</span>
@@ -130,7 +130,7 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-slot" data-qs="zai">
       <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span> export ZAI_API_KEY=yourkey</span>
@@ -139,11 +139,6 @@ agents within your iii system. You can add a provider worker later at any time.
     <div className="iii-qs-slot" data-qs="github-copilot">
       <div className="iii-qs-comment"># Set up your llm provider</div>
       <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models.</div>
-      <div className="iii-qs-comment"># Sign in once the engine is up:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger provider::github-copilot::login::start</span>
-      </div>
     </div>
     <div className="iii-qs-slot" data-qs="llamacpp">
       <div className="iii-qs-comment"># Set up your llm provider</div>
@@ -229,6 +224,11 @@ agents within your iii system. You can add a provider worker later at any time.
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>iii worker add harness console provider-github-copilot</span>
+      </div>
+      <div className="iii-qs-comment"># Sign in once the provider worker is up:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger provider::github-copilot::login::start</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="llamacpp">

--- a/docs/next/install.mdx
+++ b/docs/next/install.mdx
@@ -29,9 +29,8 @@ agents within your iii system. You can add a provider worker later at any time.
   <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-llamacpp" />
 
 <div className="iii-qs-head">
-  <span className="iii-qs-title">quickstart</span>
+  <span className="iii-qs-title">select your llm provider</span>
   <div className="iii-qs-picker">
-    <span className="iii-qs-picker-label">select your llm provider</span>
     <label className="iii-qs-pill" htmlFor="qs-none">
       no llm
     </label>

--- a/docs/next/install.mdx
+++ b/docs/next/install.mdx
@@ -1,34 +1,250 @@
 ---
 title: "Install"
-description: "Install the iii engine and set up your development environment."
+description: "Install the iii engine and set up your agentic development environment."
 owner: "devrel"
 type: "how-to"
 ---
 
 {/* TODO (community feedback): Add a direct binary-download path alongside the curl|sh installer so users who do not want to verify a remote script with a bot, or are on Windows, have an alternative. Link to the GitHub Releases page for the engine and include PATH setup instructions per OS (especially Windows). */}
 
-## 1. Install iii
+## Start a project
 
-Install the iii engine:
+The recipe below installs the engine, creates a project, and starts it. Select your llm provider, or
+select **no llm** to set up a project without one. Every recipe adds [console](./using-iii/console),
+the browser ui for your running system; a provider also adds
+[harness](https://workers.iii.dev/workers/harness) which enables both agentic development and use of
+agents within your iii system. You can add a provider worker later at any time.
 
-```bash
-curl -fsSL https://install.iii.dev/iii/main/install.sh | sh
-```
+<div className="iii-qs" role="group" aria-label="quickstart recipe">
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-none" defaultChecked />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-openai" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-openai-codex" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-anthropic" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-deepseek" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-kimi" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-openrouter" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-xai" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-zai" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-github-copilot" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-llamacpp" />
 
-## 2. Verify installation
+<div className="iii-qs-head">
+  <span className="iii-qs-title">quickstart</span>
+  <div className="iii-qs-picker">
+    <span className="iii-qs-picker-label">select your llm provider</span>
+    <label className="iii-qs-pill" htmlFor="qs-none">
+      no llm
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-openai">
+      openai api
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-openai-codex">
+      openai codex
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-anthropic">
+      anthropic
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-deepseek">
+      deepseek
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-kimi">
+      kimi (moonshot)
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-openrouter">
+      openrouter
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-xai">
+      xai (grok)
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-zai">
+      z.ai
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-github-copilot">
+      github copilot
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-llamacpp">
+      llama.cpp (local)
+    </label>
+  </div>
+</div>
 
-Check that iii has installed correctly with the following command. It should return a version
-number.
+  <div className="iii-qs-body">
+    <div className="iii-qs-slot" data-qs="none">
+      <div className="iii-qs-comment"># No llm needed. Add a provider worker whenever you want agents.</div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openai">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span> export OPENAI_API_KEY=yourkey</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openai-codex">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># No api key. This provider uses your chatgpt subscription.</div>
+      <div className="iii-qs-comment"># Sign in with the codex cli first, so ~/.codex/auth.json exists:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>codex login</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="anthropic">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span> export ANTHROPIC_API_KEY=yourkey</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="deepseek">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span> export DEEPSEEK_API_KEY=yourkey</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="kimi">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span> export MOONSHOT_API_KEY=yourkey</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openrouter">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span> export OPENROUTER_API_KEY=yourkey</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="xai">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span> export XAI_API_KEY=yourkey</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="zai">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span> export ZAI_API_KEY=yourkey</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="github-copilot">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models.</div>
+      <div className="iii-qs-comment"># Sign in once the engine is up:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger provider::github-copilot::login::start</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="llamacpp">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default.</div>
+      <div className="iii-qs-comment"># A key is only needed when llama-server runs with --api-key:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span> export LLAMACPP_API_KEY=yourkey</span>
+      </div>
+    </div>
 
-```bash
-iii --version
-```
+    <div className="iii-qs-gap" aria-hidden="true" />
+    <div className="iii-qs-comment"># Install iii & setup your project</div>
+    <div className="iii-qs-cmd">
+      <span className="iii-qs-prompt">$</span>
+      <span>curl -fsSL https://install.iii.dev/iii/main/install.sh | sh</span>
+    </div>
+    <div className="iii-qs-cmd">
+      <span className="iii-qs-prompt">$</span>
+      <span>iii project init iii-app && cd iii-app</span>
+    </div>
+    <div className="iii-qs-cmd">
+      <span className="iii-qs-prompt">$</span>
+      <span>iii</span>
+    </div>
+    <div className="iii-qs-gap" aria-hidden="true" />
+    <div className="iii-qs-comment"># New terminal, same folder</div>
+    <div className="iii-qs-slot" data-qs="none">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add console</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openai">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-openai</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openai-codex">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-openai-codex</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="anthropic">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-anthropic</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="deepseek">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-deepseek</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="kimi">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-kimi</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openrouter">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-openrouter</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="xai">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-xai</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="zai">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-zai</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="github-copilot">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-github-copilot</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="llamacpp">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-llamacpp</span>
+      </div>
+    </div>
+    <div className="iii-qs-gap" aria-hidden="true" />
+    <div className="iii-qs-comment"># Open your browser to http://localhost:3113</div>
 
-<Info title="Engine and SDK versions">
-  The engine and SDK packages can have different patch versions within the same minor line. Keep the
-  engine and SDKs on the same minor version, for example `0.11.x`, unless a release note says
-  otherwise.
-</Info>
+  </div>
+</div>
+
+{/* llm-only: The panel above is one recipe with a provider picker. Plain form: `curl -fsSL https://install.iii.dev/iii/main/install.sh | sh`, then `iii project init iii-app && cd iii-app`, then `iii`; in a second terminal in the same folder `iii worker add harness console provider-<name>`, then open http://localhost:3113. Export the provider credential in the terminal that runs the engine before starting it. Without an llm, drop harness and the provider worker: `iii worker add console`. */}
 
 {/* TODO: re-enable the "## 3. Install the VS Code Extension (Optional)" section once the iii-lsp extension is more thoroughly tested across VS Code, Cursor, Windsurf, and VSCodium. The Frame demo also needs `/images/lsp.mp4` to be captured and committed before the section is re-added. Before re-enabling, move the capability description (what completions/hover/diagnostics the extension provides) to an overview/explanation page for the extension and link to it from a single-sentence description here. ## 3. Install the VS Code Extension (Optional) The iii Language Server extension adds iii-aware editor support. See the extension overview for details. <Frame> <video autoPlay loop muted playsInline src="/images/lsp.mp4" alt="iii Language Server extension" /> </Frame> Open the Extensions panel and search for `iii-lsp`, or install from the terminal: <Tabs> <Tab title="VS Code"> code --install-extension iii-hq.iii-lsp </Tab> <Tab title="Cursor"> cursor --install-extension iii-hq.iii-lsp </Tab> <Tab title="Windsurf"> windsurf --install-extension iii-hq.iii-lsp </Tab> <Tab title="VSCodium"> codium --install-extension iii-hq.iii-lsp </Tab> </Tabs> */}
 

--- a/docs/next/install.mdx.skill.md
+++ b/docs/next/install.mdx.skill.md
@@ -27,9 +27,8 @@ agents within your iii system. You can add a provider worker later at any time.
   <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-llamacpp" />
 
 <div className="iii-qs-head">
-  <span className="iii-qs-title">quickstart</span>
+  <span className="iii-qs-title">select your llm provider</span>
   <div className="iii-qs-picker">
-    <span className="iii-qs-picker-label">select your llm provider</span>
     <label className="iii-qs-pill" htmlFor="qs-none">
       no llm
     </label>
@@ -37,7 +36,7 @@ agents within your iii system. You can add a provider worker later at any time.
       openai api
     </label>
     <label className="iii-qs-pill" htmlFor="qs-openai-codex">
-      openai codex (chatgpt)
+      openai codex
     </label>
     <label className="iii-qs-pill" htmlFor="qs-anthropic">
       anthropic

--- a/docs/next/install.mdx.skill.md
+++ b/docs/next/install.mdx.skill.md
@@ -5,28 +5,244 @@
 
 {/* TODO (community feedback): Add a direct binary-download path alongside the curl|sh installer so users who do not want to verify a remote script with a bot, or are on Windows, have an alternative. Link to the GitHub Releases page for the engine and include PATH setup instructions per OS (especially Windows). */}
 
-## 1. Install iii
+## Start a project
 
-Install the iii engine:
+The recipe below installs the engine, creates a project, and starts it. Select your llm provider, or
+select **no llm** to set up a project without one. Every recipe adds [console](./using-iii/console),
+the browser ui for your running system; a provider also adds
+[harness](https://workers.iii.dev/workers/harness) which enables both agentic development and use of
+agents within your iii system. You can add a provider worker later at any time.
 
-```bash
-curl -fsSL https://install.iii.dev/iii/main/install.sh | sh
-```
+<div className="iii-qs" role="group" aria-label="quickstart recipe">
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-none" defaultChecked />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-openai" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-openai-codex" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-anthropic" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-deepseek" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-kimi" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-openrouter" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-xai" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-zai" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-github-copilot" />
+  <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-llamacpp" />
 
-## 2. Verify installation
+<div className="iii-qs-head">
+  <span className="iii-qs-title">quickstart</span>
+  <div className="iii-qs-picker">
+    <span className="iii-qs-picker-label">select your llm provider</span>
+    <label className="iii-qs-pill" htmlFor="qs-none">
+      no llm
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-openai">
+      openai api
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-openai-codex">
+      openai codex (chatgpt)
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-anthropic">
+      anthropic
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-deepseek">
+      deepseek
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-kimi">
+      kimi (moonshot)
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-openrouter">
+      openrouter
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-xai">
+      xai (grok)
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-zai">
+      z.ai
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-github-copilot">
+      github copilot
+    </label>
+    <label className="iii-qs-pill" htmlFor="qs-llamacpp">
+      llama.cpp (local)
+    </label>
+  </div>
+</div>
 
-Check that iii has installed correctly with the following command. It should return a version
-number.
+  <div className="iii-qs-body">
+    <div className="iii-qs-slot" data-qs="none">
+      <div className="iii-qs-comment"># No llm needed. Add a provider worker whenever you want agents.</div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openai">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span> export OPENAI_API_KEY=yourkey</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openai-codex">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># No api key. This provider uses your chatgpt subscription.</div>
+      <div className="iii-qs-comment"># Sign in with the codex cli first, so ~/.codex/auth.json exists:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>codex login</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="anthropic">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span> export ANTHROPIC_API_KEY=yourkey</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="deepseek">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span> export DEEPSEEK_API_KEY=yourkey</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="kimi">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span> export MOONSHOT_API_KEY=yourkey</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openrouter">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span> export OPENROUTER_API_KEY=yourkey</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="xai">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span> export XAI_API_KEY=yourkey</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="zai">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span> export ZAI_API_KEY=yourkey</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="github-copilot">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models.</div>
+      <div className="iii-qs-comment"># Sign in once the engine is up:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger provider::github-copilot::login::start</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="llamacpp">
+      <div className="iii-qs-comment"># Set up your llm provider</div>
+      <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default.</div>
+      <div className="iii-qs-comment"># A key is only needed when llama-server runs with --api-key:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span> export LLAMACPP_API_KEY=yourkey</span>
+      </div>
+    </div>
 
-```bash
-iii --version
-```
+    <div className="iii-qs-gap" aria-hidden="true" />
+    <div className="iii-qs-comment"># Install iii & setup your project</div>
+    <div className="iii-qs-cmd">
+      <span className="iii-qs-prompt">$</span>
+      <span>curl -fsSL https://install.iii.dev/iii/main/install.sh | sh</span>
+    </div>
+    <div className="iii-qs-cmd">
+      <span className="iii-qs-prompt">$</span>
+      <span>iii project init iii-app && cd iii-app</span>
+    </div>
+    <div className="iii-qs-cmd">
+      <span className="iii-qs-prompt">$</span>
+      <span>iii</span>
+    </div>
+    <div className="iii-qs-gap" aria-hidden="true" />
+    <div className="iii-qs-comment"># New terminal, same folder</div>
+    <div className="iii-qs-slot" data-qs="none">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add console</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openai">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-openai</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openai-codex">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-openai-codex</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="anthropic">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-anthropic</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="deepseek">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-deepseek</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="kimi">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-kimi</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openrouter">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-openrouter</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="xai">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-xai</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="zai">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-zai</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="github-copilot">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-github-copilot</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="llamacpp">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii worker add harness console provider-llamacpp</span>
+      </div>
+    </div>
+    <div className="iii-qs-gap" aria-hidden="true" />
+    <div className="iii-qs-comment"># Open your browser to http://localhost:3113</div>
 
-<Info title="Engine and SDK versions">
-  The engine and SDK packages can have different patch versions within the same minor line. Keep the
-  engine and SDKs on the same minor version, for example `0.11.x`, unless a release note says
-  otherwise.
-</Info>
+  </div>
+</div>
+
+The panel above is one recipe with a provider picker. Plain form: `curl -fsSL https://install.iii.dev/iii/main/install.sh | sh`, then `iii project init iii-app && cd iii-app`, then `iii`; in a second terminal in the same folder `iii worker add harness console provider-<name>`, then open http://localhost:3113. Export the provider credential in the terminal that runs the engine before starting it. Without an llm, drop harness and the provider worker: `iii worker add console`.
 
 {/* TODO: re-enable the "## 3. Install the VS Code Extension (Optional)" section once the iii-lsp extension is more thoroughly tested across VS Code, Cursor, Windsurf, and VSCodium. The Frame demo also needs `/images/lsp.mp4` to be captured and committed before the section is re-added. Before re-enabling, move the capability description (what completions/hover/diagnostics the extension provides) to an overview/explanation page for the extension and link to it from a single-sentence description here. ## 3. Install the VS Code Extension (Optional) The iii Language Server extension adds iii-aware editor support. See the extension overview for details. <Frame> <video autoPlay loop muted playsInline src="/images/lsp.mp4" alt="iii Language Server extension" /> </Frame> Open the Extensions panel and search for `iii-lsp`, or install from the terminal: <Tabs> <Tab title="VS Code"> code --install-extension iii-hq.iii-lsp </Tab> <Tab title="Cursor"> cursor --install-extension iii-hq.iii-lsp </Tab> <Tab title="Windsurf"> windsurf --install-extension iii-hq.iii-lsp </Tab> <Tab title="VSCodium"> codium --install-extension iii-hq.iii-lsp </Tab> </Tabs> */}
 

--- a/docs/next/install.mdx.skill.md
+++ b/docs/next/install.mdx.skill.md
@@ -71,7 +71,7 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-slot" data-qs="openai">
       <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span> export OPENAI_API_KEY=yourkey</span>
@@ -88,7 +88,7 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-slot" data-qs="anthropic">
       <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span> export ANTHROPIC_API_KEY=yourkey</span>
@@ -96,7 +96,7 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-slot" data-qs="deepseek">
       <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span> export DEEPSEEK_API_KEY=yourkey</span>
@@ -104,7 +104,7 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-slot" data-qs="kimi">
       <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span> export MOONSHOT_API_KEY=yourkey</span>
@@ -112,7 +112,7 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-slot" data-qs="openrouter">
       <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span> export OPENROUTER_API_KEY=yourkey</span>
@@ -120,7 +120,7 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-slot" data-qs="xai">
       <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span> export XAI_API_KEY=yourkey</span>
@@ -128,7 +128,7 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-slot" data-qs="zai">
       <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history</div>
+      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span> export ZAI_API_KEY=yourkey</span>
@@ -137,11 +137,6 @@ agents within your iii system. You can add a provider worker later at any time.
     <div className="iii-qs-slot" data-qs="github-copilot">
       <div className="iii-qs-comment"># Set up your llm provider</div>
       <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models.</div>
-      <div className="iii-qs-comment"># Sign in once the engine is up:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger provider::github-copilot::login::start</span>
-      </div>
     </div>
     <div className="iii-qs-slot" data-qs="llamacpp">
       <div className="iii-qs-comment"># Set up your llm provider</div>
@@ -227,6 +222,11 @@ agents within your iii system. You can add a provider worker later at any time.
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>iii worker add harness console provider-github-copilot</span>
+      </div>
+      <div className="iii-qs-comment"># Sign in once the provider worker is up:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger provider::github-copilot::login::start</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="llamacpp">

--- a/docs/next/quickstart.mdx
+++ b/docs/next/quickstart.mdx
@@ -20,8 +20,8 @@ In this tutorial you will learn how iii makes it unreasonably simple to build an
 
 <Tip title="Install iii before proceeding">
   Make sure you have installed iii before proceeding. If you haven't then visit the
-  [Install](./install) guide first. There you can also learn how to setup iii for agentic
-  development.
+  [Install](./install) guide first. There you can also learn how to [set up iii for agentic
+  development](./install#start-a-project).
 </Tip>
 
 <Note>

--- a/docs/next/quickstart.mdx
+++ b/docs/next/quickstart.mdx
@@ -18,10 +18,11 @@ In this tutorial you will learn how iii makes it unreasonably simple to build an
   />
 </Frame>
 
-<Info title="Install iii before proceeding">
+<Tip title="Install iii before proceeding">
   Make sure you have installed iii before proceeding. If you haven't then visit the
-  [Install](./install) guide first.
-</Info>
+  [Install](./install) guide first. There you can also learn how to setup iii for agentic
+  development.
+</Tip>
 
 <Note>
   The Quickstart is a barebones tutorial intended to be completed within minutes. If you are more
@@ -151,8 +152,8 @@ From the folder containing iii's `config.yaml` run:
 iii worker add state
 ```
 
-Now open `workers/math-worker/src/math_worker.py` in your code editor and uncomment the state block so
-the handler looks like this:
+Now open `workers/math-worker/src/math_worker.py` in your code editor and uncomment the state block
+so the handler looks like this:
 
 ```python
 def add_handler(payload: dict) -> dict:
@@ -216,7 +217,10 @@ Open `workers/caller-worker/src/worker.ts` and uncomment the HTTP block at the b
 worker.registerFunction(
   "http::add_two_numbers",
   async (payload: { body: { a: number; b: number } }) => {
-    const result = await worker.trigger<{ a: number; b: number }, { c: number; running_total: number }>({
+    const result = await worker.trigger<
+      { a: number; b: number },
+      { c: number; running_total: number }
+    >({
       function_id: "math::add_two_numbers",
       payload: payload.body,
     });

--- a/docs/next/quickstart.mdx.skill.md
+++ b/docs/next/quickstart.mdx.skill.md
@@ -14,21 +14,17 @@ In this tutorial you will learn how iii makes it unreasonably simple to build an
   />
 </Frame>
 
-<Info title="Install iii before proceeding">
+<Tip title="Install iii before proceeding">
   Make sure you have installed iii before proceeding. If you haven't then visit the
-  [Install](./install) guide first.
-</Info>
+  [Install](./install) guide first. There you can also learn how to [set up iii for agentic
+  development](./install#start-a-project).
+</Tip>
 
 <Note>
   The Quickstart is a barebones tutorial intended to be completed within minutes. If you are more
   interested in learning and exploring the full power of iii then visit our [real world
   tutorial](./tutorials/linkly/overview).
 </Note>
-
-<Tip title="Want to jump in with an agent instead?">
-  Add harness and your LLM provider with the [Start a project](./install#start-a-project) tabs on
-  the Install page.
-</Tip>
 
 ## 1. Create the project
 

--- a/docs/next/quickstart.mdx.skill.md
+++ b/docs/next/quickstart.mdx.skill.md
@@ -25,6 +25,11 @@ In this tutorial you will learn how iii makes it unreasonably simple to build an
   tutorial](./tutorials/linkly/overview).
 </Note>
 
+<Tip title="Want to jump in with an agent instead?">
+  Add harness and your LLM provider with the [Start a project](./install#start-a-project) tabs on
+  the Install page.
+</Tip>
+
 ## 1. Create the project
 
 ```bash
@@ -147,8 +152,8 @@ From the folder containing iii's `config.yaml` run:
 iii worker add state
 ```
 
-Now open `workers/math-worker/src/math_worker.py` in your code editor and uncomment the state block so
-the handler looks like this:
+Now open `workers/math-worker/src/math_worker.py` in your code editor and uncomment the state block
+so the handler looks like this:
 
 ```python
 def add_handler(payload: dict) -> dict:
@@ -212,7 +217,10 @@ Open `workers/caller-worker/src/worker.ts` and uncomment the HTTP block at the b
 worker.registerFunction(
   "http::add_two_numbers",
   async (payload: { body: { a: number; b: number } }) => {
-    const result = await worker.trigger<{ a: number; b: number }, { c: number; running_total: number }>({
+    const result = await worker.trigger<
+      { a: number; b: number },
+      { c: number; running_total: number }
+    >({
       function_id: "math::add_two_numbers",
       payload: payload.body,
     });

--- a/docs/next/upgrading/from-0-21-x.mdx.skill.md
+++ b/docs/next/upgrading/from-0-21-x.mdx.skill.md
@@ -81,6 +81,14 @@ This step applies only to Rust workers that called the removed constructor. Node
 and Go workers need no change here. This handler was only in the Rust SDK a short time so it's
 unlikely that code was using it.
 
+## Behavior change: worker start port resolution
+
+`iii worker start` and `restart` (and the worker-manager daemon's `worker::start`) without an
+explicit `--port` now resolve the engine's `iii-worker-manager` port from `config.yaml` instead of
+always assuming `49134`. Auto-spawned registry binaries also receive `III_URL`/`III_ENGINE_URL`
+pointing at the engine's actual port, so worker builds that honor those variables connect correctly
+on non-default ports. Pass `--port` explicitly to target a specific port.
+
 ## Migration checklist
 
 - [ ] Rename the always-running workers to their unprefixed names in `config.yaml`,


### PR DESCRIPTION
## What

Ports the registry "editor pick" quickstart onto the docs Install page (`docs/next/install.mdx`):

- One terminal-style recipe whose llm-provider picker swaps two slots in place: the provider setup lines at the top and the `iii worker add` line near the bottom.
- A **no llm** option, so a reader can set up a project with or without a model. That path drops `harness` and the provider worker, since `harness` depends on `provider-openai` / `provider-anthropic`.
- The old "1. Install iii" and "2. Verify installation" steps are gone; the recipe installs the engine itself.
- The engine/SDK version callout moves to Creating Workers / Workers, where the reader picks an SDK version.
- The Quickstart page links back to the panel.

## Why

The registry homepage already had this recipe with a provider picker. The Install page is where readers land first, and it had no path that gets them to a running system with (or without) an llm.

## Notes

- No javascript and no new dependency: the picker is a visually-clipped radio group plus `:has(:checked)` rules in `docs/custom.css`. The pills are real `<label>`s, so keyboard and screen-reader use works.
- A `<select>` dropdown is not possible here: Mintlify strips `<select>`, `<option>`, `<details>`, and `<summary>` from MDX. `<input>` and `<label>` survive.
- Styling uses the existing `--iii-*` tokens, so light and dark both match the docs theme. Verified in `mint dev` with Playwright.
- The `.skill.md` artifact carries the raw markup, so a single-line `llm-only` comment gives agents the plain recipe.
- `docs/next/upgrading/from-0-21-x.mdx.skill.md` was stale in `main`; the re-render picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an interactive installation quickstart with selectable LLM providers, credential guidance, project setup, workers, and local console access.
  - Added agent-focused guidance linking to project-start instructions.
- **Documentation**
  - Clarified engine and SDK version compatibility recommendations.
  - Documented worker port resolution and behavior when using custom ports.
  - Added migration guidance for worker startup and restart workflows.
- **Style**
  - Improved documentation formatting, transitions, code highlighting, and quickstart presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->