### PR TITLE
feat(engine)!: a trigger type's provider belongs to a namespace, and a blank namespace is refused

### DIFF
--- a/docs/next/reference/engine-protocol.mdx
+++ b/docs/next/reference/engine-protocol.mdx
@@ -105,7 +105,8 @@ functions (`HttpInvocationRef`); leave it `null` for in-process handlers.
   "function_id": "math::add",
   "config": { "api_path": "/math/add", "http_method": "POST" },
   "metadata": null,
-  "namespace": "orders"
+  "namespace": "orders",
+  "trigger_namespace": null
 }
 ```
 
@@ -123,6 +124,21 @@ field must be a non-empty string; the engine rejects `null` and any other non-st
 The SDKs fill the field from the worker namespace when the caller sets no namespace on the binding,
 so the frame carries the worker's own namespace, or `default` when the worker declared none. A
 caller that sets `namespace` targets that namespace instead.
+
+`trigger_namespace` specifies where to find the trigger type's provider. It is a different question
+from `namespace`: one locates the target function, the other locates the provider that fires it.
+
+If `trigger_namespace` is not present, the engine resolves it in two steps: the registering
+connection's namespace first, then `default`. This is not the same as sending `"default"`. The two
+steps let a project register its own provider for a trigger type id that the engine also provides,
+while a worker that names nothing still reaches the engine's provider.
+
+If `trigger_namespace` is present, resolution is strict: that namespace or nothing. A binding that
+names a namespace is never moved to another provider.
+
+When a provider registers in a namespace after a binding already resolved to `default`, the engine
+moves that binding to the new provider. Start order does not decide which provider serves a
+project.
 
 These fields target `math::add` in `default`:
 
@@ -144,13 +160,21 @@ These fields target `math::add` in `orders`:
   "id": "webhook",
   "description": "HTTP webhook trigger",
   "trigger_request_format": { "type": "object", ... },
-  "call_request_format": { "type": "object", ... }
+  "call_request_format": { "type": "object", ... },
+  "namespace": null
 }
 ```
 
 `trigger_request_format` is the JSON Schema for the trigger's per-binding `config`.
 `call_request_format` is the JSON Schema for the payload delivered to bound functions when the
 trigger fires.
+
+`namespace` is the namespace this provider serves. If it is not present, the engine files the
+provider under the registering connection's namespace. Providers are keyed by
+`(namespace, trigger_type_id)`, so two workers in different namespaces can advertise the same
+`trigger_type` id without replacing each other.
+
+The engine's own providers (`http`, `cron`, `state`, `stream`) register in `default`.
 
 ## `InvokeFunction`
 

--- a/docs/next/reference/engine-protocol.mdx.skill.md
+++ b/docs/next/reference/engine-protocol.mdx.skill.md
@@ -103,7 +103,12 @@ functions (`HttpInvocationRef`); leave it `null` for in-process handlers.
   "function_id": "math::add",
   "config": { "api_path": "/math/add", "http_method": "POST" },
   "metadata": null,
+<<<<<<< HEAD
   "namespace": "orders"
+=======
+  "namespace": null,
+  "trigger_namespace": null
+>>>>>>> 78d0d93d (feat(engine)!: a trigger type's provider belongs to a namespace, and a blank namespace is refused (#2057))
 }
 ```
 
@@ -118,9 +123,35 @@ A trigger can call a function in a different namespace. For this reason, `Regist
 the target `namespace`. If this field is not present, `function_id` resolves in `default`. A present
 field must be a non-empty string; the engine rejects `null` and any other non-string value.
 
+<<<<<<< HEAD
 The SDKs fill the field from the worker namespace when the caller sets no namespace on the binding,
 so the frame carries the worker's own namespace, or `default` when the worker declared none. A
 caller that sets `namespace` targets that namespace instead.
+=======
+Both SDK paths set this field to the worker's namespace when the caller omits it: the typed helper
+`registerTriggerType(...).registerTrigger` and the low-level `registerTrigger`. A trigger names a
+function, and a worker's functions land in the worker's namespace, so a trigger that defaulted
+anywhere else would fire and resolve nothing.
+
+The wire default is unchanged: an absent `namespace` still means `default` to the engine. It is the
+SDKs that stopped omitting it. Set `namespace` explicitly to target another namespace, `default`
+included — that is how a worker inside a namespace reaches an engine builtin.
+
+`trigger_namespace` specifies where to find the trigger type's provider. It is a different question
+from `namespace`: one locates the target function, the other locates the provider that fires it.
+
+If `trigger_namespace` is not present, the engine resolves it in two steps: the registering
+connection's namespace first, then `default`. This is not the same as sending `"default"`. The two
+steps let a project register its own provider for a trigger type id that the engine also provides,
+while a worker that names nothing still reaches the engine's provider.
+
+If `trigger_namespace` is present, resolution is strict: that namespace or nothing. A binding that
+names a namespace is never moved to another provider.
+
+When a provider registers in a namespace after a binding already resolved to `default`, the engine
+moves that binding to the new provider. Start order does not decide which provider serves a
+project.
+>>>>>>> 78d0d93d (feat(engine)!: a trigger type's provider belongs to a namespace, and a blank namespace is refused (#2057))
 
 These fields target `math::add` in `default`:
 
@@ -142,13 +173,21 @@ These fields target `math::add` in `orders`:
   "id": "webhook",
   "description": "HTTP webhook trigger",
   "trigger_request_format": { "type": "object", ... },
-  "call_request_format": { "type": "object", ... }
+  "call_request_format": { "type": "object", ... },
+  "namespace": null
 }
 ```
 
 `trigger_request_format` is the JSON Schema for the trigger's per-binding `config`.
 `call_request_format` is the JSON Schema for the payload delivered to bound functions when the
 trigger fires.
+
+`namespace` is the namespace this provider serves. If it is not present, the engine files the
+provider under the registering connection's namespace. Providers are keyed by
+`(namespace, trigger_type_id)`, so two workers in different namespaces can advertise the same
+`trigger_type` id without replacing each other.
+
+The engine's own providers (`http`, `cron`, `state`, `stream`) register in `default`.
 
 ## `InvokeFunction`
 

--- a/docs/next/understanding-iii/namespaces.mdx
+++ b/docs/next/understanding-iii/namespaces.mdx
@@ -17,9 +17,34 @@ The engine uses these registry keys:
 
 - `(namespace, function_id)` for functions.
 - `(namespace, worker_name)` for workers.
+- `(namespace, trigger_type_id)` for trigger type providers.
 
 A worker connection has one namespace. Its function, service, and trigger type registrations use
 that namespace.
+
+## Trigger types and the two namespaces a trigger names
+
+A trigger names two namespaces, and they answer different questions:
+
+- **`namespace`** is where the target function resolves when the trigger fires.
+- **`trigger_namespace`** is where the trigger type's provider is found.
+
+Both are optional. `namespace` absent means the engine's default namespace.
+`trigger_namespace` absent is not `default`: the engine resolves it, taking the
+registering worker's namespace first and the default namespace second.
+
+That order is what lets a project ship its own provider for a trigger type the
+engine also provides. The engine's own providers (`http`, `cron`, `state`,
+`stream`) live in the default namespace, so a worker that names nothing reaches
+them. A project that registers its own provider for the same type id gets that
+one instead, without any worker changing how it binds.
+
+Naming `trigger_namespace` explicitly is strict: that namespace or nothing. A
+binding that names one is never moved.
+
+A provider that registers after a binding already fell back to the default
+namespace claims that binding back. Start order therefore does not decide which
+provider serves a project.
 
 ## What namespaces enable
 

--- a/docs/next/understanding-iii/namespaces.mdx.skill.md
+++ b/docs/next/understanding-iii/namespaces.mdx.skill.md
@@ -13,9 +13,34 @@ The engine uses these registry keys:
 
 - `(namespace, function_id)` for functions.
 - `(namespace, worker_name)` for workers.
+- `(namespace, trigger_type_id)` for trigger type providers.
 
 A worker connection has one namespace. Its function, service, and trigger type registrations use
 that namespace.
+
+## Trigger types and the two namespaces a trigger names
+
+A trigger names two namespaces, and they answer different questions:
+
+- **`namespace`** is where the target function resolves when the trigger fires.
+- **`trigger_namespace`** is where the trigger type's provider is found.
+
+Both are optional. `namespace` absent means the engine's default namespace.
+`trigger_namespace` absent is not `default`: the engine resolves it, taking the
+registering worker's namespace first and the default namespace second.
+
+That order is what lets a project ship its own provider for a trigger type the
+engine also provides. The engine's own providers (`http`, `cron`, `state`,
+`stream`) live in the default namespace, so a worker that names nothing reaches
+them. A project that registers its own provider for the same type id gets that
+one instead, without any worker changing how it binds.
+
+Naming `trigger_namespace` explicitly is strict: that namespace or nothing. A
+binding that names one is never moved.
+
+A provider that registers after a binding already fell back to the default
+namespace claims that binding back. Start order therefore does not decide which
+provider serves a project.
 
 ## What namespaces enable
 

--- a/engine/benches/control_plane_churn_bench.rs
+++ b/engine/benches/control_plane_churn_bench.rs
@@ -131,6 +131,9 @@ fn control_plane_churn_benchmark(c: &mut Criterion) {
                                     worker_id: None,
                                     metadata: None,
                                     namespace: "default".to_string(),
+                                    trigger_namespace: None,
+                                    home_namespace: iii::protocol::default_namespace(),
+                                    provider_namespace: iii::protocol::default_namespace(),
                                 })
                                 .await
                                 .expect("register trigger");

--- a/engine/benches/http_blackbox/mod.rs
+++ b/engine/benches/http_blackbox/mod.rs
@@ -210,6 +210,7 @@ async fn run_worker(ws_url: String, route_count: usize) {
                     }),
                     metadata: None,
                     namespace: None,
+                    trigger_namespace: None,
                 })
                 .expect("serialize RegisterTrigger")
                 .into(),

--- a/engine/benches/protocol_serde_bench.rs
+++ b/engine/benches/protocol_serde_bench.rs
@@ -31,6 +31,7 @@ fn build_messages() -> Vec<(&'static str, Message)> {
                 config: json!({"api_path": "bench/0", "http_method": "POST"}),
                 metadata: None,
                 namespace: None,
+                trigger_namespace: None,
             },
         ),
         (

--- a/engine/benches/trigger_fanout_bench.rs
+++ b/engine/benches/trigger_fanout_bench.rs
@@ -96,6 +96,9 @@ async fn build_fanout_engine(fanout: usize) -> (Engine, Arc<AtomicUsize>, Arc<No
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: iii::protocol::default_namespace(),
+                provider_namespace: iii::protocol::default_namespace(),
             })
             .await
             .expect("register trigger");

--- a/engine/benches/worker_cleanup_bench.rs
+++ b/engine/benches/worker_cleanup_bench.rs
@@ -259,6 +259,9 @@ fn worker_cleanup_benchmark(c: &mut Criterion) {
                                             worker_id: Some(worker.id),
                                             metadata: None,
                                             namespace: "default".to_string(),
+                                            trigger_namespace: None,
+                                            home_namespace: iii::protocol::default_namespace(),
+                                            provider_namespace: iii::protocol::default_namespace(),
                                         })
                                         .await
                                         .expect("register trigger");

--- a/engine/src/builtins/queue_kv.rs
+++ b/engine/src/builtins/queue_kv.rs
@@ -431,7 +431,7 @@ impl QueueKvStore {
             .entry(key.to_string())
             .or_insert_with(BTreeMap::new);
 
-        for (_, members) in set.iter_mut() {
+        for members in set.values_mut() {
             members.remove(&member);
         }
 

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -96,6 +96,16 @@ enum NamespaceState {
     Aborted(String),
 }
 
+/// The refusal every blank-namespace guard sends back, naming the field so the
+/// caller knows which of the two on a trigger was the empty one.
+fn blank_namespace_message(field: &str) -> String {
+    format!(
+        "`{field}` is empty: it was named and left blank. Give it a name, or omit it to use \
+         `{}`.",
+        DEFAULT_NAMESPACE
+    )
+}
+
 /// Registration messages are the only ones whose effect depends on the
 /// connection's namespace, so they are the only ones worth buffering.
 ///
@@ -103,6 +113,14 @@ enum NamespaceState {
 /// registration: leaving it unbuffered would let it run against an empty
 /// registry while the matching `RegisterFunction` still sits in the queue,
 /// inverting the pair and resurrecting a function the worker retired.
+///
+/// `RegisterTriggerType` is buffered because a provider is filed under
+/// `(namespace, type_id)` taken from the connection. Handling one while the
+/// namespace is still `Pending` files it under `default` — where it replaces
+/// the engine's own provider for that id and is handed everyone's bindings.
+/// Whether that happens comes down to whether an SDK flushes its registrations
+/// before or after `engine::workers::register`, which is not something a worker
+/// author chooses.
 ///
 /// `RegisterTrigger` is buffered too, to preserve arrival order relative to the
 /// same connection's `RegisterFunction`s. A trigger carries an explicit target
@@ -119,6 +137,7 @@ fn is_namespaced_registration(msg: &Message) -> bool {
             | Message::UnregisterFunction { .. }
             | Message::RegisterTrigger { .. }
             | Message::UnregisterTrigger { .. }
+            | Message::RegisterTriggerType { .. }
     )
 }
 
@@ -1116,6 +1135,9 @@ impl Engine {
                     return Ok(());
                 };
                 let stored_trigger_type = trigger_entry.trigger_type.clone();
+                // The provider this binding actually resolved to: the result
+                // may only come from the worker serving *that* one.
+                let stored_provider = trigger_entry.provider_key();
                 let stored_function_id = trigger_entry.function_id.clone();
                 let originator_id = trigger_entry.worker_id;
                 drop(trigger_entry);
@@ -1127,7 +1149,7 @@ impl Engine {
                 let registrator_worker_id = self
                     .trigger_registry
                     .trigger_types
-                    .get(&stored_trigger_type)
+                    .get(&stored_provider)
                     .and_then(|tt| tt.worker_id);
                 if registrator_worker_id != Some(worker.id) {
                     tracing::warn!(
@@ -1184,10 +1206,32 @@ impl Engine {
                 description,
                 trigger_request_format,
                 call_request_format,
+                namespace,
             } => {
+                // No ack exists for this message, so a refusal can only be
+                // logged. It is logged loudly: the provider will never be
+                // reachable, and every binding meant for it parks.
+                if crate::protocol::is_blank_namespace(namespace) {
+                    tracing::error!(
+                        worker_id = %worker.id,
+                        trigger_type_id = %id,
+                        "{}",
+                        blank_namespace_message("namespace")
+                    );
+                    return Ok(());
+                }
+
+                // The connection's namespace unless the message overrides it.
+                // This is what stops two projects providing the same type id
+                // from overwriting each other — and what makes a provider
+                // shipped inside a project reachable from that project first.
+                let provider_namespace = namespace
+                    .clone()
+                    .unwrap_or_else(|| self.connection_namespace(worker));
                 tracing::debug!(
                     worker_id = %worker.id,
                     trigger_type_id = %id,
+                    namespace = %provider_namespace,
                     description = %description,
                     "RegisterTriggerType"
                 );
@@ -1238,7 +1282,8 @@ impl Engine {
                     }
                 }
 
-                let mut trigger_type = TriggerType::new(
+                let mut trigger_type = TriggerType::new_ns(
+                    provider_namespace,
                     reg_id,
                     reg_description,
                     Box::new(worker.clone()),
@@ -1278,6 +1323,7 @@ impl Engine {
                 config,
                 metadata,
                 namespace,
+                trigger_namespace,
             } => {
                 tracing::debug!(
                     trigger_id = %id,
@@ -1286,6 +1332,32 @@ impl Engine {
                     config = ?config,
                     "RegisterTrigger"
                 );
+
+                // Either namespace named and left empty is refused. They are
+                // different questions -- one locates the target, the other the
+                // provider -- and both are answerable to the caller here.
+                for (field, value) in [
+                    ("namespace", namespace),
+                    ("trigger_namespace", trigger_namespace),
+                ] {
+                    if crate::protocol::is_blank_namespace(value) {
+                        let _ = self
+                            .send_msg(
+                                worker,
+                                Message::TriggerRegistrationResult {
+                                    id: id.clone(),
+                                    trigger_type: trigger_type.clone(),
+                                    function_id: function_id.clone(),
+                                    error: Some(crate::protocol::ErrorBody::new(
+                                        crate::protocol::INVALID_NAMESPACE,
+                                        blank_namespace_message(field),
+                                    )),
+                                },
+                            )
+                            .await;
+                        return Ok(());
+                    }
+                }
 
                 let mut reg_trigger_id = id.clone();
                 let mut reg_trigger_type = trigger_type.clone();
@@ -1319,7 +1391,7 @@ impl Engine {
                             // The namespace the trigger's target will resolve in
                             // (the message's, or `default` when absent), so the
                             // hook can authorize per target namespace.
-                            "namespace": crate::protocol::effective_namespace(&namespace),
+                            "namespace": crate::protocol::effective_namespace(namespace),
                             "context": session.context,
                         });
                         match self.call(hook_fn_id, hook_input).await {
@@ -1362,9 +1434,16 @@ impl Engine {
                 // connection: absent means the engine's default namespace. A
                 // worker can therefore expose a function in any namespace, and
                 // must opt in explicitly to reach its own namespaced functions.
-                let trigger_namespace = namespace
+                let target_namespace = namespace
                     .clone()
                     .unwrap_or_else(|| crate::protocol::DEFAULT_NAMESPACE.to_string());
+
+                // Where the binding looks for its provider, and where it looks
+                // first. `trigger_namespace` absent is not `default`: it asks
+                // the registry to try home before falling back, which is what
+                // carries an unmigrated worker onto the engine's provider while
+                // letting a project's own provider win when it has one.
+                let home_namespace = self.connection_namespace(worker);
 
                 // Gate the target the same way `InvokeFunction` does: RBAC is
                 // keyed by function id but inspects the `Function` this trigger
@@ -1372,11 +1451,11 @@ impl Engine {
                 // worker could expose any namespace's function over a trigger.
                 if let Some(session) = &worker.session {
                     let function = self
-                        .resolve_function(Some(&trigger_namespace), &reg_function_id)
+                        .resolve_function(Some(&target_namespace), &reg_function_id)
                         .ok();
                     if !crate::workers::worker::rbac_config::is_function_allowed(
                         &reg_function_id,
-                        &trigger_namespace,
+                        &target_namespace,
                         session.config.rbac.clone(),
                         &session.allowed_functions,
                         &session.forbidden_functions,
@@ -1386,7 +1465,7 @@ impl Engine {
                             worker_id = %worker.id,
                             trigger_id = %reg_trigger_id,
                             function_id = %reg_function_id,
-                            namespace = %trigger_namespace,
+                            namespace = %target_namespace,
                             "trigger registration denied by RBAC"
                         );
                         // Name the id that was actually authorized (post-prefix),
@@ -1394,7 +1473,7 @@ impl Engine {
                         // is moved into the struct below, so build the text first.
                         let denied_message = format!(
                             "function '{}' not allowed in namespace '{}'",
-                            reg_function_id, trigger_namespace
+                            reg_function_id, target_namespace
                         );
                         let result_msg = Message::TriggerRegistrationResult {
                             id: reg_trigger_id,
@@ -1419,7 +1498,12 @@ impl Engine {
                         config: reg_config,
                         worker_id: Some(worker.id),
                         metadata: metadata.clone(),
-                        namespace: trigger_namespace,
+                        namespace: target_namespace,
+                        trigger_namespace: trigger_namespace.clone(),
+                        home_namespace,
+                        // Written by the registry once it resolves; this is
+                        // only the value it starts from.
+                        provider_namespace: crate::protocol::default_namespace(),
                     })
                     .await
                 {
@@ -1483,6 +1567,38 @@ impl Engine {
                     "InvokeFunction"
                 );
 
+                // A named-but-empty namespace is a mistake, not a request for
+                // `default`. Answering the caller beats resolving somewhere
+                // they did not ask for: the call would otherwise land in
+                // whatever the empty string routes to and look like a miss.
+                if crate::protocol::is_blank_namespace(namespace) {
+                    if let Some(invocation_id) = invocation_id {
+                        let _ = self
+                            .send_msg(
+                                worker,
+                                Message::InvocationResult {
+                                    invocation_id: *invocation_id,
+                                    function_id: function_id.clone(),
+                                    result: None,
+                                    error: Some(crate::protocol::ErrorBody::new(
+                                        crate::protocol::INVALID_NAMESPACE,
+                                        blank_namespace_message("namespace"),
+                                    )),
+                                    traceparent: None,
+                                    baggage: None,
+                                },
+                            )
+                            .await;
+                    } else {
+                        tracing::warn!(
+                            worker_id = %worker.id,
+                            function_id = %function_id,
+                            "InvokeFunction carried an empty namespace; dropped"
+                        );
+                    }
+                    return Ok(());
+                }
+
                 if let Some(session) = &worker.session {
                     // Resolve strictly in the requested namespace first: RBAC is
                     // still keyed by function id, but the `Function` it inspects
@@ -1495,7 +1611,7 @@ impl Engine {
                         .ok();
                     if !crate::workers::worker::rbac_config::is_function_allowed(
                         function_id,
-                        crate::protocol::effective_namespace(&namespace),
+                        crate::protocol::effective_namespace(namespace),
                         session.config.rbac.clone(),
                         &session.allowed_functions,
                         &session.forbidden_functions,
@@ -1540,13 +1656,13 @@ impl Engine {
                     // middleware keeps intercepting user code.
                     if let Some(middleware_id) = &session.config.middleware_function_id
                         && !self
-                            .is_engine_owned_builtin(effective_namespace(&namespace), function_id)
+                            .is_engine_owned_builtin(effective_namespace(namespace), function_id)
                     {
                         let inv_id = (*invocation_id).unwrap_or_else(Uuid::new_v4);
                         // Resolve the middleware in the caller's namespace and hand
                         // it that namespace, so a namespaced invoke reaches the
                         // matching middleware and can re-target the same namespace.
-                        let ns = effective_namespace(&namespace).to_string();
+                        let ns = effective_namespace(namespace).to_string();
                         let middleware_input = serde_json::json!({
                             "function_id": function_id,
                             "payload": data,
@@ -1607,7 +1723,7 @@ impl Engine {
                         // Capture the invoke's namespace so the queue provider
                         // enqueues (and the consumer later resolves) the target
                         // in the caller's namespace rather than `default`.
-                        let target_namespace = effective_namespace(&namespace).to_string();
+                        let target_namespace = effective_namespace(namespace).to_string();
                         let traceparent = traceparent.clone();
                         let baggage = baggage.clone();
                         let queued_baggage = crate::telemetry::baggage_with_function_id(
@@ -2972,10 +3088,11 @@ impl EngineTrait for Engine {
         if self
             .trigger_registry
             .trigger_types
-            .contains_key(&trigger_type.id)
+            .contains_key(&trigger_type.key())
         {
             tracing::info!(
                 trigger_type_id = %trigger_type.id,
+                namespace = %trigger_type.namespace,
                 "Trigger type re-registered; replacing registrator and re-delivering its registrations"
             );
         }
@@ -3712,6 +3829,7 @@ mod tests {
             config: serde_json::json!({ "api_path": "charge", "http_method": "POST" }),
             metadata: None,
             namespace: Some("default".to_string()),
+            trigger_namespace: None,
         };
         // dispatch directly to skip the namespace buffer (test worker never
         // announces a namespace); we only exercise the RBAC gate.
@@ -4014,6 +4132,7 @@ mod tests {
             description: "A test trigger type".to_string(),
             trigger_request_format: None,
             call_request_format: None,
+            namespace: None,
         };
         engine
             .router_msg(&worker, &register_type_msg)
@@ -4024,7 +4143,10 @@ mod tests {
             engine
                 .trigger_registry
                 .trigger_types
-                .contains_key("my_trigger_type"),
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    "my_trigger_type"
+                )),
             "trigger type should be registered"
         );
 
@@ -4036,6 +4158,7 @@ mod tests {
             config: serde_json::json!({"key": "value"}),
             metadata: None,
             namespace: None,
+            trigger_namespace: None,
         };
         engine
             .router_msg(&worker, &register_trigger_msg)
@@ -4065,6 +4188,7 @@ mod tests {
             description: "Trigger type for unregister test".to_string(),
             trigger_request_format: None,
             call_request_format: None,
+            namespace: None,
         };
         engine
             .router_msg(&worker, &register_type_msg)
@@ -4079,6 +4203,7 @@ mod tests {
             config: serde_json::json!({}),
             metadata: None,
             namespace: None,
+            trigger_namespace: None,
         };
         engine
             .router_msg(&worker, &register_trigger_msg)
@@ -4619,7 +4744,10 @@ mod tests {
         let trigger_type = engine
             .trigger_registry
             .trigger_types
-            .get("duplicate")
+            .get(&crate::trigger::type_key(
+                crate::protocol::DEFAULT_NAMESPACE,
+                "duplicate",
+            ))
             .expect("trigger type should remain registered");
         assert_eq!(trigger_type._description, "second");
     }
@@ -4652,6 +4780,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             },
         );
         engine.trigger_registry.triggers.insert(
@@ -4664,6 +4795,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             },
         );
 
@@ -4940,6 +5074,7 @@ mod tests {
             description: "Trigger type for cleanup test".to_string(),
             trigger_request_format: None,
             call_request_format: None,
+            namespace: None,
         };
         engine
             .router_msg(&worker, &register_type_msg)
@@ -4954,6 +5089,7 @@ mod tests {
             config: serde_json::json!({}),
             metadata: None,
             namespace: None,
+            trigger_namespace: None,
         };
         engine
             .router_msg(&worker, &register_trigger_msg)
@@ -4970,7 +5106,10 @@ mod tests {
             engine
                 .trigger_registry
                 .trigger_types
-                .contains_key("cleanup_trigger_type")
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    "cleanup_trigger_type"
+                ))
         );
 
         // Drain channel messages
@@ -4991,7 +5130,10 @@ mod tests {
             !engine
                 .trigger_registry
                 .trigger_types
-                .contains_key("cleanup_trigger_type"),
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    "cleanup_trigger_type"
+                )),
             "trigger type should be removed after worker cleanup"
         );
 
@@ -5145,7 +5287,7 @@ mod tests {
 
     fn insert_trigger_type_for(engine: &Engine, type_id: &str, registrator: &WorkerConnection) {
         engine.trigger_registry.trigger_types.insert(
-            type_id.to_string(),
+            crate::trigger::type_key(crate::protocol::DEFAULT_NAMESPACE, &type_id.to_string()),
             crate::trigger::TriggerType::new(
                 type_id,
                 "test trigger type",
@@ -5179,6 +5321,9 @@ mod tests {
                 worker_id: Some(user.id),
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             },
         );
 
@@ -5280,6 +5425,9 @@ mod tests {
                     worker_id: Some(user.id),
                     metadata: None,
                     namespace: crate::protocol::DEFAULT_NAMESPACE.to_string(),
+                    trigger_namespace: None,
+                    home_namespace: crate::protocol::default_namespace(),
+                    provider_namespace: crate::protocol::default_namespace(),
                 },
             );
 
@@ -5347,6 +5495,9 @@ mod tests {
                     worker_id: Some(user.id),
                     metadata: None,
                     namespace: crate::protocol::DEFAULT_NAMESPACE.to_string(),
+                    trigger_namespace: None,
+                    home_namespace: crate::protocol::default_namespace(),
+                    provider_namespace: crate::protocol::default_namespace(),
                 },
             );
 
@@ -5422,6 +5573,9 @@ mod tests {
                 worker_id: Some(user.id),
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             },
         );
 
@@ -5493,6 +5647,9 @@ mod tests {
                 worker_id: Some(user.id),
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             },
         );
 
@@ -5536,6 +5693,7 @@ mod tests {
             config: serde_json::json!({}),
             metadata: None,
             namespace: None,
+            trigger_namespace: None,
         };
 
         engine
@@ -5559,6 +5717,120 @@ mod tests {
         assert!(!engine.trigger_registry.triggers.contains_key("trig-1"));
     }
 
+    // ── A namespace named and left blank ─────────────────────────────────
+    //
+    // The SDKs each refuse this at construction, in four different ways, and
+    // one of them (the browser) did not refuse it at all. The engine is the
+    // one party every client goes through, so it refuses too -- and it refuses
+    // rather than reading blank as absent, because the two ask for opposite
+    // things.
+
+    #[tokio::test]
+    async fn a_blank_namespace_on_invoke_is_answered_not_routed() {
+        ensure_default_meter();
+        let engine = Engine::new();
+        let (tx, mut rx) = mpsc::channel::<Outbound>(8);
+        let worker = WorkerConnection::new(tx);
+        engine.worker_registry.register_worker(worker.clone());
+
+        engine
+            .router_msg(
+                &worker,
+                &Message::InvokeFunction {
+                    invocation_id: Some(uuid::Uuid::new_v4()),
+                    function_id: "svc::run".to_string(),
+                    data: serde_json::json!({}),
+                    traceparent: None,
+                    baggage: None,
+                    action: None,
+                    metadata: None,
+                    namespace: Some(String::new()),
+                },
+            )
+            .await
+            .expect("the message is handled, not dropped");
+
+        let out = rx.try_recv().expect("the caller must be answered");
+        let Outbound::Protocol(Message::InvocationResult { error, .. }) = out else {
+            panic!("expected an InvocationResult, got {out:?}");
+        };
+        let error = error.expect("a blank namespace is an error, not a miss");
+        assert_eq!(error.code, crate::protocol::INVALID_NAMESPACE);
+    }
+
+    #[tokio::test]
+    async fn a_blank_namespace_on_a_trigger_names_which_field_was_empty() {
+        ensure_default_meter();
+        let engine = Engine::new();
+        let (tx, mut rx) = mpsc::channel::<Outbound>(8);
+        let worker = WorkerConnection::new(tx);
+        engine.worker_registry.register_worker(worker.clone());
+
+        // A trigger carries two namespaces for two questions, so the refusal
+        // has to say which one was blank.
+        for (field, namespace, trigger_namespace) in [
+            ("namespace", Some(String::new()), None),
+            ("trigger_namespace", None, Some("  ".to_string())),
+        ] {
+            engine
+                .router_msg(
+                    &worker,
+                    &Message::RegisterTrigger {
+                        id: "t1".to_string(),
+                        trigger_type: "cron".to_string(),
+                        function_id: "svc::run".to_string(),
+                        config: serde_json::json!({}),
+                        metadata: None,
+                        namespace,
+                        trigger_namespace,
+                    },
+                )
+                .await
+                .expect("handled");
+
+            let out = rx.try_recv().expect("the worker must be told");
+            let Outbound::Protocol(Message::TriggerRegistrationResult { error, .. }) = out else {
+                panic!("expected a TriggerRegistrationResult, got {out:?}");
+            };
+            let error = error.expect("a blank namespace is an error");
+            assert_eq!(error.code, crate::protocol::INVALID_NAMESPACE);
+            assert!(error.message.contains(field), "{}", error.message);
+        }
+
+        assert!(
+            engine.trigger_registry.triggers.is_empty()
+                && engine.trigger_registry.pending_triggers.is_empty(),
+            "a refused binding must not be parked either"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_blank_namespace_on_a_trigger_type_registers_nothing() {
+        ensure_default_meter();
+        let engine = Engine::new();
+        let (tx, _rx) = mpsc::channel::<Outbound>(8);
+        let worker = WorkerConnection::new(tx);
+
+        engine
+            .router_msg(
+                &worker,
+                &Message::RegisterTriggerType {
+                    id: "webhook".to_string(),
+                    description: "blank namespace".to_string(),
+                    trigger_request_format: None,
+                    call_request_format: None,
+                    namespace: Some(String::new()),
+                },
+            )
+            .await
+            .expect("handled");
+
+        assert!(
+            engine.trigger_registry.trigger_types.is_empty(),
+            "a provider with no namespace to serve must not be filed anywhere"
+        );
+    }
+
     #[tokio::test]
     async fn test_deferred_trigger_activates_when_provider_registers_type() {
         ensure_default_meter();
@@ -5577,6 +5849,7 @@ mod tests {
             config: serde_json::json!({}),
             metadata: None,
             namespace: None,
+            trigger_namespace: None,
         };
         engine
             .router_msg(&worker, &msg)
@@ -5598,6 +5871,7 @@ mod tests {
             description: "arrives after its triggers".to_string(),
             trigger_request_format: None,
             call_request_format: None,
+            namespace: None,
         };
         engine
             .router_msg(&provider, &tt_msg)
@@ -5633,6 +5907,7 @@ mod tests {
             config: serde_json::json!({}),
             metadata: None,
             namespace: None,
+            trigger_namespace: None,
         };
         engine
             .router_msg(&worker, &msg)
@@ -5663,6 +5938,7 @@ mod tests {
             description: "arrives after the owner died".to_string(),
             trigger_request_format: None,
             call_request_format: None,
+            namespace: None,
         };
         engine
             .router_msg(&provider, &tt_msg)
@@ -5690,6 +5966,7 @@ mod tests {
             description: "provided by worker A".to_string(),
             trigger_request_format: None,
             call_request_format: None,
+            namespace: None,
         };
         engine
             .router_msg(&worker_a, &tt_msg)
@@ -5707,6 +5984,7 @@ mod tests {
             config: serde_json::json!({}),
             metadata: None,
             namespace: None,
+            trigger_namespace: None,
         };
         engine
             .router_msg(&worker_b, &reg_msg)
@@ -5774,6 +6052,9 @@ mod tests {
                 worker_id: Some(dead_worker),
                 metadata: None,
                 namespace: crate::protocol::DEFAULT_NAMESPACE.to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             },
         );
 
@@ -5787,6 +6068,7 @@ mod tests {
             description: "arrives after the leak".to_string(),
             trigger_request_format: None,
             call_request_format: None,
+            namespace: None,
         };
         engine
             .router_msg(&provider, &tt_msg)
@@ -6695,6 +6977,7 @@ mod tests {
                         description: "provider".to_string(),
                         trigger_request_format: None,
                         call_request_format: None,
+                        namespace: None,
                     },
                 )
                 .await
@@ -6718,6 +7001,7 @@ mod tests {
                 config: serde_json::json!({}),
                 metadata: None,
                 namespace: None,
+                trigger_namespace: None,
             };
             engine
                 .router_msg(&old_worker, &reg_fn)
@@ -7106,6 +7390,7 @@ mod tests {
             description: "Test trigger type for cleanup".to_string(),
             trigger_request_format: None,
             call_request_format: None,
+            namespace: None,
         };
         engine
             .router_msg(&worker, &tt_msg)
@@ -7120,6 +7405,7 @@ mod tests {
             config: serde_json::json!({}),
             metadata: None,
             namespace: None,
+            trigger_namespace: None,
         };
         engine
             .router_msg(&worker, &t_msg)
@@ -7275,6 +7561,7 @@ mod tests {
             description: "Trigger type for metadata test".to_string(),
             trigger_request_format: None,
             call_request_format: None,
+            namespace: None,
         };
         engine
             .router_msg(&worker, &register_type_msg)
@@ -7288,6 +7575,7 @@ mod tests {
             config: serde_json::json!({"key": "value"}),
             metadata: Some(serde_json::json!({"team": "platform", "env": "staging"})),
             namespace: None,
+            trigger_namespace: None,
         };
         engine
             .router_msg(&worker, &register_trigger_msg)
@@ -7418,6 +7706,7 @@ mod tests {
                 config: serde_json::json!({}),
                 metadata: None,
                 namespace: None,
+                trigger_namespace: None,
             },
             Message::UnregisterTrigger {
                 id: "t1".to_string(),

--- a/engine/src/protocol.rs
+++ b/engine/src/protocol.rs
@@ -44,6 +44,26 @@ pub const WORKER_NAMESPACE_CONFLICT: &str = "WORKER_NAMESPACE_CONFLICT";
 /// refused; the connection stays open.
 pub const FUNCTION_NAMESPACE_CONFLICT: &str = "FUNCTION_NAMESPACE_CONFLICT";
 
+/// A namespace field was present and held nothing but whitespace.
+pub const INVALID_NAMESPACE: &str = "INVALID_NAMESPACE";
+
+/// Whether a namespace field was named and left empty.
+///
+/// Absent and blank are opposite intents. Absent asks for [`DEFAULT_NAMESPACE`];
+/// blank names a namespace and gives nothing to name it with. Reading blank as
+/// absent puts the worker in `default` — somewhere it never asked for, where
+/// every call and trigger it makes then follows it, and the one place an
+/// operator cannot see by reading the declaration. Filing it under the empty
+/// string is worse still: a namespace nobody can address or type.
+///
+/// The SDKs refuse this at construction, each in its own way. The engine
+/// refuses it again because it is the only party every client goes through, and
+/// because an SDK that forgets (or a hand-rolled client) must not be able to
+/// create a namespace with no name.
+pub fn is_blank_namespace(ns: &Option<String>) -> bool {
+    ns.as_deref().is_some_and(|ns| ns.trim().is_empty())
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HttpInvocationRef {
     pub url: String,
@@ -78,6 +98,14 @@ pub enum Message {
         trigger_request_format: Option<Value>,
         #[serde(skip_serializing_if = "Option::is_none")]
         call_request_format: Option<Value>,
+        /// Namespace this provider serves. Absent means the registering
+        /// connection's namespace, which is what every SDK wants and what
+        /// keeps two projects providing the same type id from overwriting each
+        /// other. In-process engine providers register in
+        /// [`DEFAULT_NAMESPACE`], where the resolution in
+        /// [`crate::trigger::TriggerRegistry`] falls back to find them.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        namespace: Option<String>,
     },
     RegisterTrigger {
         id: String,
@@ -92,6 +120,16 @@ pub enum Message {
         /// send it stay wire-compatible.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         namespace: Option<String>,
+        /// Namespace to find `trigger_type`'s provider in.
+        ///
+        /// Absent is not "default": it asks the engine to resolve, taking the
+        /// registering connection's namespace first and [`DEFAULT_NAMESPACE`]
+        /// second. That is what lets a project ship its own provider for a
+        /// type id the engine also provides, while every worker that has not
+        /// been migrated keeps reaching the engine's one without saying so.
+        /// Naming a namespace here is strict: that namespace or nothing.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        trigger_namespace: Option<String>,
     },
     TriggerRegistrationResult {
         id: String,

--- a/engine/src/trigger.rs
+++ b/engine/src/trigger.rs
@@ -64,8 +64,25 @@ pub enum RegisterTriggerOutcome {
     Deferred,
 }
 
+/// What identifies a provider: the namespace it serves and the type id it
+/// answers for.
+///
+/// The id alone was the key until trigger types became namespaced, and two
+/// projects providing the same id overwrote each other — silently, and taking
+/// the loser's bindings with them into the winner's provider.
+pub type TypeKey = (String, String);
+
+/// Builds a [`TypeKey`] without the call sites spelling out two `to_string()`s.
+pub fn type_key(namespace: &str, id: &str) -> TypeKey {
+    (namespace.to_string(), id.to_string())
+}
+
 pub struct TriggerType {
     pub id: String,
+    /// Namespace this provider serves. In-process engine providers use
+    /// [`DEFAULT_NAMESPACE`]; an SDK worker's provider uses its connection's
+    /// namespace.
+    pub namespace: String,
     pub _description: String,
     pub trigger_request_format: Option<Value>,
     pub call_request_format: Option<Value>,
@@ -75,7 +92,25 @@ pub struct TriggerType {
 }
 
 impl TriggerType {
+    /// A provider in [`DEFAULT_NAMESPACE`] — where every in-process engine
+    /// provider lives, and where a resolved lookup falls back to.
     pub fn new(
+        id: impl Into<String>,
+        description: impl Into<String>,
+        registrator: Box<dyn TriggerRegistrator>,
+        worker_id: Option<Uuid>,
+    ) -> Self {
+        Self::new_ns(
+            crate::protocol::DEFAULT_NAMESPACE,
+            id,
+            description,
+            registrator,
+            worker_id,
+        )
+    }
+
+    pub fn new_ns(
+        namespace: impl Into<String>,
         id: impl Into<String>,
         description: impl Into<String>,
         registrator: Box<dyn TriggerRegistrator>,
@@ -87,6 +122,7 @@ impl TriggerType {
         let call_response_format = Self::call_response_format_for(&id);
         Self {
             id,
+            namespace: namespace.into(),
             _description: description.into(),
             trigger_request_format,
             call_request_format,
@@ -94,6 +130,11 @@ impl TriggerType {
             registrator,
             worker_id,
         }
+    }
+
+    /// The key this provider is filed under.
+    pub fn key(&self) -> TypeKey {
+        (self.namespace.clone(), self.id.clone())
     }
 
     pub fn with_trigger_request_format<T: schemars::JsonSchema>(mut self) -> Self {
@@ -222,6 +263,62 @@ pub struct Trigger {
     /// durable registrations and for wire payloads that predate the field.
     #[serde(default = "crate::protocol::default_namespace")]
     pub namespace: String,
+    /// Namespace the caller named for the provider, if any.
+    ///
+    /// `Some` is strict: that namespace or nothing. `None` asks for the
+    /// resolution in [`TriggerRegistry::resolve_provider_key`] — `home_namespace`
+    /// first, then [`DEFAULT_NAMESPACE`] — which is what carries workers that
+    /// have not been migrated onto the engine's own providers without them
+    /// saying anything.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_namespace: Option<String>,
+    /// The registering connection's namespace: the first place a resolved
+    /// lookup looks, and the namespace a provider must later register in to
+    /// claim this binding back from the fallback.
+    ///
+    /// Kept apart from `namespace`, which is the *target*'s: a worker may bind
+    /// a trigger whose function lives elsewhere, and its provider should still
+    /// be the one at home.
+    #[serde(default = "crate::protocol::default_namespace")]
+    pub home_namespace: String,
+    /// Where the provider was actually found. Written by the registry at bind
+    /// time and read by everything that has to reach the same provider again:
+    /// replay, unregister, and the disconnect sweep.
+    #[serde(default = "crate::protocol::default_namespace")]
+    pub provider_namespace: String,
+}
+
+impl Trigger {
+    /// The three namespace fields for an engine-internal binding: one declared
+    /// in engine configuration, or registered through
+    /// `engine::register_trigger` rather than by a worker connection.
+    ///
+    /// These are engine orchestration, so they are at home in
+    /// [`DEFAULT_NAMESPACE`] and resolve their provider there — which is also
+    /// where every in-process provider registers. They stay resolvable rather
+    /// than explicit so a project that later provides the type can still be
+    /// preferred if such a binding is ever given a different home.
+    pub fn internal_namespaces() -> (Option<String>, String, String) {
+        (
+            None,
+            crate::protocol::default_namespace(),
+            crate::protocol::default_namespace(),
+        )
+    }
+
+    /// The provider this binding is currently bound to.
+    pub fn provider_key(&self) -> TypeKey {
+        (self.provider_namespace.clone(), self.trigger_type.clone())
+    }
+
+    /// Whether this binding is only on the fallback provider, and so would
+    /// prefer a provider that registers at home later.
+    ///
+    /// Explicit bindings are never re-homed: naming a namespace means that one
+    /// and no other.
+    pub fn is_on_fallback(&self) -> bool {
+        self.trigger_namespace.is_none() && self.provider_namespace != self.home_namespace
+    }
 }
 
 // Only `id` is considered for Hash and Eq/PartialEq
@@ -239,7 +336,8 @@ impl std::hash::Hash for Trigger {
 
 #[derive(Default)]
 pub struct TriggerRegistry {
-    pub trigger_types: Arc<DashMap<String, TriggerType>>,
+    /// Providers, by `(namespace, type id)`.
+    pub trigger_types: Arc<DashMap<TypeKey, TriggerType>>,
     pub triggers: Arc<DashMap<String, Trigger>>,
     /// Registration intents whose trigger type is not currently available or
     /// whose activation did not complete: the type never registered, its
@@ -288,8 +386,117 @@ impl TriggerRegistry {
             .unwrap_or_else(|| crate::protocol::DEFAULT_NAMESPACE.to_string())
     }
 
+    /// Where this binding's provider lives, or `None` when nothing provides it.
+    ///
+    /// Two steps, and the order is the whole migration story: a project that
+    /// ships its own provider for a type id gets it, and everything that has
+    /// not been migrated reaches the engine's provider in
+    /// [`DEFAULT_NAMESPACE`] without having to say so. Naming a namespace
+    /// explicitly skips both steps — that namespace or nothing, because a
+    /// caller who was specific should not be quietly served by someone else.
+    pub fn resolve_provider_key(&self, trigger: &Trigger) -> Option<TypeKey> {
+        if let Some(explicit) = &trigger.trigger_namespace {
+            let key = type_key(explicit, &trigger.trigger_type);
+            return self.trigger_types.contains_key(&key).then_some(key);
+        }
+
+        let home = type_key(&trigger.home_namespace, &trigger.trigger_type);
+        if self.trigger_types.contains_key(&home) {
+            return Some(home);
+        }
+
+        let fallback = type_key(crate::protocol::DEFAULT_NAMESPACE, &trigger.trigger_type);
+        self.trigger_types
+            .contains_key(&fallback)
+            .then_some(fallback)
+    }
+
+    /// Bindings that fell back to [`DEFAULT_NAMESPACE`] and would rather have
+    /// the provider that just registered at `namespace`.
+    ///
+    /// Without this the resolution is order-dependent: a worker that binds
+    /// before its project's provider announces itself lands on the engine's
+    /// one and stays there for good — so whether a project's own provider is
+    /// used comes down to which container started first, which is not
+    /// something anyone can see or control.
+    fn fallback_bindings_for(&self, namespace: &str, type_id: &str) -> Vec<Trigger> {
+        self.triggers
+            .iter()
+            .filter(|pair| {
+                let trigger = pair.value();
+                trigger.trigger_type == type_id
+                    && trigger.home_namespace == namespace
+                    && trigger.is_on_fallback()
+            })
+            .map(|pair| pair.value().clone())
+            .collect()
+    }
+
+    /// Move fallback bindings onto the provider that just registered at home.
+    ///
+    /// The old provider is told to let go first. A failure there is logged and
+    /// not fatal: the binding still moves, because leaving it on a provider
+    /// this registry no longer routes to would make it fire from a place
+    /// nothing can unregister.
+    async fn rehome_fallback_bindings(&self, trigger_type: &TriggerType) {
+        let candidates = self.fallback_bindings_for(&trigger_type.namespace, &trigger_type.id);
+        if candidates.is_empty() {
+            return;
+        }
+
+        for mut trigger in candidates {
+            let previous = trigger.provider_key();
+            if let Some(old) = self.trigger_types.get(&previous)
+                && let Err(err) = old.registrator.unregister_trigger(trigger.clone()).await
+            {
+                tracing::warn!(
+                    error = %err,
+                    trigger_id = %trigger.id,
+                    from = %previous.0,
+                    "Could not detach a trigger from its fallback provider; re-homing anyway"
+                );
+            }
+
+            trigger.provider_namespace = trigger_type.namespace.clone();
+            match trigger_type
+                .registrator
+                .replay_trigger(trigger.clone())
+                .await
+            {
+                Ok(()) => {
+                    tracing::info!(
+                        "{} Trigger {} (type {}) moved from {} to its own namespace {}",
+                        "[RE-HOMED]".green(),
+                        trigger.id.purple(),
+                        trigger.trigger_type.purple(),
+                        previous.0.purple(),
+                        trigger_type.namespace.purple(),
+                    );
+                    self.triggers.insert(trigger.id.clone(), trigger);
+                }
+                Err(err) => {
+                    // It is off the old provider and the new one refused it.
+                    // Park rather than leave it pointing at a provider that is
+                    // no longer routed: pending is the bucket that gets
+                    // retried on the next registration.
+                    tracing::error!(
+                        error = %err,
+                        trigger_id = %trigger.id,
+                        "Re-homing failed; the binding is parked until the trigger type re-registers"
+                    );
+                    let _park = self
+                        .park_transition
+                        .lock()
+                        .expect("park_transition lock poisoned");
+                    self.triggers.remove(&trigger.id);
+                    self.pending_triggers.insert(trigger.id.clone(), trigger);
+                }
+            }
+        }
+    }
+
     pub async fn unregister_worker(&self, worker_id: &Uuid) {
-        let worker_trigger_type_ids: Vec<String> = self
+        let worker_trigger_type_keys: Vec<TypeKey> = self
             .trigger_types
             .iter()
             .filter(|pair| pair.value().worker_id == Some(*worker_id))
@@ -323,7 +530,7 @@ impl TriggerRegistry {
                 continue;
             }
 
-            if let Some(trigger_type) = self.trigger_types.get(&trigger.trigger_type) {
+            if let Some(trigger_type) = self.trigger_types.get(&trigger.provider_key()) {
                 tracing::debug!(trigger_type_id = trigger_type.id, "Unregistering trigger");
 
                 let result: Result<(), anyhow::Error> = trigger_type
@@ -343,8 +550,8 @@ impl TriggerRegistry {
         self.pending_triggers
             .retain(|_, trigger| trigger.worker_id != Some(*worker_id));
 
-        for trigger_type_id in worker_trigger_type_ids {
-            tracing::debug!(trigger_type_id = %trigger_type_id, "Removing trigger type");
+        for key in worker_trigger_type_keys {
+            tracing::debug!(trigger_type_id = %key.1, namespace = %key.0, "Removing trigger type");
             // The entry may have been replaced by a new provider between the
             // snapshot above and now (worker restart: the replacement can
             // register before the old connection's cleanup runs). Only remove
@@ -352,43 +559,74 @@ impl TriggerRegistry {
             // then are its bindings orphaned; a replaced type keeps firing.
             let removed = self
                 .trigger_types
-                .remove_if(&trigger_type_id, |_, tt| tt.worker_id == Some(*worker_id))
+                .remove_if(&key, |_, tt| tt.worker_id == Some(*worker_id))
                 .is_some();
             if !removed {
                 tracing::debug!(
-                    trigger_type_id = %trigger_type_id,
+                    trigger_type_id = %key.1,
                     "Trigger type already replaced by another worker; leaving it"
                 );
                 continue;
             }
-            tracing::debug!(trigger_type_id = %trigger_type_id, "Trigger type removed");
+            tracing::debug!(trigger_type_id = %key.1, "Trigger type removed");
 
-            // Bindings from other owners that reference the departed type are
-            // now orphaned: nothing can fire them. Park them as pending
-            // intents so they are re-activated when the type (re)registers —
-            // a provider worker restart must not silently drop everyone
-            // else's bindings.
+            // Bindings this provider served are now orphaned: nothing can fire
+            // them. Each resolves again — a binding that only resolved here
+            // because it is at home can fall back to the engine's provider in
+            // `default`, which is the same step that carried it before its own
+            // provider existed. Whatever still resolves nowhere is parked, so a
+            // provider restart never silently drops everyone else's bindings.
             let orphaned: Vec<Trigger> = self
                 .triggers
                 .iter()
-                .filter(|pair| pair.value().trigger_type == trigger_type_id)
+                .filter(|pair| pair.value().provider_key() == key)
                 .map(|pair| pair.value().clone())
                 .collect();
-            for trigger in orphaned {
-                // Park only when this call is the one that removed the
-                // binding: a concurrent owner-disconnect cleanup may have
-                // already reaped it, and parking it anyway would resurrect a
-                // dead worker's binding as a pending intent.
+            for mut trigger in orphaned {
+                // Act only when this call is the one that removed the binding:
+                // a concurrent owner-disconnect cleanup may have already
+                // reaped it, and re-adding it would resurrect a dead worker's
+                // binding.
                 if self.triggers.remove(&trigger.id).is_none() {
                     continue;
                 }
-                tracing::warn!(
-                    "{} Trigger {} (type {}, function {}) is disabled: its trigger type was unregistered. It will be re-registered automatically when the trigger type returns.",
-                    "[DISABLED]".yellow(),
-                    trigger.id.purple(),
-                    trigger.trigger_type.purple(),
-                    trigger.function_id.purple(),
-                );
+
+                match self.resolve_provider_key(&trigger) {
+                    Some(next) => {
+                        trigger.provider_namespace = next.0.clone();
+                        let replayed = match self.trigger_types.get(&next) {
+                            Some(provider) => {
+                                provider.registrator.replay_trigger(trigger.clone()).await
+                            }
+                            None => Err(anyhow::anyhow!("provider vanished during failover")),
+                        };
+                        match replayed {
+                            Ok(()) => {
+                                tracing::info!(
+                                    "{} Trigger {} (type {}) fell back to {} after its provider left",
+                                    "[RE-HOMED]".green(),
+                                    trigger.id.purple(),
+                                    trigger.trigger_type.purple(),
+                                    next.0.purple(),
+                                );
+                                self.triggers.insert(trigger.id.clone(), trigger);
+                                continue;
+                            }
+                            Err(err) => tracing::error!(
+                                error = %err,
+                                trigger_id = %trigger.id,
+                                "Fallback provider refused the binding; parking it"
+                            ),
+                        }
+                    }
+                    None => tracing::warn!(
+                        "{} Trigger {} (type {}, function {}) is disabled: its trigger type was unregistered. It will be re-registered automatically when the trigger type returns.",
+                        "[DISABLED]".yellow(),
+                        trigger.id.purple(),
+                        trigger.trigger_type.purple(),
+                        trigger.function_id.purple(),
+                    ),
+                }
                 self.pending_triggers.insert(trigger.id.clone(), trigger);
             }
         }
@@ -398,12 +636,14 @@ impl TriggerRegistry {
         &self,
         trigger_type: TriggerType,
     ) -> Result<(), anyhow::Error> {
+        let key = trigger_type.key();
         let trigger_type_id = trigger_type.id.clone();
 
         tracing::info!(
-            "{} Trigger Type {}",
+            "{} Trigger Type {} in {}",
             "[REGISTERED]".green(),
-            trigger_type_id.purple()
+            trigger_type_id.purple(),
+            trigger_type.namespace.purple()
         );
 
         // Publish the type BEFORE any replay so every concurrent path
@@ -416,20 +656,22 @@ impl TriggerRegistry {
         //    its ownership check (see `unregister_worker`) instead of parking
         //    bindings this registration is about to replay — which would
         //    deliver them twice.
-        self.trigger_types
-            .insert(trigger_type_id.clone(), trigger_type);
+        self.trigger_types.insert(key.clone(), trigger_type);
 
+        // Only the bindings this provider actually serves. Filtering by type
+        // id alone is what sent one project's bindings into another project's
+        // provider, so the resolved key is the filter.
         let matching_triggers: Vec<Trigger> = self
             .triggers
             .iter()
-            .filter(|pair| pair.value().trigger_type == trigger_type_id)
+            .filter(|pair| pair.value().provider_key() == key)
             .map(|pair| pair.value().clone())
             .collect();
 
         // Re-fetch instead of using the inserted value: if an even newer
         // generation replaced the entry in the meantime, replay must route to
         // that one.
-        if let Some(trigger_type) = self.trigger_types.get(&trigger_type_id) {
+        if let Some(trigger_type) = self.trigger_types.get(&key) {
             for trigger in matching_triggers {
                 let result = trigger_type
                     .registrator
@@ -440,21 +682,37 @@ impl TriggerRegistry {
                 }
             }
 
+            // A parked intent resolves again from scratch: it may have been
+            // parked when nothing provided the type at all, and this
+            // registration is what makes it resolvable.
             let pending: Vec<String> = self
                 .pending_triggers
                 .iter()
-                .filter(|pair| pair.value().trigger_type == trigger_type_id)
+                .filter(|pair| {
+                    pair.value().trigger_type == trigger_type_id
+                        && self.resolve_provider_key(pair.value()).as_ref() == Some(&key)
+                })
                 .map(|pair| pair.key().clone())
                 .collect();
 
             for trigger_id in pending {
                 // `remove` claims the intent, so a concurrent drain of the
                 // same type cannot activate it twice.
-                let Some((_, trigger)) = self.pending_triggers.remove(&trigger_id) else {
+                let Some((_, mut trigger)) = self.pending_triggers.remove(&trigger_id) else {
                     continue;
                 };
+                trigger.provider_namespace = key.0.clone();
                 self.activate_pending_trigger(&trigger_type, trigger).await;
             }
+        }
+
+        // Claim back what settled on the fallback before this provider existed.
+        // Re-fetched for the same reason as above, and after the replay so a
+        // binding is never in flight to two providers at once.
+        if key.0 != crate::protocol::DEFAULT_NAMESPACE
+            && let Some(trigger_type) = self.trigger_types.get(&key)
+        {
+            self.rehome_fallback_bindings(&trigger_type).await;
         }
 
         Ok(())
@@ -525,8 +783,17 @@ impl TriggerRegistry {
         &self,
         trigger: Trigger,
     ) -> Result<RegisterTriggerOutcome, anyhow::Error> {
-        let trigger_type_id = trigger.trigger_type.clone();
-        let Some(trigger_type) = self.trigger_types.get(&trigger_type_id) else {
+        let mut trigger = trigger;
+        let resolved = self.resolve_provider_key(&trigger);
+        if let Some(key) = &resolved {
+            trigger.provider_namespace = key.0.clone();
+        }
+        let trigger = trigger;
+
+        let Some(trigger_type) = resolved
+            .as_ref()
+            .and_then(|key| self.trigger_types.get(key))
+        else {
             // Park the intent instead of failing: workers may connect in any
             // order, and a binding that arrives before its trigger type's
             // provider must survive until the provider shows up.
@@ -538,11 +805,16 @@ impl TriggerRegistry {
             // lookup above and the park, its pending drain may have already
             // run. Re-check and activate the intent ourselves — claiming it
             // via `remove` so we never double-activate with a drain.
-            if let Some(trigger_type) = self.trigger_types.get(&trigger_type_id)
-                && let Some((_, parked)) = self.pending_triggers.remove(&trigger.id)
-                && self.activate_pending_trigger(&trigger_type, parked).await
+            // Resolved again rather than reusing the earlier miss: the
+            // provider that appeared in the meantime may be either step.
+            if let Some(key) = self.resolve_provider_key(&trigger)
+                && let Some(trigger_type) = self.trigger_types.get(&key)
+                && let Some((_, mut parked)) = self.pending_triggers.remove(&trigger.id)
             {
-                return Ok(RegisterTriggerOutcome::Registered);
+                parked.provider_namespace = key.0.clone();
+                if self.activate_pending_trigger(&trigger_type, parked).await {
+                    return Ok(RegisterTriggerOutcome::Registered);
+                }
             }
 
             return Ok(RegisterTriggerOutcome::Deferred);
@@ -619,7 +891,7 @@ impl TriggerRegistry {
             trigger_entry.value().clone()
         };
 
-        if let Some(tt) = self.trigger_types.get(&trigger.trigger_type) {
+        if let Some(tt) = self.trigger_types.get(&trigger.provider_key()) {
             tt.registrator.unregister_trigger(trigger.clone()).await?;
         }
 
@@ -658,9 +930,9 @@ impl TriggerRegistry {
                 function_id = %failed.function_id,
                 "Trigger registration rejected by provider; parked as pending until the trigger type re-registers"
             );
-            let trigger_type_id = failed.trigger_type.clone();
+            let provider = failed.provider_key();
             self.pending_triggers.insert(failed.id.clone(), failed);
-            trigger_type_id
+            provider
         };
 
         // Close the park/replacement race (mirror of the unknown-type park in
@@ -684,6 +956,7 @@ impl TriggerRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol::DEFAULT_NAMESPACE;
     use std::collections::HashSet;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -778,7 +1051,351 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         }
+    }
+
+    /// A binding as a worker at `home` would register it: the provider is
+    /// resolved, not named.
+    fn resolved_trigger(id: &str, trigger_type: &str, home: &str) -> Trigger {
+        Trigger {
+            home_namespace: home.to_string(),
+            ..make_trigger(id, trigger_type)
+        }
+    }
+
+    /// A binding that names its provider's namespace: strict, no fallback.
+    fn explicit_trigger(id: &str, trigger_type: &str, home: &str, provider: &str) -> Trigger {
+        Trigger {
+            home_namespace: home.to_string(),
+            trigger_namespace: Some(provider.to_string()),
+            ..make_trigger(id, trigger_type)
+        }
+    }
+
+    fn make_trigger_type_ns(namespace: &str, id: &str) -> TriggerType {
+        TriggerType::new_ns(
+            namespace,
+            id,
+            format!("Test trigger type {} in {}", id, namespace),
+            Box::new(MockRegistrator::new()),
+            None,
+        )
+    }
+
+    // ── The four resolutions ─────────────────────────────────────────────
+    //
+    // A binding names two namespaces, and they answer different questions:
+    // where the provider is, and where the target function is. These four
+    // cover every combination of "at home" and "somewhere else".
+
+    #[tokio::test]
+    async fn a_provider_at_home_serves_its_own_namespace() {
+        let registry = TriggerRegistry::new();
+        registry
+            .register_trigger_type(make_trigger_type_ns("shop", "webhook"))
+            .await
+            .unwrap();
+
+        let trigger = resolved_trigger("t1", "webhook", "shop");
+        assert_eq!(
+            registry.register_trigger(trigger).await.unwrap(),
+            RegisterTriggerOutcome::Registered
+        );
+
+        let stored = registry.triggers.get("t1").unwrap();
+        assert_eq!(stored.provider_namespace, "shop");
+        assert!(!stored.is_on_fallback());
+    }
+
+    #[tokio::test]
+    async fn a_worker_with_no_provider_at_home_falls_back_to_default() {
+        // The migration case: the engine's providers live in `default`, and a
+        // worker in another namespace reaches them without saying anything.
+        let registry = TriggerRegistry::new();
+        registry
+            .register_trigger_type(make_trigger_type("cron"))
+            .await
+            .unwrap();
+
+        let trigger = resolved_trigger("t1", "cron", "shop");
+        assert_eq!(
+            registry.register_trigger(trigger).await.unwrap(),
+            RegisterTriggerOutcome::Registered
+        );
+
+        let stored = registry.triggers.get("t1").unwrap();
+        assert_eq!(stored.provider_namespace, DEFAULT_NAMESPACE);
+        assert!(stored.is_on_fallback(), "it is only borrowing the engine's");
+    }
+
+    #[tokio::test]
+    async fn home_wins_over_the_fallback_when_both_exist() {
+        // Both providers are up before the bind. The project's own is the one
+        // that should serve it — that is what makes shipping a replacement for
+        // a built-in type possible at all.
+        let registry = TriggerRegistry::new();
+        registry
+            .register_trigger_type(make_trigger_type("state"))
+            .await
+            .unwrap();
+        registry
+            .register_trigger_type(make_trigger_type_ns("shop", "state"))
+            .await
+            .unwrap();
+
+        registry
+            .register_trigger(resolved_trigger("t1", "state", "shop"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            registry.triggers.get("t1").unwrap().provider_namespace,
+            "shop"
+        );
+        // And both providers are still there: one did not replace the other.
+        assert_eq!(registry.trigger_types.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn naming_a_namespace_takes_that_one_and_no_other() {
+        let registry = TriggerRegistry::new();
+        registry
+            .register_trigger_type(make_trigger_type("cron"))
+            .await
+            .unwrap();
+        registry
+            .register_trigger_type(make_trigger_type_ns("shop", "cron"))
+            .await
+            .unwrap();
+
+        // Explicit `default` from a worker at home in `shop`: the provider at
+        // home exists and must NOT be preferred. A caller who was specific is
+        // not quietly served by someone else.
+        registry
+            .register_trigger(explicit_trigger("t1", "cron", "shop", DEFAULT_NAMESPACE))
+            .await
+            .unwrap();
+        assert_eq!(
+            registry.triggers.get("t1").unwrap().provider_namespace,
+            DEFAULT_NAMESPACE
+        );
+
+        // And an explicit namespace nobody provides does not fall back — it
+        // parks, the same as any other unavailable provider.
+        assert_eq!(
+            registry
+                .register_trigger(explicit_trigger("t2", "cron", "shop", "nowhere"))
+                .await
+                .unwrap(),
+            RegisterTriggerOutcome::Deferred
+        );
+        assert!(registry.pending_triggers.contains_key("t2"));
+    }
+
+    #[tokio::test]
+    async fn the_target_namespace_is_independent_of_the_provider() {
+        // Everything outside its own namespace: the provider is the engine's,
+        // the target is a third namespace, and the worker's own appears in
+        // neither resolution.
+        let registry = TriggerRegistry::new();
+        registry
+            .register_trigger_type(make_trigger_type("cron"))
+            .await
+            .unwrap();
+
+        let trigger = Trigger {
+            namespace: "billing".to_string(),
+            ..resolved_trigger("t1", "cron", "shop")
+        };
+        registry.register_trigger(trigger).await.unwrap();
+
+        let stored = registry.triggers.get("t1").unwrap();
+        assert_eq!(stored.provider_namespace, DEFAULT_NAMESPACE, "provider");
+        assert_eq!(stored.namespace, "billing", "target");
+        assert_eq!(stored.home_namespace, "shop", "the worker's own");
+    }
+
+    // ── Re-homing ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn a_provider_arriving_late_claims_back_what_fell_back() {
+        // The ordering that would otherwise decide everything silently: the
+        // binding is made before the project's own provider is up.
+        let registry = TriggerRegistry::new();
+        registry
+            .register_trigger_type(make_trigger_type("state"))
+            .await
+            .unwrap();
+        registry
+            .register_trigger(resolved_trigger("t1", "state", "shop"))
+            .await
+            .unwrap();
+        assert_eq!(
+            registry.triggers.get("t1").unwrap().provider_namespace,
+            DEFAULT_NAMESPACE
+        );
+
+        // The project's provider registers afterwards.
+        registry
+            .register_trigger_type(make_trigger_type_ns("shop", "state"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            registry.triggers.get("t1").unwrap().provider_namespace,
+            "shop",
+            "a binding must not be stuck on the fallback because of start order"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_explicit_binding_is_never_re_homed() {
+        let registry = TriggerRegistry::new();
+        registry
+            .register_trigger_type(make_trigger_type("state"))
+            .await
+            .unwrap();
+        registry
+            .register_trigger(explicit_trigger("t1", "state", "shop", DEFAULT_NAMESPACE))
+            .await
+            .unwrap();
+
+        registry
+            .register_trigger_type(make_trigger_type_ns("shop", "state"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            registry.triggers.get("t1").unwrap().provider_namespace,
+            DEFAULT_NAMESPACE,
+            "naming a namespace means that one, whatever appears later"
+        );
+    }
+
+    #[tokio::test]
+    async fn one_namespace_provider_does_not_take_another_namespace_bindings() {
+        // The defect this whole change exists for: two providers of the same
+        // type id used to overwrite each other, and the winner was handed the
+        // loser's bindings.
+        let registry = TriggerRegistry::new();
+        registry
+            .register_trigger_type(make_trigger_type_ns("shop-a", "webhook"))
+            .await
+            .unwrap();
+        registry
+            .register_trigger(resolved_trigger("t-a", "webhook", "shop-a"))
+            .await
+            .unwrap();
+
+        registry
+            .register_trigger_type(make_trigger_type_ns("shop-b", "webhook"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            registry.trigger_types.len(),
+            2,
+            "neither overwrote the other"
+        );
+        assert_eq!(
+            registry.triggers.get("t-a").unwrap().provider_namespace,
+            "shop-a",
+            "shop-a's binding must stay with shop-a's provider"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_departing_home_provider_hands_its_bindings_back_to_the_fallback() {
+        // The symmetric case. A project provider restarting must not disable
+        // the bindings it was serving when the engine still provides the type.
+        let registry = TriggerRegistry::new();
+        let worker = Uuid::new_v4();
+        registry
+            .register_trigger_type(make_trigger_type("state"))
+            .await
+            .unwrap();
+        registry
+            .register_trigger_type(TriggerType::new_ns(
+                "shop",
+                "state",
+                "the project's own",
+                Box::new(MockRegistrator::new()),
+                Some(worker),
+            ))
+            .await
+            .unwrap();
+        registry
+            .register_trigger(resolved_trigger("t1", "state", "shop"))
+            .await
+            .unwrap();
+        assert_eq!(
+            registry.triggers.get("t1").unwrap().provider_namespace,
+            "shop"
+        );
+
+        registry.unregister_worker(&worker).await;
+
+        let stored = registry
+            .triggers
+            .get("t1")
+            .expect("the binding must survive");
+        assert_eq!(
+            stored.provider_namespace, DEFAULT_NAMESPACE,
+            "it should fall back rather than be disabled"
+        );
+        assert!(registry.pending_triggers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn with_no_fallback_a_departing_provider_still_parks_its_bindings() {
+        let registry = TriggerRegistry::new();
+        let worker = Uuid::new_v4();
+        registry
+            .register_trigger_type(TriggerType::new_ns(
+                "shop",
+                "custom",
+                "only provider anywhere",
+                Box::new(MockRegistrator::new()),
+                Some(worker),
+            ))
+            .await
+            .unwrap();
+        registry
+            .register_trigger(resolved_trigger("t1", "custom", "shop"))
+            .await
+            .unwrap();
+
+        registry.unregister_worker(&worker).await;
+
+        assert!(registry.triggers.is_empty());
+        assert!(registry.pending_triggers.contains_key("t1"));
+    }
+
+    #[tokio::test]
+    async fn a_parked_binding_activates_on_whichever_step_appears_first() {
+        let registry = TriggerRegistry::new();
+        // Nothing provides it yet.
+        assert_eq!(
+            registry
+                .register_trigger(resolved_trigger("t1", "webhook", "shop"))
+                .await
+                .unwrap(),
+            RegisterTriggerOutcome::Deferred
+        );
+
+        // The fallback appears: the intent activates there.
+        registry
+            .register_trigger_type(make_trigger_type("webhook"))
+            .await
+            .unwrap();
+        assert_eq!(
+            registry.triggers.get("t1").unwrap().provider_namespace,
+            DEFAULT_NAMESPACE
+        );
+        assert!(registry.pending_triggers.is_empty());
     }
 
     fn make_trigger_type(id: &str) -> TriggerType {
@@ -812,7 +1429,14 @@ mod tests {
         let result = registry.register_trigger_type(tt).await;
         assert!(result.is_ok());
         assert_eq!(registry.trigger_types.len(), 1);
-        assert!(registry.trigger_types.contains_key("cron"));
+        assert!(
+            registry
+                .trigger_types
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    "cron"
+                ))
+        );
     }
 
     #[tokio::test]
@@ -961,7 +1585,10 @@ mod tests {
 
             let tt = registry
                 .trigger_types
-                .get("evt")
+                .get(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    "evt",
+                ))
                 .expect("replacement type survives the stale cleanup");
             assert_eq!(tt.worker_id, Some(new_worker));
             drop(tt);
@@ -1492,7 +2119,14 @@ mod tests {
         let result = registry.register_trigger_type(tt).await;
         assert!(result.is_ok());
         // The trigger type was inserted.
-        assert!(registry.trigger_types.contains_key("webhook"));
+        assert!(
+            registry
+                .trigger_types
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    "webhook"
+                ))
+        );
         // A trigger for this type was already registered explicitly, so
         // the registrator's register_trigger should have been called
         // (tested implicitly -- no panic means success).
@@ -1575,7 +2209,14 @@ mod tests {
         registry.register_trigger_type(trigger_type).await.unwrap();
 
         assert_eq!(registrator.register_count.load(Ordering::SeqCst), 1);
-        assert!(registry.trigger_types.contains_key("webhook"));
+        assert!(
+            registry
+                .trigger_types
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    "webhook"
+                ))
+        );
     }
 
     #[tokio::test]
@@ -1655,7 +2296,7 @@ mod tests {
         let registry = TriggerRegistry::new();
         let failing = Arc::new(ControlledRegistrator::new(true, false));
         registry.trigger_types.insert(
-            "webhook".to_string(),
+            crate::trigger::type_key(crate::protocol::DEFAULT_NAMESPACE, &"webhook".to_string()),
             TriggerType::new("webhook", "Webhook", Box::new(Arc::clone(&failing)), None),
         );
         registry
@@ -1678,7 +2319,7 @@ mod tests {
     async fn undeliverable_reregistration_of_live_binding_ends_parked_not_split() {
         let registry = TriggerRegistry::new();
         registry.trigger_types.insert(
-            "webhook".to_string(),
+            crate::trigger::type_key(crate::protocol::DEFAULT_NAMESPACE, &"webhook".to_string()),
             TriggerType::new(
                 "webhook",
                 "Webhook",
@@ -1709,7 +2350,7 @@ mod tests {
         let registry = TriggerRegistry::new();
         let registrator = Arc::new(ControlledRegistrator::new(false, false));
         registry.trigger_types.insert(
-            "webhook".to_string(),
+            crate::trigger::type_key(crate::protocol::DEFAULT_NAMESPACE, &"webhook".to_string()),
             TriggerType::new(
                 "webhook",
                 "Webhook",
@@ -1860,6 +2501,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let t2 = Trigger {
             id: "trigger-1".to_string(),
@@ -1869,6 +2513,9 @@ mod tests {
             worker_id: Some(Uuid::new_v4()),
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         // Same id means equal, even though other fields differ.
@@ -1891,6 +2538,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let t2 = Trigger {
             id: "trigger-2".to_string(),
@@ -1900,6 +2550,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         assert_ne!(t1, t2);
@@ -1930,6 +2583,9 @@ mod tests {
             worker_id: None,
             metadata: Some(serde_json::json!({"team": "platform", "priority": "high"})),
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let json = serde_json::to_string(&trigger).unwrap();
         let deserialized: Trigger = serde_json::from_str(&json).unwrap();
@@ -1949,6 +2605,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let json = serde_json::to_string(&trigger).unwrap();
         let deserialized: Trigger = serde_json::from_str(&json).unwrap();

--- a/engine/src/worker_connections/traits.rs
+++ b/engine/src/worker_connections/traits.rs
@@ -63,6 +63,13 @@ impl TriggerRegistrator for WorkerConnection {
                     metadata: trigger.metadata,
                     namespace: (trigger.namespace != crate::protocol::DEFAULT_NAMESPACE)
                         .then_some(trigger.namespace),
+                    // Which of its namespaces this bind belongs to. The message
+                    // only ever reaches the provider filed under this key, so
+                    // it is a statement rather than a request — and it lets a
+                    // provider serving more than one namespace tell them apart.
+                    trigger_namespace: (trigger.provider_namespace
+                        != crate::protocol::DEFAULT_NAMESPACE)
+                        .then_some(trigger.provider_namespace),
                 }))
                 .await;
             if let Err(err) = sent {
@@ -114,6 +121,13 @@ impl TriggerRegistrator for WorkerConnection {
                     metadata: trigger.metadata,
                     namespace: (trigger.namespace != crate::protocol::DEFAULT_NAMESPACE)
                         .then_some(trigger.namespace),
+                    // Which of its namespaces this bind belongs to. The message
+                    // only ever reaches the provider filed under this key, so
+                    // it is a statement rather than a request — and it lets a
+                    // provider serving more than one namespace tell them apart.
+                    trigger_namespace: (trigger.provider_namespace
+                        != crate::protocol::DEFAULT_NAMESPACE)
+                        .then_some(trigger.provider_namespace),
                 }))
                 .await
                 .map_err(|err| {
@@ -245,6 +259,9 @@ mod tests {
             worker_id,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         }
     }
 
@@ -345,6 +362,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         worker.unregister_trigger(trigger).await.unwrap();
         let msg = rx.recv().await.unwrap();

--- a/engine/src/workers/configuration/adapters/bridge.rs
+++ b/engine/src/workers/configuration/adapters/bridge.rs
@@ -276,13 +276,11 @@ impl ConfigurationAdapter for BridgeAdapter {
 
         let trigger = self
             .bridge
-            .register_trigger(RegisterTriggerInput {
-                trigger_type: "configuration".to_string(),
-                function_id: RELAY_FUNCTION_ID.to_string(),
-                config: serde_json::json!({}),
-                metadata: None,
-                namespace: None,
-            })
+            .register_trigger(RegisterTriggerInput::new(
+                "configuration".to_string(),
+                RELAY_FUNCTION_ID.to_string(),
+                serde_json::json!({}),
+            ))
             .map_err(|e| {
                 anyhow::anyhow!("failed to subscribe to remote configuration trigger: {}", e)
             })?;

--- a/engine/src/workers/configuration/trigger.rs
+++ b/engine/src/workers/configuration/trigger.rs
@@ -330,6 +330,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         worker.register_trigger(trigger.clone()).await.unwrap();
         assert_eq!(worker.triggers.id_trigger_count("iii-stream").await, 1);
@@ -379,6 +382,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         worker.register_trigger(trigger.clone()).await.unwrap();
         worker.unregister_trigger(trigger).await.unwrap();
@@ -436,6 +442,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         worker.register_trigger(trigger_a.clone()).await.unwrap();
         worker.unregister_trigger(trigger_a).await.unwrap();
@@ -450,6 +459,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         worker.register_trigger(trigger_b).await.unwrap();
         assert!(!worker.triggers.has_pending_expiry("iii-stream").await);
@@ -478,6 +490,9 @@ mod tests {
                     worker_id: None,
                     metadata: None,
                     namespace: "default".to_string(),
+                    trigger_namespace: None,
+                    home_namespace: crate::protocol::default_namespace(),
+                    provider_namespace: crate::protocol::default_namespace(),
                 },
             },
         );
@@ -498,6 +513,9 @@ mod tests {
                     worker_id: None,
                     metadata: None,
                     namespace: "default".to_string(),
+                    trigger_namespace: None,
+                    home_namespace: crate::protocol::default_namespace(),
+                    provider_namespace: crate::protocol::default_namespace(),
                 },
             },
         );

--- a/engine/src/workers/cron/configuration.rs
+++ b/engine/src/workers/cron/configuration.rs
@@ -169,6 +169,9 @@ pub async fn register_config_trigger(engine: &Engine) -> anyhow::Result<()> {
             worker_id: None,
             metadata: None,
             namespace: crate::protocol::default_namespace(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         })
         .await
         .map_err(|err| anyhow!("failed to register configuration trigger: {err:?}"))?;

--- a/engine/src/workers/cron/cron.rs
+++ b/engine/src/workers/cron/cron.rs
@@ -560,7 +560,15 @@ mod tests {
         let (engine, module) = setup_cron_module();
         let result = module.initialize().await;
         assert!(result.is_ok());
-        assert!(engine.trigger_registry.trigger_types.contains_key("cron"));
+        assert!(
+            engine
+                .trigger_registry
+                .trigger_types
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    "cron"
+                ))
+        );
     }
 
     // =========================================================================
@@ -607,6 +615,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let result = module.register_trigger(trigger).await;
         assert!(result.is_ok());
@@ -625,6 +636,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let result = module.register_trigger(trigger).await;
         assert!(result.is_err());
@@ -647,6 +661,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let result = module.register_trigger(trigger).await;
         assert!(result.is_err());
@@ -666,6 +683,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let result = module.register_trigger(trigger).await;
         assert!(result.is_ok());
@@ -686,6 +706,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let _ = module.register_trigger(trigger.clone()).await;
 
@@ -705,6 +728,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let result = module.unregister_trigger(trigger).await;
         assert!(result.is_err());
@@ -807,6 +833,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         // Register
@@ -838,6 +867,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         let result = module.register_trigger(trigger.clone()).await;
@@ -926,6 +958,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             };
             module
                 .register_trigger(trigger)

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -151,6 +151,10 @@ pub struct TriggersListInput {
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct TriggerInfoInput {
     pub id: String,
+    /// Which provider of this id. Absent means the one in the default
+    /// namespace, where every in-process engine provider lives.
+    #[serde(default)]
+    pub namespace: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default, JsonSchema)]
@@ -288,6 +292,8 @@ pub enum FunctionInfoOutput {
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct TriggerTypeSummary {
     pub id: String,
+    /// Namespace this provider serves. Two entries can share an id.
+    pub namespace: String,
     pub worker_name: String,
     pub description: String,
 }
@@ -295,6 +301,8 @@ pub struct TriggerTypeSummary {
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct TriggerTypeDetail {
     pub id: String,
+    /// Namespace this provider serves.
+    pub namespace: String,
     pub worker_name: String,
     pub description: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -482,6 +490,11 @@ pub struct RegisterTriggerInput {
     /// is GC'd when that worker disconnects. Absent for in-process callers.
     #[serde(rename = "_caller_worker_id", default)]
     pub caller_worker_id: Option<String>,
+    /// Namespace to find the trigger type's provider in. Absent asks the engine
+    /// to resolve it, which for a durable registration means
+    /// [`crate::protocol::DEFAULT_NAMESPACE`] — its home — and nothing else.
+    #[serde(default)]
+    pub trigger_namespace: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -892,6 +905,7 @@ impl EngineFunctionsWorker {
                 let tt = entry.value();
                 TriggerTypeSummary {
                     id: tt.id.clone(),
+                    namespace: tt.namespace.clone(),
                     // Guard-safe: we're inside `trigger_types.iter()`.
                     worker_name: self.owner_name_for_trigger_type(tt),
                     description: tt._description.clone(),
@@ -1063,10 +1077,14 @@ impl EngineFunctionsWorker {
         })
     }
 
-    fn build_trigger_type_detail(&self, tt_id: &str) -> Option<TriggerTypeDetail> {
-        let tt = self.engine.trigger_registry.trigger_types.get(tt_id)?;
+    fn build_trigger_type_detail(
+        &self,
+        key: &crate::trigger::TypeKey,
+    ) -> Option<TriggerTypeDetail> {
+        let tt = self.engine.trigger_registry.trigger_types.get(key)?;
         Some(TriggerTypeDetail {
             id: tt.id.clone(),
+            namespace: tt.namespace.clone(),
             // Guard-safe: we hold the `.get()` guard on this entry.
             worker_name: self.owner_name_for_trigger_type(tt.value()),
             description: tt._description.clone(),
@@ -1089,7 +1107,7 @@ impl EngineFunctionsWorker {
         let worker_name =
             Self::worker_name_for_function_id(&index, &trigger.namespace, &trigger.function_id);
 
-        let trigger_detail = self.build_trigger_type_detail(&trigger.trigger_type);
+        let trigger_detail = self.build_trigger_type_detail(&trigger.provider_key());
         let function_detail = self
             .build_function_detail(&trigger.namespace, &trigger.function_id)
             .await;
@@ -1196,16 +1214,16 @@ impl EngineFunctionsWorker {
             envelope = self.worker_detail_envelope_from_runtime(&runtime, worker_namespace.clone());
             function_ids = runtime.function_ids;
             resolved_worker_id = None;
-        } else if let Some(worker) =
-            self.engine
+        } else {
+            let worker = self
+                .engine
                 .worker_registry
                 .list_workers()
                 .into_iter()
                 .find(|w| {
                     w.name.as_deref() == Some(name)
                         && self.engine.worker_registry.get_namespace(&w.id) == worker_namespace
-                })
-        {
+                })?;
             let function_count_async = worker.get_function_ids().await;
             let function_count = function_count_async.len();
             let active_invocations = worker.invocation_count().await;
@@ -1221,8 +1239,6 @@ impl EngineFunctionsWorker {
                 latest_metrics,
             );
             function_ids = function_count_async;
-        } else {
-            return None;
         }
 
         let worker_name = envelope.name.clone();
@@ -1299,6 +1315,7 @@ impl EngineFunctionsWorker {
                 }
                 Some(TriggerTypeSummary {
                     id: tt.id.clone(),
+                    namespace: tt.namespace.clone(),
                     worker_name: owner,
                     description: tt._description.clone(),
                 })
@@ -1784,11 +1801,18 @@ impl EngineFunctionsWorker {
         &self,
         input: TriggerInfoInput,
     ) -> FunctionResult<TriggerTypeDetail, ErrorBody> {
-        match self.build_trigger_type_detail(&input.id) {
+        let namespace = input
+            .namespace
+            .clone()
+            .unwrap_or_else(crate::protocol::default_namespace);
+        match self.build_trigger_type_detail(&crate::trigger::type_key(&namespace, &input.id)) {
             Some(detail) => FunctionResult::Success(detail),
             None => FunctionResult::Failure(ErrorBody {
                 code: "NOT_FOUND".into(),
-                message: format!("Trigger type '{}' is not registered.", input.id),
+                message: format!(
+                    "Trigger type '{}' is not registered in namespace '{}'.",
+                    input.id, namespace
+                ),
                 stacktrace: None,
             }),
         }
@@ -1919,6 +1943,25 @@ impl EngineFunctionsWorker {
     ) -> FunctionResult<RegisterWorkerResult, ErrorBody> {
         let mut input = input;
         let worker_id = input.worker_id.clone();
+
+        // Refused rather than read as absent. This is the namespace the whole
+        // connection inherits -- its lease, its functions, and everything it
+        // calls or binds afterwards -- so getting it wrong here is not a local
+        // mistake.
+        if crate::protocol::is_blank_namespace(&input.namespace) {
+            return FunctionResult::Failure(ErrorBody {
+                code: crate::protocol::INVALID_NAMESPACE.into(),
+                message: format!(
+                    "namespace is empty: worker '{}' declared {:?}. Give it a name, or omit \
+                     the field to register in '{}'.",
+                    input.name.as_deref().unwrap_or("<unnamed>"),
+                    input.namespace.as_deref().unwrap_or_default(),
+                    crate::protocol::DEFAULT_NAMESPACE
+                ),
+                stacktrace: None,
+            });
+        }
+
         let declared = crate::protocol::effective_namespace(&input.namespace).to_string();
 
         // The grace timer fixes a connection to `default` when no
@@ -2058,8 +2101,12 @@ impl EngineFunctionsWorker {
             metadata: input.metadata,
             // Function-path (durable) registrations are engine orchestration and
             // resolve their target in the default namespace, matching the
-            // `fire_triggers` behavior they predate.
+            // `fire_triggers` behavior they predate. Their provider resolves
+            // there too — see `Trigger::internal_namespaces`.
             namespace: crate::protocol::default_namespace(),
+            trigger_namespace: input.trigger_namespace,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         if let Err(err) = self.engine.trigger_registry.register_trigger(trigger).await {
@@ -2158,6 +2205,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             },
         );
     }
@@ -2747,6 +2797,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         let result = module.register_trigger(trigger.clone()).await;
@@ -2772,6 +2825,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             };
             module.register_trigger(trigger).await.unwrap();
         }
@@ -2792,6 +2848,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         module.register_trigger(trigger).await.unwrap();
 
@@ -2838,6 +2897,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         module.register_trigger(trigger).await.unwrap();
 
@@ -2898,6 +2960,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "orders".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             })
             .await
             .unwrap();
@@ -3007,6 +3072,7 @@ mod tests {
             request_schema: Some(serde_json::json!({"type": "object"})),
             response_schema: None,
             instance_count: 2,
+            namespace: crate::protocol::default_namespace(),
         };
         let json = serde_json::to_value(&detail).expect("serialize");
         assert!(json.get("configuration_schema").is_some());
@@ -3051,13 +3117,19 @@ mod tests {
             engine
                 .trigger_registry
                 .trigger_types
-                .contains_key(TRIGGER_FUNCTIONS_AVAILABLE)
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    TRIGGER_FUNCTIONS_AVAILABLE
+                ))
         );
         assert!(
             engine
                 .trigger_registry
                 .trigger_types
-                .contains_key(TRIGGER_WORKERS_AVAILABLE)
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    TRIGGER_WORKERS_AVAILABLE
+                ))
         );
     }
 
@@ -3535,7 +3607,7 @@ mod tests {
     async fn triggers_list_returns_trigger_types_not_instances() {
         let (engine, module) = setup_engine_and_module();
         engine.trigger_registry.trigger_types.insert(
-            "user-type".to_string(),
+            crate::trigger::type_key(crate::protocol::DEFAULT_NAMESPACE, &"user-type".to_string()),
             crate::trigger::TriggerType::new(
                 "user-type",
                 "User type",
@@ -3544,7 +3616,10 @@ mod tests {
             ),
         );
         engine.trigger_registry.trigger_types.insert(
-            "engine::internal-type".to_string(),
+            crate::trigger::type_key(
+                crate::protocol::DEFAULT_NAMESPACE,
+                &"engine::internal-type".to_string(),
+            ),
             crate::trigger::TriggerType::new(
                 "engine::internal-type",
                 "Internal",
@@ -3616,6 +3691,7 @@ mod tests {
         let result = module
             .triggers_info(TriggerInfoInput {
                 id: "cron".to_string(),
+                namespace: None,
             })
             .await;
         match result {
@@ -3648,6 +3724,7 @@ mod tests {
         let result = module
             .triggers_info(TriggerInfoInput {
                 id: "http".to_string(),
+                namespace: None,
             })
             .await;
         match result {
@@ -3714,6 +3791,7 @@ mod tests {
         let result = module
             .triggers_info(TriggerInfoInput {
                 id: "nope".to_string(),
+                namespace: None,
             })
             .await;
         assert!(matches!(result, FunctionResult::Failure(_)));
@@ -4313,6 +4391,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             },
         );
 
@@ -4415,6 +4496,7 @@ mod tests {
                     config: serde_json::json!({}),
                     metadata: Some(meta.clone()),
                     caller_worker_id: Some(wid.to_string()),
+                    trigger_namespace: None,
                 },
                 None,
             )
@@ -4468,6 +4550,7 @@ mod tests {
                     config: serde_json::json!({}),
                     metadata: Some(serde_json::json!({ "session_id": "s" })),
                     caller_worker_id: None,
+                    trigger_namespace: None,
                 },
                 None,
             )
@@ -4545,6 +4628,7 @@ mod tests {
                     config: serde_json::json!({}),
                     metadata: None,
                     caller_worker_id: None,
+                    trigger_namespace: None,
                 },
                 Some(session),
             )
@@ -4578,6 +4662,7 @@ mod tests {
                     config: serde_json::json!({}),
                     metadata: None,
                     caller_worker_id: None,
+                    trigger_namespace: None,
                 },
                 None,
             )

--- a/engine/src/workers/external.rs
+++ b/engine/src/workers/external.rs
@@ -214,7 +214,7 @@ const BACKOFF_RESET_UPTIME: Duration = Duration::from_secs(60);
 impl ExternalWorker {
     pub fn new(info: ExternalWorkerInfo, config: Option<Value>, worker_manager_port: u16) -> Self {
         let name = info.name.clone();
-        let display_name = Box::leak(format!("ExternalWorker({})", &name).into_boxed_str());
+        let display_name = Box::leak(format!("ExternalWorker({})", name).into_boxed_str());
         Self {
             display_name,
             name,

--- a/engine/src/workers/observability/configuration.rs
+++ b/engine/src/workers/observability/configuration.rs
@@ -189,6 +189,9 @@ pub async fn register_config_trigger(engine: &Engine) -> anyhow::Result<()> {
             worker_id: None,
             metadata: None,
             namespace: crate::protocol::default_namespace(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         })
         .await
         .map_err(|err| anyhow!("failed to register configuration trigger: {err:?}"))?;

--- a/engine/src/workers/observability/metrics.rs
+++ b/engine/src/workers/observability/metrics.rs
@@ -1274,10 +1274,8 @@ pub fn get_worker_metrics_from_storage(worker_id: &str) -> Option<WorkerMetrics>
                                     event_loop_lag_ms = Some(value);
                                 }
                             }
-                            "iii.worker.uptime_seconds" => {
-                                if uptime_seconds.is_none() {
-                                    uptime_seconds = Some(value as u64);
-                                }
+                            "iii.worker.uptime_seconds" if uptime_seconds.is_none() => {
+                                uptime_seconds = Some(value as u64);
                             }
                             _ => {}
                         }

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -726,7 +726,7 @@ struct CompiledCollapseRule {
 
 impl CompiledCollapseRule {
     fn matches(&self, name: &str, service: &str) -> bool {
-        self.name.is_match(name) && self.service.as_ref().map_or(true, |s| s.is_match(service))
+        self.name.is_match(name) && self.service.as_ref().is_none_or(|s| s.is_match(service))
     }
 }
 
@@ -3710,6 +3710,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             });
             guard.insert(Trigger {
                 id: "t-error".to_string(),
@@ -3719,6 +3722,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             });
         }
 
@@ -3810,6 +3816,9 @@ mod tests {
                 config: serde_json::json!({}),
                 worker_id: None,
                 metadata: None,
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             });
             guard.insert(Trigger {
                 id: "t-error".to_string(),
@@ -3819,6 +3828,9 @@ mod tests {
                 config: serde_json::json!({ "status": "error", "service_name": "svc" }),
                 worker_id: None,
                 metadata: None,
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             });
         }
 
@@ -4036,6 +4048,9 @@ mod tests {
             config: serde_json::json!({}),
             worker_id: None,
             metadata: None,
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         });
 
         let storage = Arc::new(otel::InMemorySpanStorage::new(16));
@@ -4196,6 +4211,9 @@ mod tests {
             config: serde_json::json!({}),
             worker_id: None,
             metadata: Some(serde_json::json!({ "__binding": "session-wake-7" })),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         });
 
         let batch = vec![make_span("t1", "s1", None, "op", "svc", 1, 2, "ok", vec![])];
@@ -4227,6 +4245,9 @@ mod tests {
             config: serde_json::json!({ "level": "all" }),
             worker_id: None,
             metadata: Some(serde_json::json!({ "__binding": "log-wake-1" })),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         });
 
         let log = make_log(None, None, "INFO", 9, "hello", "svc", 1);
@@ -8474,7 +8495,10 @@ mod tests {
             engine
                 .trigger_registry
                 .trigger_types
-                .contains_key(LOG_TRIGGER_TYPE)
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    LOG_TRIGGER_TYPE
+                ))
         );
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
@@ -8521,13 +8545,19 @@ mod tests {
             !engine
                 .trigger_registry
                 .trigger_types
-                .contains_key(LOG_TRIGGER_TYPE)
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    LOG_TRIGGER_TYPE
+                ))
         );
         assert!(
             !engine
                 .trigger_registry
                 .trigger_types
-                .contains_key(TRACE_TRIGGER_TYPE)
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    TRACE_TRIGGER_TYPE
+                ))
         );
     }
 
@@ -8563,13 +8593,19 @@ mod tests {
             engine
                 .trigger_registry
                 .trigger_types
-                .contains_key(LOG_TRIGGER_TYPE)
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    LOG_TRIGGER_TYPE
+                ))
         );
         assert!(
             engine
                 .trigger_registry
                 .trigger_types
-                .contains_key(TRACE_TRIGGER_TYPE)
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    TRACE_TRIGGER_TYPE
+                ))
         );
     }
 

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -1197,9 +1197,7 @@ where
                     // finals never land in memory storage, so pending
                     // snapshots would never be replaced.
                     SdkTracerProvider::builder()
-                        .with_span_processor(
-                            iii_helpers::observability::BaggageSpanProcessor::default(),
-                        )
+                        .with_span_processor(iii_helpers::observability::BaggageSpanProcessor)
                         .with_batch_exporter(exporter)
                         .with_sampler(sampler)
                         .with_id_generator(RandomIdGenerator::default())
@@ -1222,9 +1220,8 @@ where
                         memory_storage.clone(),
                         config.service_name.clone(),
                     );
-                    let mut builder = SdkTracerProvider::builder().with_span_processor(
-                        iii_helpers::observability::BaggageSpanProcessor::default(),
-                    );
+                    let mut builder = SdkTracerProvider::builder()
+                        .with_span_processor(iii_helpers::observability::BaggageSpanProcessor);
                     if config.live_spans {
                         builder = builder.with_span_processor(LiveSpanProcessor::new(
                             memory_storage,
@@ -1255,7 +1252,7 @@ where
             );
 
             let mut builder = SdkTracerProvider::builder()
-                .with_span_processor(iii_helpers::observability::BaggageSpanProcessor::default());
+                .with_span_processor(iii_helpers::observability::BaggageSpanProcessor);
             if config.live_spans {
                 // After BaggageSpanProcessor, so pending snapshots carry the
                 // baggage-stamped attributes.
@@ -1290,9 +1287,8 @@ where
                         config.service_name.clone(),
                     );
 
-                    let mut builder = SdkTracerProvider::builder().with_span_processor(
-                        iii_helpers::observability::BaggageSpanProcessor::default(),
-                    );
+                    let mut builder = SdkTracerProvider::builder()
+                        .with_span_processor(iii_helpers::observability::BaggageSpanProcessor);
                     if config.live_spans {
                         // Pending snapshots feed ONLY the memory side; the
                         // OTLP half of the tee still sees spans on close only.
@@ -1319,9 +1315,8 @@ where
                         memory_storage.clone(),
                         config.service_name.clone(),
                     );
-                    let mut builder = SdkTracerProvider::builder().with_span_processor(
-                        iii_helpers::observability::BaggageSpanProcessor::default(),
-                    );
+                    let mut builder = SdkTracerProvider::builder()
+                        .with_span_processor(iii_helpers::observability::BaggageSpanProcessor);
                     if config.live_spans {
                         builder = builder.with_span_processor(LiveSpanProcessor::new(
                             memory_storage,

--- a/engine/src/workers/pubsub/adapters/local_adapter.rs
+++ b/engine/src/workers/pubsub/adapters/local_adapter.rs
@@ -167,6 +167,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "orders".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             },
         );
 

--- a/engine/src/workers/pubsub/configuration.rs
+++ b/engine/src/workers/pubsub/configuration.rs
@@ -180,6 +180,9 @@ pub async fn register_config_trigger(engine: &Engine) -> anyhow::Result<()> {
             worker_id: None,
             metadata: None,
             namespace: crate::protocol::default_namespace(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         })
         .await
         .map_err(|err| anyhow!("failed to register configuration trigger: {err:?}"))?;

--- a/engine/src/workers/pubsub/pubsub.rs
+++ b/engine/src/workers/pubsub/pubsub.rs
@@ -691,6 +691,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         module
@@ -731,6 +734,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             })
             .await
             .expect("register trigger without topic");
@@ -754,7 +760,10 @@ mod tests {
             engine
                 .trigger_registry
                 .trigger_types
-                .contains_key("subscribe")
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    "subscribe"
+                ))
         );
         assert_eq!(module.name(), "PubSubModule");
     }
@@ -857,6 +866,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             })
             .await
             .expect("register subscribe trigger");
@@ -887,6 +899,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             })
             .await
             .expect("register subscribe trigger");

--- a/engine/src/workers/queue/adapters/bridge.rs
+++ b/engine/src/workers/queue/adapters/bridge.rs
@@ -281,13 +281,11 @@ impl QueueAdapter for BridgeAdapter {
             }),
         );
 
-        let trigger = match self.bridge.register_trigger(RegisterTriggerInput {
-            trigger_type: "durable:subscriber".to_string(),
-            function_id: handler_path.clone(),
-            config: serde_json::json!({ "topic": topic }),
-            metadata: None,
-            namespace: None,
-        }) {
+        let trigger = match self.bridge.register_trigger(RegisterTriggerInput::new(
+            "durable:subscriber".to_string(),
+            handler_path.clone(),
+            serde_json::json!({ "topic": topic }),
+        )) {
             Ok(t) => t,
             Err(e) => {
                 tracing::error!(

--- a/engine/src/workers/queue/adapters/builtin/adapter.rs
+++ b/engine/src/workers/queue/adapters/builtin/adapter.rs
@@ -1022,6 +1022,9 @@ mod tests {
                     worker_id: None,
                     metadata: None,
                     namespace: ns.to_string(),
+                    trigger_namespace: None,
+                    home_namespace: crate::protocol::default_namespace(),
+                    provider_namespace: crate::protocol::default_namespace(),
                 },
             );
         }

--- a/engine/src/workers/queue/configuration.rs
+++ b/engine/src/workers/queue/configuration.rs
@@ -173,6 +173,9 @@ pub async fn register_config_trigger(engine: &Engine) -> anyhow::Result<()> {
             worker_id: None,
             metadata: None,
             namespace: crate::protocol::default_namespace(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         })
         .await
         .map_err(|err| anyhow!("failed to register configuration trigger: {err:?}"))?;

--- a/engine/src/workers/queue/queue.rs
+++ b/engine/src/workers/queue/queue.rs
@@ -2039,6 +2039,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let result = module.register_trigger(trigger).await;
         assert!(result.is_ok());
@@ -2056,6 +2059,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let result = module.register_trigger(trigger).await;
         assert!(result.is_ok());
@@ -2073,6 +2079,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let result = module.register_trigger(trigger).await;
         assert!(result.is_ok());
@@ -2094,6 +2103,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let result = module.register_trigger(trigger).await;
         assert!(result.is_ok());
@@ -2121,6 +2133,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let result = module.register_trigger(trigger).await;
         assert!(result.is_ok());
@@ -2138,6 +2153,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let result = module.unregister_trigger(trigger).await;
         assert!(result.is_ok());
@@ -2155,6 +2173,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let result = module.unregister_trigger(trigger).await;
         assert!(result.is_ok());
@@ -2233,7 +2254,10 @@ mod tests {
             engine
                 .trigger_registry
                 .trigger_types
-                .contains_key("durable:subscriber")
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    "durable:subscriber"
+                ))
         );
     }
 

--- a/engine/src/workers/rest_api/api_core.rs
+++ b/engine/src/workers/rest_api/api_core.rs
@@ -1542,7 +1542,15 @@ mod tests {
         module.register_functions(engine.clone());
         module.initialize().await.expect("module should initialize");
 
-        assert!(engine.trigger_registry.trigger_types.contains_key("http"));
+        assert!(
+            engine
+                .trigger_registry
+                .trigger_types
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    "http"
+                ))
+        );
     }
 
     #[tokio::test]
@@ -1635,6 +1643,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         module
@@ -1678,6 +1689,9 @@ mod tests {
             worker_id: Some(worker_a),
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         let trigger_b = Trigger {
@@ -1691,6 +1705,9 @@ mod tests {
             worker_id: Some(worker_b),
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         // 1. Worker A registers the route.
@@ -1737,6 +1754,9 @@ mod tests {
             worker_id: Some(worker_a),
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         let trigger_b = Trigger {
@@ -1750,6 +1770,9 @@ mod tests {
             worker_id: Some(worker_b),
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         module
@@ -1796,6 +1819,9 @@ mod tests {
             worker_id: Some(worker),
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         module
@@ -1822,6 +1848,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         let err = module

--- a/engine/src/workers/rest_api/configuration.rs
+++ b/engine/src/workers/rest_api/configuration.rs
@@ -172,6 +172,9 @@ pub async fn register_config_trigger(engine: &Engine) -> anyhow::Result<()> {
             worker_id: None,
             metadata: None,
             namespace: crate::protocol::default_namespace(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         })
         .await
         .map_err(|err| anyhow!("failed to register configuration trigger: {err:?}"))?;

--- a/engine/src/workers/state/configuration.rs
+++ b/engine/src/workers/state/configuration.rs
@@ -184,6 +184,9 @@ pub async fn register_config_trigger(engine: &Engine) -> anyhow::Result<()> {
             worker_id: None,
             metadata: None,
             namespace: crate::protocol::default_namespace(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         })
         .await
         .map_err(|err| anyhow!("failed to register configuration trigger: {err:?}"))?;

--- a/engine/src/workers/state/state.rs
+++ b/engine/src/workers/state/state.rs
@@ -250,15 +250,15 @@ fn state_trigger_matches(
     event_scope: &str,
     event_key: &str,
 ) -> bool {
-    if let Some(scope) = &config.scope {
-        if scope != event_scope {
-            return false;
-        }
+    if let Some(scope) = &config.scope
+        && scope != event_scope
+    {
+        return false;
     }
-    if let Some(key) = &config.key {
-        if key != event_key {
-            return false;
-        }
+    if let Some(key) = &config.key
+        && key != event_key
+    {
+        return false;
     }
     true
 }
@@ -986,6 +986,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let config = serde_json::from_value::<super::super::trigger::StateTriggerConfig>(
             trigger.config.clone(),
@@ -1192,6 +1195,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "orders".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
         let config = serde_json::from_value::<StateTriggerConfig>(trigger.config.clone()).unwrap();
         module
@@ -1436,6 +1442,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         {
@@ -1486,6 +1495,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         {
@@ -1553,6 +1565,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         {
@@ -1638,7 +1653,10 @@ mod tests {
             engine
                 .trigger_registry
                 .trigger_types
-                .contains_key(TRIGGER_TYPE)
+                .contains_key(&crate::trigger::type_key(
+                    crate::protocol::DEFAULT_NAMESPACE,
+                    TRIGGER_TYPE
+                ))
         );
 
         module.destroy().await.unwrap();
@@ -1804,6 +1822,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         let config = serde_json::from_value::<super::super::trigger::StateTriggerConfig>(
@@ -1887,6 +1908,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         let config = serde_json::from_value::<super::super::trigger::StateTriggerConfig>(
@@ -1945,6 +1969,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         let config = serde_json::from_value::<super::super::trigger::StateTriggerConfig>(

--- a/engine/src/workers/state/trigger.rs
+++ b/engine/src/workers/state/trigger.rs
@@ -188,6 +188,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         module
@@ -225,6 +228,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         };
 
         let error = module

--- a/engine/src/workers/stream/adapters/bridge.rs
+++ b/engine/src/workers/stream/adapters/bridge.rs
@@ -277,16 +277,14 @@ impl StreamAdapter for BridgeAdapter {
             }),
         );
 
-        let _ = self.bridge.register_trigger(RegisterTriggerInput {
-            trigger_type: "subscribe".to_string(),
-            function_id: handler_function_id,
-            config: serde_json::to_value(SubscribeTrigger {
+        let _ = self.bridge.register_trigger(RegisterTriggerInput::new(
+            "subscribe".to_string(),
+            handler_function_id,
+            serde_json::to_value(SubscribeTrigger {
                 topic: STREAM_EVENTS_TOPIC.to_string(),
             })
             .unwrap_or_default(),
-            metadata: None,
-            namespace: None,
-        });
+        ));
 
         self.pub_sub.watch_events().await;
         Ok(())

--- a/engine/src/workers/stream/configuration.rs
+++ b/engine/src/workers/stream/configuration.rs
@@ -172,6 +172,9 @@ pub async fn register_config_trigger(engine: &Engine) -> anyhow::Result<()> {
             worker_id: None,
             metadata: None,
             namespace: crate::protocol::default_namespace(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         })
         .await
         .map_err(|err| anyhow!("failed to register configuration trigger: {err:?}"))?;

--- a/engine/src/workers/stream/connection.rs
+++ b/engine/src/workers/stream/connection.rs
@@ -157,10 +157,8 @@ impl SocketStreamConnection {
                             }
                         }
                     }
-                    Err(e) => {
-                        if event_type == JOIN_TRIGGER_TYPE {
-                            tracing::error!(error = ?e, "Failed to invoke trigger function");
-                        }
+                    Err(e) if event_type == JOIN_TRIGGER_TYPE => {
+                        tracing::error!(error = ?e, "Failed to invoke trigger function");
                     }
                     _ => {}
                 }
@@ -538,6 +536,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             });
         connection
             .triggers
@@ -552,6 +553,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             });
 
         let join_result = connection
@@ -624,6 +628,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "orders".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             });
 
         connection
@@ -659,6 +666,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             });
 
         connection
@@ -791,6 +801,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             });
 
         connection
@@ -945,6 +958,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             });
 
         let result = connection
@@ -978,6 +994,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             });
 
         let result = connection

--- a/engine/src/workers/stream/socket.rs
+++ b/engine/src/workers/stream/socket.rs
@@ -576,6 +576,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             });
 
         let (mut client, _response) = connect_async(url).await.expect("connect websocket client");

--- a/engine/src/workers/stream/stream.rs
+++ b/engine/src/workers/stream/stream.rs
@@ -2485,6 +2485,9 @@ mod tests {
                     worker_id: None,
                     metadata: None,
                     namespace: "default".to_string(),
+                    trigger_namespace: None,
+                    home_namespace: crate::protocol::default_namespace(),
+                    provider_namespace: crate::protocol::default_namespace(),
                 },
                 config: StreamTriggerConfig {
                     stream_name: Some("events".to_string()),
@@ -2505,6 +2508,9 @@ mod tests {
                     worker_id: None,
                     metadata: None,
                     namespace: "default".to_string(),
+                    trigger_namespace: None,
+                    home_namespace: crate::protocol::default_namespace(),
+                    provider_namespace: crate::protocol::default_namespace(),
                 },
                 config: StreamTriggerConfig {
                     stream_name: Some("events".to_string()),
@@ -2525,6 +2531,9 @@ mod tests {
                     worker_id: None,
                     metadata: None,
                     namespace: "default".to_string(),
+                    trigger_namespace: None,
+                    home_namespace: crate::protocol::default_namespace(),
+                    provider_namespace: crate::protocol::default_namespace(),
                 },
                 config: StreamTriggerConfig {
                     stream_name: Some("events".to_string()),
@@ -2545,6 +2554,9 @@ mod tests {
                     worker_id: None,
                     metadata: None,
                     namespace: "default".to_string(),
+                    trigger_namespace: None,
+                    home_namespace: crate::protocol::default_namespace(),
+                    provider_namespace: crate::protocol::default_namespace(),
                 },
                 config: StreamTriggerConfig {
                     stream_name: Some("events".to_string()),
@@ -2565,6 +2577,9 @@ mod tests {
                     worker_id: None,
                     metadata: None,
                     namespace: "default".to_string(),
+                    trigger_namespace: None,
+                    home_namespace: crate::protocol::default_namespace(),
+                    provider_namespace: crate::protocol::default_namespace(),
                 },
                 config: StreamTriggerConfig {
                     stream_name: Some("events".to_string()),
@@ -2672,6 +2687,9 @@ mod tests {
                     worker_id: None,
                     metadata: None,
                     namespace: "orders".to_string(),
+                    trigger_namespace: None,
+                    home_namespace: crate::protocol::default_namespace(),
+                    provider_namespace: crate::protocol::default_namespace(),
                 },
                 config: StreamTriggerConfig {
                     stream_name: Some("events".to_string()),
@@ -2743,27 +2761,15 @@ mod tests {
             }
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
-        assert!(
-            module
-                .engine
-                .trigger_registry
-                .trigger_types
-                .contains_key(JOIN_TRIGGER_TYPE)
-        );
-        assert!(
-            module
-                .engine
-                .trigger_registry
-                .trigger_types
-                .contains_key(LEAVE_TRIGGER_TYPE)
-        );
-        assert!(
-            module
-                .engine
-                .trigger_registry
-                .trigger_types
-                .contains_key(STREAM_TRIGGER_TYPE)
-        );
+        assert!(module.engine.trigger_registry.trigger_types.contains_key(
+            &crate::trigger::type_key(crate::protocol::DEFAULT_NAMESPACE, JOIN_TRIGGER_TYPE)
+        ));
+        assert!(module.engine.trigger_registry.trigger_types.contains_key(
+            &crate::trigger::type_key(crate::protocol::DEFAULT_NAMESPACE, LEAVE_TRIGGER_TYPE)
+        ));
+        assert!(module.engine.trigger_registry.trigger_types.contains_key(
+            &crate::trigger::type_key(crate::protocol::DEFAULT_NAMESPACE, STREAM_TRIGGER_TYPE)
+        ));
         assert!(adapter.watch_events_called.load(Ordering::SeqCst));
 
         module.destroy().await.expect("stream destroy should work");

--- a/engine/src/workers/stream/trigger.rs
+++ b/engine/src/workers/stream/trigger.rs
@@ -195,6 +195,9 @@ mod tests {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: crate::protocol::default_namespace(),
+            provider_namespace: crate::protocol::default_namespace(),
         }
     }
 

--- a/engine/src/workers/telemetry/mod.rs
+++ b/engine/src/workers/telemetry/mod.rs
@@ -2008,6 +2008,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             },
         );
 
@@ -2021,6 +2024,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             },
         );
 
@@ -2657,6 +2663,9 @@ mod tests {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: crate::protocol::default_namespace(),
+                provider_namespace: crate::protocol::default_namespace(),
             })
             .await
             .expect("register trigger");

--- a/engine/tests/configuration_e2e.rs
+++ b/engine/tests/configuration_e2e.rs
@@ -217,6 +217,9 @@ async fn configuration_trigger_fires_target_and_condition_in_registering_namespa
         worker_id: None,
         metadata: None,
         namespace: "orders".to_string(),
+        trigger_namespace: None,
+        home_namespace: iii::protocol::default_namespace(),
+        provider_namespace: iii::protocol::default_namespace(),
     };
     worker
         .register_trigger(trigger)
@@ -264,6 +267,9 @@ async fn trigger_fan_out_delivers_expanded_event_payload() {
         worker_id: None,
         metadata: None,
         namespace: "default".to_string(),
+        trigger_namespace: None,
+        home_namespace: iii::protocol::default_namespace(),
+        provider_namespace: iii::protocol::default_namespace(),
     };
     worker
         .register_trigger(trigger.clone())
@@ -323,6 +329,9 @@ async fn fs_watcher_surfaces_external_file_edits_as_updates() {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .unwrap();
@@ -371,6 +380,9 @@ async fn ttl_cleanup_removes_configuration_after_last_trigger_unregistered() {
         worker_id: None,
         metadata: None,
         namespace: "default".to_string(),
+        trigger_namespace: None,
+        home_namespace: iii::protocol::default_namespace(),
+        provider_namespace: iii::protocol::default_namespace(),
     };
     worker.register_trigger(trigger.clone()).await.unwrap();
 

--- a/engine/tests/cron_configuration_e2e.rs
+++ b/engine/tests/cron_configuration_e2e.rs
@@ -165,6 +165,9 @@ fn cron_trigger(id: &str, function_id: &str, expression: &str) -> Trigger {
         worker_id: None,
         metadata: None,
         namespace: "default".to_string(),
+        trigger_namespace: None,
+        home_namespace: iii::protocol::default_namespace(),
+        provider_namespace: iii::protocol::default_namespace(),
     }
 }
 

--- a/engine/tests/http_middleware_e2e.rs
+++ b/engine/tests/http_middleware_e2e.rs
@@ -137,6 +137,9 @@ async fn register_http_trigger(
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register_trigger should succeed");
@@ -287,6 +290,9 @@ async fn http_route_invokes_target_and_condition_in_registering_namespace() {
             worker_id: None,
             metadata: None,
             namespace: "orders".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register_trigger should succeed");
@@ -371,6 +377,9 @@ async fn per_route_middleware_runs_in_route_namespace() {
             worker_id: None,
             metadata: None,
             namespace: "orders".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register_trigger should succeed");

--- a/engine/tests/namespace_introspection_e2e.rs
+++ b/engine/tests/namespace_introspection_e2e.rs
@@ -937,12 +937,14 @@ async fn workers_info_scopes_trigger_types_and_reports_namespace_by_namespace() 
         engine
             .trigger_registry
             .trigger_types
-            .get("tt-orders")
+            // A trigger type is filed under the namespace of the connection
+            // that registered it, so each worker's provider is its own.
+            .get(&iii::trigger::type_key("orders", "tt-orders"))
             .is_some()
             && engine
                 .trigger_registry
                 .trigger_types
-                .get("tt-analytics")
+                .get(&iii::trigger::type_key("analytics", "tt-analytics"))
                 .is_some()
     })
     .await;
@@ -1035,12 +1037,15 @@ async fn workers_info_excludes_connectionless_trigger_types_from_a_namespaced_ws
         engine
             .trigger_registry
             .trigger_types
-            .get("tt-own")
+            // The WS worker's own type lands in its connection's namespace;
+            // the connectionless one stays in `default`, where every
+            // in-process provider registers.
+            .get(&iii::trigger::type_key("orders", "tt-own"))
             .is_some()
             && engine
                 .trigger_registry
                 .trigger_types
-                .get("internalonly")
+                .get(&iii::trigger::type_key("default", "internalonly"))
                 .is_some()
     })
     .await;
@@ -1071,5 +1076,79 @@ async fn workers_info_excludes_connectionless_trigger_types_from_a_namespaced_ws
         !tt_ids.contains(&"internalonly"),
         "a connectionless (worker_id=None) trigger type must not attach to a \
          namespaced WS worker by name; got: {result}"
+    );
+}
+
+/// A namespace named and left blank is refused, not read as absent.
+///
+/// The two ask for opposite things: absent asks for `default`, blank names a
+/// namespace and gives nothing to name it with. Read as absent, the worker
+/// lands in `default` and every call and trigger it makes follows it there --
+/// a whole project quietly serving from the wrong namespace, and the one thing
+/// an operator cannot see by reading the declaration. Filed under the empty
+/// string instead, it lands in a namespace nobody can address or type.
+///
+/// The SDKs refuse it at construction, each in its own way, and one of them did
+/// not refuse it at all. The engine is the party every client goes through.
+#[tokio::test]
+async fn a_blank_namespace_on_register_is_refused() {
+    let (port, engine) = spawn_engine().await;
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}/"))
+        .await
+        .expect("connect");
+    let _registered = tokio::time::timeout(Duration::from_secs(5), ws.next())
+        .await
+        .expect("WorkerRegistered")
+        .expect("stream")
+        .expect("frame");
+
+    let invocation = uuid::Uuid::new_v4();
+    ws.send(WsMessage::Text(
+        json!({
+            "type": "invokefunction",
+            "invocation_id": invocation,
+            "function_id": "engine::workers::register",
+            "data": { "runtime": "node", "name": "blank-ns", "pid": 4700, "namespace": "  " },
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send register");
+
+    // The refusal comes back on the invocation, so a worker learns why rather
+    // than discovering it later through calls that resolve nowhere.
+    let mut refused = None;
+    for _ in 0..20 {
+        let Ok(Some(Ok(frame))) = tokio::time::timeout(Duration::from_secs(3), ws.next()).await
+        else {
+            break;
+        };
+        let Ok(msg) = serde_json::from_str::<Value>(frame.to_text().unwrap_or_default()) else {
+            continue;
+        };
+        if msg["type"] == "invocationresult" && msg["invocation_id"] == json!(invocation) {
+            refused = Some(msg);
+            break;
+        }
+    }
+
+    let refused = refused.expect("the register call must be answered");
+    assert_eq!(
+        refused["error"]["code"], "INVALID_NAMESPACE",
+        "unexpected: {refused}"
+    );
+
+    // And nothing was filed: no worker under the blank namespace, and none
+    // quietly placed in `default` either.
+    let listed = call_engine_fn(&engine, "engine::workers::list", json!({})).await;
+    let names: Vec<&str> = listed["workers"]
+        .as_array()
+        .map(|w| w.iter().filter_map(|w| w["name"].as_str()).collect())
+        .unwrap_or_default();
+    assert!(
+        !names.contains(&"blank-ns"),
+        "a refused registration must leave nothing behind: {names:?}"
     );
 }

--- a/engine/tests/observability_configuration_e2e.rs
+++ b/engine/tests/observability_configuration_e2e.rs
@@ -445,6 +445,9 @@ async fn register_log_recorder(harness: &Harness, fn_id: &str, level: &str) -> A
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register log trigger");

--- a/engine/tests/pubsub_configuration_e2e.rs
+++ b/engine/tests/pubsub_configuration_e2e.rs
@@ -187,6 +187,9 @@ async fn subscribe(harness: &Harness, id: &str, topic: &str, function_id: &str) 
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register subscribe trigger");

--- a/engine/tests/queue_e2e_fanout.rs
+++ b/engine/tests/queue_e2e_fanout.rs
@@ -88,6 +88,9 @@ async fn setup_engine_with_topic_triggers(function_ids: &[&str], topic: &str) ->
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: iii::protocol::default_namespace(),
+                provider_namespace: iii::protocol::default_namespace(),
             })
             .await
             .expect("register trigger should succeed");
@@ -167,6 +170,9 @@ async fn queue_subscriber_invokes_target_and_condition_in_registering_namespace(
             worker_id: None,
             metadata: None,
             namespace: "orders".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register trigger should succeed");
@@ -247,6 +253,9 @@ async fn fanout_replicas_compete_within_function() {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: iii::protocol::default_namespace(),
+                provider_namespace: iii::protocol::default_namespace(),
             })
             .await
             .expect("register trigger should succeed");
@@ -295,6 +304,9 @@ async fn fanout_mixed_functions_and_replicas() {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register trigger should succeed");
@@ -310,6 +322,9 @@ async fn fanout_mixed_functions_and_replicas() {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: iii::protocol::default_namespace(),
+                provider_namespace: iii::protocol::default_namespace(),
             })
             .await
             .expect("register trigger should succeed");
@@ -391,6 +406,9 @@ async fn fanout_unsubscribe_stops_delivery() {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register trigger A should succeed");
@@ -405,6 +423,9 @@ async fn fanout_unsubscribe_stops_delivery() {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register trigger B should succeed");
@@ -511,6 +532,9 @@ async fn fanout_with_condition_function() {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register always trigger should succeed");
@@ -528,6 +552,9 @@ async fn fanout_with_condition_function() {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register conditional trigger should succeed");

--- a/engine/tests/queue_e2e_happy_path.rs
+++ b/engine/tests/queue_e2e_happy_path.rs
@@ -135,6 +135,9 @@ async fn condition_based_filtering_routes_matching_messages_only() {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register conditional trigger should succeed");

--- a/engine/tests/rabbitmq_queue_integration.rs
+++ b/engine/tests/rabbitmq_queue_integration.rs
@@ -1335,6 +1335,9 @@ async fn rmq_fanout_two_functions_same_topic_both_receive() {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register trigger A");
@@ -1349,6 +1352,9 @@ async fn rmq_fanout_two_functions_same_topic_both_receive() {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register trigger B");
@@ -1402,6 +1408,9 @@ async fn rmq_fanout_replicas_compete_within_function() {
                 worker_id: None,
                 metadata: None,
                 namespace: "default".to_string(),
+                trigger_namespace: None,
+                home_namespace: iii::protocol::default_namespace(),
+                provider_namespace: iii::protocol::default_namespace(),
             })
             .await
             .expect("register trigger");
@@ -1457,6 +1466,9 @@ async fn rmq_fanout_dlq_per_function() {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register success trigger");
@@ -1471,6 +1483,9 @@ async fn rmq_fanout_dlq_per_function() {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register fail trigger");
@@ -1753,6 +1768,9 @@ async fn rmq_subscriber_priority_orders_by_priority() {
             worker_id: None,
             metadata: None,
             namespace: "default".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register trigger should succeed");
@@ -1858,6 +1876,9 @@ async fn rmq_subscriber_invokes_target_in_registering_namespace() {
             worker_id: None,
             metadata: None,
             namespace: "orders".to_string(),
+            trigger_namespace: None,
+            home_namespace: iii::protocol::default_namespace(),
+            provider_namespace: iii::protocol::default_namespace(),
         })
         .await
         .expect("register orders trigger");
@@ -1948,6 +1969,9 @@ async fn rmq_two_namespaces_same_topic_fid_are_distinct_queues() {
                 worker_id: None,
                 metadata: None,
                 namespace: ns.to_string(),
+                trigger_namespace: None,
+                home_namespace: iii::protocol::default_namespace(),
+                provider_namespace: iii::protocol::default_namespace(),
             })
             .await
             .unwrap_or_else(|_| panic!("register {ns} trigger"));

--- a/engine/tests/worker_trigger_e2e.rs
+++ b/engine/tests/worker_trigger_e2e.rs
@@ -206,14 +206,8 @@ fn register_subscriber(iii: &IIIClient, function_id: &str, filter: Value) -> Sub
         })
         .description("e2e test subscriber"),
     );
-    iii.register_trigger(RegisterTriggerInput {
-        trigger_type: "worker".into(),
-        function_id: function_id.to_string(),
-        config: filter,
-        metadata: None,
-        namespace: None,
-    })
-    .expect("register worker trigger");
+    iii.register_trigger(RegisterTriggerInput::new("worker", function_id, filter))
+        .expect("register worker trigger");
     Subscriber { rx }
 }
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -74,10 +74,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(json!({ "message": format!("Hello, {name}!") }))
     });
 
-    iii.register_trigger(RegisterTriggerInput { trigger_type: "http".into(), function_id: "hello::greet".into(), config: json!({
+    iii.register_trigger(RegisterTriggerInput::new("http", "hello::greet", json!({
         "api_path": "/greet",
         "http_method": "POST"
-    }) })?;
+    })))?;
 
     let result: serde_json::Value = iii
         .trigger(TriggerRequest::new("hello::greet", json!({ "name": "world" })))

--- a/sdk/packages/go/iii/client.go
+++ b/sdk/packages/go/iii/client.go
@@ -10,6 +10,7 @@ import (
 	"math/rand"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -41,6 +42,10 @@ type Client struct {
 	// the engine's default namespace. Resolved once at construction: an explicit
 	// WithNamespace wins, else the III_NAMESPACE env var, else default.
 	namespace string
+	// namespaceSet records that WithNamespace was called, which "" alone cannot
+	// say. Without it, a namespace named and left blank is indistinguishable
+	// from one never given -- and they ask for opposite things.
+	namespaceSet bool
 
 	// outbound carries connection-AGNOSTIC frames (registrations + offline-buffered
 	// invokes) to the single writer goroutine. It is shared across the client's lifetime
@@ -164,11 +169,23 @@ func WithName(name string) Option {
 	return func(cl *Client) { cl.name = name }
 }
 
-// WithNamespace sets the namespace this worker registers into. An empty
-// namespace (the default) uses the engine's `default` namespace. Takes
-// precedence over the III_NAMESPACE environment variable.
+// WithNamespace sets the namespace this worker registers into. Takes precedence
+// over the III_NAMESPACE environment variable.
+//
+// A namespace named and left blank is refused, not read as "no namespace": the
+// client is put in a terminal failed state, so [Client.Connect] returns the
+// reason and [Client.FatalError] reports it. Absent and blank ask for opposite
+// things -- absent asks for the engine's `default`, blank names a namespace and
+// gives nothing to name it with. Read as absent, the worker registers in
+// `default`, and since a worker's calls and triggers follow its namespace, the
+// whole project quietly serves from a place its declaration never named.
+//
+// To register in the engine's default namespace, do not call this.
 func WithNamespace(namespace string) Option {
-	return func(cl *Client) { cl.namespace = namespace }
+	return func(cl *Client) {
+		cl.namespace = namespace
+		cl.namespaceSet = true
+	}
 }
 
 // New creates a [Client] for the engine at url (e.g. [DefaultEngineURL]). It does not
@@ -193,10 +210,26 @@ func New(url string, opts ...Option) *Client {
 	for _, opt := range opts {
 		opt(c)
 	}
-	// Env fallback: an explicit WithNamespace already set c.namespace, so only
-	// consult III_NAMESPACE when none was given. Mirrors the other SDKs.
-	if c.namespace == "" {
-		c.namespace = os.Getenv("III_NAMESPACE")
+	if c.namespaceSet {
+		// Refused rather than read as absent, and refused here so nothing is
+		// dialled: the mistake is in the program text, and every call and
+		// trigger this worker makes would inherit it.
+		if strings.TrimSpace(c.namespace) == "" {
+			c.failFatally(fmt.Errorf(
+				"iii: namespace is empty: WithNamespace was called with %q. "+
+					"Give it a name, or do not call it to register in the engine's default namespace",
+				c.namespace,
+			))
+		}
+	} else {
+		// III_NAMESPACE is left alone when blank. `FOO=` is how a shell says
+		// "not set" -- `III_NAMESPACE=${NS}` with NS unset produces exactly
+		// that -- so reading it as absent is what the caller meant. Only the
+		// option is a mistake: nobody writes a namespace parameter and passes
+		// nothing on purpose. Mirrors the other SDKs.
+		if managed := os.Getenv("III_NAMESPACE"); strings.TrimSpace(managed) != "" {
+			c.namespace = managed
+		}
 	}
 	return c
 }
@@ -285,6 +318,26 @@ func (c *Client) RegisterTriggerType(id, description string, handler TriggerHand
 	return nil
 }
 
+// refuseBlankCallNamespace refuses a namespace that was named and left blank on
+// one call or one binding.
+//
+// Named and left empty asks for the opposite of what absent asks for, and the
+// two are only ever confused by accident: Go dropped the empty string with
+// `omitempty` and sent the call to the engine's default, while Node and Rust
+// forwarded it verbatim and Python replaced it with the worker's. One mistake,
+// four behaviours.
+//
+// Unlike the other SDKs, absent here still means the engine's `default` rather
+// than this worker's namespace: Go has not adopted namespace inheritance yet.
+func refuseBlankCallNamespace(namespace, source string) error {
+	if namespace != "" && strings.TrimSpace(namespace) == "" {
+		return fmt.Errorf(
+			"iii: namespace is empty: %s was set to %q. Give it a name, or leave it unset "+
+				"to resolve in the engine's default namespace", source, namespace)
+	}
+	return nil
+}
+
 // RegisterTrigger registers a trigger instance: fire functionID when a trigger of
 // triggerType matches config. config and optional metadata are raw JSON (may be nil).
 func (c *Client) RegisterTrigger(id, triggerType, functionID string, config json.RawMessage, metadata ...json.RawMessage) error {
@@ -298,6 +351,9 @@ func (c *Client) RegisterTriggerNamespaced(id, triggerType, functionID, namespac
 }
 
 func (c *Client) registerTrigger(id, triggerType, functionID, namespace string, config json.RawMessage, metadata ...json.RawMessage) error {
+	if err := refuseBlankCallNamespace(namespace, "RegisterTriggerNamespaced namespace"); err != nil {
+		return err
+	}
 	if config == nil {
 		config = json.RawMessage("{}")
 	}
@@ -351,6 +407,9 @@ type TriggerRequest struct {
 // ctx bounds the wait independently of [TriggerRequest.Timeout]: if ctx is cancelled
 // first, its error is returned and the pending entry is reclaimed.
 func (c *Client) Trigger(ctx context.Context, req TriggerRequest) (json.RawMessage, error) {
+	if err := refuseBlankCallNamespace(req.Namespace, "TriggerRequest.Namespace"); err != nil {
+		return nil, err
+	}
 	data := req.Data
 	if data == nil {
 		data = json.RawMessage("{}")
@@ -475,11 +534,23 @@ func (c *Client) startSupervisor() {
 // backoff) until Close. Connect is safe to call multiple times and from multiple
 // goroutines; only one supervisor ever runs.
 func (c *Client) Connect(ctx context.Context) error {
+	// A client that is already terminally failed -- a namespace named and left
+	// blank, or a rejection from an earlier attempt -- has its reason on hand.
+	// Reporting retry exhaustion instead would describe the symptom.
+	if err := c.FatalError(); err != nil {
+		return err
+	}
+
 	c.startSupervisor()
 
 	select {
 	case <-c.connected:
 		return nil
+	case <-c.fatal:
+		if err := c.FatalError(); err != nil {
+			return err
+		}
+		return ErrNotConnected
 	case <-c.failed:
 		// The supervisor gave up (MaxRetries exceeded) before ever connecting.
 		return fmt.Errorf("iii: connection failed after exhausting retries: %w", ErrNotConnected)
@@ -867,6 +938,18 @@ func (c *Client) handleRegistrationRejected(msg *RegistrationRejectedMessage) {
 	if conn != nil {
 		_ = conn.CloseNow()
 	}
+}
+
+// failFatally puts the client in the terminal failed state without a
+// connection ever being involved: the cause is in the program text, so dialling
+// would only produce a second, less honest error.
+func (c *Client) failFatally(err error) {
+	c.mu.Lock()
+	c.fatalErr = err
+	c.state = StateFailed
+	c.mu.Unlock()
+	c.fatalOnce.Do(func() { close(c.fatal) })
+	c.failOnce.Do(func() { close(c.failed) })
 }
 
 // FatalError returns the terminal registration rejection that stopped this

--- a/sdk/packages/go/iii/namespace_test.go
+++ b/sdk/packages/go/iii/namespace_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -186,5 +188,123 @@ func TestFunctionRegistrationRejectedIsNonFatal(t *testing.T) {
 	}
 	if st := c.State(); st != StateConnected {
 		t.Errorf("state = %q, want connected", st)
+	}
+}
+
+// TestBlankNamespaceIsRefused pins down that a namespace named and left blank
+// is a mistake, not a way to ask for `default`.
+//
+// Go could not tell the two apart: WithNamespace("") left the field at its zero
+// value, which is exactly what never calling it leaves, so the env fallback
+// then ran and III_NAMESPACE could overwrite the choice the caller had made
+// explicitly. Absent and blank ask for opposite things, and the failure is the
+// one nobody sees: the worker serves from a namespace its declaration never
+// named.
+func TestBlankNamespaceIsRefused(t *testing.T) {
+	for _, declared := range []string{"", "   "} {
+		c := New("ws://127.0.0.1:1", WithNamespace(declared))
+
+		err := c.FatalError()
+		if err == nil {
+			t.Fatalf("WithNamespace(%q) must be refused, got a healthy client", declared)
+		}
+		if !strings.Contains(err.Error(), "namespace is empty") {
+			t.Fatalf("WithNamespace(%q): unexpected reason: %v", declared, err)
+		}
+
+		// Connect answers with that reason rather than dialling and blaming
+		// retry exhaustion, which would describe the symptom.
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		connectErr := c.Connect(ctx)
+		cancel()
+		if !strings.Contains(fmt.Sprint(connectErr), "namespace is empty") {
+			t.Fatalf("Connect should report the real cause, got: %v", connectErr)
+		}
+	}
+}
+
+// TestBlankNamespaceDoesNotFallBackToTheEnvironment is the half that made the
+// old behaviour dangerous rather than merely wrong: an explicit blank fell
+// through to the env fallback, so III_NAMESPACE silently won an argument the
+// caller thought they had settled in the program text.
+func TestBlankNamespaceDoesNotFallBackToTheEnvironment(t *testing.T) {
+	t.Setenv("III_NAMESPACE", "from-the-environment")
+
+	c := New("ws://127.0.0.1:1", WithNamespace(""))
+
+	if c.FatalError() == nil {
+		t.Fatal("an explicit blank must be refused, not replaced by the environment")
+	}
+	if c.namespace == "from-the-environment" {
+		t.Fatal("III_NAMESPACE overwrote a namespace the caller declared")
+	}
+}
+
+// TestAbsentNamespaceStillReadsTheEnvironment is the control: the env fallback
+// is what carries managed workers, and refusing blank must not disturb it.
+func TestAbsentNamespaceStillReadsTheEnvironment(t *testing.T) {
+	t.Setenv("III_NAMESPACE", "orders")
+
+	c := New("ws://127.0.0.1:1")
+
+	if err := c.FatalError(); err != nil {
+		t.Fatalf("no namespace given is not a mistake: %v", err)
+	}
+	if c.namespace != "orders" {
+		t.Fatalf("expected the managed namespace, got %q", c.namespace)
+	}
+}
+
+// TestBlankEnvironmentNamespaceIsLeftAlone: `FOO=` is how a shell says "not
+// set" -- `III_NAMESPACE=${NS}` with NS unset produces exactly that -- so the
+// env var is read as absent rather than refused. Only the option is a mistake.
+func TestBlankEnvironmentNamespaceIsLeftAlone(t *testing.T) {
+	t.Setenv("III_NAMESPACE", "  ")
+
+	c := New("ws://127.0.0.1:1")
+
+	if err := c.FatalError(); err != nil {
+		t.Fatalf("a blank env var is absent, not a mistake: %v", err)
+	}
+	if c.namespace != "" {
+		t.Fatalf("expected no namespace, got %q", c.namespace)
+	}
+}
+
+// TestBlankCallNamespaceIsRefused: the same rule on the per-call path.
+//
+// Go dropped the empty string with `omitempty` and sent the call to the
+// engine's default, while Node and Rust forwarded it verbatim and Python
+// replaced it with the worker's. One mistake, four behaviours, none of them
+// chosen -- each language's null-coalescing operator disagreed about "".
+func TestBlankCallNamespaceIsRefused(t *testing.T) {
+	m := newMockEngine(t)
+	c := connectClient(t, m)
+
+	if err := c.RegisterTriggerNamespaced("t1", "cron", "api::process", "  ", nil); err == nil {
+		t.Fatal("a blank namespace on a binding must be refused")
+	} else if !strings.Contains(err.Error(), "namespace is empty") {
+		t.Fatalf("unexpected reason: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := c.Trigger(ctx, TriggerRequest{FunctionID: "api::ping", Namespace: " "})
+	if err == nil {
+		t.Fatal("a blank namespace on a call must be refused")
+	}
+	if !strings.Contains(err.Error(), "namespace is empty") {
+		t.Fatalf("unexpected reason: %v", err)
+	}
+}
+
+// TestAbsentCallNamespaceIsNotRefused is the control: absent is not blank, and
+// a run that refuses everything must not be able to pass.
+func TestAbsentCallNamespaceIsNotRefused(t *testing.T) {
+	m := newMockEngine(t)
+	c := connectClient(t, m)
+
+	if err := c.RegisterTrigger("t1", "cron", "api::process", nil); err != nil {
+		t.Fatalf("no namespace given is not a mistake: %v", err)
 	}
 }

--- a/sdk/packages/node/iii-browser/src/iii.ts
+++ b/sdk/packages/node/iii-browser/src/iii.ts
@@ -95,6 +95,52 @@ function randomId(): string {
   return Math.random().toString(16).slice(2, 10)
 }
 
+/**
+ * The worker's namespace, refusing one that was named and left blank.
+ *
+ * Absent and blank mean opposite things. Absent asks for the engine's
+ * `default`; blank names a namespace and gives nothing to name it with. Read as
+ * absent, the worker registers in `default`, and since a worker's calls and
+ * triggers follow its namespace, the whole project quietly serves from a place
+ * its declaration never named -- the one thing an operator cannot see by
+ * reading the declaration.
+ *
+ * The browser has no `III_NAMESPACE` to fall back to, so unlike the other SDKs
+ * there is only the option here, and an option that was written and left empty
+ * is never what someone meant.
+ */
+/**
+ * The namespace one call or one binding resolves in.
+ *
+ * `undefined` inherits the worker's. A blank one is refused: named and left
+ * empty asks for the opposite of what absent asks for, and the two are only
+ * ever confused by accident -- `??` forwards the empty string, Python's `or`
+ * coerced it and Go dropped it, so one mistake produced three behaviours.
+ */
+function callNamespace(
+  explicit: string | undefined,
+  worker: string | undefined,
+  source: string,
+): string | undefined {
+  if (explicit !== undefined && explicit.trim() === '') {
+    throw new Error(
+      `namespace is empty: ${source} was set to ${JSON.stringify(explicit)}. ` +
+        "Give it a name, or leave it unset to stay in this worker's namespace.",
+    )
+  }
+  return explicit ?? worker
+}
+
+function resolveNamespace(optionNamespace?: string): string | undefined {
+  if (optionNamespace !== undefined && optionNamespace.trim() === '') {
+    throw new Error(
+      `namespace is empty: options.namespace was set to ${JSON.stringify(optionNamespace)}. ` +
+        'Give it a name, or leave it unset to register in `default`.',
+    )
+  }
+  return optionNamespace
+}
+
 class Sdk implements ISdk {
   private ws?: WebSocket
   private functions = new Map<string, RemoteFunctionData>()
@@ -120,8 +166,9 @@ class Sdk implements ISdk {
     private readonly options?: InitOptions,
   ) {
     this.workerName = options?.workerName ?? `browser:${randomId()}`
-    // No env fallback: the browser has no `process.env`.
-    this.namespace = options?.namespace
+    // No env fallback: the browser has no `process.env`, so the option is the
+    // only source -- and the only thing that can be wrong.
+    this.namespace = resolveNamespace(options?.namespace)
     this.invocationTimeoutMs = options?.invocationTimeoutMs ?? DEFAULT_INVOCATION_TIMEOUT_MS
     this.reconnectionConfig = {
       ...DEFAULT_BRIDGE_RECONNECTION_CONFIG,
@@ -229,6 +276,19 @@ class Sdk implements ISdk {
       ...trigger,
       id,
       message_type: MessageType.RegisterTrigger,
+      // Unset means this worker's namespace, not the engine's default. A
+      // trigger names a function, and the function a worker registers lands in
+      // the worker's namespace, so defaulting anywhere else registers a trigger
+      // that fires and resolves nothing. Naming another namespace, `default`
+      // included, stays a matter of saying so.
+      ...(() => {
+        const namespace = callNamespace(
+          trigger.namespace,
+          this.namespace,
+          'RegisterTriggerInput.namespace',
+        )
+        return namespace !== undefined ? { namespace } : {}
+      })(),
     }
     this.sendMessage(MessageType.RegisterTrigger, fullTrigger, true)
     this.triggers.set(id, fullTrigger)
@@ -369,7 +429,12 @@ class Sdk implements ISdk {
   trigger = async <TInput = unknown, TOutput = any>(
     request: TriggerRequest<TInput>,
   ): Promise<TOutput> => {
-    const { function_id, payload, action, timeoutMs, namespace } = request
+    const { function_id, payload, action, timeoutMs } = request
+    // Same rule as `registerTrigger`: a call with no namespace stays in the
+    // caller's. Reaching a worker that lives elsewhere -- an engine builtin in
+    // `default`, a neighbour in another project -- is done by naming that
+    // namespace.
+    const namespace = callNamespace(request.namespace, this.namespace, 'TriggerRequest.namespace')
     const effectiveTimeout = timeoutMs ?? this.invocationTimeoutMs
 
     if (action?.type === 'void') {
@@ -377,7 +442,7 @@ class Sdk implements ISdk {
         function_id,
         data: payload,
         action,
-        // Omit when absent so the engine routes within its default namespace.
+        // Omitted only when this worker has no namespace either.
         ...(namespace !== undefined ? { namespace } : {}),
       })
       return undefined as TOutput
@@ -411,7 +476,7 @@ class Sdk implements ISdk {
         function_id,
         data: payload,
         action,
-        // Omit when absent so the engine routes within its default namespace.
+        // Omitted only when this worker has no namespace either.
         ...(namespace !== undefined ? { namespace } : {}),
       })
     })

--- a/sdk/packages/node/iii-browser/src/triggers.ts
+++ b/sdk/packages/node/iii-browser/src/triggers.ts
@@ -14,7 +14,12 @@ export type TriggerConfig<TConfig> = {
   /**
    * Namespace the trigger's target `function_id` resolves in. A provider that
    * stores this config and later fires the target must pass this namespace, or
-   * it fires in `default`. Absent means the engine's default namespace.
+   * it fires in `default`.
+   *
+   * Omitted, it is filled in with the registering worker's namespace. A trigger
+   * names a function, and a worker's functions land in the worker's namespace,
+   * so defaulting anywhere else registers a trigger that resolves nothing. Name
+   * another namespace, `default` included, to target one.
    */
   namespace?: string
 }

--- a/sdk/packages/node/iii-browser/tests/namespace-inheritance.test.ts
+++ b/sdk/packages/node/iii-browser/tests/namespace-inheritance.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { registerWorker } from '../src/iii'
+import type { ISdk } from '../src/types'
+import { MockEngine } from './mock-websocket'
+
+/**
+ * A worker's namespace is inherited by what it calls and what it registers.
+ *
+ * Wire-level: each assertion is the frame the SDK actually emits, so these hold
+ * without an engine.
+ *
+ * The browser SDK was left behind when the other SDKs adopted the rule. Its
+ * typed helper inherited, so the shape looked right; the low-level
+ * `registerTrigger` and `trigger` did not, and those are the paths a worker
+ * uses. A browser worker in `orders` therefore called into `default` and
+ * registered triggers that fired and resolved nothing -- registration
+ * succeeded, the trigger existed, it fired on time, and nothing happened.
+ */
+describe('namespace inheritance', () => {
+  let engine: MockEngine
+  let sdk: ISdk
+
+  beforeEach(() => {
+    engine = new MockEngine()
+    engine.install()
+  })
+
+  afterEach(async () => {
+    await sdk.shutdown()
+    engine.uninstall()
+  })
+
+  const connect = async (namespace?: string): Promise<void> => {
+    sdk = registerWorker('ws://test:49135', namespace ? { namespace } : {})
+    await engine.waitForOpen()
+  }
+
+  it('registers a trigger in the worker declared namespace', async () => {
+    await connect('orders')
+    sdk.registerTrigger({ type: 'cron', function_id: 'api::process', config: {} })
+
+    expect(engine.findSent('registertrigger')).toMatchObject({ namespace: 'orders' })
+  })
+
+  it('lets an explicit namespace win', async () => {
+    // Naming another namespace, `default` included, is how a worker inside one
+    // reaches an engine builtin.
+    await connect('orders')
+    sdk.registerTrigger({
+      type: 'cron',
+      function_id: 'state::sweep',
+      config: {},
+      namespace: 'default',
+    })
+
+    expect(engine.findSent('registertrigger')).toMatchObject({ namespace: 'default' })
+  })
+
+  it('leaves a worker without a namespace unchanged', async () => {
+    await connect()
+    sdk.registerTrigger({ type: 'cron', function_id: 'api::process', config: {} })
+
+    expect(engine.findSent('registertrigger')).not.toHaveProperty('namespace')
+  })
+
+  it('keeps an invocation in the caller namespace', async () => {
+    await connect('orders')
+    void sdk.trigger({ function_id: 'api::ping', payload: {}, action: { type: 'void' } })
+
+    const call = engine
+      .findAllSent('invokefunction')
+      .find((f) => f.function_id === 'api::ping')
+    expect(call).toMatchObject({ namespace: 'orders' })
+  })
+
+  it('keeps a non-void invocation in the caller namespace too', async () => {
+    // The two branches of `trigger` send separately, so both are asserted: the
+    // void one returns immediately, this one waits on a reply.
+    await connect('orders')
+    void sdk.trigger({ function_id: 'api::ask', payload: {} }).catch(() => {})
+
+    const call = engine.findAllSent('invokefunction').find((f) => f.function_id === 'api::ask')
+    expect(call).toMatchObject({ namespace: 'orders' })
+  })
+
+  /**
+   * The regression the Node SDK hit when it adopted this rule.
+   *
+   * The SDK announces itself with `engine::workers::register`, and it does so
+   * through the same call path. Once that path inherited, the announcement
+   * followed the worker into its own namespace -- where the engine does not
+   * serve that function -- so the worker never registered and every function it
+   * offered looked missing.
+   */
+  it('never redirects the workers own registration', async () => {
+    await connect('orders')
+
+    const announce = engine
+      .findAllSent('invokefunction')
+      .find((f) => f.function_id === 'engine::workers::register')
+    expect(announce, 'the worker announces itself').toBeDefined()
+    expect(announce).not.toHaveProperty('namespace')
+    // The namespace still travels, as data the engine files the worker under.
+    expect((announce as { data?: { namespace?: string } }).data?.namespace).toBe('orders')
+  })
+})
+
+/**
+ * A namespace that was declared and left blank is a mistake, not a way to ask
+ * for `default`.
+ *
+ * The browser assigned it raw, so `namespace: ''` produced a worker that
+ * registered under a namespace named by the empty string -- one nobody can
+ * address or type. The other SDKs each refused it already, in their own way.
+ */
+describe('a blank namespace is refused', () => {
+  let engine: MockEngine
+
+  beforeEach(() => {
+    engine = new MockEngine()
+    engine.install()
+  })
+
+  afterEach(() => {
+    engine.uninstall()
+  })
+
+  it.each([['', 'empty'], ['   ', 'whitespace-only']])(
+    'refuses a %s namespace',
+    (namespace) => {
+      expect(() => registerWorker('ws://test:49135', { namespace })).toThrow(/namespace is empty/)
+    },
+  )
+
+  it('says what to do instead', () => {
+    expect(() => registerWorker('ws://test:49135', { namespace: '' })).toThrow(
+      /leave it unset to register in `default`/,
+    )
+  })
+
+  it('leaves an absent namespace alone', () => {
+    // The control: absent asks for the engine's `default` and is not a mistake.
+    expect(() => registerWorker('ws://test:49135', {})).not.toThrow()
+  })
+})
+
+/**
+ * The same rule on the per-call path.
+ *
+ * `??` forwards the empty string, Python's `or` replaced it with the worker's
+ * and Go dropped it -- one mistake, four behaviours, none of them chosen. Each
+ * SDK now refuses it where it is written.
+ */
+describe('a blank namespace on one call is refused', () => {
+  let engine: MockEngine
+  let sdk: ISdk
+
+  beforeEach(async () => {
+    engine = new MockEngine()
+    engine.install()
+    sdk = registerWorker('ws://test:49135', { namespace: 'orders' })
+    await engine.waitForOpen()
+  })
+
+  afterEach(async () => {
+    await sdk.shutdown()
+    engine.uninstall()
+  })
+
+  it('refuses it on registerTrigger', () => {
+    expect(() =>
+      sdk.registerTrigger({ type: 'cron', function_id: 'api::process', config: {}, namespace: '' }),
+    ).toThrow(/namespace is empty/)
+  })
+
+  it('refuses it on trigger', async () => {
+    await expect(
+      sdk.trigger({ function_id: 'api::ping', payload: {}, namespace: '   ' }),
+    ).rejects.toThrow(/namespace is empty/)
+  })
+
+  it('still inherits when absent', () => {
+    // The control: absent is not blank, and still means this worker's.
+    sdk.registerTrigger({ type: 'cron', function_id: 'api::process', config: {} })
+    expect(engine.findSent('registertrigger')).toMatchObject({ namespace: 'orders' })
+  })
+})

--- a/sdk/packages/node/iii/src/iii-types.ts
+++ b/sdk/packages/node/iii/src/iii-types.ts
@@ -34,6 +34,12 @@ export type RegisterTriggerTypeMessage = {
   id: string
   /** Human-readable description of what this trigger type does. */
   description: string
+  /**
+   * Namespace this provider serves. Omit to let the engine use this
+   * connection's own, which is what a worker providing a trigger type for its
+   * own project wants.
+   */
+  namespace?: string
 }
 
 export type UnregisterTriggerTypeMessage = {
@@ -79,6 +85,16 @@ export type RegisterTriggerMessage = {
    * default namespace, independent of this connection's namespace.
    */
   namespace?: string
+  /**
+   * Namespace to find the trigger type's provider in.
+   *
+   * Omitting it is not the same as `'default'`: it asks the engine to resolve,
+   * taking this worker's namespace first and the engine's own second. That is
+   * what lets a project ship its own provider for a type id the engine also
+   * provides, while a worker that has not been migrated keeps reaching the
+   * engine's without saying so. Naming one is strict.
+   */
+  trigger_namespace?: string
 }
 
 export type RegisterFunctionFormat = {

--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -117,6 +117,28 @@ function resolveAddress(address?: string): string {
   return DEFAULT_ENGINE_URL
 }
 
+/**
+ * The namespace one call or one binding resolves in.
+ *
+ * `undefined` inherits the worker's. A blank one is refused: named and left
+ * empty asks for the opposite of what absent asks for, and the two are only
+ * ever confused by accident -- `??` forwards the empty string, Python's `or`
+ * coerced it and Go dropped it, so one mistake produced three behaviours.
+ */
+function callNamespace(
+  explicit: string | undefined,
+  worker: string | undefined,
+  source: string,
+): string | undefined {
+  if (explicit !== undefined && explicit.trim() === '') {
+    throw new Error(
+      `namespace is empty: ${source} was set to ${JSON.stringify(explicit)}. ` +
+        "Give it a name, or leave it unset to stay in this worker's namespace.",
+    )
+  }
+  return explicit ?? worker
+}
+
 function resolveNamespace(optionNamespace?: string): string | undefined {
   // III_NAMESPACE carries the namespace for managed workers (set by iii-worker
   // at spawn), mirroring III_WORKER_NAME. An explicit option wins; otherwise
@@ -364,11 +386,14 @@ class Sdk implements IIIClient {
       // the worker's namespace, so defaulting anywhere else registers a trigger
       // that fires and resolves nothing. Naming another namespace, `default`
       // included, stays a matter of saying so.
-      ...(trigger.namespace !== undefined
-        ? { namespace: trigger.namespace }
-        : this.namespace !== undefined
-          ? { namespace: this.namespace }
-          : {}),
+      ...(() => {
+        const namespace = callNamespace(
+          trigger.namespace,
+          this.namespace,
+          'RegisterTriggerInput.namespace',
+        )
+        return namespace !== undefined ? { namespace } : {}
+      })(),
     }
     this.sendMessage(MessageType.RegisterTrigger, fullTrigger, true)
     this.triggers.set(id, fullTrigger)
@@ -593,7 +618,7 @@ class Sdk implements IIIClient {
     // caller's. Reaching a worker that lives elsewhere -- an engine builtin in
     // `default`, a neighbour in another project -- is done by naming that
     // namespace.
-    const namespace = request.namespace ?? this.namespace
+    const namespace = callNamespace(request.namespace, this.namespace, 'TriggerRequest.namespace')
     const effectiveTimeout = timeoutMs ?? this.invocationTimeoutMs
 
     // Void is fire-and-forget, no invocation_id, no response

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -187,6 +187,25 @@ class III:
         >>> worker = register_worker('ws://localhost:49134', InitOptions(worker_name='my-worker'))
     """
 
+    def _call_namespace(self, explicit: str | None, source: str) -> str | None:
+        """The namespace one call or one binding resolves in.
+
+        ``None`` inherits the worker's. A blank one raises: named and left empty
+        asks for the opposite of what absent asks for, and the two are only ever
+        confused by accident. Python's ``or`` treats ``""`` as falsy, so a blank
+        namespace was silently replaced by the worker's here while Node and Rust
+        forwarded it and Go dropped it -- one mistake, four behaviours.
+
+        Raises:
+            ValueError: when ``explicit`` is present and holds only whitespace.
+        """
+        if explicit is not None and not explicit.strip():
+            raise ValueError(
+                f"namespace is empty: {source} was set to {explicit!r}. Give it a name, or "
+                "leave it unset to stay in this worker's namespace."
+            )
+        return explicit if explicit is not None else self._worker_namespace()
+
     def _worker_namespace(self) -> str | None:
         """Effective worker namespace: explicit option, then ``III_NAMESPACE`` env,
         else ``None`` (the engine applies its ``default`` namespace).
@@ -1159,7 +1178,16 @@ class III:
             # registers a trigger that fires and resolves nothing. Naming
             # another namespace, ``default`` included, stays a matter of saying
             # so.
-            namespace=trigger.namespace or self._worker_namespace(),
+            namespace=self._call_namespace(
+                trigger.namespace, "RegisterTriggerInput.namespace"
+            ),
+            # Passed through untouched, ``None`` included. ``None`` is the
+            # engine's two-step resolution -- this worker's namespace, then the
+            # engine's own -- which carries an unmigrated worker onto the
+            # engine's provider while letting a project's own win when it has
+            # one. The SDK cannot decide this locally: a sibling worker in the
+            # same project may be the one providing the type.
+            trigger_namespace=trigger.trigger_namespace,
         )
         self._triggers[trigger_id] = msg
         self._send_if_connected(msg)
@@ -1413,7 +1441,7 @@ class III:
         # the caller's. Reaching a worker that lives elsewhere -- an engine
         # builtin in ``default``, a neighbour in another project -- is done by
         # naming that namespace.
-        namespace = req.get("namespace") or self._worker_namespace()
+        namespace = self._call_namespace(req.get("namespace"), "TriggerRequest.namespace")
 
         timeout_ms = req.get("timeout_ms") or self._options.invocation_timeout_ms
 

--- a/sdk/packages/python/iii/src/iii/iii_types.py
+++ b/sdk/packages/python/iii/src/iii/iii_types.py
@@ -32,6 +32,10 @@ class RegisterTriggerTypeMessage(BaseModel):
     description: str
     trigger_request_format: Any | None = Field(default=None)
     call_request_format: Any | None = Field(default=None)
+    #: Namespace this provider serves. ``None`` lets the engine use this
+    #: connection's own, which is what a worker providing a trigger type for
+    #: its own project wants.
+    namespace: str | None = Field(default=None)
     message_type: MessageType = Field(default=MessageType.REGISTER_TRIGGER_TYPE, alias="type")
 
 
@@ -89,6 +93,8 @@ class RegisterTriggerInput(BaseModel):
         function_id: ID of the function this trigger invokes when it fires.
         config: Trigger-type-specific configuration, matching the shape the trigger type expects.
         metadata: Arbitrary user-specifiable metadata supplied to the triggered handler function on every invocation.
+        namespace: Namespace the target function resolves in.
+        trigger_namespace: Namespace the trigger type's provider is found in.
     """
 
     type: str = Field(
@@ -114,6 +120,14 @@ class RegisterTriggerInput(BaseModel):
             "default namespace, independent of this connection's namespace."
         ),
     )
+    trigger_namespace: str | None = Field(
+        default=None,
+        description=(
+            "Namespace to find the trigger type's provider in. Omitting it is not the "
+            "same as 'default': it asks the engine to resolve, taking this worker's "
+            "namespace first and the engine's own second. Naming one is strict."
+        ),
+    )
 
 
 class RegisterTriggerMessage(BaseModel):
@@ -125,6 +139,10 @@ class RegisterTriggerMessage(BaseModel):
     config: Any
     metadata: Any | None = Field(default=None)
     namespace: str | None = Field(default=None)
+    #: Namespace to find the trigger type's provider in. ``None`` is not
+    #: ``"default"``: it asks the engine to resolve, taking this worker's
+    #: namespace first and the engine's own second. Naming one is strict.
+    trigger_namespace: str | None = Field(default=None)
     message_type: MessageType = Field(default=MessageType.REGISTER_TRIGGER, alias="type")
 
 

--- a/sdk/packages/python/iii/tests/test_blank_namespace.py
+++ b/sdk/packages/python/iii/tests/test_blank_namespace.py
@@ -57,3 +57,32 @@ def test_a_named_namespace_still_resolves(monkeypatch: pytest.MonkeyPatch) -> No
     assert _client(None)._worker_namespace() == "billing"
     # An explicit option still wins over the managed environment.
     assert _client("orders")._worker_namespace() == "orders"
+
+
+class TestBlankCallNamespace:
+    """The same rule on the per-call path.
+
+    Python's ``or`` treats ``""`` as falsy, so a blank namespace here was
+    silently replaced by the worker's while Node and Rust forwarded it and Go
+    dropped it -- one mistake, four behaviours, none of them chosen.
+    """
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t"])
+    def test_a_blank_one_is_refused(self, blank: str) -> None:
+        client = _client("orders")
+        with pytest.raises(ValueError, match="namespace is empty"):
+            client._call_namespace(blank, "TriggerRequest.namespace")
+
+    def test_the_message_names_the_field(self) -> None:
+        client = _client("orders")
+        with pytest.raises(ValueError, match="TriggerRequest.namespace"):
+            client._call_namespace("", "TriggerRequest.namespace")
+
+    def test_an_absent_one_inherits_the_workers(self) -> None:
+        # The control: absent is not blank, and still means this worker's.
+        client = _client("orders")
+        assert client._call_namespace(None, "TriggerRequest.namespace") == "orders"
+
+    def test_an_explicit_one_still_wins(self) -> None:
+        client = _client("orders")
+        assert client._call_namespace("billing", "TriggerRequest.namespace") == "billing"

--- a/sdk/packages/rust/iii/src/builtin_triggers.rs
+++ b/sdk/packages/rust/iii/src/builtin_triggers.rs
@@ -317,13 +317,11 @@ impl IIITrigger {
 
     /// Create a [`RegisterTriggerInput`] binding this trigger to a function.
     pub fn for_function(self, function_id: impl Into<String>) -> RegisterTriggerInput {
-        RegisterTriggerInput {
-            trigger_type: self.trigger_type_id().to_string(),
-            function_id: function_id.into(),
-            config: serde_json::to_value(&self).unwrap(),
-            metadata: None,
-            namespace: None,
-        }
+        RegisterTriggerInput::new(
+            self.trigger_type_id().to_string(),
+            function_id.into(),
+            serde_json::to_value(&self).unwrap(),
+        )
     }
 }
 

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -195,13 +195,17 @@ impl<C: Serialize, R> TriggerTypeRef<C, R> {
         config: C,
         metadata: Option<Value>,
     ) -> Result<Trigger, Error> {
-        self.iii.register_trigger(RegisterTriggerInput {
-            trigger_type: self.trigger_type_id.clone(),
-            function_id: function_id.into(),
-            config: serde_json::to_value(config).map_err(|e| Error::Handler(e.to_string()))?,
-            metadata,
-            namespace: self.iii.namespace(),
-        })
+        let mut input = RegisterTriggerInput::new(
+            self.trigger_type_id.clone(),
+            function_id,
+            serde_json::to_value(config).map_err(|e| Error::Handler(e.to_string()))?,
+        );
+        // This typed helper pairs a function with its trigger, so it names the
+        // worker's namespace for the target; the low-level path resolves the
+        // same thing, and saying it here keeps the two from drifting.
+        input.metadata = metadata;
+        input.namespace = self.iii.namespace();
+        self.iii.register_trigger(input)
     }
 }
 
@@ -347,14 +351,55 @@ impl Default for WorkerMetadata {
 /// any connection, so it fails the worker at startup the way `iii compose`
 /// refuses `--ns ""`, rather than producing a client that serves in a place
 /// nobody asked for.
+/// Refuses a namespace that was named and left blank, whatever named it.
+///
+/// Absent and blank ask for opposite things. Absent asks for the engine's
+/// `default`; blank names a namespace and gives nothing to name it with. Read
+/// as absent, the worker registers in `default`, and since a worker's calls and
+/// triggers follow its namespace, the whole project quietly serves from a place
+/// its declaration never named.
+///
+/// Panics rather than returning an error: this is a mistake in the program
+/// text, made once at construction, and there is nothing a caller could do with
+/// a `Result` here except unwrap it.
+pub(crate) fn reject_blank_namespace(declared: &str, source: &str) {
+    if declared.trim().is_empty() {
+        panic!(
+            "namespace is empty: `{source}` was set to {declared:?}. \
+             Give it a name, or leave it unset to register in `default`."
+        );
+    }
+}
+
+/// The namespace one call or one binding resolves in.
+///
+/// `None` inherits the worker's. `Some("")` is refused: a namespace named and
+/// left blank asks for the opposite of what absent asks for, and the two are
+/// only ever confused by accident -- `??`, `or_else` and `or` each disagree
+/// about the empty string, which is how the SDKs ended up forwarding it,
+/// coercing it and dropping it respectively.
+///
+/// An `Err` rather than a panic: unlike a namespace declared once in
+/// `InitOptions`, a per-call one can come from data, and a caller can do
+/// something with the error.
+pub(crate) fn call_namespace(
+    explicit: Option<String>,
+    worker: Option<String>,
+    source: &str,
+) -> Result<Option<String>, Error> {
+    match explicit {
+        Some(declared) if declared.trim().is_empty() => Err(Error::Handler(format!(
+            "namespace is empty: `{source}` was set to {declared:?}. Give it a name, or leave \
+             it unset to stay in this worker's namespace."
+        ))),
+        Some(declared) => Ok(Some(declared)),
+        None => Ok(worker),
+    }
+}
+
 pub(crate) fn resolve_namespace(explicit: Option<String>) -> Option<String> {
     if let Some(declared) = explicit {
-        if declared.trim().is_empty() {
-            panic!(
-                "namespace is empty: `InitOptions.namespace` was set to {declared:?}. \
-                 Give it a name, or leave it unset to register in `default`."
-            );
-        }
+        reject_blank_namespace(&declared, "InitOptions.namespace");
         return Some(declared);
     }
 
@@ -913,9 +958,18 @@ impl IIIClient {
     /// Override the worker's target namespace (call before connect). Applied by
     /// [`register_worker`](crate::register_worker) after resolving
     /// `InitOptions.namespace` and `III_NAMESPACE`.
+    ///
+    /// # Panics
+    ///
+    /// If `namespace` is empty or only whitespace. `register_worker` resolves
+    /// its own namespace before calling this, so the check is here for the
+    /// callers that reach it directly: a blank one is the same mistake
+    /// wherever it is made, and this entry point skipped it.
     pub fn set_namespace(&self, namespace: impl Into<String>) {
+        let namespace = namespace.into();
+        reject_blank_namespace(&namespace, "IIIClient::set_namespace");
         if let Some(md) = self.inner.worker_metadata.lock_or_recover().as_mut() {
-            md.namespace = Some(namespace.into());
+            md.namespace = Some(namespace);
         }
     }
 
@@ -1212,6 +1266,10 @@ impl IIIClient {
             description: trigger_type.description,
             trigger_request_format: trigger_type.trigger_request_format,
             call_request_format: trigger_type.call_request_format,
+            // Left to the engine, which files it under this connection's
+            // namespace. A worker providing a trigger type provides it for the
+            // project it belongs to.
+            namespace: None,
         };
 
         let trigger_type_id = message.id.clone();
@@ -1260,13 +1318,11 @@ impl IIIClient {
     /// # use iii_sdk::protocol::RegisterTriggerInput;
     /// # use serde_json::json;
     /// # let worker = IIIClient::new("ws://localhost:49134");
-    /// let trigger = worker.register_trigger(RegisterTriggerInput {
-    ///     trigger_type: "http".to_string(),
-    ///     function_id: "greet".to_string(),
-    ///     config: json!({ "api_path": "/greet", "http_method": "GET" }),
-    ///     metadata: None,
-    ///     namespace: None,
-    /// })?;
+    /// let trigger = worker.register_trigger(RegisterTriggerInput::new(
+    ///     "http",
+    ///     "greet",
+    ///     json!({ "api_path": "/greet", "http_method": "GET" }),
+    /// ))?;
     /// // Later...
     /// trigger.unregister();
     /// # Ok::<(), iii_sdk::Error>(())
@@ -1285,7 +1341,19 @@ impl IIIClient {
             // registers a trigger that fires and resolves nothing. Naming
             // another namespace, `default` included, stays a matter of saying
             // so.
-            namespace: input.namespace.or_else(|| self.namespace()),
+            namespace: call_namespace(
+                input.namespace,
+                self.namespace(),
+                "RegisterTriggerInput.namespace",
+            )?,
+            // Passed through untouched, including when it is `None`. `None` is
+            // the engine's two-step resolution — this worker's namespace, then
+            // the engine's own — which is what lets a project ship its own
+            // provider for a type id the engine also provides while every
+            // unmigrated worker keeps reaching the engine's without saying so.
+            // The SDK cannot decide this locally: a sibling worker in the same
+            // project may be the one providing the type.
+            trigger_namespace: input.trigger_namespace,
         };
 
         self.inner
@@ -1373,7 +1441,11 @@ impl IIIClient {
         // the caller's. Reaching a worker that lives elsewhere -- an engine
         // builtin in `default`, a neighbour in another project -- is done by
         // naming that namespace.
-        let namespace = request.namespace.or_else(|| self.namespace());
+        let namespace = call_namespace(
+            request.namespace,
+            self.namespace(),
+            "TriggerRequest.namespace",
+        )?;
         let (tp, bg) = inject_trace_headers();
 
         // Void is fire-and-forget, no invocation_id, no response
@@ -1865,6 +1937,10 @@ impl IIIClient {
                 // provider that stores the config and later calls `trigger()`
                 // needs it to fire the target in the right namespace.
                 namespace,
+                // Which of this provider's namespaces the bind belongs to. Only
+                // meaningful to a provider serving more than one, and the
+                // engine has already routed the message here by it.
+                trigger_namespace: _,
             } => {
                 self.handle_register_trigger(
                     id,
@@ -2587,13 +2663,11 @@ mod tests {
     async fn register_trigger_unregister_removes_entry() {
         let iii = register_worker("ws://localhost:1234", InitOptions::default());
         let trigger = iii
-            .register_trigger(RegisterTriggerInput {
-                trigger_type: "demo".to_string(),
-                function_id: "functions.echo".to_string(),
-                config: json!({ "foo": "bar" }),
-                metadata: None,
-                namespace: None,
-            })
+            .register_trigger(RegisterTriggerInput::new(
+                "demo",
+                "functions.echo",
+                json!({ "foo": "bar" }),
+            ))
             .unwrap();
 
         assert_eq!(iii.inner.triggers.lock().unwrap().len(), 1);
@@ -3097,6 +3171,7 @@ mod tests {
             config: json!({}),
             metadata: None,
             namespace: None,
+            trigger_namespace: None,
         }
     }
 
@@ -3106,6 +3181,7 @@ mod tests {
             description: "tt".to_string(),
             trigger_request_format: None,
             call_request_format: None,
+            namespace: None,
         }
     }
 

--- a/sdk/packages/rust/iii/src/protocol.rs
+++ b/sdk/packages/rust/iii/src/protocol.rs
@@ -141,6 +141,9 @@ pub enum Message {
         trigger_request_format: Option<Value>,
         #[serde(skip_serializing_if = "Option::is_none")]
         call_request_format: Option<Value>,
+        /// Namespace this provider serves. Absent means the connection's own.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        namespace: Option<String>,
     },
     RegisterTrigger {
         id: String,
@@ -153,6 +156,10 @@ pub enum Message {
         /// engine's default namespace, independent of the connection's namespace.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         namespace: Option<String>,
+        /// Namespace to find the provider in. Absent asks the engine to resolve
+        /// it: this connection's namespace first, then the engine's own.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        trigger_namespace: Option<String>,
     },
     TriggerRegistrationResult {
         id: String,
@@ -263,6 +270,11 @@ pub struct RegisterTriggerTypeMessage {
     pub trigger_request_format: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub call_request_format: Option<Value>,
+    /// Namespace this provider serves. `None` lets the engine use the
+    /// connection's own, which is what a worker providing a trigger type for
+    /// its own project wants.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
 }
 
 impl RegisterTriggerTypeMessage {
@@ -272,6 +284,7 @@ impl RegisterTriggerTypeMessage {
             description: self.description.clone(),
             trigger_request_format: self.trigger_request_format.clone(),
             call_request_format: self.call_request_format.clone(),
+            namespace: self.namespace.clone(),
         }
     }
 }
@@ -279,11 +292,16 @@ impl RegisterTriggerTypeMessage {
 /// Input for [`IIIClient::register_trigger`](crate::IIIClient::register_trigger).
 /// The `id` is auto-generated internally.
 ///
-/// **Breaking change:** the `namespace` field was added. Code that constructs
-/// this with a struct literal must now set it (use `namespace: None` for the
-/// engine default). To avoid struct-literal churn, prefer the builder:
-/// `IIITrigger::Http(..).for_function(id).in_namespace(ns)`, which fills every
-/// field including `namespace`.
+/// Build it with [`RegisterTriggerInput::new`], or with
+/// [`IIITrigger`](crate::builtin_triggers::IIITrigger) for a type the engine
+/// provides. A struct literal has to name every field, so each field added here
+/// breaks it -- `namespace` did that once and `trigger_namespace` did it again,
+/// which is why the constructors exist.
+///
+/// The two are different questions. `namespace` is where the target function
+/// resolves; `trigger_namespace` is where the trigger type's provider is found,
+/// and `None` there asks the engine to take this worker's namespace first and
+/// the engine's own second.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegisterTriggerInput {
     /// Identifier of the registered trigger type this trigger uses (e.g. `storage::object-created`, `http`).
@@ -299,13 +317,72 @@ pub struct RegisterTriggerInput {
     /// engine's default namespace, independent of this connection's namespace.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
+    /// Namespace to find the trigger type's provider in. `None` asks the
+    /// engine to resolve it: this worker's namespace first, the engine's own
+    /// second. Naming one is strict.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_namespace: Option<String>,
 }
 
 impl RegisterTriggerInput {
-    /// Resolve this trigger's target function in `namespace` instead of the
-    /// engine's default namespace.
+    /// A trigger of `trigger_type`, bound to `function_id`, configured by
+    /// `config`.
+    ///
+    /// Use this for a trigger type nothing built in provides -- one this worker
+    /// or a neighbour registered. For the engine's own types, prefer
+    /// [`IIITrigger`](crate::builtin_triggers::IIITrigger), which knows the id
+    /// and the config shape:
+    ///
+    /// ```no_run
+    /// # use iii_sdk::protocol::RegisterTriggerInput;
+    /// # use serde_json::json;
+    /// RegisterTriggerInput::new("kick", "orders::sync", json!({ "every": "1m" }))
+    ///     .in_namespace("billing")
+    ///     .in_trigger_namespace("shop-a");
+    /// ```
+    ///
+    /// Everything else defaults to "not named", which is what the great
+    /// majority of registrations want. Reaching for a struct literal instead
+    /// means every field added here becomes a breaking change for the caller,
+    /// which is what this exists to stop.
+    pub fn new(
+        trigger_type: impl Into<String>,
+        function_id: impl Into<String>,
+        config: Value,
+    ) -> Self {
+        Self {
+            trigger_type: trigger_type.into(),
+            function_id: function_id.into(),
+            config,
+            metadata: None,
+            namespace: None,
+            trigger_namespace: None,
+        }
+    }
+
+    /// Resolve this trigger's target function in `namespace` instead of this
+    /// worker's.
     pub fn in_namespace(mut self, namespace: impl Into<String>) -> Self {
         self.namespace = Some(namespace.into());
+        self
+    }
+
+    /// Find the trigger type's provider in `namespace`, and only there.
+    ///
+    /// A different question from [`in_namespace`](Self::in_namespace): that one
+    /// locates the target function, this one locates the provider that fires
+    /// it. Left unset, the engine resolves it -- this worker's namespace first,
+    /// then its own -- which is what carries a worker that has not been
+    /// migrated onto the engine's providers without saying anything.
+    pub fn in_trigger_namespace(mut self, namespace: impl Into<String>) -> Self {
+        self.trigger_namespace = Some(namespace.into());
+        self
+    }
+
+    /// Deliver `metadata` to the handler alongside every payload this trigger
+    /// fires.
+    pub fn with_metadata(mut self, metadata: Value) -> Self {
+        self.metadata = Some(metadata);
         self
     }
 }
@@ -320,6 +397,8 @@ pub struct RegisterTriggerMessage {
     pub metadata: Option<Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_namespace: Option<String>,
 }
 
 impl RegisterTriggerMessage {
@@ -331,6 +410,7 @@ impl RegisterTriggerMessage {
             config: self.config.clone(),
             metadata: self.metadata.clone(),
             namespace: self.namespace.clone(),
+            trigger_namespace: self.trigger_namespace.clone(),
         }
     }
 }

--- a/sdk/packages/rust/iii/tests/api_triggers.rs
+++ b/sdk/packages/rust/iii/tests/api_triggers.rs
@@ -43,16 +43,14 @@ async fn get_endpoint() {
         }),
     );
 
-    iii.register_trigger(RegisterTriggerInput {
-        trigger_type: "http".to_string(),
-        function_id: "test::api::get::rs".to_string(),
-        config: json!({
+    iii.register_trigger(RegisterTriggerInput::new(
+        "http".to_string(),
+        "test::api::get::rs".to_string(),
+        json!({
             "api_path": "test/rs/hello",
             "http_method": "GET",
         }),
-        metadata: None,
-        namespace: None,
-    })
+    ))
     .expect("register trigger");
 
     common::settle().await;
@@ -87,16 +85,14 @@ async fn post_endpoint_with_body() {
     );
 
     let _trigger = iii
-        .register_trigger(RegisterTriggerInput {
-            trigger_type: "http".to_string(),
-            function_id: "test::api::post::rs".to_string(),
-            config: json!({
+        .register_trigger(RegisterTriggerInput::new(
+            "http".to_string(),
+            "test::api::post::rs".to_string(),
+            json!({
                 "api_path": "test/rs/items",
                 "http_method": "POST",
             }),
-            metadata: None,
-            namespace: None,
-        })
+        ))
         .expect("register trigger");
 
     common::settle().await;
@@ -193,16 +189,14 @@ async fn raw_json_request_body() {
     );
 
     let _trigger = iii
-        .register_trigger(RegisterTriggerInput {
-            trigger_type: "http".to_string(),
-            function_id: "test::api::json::raw::rs".to_string(),
-            config: json!({
+        .register_trigger(RegisterTriggerInput::new(
+            "http".to_string(),
+            "test::api::json::raw::rs".to_string(),
+            json!({
                 "api_path": "/test/rs/json/raw",
                 "http_method": "POST",
             }),
-            metadata: None,
-            namespace: None,
-        })
+        ))
         .expect("register trigger");
 
     common::settle().await;
@@ -241,16 +235,14 @@ async fn path_parameters() {
     );
 
     let _trigger = iii
-        .register_trigger(RegisterTriggerInput {
-            trigger_type: "http".to_string(),
-            function_id: "test::api::getbyid::rs".to_string(),
-            config: json!({
+        .register_trigger(RegisterTriggerInput::new(
+            "http".to_string(),
+            "test::api::getbyid::rs".to_string(),
+            json!({
                 "api_path": "test/rs/items/:id",
                 "http_method": "GET",
             }),
-            metadata: None,
-            namespace: None,
-        })
+        ))
         .expect("register trigger");
 
     common::settle().await;
@@ -286,16 +278,14 @@ async fn query_parameters() {
     );
 
     let _trigger = iii
-        .register_trigger(RegisterTriggerInput {
-            trigger_type: "http".to_string(),
-            function_id: "test::api::search::rs".to_string(),
-            config: json!({
+        .register_trigger(RegisterTriggerInput::new(
+            "http".to_string(),
+            "test::api::search::rs".to_string(),
+            json!({
                 "api_path": "test/rs/search",
                 "http_method": "GET",
             }),
-            metadata: None,
-            namespace: None,
-        })
+        ))
         .expect("register trigger");
 
     common::settle().await;
@@ -329,16 +319,14 @@ async fn custom_status_code() {
     );
 
     let _trigger = iii
-        .register_trigger(RegisterTriggerInput {
-            trigger_type: "http".to_string(),
-            function_id: "test::api::notfound::rs".to_string(),
-            config: json!({
+        .register_trigger(RegisterTriggerInput::new(
+            "http".to_string(),
+            "test::api::notfound::rs".to_string(),
+            json!({
                 "api_path": "test/rs/missing",
                 "http_method": "GET",
             }),
-            metadata: None,
-            namespace: None,
-        })
+        ))
         .expect("register trigger");
 
     common::settle().await;
@@ -375,16 +363,14 @@ async fn content_type_on_api_response_return() {
     );
 
     let _trigger = iii
-        .register_trigger(RegisterTriggerInput {
-            trigger_type: "http".to_string(),
-            function_id: "test::api::xml::return::rs".to_string(),
-            config: json!({
+        .register_trigger(RegisterTriggerInput::new(
+            "http".to_string(),
+            "test::api::xml::return::rs".to_string(),
+            json!({
                 "api_path": "test/rs/xml-return",
                 "http_method": "POST",
             }),
-            metadata: None,
-            namespace: None,
-        })
+        ))
         .expect("register trigger");
 
     common::settle().await;
@@ -472,16 +458,14 @@ async fn download_pdf_streaming() {
     );
 
     let _trigger = iii
-        .register_trigger(RegisterTriggerInput {
-            trigger_type: "http".to_string(),
-            function_id: "test::api::download::pdf::rs".to_string(),
-            config: json!({
+        .register_trigger(RegisterTriggerInput::new(
+            "http".to_string(),
+            "test::api::download::pdf::rs".to_string(),
+            json!({
                 "api_path": "test/rs/download/pdf",
                 "http_method": "GET",
             }),
-            metadata: None,
-            namespace: None,
-        })
+        ))
         .expect("register trigger");
 
     common::settle().await;
@@ -597,16 +581,14 @@ async fn upload_pdf_streaming() {
     );
 
     let _trigger = iii
-        .register_trigger(RegisterTriggerInput {
-            trigger_type: "http".to_string(),
-            function_id: "test::api::upload::pdf::rs".to_string(),
-            config: json!({
+        .register_trigger(RegisterTriggerInput::new(
+            "http".to_string(),
+            "test::api::upload::pdf::rs".to_string(),
+            json!({
                 "api_path": "test/rs/upload/pdf",
                 "http_method": "POST",
             }),
-            metadata: None,
-            namespace: None,
-        })
+        ))
         .expect("register trigger");
 
     common::settle().await;
@@ -708,16 +690,14 @@ async fn sse_streaming() {
     );
 
     let _trigger = iii
-        .register_trigger(RegisterTriggerInput {
-            trigger_type: "http".to_string(),
-            function_id: "test::api::sse::rs".to_string(),
-            config: json!({
+        .register_trigger(RegisterTriggerInput::new(
+            "http".to_string(),
+            "test::api::sse::rs".to_string(),
+            json!({
                 "api_path": "test/rs/sse",
                 "http_method": "GET",
             }),
-            metadata: None,
-            namespace: None,
-        })
+        ))
         .expect("register trigger");
 
     common::settle().await;
@@ -860,16 +840,14 @@ async fn urlencoded_form_data() {
     );
 
     let _trigger = iii
-        .register_trigger(RegisterTriggerInput {
-            trigger_type: "http".to_string(),
-            function_id: "test::api::form::urlencoded::rs".to_string(),
-            config: json!({
+        .register_trigger(RegisterTriggerInput::new(
+            "http".to_string(),
+            "test::api::form::urlencoded::rs".to_string(),
+            json!({
                 "api_path": "test/rs/form/urlencoded",
                 "http_method": "POST",
             }),
-            metadata: None,
-            namespace: None,
-        })
+        ))
         .expect("register trigger");
 
     common::settle().await;
@@ -1016,16 +994,14 @@ async fn multipart_form_data() {
     );
 
     let _trigger = iii
-        .register_trigger(RegisterTriggerInput {
-            trigger_type: "http".to_string(),
-            function_id: "test::api::form::multipart::rs".to_string(),
-            config: json!({
+        .register_trigger(RegisterTriggerInput::new(
+            "http".to_string(),
+            "test::api::form::multipart::rs".to_string(),
+            json!({
                 "api_path": "test/rs/form/multipart",
                 "http_method": "POST",
             }),
-            metadata: None,
-            namespace: None,
-        })
+        ))
         .expect("register trigger");
 
     common::settle().await;
@@ -1073,16 +1049,14 @@ async fn conflicting_route_structure_is_rejected() {
             Ok(json!({"status_code": 200, "body": {"ok": true}}))
         }),
     );
-    iii.register_trigger(RegisterTriggerInput {
-        trigger_type: "http".to_string(),
-        function_id: "test::api::conflict::a::rs".to_string(),
-        config: json!({
+    iii.register_trigger(RegisterTriggerInput::new(
+        "http".to_string(),
+        "test::api::conflict::a::rs".to_string(),
+        json!({
             "api_path": "test/rs/conflict/:listId/:userId",
             "http_method": "GET",
         }),
-        metadata: None,
-        namespace: None,
-    })
+    ))
     .expect("register trigger a");
 
     // Second route has the same axum shape with swapped param names -> conflict.
@@ -1092,16 +1066,14 @@ async fn conflicting_route_structure_is_rejected() {
             Ok(json!({"status_code": 200, "body": {"ok": true}}))
         }),
     );
-    iii.register_trigger(RegisterTriggerInput {
-        trigger_type: "http".to_string(),
-        function_id: "test::api::conflict::b::rs".to_string(),
-        config: json!({
+    iii.register_trigger(RegisterTriggerInput::new(
+        "http".to_string(),
+        "test::api::conflict::b::rs".to_string(),
+        json!({
             "api_path": "test/rs/conflict/:userId/:listId",
             "http_method": "GET",
         }),
-        metadata: None,
-        namespace: None,
-    })
+    ))
     .expect("register trigger b");
 
     common::settle().await;

--- a/sdk/packages/rust/iii/tests/healthcheck.rs
+++ b/sdk/packages/rust/iii/tests/healthcheck.rs
@@ -45,17 +45,15 @@ async fn register_healthcheck_function_and_trigger() {
     );
 
     let trigger = iii
-        .register_trigger(RegisterTriggerInput {
-            trigger_type: "http".to_string(),
-            function_id: fn_ref.id.clone(),
-            config: json!({
+        .register_trigger(RegisterTriggerInput::new(
+            "http".to_string(),
+            fn_ref.id.clone(),
+            json!({
                 "api_path": "health",
                 "http_method": "GET",
                 "description": "Healthcheck endpoint",
             }),
-            metadata: None,
-            namespace: None,
-        })
+        ))
         .expect("register trigger");
 
     let deadline = std::time::Instant::now() + Duration::from_secs(5);

--- a/sdk/packages/rust/iii/tests/middleware.rs
+++ b/sdk/packages/rust/iii/tests/middleware.rs
@@ -41,17 +41,15 @@ async fn middleware_continue_to_handler() {
         }),
     );
 
-    iii.register_trigger(RegisterTriggerInput {
-        trigger_type: "http".to_string(),
-        function_id: "test::mw::continue::handler::rs".to_string(),
-        config: json!({
+    iii.register_trigger(RegisterTriggerInput::new(
+        "http".to_string(),
+        "test::mw::continue::handler::rs".to_string(),
+        json!({
             "api_path": "test/rs/mw/continue",
             "http_method": "GET",
             "middleware_function_ids": ["test::mw::continue::rs"],
         }),
-        metadata: None,
-        namespace: None,
-    })
+    ))
     .expect("register trigger");
 
     common::settle().await;
@@ -102,17 +100,15 @@ async fn middleware_short_circuit() {
         }),
     );
 
-    iii.register_trigger(RegisterTriggerInput {
-        trigger_type: "http".to_string(),
-        function_id: "test::mw::block::handler::rs".to_string(),
-        config: json!({
+    iii.register_trigger(RegisterTriggerInput::new(
+        "http".to_string(),
+        "test::mw::block::handler::rs".to_string(),
+        json!({
             "api_path": "test/rs/mw/block",
             "http_method": "GET",
             "middleware_function_ids": ["test::mw::block::rs"],
         }),
-        metadata: None,
-        namespace: None,
-    })
+    ))
     .expect("register trigger");
 
     common::settle().await;
@@ -174,10 +170,10 @@ async fn multiple_middleware_ordering() {
         }),
     );
 
-    iii.register_trigger(RegisterTriggerInput {
-        trigger_type: "http".to_string(),
-        function_id: "test::mw::order::handler::rs".to_string(),
-        config: json!({
+    iii.register_trigger(RegisterTriggerInput::new(
+        "http".to_string(),
+        "test::mw::order::handler::rs".to_string(),
+        json!({
             "api_path": "test/rs/mw/order",
             "http_method": "GET",
             "middleware_function_ids": [
@@ -185,9 +181,7 @@ async fn multiple_middleware_ordering() {
                 "test::mw::order::second::rs",
             ],
         }),
-        metadata: None,
-        namespace: None,
-    })
+    ))
     .expect("register trigger");
 
     common::settle().await;
@@ -218,16 +212,14 @@ async fn no_middleware_regression() {
         }),
     );
 
-    iii.register_trigger(RegisterTriggerInput {
-        trigger_type: "http".to_string(),
-        function_id: "test::mw::none::rs".to_string(),
-        config: json!({
+    iii.register_trigger(RegisterTriggerInput::new(
+        "http".to_string(),
+        "test::mw::none::rs".to_string(),
+        json!({
             "api_path": "test/rs/mw/none",
             "http_method": "GET",
         }),
-        metadata: None,
-        namespace: None,
-    })
+    ))
     .expect("register trigger");
 
     common::settle().await;

--- a/sdk/packages/rust/iii/tests/namespace_inheritance.rs
+++ b/sdk/packages/rust/iii/tests/namespace_inheritance.rs
@@ -47,13 +47,11 @@ async fn a_trigger_registers_in_the_workers_namespace() {
     let mock = MockEngine::start().await;
     let iii = worker_in(&mock, Some("orders"));
 
-    iii.register_trigger(RegisterTriggerInput {
-        trigger_type: "cron".to_string(),
-        function_id: "api::process".to_string(),
-        config: json!({}),
-        metadata: None,
-        namespace: None,
-    })
+    iii.register_trigger(RegisterTriggerInput::new(
+        "cron".to_string(),
+        "api::process".to_string(),
+        json!({}),
+    ))
     .expect("registertrigger");
 
     assert_eq!(
@@ -71,13 +69,10 @@ async fn an_explicit_namespace_still_wins() {
     // Including `default`: a worker that means the engine's namespace says so,
     // which is the only way to bind a trigger to a builtin from inside a
     // namespace.
-    iii.register_trigger(RegisterTriggerInput {
-        trigger_type: "cron".to_string(),
-        function_id: "state::sweep".to_string(),
-        config: json!({}),
-        metadata: None,
-        namespace: Some("default".to_string()),
-    })
+    iii.register_trigger(
+        RegisterTriggerInput::new("cron".to_string(), "state::sweep".to_string(), json!({}))
+            .in_namespace("default".to_string()),
+    )
     .expect("registertrigger");
 
     assert_eq!(
@@ -91,13 +86,11 @@ async fn a_worker_without_a_namespace_is_unchanged() {
     let mock = MockEngine::start().await;
     let iii = worker_in(&mock, None);
 
-    iii.register_trigger(RegisterTriggerInput {
-        trigger_type: "cron".to_string(),
-        function_id: "api::process".to_string(),
-        config: json!({}),
-        metadata: None,
-        namespace: None,
-    })
+    iii.register_trigger(RegisterTriggerInput::new(
+        "cron".to_string(),
+        "api::process".to_string(),
+        json!({}),
+    ))
     .expect("registertrigger");
 
     // Absent, not null: the whole fleet runs this way today and the frame it
@@ -216,5 +209,97 @@ mod blank_namespace {
                 ..Default::default()
             },
         );
+    }
+
+    /// `register_worker` resolved its namespace before handing it over, so the
+    /// check never ran on the entry point a caller can reach directly.
+    /// A blank namespace is the same mistake wherever it is made.
+    #[test]
+    #[should_panic(expected = "namespace is empty")]
+    fn set_namespace_refuses_a_blank_one_too() {
+        let client = iii_sdk::IIIClient::new("ws://127.0.0.1:1");
+        client.set_namespace("");
+    }
+
+    #[test]
+    fn set_namespace_still_takes_a_real_one() {
+        // The control, so a run that refuses everything cannot pass.
+        let client = iii_sdk::IIIClient::with_metadata(
+            "ws://127.0.0.1:1",
+            iii_sdk::iii::WorkerMetadata {
+                name: "tester".to_string(),
+                ..Default::default()
+            },
+        );
+        client.set_namespace("orders");
+        assert_eq!(client.namespace().as_deref(), Some("orders"));
+    }
+}
+
+/// A namespace named and left blank on one call is the same mistake as one
+/// declared blank at construction -- and until now each SDK made a different
+/// one of it, because `??`, `or_else` and `or` disagree about the empty string.
+///
+/// An error rather than a panic: unlike `InitOptions.namespace`, a per-call
+/// namespace can come from data, and the caller can do something with it.
+mod blank_call_namespace {
+    use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+    use iii_sdk::{IIIClient, InitOptions, register_worker};
+    use serde_json::json;
+
+    fn worker() -> IIIClient {
+        register_worker(
+            "ws://127.0.0.1:1",
+            InitOptions {
+                namespace: Some("orders".to_string()),
+                ..Default::default()
+            },
+        )
+    }
+
+    #[test]
+    fn register_trigger_refuses_it() {
+        let err = worker()
+            .register_trigger(
+                RegisterTriggerInput::new(
+                    "cron".to_string(),
+                    "api::process".to_string(),
+                    json!({}),
+                )
+                .in_namespace(String::new()),
+            )
+            .err()
+            .expect("a blank namespace is a mistake, not the worker's");
+        assert!(err.to_string().contains("namespace is empty"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn trigger_refuses_it() {
+        let err = worker()
+            .trigger(
+                TriggerRequest {
+                    function_id: "api::ping".to_string(),
+                    payload: json!({}),
+                    action: None,
+                    timeout_ms: Some(500),
+                }
+                .namespace(""),
+            )
+            .await
+            .expect_err("a blank namespace is a mistake");
+        assert!(err.to_string().contains("namespace is empty"), "{err}");
+    }
+
+    #[test]
+    fn an_absent_one_still_inherits() {
+        // The control: absent is not blank, and still means this worker's.
+        let bound = worker()
+            .register_trigger(RegisterTriggerInput::new(
+                "cron".to_string(),
+                "api::process".to_string(),
+                json!({}),
+            ))
+            .is_ok();
+        assert!(bound, "absent is not a mistake");
     }
 }

--- a/sdk/packages/rust/iii/tests/pubsub.rs
+++ b/sdk/packages/rust/iii/tests/pubsub.rs
@@ -49,13 +49,11 @@ async fn subscribe_and_receive_published_messages() {
     );
 
     let trigger = iii
-        .register_trigger(RegisterTriggerInput {
-            trigger_type: "subscribe".to_string(),
-            function_id: fn_id.clone(),
-            config: json!({"topic": topic}),
-            metadata: None,
-            namespace: None,
-        })
+        .register_trigger(RegisterTriggerInput::new(
+            "subscribe".to_string(),
+            fn_id.clone(),
+            json!({"topic": topic}),
+        ))
         .expect("register trigger");
 
     common::settle().await;
@@ -127,22 +125,18 @@ async fn topic_isolation() {
     );
 
     let trigger_a = iii
-        .register_trigger(RegisterTriggerInput {
-            trigger_type: "subscribe".to_string(),
-            function_id: fn_id_a.clone(),
-            config: json!({"topic": topic_a}),
-            metadata: None,
-            namespace: None,
-        })
+        .register_trigger(RegisterTriggerInput::new(
+            "subscribe".to_string(),
+            fn_id_a.clone(),
+            json!({"topic": topic_a}),
+        ))
         .expect("register trigger a");
     let trigger_b = iii
-        .register_trigger(RegisterTriggerInput {
-            trigger_type: "subscribe".to_string(),
-            function_id: fn_id_b.clone(),
-            config: json!({"topic": topic_b}),
-            metadata: None,
-            namespace: None,
-        })
+        .register_trigger(RegisterTriggerInput::new(
+            "subscribe".to_string(),
+            fn_id_b.clone(),
+            json!({"topic": topic_b}),
+        ))
         .expect("register trigger b");
 
     common::settle().await;

--- a/sdk/packages/rust/iii/tests/rbac_workers.rs
+++ b/sdk/packages/rust/iii/tests/rbac_workers.rs
@@ -507,13 +507,11 @@ async fn should_deny_trigger_registration_via_hook() {
 
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    let _ = iii_client.register_trigger(iii_sdk::protocol::RegisterTriggerInput {
-        trigger_type: "test-rbac-trigger".to_string(),
-        function_id: "denied-trig::my-fn".to_string(),
-        config: json!({ "key": "value" }),
-        metadata: None,
-        namespace: None,
-    });
+    let _ = iii_client.register_trigger(iii_sdk::protocol::RegisterTriggerInput::new(
+        "test-rbac-trigger".to_string(),
+        "denied-trig::my-fn".to_string(),
+        json!({ "key": "value" }),
+    ));
 
     tokio::time::sleep(Duration::from_millis(1000)).await;
 

--- a/sdk/packages/rust/iii/tests/registration_dedup.rs
+++ b/sdk/packages/rust/iii/tests/registration_dedup.rs
@@ -149,13 +149,11 @@ async fn mixed_registration_types_each_sent_once() {
     ));
     drop(trigger_type);
     let trigger = iii
-        .register_trigger(RegisterTriggerInput {
-            trigger_type: "dedup::mixed::tt".to_string(),
-            function_id: "dedup::mixed::fn".to_string(),
-            config: json!({"foo": "bar"}),
-            metadata: None,
-            namespace: None,
-        })
+        .register_trigger(RegisterTriggerInput::new(
+            "dedup::mixed::tt".to_string(),
+            "dedup::mixed::fn".to_string(),
+            json!({"foo": "bar"}),
+        ))
         .expect("register trigger");
     drop(trigger);
 

--- a/sdk/packages/rust/iii/tests/state.rs
+++ b/sdk/packages/rust/iii/tests/state.rs
@@ -396,13 +396,11 @@ async fn reactive_state() {
 
     let key_clone = key.clone();
     let trigger = iii
-        .register_trigger(RegisterTriggerInput {
-            trigger_type: "state".to_string(),
-            function_id: fn_ref.id.clone(),
-            config: json!({"scope": SCOPE, "key": key_clone}),
-            metadata: None,
-            namespace: None,
-        })
+        .register_trigger(RegisterTriggerInput::new(
+            "state".to_string(),
+            fn_ref.id.clone(),
+            json!({"scope": SCOPE, "key": key_clone}),
+        ))
         .expect("register state trigger");
 
     let expected = Some(json!({"name": "New Test Data", "value": 200}));

--- a/sdk/packages/rust/iii/tests/trigger_type_lifecycle.rs
+++ b/sdk/packages/rust/iii/tests/trigger_type_lifecycle.rs
@@ -165,13 +165,11 @@ async fn create_consumer(state: &LifecycleState) -> iii_sdk::IIIClient {
         }),
     );
 
-    iii.register_trigger(RegisterTriggerInput {
-        trigger_type: TRIGGER_TYPE_ID.to_string(),
-        function_id: CONSUMER_FN.to_string(),
-        config: json!({ "tag": "test" }),
-        metadata: None,
-        namespace: None,
-    })
+    iii.register_trigger(RegisterTriggerInput::new(
+        TRIGGER_TYPE_ID.to_string(),
+        CONSUMER_FN.to_string(),
+        json!({ "tag": "test" }),
+    ))
     .expect("register trigger");
 
     wait_register_calls(state, 1).await;


### PR DESCRIPTION
The same work as #2057, on the branch it belongs to.

#2057 was opened against `feat/compose-daemon` because that is where it was written and tested, and it merged there. Nothing in it is compose, so it is rebased here. The one compose-only file it touched — `engine/tests/compose_daemon_e2e.rs`, whose fixtures needed the `name:` → `namespace:` rename — stays on that branch and is not in this diff.

Both defects were found by running the smoke suite across three SDKs, not by reading code.

## Trigger type providers were global

Providers lived in one registry keyed by the type id alone. The second worker to register an id **replaced the first and was replayed the first's bindings**, so one project's trigger fired through another project's provider — and when that provider disconnected, the first project's binding was disabled. Two copies of the same worker could not coexist.

Measured before touching anything, with two providers of `webhook` in two namespaces:

```
trigger_types entries        1        ← B replaced A
A's bindings replayed into B ["trig-a"]
after B disconnects          live=0 pending=1
```

Providers are now keyed by `(namespace, trigger_type_id)`, taken from the registering connection. A binding resolves its provider in two steps: **the registering worker's namespace, then `default`**.

That order is the migration path. The engine's own providers (`http`, `cron`, `state`, `stream`) register in `default`, so every worker that names nothing keeps reaching them, while a project that ships its own provider for the same id gets that one instead — with nothing changing on the consumer side. Naming `trigger_namespace` explicitly is strict: that namespace or nothing.

Resolution does not depend on start order. A provider registering at home after a binding already fell back claims it: the old provider is told to let go and the binding moves. The reverse holds too — when a project's provider disconnects, its bindings fall back rather than being disabled.

A trigger now carries three namespace fields, which are one question asked at three times: `trigger_namespace` is what the caller asked for (immutable), `home_namespace` is where they asked from (immutable), and `provider_namespace` is where it was found (rewritten on every re-home). The re-home happens long after registration, with only the stored binding in hand, and it needs all three to answer "may I move this, and where to".

### The bug the smoke suite caught mid-change

`RegisterTriggerType` was not among the registrations buffered until a connection's namespace is known. With the provider's namespace now coming from the connection, a message handled while that was still pending landed in `default` — **replacing the engine's own provider** and inheriting everyone's bindings. Whether it happened came down to whether an SDK flushed before or after `engine::workers::register`, which no worker author chooses: Node flushes early and failed where Python passed. A unit test could not have found it; it registers directly, without the connection state machine.

## A blank namespace was accepted

`effective_namespace` mapped absent to `default` and let `Some("")` through untouched. Proven with a hand-rolled WebSocket client:

```
[REGISTERED] Function probe::ping in namespace
                                              ← nothing after it
```

Nobody can address or type that namespace, and nothing reported it as wrong.

Absent and blank ask for **opposite** things. Absent asks for `default`; blank names a namespace and gives nothing to name it with. Coercing blank to `default` is the other silent failure: the worker serves from somewhere it never named, and every call and trigger it makes follows it there.

The engine now refuses at all five entry points a namespace has, each on the channel that entry point already owns — the invocation result, the trigger registration result, or an error log for a trigger type, which has no ack and whose bindings will all park.

Nothing legitimate sent blank: Go drops it with `omitempty`, and Node, Python and Rust refuse before the wire. What this catches is the browser SDK and the per-call paths.

## SDKs

**Browser** was left behind when the others adopted namespace inheritance. Its typed helper inherited, so the shape looked right; the low-level `registerTrigger` and `trigger` did not, and those are the paths a worker uses. A browser worker in `orders` called into `default` and registered triggers that fired and resolved nothing. Both branches of `trigger` are covered — they build their frames separately, which is how the non-void one would have stayed unfixed.

**A blank namespace on one call** produced four behaviours, and nobody chose any of them; each language's null-coalescing operator simply disagreed about the empty string:

| | | |
|---|---|---|
| Node / browser | `request.namespace ?? this.namespace` | forwarded `''` verbatim |
| Rust | `request.namespace.or_else(...)` | forwarded `""` verbatim |
| Python | `req.get("namespace") or worker_ns` | replaced it silently |
| Go | `omitempty` | dropped it to `default` |

Python's was the worst kind: a working call in a namespace the caller did not write. All five now refuse it where it is written, each in its own idiom.

**Go** also could not tell a blank `WithNamespace("")` from never calling it, so `III_NAMESPACE` silently won an argument the caller had settled in code. It now fails terminally, and `Connect` reports the real cause instead of blaming retry exhaustion. **Rust**'s `set_namespace` skipped the blank check entirely; both paths now share one refusal.

**`RegisterTriggerInput` grew constructors.** It was a bare struct, so every field added to it broke every caller — `namespace` did that once and `trigger_namespace` did it again, 43 mechanical edits whose only content was `trigger_namespace: None`. The escape hatch existed and almost nobody took it (48 literals against 2 uses of the `IIITrigger` builder), and that builder is closed to the nine types the engine provides — so a worker registering its own type had no way out at all. `RegisterTriggerInput::new(...)` covers those and `in_trigger_namespace` completes the pair `in_namespace` started. All 48 literals move over; the next field added there is additive.

## Documentation

The protocol reference is reconciled by hand rather than taken from either side: this branch had already rewritten the paragraph on how the SDKs fill `namespace` (#2054), so that wording is kept and the `trigger_namespace` rules are added after it.

## Verification

On this base: 2068 engine lib tests, 23 e2e, 65 + 13 SDK, 44 doctests, fmt clean, clippy **down from 30 warnings to 12**.

Across the SDKs: browser 72, Node 9, Python 38, Go `build`/`vet`/`test` — Go was compiled and tested against a real toolchain rather than written blind.

`iii-hq/smoke-tests`: **101/101** against a local build, then **101/101** again against the published `iii-alpha/v0.22.1-alpha.10`, which was cut from this work. New scenarios there: `trigger_type_namespace_isolation` (9 checks × 3 languages; scores 2/7 against an engine without this change) and `ns_blank_namespace_engine`, which carries no SDK at all because the point is what the engine does for a client that has none of the SDK validation.

Two existing scenarios asserted the world this replaces and were rewritten: `trigger_type_cross_namespace` claimed types were a global vocabulary, and `http_route_resolves_in_its_namespace` claimed an omitted trigger namespace meant `default` — stale since the SDKs began inheriting, and failing 1/2 in all three languages against every engine that shipped that change.
