### PR TITLE
feat(cli): `-n` is the short spelling of `--namespace`

### DIFF
--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -97,7 +97,7 @@ iii trigger [OPTIONS] [FUNCTION_PATH] [KV]...
 | `--address <ADDRESS>` | Engine host address [default: localhost] |
 | `--port <PORT>` | Engine WebSocket port [default: 49134] |
 | `--timeout-ms <TIMEOUT_MS>` | Max time to wait for the invocation result (milliseconds) [default: 30000] |
-| `--namespace <NS>` | Namespace to resolve FUNCTION_PATH in. Omit to resolve in the engine's `default` namespace; routing is strict, so a function registered in another namespace is only reachable with this flag |
+| `-n, --namespace <NS>` | Namespace to resolve FUNCTION_PATH in. Omit to resolve in the engine's `default` namespace; routing is strict, so a function registered in another namespace is only reachable with this flag |
 
 <Note>
   `iii trigger <function> --help` additionally queries a running engine for the function's description and request schema. That output depends on which workers are registered and is not part of this page; see [Creating Workers / Functions](../creating-workers/functions#attach-request-and-response-schemas).

--- a/engine/src/cli_trigger/mod.rs
+++ b/engine/src/cli_trigger/mod.rs
@@ -56,7 +56,7 @@ pub struct TriggerArgs {
     /// Namespace to resolve FUNCTION_PATH in. Omit to resolve in the engine's
     /// `default` namespace; routing is strict, so a function registered in
     /// another namespace is only reachable with this flag.
-    #[arg(long, value_name = "NS")]
+    #[arg(short = 'n', long, value_name = "NS")]
     pub namespace: Option<String>,
 
     /// Print help. With a FUNCTION_PATH, queries a running engine for that


### PR DESCRIPTION
`iii trigger` had only the long form, and it is the flag every namespaced call needs — a function outside `default` is unreachable without it, so it gets typed constantly.

`-n` was free. The pair now matches what `iii compose` takes, so the two commands an operator uses together spell the same thing the same way.

Split out of #2059: this was pushed to that branch after it had already merged, so it never travelled with it.

```console
$ iii trigger compose::status -n loja file=./worker-compose.yaml
{ "namespace": "smoke", ... }
```

Both spellings verified against a live engine, not just `--help`. The committed CLI reference is regenerated from the clap definitions.
