### PR TITLE
fix(engine): resolve iii-worker Linux asset target

### DIFF
--- a/engine/src/cli/mod.rs
+++ b/engine/src/cli/mod.rs
@@ -91,7 +91,7 @@ pub async fn handle_dispatch(
             }
         };
 
-        let asset_name = platform::asset_name(spec.name);
+        let asset_name = platform::asset_name(spec);
         let asset = match github::find_asset(&release, &asset_name) {
             Some(a) => a,
             None => {
@@ -101,7 +101,7 @@ pub async fn handle_dispatch(
         };
 
         let checksum_url = if spec.has_checksum {
-            let checksum_name = platform::checksum_asset_name(spec.name);
+            let checksum_name = platform::checksum_asset_name(spec);
             github::find_asset(&release, &checksum_name).map(|a| a.browser_download_url.clone())
         } else {
             None

--- a/engine/src/cli/platform.rs
+++ b/engine/src/cli/platform.rs
@@ -51,6 +51,20 @@ pub fn current_target() -> &'static str {
     compile_error!("unsupported target platform for iii")
 }
 
+/// Resolves the release target published for a binary from the CLI's preferred
+/// target for the current host.
+fn release_target_for<'a>(spec: &BinarySpec, host_target: &'a str) -> &'a str {
+    spec.asset_target_overrides
+        .iter()
+        .find_map(|(from, to)| (*from == host_target).then_some(*to))
+        .unwrap_or(host_target)
+}
+
+/// Returns the release target published for a binary on the current host.
+pub fn release_target(spec: &BinarySpec) -> &'static str {
+    release_target_for(spec, current_target())
+}
+
 /// Returns the archive extension for the current platform.
 pub fn archive_extension() -> &'static str {
     if cfg!(target_os = "windows") {
@@ -60,15 +74,20 @@ pub fn archive_extension() -> &'static str {
     }
 }
 
-/// Constructs the expected asset filename for a binary on the current platform.
-/// e.g., "iii-console-aarch64-apple-darwin.tar.gz"
-pub fn asset_name(binary_name: &str) -> String {
+/// Constructs the expected asset filename for a binary and host target.
+fn asset_name_for(spec: &BinarySpec, host_target: &str) -> String {
     format!(
         "{}-{}.{}",
-        binary_name,
-        current_target(),
+        spec.name,
+        release_target_for(spec, host_target),
         archive_extension()
     )
+}
+
+/// Constructs the expected asset filename for a binary on the current platform.
+/// e.g., "iii-console-aarch64-apple-darwin.tar.gz"
+pub fn asset_name(spec: &BinarySpec) -> String {
+    asset_name_for(spec, current_target())
 }
 
 /// Returns the platform-appropriate data directory for iii.
@@ -131,10 +150,9 @@ pub fn state_file_path() -> PathBuf {
     data_dir().join("state.json")
 }
 
-/// Checks whether the current platform is supported by the given binary.
-/// Returns Ok(()) if supported, or an error with a helpful message if not.
-pub fn check_platform_support(spec: &BinarySpec) -> Result<(), RegistryError> {
-    let target = current_target();
+/// Checks whether a host target maps to a supported release target.
+fn check_platform_support_for(spec: &BinarySpec, host_target: &str) -> Result<(), RegistryError> {
+    let target = release_target_for(spec, host_target);
     if spec.supported_targets.contains(&target) {
         Ok(())
     } else {
@@ -150,6 +168,12 @@ pub fn check_platform_support(spec: &BinarySpec) -> Result<(), RegistryError> {
             supported,
         })
     }
+}
+
+/// Checks whether the current platform is supported by the given binary.
+/// Returns Ok(()) if supported, or an error with a helpful message if not.
+pub fn check_platform_support(spec: &BinarySpec) -> Result<(), RegistryError> {
+    check_platform_support_for(spec, current_target())
 }
 
 /// Formats a target triple into a human-readable string.
@@ -186,11 +210,20 @@ pub fn find_existing_binary(binary_name: &str) -> Option<PathBuf> {
     iii::bin_resolve::find_existing_binary(binary_name)
 }
 
+/// Constructs the expected checksum asset filename for a binary and host target.
+fn checksum_asset_name_for(spec: &BinarySpec, host_target: &str) -> String {
+    format!(
+        "{}-{}.sha256",
+        spec.name,
+        release_target_for(spec, host_target)
+    )
+}
+
 /// Constructs the expected checksum asset filename for a binary.
 /// e.g., "iii-console-aarch64-apple-darwin.sha256"
 /// Note: taiki-e produces checksums as separate assets WITHOUT the archive extension.
-pub fn checksum_asset_name(binary_name: &str) -> String {
-    format!("{}-{}.sha256", binary_name, current_target())
+pub fn checksum_asset_name(spec: &BinarySpec) -> String {
+    checksum_asset_name_for(spec, current_target())
 }
 
 /// Ensures the storage directories exist.
@@ -218,6 +251,13 @@ pub fn ensure_dirs() -> Result<(), super::error::StorageError> {
 mod tests {
     use super::*;
 
+    fn binary_spec(name: &str) -> &'static BinarySpec {
+        crate::cli::registry::REGISTRY
+            .iter()
+            .find(|spec| spec.name == name)
+            .unwrap_or_else(|| panic!("{name} must be registered"))
+    }
+
     #[test]
     fn test_current_target_not_empty() {
         assert!(!current_target().is_empty());
@@ -231,9 +271,44 @@ mod tests {
 
     #[test]
     fn test_asset_name_format() {
-        let name = asset_name("iii-console");
+        let console = binary_spec("iii-console");
+        let name = asset_name(console);
         assert!(name.starts_with("iii-console-"));
         assert!(name.ends_with(archive_extension()));
+    }
+
+    #[test]
+    fn worker_release_target_uses_gnu_on_linux_x86_64() {
+        let worker = binary_spec("iii-worker");
+
+        assert_eq!(
+            release_target_for(worker, "x86_64-unknown-linux-musl"),
+            "x86_64-unknown-linux-gnu"
+        );
+    }
+
+    #[test]
+    fn worker_asset_names_use_gnu_on_linux_x86_64() {
+        let worker = binary_spec("iii-worker");
+
+        assert_eq!(
+            asset_name_for(worker, "x86_64-unknown-linux-musl"),
+            "iii-worker-x86_64-unknown-linux-gnu.tar.gz"
+        );
+        assert_eq!(
+            checksum_asset_name_for(worker, "x86_64-unknown-linux-musl"),
+            "iii-worker-x86_64-unknown-linux-gnu.sha256"
+        );
+    }
+
+    #[test]
+    fn worker_platform_support_accepts_linux_x86_64() {
+        let worker = binary_spec("iii-worker");
+
+        assert!(
+            check_platform_support_for(worker, "x86_64-unknown-linux-musl").is_ok(),
+            "Linux x86_64 must be supported through the worker's GNU asset override"
+        );
     }
 
     #[test]
@@ -309,9 +384,8 @@ mod tests {
 
     #[test]
     fn test_platform_support_check() {
-        use crate::cli::registry::REGISTRY;
         // iii-console supports all major platforms
-        let console = &REGISTRY[0];
+        let console = binary_spec("iii-console");
         let result = check_platform_support(console);
         assert!(result.is_ok());
     }

--- a/engine/src/cli/registry.rs
+++ b/engine/src/cli/registry.rs
@@ -12,6 +12,9 @@ pub struct BinarySpec {
     pub repo: &'static str,
     pub has_checksum: bool,
     pub supported_targets: &'static [&'static str],
+    /// Maps the CLI's preferred host target to the target actually published
+    /// for this binary.
+    pub asset_target_overrides: &'static [(&'static str, &'static str)],
     pub commands: &'static [CommandMapping],
     pub tag_prefix: Option<&'static str>,
 }
@@ -39,6 +42,7 @@ pub static SELF_SPEC: BinarySpec = BinarySpec {
         "x86_64-unknown-linux-musl",
         "aarch64-unknown-linux-gnu",
     ],
+    asset_target_overrides: &[],
     commands: &[],
     tag_prefix: Some("iii"),
 };
@@ -56,6 +60,7 @@ pub static REGISTRY: &[BinarySpec] = &[
             "aarch64-apple-darwin",
             "x86_64-apple-darwin",
         ],
+        asset_target_overrides: &[],
         commands: &[],
         tag_prefix: Some("iii"),
     },
@@ -72,6 +77,7 @@ pub static REGISTRY: &[BinarySpec] = &[
             "x86_64-unknown-linux-musl",
             "aarch64-unknown-linux-gnu",
         ],
+        asset_target_overrides: &[],
         commands: &[CommandMapping {
             cli_command: "console",
             binary_subcommand: None,
@@ -91,6 +97,7 @@ pub static REGISTRY: &[BinarySpec] = &[
             "x86_64-unknown-linux-musl",
             "aarch64-unknown-linux-gnu",
         ],
+        asset_target_overrides: &[],
         commands: &[CommandMapping {
             cli_command: "cloud",
             binary_subcommand: None,
@@ -103,11 +110,10 @@ pub static REGISTRY: &[BinarySpec] = &[
         has_checksum: true,
         supported_targets: &[
             "aarch64-apple-darwin",
-            "x86_64-apple-darwin",
             "x86_64-unknown-linux-gnu",
-            "x86_64-unknown-linux-musl",
             "aarch64-unknown-linux-gnu",
         ],
+        asset_target_overrides: &[("x86_64-unknown-linux-musl", "x86_64-unknown-linux-gnu")],
         commands: &[CommandMapping {
             cli_command: "worker",
             binary_subcommand: None,
@@ -204,6 +210,20 @@ mod tests {
     fn test_console_has_checksum() {
         let (spec, _) = resolve_command("console").unwrap();
         assert!(spec.has_checksum);
+    }
+
+    #[test]
+    fn worker_supported_targets_match_release_matrix() {
+        let (worker, _) = resolve_command("worker").unwrap();
+
+        assert_eq!(
+            worker.supported_targets,
+            &[
+                "aarch64-apple-darwin",
+                "x86_64-unknown-linux-gnu",
+                "aarch64-unknown-linux-gnu",
+            ]
+        );
     }
 
     #[test]

--- a/engine/src/cli/update.rs
+++ b/engine/src/cli/update.rs
@@ -240,7 +240,7 @@ pub async fn update_binary(
         && *actual >= latest_version
     {
         // Sync state to match reality so future checks are fast
-        state.record_install(spec.name, actual.clone(), platform::asset_name(spec.name));
+        state.record_install(spec.name, actual.clone(), platform::asset_name(spec));
         return Ok(UpdateResult::AlreadyUpToDate {
             binary: spec.name.to_string(),
             version: actual.clone(),
@@ -248,19 +248,19 @@ pub async fn update_binary(
     }
 
     // Find asset for current platform
-    let asset_name = platform::asset_name(spec.name);
+    let asset_name = platform::asset_name(spec);
     let asset = github::find_asset(&release, &asset_name).ok_or_else(|| {
         UpdateError::Github(IiiGithubError::Network(
             super::error::NetworkError::AssetNotFound {
                 binary: spec.name.to_string(),
-                platform: platform::current_target().to_string(),
+                platform: platform::release_target(spec).to_string(),
             },
         ))
     })?;
 
     // Find checksum asset in release (separate asset, not appended URL)
     let checksum_url = if spec.has_checksum {
-        let checksum_name = platform::checksum_asset_name(spec.name);
+        let checksum_name = platform::checksum_asset_name(spec);
         github::find_asset(&release, &checksum_name).map(|a| a.browser_download_url.clone())
     } else {
         None
@@ -351,25 +351,25 @@ pub async fn self_update(
     if let Some(ref actual) = detected_version
         && *actual >= latest_version
     {
-        state.record_install(spec.name, actual.clone(), platform::asset_name(spec.name));
+        state.record_install(spec.name, actual.clone(), platform::asset_name(spec));
         return Ok(UpdateResult::AlreadyUpToDate {
             binary: spec.name.to_string(),
             version: actual.clone(),
         });
     }
 
-    let asset_name = platform::asset_name(spec.name);
+    let asset_name = platform::asset_name(spec);
     let asset = github::find_asset(&release, &asset_name).ok_or_else(|| {
         UpdateError::Github(IiiGithubError::Network(
             super::error::NetworkError::AssetNotFound {
                 binary: spec.name.to_string(),
-                platform: platform::current_target().to_string(),
+                platform: platform::release_target(spec).to_string(),
             },
         ))
     })?;
 
     let checksum_url = if spec.has_checksum {
-        let checksum_name = platform::checksum_asset_name(spec.name);
+        let checksum_name = platform::checksum_asset_name(spec);
         github::find_asset(&release, &checksum_name).map(|a| a.browser_download_url.clone())
     } else {
         None


### PR DESCRIPTION
## Summary

- resolve release asset targets per managed binary
- map `iii-worker` on Linux x86_64 to the published GNU asset
- align the worker registry with the release matrix and cover the behavior with regression tests

## Root cause

The CLI selected `x86_64-unknown-linux-musl` globally for Linux x86_64. The worker release intentionally publishes only `x86_64-unknown-linux-gnu` because its virtualization stack requires glibc, while the registry incorrectly advertised the musl target. As a result, `iii update` requested an asset that did not exist.

## Impact

`iii update`, self-update bookkeeping, and managed-binary auto-download now resolve the release target from the binary specification. Other binaries keep their existing platform target, while `iii-worker` selects the GNU archive and checksum on Linux x86_64.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p iii`
- `cargo clippy -p iii --bin iii` (passes with pre-existing warnings outside this change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform-specific asset resolution for binary downloads and updates.
  * Corrected Linux x86_64 GNU asset selection for the worker binary.
  * Updated checksum lookup and missing-asset messages to reflect the correct release target.
  * Improved platform support validation for binaries with target-specific mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->